### PR TITLE
Reverse win gtest condition (#450)

### DIFF
--- a/projects/rocprim/test/rocprim/test_utils_assertions.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_assertions.hpp
@@ -90,12 +90,12 @@ void inline protected_assert_eq(T val, T expected, size_t index)
 {
     if constexpr (UseGTestAssert)
     {
-        const bool result = (val == expected);
-        ASSERT_TRUE(result) << "where index = " << index;
+        ASSERT_EQ(val, expected) << "where index = " << index;
     }
     else
     {
-        ASSERT_EQ(val, expected) << "where index = " << index;
+        const bool result = (val == expected);
+        ASSERT_TRUE(result) << "where index = " << index;
     }
 }
 
@@ -104,12 +104,12 @@ void inline protected_assert_eq(T val, T expected)
 {
     if constexpr (UseGTestAssert)
     {
-        const bool result = (val == expected);
-        ASSERT_TRUE(result);
+        ASSERT_EQ(val, expected);
     }
     else
     {
-        ASSERT_EQ(val, expected);
+        const bool result = (val == expected);
+        ASSERT_TRUE(result);
     }
 }
 


### PR DESCRIPTION
Reverse UseGTestAssert condition on Windows
    
Recently, we added a check to see if GTest's ASSERT_EQ assertion should be used within the assert_eq function. The code in the if/else blocks that act on the results of this check was inverted (the "else" code block should be the "if" block, and vice-versa). This change fixes the issue by swapping the code blocks.

This change should be merged after #449.