### PR TITLE
Increasing rocprim test coverage

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -94,6 +94,7 @@ when the input or inital type was smaller than the output type.
 * Fixed device radix sort not returning the correct required temporary storage when a double buffer contains `nullptr`.
 * Fixed constness of equality operators (`==` and `!=`) in `rocprim::key_value_pair`.
 * Fixed an issue for the comparison operators in `arg_index_iterator` and `texture_cache_iterator`, where `<` and `>` comparators were swapped.
+* Fixed an issue for the `rocprim::thread_reduce` not working correctly with a prefix value.
 
 ### Known issues
 * When using `rocprim::deterministic_inclusive_scan_by_key` and `rocprim::deterministic_exclusive_scan_by_key` the intermediate values can change order on Navi3x

--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -93,6 +93,7 @@ when the input or inital type was smaller than the output type.
 * Fixed an issue where `device_segmented_reduce` reported autotuning throughput being 5x lower than it was in reality.
 * Fixed device radix sort not returning the correct required temporary storage when a double buffer contains `nullptr`.
 * Fixed constness of equality operators (`==` and `!=`) in `rocprim::key_value_pair`.
+* Fixed an issue for the comparison operators in `arg_index_iterator` and `texture_cache_iterator`, where `<` and `>` comparators were swapped.
 
 ### Known issues
 * When using `rocprim::deterministic_inclusive_scan_by_key` and `rocprim::deterministic_exclusive_scan_by_key` the intermediate values can change order on Navi3x

--- a/projects/rocprim/benchmark/benchmark_device_merge_sort.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_merge_sort.cpp
@@ -50,10 +50,16 @@ int main(int argc, char* argv[])
     CREATE_BENCHMARK(rocprim::int128_t)
     CREATE_BENCHMARK(rocprim::uint128_t)
 
-    using custom_float2          = common::custom_type<float, float>;
-    using custom_double2         = common::custom_type<double, double>;
-    using custom_int2            = common::custom_type<int, int>;
-    using custom_char_double     = common::custom_type<char, double>; // used by ssbk benchmark
+    using custom_float2  = common::custom_type<float, float>;
+    using custom_double2 = common::custom_type<double, double>;
+    using custom_double2_copy
+        = common::custom_type_copyable<double,
+                                       double>; // specific benchmark for specialization workaround
+    using custom_int2        = common::custom_type<int, int>;
+    using custom_char_double = common::custom_type<char, double>; // used by ssbk
+    using custom_char_double_copy
+        = common::custom_type_copyable<char,
+                                       double>; // specific benchmark for specialization workaround
     using custom_longlong_double = common::custom_type<long long, double>;
     using huge_float2_1024       = common::custom_huge_type<1024, float, float>;
     using huge_float2_2048       = common::custom_huge_type<2048, float, float>;
@@ -69,8 +75,10 @@ int main(int argc, char* argv[])
     CREATE_BENCHMARK(huge_float2_2048)
     CREATE_BENCHMARK(long long, custom_double2)
     CREATE_BENCHMARK(custom_double2, custom_double2)
+    CREATE_BENCHMARK(custom_double2, custom_double2_copy)
     CREATE_BENCHMARK(custom_int2, custom_double2)
     CREATE_BENCHMARK(custom_int2, custom_char_double)
+    CREATE_BENCHMARK(custom_int2, custom_char_double_copy)
     CREATE_BENCHMARK(custom_int2, custom_longlong_double)
     CREATE_BENCHMARK(rocprim::int128_t, rocprim::int128_t)
     CREATE_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)

--- a/projects/rocprim/benchmark/benchmark_device_merge_sort.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_merge_sort.hpp
@@ -140,7 +140,21 @@ struct device_merge_sort_benchmark : public benchmark_utils::autotune_interface
                                         seed.get_0());
 
         std::vector<value_type> values_input(size);
-        std::iota(values_input.begin(), values_input.end(), 0);
+
+        if constexpr(common::is_custom_type_copyable<value_type>::value)
+        {
+            for(size_t i = 0; i < size; i++)
+            {
+                value_type value;
+                value.x         = static_cast<typename value_type::first_type>(i);
+                value.y         = static_cast<typename value_type::second_type>(i);
+                values_input[i] = value;
+            }
+        }
+        else
+        {
+            std::iota(values_input.begin(), values_input.end(), 0);
+        }
 
         key_type* d_keys_input;
         key_type* d_keys_output;

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -694,8 +694,8 @@ public:
     static std::string format_name(std::string string)
     {
         format     format = get_format();
-        std::regex r(
-            "([A-z0-9]*):\\s*((?:common::custom_type<[A-z0-9,]*>)|[A-z:\\(\\)\\.<>\\s0-9]*)(\\}*)");
+        std::regex r("([A-z0-9]*):\\s*((?:common::custom_type<[A-z0-9,]*>)|(?:common::custom_type_"
+                     "copyable<[A-z0-9,]*>)|[A-z:\\(\\)\\.<>\\s0-9]*)(\\}*)");
         // First we perform some checks
         bool checks[4] = {false};
         for(std::sregex_iterator i = std::sregex_iterator(string.begin(), string.end(), r);
@@ -916,6 +916,16 @@ template<>
 inline const char* Traits<rocprim::uint128_t>::name()
 {
     return "rocprim::uint128_t";
+}
+template<>
+inline const char* Traits<common::custom_type_copyable<char, double>>::name()
+{
+    return "common::custom_type_copyable<char,double>";
+}
+template<>
+inline const char* Traits<common::custom_type_copyable<double, double>>::name()
+{
+    return "common::custom_type_copyable<double,double>";
 }
 
 inline const char* get_block_scan_algorithm_name(rocprim::block_scan_algorithm alg)

--- a/projects/rocprim/common/utils_custom_type.hpp
+++ b/projects/rocprim/common/utils_custom_type.hpp
@@ -138,6 +138,85 @@ struct custom_type
     }
 };
 
+template<typename T, typename U = T, bool NonZero = false>
+struct custom_type_copyable
+{
+    using first_type  = T;
+    using second_type = U;
+
+    using value_type = std::conditional_t<std::is_same<T, U>::value, T, void>;
+
+    T x;
+    U y;
+
+    ROCPRIM_HOST_DEVICE constexpr inline custom_type_copyable()
+        : x(NonZero ? 12 : 0), y(NonZero ? 34 : 0)
+    {}
+
+    ROCPRIM_HOST_DEVICE inline custom_type_copyable(T x, U y) : x(x), y(y) {}
+
+    ROCPRIM_HOST_DEVICE inline custom_type_copyable(T xy) : x(xy), y(xy) {}
+
+    template<typename V, typename W>
+    ROCPRIM_HOST_DEVICE inline custom_type_copyable(
+        const custom_type_copyable<V, W, NonZero>& other)
+        : x(static_cast<T>(other.x)), y(static_cast<U>(other.y))
+    {}
+
+    ROCPRIM_HOST_DEVICE
+    inline bool
+        operator<(const custom_type_copyable& other) const
+    {
+        rocprim::less<T>     less_T;
+        rocprim::equal_to<T> equal_to_T;
+        rocprim::less<U>     less_U;
+        return (less_T(x, other.x) || (equal_to_T(x, other.x) && less_U(y, other.y)));
+    }
+
+    ROCPRIM_HOST_DEVICE
+    inline bool
+        operator>(const custom_type_copyable& other) const
+    {
+        rocprim::greater<T>  greater_T;
+        rocprim::equal_to<T> equal_to_T;
+        rocprim::greater<U>  greater_U;
+        return (greater_T(x, other.x) || (equal_to_T(x, other.x) && greater_U(y, other.y)));
+    }
+
+    ROCPRIM_HOST_DEVICE
+    inline bool
+        operator==(const custom_type_copyable& other) const
+    {
+        rocprim::equal_to<T> equal_to_T;
+        rocprim::equal_to<U> equal_to_U;
+        return (equal_to_T(x, other.x) && equal_to_U(y, other.y));
+    }
+
+    ROCPRIM_HOST_DEVICE
+    inline bool
+        operator!=(const custom_type_copyable& other) const
+    {
+        return !(*this == other);
+    }
+
+    friend inline std::ostream& operator<<(std::ostream& stream, const custom_type_copyable& value)
+    {
+        stream << "[" << value.x << "; " << value.y << "]";
+        return stream;
+    }
+};
+
+static_assert(std::is_trivially_copyable<custom_type_copyable<char, double>>::value,
+              "custom_type_copyable is not trivially copyable");
+
+template<typename T>
+struct is_custom_type_copyable : std::false_type
+{};
+
+template<typename T, typename U, bool NonZero>
+struct is_custom_type_copyable<common::custom_type_copyable<T, U, NonZero>> : std::true_type
+{};
+
 template<unsigned int Size, class T, typename U = T, bool NonZero = false>
 struct custom_huge_type : custom_type<T, U, NonZero>
 {
@@ -181,6 +260,10 @@ struct is_custom_type<common::custom_type<T, U, NonZero>> : std::true_type
 
 template<unsigned int Size, typename T, typename U, bool NonZero>
 struct is_custom_type<common::custom_huge_type<Size, T, U, NonZero>> : std::true_type
+{};
+
+template<typename T, typename U, bool NonZero>
+struct is_custom_type<common::custom_type_copyable<T, U, NonZero>> : std::true_type
 {};
 } // namespace common
 

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -150,11 +150,11 @@
 // Only defined when support is present, in contrast to ROCPRIM_DETAIL_USE_DPP, which should be
 // always defined
 #if defined(__HIP_DEVICE_COMPILE__) && defined(__AMDGCN__) \
-    && (!defined(__GFX6__) && !defined(__GFX7__)) && !defined(ROCPRIM_TARGET_SPIRV)
+    && (!defined(__GFX6__) && !defined(__GFX7__)) && !(defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1)
     #define ROCPRIM_DETAIL_HAS_DPP 1
 #endif
 
-#if !defined(ROCPRIM_DISABLE_DPP) && defined(ROCPRIM_DETAIL_HAS_DPP)
+#if (!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) && (defined(ROCPRIM_DETAIL_HAS_DPP) && ROCPRIM_DETAIL_HAS_DPP == 1)
     #define ROCPRIM_DETAIL_USE_DPP 1
 #else
     #define ROCPRIM_DETAIL_USE_DPP 0

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -150,11 +150,11 @@
 // Only defined when support is present, in contrast to ROCPRIM_DETAIL_USE_DPP, which should be
 // always defined
 #if defined(__HIP_DEVICE_COMPILE__) && defined(__AMDGCN__) \
-    && (!defined(__GFX6__) && !defined(__GFX7__))
+    && (!defined(__GFX6__) && !defined(__GFX7__)) && !defined(ROCPRIM_TARGET_SPIRV)
     #define ROCPRIM_DETAIL_HAS_DPP 1
 #endif
 
-#if !defined(ROCPRIM_DISABLE_DPP) && defined(ROCPRIM_DETAIL_HAS_DPP) && !ROCPRIM_TARGET_SPIRV
+#if !defined(ROCPRIM_DISABLE_DPP) && defined(ROCPRIM_DETAIL_HAS_DPP)
     #define ROCPRIM_DETAIL_USE_DPP 1
 #else
     #define ROCPRIM_DETAIL_USE_DPP 0

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -150,11 +150,13 @@
 // Only defined when support is present, in contrast to ROCPRIM_DETAIL_USE_DPP, which should be
 // always defined
 #if defined(__HIP_DEVICE_COMPILE__) && defined(__AMDGCN__) \
-    && (!defined(__GFX6__) && !defined(__GFX7__)) && !(defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1)
+    && (!defined(__GFX6__) && !defined(__GFX7__))          \
+    && !(defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1)
     #define ROCPRIM_DETAIL_HAS_DPP 1
 #endif
 
-#if (!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) && (defined(ROCPRIM_DETAIL_HAS_DPP) && ROCPRIM_DETAIL_HAS_DPP == 1)
+#if(!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) \
+    && (defined(ROCPRIM_DETAIL_HAS_DPP) && ROCPRIM_DETAIL_HAS_DPP == 1)
     #define ROCPRIM_DETAIL_USE_DPP 1
 #else
     #define ROCPRIM_DETAIL_USE_DPP 0

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -306,8 +306,9 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void
 }
 
 template<unsigned int BlockSize, unsigned int ActiveChannels, class Counter>
