### PR TITLE
[hiprand] Docs: Update repository and path information for rocm-libraries switchover

### DIFF
--- a/projects/hiprand/README.md
+++ b/projects/hiprand/README.md
@@ -52,6 +52,9 @@ supported platforms):
   [hipRAND build wiki](https://github.com/ROCm/hipRAND/wiki/Build) has helpful
   information on how to configure CMake and build manually.
 
+  For information on cloning and building the hipRAND library, see the
+  [hipRAND installation documentation](https://rocm.docs.amd.com/projects/hipRAND/en/latest/install/installation.html) for version 7.0 or later.
+
 ### Supported functions
 
 You can find a list of

--- a/projects/hiprand/README.md
+++ b/projects/hiprand/README.md
@@ -8,7 +8,7 @@ application and the backend RAND library, where it marshals inputs to the backen
 application. hipRAND exports an interface that doesn't require the client to change, regardless of the
 chosen backend.
 
-hipRAND supports [rocRAND](https://github.com/ROCm/rocRAND) and
+hipRAND supports [rocRAND](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocrand) and
 [NVIDIA CUDA cuRAND](https://developer.nvidia.com/curand).
 
 ## Requirements
@@ -37,7 +37,7 @@ supported platforms):
 
 * Bash helper build script:
 
-  The helper script `install` is located in the root repository. Note that this method doesn't take many
+  The helper script `install` is located in the root of the `projects/hiprand` folder. Note that this method doesn't take many
   options and hard-codes a configuration that you can specify by invoking CMake directly.
 
   A few commands in the script need sudo access, so it may prompt you for a password.

--- a/projects/hiprand/docs/index.rst
+++ b/projects/hiprand/docs/index.rst
@@ -14,8 +14,11 @@ where it marshals inputs to the backend and results to the application. hipRAND 
 require the client to change, regardless of the chosen backend.
 It uses rocRAND in a ROCm environment and cuRAND in a CUDA environment and provides C, C++, and Python API wrappers.
 
-The hipRAND public repository is located at `<https://github.com/ROCm/hipRAND>`_.
+The hipRAND public repository is located at `<https://github.com/ROCm/rocm-libraries/tree/develop/projects/hiprand>`_.
 
+.. note::
+
+   The hipRAND repository for ROCm release 6.4 and earlier is located at `<https://github.com/ROCm/hipRAND>`_.
 
 .. grid:: 2
   :gutter: 3
@@ -30,7 +33,7 @@ The hipRAND public repository is located at `<https://github.com/ROCm/hipRAND>`_
 
   .. grid-item-card:: Examples
 
-    * `Examples <https://github.com/ROCm/hipRAND/tree/develop/python/hiprand/examples>`_
+    * `Examples <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hiprand/python/hiprand/examples>`_
 
   .. grid-item-card:: API reference
 

--- a/projects/hiprand/docs/index.rst
+++ b/projects/hiprand/docs/index.rst
@@ -18,7 +18,7 @@ The hipRAND public repository is located at `<https://github.com/ROCm/rocm-libra
 
 .. note::
 
-   The hipRAND repository for ROCm release 6.4 and earlier is located at `<https://github.com/ROCm/hipRAND>`_.
+   The hipRAND repository for ROCm 6.4 and earlier is located at `<https://github.com/ROCm/hipRAND>`_.
 
 .. grid:: 2
   :gutter: 3

--- a/projects/hiprand/docs/install/installation.rst
+++ b/projects/hiprand/docs/install/installation.rst
@@ -57,7 +57,7 @@ To build hipRAND, CMake version 3.16 or later is required.
 Additionally, to build hipRAND for the ROCm platform, the following components are required:
 
 * `ROCm Software <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_ (version 5.0.0 or later)
-* `rocRAND <https://github.com/ROCm/rocRAND.git>`_
+* `rocRAND <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocrand>`_
 
 To build hipRAND for the CUDA platform, the following applications are required:
 
@@ -67,13 +67,13 @@ To build hipRAND for the CUDA platform, the following applications are required:
 Downloading the source code
 ----------------------------
 
-You can find the hipRAND source code in the `hipRAND GitHub Repository <https://github.com/ROCm/hipRAND>`_.
+You can find the hipRAND source code in the `hipRAND GitHub repository <https://github.com/ROCm/hipRAND>`_.
 Use the branch that matches the ROCm version installed on the system.
-For example, on a system with ROCm 6.3 installed, use the following command to obtain the hipRAND version 6.3 source code:
+For example, on a system with ROCm 7.0 installed, use the following command to obtain the hipRAND version 7.0 source code:
 
 .. code-block:: shell
 
-    git checkout -b release/rocm-rel-6.3 https://github.com/ROCm/hipRAND.git
+   git clone -b release/rocm-rel-7.0 https://github.com/ROCm/rocm-libraries.git
 
 Building the library
 ----------------------------
@@ -82,7 +82,7 @@ After obtaining the sources and dependencies, build hipRAND for ROCm software us
 
 .. code-block:: shell
 
-    cd hipRAND
+    cd rocm-libraries/projects/hiprand
     ./install --install
 
 This automatically builds all required dependencies, excluding Git and the requirements listed above,
@@ -95,12 +95,12 @@ Building with CMake
 ----------------------------
 
 For a more detailed installation process, build hipRAND manually using CMake.
-This enables certain configuration options that are not available through the ``./install`` script.
+This enables certain configuration options that are not available through the ``install`` script.
 To build hipRAND, use CMake with the following configuration:
 
 .. code-block:: shell
 
-    cd hipRAND; mkdir build; cd build
+    cd rocm-libraries/projects/hiprand; mkdir build; cd build
     # Configure the project
     CXX=<compiler> cmake [options] ..
     # Build
@@ -143,7 +143,7 @@ Use the following tips to troubleshoot build problems.
       rocrandConfig.cmake
       rocrand-config.cmake
 
-   **Solution**: Install `rocRAND <https://github.com/ROCm/rocRAND.git>`_.
+   **Solution**: Install `rocRAND <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocrand>`_.
 
 *  ``ROCM`` package configuration file not found:
 
@@ -178,7 +178,7 @@ The hipRAND Python API Wrapper requires the following dependencies:
 
    .. code-block:: shell
 
-      export HIPRAND_PATH=~/hipRAND/build/library/
+      export HIPRAND_PATH=~/rocm-libraries/projects/hiprand/build/library/
 
 Installation
 ----------------------------
@@ -187,12 +187,12 @@ To install the Python hipRAND module using ``pip``, run these commands:
 
 .. code-block:: shell
 
-   cd hipRAND/python/hiprand
+   cd rocm-libraries/projects/hiprand/python/hiprand
    pip install .
 
 Use these commands to run the tests:
 
 .. code-block:: shell
 
-   cd hipRAND/python/hiprand
+   cd rocm-libraries/projects/hiprand/python/hiprand
    python tests/hiprand_test.py

--- a/projects/hiprand/docs/install/installation.rst
+++ b/projects/hiprand/docs/install/installation.rst
@@ -67,13 +67,45 @@ To build hipRAND for the CUDA platform, the following applications are required:
 Downloading the source code
 ----------------------------
 
-You can find the hipRAND source code in the `hipRAND GitHub repository <https://github.com/ROCm/hipRAND>`_.
+The hipRAND source code is available from the `hiprand folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hiprand>`_ of
+the `rocm-libraries <https://github.com/ROCm/rocm-libraries>`_ GitHub repository.
 Use the branch that matches the ROCm version installed on the system.
-For example, on a system with ROCm 7.0 installed, use the following command to obtain the hipRAND version 7.0 source code:
+The hipRAND source code can be cloned in two different ways.
 
-.. code-block:: shell
+.. note::
 
-   git clone -b release/rocm-rel-7.0 https://github.com/ROCm/rocm-libraries.git
+   For both methods, replace all occurrences of "x.y" in the commands with the version number matching your ROCm installation.
+   For example, if you have ROCm 7.0 installed, clone the ``release/rocm-rel-7.0`` branch.
+
+*  Clone the entire `rocm-libraries <https://github.com/ROCm/rocm-libraries>`_ repository.
+   This is the default method and is the preferred option if you need to install other
+   ROCm libraries alongside hipRAND. However, due to the download size, ``git clone``
+   might take some time to complete.
+
+   On a system with ROCm x.y installed, use the following command to obtain the source code
+   for hipRAND version x.y. Replace x.y with the actual version:
+
+   .. code-block:: shell
+
+      git clone -b release/rocm-rel-7.0 https://github.com/ROCm/rocm-libraries.git
+
+*  Clone the individual hipRAND project folder. This option only fetches the hipRAND source code,
+   without any additional ROCm libraries. This significantly reduces the amount of time required
+   to complete the clone operation. However, it requires Git 2.25 or later.
+   To use this method to obtain the source code for hipRAND version x.y, run the following commands.
+   Replace x.y with the actual version:
+
+   .. code-block:: shell
+
+      git clone -b release/rocm-rel-x.y --no-checkout --depth=1 --filter=tree:0 https://github.com/ROCm/rocm-libraries.git
+      cd rocm-libraries
+      git sparse-checkout set --cone projects/hiprand
+      git checkout release/rocm-rel-x.y
+
+.. note::
+
+   To build ROCm release 6.4 and older, use the hipRAND repository at `<https://github.com/ROCm/hipRAND>`_.
+   For more information, see the documentation associated with the release you want to build.
 
 Building the library
 ----------------------------

--- a/projects/hiprand/docs/install/installation.rst
+++ b/projects/hiprand/docs/install/installation.rst
@@ -104,7 +104,7 @@ The hipRAND source code can be cloned in two different ways.
 
 .. note::
 
-   To build ROCm 6.4 and older, use the hipRAND repository at `<https://github.com/ROCm/hipRAND>`_.
+   To build ROCm 6.4 and earlier, use the hipRAND repository at `<https://github.com/ROCm/hipRAND>`_.
    For more information, see the documentation associated with the release you want to build.
 
 Building the library

--- a/projects/hiprand/docs/install/installation.rst
+++ b/projects/hiprand/docs/install/installation.rst
@@ -78,9 +78,9 @@ The hipRAND source code can be cloned in two different ways.
    For example, if you have ROCm 7.0 installed, clone the ``release/rocm-rel-7.0`` branch.
 
 *  Clone the entire `rocm-libraries <https://github.com/ROCm/rocm-libraries>`_ repository.
-   This is the default method and is the preferred option if you need to install other
+   This is the default method and is the recommended option if you need to install other
    ROCm libraries alongside hipRAND. However, due to the download size, ``git clone``
-   might take some time to complete.
+   might take a significant amount of time to complete.
 
    On a system with ROCm x.y installed, use the following command to obtain the source code
    for hipRAND version x.y. Replace x.y with the actual version:
@@ -104,7 +104,7 @@ The hipRAND source code can be cloned in two different ways.
 
 .. note::
 
-   To build ROCm release 6.4 and older, use the hipRAND repository at `<https://github.com/ROCm/hipRAND>`_.
+   To build ROCm 6.4 and older, use the hipRAND repository at `<https://github.com/ROCm/hipRAND>`_.
    For more information, see the documentation associated with the release you want to build.
 
 Building the library

--- a/projects/hiprand/docs/sphinx/_toc.yml.in
+++ b/projects/hiprand/docs/sphinx/_toc.yml.in
@@ -14,7 +14,7 @@ subtrees:
 
 - caption: Examples
   entries:
-  - url: https://github.com/ROCm/hipRAND/tree/develop/python/hiprand/examples
+  - url: https://github.com/ROCm/rocm-libraries/tree/develop/projects/hiprand/python/hiprand/examples
     title: Examples
 
 - caption: API reference


### PR DESCRIPTION
This is a companion to https://github.com/ROCm/rocm-libraries/pull/232. It updates the hiprand docs index page, install instructions, and links to the GitHub to reference rocm-libraries rather than the legacy hipRAND repo. It also adds a note directing users of pre-7.0 branches to the old repository and documentation.

NOTE: This is intended for the 7.0 branch and later. A different change will be applied to the 6.4 branch explaining the situation from the perspective of older branches.