### PR TITLE
Include string.h in rocrand_mtgp32.h

### DIFF
--- a/projects/rocrand/library/include/rocrand/rocrand_mtgp32.h
+++ b/projects/rocrand/library/include/rocrand/rocrand_mtgp32.h
@@ -60,6 +60,7 @@
 #include <hip/hip_runtime.h>
 
 #include <stdlib.h>
+#include <string.h>
 
 #define MTGP_MEXP 11213
 #define MTGP_N 351


### PR DESCRIPTION
The header file refers to memset but is missing include of string.h. The issue comes up after the removal of standard headers like string.h from hip runtime headers.