-ROCPRIM_DEVICE ROCPRIM_INLINE void init_histogram(fixed_array<Counter*, ActiveChannels> histogram,
-                                                  fixed_array<unsigned int, ActiveChannels> bins)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void init_histogram(fixed_array<Counter*, ActiveChannels>           histogram,
+                    const fixed_array<unsigned int, ActiveChannels> bins)
 {
     const unsigned int flat_id  = ::rocprim::detail::block_thread_id<0>();
     const unsigned int block_id = ::rocprim::detail::block_id<0>();
@@ -329,17 +330,17 @@ template<unsigned int BlockSize,
          class SampleIterator,
          class Counter,
          class SampleToBinOp>
-ROCPRIM_DEVICE ROCPRIM_INLINE void
-    histogram_shared(SampleIterator                             samples,
-                     unsigned int                               columns,
-                     unsigned int                               rows,
-                     unsigned int                               row_stride,
-                     unsigned int                               rows_per_block,
-                     unsigned int                               shared_histograms,
-                     fixed_array<Counter*, ActiveChannels>      histogram,
-                     fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                     fixed_array<unsigned int, ActiveChannels>  bins,
-                     unsigned int*                              block_histogram_start)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void histogram_shared(SampleIterator                                   samples,
+                      unsigned int                                     columns,
+                      unsigned int                                     rows,
+                      unsigned int                                     row_stride,
+                      unsigned int                                     rows_per_block,
+                      unsigned int                                     shared_histograms,
+                      fixed_array<Counter*, ActiveChannels>            histogram,
+                      const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
+                      const fixed_array<unsigned int, ActiveChannels>  bins,
+                      unsigned int*                                    block_histogram_start)
 {
     using sample_type        = typename std::iterator_traits<SampleIterator>::value_type;
     using sample_vector_type = sample_vector<sample_type, Channels>;
@@ -456,13 +457,13 @@ template<unsigned int BlockSize,
          class SampleIterator,
          class Counter,
          class SampleToBinOp>
-ROCPRIM_DEVICE ROCPRIM_INLINE void
-    histogram_global(SampleIterator                             samples,
-                     unsigned int                               columns,
-                     unsigned int                               row_stride,
-                     fixed_array<Counter*, ActiveChannels>      histogram,
-                     fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                     fixed_array<unsigned int, ActiveChannels>  bins_bits)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void histogram_global(SampleIterator                                   samples,
+                      unsigned int                                     columns,
+                      unsigned int                                     row_stride,
+                      fixed_array<Counter*, ActiveChannels>            histogram,
+                      const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
+                      const fixed_array<unsigned int, ActiveChannels>  bins_bits)
 {
     using sample_type        = typename std::iterator_traits<SampleIterator>::value_type;
     using sample_vector_type = sample_vector<sample_type, Channels>;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_merge_sort.hpp
@@ -230,7 +230,7 @@ struct block_permute_values_impl<Value,
                                  ItemsPerThread,
                                  std::enable_if_t<(std::is_trivially_copyable<Value>::value
                                                    && !rocprim::is_floating_point<Value>::value
-                                                   && !std::is_integral<Value>::value)>>
+                                                   && !rocprim::is_integral<Value>::value)>>
 {
     static constexpr unsigned int items_per_block = ItemsPerThread * BlockSize;
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_merge_sort_mergepath.hpp
@@ -98,8 +98,9 @@ struct block_merge_impl<
     Value,
     BlockSize,
     ItemsPerThread,
-    std::enable_if_t<!std::is_trivially_copyable<Value>::value
-                     || rocprim::is_floating_point<Value>::value || std::is_integral<Value>::value>>
+    std::enable_if_t<
+        !std::is_trivially_copyable<Value>::value || rocprim::is_floating_point<Value>::value
+        || rocprim::is_integral<Value>::value || std::is_same<Value, ::rocprim::empty_type>::value>>
 {
 
     static constexpr bool         with_values = !std::is_same<Value, ::rocprim::empty_type>::value;
@@ -264,9 +265,9 @@ struct block_merge_impl<Key,
                         ItemsPerThread,
                         std::enable_if_t<std::is_trivially_copyable<Value>::value
                                          && !rocprim::is_floating_point<Value>::value
-                                         && !std::is_integral<Value>::value>>
+                                         && !rocprim::is_integral<Value>::value
+                                         && !std::is_same<Value, ::rocprim::empty_type>::value>>
 {
-
     static constexpr bool         with_values = !std::is_same<Value, ::rocprim::empty_type>::value;
     static constexpr unsigned int items_per_tile = BlockSize * ItemsPerThread;
 
@@ -301,7 +302,6 @@ struct block_merge_impl<Key,
                                                               const OffsetT*       merge_partitions,
                                                               storage_type&        storage)
         {
-
             auto& keys_shared   = storage.keys.get();
             auto& values_shared = storage.values.get();
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -44,8 +44,8 @@ namespace detail
 
 template<class Config, unsigned int ActiveChannels, class Counter>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
-    init_histogram_kernel(fixed_array<Counter*, ActiveChannels>     histogram,
-                          fixed_array<unsigned int, ActiveChannels> bins)
+    init_histogram_kernel(fixed_array<Counter*, ActiveChannels>           histogram,
+                          const fixed_array<unsigned int, ActiveChannels> bins)
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
@@ -59,15 +59,15 @@ template<class Config,
          class Counter,
          class SampleToBinOp>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
-    histogram_shared_kernel(SampleIterator                             samples,
-                            unsigned int                               columns,
-                            unsigned int                               rows,
-                            unsigned int                               row_stride,
-                            unsigned int                               rows_per_block,
-                            unsigned int                               shared_histograms,
-                            fixed_array<Counter*, ActiveChannels>      histogram,
-                            fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                            fixed_array<unsigned int, ActiveChannels>  bins)
+    histogram_shared_kernel(SampleIterator                                   samples,
+                            unsigned int                                     columns,
+                            unsigned int                                     rows,
+                            unsigned int                                     row_stride,
+                            unsigned int                                     rows_per_block,
+                            unsigned int                                     shared_histograms,
+                            fixed_array<Counter*, ActiveChannels>            histogram,
+                            const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
+                            const fixed_array<unsigned int, ActiveChannels>  bins)
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
@@ -100,12 +100,12 @@ template<class Config,
          class Counter,
          class SampleToBinOp>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
-    histogram_global_kernel(SampleIterator                             samples,
-                            unsigned int                               columns,
-                            unsigned int                               row_stride,
-                            fixed_array<Counter*, ActiveChannels>      histogram,
-                            fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                            fixed_array<unsigned int, ActiveChannels>  bins_bits)
+    histogram_global_kernel(SampleIterator                                   samples,
+                            unsigned int                                     columns,
+                            unsigned int                                     row_stride,
+                            fixed_array<Counter*, ActiveChannels>            histogram,
+                            const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
+                            const fixed_array<unsigned int, ActiveChannels>  bins_bits)
 {
     static constexpr histogram_config_params params = device_params<Config>();
 

--- a/projects/rocprim/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
@@ -181,25 +181,25 @@ public:
     ROCPRIM_HOST_DEVICE inline
     bool operator<(arg_index_iterator other) const
     {
-        return (iterator_ - other.iterator_) > 0;
+        return (iterator_ - other.iterator_) < 0;
     }
 
     ROCPRIM_HOST_DEVICE inline
     bool operator<=(arg_index_iterator other) const
     {
-        return (iterator_ - other.iterator_) >= 0;
+        return (iterator_ - other.iterator_) <= 0;
     }
 
     ROCPRIM_HOST_DEVICE inline
     bool operator>(arg_index_iterator other) const
     {
-        return (iterator_ - other.iterator_) < 0;
+        return (iterator_ - other.iterator_) > 0;
     }
 
     ROCPRIM_HOST_DEVICE inline
     bool operator>=(arg_index_iterator other) const
     {
-        return (iterator_ - other.iterator_) <= 0;
+        return (iterator_ - other.iterator_) >= 0;
     }
 
     ROCPRIM_HOST_DEVICE inline

--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -306,25 +306,25 @@ public:
     ROCPRIM_HOST_DEVICE inline
     bool operator<(texture_cache_iterator other) const
     {
-        return (ptr - other.ptr) > 0;
+        return (ptr - other.ptr) < 0;
     }
 
     ROCPRIM_HOST_DEVICE inline
     bool operator<=(texture_cache_iterator other) const
     {
-        return (ptr - other.ptr) >= 0;
+        return (ptr - other.ptr) <= 0;
     }
 
     ROCPRIM_HOST_DEVICE inline
     bool operator>(texture_cache_iterator other) const
     {
-        return (ptr - other.ptr) < 0;
+        return (ptr - other.ptr) > 0;
     }
 
     ROCPRIM_HOST_DEVICE inline
     bool operator>=(texture_cache_iterator other) const
     {
-        return (ptr - other.ptr) <= 0;
+        return (ptr - other.ptr) >= 0;
     }
     #endif // DOXYGEN_SHOULD_SKIP_THIS
 

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_reduce.hpp
@@ -54,9 +54,10 @@ template<int Length, typename T, typename ReductionOp, typename Prefix = std::mo
 ROCPRIM_DEVICE ROCPRIM_INLINE
 auto thread_reduce(T* input, ReductionOp reduction_op, Prefix prefix = {})
 {
-    T retval = input[0];
+    constexpr bool no_prefix = std::is_same_v<Prefix, std::monostate>;
 
-    if constexpr(std::is_same_v<Prefix, std::monostate>)
+    T retval;
+    if constexpr(no_prefix)
     {
         retval = input[0];
     }
@@ -66,7 +67,7 @@ auto thread_reduce(T* input, ReductionOp reduction_op, Prefix prefix = {})
     }
 
     ROCPRIM_UNROLL
-    for(int i = 1; i < Length; ++i)
+    for(int i = 0 + no_prefix; i < Length; ++i)
     {
         retval = reduction_op(retval, input[i]);
     }

--- a/projects/rocprim/test/rocprim/CMakeLists.txt
+++ b/projects/rocprim/test/rocprim/CMakeLists.txt
@@ -313,6 +313,7 @@ add_rocprim_test("rocprim.lookback_reproducibility" test_lookback_reproducibilit
 add_rocprim_test("rocprim.radix_key_codec" test_radix_key_codec.cpp)
 add_rocprim_test("rocprim.predicate_iterator" test_predicate_iterator.cpp)
 add_rocprim_test("rocprim.reverse_iterator" test_reverse_iterator.cpp)
+add_rocprim_test("rocprim.rocprim_types" test_rocprim_types.cpp)
 add_rocprim_test("rocprim.texture_cache_iterator" test_texture_cache_iterator.cpp)
 add_rocprim_test("rocprim.thread" test_thread.cpp)
 add_rocprim_test("rocprim.thread_algos" test_thread_algos.cpp)

--- a/projects/rocprim/test/rocprim/CMakeLists.txt
+++ b/projects/rocprim/test/rocprim/CMakeLists.txt
@@ -79,6 +79,13 @@ function(add_rocprim_test_internal TEST_NAME TEST_SOURCES TEST_TARGET)
       $<$<COMPILE_LANGUAGE:HIP>:$<$<HIP_COMPILER_ID:MSVC>:/bigobj>>
   )
 
+  function(add_rocprim_test_disable_dpp TEST_NAME TEST_SOURCES)
+    get_rocprim_test_target(${TEST_SOURCES} TEST_TARGET)
+    set(TEST_TARGET "${TEST_TARGET}_disable_dpp")
+    add_rocprim_test_internal("${TEST_NAME}_disable_dpp" "${TEST_SOURCES}" ${TEST_TARGET})
+    target_compile_definitions(${TEST_TARGET} PRIVATE ROCPRIM_DISABLE_DPP=1)
+  endfunction()
+
   if(WIN32)
     # Usage of 128-bit integral types (__int128_t and __uint128_t, whose alignment is 16 bytes)
     # requires an extended alignment support. Otherwise, a static assert will be triggered in
@@ -323,6 +330,7 @@ add_rocprim_test("rocprim.warp_exchange" test_warp_exchange.cpp)
 add_rocprim_test("rocprim.warp_load" test_warp_load.cpp)
 add_rocprim_test("rocprim.warp_reduce" test_warp_reduce.cpp)
 add_rocprim_test("rocprim.warp_scan" test_warp_scan.cpp)
+add_rocprim_test_disable_dpp("rocprim.warp_scan_disable_dpp" test_warp_scan.cpp)
 add_rocprim_test("rocprim.warp_sort" test_warp_sort.cpp)
 add_rocprim_test("rocprim.warp_store" test_warp_store.cpp)
 add_rocprim_test("rocprim.zip_iterator" test_zip_iterator.cpp)

--- a/projects/rocprim/test/rocprim/CMakeLists.txt
+++ b/projects/rocprim/test/rocprim/CMakeLists.txt
@@ -313,6 +313,7 @@ add_rocprim_test("rocprim.lookback_reproducibility" test_lookback_reproducibilit
 add_rocprim_test("rocprim.radix_key_codec" test_radix_key_codec.cpp)
 add_rocprim_test("rocprim.predicate_iterator" test_predicate_iterator.cpp)
 add_rocprim_test("rocprim.reverse_iterator" test_reverse_iterator.cpp)
+add_rocprim_test("rocprim.rocprim_tuple" test_rocprim_tuple.cpp)
 add_rocprim_test("rocprim.rocprim_types" test_rocprim_types.cpp)
 add_rocprim_test("rocprim.texture_cache_iterator" test_texture_cache_iterator.cpp)
 add_rocprim_test("rocprim.thread" test_thread.cpp)

--- a/projects/rocprim/test/rocprim/test_arg_index_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_arg_index_iterator.cpp
@@ -62,37 +62,94 @@ using RocprimArgIndexIteratorTestsParams
 
 TYPED_TEST_SUITE(RocprimArgIndexIteratorTests, RocprimArgIndexIteratorTestsParams);
 
-TYPED_TEST(RocprimArgIndexIteratorTests, Equal)
+TYPED_TEST(RocprimArgIndexIteratorTests, Basic)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using T = typename TestFixture::input_type;
+    using T        = typename TestFixture::input_type;
     using Iterator = typename rocprim::arg_index_iterator<T*>;
+    using Value    = typename Iterator::value_type;
 
     for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
     {
-        unsigned int seed_value = seed_index < random_seeds_count  ? rand() : seeds[seed_index - random_seeds_count];
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
         SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
 
-        std::vector<T> input = test_utils::get_random_data_wrapped<T>(5, 1, 200, seed_value);
+        std::vector<T> input = test_utils::get_random_data_wrapped<T>(10, 1, 200, seed_value);
 
-        Iterator x(input.data());
-        Iterator y = x;
-        for(size_t i = 0; i < 5; i++)
-        {
-            ASSERT_EQ(x[i].key, i);
-            ASSERT_EQ(x[i].value, input[i]);
-        }
-        ASSERT_EQ(x[2].value, input[2]);
+        Iterator begin = rocprim::make_arg_index_iterator(input.data());
+        Iterator mid   = begin + 5;
+        Iterator end   = begin + 10;
 
-        x += 2;
-        for(size_t i = 0; i < 2; i++)
+        // Pre-increment
+        Iterator it = begin;
+        ++it;
+        ASSERT_EQ((*it).key, 1);
+        ASSERT_EQ((*it).value, input[1]);
+
+        // Post-increment
+        Iterator post = it++;
+        ASSERT_EQ((*post).key, 1);
+        ASSERT_EQ((*it).key, 2);
+
+        // Pre-decrement via -=
+        it -= 2;
+        ASSERT_EQ((*it).key, 0);
+
+        // operator+
+        Iterator plus_it = begin + 3;
+        ASSERT_EQ((*plus_it).key, 3);
+        ASSERT_EQ((*plus_it).value, input[3]);
+        Iterator plus_it_rev = 3 + begin;
+        ASSERT_EQ((*plus_it_rev).key, 3);
+        ASSERT_EQ((*plus_it_rev).value, input[3]);
+
+        // operator-
+        Iterator minus_it = end - 3;
+        ASSERT_EQ((*minus_it).key, 7);
+        ASSERT_EQ((*minus_it).value, input[7]);
+
+        // compound assignment +=
+        Iterator a = begin;
+        a += 4;
+        ASSERT_EQ((*a).key, 4);
+        ASSERT_EQ((*a).value, input[4]);
+
+        // compound assignment -=
+        a -= 2;
+        ASSERT_EQ((*a).key, 2);
+        ASSERT_EQ((*a).value, input[2]);
+
+        // Subtraction of iterators (distance)
+        ASSERT_EQ(end - begin, 10);
+        ASSERT_EQ(mid - begin, 5);
+        ASSERT_EQ(begin - mid, -5);
+
+        // Indexing operator[]
+        for(int i = 0; i < 10; i++)
         {
-            y++;
+            Value v = begin[i];
+            ASSERT_EQ(v.key, i);
+            ASSERT_EQ(v.value, input[i]);
         }
-        ASSERT_TRUE(x == y);
+
+        // Comparisons
+        ASSERT_TRUE(begin == begin);
+        ASSERT_TRUE(begin != end);
+        ASSERT_TRUE(begin < end);
+        ASSERT_TRUE(end > begin);
+        ASSERT_TRUE(begin <= begin);
+        ASSERT_TRUE(begin <= end);
+        ASSERT_TRUE(end >= begin);
+        ASSERT_TRUE(end >= end);
+
+        // Normalize test
+        Iterator normalized = mid;
+        normalized.normalize();
+        ASSERT_EQ((*normalized).key, 0);
     }
 }
 
@@ -134,36 +191,20 @@ TYPED_TEST(RocprimArgIndexIteratorTests, ReduceArgMinimum)
         Iterator x(input.data());
         key_value expected = std::accumulate(x, x + size, max, reduce_op);
 
-        // temp storage
-        size_t temp_storage_size_bytes;
-
-        // Get size of d_temp_storage
-        HIP_CHECK(rocprim::reduce(nullptr,
-                                  temp_storage_size_bytes,
-                                  d_iter,
-                                  d_output.get(),
-                                  max,
-                                  input.size(),
-                                  reduce_op,
-                                  stream,
-                                  debug_synchronous));
-
-        // temp_storage_size_bytes must be >0
-        ASSERT_GT(temp_storage_size_bytes, 0);
-        common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-        // Run
-        HIP_CHECK(rocprim::reduce(d_temp_storage.get(),
-                                  temp_storage_size_bytes,
-                                  d_iter,
-                                  d_output.get(),
-                                  max,
-                                  input.size(),
-                                  reduce_op,
-                                  stream,
-                                  debug_synchronous));
-        HIP_CHECK(hipGetLastError());
-        HIP_CHECK(hipDeviceSynchronize());
+        test_utils::test_kernel_wrapper(
+            [&](void* temp_storage, size_t& storage_bytes)
+            {
+                return rocprim::reduce(temp_storage,
+                                       storage_bytes,
+                                       d_iter,
+                                       d_output.get(),
+                                       max,
+                                       input.size(),
+                                       reduce_op,
+                                       stream,
+                                       debug_synchronous);
+            },
+            stream);
 
         // Copy output to host
         output = d_output.load();

--- a/projects/rocprim/test/rocprim/test_constant_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_constant_iterator.cpp
@@ -60,6 +60,92 @@ using RocprimConstantIteratorTestsParams
 
 TYPED_TEST_SUITE(RocprimConstantIteratorTests, RocprimConstantIteratorTestsParams);
 
+TYPED_TEST(RocprimConstantIteratorTests, Basic)
+{
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    using T          = typename TestFixture::input_type;
+    using Iterator   = rocprim::constant_iterator<T>;
+    using value_type = typename Iterator::value_type;
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        T        value = test_utils::get_random_value<T>(1, 100, seed_value);
+        Iterator begin = rocprim::make_constant_iterator<T>(value, 0);
+        Iterator mid   = begin + 5;
+        Iterator end   = begin + 10;
+
+        // Pre-increment
+        Iterator it = begin;
+        ++it;
+        ASSERT_EQ(*it, value);
+
+        // Post-increment
+        Iterator post = it++;
+        ASSERT_EQ(*post, value);
+        ASSERT_EQ(*it, value);
+
+        // Pre-decrement
+        --it;
+        ASSERT_EQ(*it, value);
+
+        // Post-decrement
+        post = it--;
+        ASSERT_EQ(*post, value);
+        ASSERT_EQ(*it, value);
+
+        // operator+
+        Iterator plus_it = begin + 3;
+        ASSERT_EQ(*plus_it, value);
+        Iterator plus_it_rev = 3 + begin;
+        ASSERT_EQ(*plus_it_rev, value);
+
+        // operator-
+        Iterator minus_it = end - 3;
+        ASSERT_EQ(*minus_it, value);
+
+        // compound assignment +=
+        Iterator a = begin;
+        a += 4;
+        ASSERT_EQ(*a, value);
+
+        // compound assignment -=
+        a -= 2;
+        ASSERT_EQ(*a, value);
+
+        // Subtraction of iterators (distance)
+        ASSERT_EQ(end - begin, 10);
+        ASSERT_EQ(mid - begin, 5);
+        ASSERT_EQ(begin - mid, -5);
+
+        // Indexing operator[]
+        for(int i = 0; i < 10; i++)
+        {
+            ASSERT_EQ(begin[i], value);
+        }
+
+        // Comparisons
+        ASSERT_TRUE(begin == begin);
+        ASSERT_TRUE(begin != end);
+        ASSERT_TRUE(begin < end);
+        ASSERT_TRUE(end > begin);
+        ASSERT_TRUE(begin <= begin);
+        ASSERT_TRUE(begin <= end);
+        ASSERT_TRUE(end >= begin);
+        ASSERT_TRUE(end >= end);
+
+        // Arrow operator
+        const value_type* ptr = begin.operator->();
+        ASSERT_EQ(*ptr, value);
+    }
+}
+
 template<class T>
 struct transform
 {

--- a/projects/rocprim/test/rocprim/test_counting_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_counting_iterator.cpp
@@ -24,6 +24,7 @@
 
 // required test headers
 #include "test_seed.hpp"
+#include "test_utils_assertions.hpp"
 #include "test_utils_data_generation.hpp"
 
 // required common headers
@@ -59,6 +60,92 @@ using RocprimCountingIteratorTestsParams
                        RocprimCountingIteratorParams<size_t>>;
 
 TYPED_TEST_SUITE(RocprimCountingIteratorTests, RocprimCountingIteratorTestsParams);
+
+TYPED_TEST(RocprimCountingIteratorTests, Basic)
+{
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    using T          = typename TestFixture::input_type;
+    using Iterator   = rocprim::counting_iterator<T>;
+    using value_type = typename Iterator::value_type;
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        T        start_value = test_utils::get_random_value<T>(1, 100, seed_value);
+        Iterator begin       = rocprim::make_counting_iterator<T>(start_value);
+        Iterator mid         = begin + 5;
+        Iterator end         = begin + 10;
+
+        // Pre-increment
+        Iterator it = begin;
+        ++it;
+        ASSERT_EQ(*it, start_value + 1);
+
+        // Post-increment
+        Iterator post = it++;
+        ASSERT_EQ(*post, start_value + 1);
+        ASSERT_EQ(*it, start_value + 2);
+
+        // Pre-decrement
+        --it;
+        ASSERT_EQ(*it, start_value + 1);
+
+        // Post-decrement
+        post = it--;
+        ASSERT_EQ(*post, start_value + 1);
+        ASSERT_EQ(*it, start_value + 0);
+
+        // operator+
+        Iterator plus_it = begin + 3;
+        ASSERT_EQ(*plus_it, start_value + 3);
+        Iterator plus_it_rev = 3 + begin;
+        ASSERT_EQ(*plus_it_rev, start_value + 3);
+
+        // operator-
+        Iterator minus_it = end - 3;
+        ASSERT_EQ(*minus_it, start_value + 7);
+
+        // compound assignment +=
+        Iterator a = begin;
+        a += 4;
+        ASSERT_EQ(*a, start_value + 4);
+
+        // compound assignment -=
+        a -= 2;
+        ASSERT_EQ(*a, start_value + 2);
+
+        // Subtraction of iterators (distance)
+        ASSERT_EQ(end - begin, T(10));
+        ASSERT_EQ(mid - begin, T(5));
+        ASSERT_EQ(begin - mid, T(-5));
+
+        // Indexing operator[]
+        for(int i = 0; i < 10; i++)
+        {
+            ASSERT_EQ(begin[i], start_value + i);
+        }
+
+        // Comparisons
+        ASSERT_TRUE(begin == begin);
+        ASSERT_TRUE(begin != end);
+        ASSERT_TRUE(begin < end);
+        ASSERT_TRUE(end > begin);
+        ASSERT_TRUE(begin <= begin);
+        ASSERT_TRUE(begin <= end);
+        ASSERT_TRUE(end >= begin);
+        ASSERT_TRUE(end >= end);
+
+        // Arrow operator
+        const value_type* ptr = begin.operator->();
+        ASSERT_EQ(*ptr, start_value);
+    }
+}
 
 template<class T>
 struct transform
@@ -119,10 +206,6 @@ TYPED_TEST(RocprimCountingIteratorTests, Transform)
         output = d_output.load();
 
         // Validating results
-        for(size_t i = 0; i < output.size(); i++)
-        {
-            ASSERT_EQ(output[i], expected[i]) << "where index = " << i;
-        }
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
     }
-
 }

--- a/projects/rocprim/test/rocprim/test_device_histogram.cpp
+++ b/projects/rocprim/test/rocprim/test_device_histogram.cpp
@@ -27,6 +27,7 @@
 #include "../../common/utils_device_ptr.hpp"
 
 // required test headers
+#include "indirect_iterator.hpp"
 #include "test_seed.hpp"
 #include "test_utils.hpp"
 #include "test_utils_data_generation.hpp"
@@ -125,20 +126,22 @@ template<class SampleType,
          unsigned int Bins,
          int          LowerLevel,
          int          UpperLevel,
-         class LevelType   = SampleType,
-         class CounterType = int,
-         class Config      = rocprim::default_config,
-         bool UseGraphs    = false>
+         class LevelType          = SampleType,
+         class CounterType        = int,
+         class Config             = rocprim::default_config,
+         bool UseIndirectIterator = false,
+         bool UseGraphs           = false>
 struct params1
 {
-    using sample_type                         = SampleType;
-    static constexpr unsigned int bins        = Bins;
-    static constexpr int          lower_level = LowerLevel;
-    static constexpr int          upper_level = UpperLevel;
-    using level_type                          = LevelType;
-    using counter_type                        = CounterType;
-    using config                              = Config;
-    static constexpr bool         use_graphs  = UseGraphs;
+    using sample_type                           = SampleType;
+    static constexpr unsigned int bins          = Bins;
+    static constexpr int          lower_level   = LowerLevel;
+    static constexpr int          upper_level   = UpperLevel;
+    using level_type                            = LevelType;
+    using counter_type                          = CounterType;
+    using config                                = Config;
+    static constexpr bool use_indirect_iterator = UseIndirectIterator;
+    static constexpr bool use_graphs            = UseGraphs;
 };
 
 template<class Params>
@@ -153,6 +156,7 @@ using Params1
     = ::testing::Types<params1<int, 10, 0, 10>,
                        params1<float, 10, 0, 10>,
                        params1<float, 10, 0, 10, float, float>,
+                       params1<int, 10, 0, 10, unsigned long, unsigned long>,
                        params1<rocprim::half, 10, 0, 10>,
                        params1<rocprim::bfloat16, 10, 0, 10>,
                        params1<int8_t, 10, 0, 10>,
@@ -165,7 +169,8 @@ using Params1
                        params1<double, 10, 0, 1000, double, double>,
                        params1<int, 123, 100, 5635, int>,
                        params1<double, 55, -123, +123, double, unsigned int, custom_config1>,
-                       params1<int, 10, 0, 10, int, int, rocprim::default_config, true>>;
+                       params1<int, 10, 0, 10, int, int, rocprim::default_config, true>,
+                       params1<int, 10, 0, 10, int, int, rocprim::default_config, false, true>>;
 
 TYPED_TEST_SUITE(RocprimDeviceHistogramEven, Params1);
 
@@ -222,10 +227,12 @@ TYPED_TEST(RocprimDeviceHistogramEven, Even)
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using sample_type = typename TestFixture::params::sample_type;
+    using sample_type  = typename TestFixture::params::sample_type;
     using counter_type = typename TestFixture::params::counter_type;
-    using level_type = typename TestFixture::params::level_type;
-    constexpr unsigned int bins = TestFixture::params::bins;
+    using level_type   = typename TestFixture::params::level_type;
+    using config       = typename TestFixture::params::config;
+
+    constexpr unsigned int bins        = TestFixture::params::bins;
     const level_type       lower_level = static_cast<level_type>(TestFixture::params::lower_level);
     const level_type       upper_level = static_cast<level_type>(TestFixture::params::upper_level);
 
@@ -287,93 +294,48 @@ TYPED_TEST(RocprimDeviceHistogramEven, Even)
                 }
             }
 
-            using config = typename TestFixture::params::config;
+            auto input_it
+                = test_utils::wrap_in_indirect_iterator<TestFixture::params::use_indirect_iterator>(
+                    d_input.get());
 
-            size_t temporary_storage_bytes = 0;
-            if(rows == 1)
-            {
-                HIP_CHECK(rocprim::histogram_even<config>(nullptr,
-                                                          temporary_storage_bytes,
-                                                          d_input.get(),
-                                                          static_cast<unsigned int>(columns),
-                                                          d_histogram.get(),
-                                                          bins + 1,
-                                                          lower_level,
-                                                          upper_level,
-                                                          stream,
-                                                          debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::histogram_even<config>(nullptr,
-                                                          temporary_storage_bytes,
-                                                          d_input.get(),
-                                                          columns,
-                                                          rows,
-                                                          row_stride_bytes,
-                                                          d_histogram.get(),
-                                                          bins + 1,
-                                                          lower_level,
-                                                          upper_level,
-                                                          stream,
-                                                          debug_synchronous));
-            }
-
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            if(rows == 1)
-            {
-                HIP_CHECK(rocprim::histogram_even<config>(d_temporary_storage.get(),
-                                                          temporary_storage_bytes,
-                                                          d_input.get(),
-                                                          columns,
-                                                          d_histogram.get(),
-                                                          bins + 1,
-                                                          lower_level,
-                                                          upper_level,
-                                                          stream,
-                                                          debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::histogram_even<config>(d_temporary_storage.get(),
-                                                          temporary_storage_bytes,
-                                                          d_input.get(),
-                                                          columns,
-                                                          rows,
-                                                          row_stride_bytes,
-                                                          d_histogram.get(),
-                                                          bins + 1,
-                                                          lower_level,
-                                                          upper_level,
-                                                          stream,
-                                                          debug_synchronous));
-            }
-
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    if(rows == 1)
+                    {
+                        return rocprim::histogram_even<config>(temp_storage,
+                                                               storage_bytes,
+                                                               input_it,
+                                                               static_cast<unsigned int>(columns),
+                                                               d_histogram.get(),
+                                                               bins + 1,
+                                                               lower_level,
+                                                               upper_level,
+                                                               stream,
+                                                               debug_synchronous);
+                    }
+                    else
+                    {
+                        return rocprim::histogram_even<config>(temp_storage,
+                                                               storage_bytes,
+                                                               input_it,
+                                                               columns,
+                                                               rows,
+                                                               row_stride_bytes,
+                                                               d_histogram.get(),
+                                                               bins + 1,
+                                                               lower_level,
+                                                               upper_level,
+                                                               stream,
+                                                               debug_synchronous);
+                    }
+                },
+                stream,
+                TestFixture::params::use_graphs);
 
             const auto histogram = d_histogram.load();
 
-            for(size_t i = 0; i < bins; i++)
-            {
-                ASSERT_EQ(histogram[i], histogram_expected[i]);
-            }
-
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(histogram, histogram_expected, bins));
         }
     }
 
@@ -461,9 +423,11 @@ TYPED_TEST(RocprimDeviceHistogramRange, Range)
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using sample_type = typename TestFixture::params::sample_type;
+    using sample_type  = typename TestFixture::params::sample_type;
     using counter_type = typename TestFixture::params::counter_type;
-    using level_type = typename TestFixture::params::level_type;
+    using level_type   = typename TestFixture::params::level_type;
+    using config       = typename TestFixture::params::config;
+
     constexpr unsigned int bins = TestFixture::params::bins;
 
     hipStream_t stream = 0; // default
@@ -537,96 +501,50 @@ TYPED_TEST(RocprimDeviceHistogramRange, Range)
             rocprim::transform_iterator<sample_type*, transform_op<sample_type>, sample_type>
                 d_input2(d_input.get(), transform_op<sample_type>());
 
-            using config = typename TestFixture::params::config;
-
-            size_t temporary_storage_bytes = 0;
-            if(rows == 1)
-            {
-                HIP_CHECK(rocprim::histogram_range<config>(nullptr,
-                                                           temporary_storage_bytes,
-                                                           d_input2,
-                                                           columns,
-                                                           d_histogram.get(),
-                                                           bins + 1,
-                                                           d_levels.get(),
-                                                           stream,
-                                                           debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::histogram_range<config>(nullptr,
-                                                           temporary_storage_bytes,
-                                                           d_input2,
-                                                           columns,
-                                                           rows,
-                                                           row_stride_bytes,
-                                                           d_histogram.get(),
-                                                           bins + 1,
-                                                           d_levels.get(),
-                                                           stream,
-                                                           debug_synchronous));
-            }
-
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            if(rows == 1)
-            {
-                HIP_CHECK(rocprim::histogram_range<config>(d_temporary_storage.get(),
-                                                           temporary_storage_bytes,
-                                                           d_input2,
-                                                           columns,
-                                                           d_histogram.get(),
-                                                           bins + 1,
-                                                           d_levels.get(),
-                                                           stream,
-                                                           debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::histogram_range<config>(d_temporary_storage.get(),
-                                                           temporary_storage_bytes,
-                                                           d_input2,
-                                                           columns,
-                                                           rows,
-                                                           row_stride_bytes,
-                                                           d_histogram.get(),
-                                                           bins + 1,
-                                                           d_levels.get(),
-                                                           stream,
-                                                           debug_synchronous));
-            }
-
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    if(rows == 1)
+                    {
+                        return rocprim::histogram_range<config>(temp_storage,
+                                                                storage_bytes,
+                                                                d_input2,
+                                                                columns,
+                                                                d_histogram.get(),
+                                                                bins + 1,
+                                                                d_levels.get(),
+                                                                stream,
+                                                                debug_synchronous);
+                    }
+                    else
+                    {
+                        return rocprim::histogram_range<config>(temp_storage,
+                                                                storage_bytes,
+                                                                d_input2,
+                                                                columns,
+                                                                rows,
+                                                                row_stride_bytes,
+                                                                d_histogram.get(),
+                                                                bins + 1,
+                                                                d_levels.get(),
+                                                                stream,
+                                                                debug_synchronous);
+                    }
+                },
+                stream,
+                TestFixture::params::use_graphs);
 
             const auto histogram = d_histogram.load();
 
-            for(size_t i = 0; i < bins; i++)
-            {
-                ASSERT_EQ(histogram[i], histogram_expected[i]);
-            }
-
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(histogram, histogram_expected, bins));
         }
     }
 
-    if (TestFixture::params::use_graphs)
+    if(TestFixture::params::use_graphs)
+    {
         HIP_CHECK(hipStreamDestroy(stream));
+    }
 }
-
 
 template<class SampleType,
          unsigned int Channels,
@@ -682,10 +600,12 @@ TYPED_TEST(RocprimDeviceHistogramMultiEven, MultiEven)
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using sample_type = typename TestFixture::params::sample_type;
+    using sample_type  = typename TestFixture::params::sample_type;
     using counter_type = typename TestFixture::params::counter_type;
-    using level_type = typename TestFixture::params::level_type;
-    constexpr unsigned int channels = TestFixture::params::channels;
+    using level_type   = typename TestFixture::params::level_type;
+    using config       = typename TestFixture::params::config;
+
+    constexpr unsigned int channels        = TestFixture::params::channels;
     constexpr unsigned int active_channels = TestFixture::params::active_channels;
 
     unsigned int bins[active_channels];
@@ -796,113 +716,60 @@ TYPED_TEST(RocprimDeviceHistogramMultiEven, MultiEven)
             rocprim::transform_iterator<sample_type*, transform_op<sample_type>, sample_type>
                 d_input2(d_input.get(), transform_op<sample_type>());
 
-            using config = typename TestFixture::params::config;
-
-            size_t temporary_storage_bytes = 0;
-            if(rows == 1)
-            {
-                HIP_CHECK((rocprim::multi_histogram_even<channels, active_channels, config>(
-                    nullptr,
-                    temporary_storage_bytes,
-                    d_input2,
-                    columns,
-                    d_histogram,
-                    num_levels,
-                    lower_level,
-                    upper_level,
-                    stream,
-                    debug_synchronous)));
-            }
-            else
-            {
-                HIP_CHECK((rocprim::multi_histogram_even<channels, active_channels, config>(
-                    nullptr,
-                    temporary_storage_bytes,
-                    d_input2,
-                    columns,
-                    rows,
-                    row_stride_bytes,
-                    d_histogram,
-                    num_levels,
-                    lower_level,
-                    upper_level,
-                    stream,
-                    debug_synchronous)));
-            }
-
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            if(rows == 1)
-            {
-                HIP_CHECK((rocprim::multi_histogram_even<channels, active_channels, config>(
-                    d_temporary_storage.get(),
-                    temporary_storage_bytes,
-                    d_input2,
-                    columns,
-                    d_histogram,
-                    num_levels,
-                    lower_level,
-                    upper_level,
-                    stream,
-                    debug_synchronous)));
-            }
-            else
-            {
-                HIP_CHECK((rocprim::multi_histogram_even<channels, active_channels, config>(
-                    d_temporary_storage.get(),
-                    temporary_storage_bytes,
-                    d_input2,
-                    columns,
-                    rows,
-                    row_stride_bytes,
-                    d_histogram,
-                    num_levels,
-                    lower_level,
-                    upper_level,
-                    stream,
-                    debug_synchronous)));
-            }
-
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    if(rows == 1)
+                    {
+                        return rocprim::multi_histogram_even<channels, active_channels, config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_input2,
+                            columns,
+                            d_histogram,
+                            num_levels,
+                            lower_level,
+                            upper_level,
+                            stream,
+                            debug_synchronous);
+                    }
+                    else
+                    {
+                        return rocprim::multi_histogram_even<channels, active_channels, config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_input2,
+                            columns,
+                            rows,
+                            row_stride_bytes,
+                            d_histogram,
+                            num_levels,
+                            lower_level,
+                            upper_level,
+                            stream,
+                            debug_synchronous);
+                    }
+                },
+                stream,
+                TestFixture::params::use_graphs);
 
             std::vector<counter_type> histogram[active_channels];
             for(unsigned int channel = 0; channel < active_channels; channel++)
             {
                 histogram[channel] = std::vector<counter_type>(bins[channel]);
-                HIP_CHECK(
-                    hipMemcpy(
-                        histogram[channel].data(), d_histogram[channel],
-                        bins[channel] * sizeof(counter_type),
-                        hipMemcpyDeviceToHost
-                    )
-                );
+                HIP_CHECK(hipMemcpy(histogram[channel].data(),
+                                    d_histogram[channel],
+                                    bins[channel] * sizeof(counter_type),
+                                    hipMemcpyDeviceToHost));
                 HIP_CHECK(hipFree(d_histogram[channel]));
             }
 
             for(unsigned int channel = 0; channel < active_channels; channel++)
             {
                 SCOPED_TRACE(testing::Message() << "with channel = " << channel);
-
-                for(size_t i = 0; i < bins[channel]; i++)
-                {
-                    ASSERT_EQ(histogram[channel][i], histogram_expected[channel][i]);
-                }
-            }
-
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
+                ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(histogram[channel],
+                                                              histogram_expected[channel],
+                                                              bins[channel]));
             }
         }
     }
@@ -966,10 +833,12 @@ TYPED_TEST(RocprimDeviceHistogramMultiRange, MultiRange)
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using sample_type = typename TestFixture::params::sample_type;
+    using sample_type  = typename TestFixture::params::sample_type;
     using counter_type = typename TestFixture::params::counter_type;
-    using level_type = typename TestFixture::params::level_type;
-    constexpr unsigned int channels = TestFixture::params::channels;
+    using level_type   = typename TestFixture::params::level_type;
+    using config       = typename TestFixture::params::config;
+
+    constexpr unsigned int channels        = TestFixture::params::channels;
     constexpr unsigned int active_channels = TestFixture::params::active_channels;
 
     hipStream_t stream = 0;
@@ -1105,81 +974,40 @@ TYPED_TEST(RocprimDeviceHistogramMultiRange, MultiRange)
                 }
             }
 
