### PR TITLE
hipBLASLt/rocRoller: Origami usage in rocRoller integration

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/include/rocroller_host_internal.hpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/include/rocroller_host_internal.hpp
@@ -1,0 +1,193 @@
+/*! \file */
+/* ************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2024-2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+/*********************************************************
+ * Use this for any header contents that you don't want exposed. *
+ *********************************************************/
+
+#pragma once
+
+#include <rocRoller/DataTypes/DataTypes.hpp>
+#include <rocRoller/Operations/Command.hpp>
+#include <Tensile/analytical/Utils.hpp>
+
+/**
+ * @brief KernelType
+ *
+ * All of the values required for different types of kernels.
+ * This should not include any optimization flags.
+ *
+ */
+struct KernelType
+{
+    rocRoller::DataType typeA;
+    rocRoller::DataType typeB;
+    rocRoller::DataType typeC;
+    rocRoller::DataType typeD;
+    rocRoller::DataType typeAcc = rocRoller::DataType::Float;
+
+    hipblasOperation_t transA;
+    hipblasOperation_t transB;
+
+    rocRoller::Operations::ScaleMode scaleAMode;
+    rocRoller::Operations::ScaleMode scaleBMode;
+
+    size_t scaleABlockRowSize = 32u;
+    size_t scaleABlockColSize = 1u;
+    size_t scaleBBlockRowSize = 1u;
+    size_t scaleBBlockColSize = 32u;
+
+    auto operator<=>(const KernelType& other) const = default;
+};
+
+/**
+ * @brief WorkGroupTileSize
+ *
+ * The size of a tile that will be executed by a work group.
+ *
+ */
+struct WorkGroupTileSize
+{
+    int m;
+    int n;
+    int k;
+};
+
+/**
+ * @brief MachineInstructionSize
+ *
+ * The machine instruction that will be used for matrix multiplication operations
+ *
+ */
+struct MachineInstructionSize
+{
+    int m = -1;
+    int n = -1;
+    int k = -1;
+    int b = -1;
+};
+
+/**
+ **************************************************************************************************
+ * This section defines the lists of macro-tile/matrix-instruction combinations so that they are
+ * compile-time known.
+ */
+
+constexpr std::array<WorkGroupTileSize, 23> possibleTileSizes = {{
+    {256, 256, 128}, {256, 128, 128}, {128, 256, 128}, {256, 64, 128}, {64, 256, 128},
+    {128, 128, 128}, {256, 32, 128},  {32, 256, 128},  {128, 64, 128}, {64, 128, 128},
+    {256, 16, 128},  {16, 256, 128},  {128, 32, 128},  {32, 128, 128}, {64, 64, 128},
+    {64, 32, 128},   {32, 64, 128},   {64, 16, 128},   {16, 64, 128},  {32, 32, 64},
+    {32, 16, 128},   {16, 32, 128},   {16, 16, 128}
+}};
+
+constexpr MachineInstructionSize pickMI(rocRoller::DataType typeA, rocRoller::DataType typeB, WorkGroupTileSize wgt) {
+    if (typeA == rocRoller::DataType::Half || typeA == rocRoller::DataType::BFloat16) {
+        return {32, 32, 8, 1};
+    } else if (typeA == rocRoller::DataType::Float) {
+        return {32, 32, 2, 1};
+    } else {
+        if ((typeA == rocRoller::DataType::FP6 || typeA == rocRoller::DataType::BF6 ||
+             typeB == rocRoller::DataType::FP6 || typeB == rocRoller::DataType::BF6) &&
+            ((wgt.m == 256 && wgt.n == 64) || (wgt.m == 64 && wgt.n == 256))) {
+            return {32, 32, 64, 1};
+        } else if (wgt.k % 128 == 0) {
+            return {16, 16, 128, 1};
+        } else {
+            return {32, 32, 64, 1};
+        }
+    }
+}
+
+template <rocRoller::DataType typeA, rocRoller::DataType typeB>
+constexpr auto generateTileList() {
+    std::array<TensileLite::analytical::TileTuple, possibleTileSizes.size()> tileList{};
+
+    for (size_t i = 0; i < possibleTileSizes.size(); ++i) {
+        const auto& wgt = possibleTileSizes[i];
+        auto MI = pickMI(typeA, typeB, wgt);
+
+        int wgtk = wgt.k;
+        if (typeA == rocRoller::DataType::Half || typeA == rocRoller::DataType::BFloat16 || typeA == rocRoller::DataType::Float) {
+            wgtk = 32;
+        }
+
+        tileList[i] = std::make_tuple(
+            wgt.m, wgt.n, wgtk,
+            MI.m, MI.n, MI.k,
+            1 // occupancy
+        );
+    }
+
+    return tileList;
+}
+
+using TileListGeneratorFn = std::vector<TensileLite::analytical::TileTuple>(*)();
+
+template <rocRoller::DataType A, rocRoller::DataType B>
+std::vector<TensileLite::analytical::TileTuple> generateTileListWrapper() {
+    constexpr auto arr = generateTileList<A, B>();
+    return {arr.begin(), arr.end()};
+}
+
+#define INSTANTIATE_TILE_LIST(A, B) \
+    { {rocRoller::DataType::A, rocRoller::DataType::B}, &generateTileListWrapper<rocRoller::DataType::A, rocRoller::DataType::B> }
+
+#define INSTANTIATE_TILE_LIST_FOR(A) \
+    INSTANTIATE_TILE_LIST(A, Half), \
+    INSTANTIATE_TILE_LIST(A, Float), \
+    INSTANTIATE_TILE_LIST(A, BFloat16), \
+    INSTANTIATE_TILE_LIST(A, FP8), \
+    INSTANTIATE_TILE_LIST(A, BF8), \
+    INSTANTIATE_TILE_LIST(A, FP4), \
+    INSTANTIATE_TILE_LIST(A, BF6), \
+    INSTANTIATE_TILE_LIST(A, FP6)
+
+const std::map<std::pair<rocRoller::DataType, rocRoller::DataType>, TileListGeneratorFn> tileListGenerators = {
+    INSTANTIATE_TILE_LIST_FOR(Half),
+    INSTANTIATE_TILE_LIST_FOR(Float),
+    INSTANTIATE_TILE_LIST_FOR(BFloat16),
+    INSTANTIATE_TILE_LIST_FOR(FP8),
+    INSTANTIATE_TILE_LIST_FOR(BF8),
+    INSTANTIATE_TILE_LIST_FOR(FP4),
+    INSTANTIATE_TILE_LIST_FOR(BF6),
+    INSTANTIATE_TILE_LIST_FOR(FP6)
+};
+
+std::vector<TensileLite::analytical::TileTuple> getTileListForKernelType(KernelType kernelType)
+{
+    auto key = std::make_pair(kernelType.typeA, kernelType.typeB);
+    auto it = tileListGenerators.find(key);
+    if (it != tileListGenerators.end())
+        return it->second();
+    throw std::runtime_error("Unsupported DataType combination");
+}
+
+/**
+ *
+ **************************************************************************************************
+ */

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
@@ -29,6 +29,7 @@
  *********************************************************/
 
 #include "rocroller_host.hpp"
