### PR TITLE
[rocRoller] math-ci - set ROCROLLER_BUILD_DIR

### DIFF
--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -79,7 +79,7 @@ def runTestCommand (platform, project)
                 pushd build
                 echo Using `nproc` threads for testing.
                 OMP_NUM_THREADS=8 ctest -j ${numThreads} --output-on-failure ${testExclude}
-                export ROCROLLER_BUILD_DIRECTORY=`pwd`
+                export ROCROLLER_BUILD_DIR=`pwd`
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950
             """

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -79,7 +79,7 @@ def runTestCommand (platform, project)
                 pushd build
                 echo Using `nproc` threads for testing.
                 OMP_NUM_THREADS=8 ctest -j ${numThreads} --output-on-failure ${testExclude}
-
+                export ROCROLLER_BUILD_DIRECTORY=`pwd`
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950
             """


### PR DESCRIPTION
Resolves math-ci precheckin failures