-            using config = typename TestFixture::params::config;
-
-            size_t temporary_storage_bytes = 0;
-            if(rows == 1)
-            {
-                HIP_CHECK((rocprim::multi_histogram_range<channels, active_channels, config>(
-                    nullptr,
-                    temporary_storage_bytes,
-                    d_input.get(),
-                    columns,
-                    d_histogram,
-                    num_levels,
-                    d_levels,
-                    stream,
-                    debug_synchronous)));
-            }
-            else
-            {
-                HIP_CHECK((rocprim::multi_histogram_range<channels, active_channels, config>(
-                    nullptr,
-                    temporary_storage_bytes,
-                    d_input.get(),
-                    columns,
-                    rows,
-                    row_stride_bytes,
-                    d_histogram,
-                    num_levels,
-                    d_levels,
-                    stream,
-                    debug_synchronous)));
-            }
-
-            ASSERT_GT(temporary_storage_bytes, 0U);
-
-            common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            if(rows == 1)
-            {
-                HIP_CHECK((rocprim::multi_histogram_range<channels, active_channels, config>(
-                    d_temporary_storage.get(),
-                    temporary_storage_bytes,
-                    d_input.get(),
-                    columns,
-                    d_histogram,
-                    num_levels,
-                    d_levels,
-                    stream,
-                    debug_synchronous)));
-            }
-            else
-            {
-                HIP_CHECK((rocprim::multi_histogram_range<channels, active_channels, config>(
-                    d_temporary_storage.get(),
-                    temporary_storage_bytes,
-                    d_input.get(),
-                    columns,
-                    rows,
-                    row_stride_bytes,
-                    d_histogram,
-                    num_levels,
-                    d_levels,
-                    stream,
-                    debug_synchronous)));
-            }
-
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream);
-            }
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    if(rows == 1)
+                    {
+                        return rocprim::multi_histogram_range<channels, active_channels, config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_input.get(),
+                            columns,
+                            d_histogram,
+                            num_levels,
+                            d_levels,
+                            stream,
+                            debug_synchronous);
+                    }
+                    else
+                    {
+                        return rocprim::multi_histogram_range<channels, active_channels, config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_input.get(),
+                            columns,
+                            rows,
+                            row_stride_bytes,
+                            d_histogram,
+                            num_levels,
+                            d_levels,
+                            stream,
+                            debug_synchronous);
+                    }
+                },
+                stream,
+                TestFixture::params::use_graphs);
 
             std::vector<counter_type> histogram[active_channels];
             for(unsigned int channel = 0; channel < active_channels; channel++)
@@ -1196,19 +1024,12 @@ TYPED_TEST(RocprimDeviceHistogramMultiRange, MultiRange)
                 HIP_CHECK(hipFree(d_histogram[channel]));
             }
 
-            if(TestFixture::params::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
-
             for(unsigned int channel = 0; channel < active_channels; channel++)
             {
                 SCOPED_TRACE(testing::Message() << "with channel = " << channel);
-
-                for(size_t i = 0; i < bins[channel]; i++)
-                {
-                    ASSERT_EQ(histogram[channel][i], histogram_expected[channel][i]);
-                }
+                ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(histogram[channel],
+                                                              histogram_expected[channel],
+                                                              bins[channel]));
             }
         }
     }

--- a/projects/rocprim/test/rocprim/test_device_merge_sort.cpp
+++ b/projects/rocprim/test/rocprim/test_device_merge_sort.cpp
@@ -27,6 +27,7 @@
 #include "../../common/utils_device_ptr.hpp"
 
 // required test headers
+#include "indirect_iterator.hpp"
 #include "test_seed.hpp"
 #include "test_utils.hpp"
 #include "test_utils_assertions.hpp"
@@ -54,18 +55,20 @@
 #include <vector>
 
 // Params for tests
-template<
-    class KeyType,
-    class ValueType = KeyType,
-    class CompareFunction = ::rocprim::less<KeyType>,
-    bool UseGraphs = false
->
+template<class KeyType,
+         class ValueType          = KeyType,
+         class CompareFunction    = ::rocprim::less<KeyType>,
+         bool UseGraphs           = false,
+         bool UseIndirectIterator = false,
+         class Config             = ::rocprim::default_config>
 struct DeviceSortParams
 {
-    using key_type = KeyType;
-    using value_type = ValueType;
-    using compare_function = CompareFunction;
-    static constexpr bool use_graphs = UseGraphs;
+    using key_type                              = KeyType;
+    using value_type                            = ValueType;
+    using compare_function                      = CompareFunction;
+    static constexpr bool use_graphs            = UseGraphs;
+    static constexpr bool use_indirect_iterator = UseIndirectIterator;
+    using config                                = Config;
 };
 
 // ---------------------------------------------------------
@@ -76,11 +79,13 @@ template<class Params>
 class RocprimDeviceSortTests : public ::testing::Test
 {
 public:
-    using key_type = typename Params::key_type;
-    using value_type = typename Params::value_type;
-    using compare_function = typename Params::compare_function;
-    const bool debug_synchronous = false;
-    bool use_graphs = Params::use_graphs;
+    using key_type                              = typename Params::key_type;
+    using value_type                            = typename Params::value_type;
+    using compare_function                      = typename Params::compare_function;
+    static constexpr bool debug_synchronous     = false;
+    static constexpr bool use_graphs            = Params::use_graphs;
+    static constexpr bool use_indirect_iterator = Params::use_indirect_iterator;
+    using config                                = typename Params::config;
 };
 
 using RocprimDeviceSortTestsParams = ::testing::Types<
@@ -88,11 +93,13 @@ using RocprimDeviceSortTestsParams = ::testing::Types<
     DeviceSortParams<signed char, common::custom_type<float, float, true>>,
     DeviceSortParams<int>,
     DeviceSortParams<common::custom_type<int, int, true>>,
+    DeviceSortParams<common::custom_type_copyable<char, double, true>>,
     DeviceSortParams<unsigned long>,
     DeviceSortParams<long long>,
     DeviceSortParams<float, double>,
     DeviceSortParams<int8_t, int8_t>,
     DeviceSortParams<uint8_t, uint8_t>,
+    DeviceSortParams<rocprim::uint128_t, rocprim::uint128_t>,
     DeviceSortParams<rocprim::half, rocprim::half, rocprim::less<rocprim::half>>,
     DeviceSortParams<rocprim::bfloat16, rocprim::bfloat16, rocprim::less<rocprim::bfloat16>>,
     DeviceSortParams<int, float, ::rocprim::greater<int>>,
@@ -102,12 +109,20 @@ using RocprimDeviceSortTestsParams = ::testing::Types<
                      common::custom_type<double, double, true>>,
     DeviceSortParams<int, test_utils::custom_float_type>,
     DeviceSortParams<test_utils::custom_test_array_type<int, 4>>,
+    // Test the algorithm with graphs
     DeviceSortParams<int, int, ::rocprim::less<int>, true>,
+    // Test the virtual shared memory
     DeviceSortParams<int, common::custom_huge_type<2048, float>>,
-    DeviceSortParams<common::custom_huge_type<2048, float>>>;
-
-static_assert(std::is_trivially_copyable<test_utils::custom_float_type>::value,
-              "Type must be trivially copyable to cover merge sort specialized kernel");
+    DeviceSortParams<common::custom_huge_type<2048, float>>,
+    // Test with iterators
+    DeviceSortParams<int, int, ::rocprim::less<int>, false, true>,
+    // Test with custom config
+    DeviceSortParams<int,
+                     int,
+                     ::rocprim::less<int>,
+                     false,
+                     false,
+                     rocprim::merge_sort_config<128, 64, 2, 128, 64, 2>>>;
 
 TYPED_TEST_SUITE(RocprimDeviceSortTests, RocprimDeviceSortTestsParams);
 
@@ -117,9 +132,17 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using key_type = typename TestFixture::key_type;
-    using compare_function = typename TestFixture::compare_function;
+    using key_type               = typename TestFixture::key_type;
+    using compare_function       = typename TestFixture::compare_function;
+    using config                 = typename TestFixture::config;
     const bool debug_synchronous = TestFixture::debug_synchronous;
+
+    hipStream_t stream = 0; // default
+    if(TestFixture::use_graphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     bool in_place = false;
 
@@ -130,13 +153,6 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
 
         for(size_t size : test_utils::get_sizes(seed_value))
         {
-            hipStream_t stream = 0; // default
-            if (TestFixture::use_graphs)
-            {
-                // Default stream does not support hipGraph stream capture, so create one
-                HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-            }
-
             SCOPED_TRACE(testing::Message() << "with size = " << size);
 
             in_place = !in_place;
@@ -168,11 +184,15 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             std::vector<key_type> expected(input);
             std::stable_sort(expected.begin(), expected.end(), compare_op);
 
+            auto input_it
+                = test_utils::wrap_in_indirect_iterator<TestFixture::use_indirect_iterator>(
+                    d_input.get());
+
             // Get size of d_temp_storage
             size_t temp_storage_size_bytes;
             HIP_CHECK(rocprim::merge_sort(nullptr,
                                           temp_storage_size_bytes,
-                                          d_input.get(),
+                                          input_it,
                                           d_output.get(),
                                           input.size(),
                                           compare_op,
@@ -200,7 +220,7 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             // Run
             HIP_CHECK(rocprim::merge_sort(d_temp_storage.get(),
                                           temp_storage_size_bytes,
-                                          d_input.get(),
+                                          input_it,
                                           d_output.get(),
                                           input.size(),
                                           compare_op,
@@ -220,13 +240,12 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
 
             // Check if output values are as expected
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
-
-            if (TestFixture::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-                HIP_CHECK(hipStreamDestroy(stream));
-            }
         }
+    }
+
+    if(TestFixture::use_graphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
     }
 }
 
@@ -237,10 +256,18 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using key_type = typename TestFixture::key_type;
-    using value_type = typename TestFixture::value_type;
-    using compare_function = typename TestFixture::compare_function;
+    using key_type               = typename TestFixture::key_type;
+    using value_type             = typename TestFixture::value_type;
+    using compare_function       = typename TestFixture::compare_function;
+    using config                 = typename TestFixture::config;
     const bool debug_synchronous = TestFixture::debug_synchronous;
+
+    hipStream_t stream = 0; // default
+    if(TestFixture::use_graphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     bool in_place = false;
 
@@ -251,13 +278,6 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
 
         for(size_t size : test_utils::get_sizes(seed_value))
         {
-            hipStream_t stream = 0; // default
-            if (TestFixture::use_graphs)
-            {
-                // Default stream does not support hipGraph stream capture, so create one
-                HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-            }
-
             SCOPED_TRACE(testing::Message() << "with size = " << size);
 
             in_place = !in_place;
@@ -309,14 +329,22 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
                              [compare_op](const key_value& a, const key_value& b)
                              { return compare_op(a.first, b.first); });
 
+            auto input_keys_it
+                = test_utils::wrap_in_indirect_iterator<TestFixture::use_indirect_iterator>(
+                    d_keys_input.get());
+
+            auto input_values_it
+                = test_utils::wrap_in_indirect_iterator<TestFixture::use_indirect_iterator>(
+                    d_values_input.get());
+
             // Get size of d_temp_storage
             size_t temp_storage_size_bytes;
             HIP_CHECK(rocprim::merge_sort(nullptr,
                                           temp_storage_size_bytes,
-                                          d_keys_input.get(),
+                                          input_keys_it,
                                           d_keys_output.get(),
                                           d_values_input.get(),
-                                          d_values_output.get(),
+                                          input_values_it,
                                           keys_input.size(),
                                           compare_op,
                                           stream,
@@ -324,6 +352,7 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
 
             // temp_storage_size_bytes must be >0
             ASSERT_GT(temp_storage_size_bytes, 0);
+
 
             // allocate temporary storage
             common::device_ptr<void> d_temp_storage;
@@ -343,9 +372,9 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             // Run
             HIP_CHECK(rocprim::merge_sort(d_temp_storage.get(),
                                           temp_storage_size_bytes,
-                                          d_keys_input.get(),
+                                          input_keys_it,
                                           d_keys_output.get(),
-                                          d_values_input.get(),
+                                          input_values_it,
                                           d_values_output.get(),
                                           keys_input.size(),
                                           compare_op,
@@ -375,13 +404,12 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected_key));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, expected_value));
-
-            if (TestFixture::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-                HIP_CHECK(hipStreamDestroy(stream));
-            }
         }
+    }
+
+    if(TestFixture::use_graphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
     }
 }
 

--- a/projects/rocprim/test/rocprim/test_device_merge_sort.cpp
+++ b/projects/rocprim/test/rocprim/test_device_merge_sort.cpp
@@ -190,14 +190,14 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
 
             // Get size of d_temp_storage
             size_t temp_storage_size_bytes;
-            HIP_CHECK(rocprim::merge_sort(nullptr,
-                                          temp_storage_size_bytes,
-                                          input_it,
-                                          d_output.get(),
-                                          input.size(),
-                                          compare_op,
-                                          stream,
-                                          debug_synchronous));
+            HIP_CHECK(rocprim::merge_sort<config>(nullptr,
+                                                  temp_storage_size_bytes,
+                                                  input_it,
+                                                  d_output.get(),
+                                                  input.size(),
+                                                  compare_op,
+                                                  stream,
+                                                  debug_synchronous));
 
             // temp_storage_size_bytes must be >0
             ASSERT_GT(temp_storage_size_bytes, 0);
@@ -218,14 +218,14 @@ TYPED_TEST(RocprimDeviceSortTests, SortKey)
             }
 
             // Run
-            HIP_CHECK(rocprim::merge_sort(d_temp_storage.get(),
-                                          temp_storage_size_bytes,
-                                          input_it,
-                                          d_output.get(),
-                                          input.size(),
-                                          compare_op,
-                                          stream,
-                                          debug_synchronous));
+            HIP_CHECK(rocprim::merge_sort<config>(d_temp_storage.get(),
+                                                  temp_storage_size_bytes,
+                                                  input_it,
+                                                  d_output.get(),
+                                                  input.size(),
+                                                  compare_op,
+                                                  stream,
+                                                  debug_synchronous));
 
             if(TestFixture::use_graphs)
             {
@@ -339,20 +339,19 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
 
             // Get size of d_temp_storage
             size_t temp_storage_size_bytes;
-            HIP_CHECK(rocprim::merge_sort(nullptr,
-                                          temp_storage_size_bytes,
-                                          input_keys_it,
-                                          d_keys_output.get(),
-                                          d_values_input.get(),
-                                          input_values_it,
-                                          keys_input.size(),
-                                          compare_op,
-                                          stream,
-                                          debug_synchronous));
+            HIP_CHECK(rocprim::merge_sort<config>(nullptr,
+                                                  temp_storage_size_bytes,
+                                                  input_keys_it,
+                                                  d_keys_output.get(),
+                                                  d_values_input.get(),
+                                                  input_values_it,
+                                                  keys_input.size(),
+                                                  compare_op,
+                                                  stream,
+                                                  debug_synchronous));
 
             // temp_storage_size_bytes must be >0
             ASSERT_GT(temp_storage_size_bytes, 0);
-
 
             // allocate temporary storage
             common::device_ptr<void> d_temp_storage;
@@ -370,16 +369,16 @@ TYPED_TEST(RocprimDeviceSortTests, SortKeyValue)
             }
 
             // Run
-            HIP_CHECK(rocprim::merge_sort(d_temp_storage.get(),
-                                          temp_storage_size_bytes,
-                                          input_keys_it,
-                                          d_keys_output.get(),
-                                          input_values_it,
-                                          d_values_output.get(),
-                                          keys_input.size(),
-                                          compare_op,
-                                          stream,
-                                          debug_synchronous));
+            HIP_CHECK(rocprim::merge_sort<config>(d_temp_storage.get(),
+                                                  temp_storage_size_bytes,
+                                                  input_keys_it,
+                                                  d_keys_output.get(),
+                                                  input_values_it,
+                                                  d_values_output.get(),
+                                                  keys_input.size(),
+                                                  compare_op,
+                                                  stream,
+                                                  debug_synchronous));
 
             if(TestFixture::use_graphs)
             {

--- a/projects/rocprim/test/rocprim/test_device_partition.cpp
+++ b/projects/rocprim/test/rocprim/test_device_partition.cpp
@@ -522,8 +522,8 @@ TYPED_TEST(RocprimDevicePartitionTests, PartitionTwoWayPredicate)
             // Calculate expected_selected and expected_rejected results on host
             std::vector<U> expected_selected;
             std::vector<U> expected_rejected;
-            expected_selected.reserve(input.size()/2);
-            expected_rejected.reserve(input.size()/2);
+            expected_selected.reserve(input.size() / 2);
+            expected_rejected.reserve(input.size() / 2);
             for(size_t i = 0; i < input.size(); i++)
             {
                 if(select_op(input[i]))
@@ -720,18 +720,16 @@ TYPED_TEST(RocprimDevicePartitionTests, PartitionTwoWayFlag)
 
             // Run
             HIP_CHECK(rocprim::partition_two_way<config>(
-                        d_temp_storage.get(),
-                        temp_storage_size_bytes,
-                        d_input.get(),
-                        d_flags.get(),
-                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(
-                            d_selected.get()),
-                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(
-                            d_rejected.get()),
-                        d_selected_count_output.get(),
-                        input.size(),
-                        stream,
-                        debug_synchronous));
+                d_temp_storage.get(),
+                temp_storage_size_bytes,
+                d_input.get(),
+                d_flags.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_selected.get()),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_rejected.get()),
+                d_selected_count_output.get(),
+                input.size(),
+                stream,
+                debug_synchronous));
 
             if(TestFixture::use_graphs)
             {

--- a/projects/rocprim/test/rocprim/test_device_partition.cpp
+++ b/projects/rocprim/test/rocprim/test_device_partition.cpp
@@ -298,45 +298,22 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateEmptyInput)
                                                               out_of_bounds.device_pointer(),
                                                               0);
 
-    // temp storage
-    size_t temp_storage_size_bytes;
-    // Get size of d_temp_storage
-    HIP_CHECK(rocprim::partition<config>(nullptr,
-                                         temp_storage_size_bytes,
-                                         rocprim::make_constant_iterator<T>(T(345)),
-                                         d_checking_output,
-                                         d_selected_count_output.get(),
-                                         0,
-                                         select_op,
-                                         stream,
-                                         debug_synchronous));
+    test_utils::test_kernel_wrapper(
+        [&](void* temp_storage, size_t& storage_bytes)
+        {
+            return rocprim::partition<config>(temp_storage,
+                                              storage_bytes,
+                                              rocprim::make_constant_iterator<T>(T(345)),
+                                              d_checking_output,
+                                              d_selected_count_output.get(),
+                                              0,
+                                              select_op,
+                                              stream,
+                                              debug_synchronous);
+        },
+        stream,
+        TestFixture::use_graphs);
 
-    // allocate temporary storage
-    common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-    test_utils::GraphHelper gHelper;
-    if(TestFixture::use_graphs)
-    {
-        gHelper.startStreamCapture(stream);
-    }
-
-    // Run
-    HIP_CHECK(rocprim::partition<config>(d_temp_storage.get(),
-                                         temp_storage_size_bytes,
-                                         rocprim::make_constant_iterator<T>(T(345)),
-                                         d_checking_output,
-                                         d_selected_count_output.get(),
-                                         0,
-                                         select_op,
-                                         stream,
-                                         debug_synchronous));
-
-    if(TestFixture::use_graphs)
-    {
-        gHelper.createAndLaunchGraph(stream, true, false);
-    }
-
-    HIP_CHECK(hipDeviceSynchronize());
     ASSERT_FALSE(out_of_bounds.get());
 
     // Check if number of selected value is 0
@@ -345,7 +322,6 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateEmptyInput)
 
     if (TestFixture::use_graphs)
     {
-        gHelper.cleanupGraphHelper();
         HIP_CHECK(hipStreamDestroy(stream));
     }
 }
@@ -494,7 +470,7 @@ TYPED_TEST(RocprimDevicePartitionTests, Predicate)
     }
 }
 
-TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
+TYPED_TEST(RocprimDevicePartitionTests, PartitionTwoWayPredicate)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
@@ -546,8 +522,8 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
             // Calculate expected_selected and expected_rejected results on host
             std::vector<U> expected_selected;
             std::vector<U> expected_rejected;
-            expected_selected.reserve(input.size() / 2);
-            expected_rejected.reserve(input.size() / 2);
+            expected_selected.reserve(input.size()/2);
+            expected_rejected.reserve(input.size()/2);
             for(size_t i = 0; i < input.size(); i++)
             {
                 if(select_op(input[i]))
@@ -605,6 +581,157 @@ TYPED_TEST(RocprimDevicePartitionTests, PredicateTwoWay)
                 select_op,
                 stream,
                 debug_synchronous));
+
+            if(TestFixture::use_graphs)
+            {
+                gHelper.createAndLaunchGraph(stream, true, false);
+            }
+
+            HIP_CHECK(hipDeviceSynchronize());
+
+            // Check if number of selected value is as expected
+            unsigned int selected_count_output = d_selected_count_output.load()[0];
+            ASSERT_EQ(selected_count_output, expected_selected.size());
+
+            // Check if output values are as expected
+            const auto selected = d_selected.load();
+            const auto rejected = d_rejected.load();
+
+            ASSERT_NO_FATAL_FAILURE(
+                test_utils::assert_eq(selected, expected_selected, expected_selected.size()));
+            ASSERT_NO_FATAL_FAILURE(
+                test_utils::assert_eq(rejected, expected_rejected, expected_rejected.size()));
+
+            if(TestFixture::use_graphs)
+            {
+                gHelper.cleanupGraphHelper();
+            }
+        }
+    }
+
+    if(TestFixture::use_graphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
+    }
+}
+
+TYPED_TEST(RocprimDevicePartitionTests, PartitionTwoWayFlag)
+{
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    using T      = typename TestFixture::input_type;
+    using U      = typename TestFixture::output_type;
+    using F      = typename TestFixture::flag_type;
+    using config = typename TestFixture::config;
+
+    static constexpr bool use_identity_iterator = TestFixture::use_identity_iterator;
+    const bool            debug_synchronous     = TestFixture::debug_synchronous;
+
+    hipStream_t stream = 0; // default stream
+    if(TestFixture::use_graphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        for(auto size : test_utils::get_sizes(seed_value))
+        {
+            SCOPED_TRACE(testing::Message() << "with size = " << size);
+
+            // Generate data
+            std::vector<T> input = test_utils::get_random_data_wrapped<T>(size, 1, 100, seed_value);
+            std::vector<F> flags = test_utils::get_random_data01<F>(size, 0.25, seed_value);
+
+            common::device_ptr<T>            d_input;
+            common::device_ptr<F>            d_flags;
+            common::device_ptr<U>            d_selected;
+            common::device_ptr<U>            d_rejected;
+            common::device_ptr<unsigned int> d_selected_count_output;
+
+            if(!d_input.resize_with_memory_check(size) || !d_flags.resize_with_memory_check(size)
+               || !d_selected.resize_with_memory_check(size)
+               || !d_rejected.resize_with_memory_check(size)
+               || !d_selected_count_output.resize_with_memory_check(1))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
+
+            d_input.store(input);
+            d_flags.store(flags);
+
+            // Calculate expected_selected and expected_rejected results on host
+            std::vector<U> expected_selected;
+            std::vector<U> expected_rejected;
+            expected_selected.reserve(input.size() / 2);
+            expected_rejected.reserve(input.size() / 2);
+            for(size_t i = 0; i < input.size(); i++)
+            {
+                if(flags[i] != 0)
+                {
+                    expected_selected.push_back(input[i]);
+                }
+                else
+                {
+                    expected_rejected.push_back(input[i]);
+                }
+            }
+
+            // temp storage
+            size_t temp_storage_size_bytes;
+            // Get size of d_temp_storage
+            HIP_CHECK(rocprim::partition_two_way<config>(
+                nullptr,
+                temp_storage_size_bytes,
+                d_input.get(),
+                d_flags.get(),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_selected.get()),
+                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_rejected.get()),
+                d_selected_count_output.get(),
+                input.size(),
+                stream,
+                debug_synchronous));
+
+            // temp_storage_size_bytes must be >0
+            ASSERT_GT(temp_storage_size_bytes, 0);
+
+            // allocate temporary storage
+            common::device_ptr<void> d_temp_storage;
+
+            if(!d_temp_storage.resize_with_memory_check(temp_storage_size_bytes))
+            {
+                std::cout << "Out of memory. Skipping test for size = " << size << std::endl;
+                break;
+            }
+
+            test_utils::GraphHelper gHelper;
+            if(TestFixture::use_graphs)
+            {
+                gHelper.startStreamCapture(stream);
+            }
+
+            // Run
+            HIP_CHECK(rocprim::partition_two_way<config>(
+                        d_temp_storage.get(),
+                        temp_storage_size_bytes,
+                        d_input.get(),
+                        d_flags.get(),
+                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                            d_selected.get()),
+                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                            d_rejected.get()),
+                        d_selected_count_output.get(),
+                        input.size(),
+                        stream,
+                        debug_synchronous));
 
             if(TestFixture::use_graphs)
             {
@@ -1116,42 +1243,21 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartition)
 
         common::device_ptr<size_t> d_count_output(1);
 
-        size_t temporary_storage_size;
-
-        HIP_CHECK(rocprim::partition(nullptr,
-                                     temporary_storage_size,
-                                     input_iterator,
-                                     output_checker_it,
-                                     d_count_output.get(),
-                                     size,
-                                     predicate,
-                                     stream,
-                                     debug_synchronous));
-
-        ASSERT_NE(0, temporary_storage_size);
-
-        common::device_ptr<void> d_temporary_storage(temporary_storage_size);
-
-        test_utils::GraphHelper gHelper;
-        if(use_graphs)
-        {
-            gHelper.startStreamCapture(stream);
-        }
-
-        HIP_CHECK(rocprim::partition(d_temporary_storage.get(),
-                                     temporary_storage_size,
-                                     input_iterator,
-                                     output_checker_it,
-                                     d_count_output.get(),
-                                     size,
-                                     predicate,
-                                     stream,
-                                     debug_synchronous));
-
-        if(use_graphs)
-        {
-            gHelper.createAndLaunchGraph(stream);
-        }
+        test_utils::test_kernel_wrapper(
+            [&](void* temp_storage, size_t& storage_bytes)
+            {
+                return rocprim::partition(temp_storage,
+                                          storage_bytes,
+                                          input_iterator,
+                                          output_checker_it,
+                                          d_count_output.get(),
+                                          size,
+                                          predicate,
+                                          stream,
+                                          debug_synchronous);
+            },
+            stream,
+            use_graphs);
 
         size_t count_output{};
         HIP_CHECK(hipMemcpyWithStream(&count_output,
@@ -1171,11 +1277,6 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartition)
                                       stream));
 
         ASSERT_EQ(incorrect_flag, 0);
-
-        if(use_graphs)
-        {
-            gHelper.cleanupGraphHelper();
-        }
     }
 
     if(use_graphs)
@@ -1229,43 +1330,22 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionTwoWay)
 
         common::device_ptr<size_t> d_count_output(1);
 
