### PR TITLE
Fix typos in VirtualWaveSize warning

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/block/block_exchange.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/block/block_exchange.hpp
@@ -668,7 +668,7 @@ public:
     {
         static_assert(detail::is_power_of_two(VirtualWaveSize)
                           && VirtualWaveSize <= arch::wavefront::max_size(),
-                      "VirtualWaveSize must be a power of two and equal or less"
+                      "VirtualWaveSize must be a power of two and equal or less "
                       "than the size of hardware warp.");
         assert(VirtualWaveSize <= arch::wavefront::size());
 

--- a/projects/rocprim/rocprim/include/rocprim/block/block_load_func.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/block/block_load_func.hpp
@@ -379,7 +379,7 @@ void block_load_direct_warp_striped(unsigned int  flat_id,
 {
     static_assert(detail::is_power_of_two(VirtualWaveSize)
                       && VirtualWaveSize <= arch::wavefront::max_size(),
-                  "VirtualWaveSize must be a power of two and equal or less"
+                  "VirtualWaveSize must be a power of two and equal or less "
                   "than the size of hardware warp.");
     assert(VirtualWaveSize <= arch::wavefront::size());
 
@@ -469,7 +469,7 @@ void block_load_direct_warp_striped(unsigned int  flat_id,
 {
     static_assert(detail::is_power_of_two(VirtualWaveSize)
                       && VirtualWaveSize <= arch::wavefront::max_size(),
-                  "VirtualWaveSize must be a power of two and equal or less"
+                  "VirtualWaveSize must be a power of two and equal or less "
                   "than the size of hardware warp.");
     assert(VirtualWaveSize <= arch::wavefront::size());
 
@@ -582,7 +582,7 @@ void block_load_direct_warp_striped(unsigned int  flat_id,
 {
     static_assert(detail::is_power_of_two(VirtualWaveSize)
                       && VirtualWaveSize <= arch::wavefront::max_size(),
-                  "VirtualWaveSize must be a power of two and equal or less"
+                  "VirtualWaveSize must be a power of two and equal or less "
                   "than the size of hardware warp.");
     assert(VirtualWaveSize <= arch::wavefront::size());
 
@@ -695,7 +695,7 @@ auto block_load_direct_blocked_cast(unsigned int flat_id,
 {
     static_assert(detail::is_power_of_two(VirtualWaveSize)
                       && VirtualWaveSize <= arch::wavefront::max_size(),
-                  "VirtualWaveSize must be a power of two and equal or less"
+                  "VirtualWaveSize must be a power of two and equal or less "
                   "than the size of hardware warp.");
     assert(VirtualWaveSize <= arch::wavefront::size());
 

--- a/projects/rocprim/rocprim/include/rocprim/block/block_store_func.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/block/block_store_func.hpp
@@ -310,7 +310,7 @@ void block_store_direct_warp_striped(unsigned int   flat_id,
 
     static_assert(detail::is_power_of_two(VirtualWaveSize)
                       && VirtualWaveSize <= arch::wavefront::max_size(),
-                  "VirtualWaveSize must be a power of two and equal or less"
+                  "VirtualWaveSize must be a power of two and equal or less "
                   "than the size of hardware warp.");
     unsigned int thread_id   = detail::logical_lane_id<VirtualWaveSize>();
     unsigned int warp_id     = flat_id / VirtualWaveSize;
@@ -402,7 +402,7 @@ void block_store_direct_warp_striped(unsigned int   flat_id,
 
     static_assert(detail::is_power_of_two(VirtualWaveSize)
                       && VirtualWaveSize <= arch::wavefront::max_size(),
-                  "VirtualWaveSize must be a power of two and equal or less"
+                  "VirtualWaveSize must be a power of two and equal or less "
                   "than the size of hardware warp.");
     assert(VirtualWaveSize <= arch::wavefront::size());
 


### PR DESCRIPTION
Fix warning message from

`VirtualWaveSize must be a power of two and equal or lessthan the size of hardware warp.`

to

`VirtualWaveSize must be a power of two and equal or less than the size of hardware warp.`