### PR TITLE
fix(rocprim): undeprecated internal use of 'detail::raw_storage'

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -53,6 +53,7 @@ This is a complete list of affected functions and how their default accumulator 
   * `rocprim::deterministic_exclusive_scan`
     * Previous default: `class AccType = detail::input_type_t<InitValueType>>`
     * Current default: `class AccType = rocprim::accumulator_t<BinaryFunction, rocprim::detail::input_type_t<InitValueType>>`
+* Undeprecated internal `detail::raw_storage`.
     
 ### Deprecations
 

--- a/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
@@ -190,10 +190,11 @@ struct match_fundamental_type
         >::type;
 };
 
-// A storage-backing wrapper that allows types with non-trivial constructors to be aliased in unions
+// A storage-backing wrapper that allows types with non-trivial constructors to be aliased in unions.
+// Due to the reinterpret cast, it may in some cases be technically UB, but the generated code is usually
+// more performant than proper code.
 template<typename T>
-struct [[deprecated("To store non default-constructible types in local memory, use "
-                    "rocprim::uninitialized_array instead")]] raw_storage
+struct raw_storage
 {
     // Biggest memory-access word that T is a whole multiple of and is not larger than the alignment of T
     using device_word = typename detail::match_fundamental_type<T>::type;


### PR DESCRIPTION
`detail::raw_storage` is still used quite often due to its performance relative to other APIs. Let's undeprecate this until the alternatives are equally performing.