-        size_t temporary_storage_size;
-        HIP_CHECK(rocprim::partition_two_way(nullptr,
-                                             temporary_storage_size,
-                                             input_iterator,
-                                             select_checker_it,
-                                             reject_checker_it,
-                                             d_count_output.get(),
-                                             size,
-                                             predicate,
-                                             stream,
-                                             debug_synchronous));
-
-        ASSERT_NE(0, temporary_storage_size);
-
-        common::device_ptr<void> d_temporary_storage(temporary_storage_size);
-
-        test_utils::GraphHelper gHelper;
-        if(use_graphs)
-        {
-            gHelper.startStreamCapture(stream);
-        }
-
-        HIP_CHECK(rocprim::partition_two_way(d_temporary_storage.get(),
-                                             temporary_storage_size,
-                                             input_iterator,
-                                             select_checker_it,
-                                             reject_checker_it,
-                                             d_count_output.get(),
-                                             size,
-                                             predicate,
-                                             stream,
-                                             debug_synchronous));
-
-        if(use_graphs)
-        {
-            gHelper.createAndLaunchGraph(stream);
-        }
+        test_utils::test_kernel_wrapper(
+            [&](void* temp_storage, size_t& storage_bytes)
+            {
+                return rocprim::partition_two_way(temp_storage,
+                                                  storage_bytes,
+                                                  input_iterator,
+                                                  select_checker_it,
+                                                  reject_checker_it,
+                                                  d_count_output.get(),
+                                                  size,
+                                                  predicate,
+                                                  stream,
+                                                  debug_synchronous);
+            },
+            stream,
+            use_graphs);
 
         size_t count_output{};
         HIP_CHECK(hipMemcpyWithStream(&count_output,
@@ -1292,11 +1372,6 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionTwoWay)
 
         ASSERT_EQ(incorrect_select_flag, 0);
         ASSERT_EQ(incorrect_reject_flag, 0);
-
-        if(use_graphs)
-        {
-            gHelper.cleanupGraphHelper();
-        }
     }
 
     if(use_graphs)
@@ -1351,47 +1426,24 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionThreeWay)
 
         common::device_ptr<size_t> d_count_output(2);
 
-        size_t temporary_storage_size;
-        HIP_CHECK(rocprim::partition_three_way(nullptr,
-                                               temporary_storage_size,
-                                               input_iterator,
-                                               output_checker_a,
-                                               output_checker_b,
-                                               unselected_output,
-                                               d_count_output.get(),
-                                               size,
-                                               predicate_a,
-                                               predicate_b,
-                                               stream,
-                                               debug_synchronous));
-
-        ASSERT_NE(0, temporary_storage_size);
-
-        common::device_ptr<void> d_temporary_storage(temporary_storage_size);
-
-        test_utils::GraphHelper gHelper;
-        if(use_graphs)
-        {
-            gHelper.startStreamCapture(stream);
-        }
-
-        HIP_CHECK(rocprim::partition_three_way(d_temporary_storage.get(),
-                                               temporary_storage_size,
-                                               input_iterator,
-                                               output_checker_a,
-                                               output_checker_b,
-                                               unselected_output,
-                                               d_count_output.get(),
-                                               size,
-                                               predicate_a,
-                                               predicate_b,
-                                               stream,
-                                               debug_synchronous));
-
-        if(use_graphs)
-        {
-            gHelper.createAndLaunchGraph(stream);
-        }
+        test_utils::test_kernel_wrapper(
+            [&](void* temp_storage, size_t& storage_bytes)
+            {
+                return rocprim::partition_three_way(temp_storage,
+                                                    storage_bytes,
+                                                    input_iterator,
+                                                    output_checker_a,
+                                                    output_checker_b,
+                                                    unselected_output,
+                                                    d_count_output.get(),
+                                                    size,
+                                                    predicate_a,
+                                                    predicate_b,
+                                                    stream,
+                                                    debug_synchronous);
+            },
+            stream,
+            use_graphs);
 
         size_t count_output[2]{};
         HIP_CHECK(hipMemcpyWithStream(&count_output,
@@ -1415,11 +1467,6 @@ TEST_P(RocprimDevicePartitionLargeInputTests, LargeInputPartitionThreeWay)
                                       stream));
 
         ASSERT_EQ(incorrect_flag, 0);
-
-        if(use_graphs)
-        {
-            gHelper.cleanupGraphHelper();
-        }
     }
 
     if(use_graphs)
@@ -1526,37 +1573,20 @@ TEST(RocprimDevicePartitionBlockSizeTests, BlockSize)
             }
             std::reverse(expected_rejected.begin(), expected_rejected.end());
 
-            // temp storage
-            size_t temp_storage_size_bytes;
-            // Get size of d_temp_storage
-            HIP_CHECK(rocprim::partition(nullptr,
-                                         temp_storage_size_bytes,
-                                         d_input.get(),
-                                         d_output.get(),
-                                         d_selected_count_output.get(),
-                                         input.size(),
-                                         select_op,
-                                         stream,
-                                         debug_synchronous));
-
-            // temp_storage_size_bytes must be >0
-            ASSERT_GT(temp_storage_size_bytes, 0);
-
-            // allocate temporary storage
-            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-            // Run
-            HIP_CHECK(rocprim::partition(d_temp_storage.get(),
-                                         temp_storage_size_bytes,
-                                         d_input.get(),
-                                         d_output.get(),
-                                         d_selected_count_output.get(),
-                                         input.size(),
-                                         select_op,
-                                         stream,
-                                         debug_synchronous));
-
-            HIP_CHECK(hipDeviceSynchronize());
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    return rocprim::partition(temp_storage,
+                                              storage_bytes,
+                                              d_input.get(),
+                                              d_output.get(),
+                                              d_selected_count_output.get(),
+                                              input.size(),
+                                              select_op,
+                                              stream,
+                                              debug_synchronous);
+                },
+                stream);
 
             // Check if number of selected value is as expected_selected
             unsigned int selected_count_output = d_selected_count_output.load()[0];

--- a/projects/rocprim/test/rocprim/test_device_scan.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan.cpp
@@ -561,6 +561,244 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
     }
 }
 
+template<class T, class scan_state_type>
+__global__
+void complete_value(T* values, scan_state_type scan_state)
+{
+    values[blockIdx.x] = scan_state.get_complete_value(blockIdx.x);
+}
+
+TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
+{
+    using T            = typename TestFixture::input_type;
+    using U            = typename TestFixture::output_type;
+    using scan_op_type = typename TestFixture::scan_op_type;
+    // If scan_op_type is rocprim::plus and input_type is bfloat16 or half,
+    // use float as device-side accumulator and double as host-side accumulator
+    using is_plus_op                 = test_utils::is_plus_operator<scan_op_type>;
+    using acc_type                   = typename accum_type<U, scan_op_type>::type;
+    using scan_state_type            = rocprim::detail::lookback_scan_state<acc_type>;
+    using scan_state_with_sleep_type = rocprim::detail::lookback_scan_state<acc_type, true>;
+
+    const bool deterministic     = TestFixture::deterministic;
+    const bool use_initial_value = TestFixture::use_initial_value;
+
+    using Config = typename TestFixture::config_helper::template type<false>;
+    using config = rocprim::detail::wrapped_scan_config<Config, acc_type>;
+
+    hipStream_t stream = hipStreamDefault;
+
+    rocprim::detail::target_arch target_arch;
+    HIP_CHECK(host_target_arch(stream, target_arch));
+    const rocprim::detail::scan_config_params params
+        = rocprim::detail::dispatch_target_arch<config>(target_arch);
+
+    // For non-associative operations in inclusive scan
+    // intermediate results use the type of input iterator, then
+    // as all conversions in the tests are to more precise types,
+    // intermediate results use the same or more precise acc_type,
+    // all scan operations use the same acc_type,
+    // and all output types are the same acc_type,
+    // therefore the only source of error is precision of operation itself
+    constexpr float single_op_precision = is_plus_op::value ? test_utils::precision<acc_type> : 0;
+
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        const unsigned int block_size       = params.kernel_config.block_size;
+        const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+        const auto         items_per_block  = block_size * items_per_thread;
+        const auto         size             = items_per_block;
+
+        unsigned int number_of_blocks = (size + items_per_block - 1) / items_per_block;
+
+        if(single_op_precision * size > 0.5)
+        {
+            std::cout << "Test is skipped from size " << size
+                      << " on, potential error of summation is more than 0.5 of the result "
+                         "with current or larger size"
+                      << std::endl;
+            break;
+        }
+        hipStream_t stream = hipStreamDefault;
+        if(TestFixture::use_graphs)
+        {
+            // Default stream does not support hipGraph stream capture, so create one
+            HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+        }
+
+        SCOPED_TRACE(testing::Message() << "with size = " << size);
+
+        // Generate data
+        std::vector<T> input = test_utils::get_random_data_wrapped<T>(size, 1, 10, seed_value);
+
+        common::device_ptr<T> d_input(input);
+        common::device_ptr<U> d_output(input.size());
+
+        // Scan function
+        scan_op_type scan_op;
+
+        // Calculate expected results on host
+        std::vector<U> expected(input.size());
+        acc_type       initial_value;
+        if(use_initial_value)
+        {
+            initial_value = test_utils::get_random_value<acc_type>(1, 10, seed_value);
+            test_utils::host_inclusive_scan(input.begin(),
+                                            input.end(),
+                                            expected.begin(),
+                                            scan_op,
+                                            initial_value);
+        }
+        else
+        {
+            test_utils::host_inclusive_scan(input.begin(), input.end(), expected.begin(), scan_op);
+        }
+        SCOPED_TRACE(use_initial_value
+                         ? (testing::Message() << "with initial_value = " << initial_value)
+                         : (testing::Message() << "without initial_value"));
+
+        auto input_iterator
+            = rocprim::make_transform_iterator(d_input.get(),
+                                               [](T in) { return static_cast<acc_type>(in); });
+
+        // Pointer to array with block_prefixes
+        acc_type* previous_last_element;
+        acc_type* new_last_element;
+
+        rocprim::detail::temp_storage::layout layout{};
+        HIP_CHECK(scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
+
+        size_t storage_size;
+        HIP_CHECK(scan_state_type::get_storage_size(number_of_blocks, stream, storage_size));
+
+        // temp_storage_size_bytes must be >0
+        ASSERT_GT(storage_size, 0);
+
+        // Allocate temporary storage
+        common::device_ptr<void> d_temp_storage(storage_size);
+        common::device_ptr<U>    d_save_dest(std::vector<U>(1));
+
+        scan_state_type scan_state{};
+        HIP_CHECK(
+            scan_state_type::create(scan_state, d_temp_storage.get(), number_of_blocks, stream));
+        scan_state_with_sleep_type scan_state_with_sleep{};
+        HIP_CHECK(scan_state_with_sleep_type::create(scan_state_with_sleep,
+                                                     d_temp_storage.get(),
+                                                     number_of_blocks,
+                                                     stream));
+
+        // Call the provided function with either scan_state or scan_state_with_sleep based on
+        // the value of use_sleep
+        bool use_sleep;
+        HIP_CHECK(rocprim::detail::is_sleep_scan_state_used(stream, use_sleep))
+        auto with_scan_state
+            = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
+        {
+            if(use_sleep)
+            {
+                return func(scan_state_with_sleep);
+            }
+            else
+            {
+                return func(scan_state);
+            }
+        };
+        auto grid_size = (number_of_blocks + block_size - 1) / block_size;
+        with_scan_state(
+            [&](const auto scan_state)
+            {
+                rocprim::detail::init_lookback_scan_state_kernel<<<dim3(grid_size),
+                                                                   dim3(block_size),
+                                                                   0,
+                                                                   stream>>>(scan_state,
+                                                                             number_of_blocks);
+            });
+
+        HIP_CHECK(hipGetLastError());
+        HIP_CHECK(hipDeviceSynchronize());
+
+        test_utils::GraphHelper gHelper;
+        if(TestFixture::use_graphs)
+        {
+            gHelper.startStreamCapture(stream);
+        }
+
+        static constexpr bool Exclusive = false;
+
+        grid_size = number_of_blocks;
+
+        with_scan_state(
+            [&](const auto scan_state)
+            {
+                rocprim::detail::lookback_scan_kernel<
+                    deterministic ? rocprim::detail::lookback_scan_determinism::deterministic
+                                  : rocprim::detail::lookback_scan_determinism::nondeterministic,
+                    Exclusive,
+                    use_initial_value,
+                    config,
+                    decltype(input_iterator),
+                    U*,
+                    scan_op_type,
+                    acc_type,
+                    acc_type>
+                    <<<dim3(grid_size), dim3(block_size), 0, stream>>>(input_iterator,
+                                                                       d_output.get(),
+                                                                       size,
+                                                                       initial_value,
+                                                                       scan_op,
+                                                                       scan_state,
+                                                                       number_of_blocks,
+                                                                       previous_last_element,
+                                                                       new_last_element,
+                                                                       false,
+                                                                       false);
+            });
+
+        if(TestFixture::use_graphs)
+        {
+            gHelper.createAndLaunchGraph(stream, true, false);
+        }
+
+        HIP_CHECK(hipGetLastError());
+        HIP_CHECK(hipDeviceSynchronize());
+
+        // Copy output to host
+        const auto output = d_output.load();
+
+        // Check if output values are as expected
+        ASSERT_NO_FATAL_FAILURE(
+            test_utils::assert_near(output, expected, single_op_precision * size));
+
+        common::device_ptr<U> d_output_complete(grid_size);
+        with_scan_state(
+            [&](const auto scan_state) {
+                complete_value<<<dim3(grid_size), dim3(1), 0, stream>>>(d_output_complete.get(),
+                                                                        scan_state);
+            });
+
+        HIP_CHECK(hipGetLastError());
+        HIP_CHECK(hipDeviceSynchronize());
+
+        const auto output_complete = d_output_complete.load();
+
+        test_utils::assert_near(output_complete[0], output[size - 1], single_op_precision * size);
+
+        if(TestFixture::use_graphs)
+        {
+            gHelper.cleanupGraphHelper();
+            HIP_CHECK(hipStreamDestroy(stream));
+        }
+    }
+}
+
 TYPED_TEST_SUITE(RocprimDeviceScanTests, RocprimDeviceScanTestsParams);
 
 TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
@@ -600,49 +838,25 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
         = rocprim::make_transform_iterator(rocprim::make_constant_iterator<T>(T(345)),
                                            [](T in) { return static_cast<acc_type>(in); });
 
-    // Get size of d_temp_storage
-    size_t temp_storage_size_bytes;
-    HIP_CHECK(invoke_inclusive_scan<deterministic>(nullptr,
-                                                   temp_storage_size_bytes,
-                                                   input_iterator,
-                                                   d_checking_output,
-                                                   0,
-                                                   scan_op,
-                                                   stream,
-                                                   debug_synchronous));
-
-    // Allocate temporary storage
-    common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-    test_utils::GraphHelper gHelper;
-    if(TestFixture::use_graphs)
-    {
-        gHelper.startStreamCapture(stream);
-    }
-
-    // Run
-    HIP_CHECK(invoke_inclusive_scan<deterministic>(d_temp_storage.get(),
-                                                   temp_storage_size_bytes,
-                                                   input_iterator,
-                                                   d_checking_output,
-                                                   0,
-                                                   scan_op,
-                                                   stream,
-                                                   debug_synchronous));
-
-    if(TestFixture::use_graphs)
-    {
-        gHelper.createAndLaunchGraph(stream, true, false);
-    }
-
-    HIP_CHECK(hipGetLastError());
-    HIP_CHECK(hipDeviceSynchronize());
+    test_utils::test_kernel_wrapper(
+        [&](void* temp_storage, size_t& storage_bytes)
+        {
+            return invoke_inclusive_scan<deterministic>(temp_storage,
+                                                        storage_bytes,
+                                                        input_iterator,
+                                                        d_checking_output,
+                                                        0,
+                                                        scan_op,
+                                                        stream,
+                                                        debug_synchronous);
+        },
+        stream,
+        TestFixture::use_graphs);
 
     ASSERT_FALSE(out_of_bounds.get());
 
     if(TestFixture::use_graphs)
     {
-        gHelper.cleanupGraphHelper();
         HIP_CHECK(hipStreamDestroy(stream));
     }
 }
@@ -668,8 +882,18 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
     constexpr float single_op_precision = is_plus_op::value ? test_utils::precision<acc_type> : 0;
 
     static constexpr bool use_identity_iterator = TestFixture::use_identity_iterator;
-    const bool            deterministic         = TestFixture::deterministic;
+    static constexpr bool deterministic         = TestFixture::deterministic;
+    static constexpr bool use_initial_value     = TestFixture::use_initial_value;
+
     using Config = typename TestFixture::config_helper::template type<false>;
+
+    // Default
+    hipStream_t stream = 0;
+    if(TestFixture::use_graphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
@@ -692,14 +916,6 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
                 break;
             }
 
-            // Default
-            hipStream_t stream = 0;
-            if(TestFixture::use_graphs)
-            {
-                // Default stream does not support hipGraph stream capture, so create one
-                HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-            }
-
             SCOPED_TRACE(testing::Message() << "with size = " << size);
 
             // Generate data
@@ -714,7 +930,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
             // Calculate expected results on host
             std::vector<U> expected(input.size());
             acc_type       initial_value;
-            if(TestFixture::use_initial_value)
+            if(use_initial_value)
             {
                 initial_value = test_utils::get_random_value<acc_type>(1, 10, seed_value);
                 test_utils::host_inclusive_scan(input.begin(),
@@ -730,7 +946,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
                                                 expected.begin(),
                                                 scan_op);
             }
-            SCOPED_TRACE(TestFixture::use_initial_value
+            SCOPED_TRACE(use_initial_value
                              ? (testing::Message() << "with initial_value = " << initial_value)
                              : (testing::Message() << "without initial_value"));
 
@@ -738,80 +954,39 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
                 = rocprim::make_transform_iterator(d_input.get(),
                                                    [](T in) { return static_cast<acc_type>(in); });
 
-            // Get size of d_temp_storage
-            size_t temp_storage_size_bytes;
-            if(TestFixture::use_initial_value)
-            {
-                HIP_CHECK((invoke_inclusive_scan<deterministic, Config>(
-                    nullptr,
-                    temp_storage_size_bytes,
-                    input_iterator,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
-                    initial_value,
-                    input.size(),
-                    scan_op,
-                    stream,
-                    TestFixture::debug_synchronous)));
-            }
-            else
-            {
-                HIP_CHECK((invoke_inclusive_scan<deterministic, Config>(
-                    nullptr,
-                    temp_storage_size_bytes,
-                    input_iterator,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
-                    input.size(),
-                    scan_op,
-                    stream,
-                    TestFixture::debug_synchronous)));
-            }
-
-            // temp_storage_size_bytes must be >0
-            ASSERT_GT(temp_storage_size_bytes, 0);
-
-            // Allocate temporary storage
-            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(TestFixture::use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            // Run
-            if(TestFixture::use_initial_value)
-            {
-                HIP_CHECK((invoke_inclusive_scan<deterministic, Config>(
-                    d_temp_storage.get(),
-                    temp_storage_size_bytes,
-                    input_iterator,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
-                    initial_value,
-                    input.size(),
-                    scan_op,
-                    stream,
-                    TestFixture::debug_synchronous)));
-            }
-            else
-            {
-                HIP_CHECK((invoke_inclusive_scan<deterministic, Config>(
-                    d_temp_storage.get(),
-                    temp_storage_size_bytes,
-                    input_iterator,
-                    test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
-                    input.size(),
-                    scan_op,
-                    stream,
-                    TestFixture::debug_synchronous)));
-            }
-
-            if(TestFixture::use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream, true, false);
-            }
-
-            HIP_CHECK(hipGetLastError());
-            HIP_CHECK(hipDeviceSynchronize());
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    if constexpr(use_initial_value)
+                    {
+                        return invoke_inclusive_scan<deterministic, Config>(
+                            temp_storage,
+                            storage_bytes,
+                            input_iterator,
+                            test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                                d_output.get()),
+                            initial_value,
+                            input.size(),
+                            scan_op,
+                            stream,
+                            TestFixture::debug_synchronous);
+                    }
+                    else
+                    {
+                        return invoke_inclusive_scan<deterministic, Config>(
+                            temp_storage,
+                            storage_bytes,
+                            input_iterator,
+                            test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                                d_output.get()),
+                            input.size(),
+                            scan_op,
+                            stream,
+                            TestFixture::debug_synchronous);
+                    }
+                },
+                stream,
+                TestFixture::use_graphs);
 
             // Copy output to host
             const auto output = d_output.load();
@@ -825,13 +1000,12 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
                         test_utils::assert_near(output[i], expected[i], single_op_precision * i));
                 }
             }
-
-            if(TestFixture::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-                HIP_CHECK(hipStreamDestroy(stream));
-            }
         }
+    }
+
+    if(TestFixture::use_graphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
     }
 }
 
@@ -858,8 +1032,17 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
 
     const bool            debug_synchronous     = TestFixture::debug_synchronous;
     static constexpr bool use_identity_iterator = TestFixture::use_identity_iterator;
-    const bool            deterministic         = TestFixture::deterministic;
+    static constexpr bool deterministic         = TestFixture::deterministic;
+
     using Config = typename TestFixture::config_helper::template type<false>;
+
+    // Default
+    hipStream_t stream = 0;
+    if(TestFixture::use_graphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
 
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
@@ -880,14 +1063,6 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
                              "with current or larger size"
                           << std::endl;
                 break;
-            }
-
-            // Default
-            hipStream_t stream = 0;
-            if(TestFixture::use_graphs)
-            {
-                // Default stream does not support hipGraph stream capture, so create one
-                HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
             }
 
             SCOPED_TRACE(testing::Message() << "with size = " << size);
@@ -914,50 +1089,23 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
                 = rocprim::make_transform_iterator(d_input.get(),
                                                    [](T in) { return static_cast<acc_type>(in); });
 
-            // Get size of d_temp_storage
-            size_t temp_storage_size_bytes;
-            HIP_CHECK((invoke_exclusive_scan<deterministic, Config>(
-                nullptr,
-                temp_storage_size_bytes,
-                input_iterator,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
-                initial_value,
-                input.size(),
-                scan_op,
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    return invoke_exclusive_scan<deterministic, Config>(
+                        temp_storage,
+                        storage_bytes,
+                        input_iterator,
+                        test_utils::wrap_in_identity_iterator<use_identity_iterator>(
+                            d_output.get()),
+                        initial_value,
+                        input.size(),
+                        scan_op,
+                        stream,
+                        debug_synchronous);
+                },
                 stream,
-                debug_synchronous)));
-
-            // temp_storage_size_bytes must be >0
-            ASSERT_GT(temp_storage_size_bytes, 0);
-
-            // Allocate temporary storage
-            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(TestFixture::use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            // Run
-            HIP_CHECK((invoke_exclusive_scan<deterministic, Config>(
-                d_temp_storage.get(),
-                temp_storage_size_bytes,
-                input_iterator,
-                test_utils::wrap_in_identity_iterator<use_identity_iterator>(d_output.get()),
-                initial_value,
-                input.size(),
-                scan_op,
-                stream,
-                debug_synchronous)));
-
-            if(TestFixture::use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream, true, false);
-            }
-
-            HIP_CHECK(hipGetLastError());
-            HIP_CHECK(hipDeviceSynchronize());
+                TestFixture::use_graphs);
 
             // Copy output to host
             const auto output = d_output.load();
@@ -971,13 +1119,12 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
                         test_utils::assert_near(output[i], expected[i], single_op_precision * i));
                 }
             }
-
-            if(TestFixture::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-                HIP_CHECK(hipStreamDestroy(stream));
-            }
         }
+    }
+
+    if(TestFixture::use_graphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
     }
 }
 
@@ -1000,6 +1147,14 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
     const bool deterministic     = TestFixture::deterministic;
     using Config                 = typename TestFixture::config_helper::template type<true>;
 
+    // Default
+    hipStream_t stream = 0;
+    if(TestFixture::use_graphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
+
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
@@ -1019,14 +1174,6 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
                              "with current or larger size"
                           << std::endl;
                 break;
-            }
-
-            // Default
-            hipStream_t stream = 0;
-            if(TestFixture::use_graphs)
-            {
-                // Default stream does not support hipGraph stream capture, so create one
-                HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
             }
 
             SCOPED_TRACE(testing::Message() << "with size = " << size);
@@ -1068,50 +1215,22 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
                 = rocprim::make_transform_iterator(d_input.get(),
                                                    [](T in) { return static_cast<acc_type>(in); });
 
-            // Get size of d_temp_storage
-            size_t temp_storage_size_bytes;
-            HIP_CHECK((invoke_inclusive_scan_by_key<deterministic, Config>(nullptr,
-                                                                           temp_storage_size_bytes,
-                                                                           d_keys.get(),
-                                                                           input_iterator,
-                                                                           d_output.get(),
-                                                                           input.size(),
-                                                                           scan_op,
-                                                                           keys_compare_op,
-                                                                           stream,
-                                                                           debug_synchronous)));
-
-            // temp_storage_size_bytes must be >0
-            ASSERT_GT(temp_storage_size_bytes, 0);
-
-            // Allocate temporary storage
-            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(TestFixture::use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            // Run
-            HIP_CHECK((invoke_inclusive_scan_by_key<deterministic, Config>(d_temp_storage.get(),
-                                                                           temp_storage_size_bytes,
-                                                                           d_keys.get(),
-                                                                           input_iterator,
-                                                                           d_output.get(),
-                                                                           input.size(),
-                                                                           scan_op,
-                                                                           keys_compare_op,
-                                                                           stream,
-                                                                           debug_synchronous)));
-
-            if(TestFixture::use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream, true, false);
-            }
-
-            HIP_CHECK(hipGetLastError());
-            HIP_CHECK(hipDeviceSynchronize());
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    return invoke_inclusive_scan_by_key<deterministic, Config>(temp_storage,
+                                                                               storage_bytes,
+                                                                               d_keys.get(),
+                                                                               input_iterator,
+                                                                               d_output.get(),
+                                                                               input.size(),
+                                                                               scan_op,
+                                                                               keys_compare_op,
+                                                                               stream,
+                                                                               debug_synchronous);
+                },
+                stream,
+                TestFixture::use_graphs);
 
             // Copy output to host
             const auto output = d_output.load();
@@ -1119,13 +1238,12 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
             // Check if output values are as expected
             ASSERT_NO_FATAL_FAILURE(
                 test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
-
-            if(TestFixture::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-                HIP_CHECK(hipStreamDestroy(stream));
-            }
         }
+    }
+
+    if(TestFixture::use_graphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
     }
 }
 
@@ -1149,6 +1267,14 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
     const bool deterministic     = TestFixture::deterministic;
     using Config                 = typename TestFixture::config_helper::template type<true>;
 
+    // Default
+    hipStream_t stream = 0;
+    if(TestFixture::use_graphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
+
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
@@ -1168,14 +1294,6 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
                              "with current or larger size"
                           << std::endl;
                 break;
-            }
-
-            // Default
-            hipStream_t stream = 0;
-            if(TestFixture::use_graphs)
-            {
-                // Default stream does not support hipGraph stream capture, so create one
-                HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
             }
 
             SCOPED_TRACE(testing::Message() << "with size = " << size);
@@ -1220,52 +1338,23 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
                 = rocprim::make_transform_iterator(d_input.get(),
                                                    [](T in) { return static_cast<acc_type>(in); });
 
