### PR TITLE
fix(hipcub, rocprim, rocthrust): print rocminfo stdout on error

### DIFF
--- a/projects/hipcub/cmake/GenerateResourceSpec.cmake
+++ b/projects/hipcub/cmake/GenerateResourceSpec.cmake
@@ -17,6 +17,7 @@ execute_process(
 
 if(ROCMINFO_EXIT_CODE)
   message(SEND_ERROR "rocminfo exited with ${ROCMINFO_EXIT_CODE}")
+  message(SEND_ERROR ${ROCMINFO_STDOUT})
   message(FATAL_ERROR ${ROCMINFO_STDERR})
 endif()
 

--- a/projects/rocprim/cmake/GenerateResourceSpec.cmake
+++ b/projects/rocprim/cmake/GenerateResourceSpec.cmake
@@ -17,6 +17,7 @@ execute_process(
 
 if(ROCMINFO_EXIT_CODE)
   message(SEND_ERROR "rocminfo exited with ${ROCMINFO_EXIT_CODE}")
+  message(SEND_ERROR ${ROCMINFO_STDOUT})
   message(FATAL_ERROR ${ROCMINFO_STDERR})
 endif()
 

--- a/projects/rocthrust/cmake/GenerateResourceSpec.cmake
+++ b/projects/rocthrust/cmake/GenerateResourceSpec.cmake
@@ -17,6 +17,7 @@ execute_process(
 
 if(ROCMINFO_EXIT_CODE)
   message(SEND_ERROR "rocminfo exited with ${ROCMINFO_EXIT_CODE}")
+  message(SEND_ERROR ${ROCMINFO_STDOUT})
   message(FATAL_ERROR ${ROCMINFO_STDERR})
 endif()
 


### PR DESCRIPTION
## Scope
`GenerateResourceSpec.cmake` contained this:

```cmake
execute_process(
  COMMAND ${ROCMINFO_EXECUTABLE}
  RESULT_VARIABLE ROCMINFO_EXIT_CODE
  OUTPUT_VARIABLE ROCMINFO_STDOUT
  ERROR_VARIABLE ROCMINFO_STDERR
)

if(ROCMINFO_EXIT_CODE)
  message(SEND_ERROR "rocminfo exited with ${ROCMINFO_EXIT_CODE}")
  message(FATAL_ERROR ${ROCMINFO_STDERR})
endif()
```

The first block runs rocminfo, and captures its exit code, stdout, and stderr.

While trying to run the CI locally, I got rocminfo to throw an error, but I noticed that the error didn't get printed:

![image](https://github.com/user-attachments/assets/f17f0315-6644-4ac8-87fb-233692a6ce88)

This MR fixes it by letting CMake print rocminfo's stdout, as rocminfo apparently printed this specific error message to stdout:

![image](https://github.com/user-attachments/assets/5d987d5b-1c43-4c48-99be-3ec319a2234e)

## Notes for the reviewer
This is a small fix that does not affect the CI under normal circumstances.

I'm not sure if rocminfo ever prints anything to stderr, but it may in the future, which is why I still let CMake print rocminfo's stderr output.

Both `message(SEND_ERROR "message")` and `message(FATAL_ERROR "message")` print `message` to stderr, but `FATAL_ERROR` also causes the program to immediately exit.