### PR TITLE
[hipblaslt] Resolve 301 errors on 942

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext-op.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext-op.cpp
@@ -216,8 +216,7 @@ namespace
 
             for(auto& adapter : adapters)
             {
-                //setup code object root only, ignore the error
-                err = adapter->initializeLazyLoading("", lib.getLibraryFolder());
+                adapter->codeObjectDir(lib.getLibraryFolder());
             }
         }
         catch(const std::runtime_error& e)

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_transform.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_transform.cpp
@@ -77,7 +77,7 @@ namespace
             {
                 for(auto& adp : adapters)
                 {
-                    (void)adp->initializeLazyLoading("", coFolder);
+                    adp->codeObjectDir(coFolder);
                 }
             }
             catch(const std::runtime_error& e)

--- a/projects/hipblaslt/tensilelite/Tensile/Source/lib/include/Tensile/hip/HipSolutionAdapter.hpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/lib/include/Tensile/hip/HipSolutionAdapter.hpp
@@ -50,6 +50,8 @@ namespace TensileLite
                 return m_name;
             }
 
+            void codeObjectDir(std::string codeObjectDir);
+
             hipError_t loadCodeObjectFile(std::string const& path);
 
             hipError_t initializeLazyLoading(std::string architecture, std::string codeObjectDir);

--- a/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -265,6 +265,17 @@ namespace TensileLite
             return err;
         }
 
+        // We should update the constructor to set this to avoid
+        // avoid separating construction and initialization
+        void SolutionAdapter::codeObjectDir(std::string codeObjectDir)
+        {
+            if(codeObjectDir.back() != '/');
+                codeObjectDir += '/';
+            m_access.lock();
+            m_codeObjectDirectory = codeObjectDir;
+            m_access.unlock();
+        }
+
         hipError_t SolutionAdapter::initializeLazyLoading(std::string arch,
                                                           std::string codeObjectDir)
         {

--- a/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -298,8 +298,6 @@ namespace TensileLite
 
                     if(err == hipSuccess)
                         return err;
-                    else if(err == hipErrorFileNotFound)
-                        (void)hipGetLastError(); // clear hipErrorFileNotFound
                 }
 
                 return err;


### PR DESCRIPTION
As described in #466, 301 failures are observed when running hipblaslt pre_checkin_matmul_gemm_amaxAB_mix_precisions tests on gfx942. While tests have passed for the past 6 months there were recent changes in dependencies that surfaced these failures. The precise reason these tests previously passed is still unknown. However, investigation into the failures led to discovering that there are two places in the code where the method `HipSolutionAdapter::initializeLazyLoading` was misused. In particular, we were doing the following:

```
adapter->initializeLazyLoading("", "/path/to/library/dir")
```

As seen above, the first argument is an empty string but should be a string representing an architecture of interest e.g. `gfx942`. As such, the  `HipSolutionAdapter::initializeLazyLoading` tries to load a library of the form:

```
"Kernels.so-000-" + arch + ".hsaco""
```

where `arch` is an empty string which will inevitably fail. In turn, the expected failure was previously ignored. Up to this point, with some luck the error was cleared before/after calling `fill_batch`. However, there is no reason to encounter this error in the first place. The purpose of calling `HipSolutionAdapter::initializeLazyLoading` was to take advantage of a side effect of the function where a member variable representing the library directory path is set.

This patch adds a new function that separates setting the member variable from initializing lazy loading such that the error is not encountered in the first place.