-            // Get size of d_temp_storage
-            size_t temp_storage_size_bytes;
-            HIP_CHECK((invoke_exclusive_scan_by_key<deterministic, Config>(nullptr,
-                                                                           temp_storage_size_bytes,
-                                                                           d_keys.get(),
-                                                                           input_iterator,
-                                                                           d_output.get(),
-                                                                           initial_value,
-                                                                           input.size(),
-                                                                           scan_op,
-                                                                           keys_compare_op,
-                                                                           stream,
-                                                                           debug_synchronous)));
-
-            // temp_storage_size_bytes must be >0
-            ASSERT_GT(temp_storage_size_bytes, 0);
-
-            // Allocate temporary storage
-            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(TestFixture::use_graphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            // Run
-            HIP_CHECK((invoke_exclusive_scan_by_key<deterministic, Config>(d_temp_storage.get(),
-                                                                           temp_storage_size_bytes,
-                                                                           d_keys.get(),
-                                                                           input_iterator,
-                                                                           d_output.get(),
-                                                                           initial_value,
-                                                                           input.size(),
-                                                                           scan_op,
-                                                                           keys_compare_op,
-                                                                           stream,
-                                                                           debug_synchronous)));
-
-            if(TestFixture::use_graphs)
-            {
-                gHelper.createAndLaunchGraph(stream, true, false);
-            }
-
-            HIP_CHECK(hipGetLastError());
-            HIP_CHECK(hipDeviceSynchronize());
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    return invoke_exclusive_scan_by_key<deterministic, Config>(temp_storage,
+                                                                               storage_bytes,
+                                                                               d_keys.get(),
+                                                                               input_iterator,
+                                                                               d_output.get(),
+                                                                               initial_value,
+                                                                               input.size(),
+                                                                               scan_op,
+                                                                               keys_compare_op,
+                                                                               stream,
+                                                                               debug_synchronous);
+                },
+                stream,
+                TestFixture::use_graphs);
 
             // Copy output to host
             const auto output = d_output.load();
@@ -1273,13 +1362,12 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
             // Check if output values are as expected
             ASSERT_NO_FATAL_FAILURE(
                 test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
-
-            if(TestFixture::use_graphs)
-            {
-                gHelper.cleanupGraphHelper();
-                HIP_CHECK(hipStreamDestroy(stream));
-            }
         }
+    }
+
+    if(TestFixture::use_graphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
     }
 }
 
@@ -1394,81 +1482,42 @@ void testLargeIndicesInclusiveScan()
 
             OutputIterator output_it{d_output.get(), size - 1};
 
-            // Get temporary array size
             size_t initial_value = 0;
-            size_t temp_storage_size_bytes;
-            if constexpr(UseInitialValue)
-            {
-                initial_value = test_utils::get_random_value<size_t>(0, 10000, seed_value);
-                HIP_CHECK(rocprim::inclusive_scan(nullptr,
-                                                  temp_storage_size_bytes,
-                                                  input_begin,
-                                                  output_it,
-                                                  initial_value,
-                                                  size,
-                                                  ::rocprim::plus<T>(),
-                                                  stream,
-                                                  debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::inclusive_scan(nullptr,
-                                                  temp_storage_size_bytes,
-                                                  input_begin,
-                                                  output_it,
-                                                  size,
-                                                  ::rocprim::plus<T>(),
-                                                  stream,
-                                                  debug_synchronous));
-            }
 
-            // temp_storage_size_bytes must be >0
-            ASSERT_GT(temp_storage_size_bytes, 0);
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    if constexpr(UseInitialValue)
+                    {
+                        initial_value = test_utils::get_random_value<size_t>(0, 10000, seed_value);
+                        return rocprim::inclusive_scan(temp_storage,
+                                                       storage_bytes,
+                                                       input_begin,
+                                                       output_it,
+                                                       initial_value,
+                                                       size,
+                                                       ::rocprim::plus<T>(),
+                                                       stream,
+                                                       debug_synchronous);
+                    }
+                    else
+                    {
+                        return rocprim::inclusive_scan(temp_storage,
+                                                       storage_bytes,
+                                                       input_begin,
+                                                       output_it,
+                                                       size,
+                                                       ::rocprim::plus<T>(),
+                                                       stream,
+                                                       debug_synchronous);
+                    }
+                },
+                stream,
+                UseGraphs);
 
-            // Allocate temporary storage
-            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(UseGraphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            // Run
-            if constexpr(UseInitialValue)
-            {
-                HIP_CHECK(rocprim::inclusive_scan(d_temp_storage.get(),
-                                                  temp_storage_size_bytes,
-                                                  input_begin,
-                                                  output_it,
-                                                  initial_value,
-                                                  size,
-                                                  ::rocprim::plus<T>(),
-                                                  stream,
-                                                  debug_synchronous));
-            }
-            else
-            {
-                HIP_CHECK(rocprim::inclusive_scan(d_temp_storage.get(),
-                                                  temp_storage_size_bytes,
-                                                  input_begin,
-                                                  output_it,
-                                                  size,
-                                                  ::rocprim::plus<T>(),
-                                                  stream,
-                                                  debug_synchronous));
-            }
             SCOPED_TRACE(UseInitialValue
                              ? (testing::Message() << "with initial_value = " << initial_value)
                              : (testing::Message() << "without initial_value"));
-
-            if(UseGraphs)
-            {
-                gHelper.createAndLaunchGraph(stream, true, false);
-            }
-
-            HIP_CHECK(hipGetLastError());
-            HIP_CHECK(hipDeviceSynchronize());
 
             // Copy output to host
             const auto output = d_output.load()[0];
@@ -1483,11 +1532,6 @@ void testLargeIndicesInclusiveScan()
                   + initial_value;
 
             ASSERT_EQ(output, expected_output);
-
-            if(UseGraphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
         }
     }
 
@@ -1558,48 +1602,21 @@ void testLargeIndicesExclusiveScan()
 
             OutputIterator output_it{d_output.get(), size - 1};
 
-            // Get temporary array size
-            size_t temp_storage_size_bytes;
-            HIP_CHECK(rocprim::exclusive_scan(nullptr,
-                                              temp_storage_size_bytes,
-                                              input_begin,
-                                              output_it,
-                                              initial_value,
-                                              size,
-                                              ::rocprim::plus<T>(),
-                                              stream,
-                                              debug_synchronous));
-
-            // temp_storage_size_bytes must be >0
-            ASSERT_GT(temp_storage_size_bytes, 0);
-
-            // Allocate temporary storage
-            common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-            test_utils::GraphHelper gHelper;
-            if(UseGraphs)
-            {
-                gHelper.startStreamCapture(stream);
-            }
-
-            // Run
-            HIP_CHECK(rocprim::exclusive_scan(d_temp_storage.get(),
-                                              temp_storage_size_bytes,
-                                              input_begin,
-                                              output_it,
-                                              initial_value,
-                                              size,
-                                              ::rocprim::plus<T>(),
-                                              stream,
-                                              debug_synchronous));
-
-            if(UseGraphs)
-            {
-                gHelper.createAndLaunchGraph(stream, true, false);
-            }
-
-            HIP_CHECK(hipGetLastError());
-            HIP_CHECK(hipDeviceSynchronize());
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    return rocprim::exclusive_scan(temp_storage,
+                                                   storage_bytes,
+                                                   input_begin,
+                                                   output_it,
+                                                   initial_value,
+                                                   size,
+                                                   ::rocprim::plus<T>(),
+                                                   stream,
+                                                   debug_synchronous);
+                },
+                stream,
+                UseGraphs);
 
             // Copy output to host
             const auto output = d_output.load()[0];
@@ -1615,11 +1632,6 @@ void testLargeIndicesExclusiveScan()
             const T expected_output = initial_value + product;
 
             ASSERT_EQ(output, expected_output);
-
-            if(UseGraphs)
-            {
-                gHelper.cleanupGraphHelper();
-            }
         }
     }
 
@@ -1830,45 +1842,22 @@ void large_indices_scan_by_key_test(ScanByKeyFun scan_by_key_fun)
                                                              { return value / run_length; });
     const auto values_input = rocprim::counting_iterator<size_t>(0);
 
-    size_t temp_storage_size_bytes;
-    HIP_CHECK(scan_by_key_fun(nullptr,
-                              temp_storage_size_bytes,
-                              keys_input,
-                              values_input,
-                              run_length,
-                              d_incorrect_flag.get(),
-                              size,
-                              stream,
-                              debug_synchronous,
-                              seed_value));
-
-    ASSERT_GT(temp_storage_size_bytes, 0);
-
-    common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-
-    test_utils::GraphHelper gHelper;
-    if(UseGraphs)
-    {
-        gHelper.startStreamCapture(stream);
-    }
-
-    HIP_CHECK(scan_by_key_fun(d_temp_storage.get(),
-                              temp_storage_size_bytes,
-                              keys_input,
-                              values_input,
-                              run_length,
-                              d_incorrect_flag.get(),
-                              size,
-                              stream,
-                              debug_synchronous,
-                              seed_value));
-
-    if(UseGraphs)
-    {
-        gHelper.createAndLaunchGraph(stream);
-    }
-
-    HIP_CHECK(hipGetLastError());
+    test_utils::test_kernel_wrapper(
+        [&](void* temp_storage, size_t& storage_bytes)
+        {
+            return scan_by_key_fun(temp_storage,
+                                   storage_bytes,
+                                   keys_input,
+                                   values_input,
+                                   run_length,
+                                   d_incorrect_flag.get(),
+                                   size,
+                                   stream,
+                                   debug_synchronous,
+                                   seed_value);
+        },
+        stream,
+        UseGraphs);
 
     const auto incorrect_flag = d_incorrect_flag.load()[0];
 
@@ -1876,7 +1865,6 @@ void large_indices_scan_by_key_test(ScanByKeyFun scan_by_key_fun)
 
     if(UseGraphs)
     {
-        gHelper.cleanupGraphHelper();
         HIP_CHECK(hipStreamDestroy(stream));
     }
 }

--- a/projects/rocprim/test/rocprim/test_discard_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_discard_iterator.cpp
@@ -26,6 +26,7 @@
 
 // required test headers
 #include "test_seed.hpp"
+#include "test_utils.hpp"
 #include "test_utils_data_generation.hpp"
 
 // required rocprim headers
@@ -35,13 +36,13 @@
 
 #include <cstddef>
 
-TEST(RocprimDiscardIteratorTests, Equal)
+TEST(RocprimDiscardIteratorTests, Basic)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using Iterator = typename rocprim::discard_iterator;
+    using Iterator = rocprim::discard_iterator;
 
     for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
     {
@@ -49,46 +50,61 @@ TEST(RocprimDiscardIteratorTests, Equal)
             = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
         SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
 
-        Iterator x(test_utils::get_random_value<size_t>(0, 200, seed_value));
-        Iterator y = x;
-        ASSERT_TRUE(x == y);
+        const size_t base_index
+            = static_cast<size_t>(test_utils::get_random_value<int>(1, 100, seed_value));
+        Iterator it = rocprim::make_discard_iterator(base_index);
 
-        x += 100;
-        for(size_t i = 0; i < 100; i++)
-        {
-            y++;
-        }
-        ASSERT_TRUE(x == y);
+        // Check dereferencing returns discard_value (should be callable)
+        auto discard_val = *it;
+        static_assert(std::is_same<decltype(discard_val), typename Iterator::value_type>::value,
+                      "Dereferencing should yield discard_value.");
 
-        y--;
-        ASSERT_TRUE(x != y);
-    }
-}
+        // Post-increment
+        Iterator post = it++;
+        ASSERT_EQ((it - post), 1);
 
-TEST(RocprimDiscardIteratorTests, Less)
-{
-    int device_id = test_common_utils::obtain_device_from_ctest();
-    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
-    HIP_CHECK(hipSetDevice(device_id));
+        // Pre-increment
+        ++it;
+        ASSERT_EQ((it - post), 2);
 
-    using Iterator = typename rocprim::discard_iterator;
+        // Post-decrement
+        Iterator post_dec = it--;
+        ASSERT_EQ((post_dec - it), 1);
 
-    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
-    {
-        unsigned int seed_value
-            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
-        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+        // Pre-decrement
+        --it;
+        ASSERT_EQ((post_dec - it), 2);
 
-        Iterator x(test_utils::get_random_value<size_t>(0, 200, seed_value));
-        Iterator y = x + 1;
-        ASSERT_TRUE(x < y);
+        // Arithmetic operations
+        Iterator it_plus_5 = it + 5;
+        ASSERT_EQ(it_plus_5 - it, 5);
 
-        x += 100;
-        for(size_t i = 0; i < 100; i++)
-        {
-            y++;
-        }
-        ASSERT_TRUE(x < y);
+        Iterator it_5_plus = 5 + it;
+        ASSERT_EQ(it_5_plus - it, 5);
+
+        Iterator it_minus_3 = it_plus_5 - 3;
+        ASSERT_EQ(it_minus_3 - it, 2);
+
+        it += 12;
+        ASSERT_EQ(it - post, 12);
+
+        it -= 4;
+        ASSERT_EQ(it - post, 8);
+
+        // Comparison checks
+        Iterator a(100);
+        Iterator b(105);
+        ASSERT_TRUE(a < b);
+        ASSERT_TRUE(b > a);
+        ASSERT_TRUE(a <= b);
+        ASSERT_TRUE(b >= a);
+        ASSERT_TRUE(a != b);
+        ASSERT_TRUE(a == a);
+
+        // Operator[] returns discard_value
+        auto val = a[3];
+        static_assert(std::is_same<decltype(val), typename Iterator::value_type>::value,
+                      "operator[] should return discard_value");
     }
 }
 
@@ -114,44 +130,26 @@ TEST(RocprimDiscardIteratorTests, ReduceByKey)
     common::device_ptr<int> d_values_input(values_input);
     common::device_ptr<int> d_aggregates_output(aggregates_expected.size());
 
-    // Get temporary storage size
-    size_t temporary_storage_bytes;
-    HIP_CHECK(rocprim::reduce_by_key(nullptr,
-                                     temporary_storage_bytes,
-                                     d_keys_input.get(),
-                                     d_values_input.get(),
-                                     values_input.size(),
-                                     rocprim::make_discard_iterator(),
-                                     d_aggregates_output.get(),
-                                     rocprim::make_discard_iterator(),
-                                     rocprim::plus<int>(),
-                                     rocprim::equal_to<int>(),
-                                     stream,
-                                     debug_synchronous));
-    HIP_CHECK(hipDeviceSynchronize());
-
-    ASSERT_GT(temporary_storage_bytes, 0);
-
-    common::device_ptr<void> d_temporary_storage(temporary_storage_bytes);
-
-    HIP_CHECK(rocprim::reduce_by_key(d_temporary_storage.get(),
-                                     temporary_storage_bytes,
-                                     d_keys_input.get(),
-                                     d_values_input.get(),
-                                     values_input.size(),
-                                     rocprim::make_discard_iterator(),
-                                     d_aggregates_output.get(),
-                                     rocprim::make_discard_iterator(),
-                                     rocprim::plus<int>(),
-                                     rocprim::equal_to<int>(),
-                                     stream,
-                                     debug_synchronous));
-    HIP_CHECK(hipDeviceSynchronize());
+    test_utils::test_kernel_wrapper(
+        [&](void* temp_storage, size_t& storage_bytes)
+        {
+            return rocprim::reduce_by_key(temp_storage,
+                                          storage_bytes,
+                                          d_keys_input.get(),
+                                          d_values_input.get(),
+                                          values_input.size(),
+                                          rocprim::make_discard_iterator(),
+                                          d_aggregates_output.get(),
+                                          rocprim::make_discard_iterator(),
+                                          rocprim::plus<int>(),
+                                          rocprim::equal_to<int>(),
+                                          stream,
+                                          debug_synchronous);
+        },
+        stream);
 
     // Check if output values are as expected
     std::vector<int> aggregates_output = d_aggregates_output.load();
-    for(size_t i = 0; i < aggregates_output.size(); i++)
-    {
-        ASSERT_EQ(aggregates_output[i], aggregates_expected[i]);
-    }
+
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(aggregates_output, aggregates_expected));
 }

--- a/projects/rocprim/test/rocprim/test_predicate_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_predicate_iterator.cpp
@@ -67,6 +67,139 @@ struct set_to
     }
 };
 
+// Params for tests
+template<class InputType>
+struct RocprimPredicateIteratorParams
+{
+    using input_type = InputType;
+};
+
+template<class Params>
+class RocprimPredicateIteratorTests : public ::testing::Test
+{
+public:
+    using input_type             = typename Params::input_type;
+    const bool debug_synchronous = false;
+};
+
+using RocprimPredicateIteratorTestsParams
+    = ::testing::Types<RocprimPredicateIteratorParams<int>,
+                       RocprimPredicateIteratorParams<unsigned int>,
+                       RocprimPredicateIteratorParams<unsigned long>>;
+
+TYPED_TEST_SUITE(RocprimPredicateIteratorTests, RocprimPredicateIteratorTestsParams);
+
+TYPED_TEST(RocprimPredicateIteratorTests, Basic)
+{
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    using T        = typename TestFixture::input_type;
+    using Iterator = rocprim::predicate_iterator<T*, T*, is_odd>;
+    using Proxy    = typename Iterator::value_type;
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; ++seed_index)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        std::vector<T> input = test_utils::get_random_data_wrapped<T>(10, 1, 100, seed_value);
+
+        std::vector<T> flags = input; // using input itself to apply is_odd
+
+        Iterator begin = rocprim::make_predicate_iterator(input.data(), flags.data(), is_odd{});
+        Iterator mid   = begin + 5;
+        Iterator end   = begin + 10;
+
+        // Pre-increment
+        Iterator it = begin;
+        ++it;
+        ASSERT_EQ(static_cast<T>(*it), input[1] % 2 ? input[1] : T{});
+
+        // Post-increment
+        Iterator post = it++;
+        ASSERT_EQ(static_cast<T>(*post), input[1] % 2 ? input[1] : T{});
+        ASSERT_EQ(static_cast<T>(*it), input[2] % 2 ? input[2] : T{});
+
+        // Pre-decrement
+        it = begin + 2;
+        --it;
+        ASSERT_EQ(static_cast<T>(*it), input[1] % 2 ? input[1] : T{});
+
+        // Post-decrement
+        Iterator post_dec = it--;
+        ASSERT_EQ(static_cast<T>(*post_dec), input[1] % 2 ? input[1] : T{});
+        ASSERT_EQ(static_cast<T>(*it), input[0] % 2 ? input[0] : T{});
+
+        // operator+
+        Iterator plus_it = begin + 3;
+        ASSERT_EQ(static_cast<T>(*plus_it), input[3] % 2 ? input[3] : T{});
+        Iterator plus_i_rev = 3 + begin;
+        ASSERT_EQ(static_cast<T>(*plus_i_rev), input[3] % 2 ? input[3] : T{});
+
+        // operator-
+        Iterator minus_it = end - 3;
+        ASSERT_EQ(static_cast<T>(*minus_it), input[7] % 2 ? input[7] : T{});
+
+        // compound assignment +=
+        Iterator a = begin;
+        a += 4;
+        ASSERT_EQ(static_cast<T>(*a), input[4] % 2 ? input[4] : T{});
+
+        // compound assignment -=
+        a -= 2;
+        ASSERT_EQ(static_cast<T>(*a), input[2] % 2 ? input[2] : T{});
+
+        // Subtraction of iterators (distance)
+        ASSERT_EQ(end - begin, 10);
+        ASSERT_EQ(mid - begin, 5);
+        ASSERT_EQ(begin - mid, -5);
+
+        // Indexing operator[]
+        for(int i = 0; i < 10; ++i)
+        {
+            Proxy proxy    = begin[i];
+            T     expected = input[i] % 2 ? input[i] : T{};
+            ASSERT_EQ(static_cast<T>(proxy), expected);
+        }
+
+        // Comparisons
+        ASSERT_TRUE(begin == begin);
+        ASSERT_TRUE(begin != end);
+        ASSERT_TRUE(begin < end);
+        ASSERT_TRUE(end > begin);
+        ASSERT_TRUE(begin <= begin);
+        ASSERT_TRUE(begin <= end);
+        ASSERT_TRUE(end >= begin);
+        ASSERT_TRUE(end >= end);
+
+        // Arrow operator (returns proxy, which we can test through conversion)
+        Proxy p = *begin;
+        ASSERT_EQ(static_cast<T>(p), input[0] % 2 ? input[0] : T{});
+
+        // Assignment via proxy: only odd-indexed data should be modified
+        for(int i = 0; i < 10; ++i)
+        {
+            begin[i] = T{999};
+        }
+
+        for(int i = 0; i < 10; ++i)
+        {
+            if(input[i] % 2)
+            {
+                ASSERT_EQ(input[i], T{999});
+            }
+
+            else
+            {
+                ASSERT_NE(input[i], T{999});
+            }
+        }
+    }
+}
+
 TEST(RocprimPredicateIteratorTests, TypeTraits)
 {
     using value_type = int;

--- a/projects/rocprim/test/rocprim/test_rocprim_tuple.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_tuple.cpp
@@ -1,0 +1,384 @@
+// Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "../common_test_header.hpp"
+
+#include "test_utils.hpp"
+
+//tuple_size : check size for various tuples and their cv‑qualified variants
+TEST(TupleSize, BasicAndCV)
+{
+    using Empty  = rocprim::tuple<>;
+    using Single = rocprim::tuple<int>;
+    using Mixed  = rocprim::tuple<int, double, char>;
+
+    // Compile time assertions
+    static_assert(rocprim::tuple_size<Empty>::value == 0, "");
+    static_assert(rocprim::tuple_size<Single>::value == 1, "");
+    static_assert(rocprim::tuple_size<Mixed>::value == 3, "");
+
+    // const/ volatile specific, cv‑qualified tuples must report the same size
+    static_assert(rocprim::tuple_size<const Mixed>::value == 3, "");
+    static_assert(rocprim::tuple_size<volatile Mixed>::value == 3, "");
+    static_assert(rocprim::tuple_size<const volatile Mixed>::value == 3, "");
+
+    // Runtime assertions
+    EXPECT_EQ(rocprim::tuple_size<Mixed>::value, 3u);
+}
+
+// get<I> : read / write / cv‑correctness
+TEST(Get, ValueAndReference)
+{
+    rocprim::tuple<int, double> t{1, 2.0};
+
+    // Runtime value access
+    EXPECT_EQ(rocprim::get<0>(t), 1);
+    EXPECT_DOUBLE_EQ(rocprim::get<1>(t), 2.0);
+
+    // Lvalue reference must be writable
+    rocprim::get<0>(t) = 10;
+    EXPECT_EQ(rocprim::get<0>(t), 10);
+
+    // Reading through const tuple returns const&
+    const auto& ct = t;
+    static_assert(std::is_same_v<decltype(rocprim::get<0>(ct)), const int&>);
+}
+
+// tuple_element : index -> type mapping (+ alias tuple_element_t)
+TEST(TupleElement, Types)
+{
+    using T0 = rocprim::tuple<int>;
+    static_assert(std::is_same_v<rocprim::tuple_element<0, T0>::type, int>, "");
+
+    using T3 = rocprim::tuple<int, double, char>;
+    static_assert(std::is_same_v<rocprim::tuple_element<0, T3>::type, int>, "");
+    static_assert(std::is_same_v<rocprim::tuple_element<1, T3>::type, double>, "");
+    static_assert(std::is_same_v<rocprim::tuple_element<2, T3>::type, char>, "");
+
+    // alias helper
+    static_assert(std::is_same_v<rocprim::tuple_element_t<1, T3>, double>, "");
+
+    // cv‑qualified tuple_element
+    using T = rocprim::tuple<int, double>;
+
+    static_assert(std::is_same_v<rocprim::tuple_element<0, const T>::type, const int>, "");
+    static_assert(std::is_same_v<rocprim::tuple_element<1, volatile T>::type, volatile double>, "");
+    static_assert(
+        std::is_same_v<rocprim::tuple_element<0, const volatile T>::type, const volatile int>,
+        "");
+
+    // Verify rocprim::get<I>() pairs with tuple_element_t
+    rocprim::tuple<int, char> t{42, 'x'};
+    static_assert(std::is_same_v<decltype(rocprim::get<0>(t)), int&>, "");
+    EXPECT_EQ(rocprim::get<0>(t), 42);
+    EXPECT_EQ(rocprim::get<1>(t), 'x');
+}
+
+// custom_forward : perfect‑forwarding category check
+TEST(CustomForward, ValueCategoryAndType)
+{
+    int  x    = 1;
+    int& lref = x;
+
+    // Should return int& when parameter is lvalue
+    static_assert(std::is_same_v<decltype(rocprim::detail::custom_forward<int&>(lref)), int&>);
+
+    // Should return int&& when parameter is rvalue
+    static_assert(
+        std::is_same_v<decltype(rocprim::detail::custom_forward<int&&>(std::move(x))), int&&>);
+}
+
+//is_final trait : detects final classes
+namespace
+{
+struct NonFinal
+{};
+struct Final final
+{};
+} // namespace
+
+TEST(IsFinalTrait, DetectsCorrectly)
+{
+    static_assert(!rocprim::detail::is_final<NonFinal>::value, "NonFinal should be false");
+    static_assert(rocprim::detail::is_final<Final>::value, "Final should be true");
+}
+
+// tuple_value : one element storage + EBO, tested with Typed-Test
+namespace
+{
+struct Empty // Empty type to trigger EBO
+{};
+struct EmptyFinal final // Final empty type
+{};
+struct NonEmpty // Normal type
+{
+    int x;
+};
+using Builtin = int; // Built-in type
+
+using Params = ::testing::Types<Empty, EmptyFinal, NonEmpty, Builtin>;
+} // namespace
+
+template<class T>
+class TupleValueTyped : public ::testing::Test
+{};
+TYPED_TEST_SUITE(TupleValueTyped, Params);
+
+// Compile‑time checks (size, get(), constructibility)
+TYPED_TEST(TupleValueTyped, CompileTimeTraits)
+{
+    using T  = TypeParam;
+    using TV = rocprim::detail::tuple_value<0, T>;
+
+    if constexpr(std::is_empty_v<T> && !rocprim::detail::is_final<T>::value)
+        static_assert(sizeof(TV) == 1, "EBO failed");
+    else
+        static_assert(sizeof(TV) >= sizeof(T), "size too small?");
+
+    TV tv;
+    static_assert(std::is_same_v<decltype(tv.get()), T&>);
+    static_assert(std::is_same_v<decltype(std::as_const(tv).get()), const T&>);
+
+    static_assert(std::is_constructible_v<TV, T&&>);
+    static_assert(std::is_assignable_v<TV&, T&&>);
+}
+
+// Runtime swap() behaviour
+TEST(TupleValueRuntime, SwapAndGet)
+{
+    using TV = rocprim::detail::tuple_value<0, int>;
+
+    TV a{1}, b{2};
+    a.swap(b);
+
+    EXPECT_EQ(a.get(), 2);
+    EXPECT_EQ(b.get(), 1);
+}
+
+template<class T>
+class TupleImplTyped : public ::testing::Test
+{};
+TYPED_TEST_SUITE(TupleImplTyped, Params);
+
+// tuple_impl : internal aggregate of N tuple_value bases
+TYPED_TEST(TupleImplTyped, CompileTimeTraits)
+{
+    using T = TypeParam;
+
+    using Impl = rocprim::detail::tuple_impl<rocprim::make_index_sequence<3>, T, char, double>;
+
+    // size check : removing an empty non‑final element should not change size
+    if constexpr(std::is_empty_v<T> && !rocprim::detail::is_final<T>::value)
+    {
+        using ImplNoEmpty
+            = rocprim::detail::tuple_impl<rocprim::make_index_sequence<2>, char, double>;
+
+        static_assert(sizeof(Impl) == sizeof(ImplNoEmpty), "EBO failed: empty element adds size");
+    }
+
+    static_assert(std::is_constructible_v<Impl, T, char, double>);
+    static_assert(std::is_assignable_v<Impl&, Impl const&>);
+}
+
+// tuple<Types...> : public API
+//  a) Compile‑time: Typed‑Tests for constructors & assignment
+//  b) Runtime behaviour: Unit TEST for Ctor/Assign/Swap/Get
+template<class T>
+class TupleTyped : public ::testing::Test
+{};
+TYPED_TEST_SUITE(TupleTyped, Params);
+
+// a) Compile‑time
+TYPED_TEST(TupleTyped, CompileTimeConstructAssign)
+{
+    using T    = TypeParam;
+    using Tup1 = rocprim::tuple<T>;
+    using Tup3 = rocprim::tuple<T, char, double>;
+
+    // Default‑constructible when each element is default‑constructible
+    static_assert(std::is_default_constructible_v<Tup1>);
+    static_assert(std::is_default_constructible_v<Tup3>);
+
+    // Direct value constructor
+    static_assert(std::is_constructible_v<Tup3, T, char, double>);
+
+    // Converting copy / move ctor
+    static_assert(std::is_constructible_v<Tup3, const Tup3&>);
+    static_assert(std::is_constructible_v<Tup3, Tup3&&>);
+
+    // Assignment operators
+    static_assert(std::is_assignable_v<Tup3&, const Tup3&>);
+    static_assert(std::is_assignable_v<Tup3&, Tup3&&>);
+}
+
+// b) Runtime behaviour
+TEST(TupleRuntime, CtorAssignSwapGet)
+{
+    rocprim::tuple<int, double, char> t1{1, 2.5, 'a'};
+    rocprim::tuple<int, double, char> t2{10, 20.0, 'z'};
+
+    // Verify construction & access
+    EXPECT_EQ(rocprim::get<0>(t1), 1);
+    EXPECT_DOUBLE_EQ(rocprim::get<1>(t1), 2.5);
+    EXPECT_EQ(rocprim::get<2>(t1), 'a');
+
+    // Copy assignment
+    t2 = t1;
+    EXPECT_EQ(rocprim::get<0>(t2), 1);
+    EXPECT_EQ(rocprim::get<2>(t2), 'a');
+
+    // Move assignment
+    t1 = rocprim::tuple<int, double, char>{5, 7.7, 'b'};
+    EXPECT_EQ(rocprim::get<0>(t1), 5);
+
+    // swap
+    t1.swap(t2);
+    EXPECT_EQ(rocprim::get<0>(t1), 1);
+    EXPECT_EQ(rocprim::get<0>(t2), 5);
+}
+
+// Empty tuple<> specialisation — compile‑time + runtime
+TEST(EmptyTuple, CompileTimeAndRuntime)
+{
+    using E = rocprim::tuple<>;
+
+    // Compile‑time
+    static_assert(std::is_default_constructible_v<E>);
+    static_assert(std::is_trivially_destructible_v<E>);
+
+    // Runtime: swap is a no‑op but still callable
+    E e1, e2;
+    e1.swap(e2);
+    SUCCEED();
+}
+
+// tuple comparisons: ==, !=, <, >, <=, >=, free swap
+
+// operator== and operator!= on empty tuples
+TEST(TupleComparison, EmptyTuples)
+{
+    rocprim::tuple<> a, b;
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a != b);
+    EXPECT_FALSE(a < b);
+    EXPECT_FALSE(a > b);
+    EXPECT_TRUE(a <= b);
+    EXPECT_TRUE(a >= b);
+}
+
+// operator== and operator!= on non-empty tuples
+TEST(TupleComparison, EqualAndNotEqual)
+{
+    rocprim::tuple<int, char> t1{1, 'a'};
+    rocprim::tuple<int, char> t2{1, 'a'};
+    rocprim::tuple<int, char> t3{2, 'b'};
+
+    EXPECT_TRUE(t1 == t2);
+    EXPECT_FALSE(t1 != t2);
+
+    EXPECT_FALSE(t1 == t3);
+    EXPECT_TRUE(t1 != t3);
+}
+
+// Lexicographical operator<, >, <=, >=
+TEST(TupleComparison, LexicographicalOrder)
+{
+    rocprim::tuple<int, int> a{1, 2};
+    rocprim::tuple<int, int> b{1, 3};
+    rocprim::tuple<int, int> c{2, 0};
+
+    // a < b because 2 < 3 at index 1
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(a > b);
+    EXPECT_TRUE(a <= b);
+    EXPECT_FALSE(a >= b);
+
+    // b < c because 1 < 2 at index 0
+    EXPECT_TRUE(b < c);
+    EXPECT_FALSE(b > c);
+
+    // transitive: a < c
+    EXPECT_TRUE(a < c);
+}
+
+// Free swap calls member swap
+TEST(TupleSwapFree, FreeSwap)
+{
+    rocprim::tuple<int, char> t1{5, 'x'};
+    rocprim::tuple<int, char> t2{6, 'y'};
+
+    swap(t1, t2);
+    EXPECT_EQ(rocprim::get<0>(t1), 6);
+    EXPECT_EQ(rocprim::get<1>(t1), 'y');
+    EXPECT_EQ(rocprim::get<0>(t2), 5);
+    EXPECT_EQ(rocprim::get<1>(t2), 'x');
+}
+
+// get<I> rvalue overload
+TEST(GetRvalue, RvalueReferenceReturn)
+{
+    rocprim::tuple<int, double, char> t{1, 2.0, 'c'};
+    // rvalue get should return T&& and preserve value
+    using R0 = decltype(rocprim::get<0>(std::move(t)));
+    static_assert(std::is_same_v<R0, int&&>);
+    // example use: move out char
+    char c = rocprim::get<2>(rocprim::tuple<int, double, char>{9, 9.9, 'z'});
+    EXPECT_EQ(c, 'z');
+}
+
+// make_tuple: deduce types and handle reference_wrapper
+TEST(MakeTuple, TypeDeductionAndValues)
+{
+    auto t1 = rocprim::make_tuple(10, 3.14, 'x');
+    static_assert(std::is_same_v<decltype(t1), rocprim::tuple<int, double, char>>);
+    EXPECT_EQ(rocprim::get<0>(t1), 10);
+    EXPECT_DOUBLE_EQ(rocprim::get<1>(t1), 3.14);
+    EXPECT_EQ(rocprim::get<2>(t1), 'x');
+
+    int  a  = 5;
+    auto t2 = rocprim::make_tuple(std::ref(a), 7);
+    static_assert(std::is_same_v<decltype(t2), rocprim::tuple<int&, int>>);
+    EXPECT_EQ(rocprim::get<0>(t2), 5);
+    rocprim::get<0>(t2) = 20;
+    EXPECT_EQ(a, 20);
+}
+
+// rocprim::tie and ignore: unpacking and placeholder behavior
+TEST(TieIgnore, TieAssignAndIgnore)
+{
+    int  x = 0;
+    char y = ' ';
+
+    auto tied = rocprim::tie(x, y);
+    static_assert(std::is_same_v<decltype(tied), rocprim::tuple<int&, char&>>);
+    rocprim::tuple<int, char> src{42, 'A'};
+    tied = src; // assigns x=42, y='A'
+    EXPECT_EQ(x, 42);
+    EXPECT_EQ(y, 'A');
+
+    // ignore first element
+    x = 1;
+    y = 'b';
+
+    auto tied2 = rocprim::tie(rocprim::ignore, y);
+    tied2      = rocprim::tuple<int, char>{99, 'Z'};
+    EXPECT_EQ(x, 1); // unchanged
+    EXPECT_EQ(y, 'Z'); // updated
+}