+#include "rocroller_host_internal.hpp"
 #include "Debug.hpp"
 #include "handle.h"
 #include "utility.hpp"
@@ -36,8 +37,9 @@
 #include <rocRoller/CommandSolution.hpp>
 #include <rocRoller/Expression.hpp>
 #include <rocRoller/KernelGraph/CoordinateGraph/Dimension.hpp>
-#include <rocRoller/Operations/Command.hpp>
 #include <rocRoller/TensorDescriptor.hpp>
+
+#include <Tensile/analytical/Utils.hpp>
 
 using namespace rocRoller;
 
@@ -47,62 +49,6 @@ const int MAX_BITS_WORKGROUPTILE_K    = 7;
 const int MAX_BITS_PREFETCH_IN_FLIGHT = 4;
 const int REQUIRED_MULTIPLE_M_N       = 16;
 const int REQUIRED_MULTIPLE_K         = 32;
-
-/**
- * @brief KernelType
- *
- * All of the values required for different types of kernels.
- * This should not include any optimization flags.
- *
- */
-struct KernelType
-{
-    rocRoller::DataType typeA;
-    rocRoller::DataType typeB;
-    rocRoller::DataType typeC;
-    rocRoller::DataType typeD;
-    rocRoller::DataType typeAcc = rocRoller::DataType::Float;
-
-    hipblasOperation_t transA;
-    hipblasOperation_t transB;
-
-    rocRoller::Operations::ScaleMode scaleAMode;
-    rocRoller::Operations::ScaleMode scaleBMode;
-
-    size_t scaleABlockRowSize = 32u;
-    size_t scaleABlockColSize = 1u;
-    size_t scaleBBlockRowSize = 1u;
-    size_t scaleBBlockColSize = 32u;
-
-    auto operator<=>(const KernelType& other) const = default;
-};
-
-/**
- * @brief WorkGroupTileSize
- *
- * The size of a tile that will be executed by a work group.
- *
- */
-struct WorkGroupTileSize
-{
-    int m;
-    int n;
-    int k;
-};
-
-/**
- * @brief MachineInstructionSize
- *
- * The machine instruction that will be used for matrix multiplication operations
- *
- */
-struct MachineInstructionSize
-{
-    int m = -1;
-    int n = -1;
-    int k = -1;
-    int b = -1;
-};
 
 /**
  * @brief SolutionIndex Parameters
@@ -644,12 +590,6 @@ KernelType genKernelType(const RocblasltContractionProblem& prob)
     return kernelType;
 }
 
-const std::vector<WorkGroupTileSize> possibleTileSizes
-    = {{256, 256, 128}, {256, 128, 128}, {128, 256, 128}, {256, 64, 128}, {64, 256, 128},
-       {128, 128, 128}, {256, 32, 128},  {32, 256, 128},  {128, 64, 128}, {64, 128, 128},
-       {256, 16, 128},  {16, 256, 128},  {128, 32, 128},  {32, 128, 128}, {64, 64, 128},
-       {64, 32, 128},   {32, 64, 128},   {64, 16, 128},   {16, 64, 128},  {32, 32, 64},
-       {32, 16, 128},   {16, 32, 128},   {16, 16, 128}};
 
 /**
  * @brief Choose the SolutionIndexParameters to use for a given problem
@@ -668,8 +608,38 @@ std::vector<SolutionIndexParameters> chooseSolutionIndexParameters(
 {
     std::vector<SolutionIndexParameters> params;
 
-    for(auto const& wgt : possibleTileSizes)
+    std::vector<TensileLite::analytical::TileTuple> tile_list = getTileListForKernelType(kernelType);
+
+    size_t elementSizeA_bits = rocRoller::DataTypeInfo::Get(kernelType.typeA).elementBits; 
+    size_t elementSizeB_bits = rocRoller::DataTypeInfo::Get(kernelType.typeB).elementBits;
+    size_t elementSizeC_bits = rocRoller::DataTypeInfo::Get(kernelType.typeC).elementBits; 
+
+    const TensileLite::analytical::Hardware analaytical_hardware = TensileLite::analytical::Hardware::getHardwareForDevice(0);
+
+    int WGM = std::sqrt(std::floor(analaytical_hardware.N_CU / analaytical_hardware.NUM_XCD));
+
+    auto selected_tiles = TensileLite::analytical::select_best_macro_tile_size(
+        prob.m,
+        prob.n,
+        prob.k,
+        prob.batch_count,
+        prob.trans_a == hipblasOperation_t::HIPBLAS_OP_T,
+        prob.trans_b == hipblasOperation_t::HIPBLAS_OP_T,
+        analaytical_hardware,
+        tile_list,
+        elementSizeA_bits,
+        elementSizeA_bits,
+        elementSizeC_bits,
+        kernelType.scaleABlockRowSize * kernelType.scaleABlockColSize, //Handle A vs B block size.
+        0.8,
+        false,
+        false,
+        WGM);
+
+    for(auto const& selected_tile : selected_tiles)
     {
+        WorkGroupTileSize wgt{(int)std::get<1>(selected_tile), (int)std::get<2>(selected_tile), (int)std::get<3>(selected_tile)};
+
         if((requestedAlgoCount == -1)
            || (prob.m % wgt.m == 0 && prob.n % wgt.n == 0 && prob.k % wgt.k == 0))
         {
@@ -682,13 +652,6 @@ std::vector<SolutionIndexParameters> chooseSolutionIndexParameters(
                 continue;
 
             params.push_back({wgt, 1});
-
-            if(kernelType.typeA == rocRoller::DataType::Half
-               || kernelType.typeA == rocRoller::DataType::BFloat16
-               || kernelType.typeA == rocRoller::DataType::Float)
-            {
-                params.back().workgroupTile.k = 32;
-            }
 
             // Other datatypes run out of registers when prefetchInFlight is too
             // large.
@@ -733,32 +696,7 @@ std::shared_ptr<SolutionParameters>
 
     gemm->workgroupTile = solutionIndexParameters.workgroupTile;
 
-    // Choose the Machine Instruction to use
-    if(gemm->kernelType.typeA == rocRoller::DataType::Half
-       || gemm->kernelType.typeA == rocRoller::DataType::BFloat16)
-    {
-        gemm->machineInstruction = {32, 32, 8, 1};
-    }
-    else if(gemm->kernelType.typeA == rocRoller::DataType::Float)
-    {
-        gemm->machineInstruction = {32, 32, 2, 1};
-    }
-    else
-    {
-        // F6 with 16X16X256 MI gives higher rnorms than expected with
-        // certain tile sizes
-        if((gemm->kernelType.typeA == rocRoller::DataType::FP6
-            || gemm->kernelType.typeA == rocRoller::DataType::BF6
-            || gemm->kernelType.typeB == rocRoller::DataType::FP6
-            || gemm->kernelType.typeB == rocRoller::DataType::BF6)
-           && ((gemm->workgroupTile.m == 256 && gemm->workgroupTile.n == 64)
-               || (gemm->workgroupTile.m == 64 && gemm->workgroupTile.n == 256)))
-            gemm->machineInstruction = {32, 32, 64, 1};
-        else if(gemm->workgroupTile.k % 128 == 0)
-            gemm->machineInstruction = {16, 16, 128, 1};
-        else
-            gemm->machineInstruction = {32, 32, 64, 1};
-    }
+    gemm->machineInstruction = pickMI(gemm->kernelType.typeA, gemm->kernelType.typeB, gemm->workgroupTile);
 
     if(gemm->workgroupTile.m / gemm->machineInstruction.m == 1)
         gemm->workgroupSizeX = gemm->wavefrontSize;
@@ -812,14 +750,20 @@ std::shared_ptr<SolutionParameters>
 
     // LDS can only be used for scaling data with certain workgroup tile sizes
     auto workgroupSize = gemm->workgroupSizeX * gemm->workgroupSizeY;
-    auto numScaleElementsA
-        = gemm->workgroupTile.m
+    auto numScaleElementsA = 0;
+    if(gemm->kernelType.scaleABlockRowSize * gemm->kernelType.scaleABlockColSize != 0)
+    {
+        numScaleElementsA = gemm->workgroupTile.m
           * (gemm->workgroupTile.k
              / (gemm->kernelType.scaleABlockRowSize * gemm->kernelType.scaleABlockColSize));
-    auto numScaleElementsB
-        = gemm->workgroupTile.n
+    }
+    auto numScaleElementsB = 0;
+    if(gemm->kernelType.scaleBBlockRowSize * gemm->kernelType.scaleBBlockColSize != 0)
+    {
+        numScaleElementsB = gemm->workgroupTile.n
           * (gemm->workgroupTile.k
              / (gemm->kernelType.scaleBBlockRowSize * gemm->kernelType.scaleBBlockColSize));
+    }
     if(numScaleElementsA % workgroupSize != 0)
     {
         gemm->loadLDSScaleA     = false;

--- a/projects/hipblaslt/next-cmake/host-library/include/rocblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/next-cmake/host-library/include/rocblaslt/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(hipblaslt
         "${_CMAKE_CURRENT_SOURCE_DIR1}/rocblaslt-auxiliary.h"
         "${_CMAKE_CURRENT_SOURCE_DIR2}/utility.hpp"
         "${_CMAKE_CURRENT_SOURCE_DIR2}/rocroller_host.hpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR2}/rocroller_host_internal.hpp"
         "${_CMAKE_CURRENT_SOURCE_DIR2}/rocblaslt_mat_utils.hpp"
         "${_CMAKE_CURRENT_SOURCE_DIR2}/tuple_helper.hpp"
         "${_CMAKE_CURRENT_SOURCE_DIR2}/tensile_host.hpp"

--- a/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/analytical/Hardware.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/analytical/Hardware.cpp
@@ -95,6 +95,7 @@ namespace TensileLite
                     {MatrixInstruction(16, 16, 128, 8), 32}, // V_MFMA_F32_16X16X128_F8
                     {MatrixInstruction(16, 16, 128, 6), 16}, // V_MFMA_F32_16X16X128_F6
                     {MatrixInstruction(16, 16, 128, 4), 16}, // V_MFMA_F32_16X16X128_F4
+                    {MatrixInstruction(32, 32, 64, 4), 32},  // V_MFMA_F32_32X32X64_F4
 
                 }}};
 

--- a/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/analytical/Hardware.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/analytical/Hardware.cpp
@@ -95,6 +95,8 @@ namespace TensileLite
                     {MatrixInstruction(16, 16, 128, 8), 32}, // V_MFMA_F32_16X16X128_F8
                     {MatrixInstruction(16, 16, 128, 6), 16}, // V_MFMA_F32_16X16X128_F6
                     {MatrixInstruction(16, 16, 128, 4), 16}, // V_MFMA_F32_16X16X128_F4
+                    {MatrixInstruction(32, 32, 64, 8), 64},  // V_MFMA_F32_32X32X64_F8
+                    {MatrixInstruction(32, 32, 64, 6), 32},  // V_MFMA_F32_32X32X64_F6
                     {MatrixInstruction(32, 32, 64, 4), 32},  // V_MFMA_F32_32X32X64_F4
 
                 }}};


### PR DESCRIPTION
This PR enables the hipBLASLt rocRoller integration to use the origami model to select the macro tile.