### PR TITLE
[hipBLASLt] Docs: change GitHub links and install instructions to account for repo change

### DIFF
--- a/projects/hipblaslt/README.md
+++ b/projects/hipblaslt/README.md
@@ -125,6 +125,6 @@ To build and run TensileLite Host Library Tests, use the following commands:
 ## Contribute
 
 If you want to submit an issue, you can do so on
-[GitHub](https://github.com/ROCm/rocm-libraries/issuess).
+[GitHub](https://github.com/ROCm/rocm-libraries/issues).
 
 To contribute to our repository, you can create a GitHub pull request.

--- a/projects/hipblaslt/README.md
+++ b/projects/hipblaslt/README.md
@@ -66,20 +66,27 @@ Required software:
 * CMake 3.16.8 or later
 * python3.8 or later
 * python3.8-venv or later
-* AMD [ROCm](https://github.com/RadeonOpenCompute/ROCm), version 5.5 or later
-* [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)
+* AMD [ROCm](https://github.com/ROCm/ROCm), version 5.5 or later
+* [hipBLAS-common](https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common)
 * [roctracer](https://github.com/ROCm/roctracer)
 
 ## Build and install
 
 You can build hipBLASLt using the `install.sh` script:
 
+> [!NOTE]
+> The following clone command downloads all components in the [rocm-libraries](https://github.com/ROCm/rocm-libraries) GitHub repository.
+This is recommended for working with multiple library components, but can take a very long time to
+download. For a shorter download process that only clones the hipBLASLt library, see the
+[hipBLASLt installation documentation](https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/installation.html)
+for version 7.0 or later.
+
 ```bash
-# Clone hipBLASLt using git
-git clone https://github.com/ROCmSoftwarePlatform/hipBLASLt
+# Clone rocm-libraries including hipBLASLt using git
+git clone https://github.com/ROCm/rocm-libraries.git
 
 # Go to hipBLASLt directory
-cd hipBLASLt
+cd rocm-libraries/projects/hipBLASLt
 
 # Run requirements.txt in folder tensilelite
 python3 -m pip install -r tensilelite/requirements.txt
@@ -118,6 +125,6 @@ To build and run TensileLite Host Library Tests, use the following commands:
 ## Contribute
 
 If you want to submit an issue, you can do so on
-[GitHub](https://github.com/ROCmSoftwarePlatform/hipBLASLt/issues).
+[GitHub](https://github.com/ROCm/rocm-libraries/issuess).
 
 To contribute to our repository, you can create a GitHub pull request.

--- a/projects/hipblaslt/docs/index.rst
+++ b/projects/hipblaslt/docs/index.rst
@@ -11,7 +11,11 @@ hipBLASLt documentation
 hipBLASLt is a library that provides General Matrix-Matrix (GEMM) operations with flexible APIs and extends functionality beyond the traditional BLAS library.
 To learn more, see :doc:`What is hipBLASLt?<./what-is-hipBLASLt>`
 
-The hipBLASLt public repository is located at `<https://github.com/ROCm/hipBLASLt>`_.
+The hipBLASLt public repository is located at `<https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblaslt>`_.
+
+.. note::
+
+   The hipBLASLt repository for ROCm release 6.4 and earlier is located at `<https://github.com/ROCm/hipBLASLt>`_.
 
 .. grid:: 2
   :gutter: 3
@@ -38,7 +42,7 @@ The hipBLASLt public repository is located at `<https://github.com/ROCm/hipBLASL
   .. grid-item-card:: Examples
 
     * :doc:`Code Samples <./samples/samples>`
-    * `hipBLASLt client examples <https://github.com/ROCm/hipBLASLt/tree/develop/clients/samples>`_
+    * `hipBLASLt client examples <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblaslt/clients/samples>`_
 
   .. grid-item-card:: API reference
 

--- a/projects/hipblaslt/docs/install/building-installing-hipblaslt.rst
+++ b/projects/hipblaslt/docs/install/building-installing-hipblaslt.rst
@@ -37,10 +37,16 @@ The following sections explain how to use the ``install.sh`` script, including t
 Building the library dependencies and library
 ---------------------------------------------
 
-The root of the hipBLASLt `GitHub repository <https://github.com/ROCm/hipBLASLt>`_ contains the ``install.sh`` Bash script for building and installing hipBLASLt with a single command.
+The root of the `hipblaslt folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblaslt>`_
+in the `rocm-libraries <https://github.com/ROCm/rocm-libraries>`_ GitHub repository contains the ``install.sh`` Bash script for building and installing hipBLASLt with a single command.
 It includes several options and hard-coded configuration items that can be specified through invoking CMake directly,
 but it's a great way to get started quickly and can serve as an example showing how to build and install hipBLASLt.
 A few commands in the script require ``sudo`` access, which might prompt you for a password.
+
+.. note::
+
+   To build ROCm release 6.4 and older, use the hipBLASLt repository at `<https://github.com/ROCm/hipBLASLt>`_.
+   Select the documentation associated with the release you want to build.
 
 Some typical examples showing how to use ``install.sh`` to build the library dependencies and library are
 listed in the table below:
@@ -106,7 +112,7 @@ Building the library manually
 
 Before building hipBLASLt manually, ensure the following dependencies are installed on your system:
 
-*  The `hipBLAS-common <https://github.com/ROCm/hipBLAS-common>`_ header files.
+*  The `hipBLAS-common <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common>`_ header files.
 *  The `ROC-tracer (ROC-TX) <https://github.com/ROCm/roctracer>`_ library (this is typically pre-installed).
 
 Building hipBLASLt

--- a/projects/hipblaslt/docs/install/building-installing-hipblaslt.rst
+++ b/projects/hipblaslt/docs/install/building-installing-hipblaslt.rst
@@ -45,7 +45,7 @@ A few commands in the script require ``sudo`` access, which might prompt you for
 
 .. note::
 
-   To build ROCm release 6.4 and older, use the hipBLASLt repository at `<https://github.com/ROCm/hipBLASLt>`_.
+   To build ROCm 6.4 and older, use the hipBLASLt repository at `<https://github.com/ROCm/hipBLASLt>`_.
    Select the documentation associated with the release you want to build.
 
 Some typical examples showing how to use ``install.sh`` to build the library dependencies and library are

--- a/projects/hipblaslt/docs/sphinx/_toc.yml.in
+++ b/projects/hipblaslt/docs/sphinx/_toc.yml.in
@@ -39,7 +39,7 @@ subtrees:
       - file: samples/client_extop_softmax
       - file: samples/sample_hipblaslt_ext_op_layernorm
       - file: samples/sample_hipblaslt_ext_op_amax
-  - url: https://github.com/ROCm/hipBLASLt/tree/develop/clients/samples
+  - url: https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblaslt/clients/samples
     title: hipBLASLt client examples
 
 - caption: API reference


### PR DESCRIPTION
This points GitHub links for components that have moved to the mono-repo to the new location and makes other adjustments to the Readme, index, install instructions, and ToC to account for the change. It also adds a note pointing to the older repository for those who want to use 6.4 or earlier. This change is only intended for 7.0+ on the new repository.