--- a/projects/rocprim/test/rocprim/test_rocprim_types.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_types.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +42,7 @@ using Params = ::testing::Types<char,
 
 template<class T>
 ROCPRIM_HOST_DEVICE
-inline T get_random_full_range(std::uint32_t seed = std::rand())
+inline T get_random_full_range(unsigned int seed = std::rand())
 {
     return test_utils::get_random_value<T>(rocprim::numeric_limits<T>::min(),
                                            rocprim::numeric_limits<T>::max(),
@@ -63,6 +63,11 @@ TYPED_TEST_SUITE(DoubleBufferTest, Params);
 
 TYPED_TEST(DoubleBufferTest, TestDoubleBuffer)
 {
+    // Test default construction
+    rocprim::double_buffer<int> db_default;
+    EXPECT_EQ(db_default.current(), nullptr);
+    EXPECT_EQ(db_default.alternate(), nullptr);
+
     // Test current buffer
     EXPECT_EQ(this->db.current(), &this->value1);
 
@@ -89,6 +94,10 @@ TYPED_TEST_SUITE(FutureValueTest, Params);
 TYPED_TEST(FutureValueTest, TestFutureValue)
 {
     using T = TypeParam;
+
+    // Test const future value
+    const auto cfv = this->fv;
+    EXPECT_EQ(static_cast<T>(cfv), this->value);
 
     // Test value access
     this->value = get_random_full_range<T>();

--- a/projects/rocprim/test/rocprim/test_rocprim_types.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_types.cpp
@@ -49,7 +49,7 @@ inline T get_random_full_range(unsigned int seed = std::rand())
                                            seed);
 }
 
-template <typename T>
+template<typename T>
 class DoubleBufferTest : public ::testing::Test
 {
 protected:
@@ -80,12 +80,12 @@ TYPED_TEST(DoubleBufferTest, TestDoubleBuffer)
     EXPECT_EQ(this->db.alternate(), &this->value1);
 }
 
-template <typename T>
+template<typename T>
 class FutureValueTest : public ::testing::Test
 {
 protected:
     T value{};
-    
+
     rocprim::future_value<T> fv{&value};
 };
 
@@ -102,7 +102,7 @@ TYPED_TEST(FutureValueTest, TestFutureValue)
     // Test value access
     this->value = get_random_full_range<T>();
     EXPECT_EQ(static_cast<TypeParam>(this->fv), this->value);
- 
+
     // Test plain input value
     T val = get_random_full_range<T>();
     EXPECT_EQ(rocprim::detail::get_input_value(val), val);
@@ -118,14 +118,12 @@ struct kv_tag
     using value_type = V;
 };
 
-using TestPairs = ::testing::Types<
-    kv_tag<char, int>,
-//  __half breaks down currently
-//  kv_tag<int, rocprim::half>,
-    kv_tag<unsigned int, double>,
-    kv_tag<long long, float>,
-    kv_tag<unsigned long long, rocprim::uint128_t>
->;
+using TestPairs = ::testing::Types<kv_tag<char, int>,
+                                   //  __half breaks down currently
+                                   //  kv_tag<int, rocprim::half>,
+                                   kv_tag<unsigned int, double>,
+                                   kv_tag<long long, float>,
+                                   kv_tag<unsigned long long, rocprim::uint128_t>>;
 
 template<class Pair>
 class KeyValuePairTest : public ::testing::Test
@@ -139,8 +137,8 @@ TYPED_TEST_SUITE(KeyValuePairTest, TestPairs);
 
 TYPED_TEST(KeyValuePairTest, TestKeyValuePair)
 {
-    using K = typename TestFixture::key_type;
-    using V = typename TestFixture::value_type;
+    using K       = typename TestFixture::key_type;
+    using V       = typename TestFixture::value_type;
     using kv_type = typename TestFixture::kv_type;
 
     K k = get_random_full_range<K>();
@@ -159,25 +157,27 @@ TYPED_TEST(KeyValuePairTest, TestKeyValuePair)
     do
     {
         k_diff = get_random_full_range<K>();
-    } while(k_diff == k);
-    
+    }
+    while(k_diff == k);
+
     do
     {
         v_diff = get_random_full_range<V>();
-    } while(v_diff == v);
+    }
+    while(v_diff == v);
 
     kv_type kv_diff_key{k_diff, v};
     kv_type kv_diff_val{k, v_diff};
 
     // Test operator == and !=
-    EXPECT_TRUE (kv1 == kv2);
+    EXPECT_TRUE(kv1 == kv2);
     EXPECT_FALSE(kv1 != kv2);
 
     EXPECT_FALSE(kv1 == kv_diff_key);
-    EXPECT_TRUE (kv1 != kv_diff_key);
+    EXPECT_TRUE(kv1 != kv_diff_key);
 
     EXPECT_FALSE(kv1 == kv_diff_val);
-    EXPECT_TRUE (kv1 != kv_diff_val);
+    EXPECT_TRUE(kv1 != kv_diff_val);
 }
 
 template<class T>
@@ -185,7 +185,7 @@ class UninitializedArrayTest : public ::testing::Test
 {
 protected:
     static constexpr unsigned int Count = 10;
-    using ua_type = rocprim::uninitialized_array<T, Count>;
+    using ua_type                       = rocprim::uninitialized_array<T, Count>;
 
     ua_type ua;
 };
@@ -204,9 +204,9 @@ TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
     using V = TypeParam;
     for(unsigned int i = 0; i < TestFixture::Count; ++i)
     {
-        V val = get_random_full_range<V>();
-        V& ref = this->ua.emplace(i, val);              // Emplace construction
-        EXPECT_EQ(ref, val);                            // Same value by reference
+        V  val = get_random_full_range<V>();
+        V& ref = this->ua.emplace(i, val); // Emplace construction
+        EXPECT_EQ(ref, val); // Same value by reference
         EXPECT_EQ(this->ua.get_unsafe_array()[i], val); // Same value in array
     }
 
@@ -216,7 +216,7 @@ TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
 
     auto& arr = this->ua.get_unsafe_array();
     EXPECT_EQ(&arr[0], &this->ua.get_unsafe_array()[0]); // Same address
-    EXPECT_EQ(arr[0],  v0);                              // Same content
+    EXPECT_EQ(arr[0], v0); // Same content
 
     for(unsigned int i = 0; i < TestFixture::Count; ++i)
     {
@@ -225,7 +225,7 @@ TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
 
     // Test move construction
     typename TestFixture::ua_type moved{std::move(this->ua)};
-    auto& arr_moved = moved.get_unsafe_array();
+    auto&                         arr_moved = moved.get_unsafe_array();
     for(unsigned int i = 0; i < TestFixture::Count; ++i)
     {
         EXPECT_EQ(arr_moved[i], V(i + 1));

--- a/projects/rocprim/test/rocprim/test_rocprim_types.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_types.cpp
@@ -1,0 +1,75 @@
+// MIT License
+//
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "../common_test_header.hpp"
+
+using Params = ::testing::Types<
+    char,
+    unsigned char,
+    int8_t,
+    uint8_t,
+    short,
+    unsigned short,
+    int16_t,
+    uint16_t,
+    rocprim::half,
+    rocprim::bfloat16,
+    int,
+    unsigned int,
+    int32_t,
+    uint32_t,
+    float,
+    long long,
+    unsigned long long,
+    int64_t,
+    uint64_t,
+    double,
+    rocprim::int128_t,
+    rocprim::uint128_t>;
+
+template <typename T>
+class DoubleBufferTest : public ::testing::Test
+{
+protected:
+    T value1{};
+    T value2{};
+    rocprim::double_buffer<T> db{&value1, &value2};
+};
+
+TYPED_TEST_SUITE(DoubleBufferTest, Params);
+
+TYPED_TEST(DoubleBufferTest, CurrentBuffer)
+{
+    EXPECT_EQ(this->db.current(), &this->value1);
+}
+
+TYPED_TEST(DoubleBufferTest, AlternateBuffer)
+{
+    EXPECT_EQ(this->db.alternate(), &this->value2);
+}
+
+TYPED_TEST(DoubleBufferTest, SwapBuffers)
+{
+    this->db.swap();
+    EXPECT_EQ(this->db.current(), &this->value2);
+    EXPECT_EQ(this->db.alternate(), &this->value1);
+}

--- a/projects/rocprim/test/rocprim/test_rocprim_types.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_types.cpp
@@ -25,27 +25,29 @@
 #include "test_utils.hpp"
 
 using Params = ::testing::Types<char,
-                                unsigned char,
                                 int8_t,
-                                uint8_t,
                                 short,
-                                unsigned short,
-                                int16_t,
                                 uint16_t,
                                 rocprim::half,
                                 rocprim::bfloat16,
                                 int,
                                 unsigned int,
-                                int32_t,
-                                uint32_t,
                                 float,
                                 long long,
                                 unsigned long long,
                                 int64_t,
-                                uint64_t,
                                 double,
                                 rocprim::int128_t,
                                 rocprim::uint128_t>;
+
+template<class T>
+ROCPRIM_HOST_DEVICE
+inline T get_random_full_range(std::uint32_t seed = std::rand())
+{
+    return test_utils::get_random_value<T>(rocprim::numeric_limits<T>::min(),
+                                           rocprim::numeric_limits<T>::max(),
+                                           seed);
+}
 
 template <typename T>
 class DoubleBufferTest : public ::testing::Test
@@ -59,17 +61,17 @@ protected:
 
 TYPED_TEST_SUITE(DoubleBufferTest, Params);
 
-TYPED_TEST(DoubleBufferTest, CurrentBuffer)
+TYPED_TEST(DoubleBufferTest, CurrentBufferTest)
 {
     EXPECT_EQ(this->db.current(), &this->value1);
 }
 
-TYPED_TEST(DoubleBufferTest, AlternateBuffer)
+TYPED_TEST(DoubleBufferTest, AlternateBufferTest)
 {
     EXPECT_EQ(this->db.alternate(), &this->value2);
 }
 
-TYPED_TEST(DoubleBufferTest, SwapBuffers)
+TYPED_TEST(DoubleBufferTest, SwapBuffersTest)
 {
     this->db.swap();
     EXPECT_EQ(this->db.current(), &this->value2);
@@ -80,35 +82,114 @@ template <typename T>
 class FutureValueTest : public ::testing::Test
 {
 protected:
-    using ValueType = T;
+    using value_type = T;
 
-    ValueType value{};
+    value_type value{};
     
-    rocprim::future_value<ValueType> fv{&value};
+    rocprim::future_value<value_type> fv{&value};
 };
 
 TYPED_TEST_SUITE(FutureValueTest, Params);
 
-TYPED_TEST(FutureValueTest, ValueAccess)
+TYPED_TEST(FutureValueTest, MemberAccessTest)
 {
-    using T = typename TestFixture::ValueType;
+    using T = typename TestFixture::value_type;
 
-    this->value = test_utils::get_random_value<T>(0, 100, rand());
+    this->value = get_random_full_range<T>();
     EXPECT_EQ(static_cast<TypeParam>(this->fv), this->value);
 }
 
-TYPED_TEST(FutureValueTest, GetInputValuePlain)
+TYPED_TEST(FutureValueTest, GetInputValuePlainTest)
 {
-    using T = typename TestFixture::ValueType;
+    using T = typename TestFixture::value_type;
     
-    T val = test_utils::get_random_value<T>(0, 100, rand());
+    T val = get_random_full_range<T>();
     EXPECT_EQ(rocprim::detail::get_input_value(val), val);
 }
 
-TYPED_TEST(FutureValueTest, GetInputValueFuture)
+TYPED_TEST(FutureValueTest, GetInputValueFutureTest)
 {
-    using T = typename TestFixture::ValueType;
+    using T = typename TestFixture::value_type;
     
-    this->value = test_utils::get_random_value<T>(0, 100, rand());
+    this->value = get_random_full_range<T>();
     EXPECT_EQ(rocprim::detail::get_input_value(this->fv), this->value);
+}
+
+template<class K, class V>
+struct kv_tag
+{
+    using key_type   = K;
+    using value_type = V;
+};
+
+using TestPairs = ::testing::Types<
+    kv_tag<char, int>,
+//  __half breaks down currently
+//  kv_tag<int, rocprim::half>,
+    kv_tag<unsigned int, double>,
+    kv_tag<long long, float>,
+    kv_tag<unsigned long long, rocprim::uint128_t>
+>;
+
+template<class Pair>
+class KeyValuePairTest : public ::testing::Test
+{
+protected:
+    using key_type   = typename Pair::key_type;
+    using value_type = typename Pair::value_type;
+    using kv_type    = rocprim::key_value_pair<key_type, value_type>;
+};
+TYPED_TEST_SUITE(KeyValuePairTest, TestPairs);
+
+TYPED_TEST(KeyValuePairTest, MemberAccessTest)
+{
+    using K = typename TestFixture::key_type;
+    using V = typename TestFixture::value_type;
+    using kv_type = typename TestFixture::kv_type;
+
+    K k = get_random_full_range<K>();
+    V v = get_random_full_range<V>();
+
+    kv_type kv{k, v};
+
+    EXPECT_EQ(kv.key,   k);
+    EXPECT_EQ(kv.value, v);
+}
+
+TYPED_TEST(KeyValuePairTest, EqualityOperatorTest)
+{
+    using K = typename TestFixture::key_type;
+    using V = typename TestFixture::value_type;
+    using kv_type = typename TestFixture::kv_type;
+
+    K k = get_random_full_range<K>();
+    V v = get_random_full_range<V>();
+
+    kv_type kv1{k, v};
+    kv_type kv2{k, v};
+
+    K k_diff;
+    V v_diff;
+
+    do
+    {
+        k_diff = get_random_full_range<K>();
+    } while(k_diff == k);
+    
+    do
+    {
+        v_diff = get_random_full_range<V>();
+    } while(v_diff == v);
+
+    kv_type kv_diff_key{k_diff, v};
+    kv_type kv_diff_val{k, v_diff};
+
+    EXPECT_TRUE (kv1 == kv2);
+    EXPECT_FALSE(kv1 != kv2);
+
+    EXPECT_FALSE(kv1 == kv_diff_key);
+    EXPECT_TRUE (kv1 != kv_diff_key);
+
+    EXPECT_FALSE(kv1 == kv_diff_val);
+    EXPECT_TRUE (kv1 != kv_diff_val);
 }

--- a/projects/rocprim/test/rocprim/test_rocprim_types.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_types.cpp
@@ -22,29 +22,30 @@
 
 #include "../common_test_header.hpp"
 
-using Params = ::testing::Types<
-    char,
-    unsigned char,
-    int8_t,
-    uint8_t,
-    short,
-    unsigned short,
-    int16_t,
-    uint16_t,
-    rocprim::half,
-    rocprim::bfloat16,
-    int,
-    unsigned int,
-    int32_t,
-    uint32_t,
-    float,
-    long long,
-    unsigned long long,
-    int64_t,
-    uint64_t,
-    double,
-    rocprim::int128_t,
-    rocprim::uint128_t>;
+#include "test_utils.hpp"
+
+using Params = ::testing::Types<char,
+                                unsigned char,
+                                int8_t,
+                                uint8_t,
+                                short,
+                                unsigned short,
+                                int16_t,
+                                uint16_t,
+                                rocprim::half,
+                                rocprim::bfloat16,
+                                int,
+                                unsigned int,
+                                int32_t,
+                                uint32_t,
+                                float,
+                                long long,
+                                unsigned long long,
+                                int64_t,
+                                uint64_t,
+                                double,
+                                rocprim::int128_t,
+                                rocprim::uint128_t>;
 
 template <typename T>
 class DoubleBufferTest : public ::testing::Test
@@ -52,6 +53,7 @@ class DoubleBufferTest : public ::testing::Test
 protected:
     T value1{};
     T value2{};
+
     rocprim::double_buffer<T> db{&value1, &value2};
 };
 
@@ -72,4 +74,41 @@ TYPED_TEST(DoubleBufferTest, SwapBuffers)
     this->db.swap();
     EXPECT_EQ(this->db.current(), &this->value2);
     EXPECT_EQ(this->db.alternate(), &this->value1);
+}
+
+template <typename T>
+class FutureValueTest : public ::testing::Test
+{
+protected:
+    using ValueType = T;
+
+    ValueType value{};
+    
+    rocprim::future_value<ValueType> fv{&value};
+};
+
+TYPED_TEST_SUITE(FutureValueTest, Params);
+
+TYPED_TEST(FutureValueTest, ValueAccess)
+{
+    using T = typename TestFixture::ValueType;
+
+    this->value = test_utils::get_random_value<T>(0, 100, rand());
+    EXPECT_EQ(static_cast<TypeParam>(this->fv), this->value);
+}
+
+TYPED_TEST(FutureValueTest, GetInputValuePlain)
+{
+    using T = typename TestFixture::ValueType;
+    
+    T val = test_utils::get_random_value<T>(0, 100, rand());
+    EXPECT_EQ(rocprim::detail::get_input_value(val), val);
+}
+
+TYPED_TEST(FutureValueTest, GetInputValueFuture)
+{
+    using T = typename TestFixture::ValueType;
+    
+    this->value = test_utils::get_random_value<T>(0, 100, rand());
+    EXPECT_EQ(rocprim::detail::get_input_value(this->fv), this->value);
 }

--- a/projects/rocprim/test/rocprim/test_rocprim_types.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_types.cpp
@@ -79,18 +79,16 @@ template <typename T>
 class FutureValueTest : public ::testing::Test
 {
 protected:
-    using value_type = T;
-
-    value_type value{};
+    T value{};
     
-    rocprim::future_value<value_type> fv{&value};
+    rocprim::future_value<T> fv{&value};
 };
 
 TYPED_TEST_SUITE(FutureValueTest, Params);
 
 TYPED_TEST(FutureValueTest, TestFutureValue)
 {
-    using T = typename TestFixture::value_type;
+    using T = TypeParam;
 
     // Test value access
     this->value = get_random_full_range<T>();
@@ -171,4 +169,56 @@ TYPED_TEST(KeyValuePairTest, TestKeyValuePair)
 
     EXPECT_FALSE(kv1 == kv_diff_val);
     EXPECT_TRUE (kv1 != kv_diff_val);
+}
+
+template<class T>
+class UninitializedArrayTest : public ::testing::Test
+{
+protected:
+    static constexpr unsigned int Count = 10;
+    using ua_type = rocprim::uninitialized_array<T, Count>;
+
+    ua_type ua;
+};
+TYPED_TEST_SUITE(UninitializedArrayTest, Params);
+
+TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
+{
+    // Test class traits
+    using ua = typename TestFixture::ua_type;
+    static_assert(!std::is_copy_constructible<ua>::value, "Should not be copy-constructible");
+    static_assert(!std::is_copy_assignable<ua>::value, "Should not be copy-assignable");
+    static_assert(std::is_move_constructible<ua>::value, "Should be move-constructible");
+    static_assert(std::is_move_assignable<ua>::value, "Should be move-assignable");
+
+    // Test emplace construction
+    using V = TypeParam;
+    for(unsigned int i = 0; i < TestFixture::Count; ++i)
+    {
+        V val = get_random_full_range<V>();
+        V& ref = this->ua.emplace(i, val);              // Emplace construction
+        EXPECT_EQ(ref, val);                            // Same value by reference
+        EXPECT_EQ(this->ua.get_unsafe_array()[i], val); // Same value in array
+    }
+
+    // Test memory consistency
+    V v0 = get_random_full_range<V>();
+    this->ua.emplace(0, v0);
+
+    auto& arr = this->ua.get_unsafe_array();
+    EXPECT_EQ(&arr[0], &this->ua.get_unsafe_array()[0]); // Same address
+    EXPECT_EQ(arr[0],  v0);                              // Same content
+
+    for(unsigned int i = 0; i < TestFixture::Count; ++i)
+    {
+        this->ua.emplace(i, V(i + 1));
+    }
+
+    // Test move construction
+    typename TestFixture::ua_type moved{std::move(this->ua)};
+    auto& arr_moved = moved.get_unsafe_array();
+    for(unsigned int i = 0; i < TestFixture::Count; ++i)
+    {
+        EXPECT_EQ(arr_moved[i], V(i + 1));
+    }
 }

--- a/projects/rocprim/test/rocprim/test_rocprim_types.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_types.cpp
@@ -61,18 +61,15 @@ protected:
 
 TYPED_TEST_SUITE(DoubleBufferTest, Params);
 
-TYPED_TEST(DoubleBufferTest, CurrentBufferTest)
+TYPED_TEST(DoubleBufferTest, TestDoubleBuffer)
 {
+    // Test current buffer
     EXPECT_EQ(this->db.current(), &this->value1);
-}
 
-TYPED_TEST(DoubleBufferTest, AlternateBufferTest)
-{
+    // Test alternate buffer
     EXPECT_EQ(this->db.alternate(), &this->value2);
-}
 
-TYPED_TEST(DoubleBufferTest, SwapBuffersTest)
-{
+    // Test swap buffers
     this->db.swap();
     EXPECT_EQ(this->db.current(), &this->value2);
     EXPECT_EQ(this->db.alternate(), &this->value1);
@@ -91,27 +88,19 @@ protected:
 
 TYPED_TEST_SUITE(FutureValueTest, Params);
 
-TYPED_TEST(FutureValueTest, MemberAccessTest)
+TYPED_TEST(FutureValueTest, TestFutureValue)
 {
     using T = typename TestFixture::value_type;
 
+    // Test value access
     this->value = get_random_full_range<T>();
     EXPECT_EQ(static_cast<TypeParam>(this->fv), this->value);
-}
-
-TYPED_TEST(FutureValueTest, GetInputValuePlainTest)
-{
-    using T = typename TestFixture::value_type;
-    
+ 
+    // Test plain input value
     T val = get_random_full_range<T>();
     EXPECT_EQ(rocprim::detail::get_input_value(val), val);
-}
 
-TYPED_TEST(FutureValueTest, GetInputValueFutureTest)
-{
-    using T = typename TestFixture::value_type;
-    
-    this->value = get_random_full_range<T>();
+    // Test future input value
     EXPECT_EQ(rocprim::detail::get_input_value(this->fv), this->value);
 }
 
@@ -141,22 +130,7 @@ protected:
 };
 TYPED_TEST_SUITE(KeyValuePairTest, TestPairs);
 
-TYPED_TEST(KeyValuePairTest, MemberAccessTest)
-{
-    using K = typename TestFixture::key_type;
-    using V = typename TestFixture::value_type;
-    using kv_type = typename TestFixture::kv_type;
-
-    K k = get_random_full_range<K>();
-    V v = get_random_full_range<V>();
-
-    kv_type kv{k, v};
-
-    EXPECT_EQ(kv.key,   k);
-    EXPECT_EQ(kv.value, v);
-}
-
-TYPED_TEST(KeyValuePairTest, EqualityOperatorTest)
+TYPED_TEST(KeyValuePairTest, TestKeyValuePair)
 {
     using K = typename TestFixture::key_type;
     using V = typename TestFixture::value_type;
@@ -167,6 +141,10 @@ TYPED_TEST(KeyValuePairTest, EqualityOperatorTest)
 
     kv_type kv1{k, v};
     kv_type kv2{k, v};
+
+    // Test value access
+    EXPECT_EQ(kv1.key, k);
+    EXPECT_EQ(kv1.value, v);
 
     K k_diff;
     V v_diff;
@@ -184,6 +162,7 @@ TYPED_TEST(KeyValuePairTest, EqualityOperatorTest)
     kv_type kv_diff_key{k_diff, v};
     kv_type kv_diff_val{k, v_diff};
 
+    // Test operator == and !=
     EXPECT_TRUE (kv1 == kv2);
     EXPECT_FALSE(kv1 != kv2);
 

--- a/projects/rocprim/test/rocprim/test_rocprim_types.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_types.cpp
@@ -63,21 +63,23 @@ TYPED_TEST_SUITE(DoubleBufferTest, Params);
 
 TYPED_TEST(DoubleBufferTest, TestDoubleBuffer)
 {
+    using T = TypeParam;
+
     // Test default construction
-    rocprim::double_buffer<int> db_default;
-    EXPECT_EQ(db_default.current(), nullptr);
-    EXPECT_EQ(db_default.alternate(), nullptr);
+    rocprim::double_buffer<T> db_default;
+    test_utils::assert_eq(db_default.current(), static_cast<T*>(nullptr));
+    test_utils::assert_eq(db_default.alternate(), static_cast<T*>(nullptr));
 
     // Test current buffer
-    EXPECT_EQ(this->db.current(), &this->value1);
+    test_utils::assert_eq(this->db.current(), &this->value1);
 
     // Test alternate buffer
-    EXPECT_EQ(this->db.alternate(), &this->value2);
+    test_utils::assert_eq(this->db.alternate(), &this->value2);
 
     // Test swap buffers
     this->db.swap();
-    EXPECT_EQ(this->db.current(), &this->value2);
-    EXPECT_EQ(this->db.alternate(), &this->value1);
+    test_utils::assert_eq(this->db.current(), &this->value2);
+    test_utils::assert_eq(this->db.alternate(), &this->value1);
 }
 
 template<typename T>
@@ -97,18 +99,18 @@ TYPED_TEST(FutureValueTest, TestFutureValue)
 
     // Test const future value
     const auto cfv = this->fv;
-    EXPECT_EQ(static_cast<T>(cfv), this->value);
+    test_utils::assert_eq(static_cast<T>(cfv), this->value);
 
     // Test value access
     this->value = get_random_full_range<T>();
-    EXPECT_EQ(static_cast<TypeParam>(this->fv), this->value);
+    test_utils::assert_eq(static_cast<TypeParam>(this->fv), this->value);
 
     // Test plain input value
     T val = get_random_full_range<T>();
-    EXPECT_EQ(rocprim::detail::get_input_value(val), val);
+    test_utils::assert_eq(rocprim::detail::get_input_value(val), val);
 
     // Test future input value
-    EXPECT_EQ(rocprim::detail::get_input_value(this->fv), this->value);
+    test_utils::assert_eq(rocprim::detail::get_input_value(this->fv), this->value);
 }
 
 template<class K, class V>
@@ -148,8 +150,8 @@ TYPED_TEST(KeyValuePairTest, TestKeyValuePair)
     kv_type kv2{k, v};
 
     // Test value access
-    EXPECT_EQ(kv1.key, k);
-    EXPECT_EQ(kv1.value, v);
+    test_utils::assert_eq(kv1.key, k);
+    test_utils::assert_eq(kv1.value, v);
 
     K k_diff;
     V v_diff;
@@ -206,8 +208,8 @@ TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
     {
         V  val = get_random_full_range<V>();
         V& ref = this->ua.emplace(i, val); // Emplace construction
-        EXPECT_EQ(ref, val); // Same value by reference
-        EXPECT_EQ(this->ua.get_unsafe_array()[i], val); // Same value in array
+        test_utils::assert_eq(ref, val); // Same value by reference
+        test_utils::assert_eq(this->ua.get_unsafe_array()[i], val); // Same value in array
     }
 
     // Test memory consistency
@@ -215,8 +217,8 @@ TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
     this->ua.emplace(0, v0);
 
     auto& arr = this->ua.get_unsafe_array();
-    EXPECT_EQ(&arr[0], &this->ua.get_unsafe_array()[0]); // Same address
-    EXPECT_EQ(arr[0], v0); // Same content
+    test_utils::assert_eq(&arr[0], &this->ua.get_unsafe_array()[0]); // Same address
+    test_utils::assert_eq(arr[0], v0); // Same content
 
     for(unsigned int i = 0; i < TestFixture::Count; ++i)
     {
@@ -228,6 +230,6 @@ TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
     auto&                         arr_moved = moved.get_unsafe_array();
     for(unsigned int i = 0; i < TestFixture::Count; ++i)
     {
-        EXPECT_EQ(arr_moved[i], V(i + 1));
+        test_utils::assert_eq(arr_moved[i], V(i + 1));
     }
 }

--- a/projects/rocprim/test/rocprim/test_texture_cache_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_texture_cache_iterator.cpp
@@ -26,7 +26,9 @@
 #include "../../common/utils_device_ptr.hpp"
 
 // required test headers
+#include "test_utils_assertions.hpp"
 #include "test_utils_data_generation.hpp"
+#include "test_utils_get_random_data.hpp"
 
 // required rocprim headers
 #include <rocprim/device/device_transform.hpp>
@@ -140,5 +142,113 @@ TYPED_TEST(RocprimTextureCacheIteratorTests, Transform)
         }
 
         HIP_CHECK(x.unbind_texture());
