### PR TITLE
[rocThrust] Make constant, counting iterator constructors constexpr

### DIFF
--- a/projects/rocthrust/thrust/iterator/constant_iterator.h
+++ b/projects/rocthrust/thrust/iterator/constant_iterator.h
@@ -140,7 +140,7 @@ public:
    *       value returned by \c Incrementable's null constructor. For example,
    *       when <tt>Incrementable == int</tt>, \c 0.
    */
-  THRUST_HOST_DEVICE constant_iterator(value_type const& v, incrementable const& i = incrementable())
+  THRUST_HOST_DEVICE constexpr constant_iterator(value_type const& v, incrementable const& i = incrementable())
       : super_t(base_iterator(i))
       , m_value(v)
   {}

--- a/projects/rocthrust/thrust/iterator/counting_iterator.h
+++ b/projects/rocthrust/thrust/iterator/counting_iterator.h
@@ -146,7 +146,7 @@ public:
   /*! Default constructor initializes this \p counting_iterator's counter to
    * `Incrementable{}`.
    */
-  THRUST_HOST_DEVICE counting_iterator()
+  THRUST_HOST_DEVICE constexpr counting_iterator()
       : super_t(Incrementable{})
   {}
 


### PR DESCRIPTION
This change allows users to construct instances of `const_iterator` or `counting_iterator` inside of a `constexpr` function.