+    }
+}
+
+template<typename T, int NumOps>
+__global__
+void texture_iterator_kernel(rocprim::texture_cache_iterator<T> it, T* input, int* output)
+{
+    const int i = threadIdx.x * NumOps;
+
+    // Test dereference
+    output[i] = (*it == input[0]);
+
+    // Test pre-increment
+    ++it;
+    output[i + 1] = (*it == input[1]);
+
+    // Test post-increment
+    rocprim::texture_cache_iterator<T> temp = it++;
+    output[i + 2]                           = (*temp == input[1]);
+    output[i + 3]                           = (*it == input[2]);
+
+    // Test +=
+    it += 2;
+    output[i + 4] = (*it == input[4]);
+
+    // Test -=
+    it -= 2;
+    output[i + 5] = (*it == input[2]);
+
+    // Indexing
+    output[i + 6] = (it[1] == input[3]);
+
+    // Addition
+    auto it_plus  = it + 2;
+    output[i + 7] = (*it_plus == input[4]);
+    output[i + 8] = (*(2 + it) == input[4]);
+
+    // Subtraction
+    auto it_minus = it_plus - 2;
+    output[i + 9] = (*it_minus == input[2]);
+
+    auto begin = it - 2;
+    auto end   = it + 2;
+
+    // Comparisons
+    output[i + 10] = (begin == begin) ? true : false;
+    output[i + 11] = (begin != end) ? true : false;
+    output[i + 12] = (begin < end) ? true : false;
+    output[i + 13] = (end > begin) ? true : false;
+    output[i + 14] = (begin <= begin) ? true : false;
+    output[i + 15] = (begin <= end) ? true : false;
+    output[i + 16] = (end >= begin) ? true : false;
+    output[i + 17] = (end >= end) ? true : false;
+
+    // Substracting iterators
+    output[i + 18] = ((end - begin) == 4);
+}
+
+TYPED_TEST(RocprimTextureCacheIteratorTests, DeviceIteratorOps)
+{
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+
+    hipDeviceProp_t props;
+    HIP_CHECK(hipGetDeviceProperties(&props, device_id));
+    std::string deviceName = std::string(props.gcnArchName);
+    if(deviceName.rfind("gfx94", 0) == 0 || deviceName.rfind("gfx120", 0) == 0
+       || deviceName.rfind("gfx95", 0) == 0)
+    {
+        GTEST_SKIP()
+            << "Test not run on gfx94x, gfx120x, or gfx95x as texture cache API is not supported";
+    }
+
+    HIP_CHECK(hipSetDevice(device_id));
+
+    using T        = typename TestFixture::input_type;
+    using Iterator = rocprim::texture_cache_iterator<T>;
+
+    constexpr int num_threads  = 10;
+    constexpr int num_ops      = 19;
+    constexpr int result_count = num_threads * num_ops;
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        std::vector<T> input = test_utils::get_random_data_wrapped<T>(10, 1, 200, seed_value);
+
+        common::device_ptr<T>   d_input(input);
+        common::device_ptr<int> d_output(result_count);
+
+        Iterator it;
+        HIP_CHECK(it.bind_texture(d_input.get(), sizeof(T) * input.size()));
+
+        texture_iterator_kernel<T, num_ops>
+            <<<dim3(1), dim3(num_threads), 0, 0>>>(it, d_input.get(), d_output.get());
+
+        HIP_CHECK(hipDeviceSynchronize());
+        HIP_CHECK(hipGetLastError());
+
+        std::vector<int> host_output = d_output.load();
+        std::vector<int> expected(result_count, true);
+
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(host_output, expected));
+
+        HIP_CHECK(it.unbind_texture());
     }
 }

--- a/projects/rocprim/test/rocprim/test_thread_algos.cpp
+++ b/projects/rocprim/test/rocprim/test_thread_algos.cpp
@@ -302,7 +302,7 @@ template<class Type, int32_t Length>
 __global__
 void thread_reduce_kernel_array_prefix(Type* const device_input, Type* device_output, Type prefix)
 {
-    size_t index        = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
+    size_t index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
 
     Type device_input_array[Length];
     for(int32_t i = 0; i < Length; i++)
@@ -389,7 +389,9 @@ void thread_scan_inclusive_kernel(Type* const device_input, Type* device_output)
 
 template<class Type, int32_t Length>
 __global__
-void thread_scan_inclusive_kernel_array_prefix(Type* const device_input, Type* device_output, Type prefix)
+void thread_scan_inclusive_kernel_array_prefix(Type* const device_input,
+                                               Type*       device_output,
+                                               Type        prefix)
 {
     size_t index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
 

--- a/projects/rocprim/test/rocprim/test_thread_algos.cpp
+++ b/projects/rocprim/test/rocprim/test_thread_algos.cpp
@@ -36,7 +36,6 @@
 #include "test_utils_assertions.hpp"
 #include "test_utils_data_generation.hpp"
 
-#include <cstdint>
 #include <rocprim/config.hpp>
 #include <rocprim/functional.hpp>
 #include <rocprim/intrinsics/thread.hpp>

--- a/projects/rocprim/test/rocprim/test_thread_algos.cpp
+++ b/projects/rocprim/test/rocprim/test_thread_algos.cpp
@@ -36,6 +36,7 @@
 #include "test_utils_assertions.hpp"
 #include "test_utils_data_generation.hpp"
 
+#include <cstdint>
 #include <rocprim/config.hpp>
 #include <rocprim/functional.hpp>
 #include <rocprim/intrinsics/thread.hpp>
@@ -292,23 +293,39 @@ template<class Type, int32_t Length>
 __global__
 void thread_reduce_kernel(Type* const device_input, Type* device_output)
 {
-    size_t input_index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
-    size_t output_index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
-    device_output[output_index] = rocprim::thread_reduce<Length>(&device_input[input_index], sum_op());
+    size_t index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
+
+    device_output[index] = rocprim::thread_reduce<Length>(&device_input[index], sum_op());
+}
+
+template<class Type, int32_t Length>
+__global__
+void thread_reduce_kernel_array_prefix(Type* const device_input, Type* device_output, Type prefix)
+{
+    size_t index        = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
+
+    Type device_input_array[Length];
+    for(int32_t i = 0; i < Length; i++)
+    {
+        device_input_array[i] = device_input[index + i];
+    }
+
+    device_output[index] = rocprim::thread_reduce(device_input_array, sum_op(), prefix);
 }
 
 TYPED_TEST(RocprimThreadOperationTests, Reduction)
 {
-    using T = typename TestFixture::type;
-    static constexpr uint32_t length = 4;
+    using T                              = typename TestFixture::type;
+    static constexpr uint32_t length     = 4;
     static constexpr uint32_t block_size = 128 / length;
-    static constexpr uint32_t grid_size = 128;
-    static constexpr uint32_t size = block_size * grid_size * length;
-    sum_op operation;
+    static constexpr uint32_t grid_size  = 128;
+    static constexpr uint32_t size       = block_size * grid_size * length;
+    sum_op                    operation;
 
     for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
     {
-        unsigned int seed_value = seed_index < random_seeds_count  ? rand() : seeds[seed_index - random_seeds_count];
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
         SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
 
         // Generate data
@@ -316,64 +333,92 @@ TYPED_TEST(RocprimThreadOperationTests, Reduction)
         std::vector<T> output(size);
         std::vector<T> expected(size);
 
-        // Calculate expected results on host
-        for(uint32_t grid_index = 0; grid_index < grid_size; grid_index++)
+        for(uint32_t prefix = 0; prefix < 2; prefix++)
         {
-            for(uint32_t i = 0; i < block_size; i++)
+            // Calculate expected results on host
+            for(uint32_t grid_index = 0; grid_index < grid_size; grid_index++)
             {
-                uint32_t offset = (grid_index * block_size + i) * length;
-                T result = T(0);
-                for(uint32_t j = 0; j < length; j++)
+                for(uint32_t i = 0; i < block_size; i++)
                 {
-                    result = operation(result, input[offset + j]);
+                    uint32_t offset = (grid_index * block_size + i) * length;
+                    T        result = T(prefix);
+                    for(uint32_t j = 0; j < length; j++)
+                    {
+                        result = operation(result, input[offset + j]);
+                    }
+                    expected[offset] = result;
                 }
-                expected[offset] = result;
             }
-        }
 
-        // Preparing device
-        common::device_ptr<T> device_input(input);
-        common::device_ptr<T> device_output(input.size());
+            // Preparing device
+            common::device_ptr<T> device_input(input);
+            common::device_ptr<T> device_output(input.size());
+            if(prefix == 0)
+            {
+                thread_reduce_kernel<T, length>
+                    <<<grid_size, block_size>>>(device_input.get(), device_output.get());
+            }
+            else
+            {
+                thread_reduce_kernel_array_prefix<T, length>
+                    <<<grid_size, block_size>>>(device_input.get(), device_output.get(), T(prefix));
+            }
 
-        thread_reduce_kernel<T, length>
-            <<<grid_size, block_size>>>(device_input.get(), device_output.get());
-        HIP_CHECK(hipGetLastError());
+            HIP_CHECK(hipGetLastError());
 
-        // Reading results back
-        output = device_output.load();
+            // Reading results back
+            output = device_output.load();
 
-        // Verifying results
-        for(size_t i = 0; i < output.size(); i+=length)
-        {
-            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[i], expected[i]));
+            // Verifying results
+            for(size_t i = 0; i < output.size(); i += length)
+            {
+                ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[i], expected[i]));
+            }
         }
     }
 }
 
 template<class Type, int32_t Length>
 __global__
-void thread_scan_kernel(Type* const device_input, Type* device_output)
+void thread_scan_inclusive_kernel(Type* const device_input, Type* device_output)
 {
-    size_t input_index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
-    size_t output_index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
+    size_t index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
 
-    rocprim::thread_scan_inclusive<Length>(&device_input[input_index],
-                                                  &device_output[output_index],
-                                                  sum_op());
+    rocprim::thread_scan_inclusive<Length>(&device_input[index], &device_output[index], sum_op());
 }
 
-TYPED_TEST(RocprimThreadOperationTests, Scan)
+template<class Type, int32_t Length>
+__global__
+void thread_scan_inclusive_kernel_array_prefix(Type* const device_input, Type* device_output, Type prefix)
 {
-    using T = typename TestFixture::type;
-    static constexpr uint32_t length = 4;
+    size_t index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
+
+    Type device_input_array[Length];
+    for(int32_t i = 0; i < Length; i++)
+    {
+        device_input_array[i] = device_input[index + i];
+    }
+
+    rocprim::thread_scan_inclusive<Length>(&device_input[index],
+                                           &device_output[index],
+                                           sum_op(),
+                                           prefix,
+                                           threadIdx.x > 0);
+}
+
+TYPED_TEST(RocprimThreadOperationTests, ScanInclusive)
+{
+    using T                              = typename TestFixture::type;
+    static constexpr uint32_t length     = 4;
     static constexpr uint32_t block_size = 128 / length;
-    static constexpr uint32_t grid_size = 128;
-    static constexpr uint32_t size = block_size * grid_size * length;
-    sum_op operation;
+    static constexpr uint32_t grid_size  = 128;
+    static constexpr uint32_t size       = block_size * grid_size * length;
+    sum_op                    operation;
 
     for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
     {
-        unsigned int seed_value = seed_index < random_seeds_count  ? rand() : seeds[seed_index - random_seeds_count];
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
         SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
 
         // Generate data
@@ -381,18 +426,112 @@ TYPED_TEST(RocprimThreadOperationTests, Scan)
         std::vector<T> output(size);
         std::vector<T> expected(size);
 
+        for(uint32_t prefix = 0; prefix < 2; prefix++)
+        {
+            // Calculate expected results on host
+            for(uint32_t grid_index = 0; grid_index < grid_size; grid_index++)
+            {
+                for(uint32_t i = 0; i < block_size; i++)
+                {
+                    uint32_t offset = (grid_index * block_size + i) * length;
+                    // Skip the first value of every block
+                    T result         = i > 0 ? T(prefix) : T(0);
+                    expected[offset] = result;
+                    for(uint32_t j = 0; j < length; j++)
+                    {
+                        result               = operation(result, input[offset + j]);
+                        expected[offset + j] = result;
+                    }
+                }
+            }
+
+            // Preparing device
+            common::device_ptr<T> device_input(input);
+            common::device_ptr<T> device_output(input.size());
+            if(prefix == 0)
+            {
+                thread_scan_inclusive_kernel<T, length>
+                    <<<grid_size, block_size>>>(device_input.get(), device_output.get());
+            }
+            else
+            {
+                thread_scan_inclusive_kernel_array_prefix<T, length>
+                    <<<grid_size, block_size>>>(device_input.get(), device_output.get(), T(prefix));
+            }
+            HIP_CHECK(hipGetLastError());
+
+            // Reading results back
+            output = device_output.load();
+
+            // Verifying results
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
+        }
+    }
+}
+
+template<class Type, int32_t Length>
+__global__
+void thread_scan_exclusive_kernel(Type* const device_input, Type* device_output, Type prefix)
+{
+    size_t index = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
+
+    Type device_input_array[Length];
+    for(int32_t i = 0; i < Length; i++)
+    {
+        device_input_array[i] = device_input[index + i];
+    }
+
+    rocprim::thread_scan_exclusive<Length>(&device_input[index],
+                                           &device_output[index],
+                                           sum_op(),
+                                           prefix,
+                                           threadIdx.x > 0);
+}
+
+TYPED_TEST(RocprimThreadOperationTests, ScanExclusive)
+{
+    using T                              = typename TestFixture::type;
+    static constexpr uint32_t length     = 4;
+    static constexpr uint32_t block_size = 128 / length;
+    static constexpr uint32_t grid_size  = 128;
+    static constexpr uint32_t size       = block_size * grid_size * length;
+    sum_op                    operation;
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        // Generate data
+        std::vector<T> input = test_utils::get_random_data_wrapped<T>(size, 2, 200, seed_value);
+        std::vector<T> output(size);
+        std::vector<T> expected(size);
+        T              prefix = test_utils::get_random_value<T>(2, 200, seed_value);
+
         // Calculate expected results on host
         for(uint32_t grid_index = 0; grid_index < grid_size; grid_index++)
         {
             for(uint32_t i = 0; i < block_size; i++)
             {
                 uint32_t offset = (grid_index * block_size + i) * length;
-                T result = input[offset];
-                expected[offset] = result;
+
+                // Initialize the scan with the first value and apply prefix if needed
+                T inclusive = input[offset];
+                inclusive   = i > 0 ? operation(prefix, inclusive) : inclusive;
+
+                // First output value is the prefix
+                expected[offset] = prefix;
+
+                // Exclusive value to track for the next element
+                T exclusive = inclusive;
+
+                // Perform the rest of the scan
                 for(uint32_t j = 1; j < length; j++)
                 {
-                    result = operation(result, input[offset + j]);
-                    expected[offset + j] = result;
+                    inclusive            = operation(exclusive, input[offset + j]);
+                    expected[offset + j] = exclusive;
+                    exclusive            = inclusive;
                 }
             }
         }
@@ -401,8 +540,9 @@ TYPED_TEST(RocprimThreadOperationTests, Scan)
         common::device_ptr<T> device_input(input);
         common::device_ptr<T> device_output(input.size());
 
-        thread_scan_kernel<T, length>
-            <<<grid_size, block_size>>>(device_input.get(), device_output.get());
+        thread_scan_exclusive_kernel<T, length>
+            <<<grid_size, block_size>>>(device_input.get(), device_output.get(), prefix);
+
         HIP_CHECK(hipGetLastError());
 
         // Reading results back
@@ -575,4 +715,77 @@ TYPED_TEST(RocprimThreadOperationTests, Search)
     using OffsetT = unsigned int;
     merge_path_search_test<T, OffsetT, rocprim::less<T>>();
     merge_path_search_test<T, OffsetT, rocprim::greater<T>>();
+}
+
+template<class Type, class OffsetT, OffsetT Length>
+__global__
+void upper_lower_bound_kernel(Type* const device_input, OffsetT* device_output, Type value)
+{
+    size_t index_input  = (blockIdx.x * blockDim.x + threadIdx.x) * Length;
+    size_t index_output = (blockIdx.x * blockDim.x + threadIdx.x) * 3;
+
+    device_output[index_output] = rocprim::lower_bound(&device_input[index_input], Length, value);
+    device_output[index_output + 1]
+        = rocprim::upper_bound(&device_input[index_input], Length, value);
+    device_output[index_output + 2]
+        = rocprim::static_upper_bound<Length>(&device_input[index_input], Length, value);
+}
+
+TYPED_TEST(RocprimThreadOperationTests, UpperLowerBound)
+{
+    using T                              = typename TestFixture::type;
+    using OffsetT                        = uint32_t;
+    static constexpr uint32_t length     = 16;
+    static constexpr uint32_t block_size = 256 / length;
+    static constexpr uint32_t grid_size  = 128;
+    static constexpr uint32_t size       = block_size * grid_size * length;
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        // Generate data
+        std::vector<T> input = test_utils::get_random_data_wrapped<T>(size, 1, 10, seed_value);
+        std::vector<OffsetT> output(block_size * grid_size * 3);
+        std::vector<OffsetT> expected(block_size * grid_size * 3);
+        T                    value = test_utils::get_random_value<T>(1, 10, seed_value);
+
+        // Calculate expected results on host
+        for(uint32_t grid_index = 0; grid_index < grid_size; grid_index++)
+        {
+            for(uint32_t i = 0; i < block_size; i++)
+            {
+                uint32_t offset          = (grid_index * block_size + i) * length;
+                uint32_t offset_expected = (grid_index * block_size + i) * 3;
+
+                expected[offset_expected] = std::lower_bound(input.begin() + offset,
+                                                             input.begin() + offset + length,
+                                                             value)
+                                            - (input.begin() + offset);
+                expected[offset_expected + 1] = std::upper_bound(input.begin() + offset,
+                                                                 input.begin() + offset + length,
+                                                                 value)
+                                                - (input.begin() + offset);
+
+                expected[offset_expected + 2] = expected[offset_expected + 1];
+            }
+        }
+
+        // Preparing device
+        common::device_ptr<T>       device_input(input);
+        common::device_ptr<OffsetT> device_output(output.size());
+
+        upper_lower_bound_kernel<T, OffsetT, length>
+            <<<grid_size, block_size>>>(device_input.get(), device_output.get(), value);
+
+        HIP_CHECK(hipGetLastError());
+
+        // Reading results back
+        output = device_output.load();
+
+        // Verifying results
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
+    }
 }

--- a/projects/rocprim/test/rocprim/test_transform_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_transform_iterator.cpp
@@ -91,6 +91,101 @@ using RocprimTransformIteratorTestsParams
 
 TYPED_TEST_SUITE(RocprimTransformIteratorTests, RocprimTransformIteratorTestsParams);
 
+TYPED_TEST(RocprimTransformIteratorTests, Basic)
+{
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    using input_type     = typename TestFixture::input_type;
+    using value_type     = typename TestFixture::value_type;
+    using unary_function = typename TestFixture::unary_function;
+    using iterator_type =
+        typename rocprim::transform_iterator<input_type*, unary_function, value_type>;
+    using difference_type = typename iterator_type::difference_type;
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        std::vector<input_type> input
+            = test_utils::get_random_data_wrapped<input_type>(10, 1, 200, seed_value);
+
+        unary_function transform;
+
+        auto begin = rocprim::make_transform_iterator<input_type*, unary_function>(input.data(),
+                                                                                   transform);
+        auto mid   = begin + 5;
+        auto end   = begin + 10;
+
+        // Pre-increment
+        auto it = begin;
+        ++it;
+        ASSERT_EQ(*it, transform(input[1]));
+
+        // Post-increment
+        auto post = it++;
+        ASSERT_EQ(*post, transform(input[1]));
+        ASSERT_EQ(*it, transform(input[2]));
+
+        // Pre-decrement
+        it = it + 2;
+        --it;
+        ASSERT_EQ(*it, transform(input[3]));
+
+        // Post-decrement
+        post = it--;
+        ASSERT_EQ(*post, transform(input[3]));
+        ASSERT_EQ(*it, transform(input[2]));
+
+        // Pre-decrement via -=
+        it -= 2;
+        ASSERT_EQ(*it, transform(input[0]));
+
+        // operator+
+        auto plus_it = begin + 3;
+        ASSERT_EQ(*plus_it, transform(input[3]));
+        auto plus_it_rev = 3 + begin;
+        ASSERT_EQ(*plus_it_rev, transform(input[3]));
+
+        // operator-
+        auto minus_it = end - 3;
+        ASSERT_EQ(*minus_it, transform(input[7]));
+
+        // compound assignment +=
+        auto a = begin;
+        a += 4;
+        ASSERT_EQ(*a, transform(input[4]));
+
+        // compound assignment -=
+        a -= 2;
+        ASSERT_EQ(*a, transform(input[2]));
+
+        // Subtraction of iterators (distance)
+        ASSERT_EQ(end - begin, difference_type(10));
+        ASSERT_EQ(mid - begin, difference_type(5));
+        ASSERT_EQ(begin - mid, difference_type(-5));
+
+        // Indexing operator[]
+        for(int i = 0; i < 10; i++)
+        {
+            ASSERT_EQ(begin[i], transform(input[i]));
+        }
+
+        // Comparisons
+        ASSERT_TRUE(begin == begin);
+        ASSERT_TRUE(begin != end);
+        ASSERT_TRUE(begin < end);
+        ASSERT_TRUE(end > begin);
+        ASSERT_TRUE(begin <= begin);
+        ASSERT_TRUE(begin <= end);
+        ASSERT_TRUE(end >= begin);
+        ASSERT_TRUE(end >= end);
+    }
+}
+
 TYPED_TEST(RocprimTransformIteratorTests, TransformReduce)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
@@ -129,35 +224,20 @@ TYPED_TEST(RocprimTransformIteratorTests, TransformReduce)
         value_type expected = std::accumulate(x, x + size, value_type(0), reduce_op);
 
         auto d_iter = iterator_type(d_input.get(), transform);
-        // temp storage
-        size_t temp_storage_size_bytes;
-        // Get size of d_temp_storage
-        HIP_CHECK(rocprim::reduce(nullptr,
-                                  temp_storage_size_bytes,
-                                  d_iter,
-                                  d_output.get(),
-                                  value_type(0),
-                                  input.size(),
-                                  reduce_op,
-                                  stream));
 
-        // temp_storage_size_bytes must be >0
-        ASSERT_GT(temp_storage_size_bytes, 0);
-
-        // allocate temporary storage
-        common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-        // Run
-        HIP_CHECK(rocprim::reduce(d_temp_storage.get(),
-                                  temp_storage_size_bytes,
-                                  d_iter,
-                                  d_output.get(),
-                                  value_type(0),
-                                  input.size(),
-                                  reduce_op,
-                                  stream,
-                                  TestFixture::debug_synchronous));
-        HIP_CHECK(hipGetLastError());
-        HIP_CHECK(hipDeviceSynchronize());
+        test_utils::test_kernel_wrapper(
+            [&](void* temp_storage, size_t& storage_bytes)
+            {
+                return rocprim::reduce(temp_storage,
+                                       storage_bytes,
+                                       d_iter,
+                                       d_output.get(),
+                                       value_type(0),
+                                       input.size(),
+                                       reduce_op,
+                                       stream);
+            },
+            stream);
 
         output = d_output.load();
 

--- a/projects/rocprim/test/rocprim/test_utils.hpp
+++ b/projects/rocprim/test/rocprim/test_utils.hpp
@@ -660,6 +660,7 @@ inline auto test_kernel_wrapper(F func, hipStream_t stream, const bool use_graph
         gHelper.createAndLaunchGraph(stream);
     }
 
+    HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     if(use_graphs)

--- a/projects/rocprim/test/rocprim/test_utils.hpp
+++ b/projects/rocprim/test/rocprim/test_utils.hpp
@@ -26,6 +26,7 @@
 #include "../../common/utils.hpp"
 #include "../../common/utils_custom_type.hpp"
 #include "../../common/utils_data_generation.hpp"
+#include "../../common/utils_device_ptr.hpp"
 #include "../../common/utils_half.hpp"
 
 // Identity iterator
@@ -628,6 +629,43 @@ template<bool MakeConst, typename T>
 inline auto wrap_in_const(T* ptr) -> typename std::enable_if_t<!MakeConst, T*>
 {
     return ptr;
+}
+
+template<typename F>
+inline auto test_kernel_wrapper(F func, hipStream_t stream, const bool use_graphs = false)
+{
+    // temp storage
+    size_t temp_storage_size_bytes;
+
+    // Get size of d_temp_storage
+    HIP_CHECK(func(nullptr, temp_storage_size_bytes));
+
+    // temp_storage_size_bytes must be >0
+    ASSERT_GT(temp_storage_size_bytes, 0);
+
+    // allocate temporary storage
+    common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
+
+    test_utils::GraphHelper gHelper;
+    if(use_graphs)
+    {
+        gHelper.startStreamCapture(stream);
+    }
+
+    // Run
+    HIP_CHECK(func(d_temp_storage.get(), temp_storage_size_bytes));
+
+    if(use_graphs)
+    {
+        gHelper.createAndLaunchGraph(stream);
+    }
+
+    HIP_CHECK(hipDeviceSynchronize());
+
+    if(use_graphs)
+    {
+        gHelper.cleanupGraphHelper();
+    }
 }
 
 } // namespace test_utils

--- a/projects/rocprim/test/rocprim/test_utils.hpp
+++ b/projects/rocprim/test/rocprim/test_utils.hpp
@@ -39,11 +39,6 @@
 #include "test_utils_assertions.hpp"
 #include "test_utils_bfloat16.hpp"
 #include "test_utils_custom_test_types.hpp"
-#include "test_utils_data_generation.hpp"
-#ifdef WITH_ROCRAND
-    #include "test_utils_data_generation_with_rocrand.hpp"
-#endif
-#include "test_utils_assertions.hpp"
 #include "test_utils_get_random_data.hpp"
 #include "test_utils_hipgraphs.hpp"
 

--- a/projects/rocprim/test/rocprim/test_utils_data_generation.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_data_generation.hpp
@@ -329,36 +329,79 @@ inline OutputIter segmented_generate_n(OutputIter it, size_t size, Generator&& g
     return it + size;
 }
 
+template<typename T, typename U, typename V>
+auto make_distribution(U min, V max)
+{
+    if constexpr(rocprim::is_floating_point<T>::value)
+    {
+        using dis_type = typename std::conditional<std::is_same<rocprim::half, T>::value
+                                                       || std::is_same<rocprim::bfloat16, T>::value,
+                                                   float,
+                                                   T>::type;
+        return std::uniform_real_distribution<dis_type>(static_cast<dis_type>(min),
+                                                        static_cast<dis_type>(max));
+    }
+    else
+    {
+        using dist_t
+            = std::conditional_t<common::is_valid_for_int_distribution<T>::value,
+                                 T,
+                                 std::conditional_t<std::is_signed<T>::value, int, unsigned int>>;
+
+        return common::uniform_int_distribution<dist_t>(saturate_cast<dist_t>(min),
+                                                        saturate_cast<dist_t>(max));
+    }
+}
+
 template<class OutputIter, class U, class V, class Generator>
 inline auto generate_random_data_n(OutputIter it, size_t size, U min, V max, Generator&& gen)
-    -> std::enable_if_t<rocprim::is_integral<common::it_value_t<OutputIter>>::value, OutputIter>
+    -> std::enable_if_t<(rocprim::is_integral<common::it_value_t<OutputIter>>::value
+                         || rocprim::is_floating_point<common::it_value_t<OutputIter>>::value)
+                            && !common::is_custom_type<common::it_value_t<OutputIter>>::value,
+                        OutputIter>
 {
     using T = common::it_value_t<OutputIter>;
 
-    using dis_type = typename std::conditional<
-        common::is_valid_for_int_distribution<T>::value,
-        T,
-        typename std::conditional<rocprim::is_signed<T>::value, int, unsigned int>::type>::type;
-    common::uniform_int_distribution<dis_type> distribution(saturate_cast<dis_type>(min),
-                                                            saturate_cast<dis_type>(max));
+    auto distribution = make_distribution<T>(min, max);
 
     return segmented_generate_n(it, size, [&]() { return static_cast<T>(distribution(gen)); });
 }
 
 template<class OutputIter, class U, class V, class Generator>
 inline auto generate_random_data_n(OutputIter it, size_t size, U min, V max, Generator&& gen)
-    -> std::enable_if_t<rocprim::is_floating_point<common::it_value_t<OutputIter>>::value
-                            && !common::is_custom_type<common::it_value_t<OutputIter>>::value,
-                        OutputIter>
+    -> std::enable_if_t<
+        std::is_same_v<common::it_value_t<OutputIter>, test_utils::custom_float_type>,
+        OutputIter>
 {
-    using T = common::it_value_t<OutputIter>;
+    using T       = common::it_value_t<OutputIter>;
+    using value_t = typename T::value_type;
 
-    // Generate floats when T is half or bfloat16
-    using dis_type = typename std::conditional<std::is_same<rocprim::half, T>::value || std::is_same<rocprim::bfloat16, T>::value, float, T>::type;
-    std::uniform_real_distribution<dis_type> distribution(static_cast<dis_type>(min),
-                                                          static_cast<dis_type>(max));
+    value_t min_temp;
+    value_t max_temp;
 
-    return segmented_generate_n(it, size, [&]() { return static_cast<T>(distribution(gen)); });
+    if constexpr(common::is_custom_type<U>::value)
+    {
+        min_temp = min.x;
+    }
+    else
+    {
+        min_temp = min;
+    }
+
+    if constexpr(common::is_custom_type<V>::value)
+    {
+        max_temp = max.x;
+    }
+    else
+    {
+        max_temp = max;
+    }
+
+    auto distribution = make_distribution<value_t>(min_temp, max_temp);
+
+    return segmented_generate_n(it,
+                                size,
+                                [&]() { return static_cast<value_t>(distribution(gen)); });
 }
 
 template<class OutputIter, class Generator>
@@ -369,47 +412,23 @@ inline auto generate_random_data_n(OutputIter                     it,
                                    Generator&&                    gen)
     -> std::enable_if_t<
         common::is_custom_type<common::it_value_t<OutputIter>>::value
-            && rocprim::is_integral<typename common::it_value_t<OutputIter>::value_type>::value,
+            && !(rocprim::is_integral<common::it_value_t<OutputIter>>::value
+                 || rocprim::is_floating_point<common::it_value_t<OutputIter>>::value),
         OutputIter>
 {
-    using T       = common::it_value_t<OutputIter>;
-    using value_t = typename T::value_type;
+    using T        = common::it_value_t<OutputIter>;
+    using first_t  = typename T::first_type;
+    using second_t = typename T::second_type;
 
-    using distribution_t
-        = std::conditional_t<common::is_valid_for_int_distribution<value_t>::value,
-                             value_t,
-                             std::conditional_t<std::is_signed<value_t>::value, int, unsigned int>>;
-
-    common::uniform_int_distribution<distribution_t> distribution(
-        saturate_cast<distribution_t>(min.x),
-        saturate_cast<distribution_t>(max.x));
+    auto first_dist  = make_distribution<first_t>(min.x, max.x);
+    auto second_dist = make_distribution<second_t>(min.y, max.y);
 
     return segmented_generate_n(it,
                                 size,
                                 [&]() {
-                                    return T(static_cast<value_t>(distribution(gen)),
-                                             static_cast<value_t>(distribution(gen)));
+                                    return T(static_cast<first_t>(first_dist(gen)),
+                                             static_cast<second_t>(second_dist(gen)));
                                 });
-}
-
-template<class OutputIter, class Generator>
-inline auto generate_random_data_n(OutputIter                     it,
-                                   size_t                         size,
-                                   common::it_value_t<OutputIter> min,
-                                   common::it_value_t<OutputIter> max,
-                                   Generator&&                    gen)
-    -> std::enable_if_t<common::is_custom_type<common::it_value_t<OutputIter>>::value
-                            && rocprim::is_floating_point<
-                                typename common::it_value_t<OutputIter>::value_type>::value,
-                        OutputIter>
-{
-    using T = typename std::iterator_traits<OutputIter>::value_type;
-
-    std::uniform_real_distribution<typename T::value_type> distribution(min.x, max.x);
-
-    return segmented_generate_n(it,
-                                size,
-                                [&]() { return T(distribution(gen), distribution(gen)); });
 }
 
 template<class OutputIter, class Generator>

--- a/projects/rocprim/test/rocprim/test_utils_data_generation_with_rocrand.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_data_generation_with_rocrand.hpp
@@ -42,18 +42,6 @@ namespace test_utils_with_rocrand
 template<typename T, class StateT, typename U, typename V>
 inline __device__
 auto generate_casting(T* output, StateT& state, U min, V max, unsigned int global_id)
-    -> std::enable_if_t<rocprim::is_integral<T>::value>
-{
-    output[global_id]
-        = static_cast<T>((static_cast<float>(rocrand(&state)) / static_cast<float>(UINT_MAX))
-                             * (static_cast<float>(max) - static_cast<float>(min))
-                         + static_cast<float>(min));
-}
-
-template<typename T, class StateT, typename U, typename V>
-inline __device__
-auto generate_casting(T* output, StateT& state, U min, V max, unsigned int global_id)
-    -> std::enable_if_t<!rocprim::is_integral<T>::value>
 {
 
     float f_value = (static_cast<float>(rocrand(&state)) / static_cast<float>(UINT_MAX))
@@ -64,9 +52,14 @@ auto generate_casting(T* output, StateT& state, U min, V max, unsigned int globa
     {
         output[global_id] = static_cast<T>(__float2half_rn(f_value));
     }
+    else if constexpr(common::is_custom_type_copyable<T>::value)
+    {
+        output[global_id].x = static_cast<typename T::first_type>(f_value);
+        output[global_id].y = static_cast<typename T::second_type>(f_value);
+    }
     else
     {
-        output[global_id] = f_value;
+        output[global_id] = static_cast<T>(f_value);
     }
 }
 

--- a/projects/rocprim/test/rocprim/test_utils_data_generation_with_rocrand.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_data_generation_with_rocrand.hpp
@@ -65,15 +65,22 @@ auto generate_casting(T* output, StateT& state, U min, V max, unsigned int globa
 
 template<typename T, class StateT, typename U, typename V>
 __global__
-void generate_random_kernel(
-    T* output, U min, V max, const unsigned long long seed = 0, const unsigned long long offset = 0)
+void generate_random_kernel(T*                       output,
+                            U                        min,
+                            V                        max,
+                            const unsigned long long size,
+                            const unsigned long long seed   = 0,
+                            const unsigned long long offset = 0)
 {
     const unsigned int flat_id = blockIdx.x * blockDim.x + threadIdx.x;
 
-    StateT             state;
-    const unsigned int subsequence = flat_id;
-    rocrand_init(seed, subsequence, offset, &state);
-    generate_casting(output, state, min, max, flat_id);
+    if(flat_id < size)
+    {
+        StateT             state;
+        const unsigned int subsequence = flat_id;
+        rocrand_init(seed, subsequence, offset, &state);
+        generate_casting(output, state, min, max, flat_id);
+    }
 }
 
 template<class OutputIter, class U, class V>
@@ -94,7 +101,7 @@ inline auto
     int           blocksPerGrid   = (size + threadsPerBlock - 1) / threadsPerBlock;
 
     generate_random_kernel<T, state_t, U, V>
-        <<<blocksPerGrid, threadsPerBlock>>>(d_random_data.get(), min, max, seed_value, 0);
+        <<<blocksPerGrid, threadsPerBlock>>>(d_random_data.get(), min, max, size, seed_value, 0);
     HIP_CHECK(hipGetLastError());
 
     HIP_CHECK(hipMemcpy(it.data(), d_random_data.get(), size * sizeof(T), hipMemcpyDeviceToHost));

--- a/projects/rocprim/test/rocprim/test_utils_get_random_data.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_get_random_data.hpp
@@ -23,6 +23,11 @@
 #ifndef ROCPRIM_TEST_UTILS_GET_RANDOM_DATA_HPP
 #define ROCPRIM_TEST_UTILS_GET_RANDOM_DATA_HPP
 
+#include "test_utils_data_generation.hpp"
+#ifdef WITH_ROCRAND
+    #include "test_utils_data_generation_with_rocrand.hpp"
+#endif
+
 namespace test_utils
 {
 template<class T, class U, class V>

--- a/projects/rocprim/test/rocprim/test_warp_scan.hpp
+++ b/projects/rocprim/test/rocprim/test_warp_scan.hpp
@@ -41,7 +41,7 @@
     #include "test_warp_scan.cpp"
 #endif
 
-test_suite_type_def(suite_name, name_suffix)
+test_suite_type_def(suite_name, name_suffix);
 
 typed_test_suite_def(RocprimWarpScanTests, name_suffix, warp_params);
 

--- a/projects/rocprim/test/rocprim/test_warp_scan.hpp
+++ b/projects/rocprim/test/rocprim/test_warp_scan.hpp
@@ -43,7 +43,7 @@
 
 test_suite_type_def(suite_name, name_suffix)
 
-    typed_test_suite_def(RocprimWarpScanTests, name_suffix, warp_params);
+typed_test_suite_def(RocprimWarpScanTests, name_suffix, warp_params);
 
 typed_test_def(RocprimWarpScanTests, name_suffix, InclusiveScan)
 {

--- a/projects/rocprim/test/rocprim/test_zip_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_zip_iterator.cpp
@@ -145,7 +145,10 @@ TEST(RocprimZipIteratorTests, Basics)
     ASSERT_EQ((zit2[0]), rocprim::make_tuple(1, 6, 1.0));
     ASSERT_EQ((zit2[2]), rocprim::make_tuple(3, 8, 3.0));
     // +
-    ASSERT_EQ(*(zit2+3), rocprim::make_tuple(4, 9, 4.0));
+    ASSERT_EQ(*(zit2 + 3), rocprim::make_tuple(4, 9, 4.0));
+    ASSERT_EQ(*(3 + zit2), rocprim::make_tuple(4, 9, 4.0));
+    // -
+    ASSERT_EQ(*(zit - 1), rocprim::make_tuple(1, 6, 1));
 }
 
 template<class T1, class T2, class T3>
@@ -295,44 +298,24 @@ TEST(RocprimZipIteratorTests, TransformReduce)
         U2 expected2 = std::accumulate(input2.begin(), input2.end(), T2(0))
             + std::accumulate(input3.begin(), input3.end(), T2(0));
 
-        // temp storage
-        size_t temp_storage_size_bytes;
-        // Get size of d_temp_storage
-        HIP_CHECK(rocprim::reduce(
-            nullptr,
-            temp_storage_size_bytes,
-            rocprim::make_transform_iterator(
-                rocprim::make_zip_iterator(
-                    rocprim::make_tuple(d_input1.get(), d_input2.get(), d_input3.get())),
-                tuple3to2_transform_op<T1, T2, T3>()),
-            rocprim::make_zip_iterator(rocprim::make_tuple(d_output1.get(), d_output2.get())),
-            input1.size(),
-            tuple2_reduce_op<T1, T2>(),
-            stream,
-            debug_synchronous));
-        HIP_CHECK(hipDeviceSynchronize());
-
-        // temp_storage_size_bytes must be >0
-        ASSERT_GT(temp_storage_size_bytes, 0);
-
-        // allocate temporary storage
-        common::device_ptr<void> d_temp_storage(temp_storage_size_bytes);
-        ASSERT_NE(d_temp_storage.get(), nullptr);
-
-        // Run
-        HIP_CHECK(rocprim::reduce(
-            d_temp_storage.get(),
-            temp_storage_size_bytes,
-            rocprim::make_transform_iterator(
-                rocprim::make_zip_iterator(
-                    rocprim::make_tuple(d_input1.get(), d_input2.get(), d_input3.get())),
-                tuple3to2_transform_op<T1, T2, T3>()),
-            rocprim::make_zip_iterator(rocprim::make_tuple(d_output1.get(), d_output2.get())),
-            input1.size(),
-            tuple2_reduce_op<T1, T2>(),
-            stream,
-            debug_synchronous));
-        HIP_CHECK(hipDeviceSynchronize());
+        test_utils::test_kernel_wrapper(
+            [&](void* temp_storage, size_t& storage_bytes)
+            {
+                return rocprim::reduce(
+                    temp_storage,
+                    storage_bytes,
+                    rocprim::make_transform_iterator(
+                        rocprim::make_zip_iterator(
+                            rocprim::make_tuple(d_input1.get(), d_input2.get(), d_input3.get())),
+                        tuple3to2_transform_op<T1, T2, T3>()),
+                    rocprim::make_zip_iterator(
+                        rocprim::make_tuple(d_output1.get(), d_output2.get())),
+                    input1.size(),
+                    tuple2_reduce_op<T1, T2>(),
+                    stream,
+                    debug_synchronous);
+            },
+            stream);
 
         // Copy output to host
         output1 = d_output1.load();


### PR DESCRIPTION
In this commit we have added test coverage,  made some bug fixes and added a wrapper function for a common pattern in the tests. This `test_kernel_wrapper` function reduces the amount of code used.

In https://github.com/ROCm/rocm-libraries/pull/242/commits/0318f427d0eab1f29c331a6c16a0371e3e4f1724 we have added coverage of the `warp_scan_shuffle` by forcing dpp off in cmake on the `warp_scan` test.

In https://github.com/ROCm/rocm-libraries/pull/242/commits/30d54c18bb662c7e082c62f30ded9f17a84cd1bd we have added the missing test cases for the thread_algos in the thread directory. (Except for thread_operators, these functions are mostly duplicates probably needs to be cleanly moved/deprecated). We also found a bug in `thread_reduce` with the tests and fixed this.

In https://github.com/ROCm/rocm-libraries/pull/242/commits/48780ff57449c9315bf4c4a42e8c338aaa7e4b78 https://github.com/ROCm/rocm-libraries/pull/242/commits/37aa542fb924bc4f76310d589b56fe94231b199b https://github.com/ROCm/rocm-libraries/pull/242/commits/05a9e12013a5ab9c44e6b9f5a5a7451156e8cade https://github.com/ROCm/rocm-libraries/pull/242/commits/f5f1dbe7ac5944d508c6f5207e7279607dd1a71a https://github.com/ROCm/rocm-libraries/pull/242/commits/343e275b619ee94032590ec3a760aaaae85f8c1f https://github.com/ROCm/rocm-libraries/pull/242/commits/8007fe6c466e90fd007df3926c3692a9fadc10a1 we have added unit tests for the files in the types directory. 

In https://github.com/ROCm/rocm-libraries/pull/242/commits/40ca3e2cab44b8d59fd0fef2ad6988de3a5dbda2 we have introduced the  `test_kernel_wrapper` and added the missing `PartitionTwoWayFlag` test.

In https://github.com/ROCm/rocm-libraries/pull/242/commits/7a4e7ba4ccbb7f45aa10513a4b3ac5285936bf62 unit tests for the rocprim::tuple type are added.

In https://github.com/ROCm/rocm-libraries/pull/242/commits/29eac9abbb08c64cbeb6ee344e1a1ae69996f2fb we have added extra test coverage by introducing a new type that will go into the untested path. We have also added this type to the benchmark to show [this specialization](https://github.com/ROCm/rocm-libraries/pull/242/commits/29eac9abbb08c64cbeb6ee344e1a1ae69996f2fb#diff-22a70b2ad081732e222004ded43ce0db7145ff196f7b723289425dcb5b6c732dR228) is still needed. We also changed the `std::is_integral` to `rocprim::is_integral` to not include  `(u)int128_t` for this specialization, this does not impact performance.  The specialization enable_if was also slightly changed to make it clearer which path is chosen (does not make a difference in actual executed code). Also custom config and a iterator was added to the tests of merge_sort.

In https://github.com/ROCm/rocm-libraries/pull/242/commits/f5614d585d521fbcee8ae324dcda783f1181253e test coverage was added for the device_scan_common.hpp file. 

In https://github.com/ROCm/rocm-libraries/pull/242/commits/1d2a40aaa6df6b7a4dc6bdf5acb2b1054fbc9b92 test coverage was increased by actually using `const fixed_array` and including a `Level` type which goes into the base path of  sample_to_bin_even struct. We also added an iterator as a type to the test. Also the new test wrapper was used.

In https://github.com/ROCm/rocm-libraries/pull/242/commits/c518f4259bac8541232d5758efe2bc46b68a87c4 test coverage was increased for the iterators, a lot of the operators where missing. Also some cleaning up of the tests was done including the wrapper when possible. There was also a bug found for the comperator in `arg_index_iterator` and `texture_cache_iterator`, which was also fixed. The `->` operator is not tested for `test_texture_cache`, `arg_index_iterator`, `transform_iterator` and `zip_iterator`. They currently do not seem to work, I am working on a possible fix but will be added in a later PR.