### PR TITLE
[ci] - Adding PR gates for azure

### DIFF
--- a/.azuredevops/hipblaslt.yml
+++ b/.azuredevops/hipblaslt.yml
@@ -35,7 +35,20 @@ trigger:
     - projects/hipblaslt/.*.y*ml
     - projects/hipblaslt/*.md
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/hipblaslt
+    exclude:
+    - projects/hipblaslt/.githooks
+    - projects/hipblaslt/.github
+    - projects/hipblaslt/docs
+    - projects/hipblaslt/CODEOWNERS
+    - projects/hipblaslt/.*.y*ml
+    - projects/hipblaslt/*.md
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/hipBLASLt.yml@pipelines_repo

--- a/.azuredevops/hipcub.yml
+++ b/.azuredevops/hipcub.yml
@@ -38,7 +38,23 @@ trigger:
     - projects/hipcub/LICENSE.txt
     - projects/hipcub/NOTICES.txt
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/hipcub
+    exclude:
+    - projects/hipcub/.githooks
+    - projects/hipcub/.github
+    - projects/hipcub/.gitlab
+    - projects/hipcub/.jenkins
+    - projects/hipcub/docs
+    - projects/hipcub/.*.y*ml
+    - projects/hipcub/*.md
+    - projects/hipcub/LICENSE.txt
+    - projects/hipcub/NOTICES.txt
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/hipCUB.yml@pipelines_repo

--- a/.azuredevops/hipfft.yml
+++ b/.azuredevops/hipfft.yml
@@ -35,7 +35,20 @@ trigger:
     - projects/hipfft/.*.y*ml
     - projects/hipfft/*.md
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/hipfft
+    exclude:
+    - projects/hipfft/.githooks
+    - projects/hipfft/.github
+    - projects/hipfft/.jenkins
+    - projects/hipfft/docs
+    - projects/hipfft/.*.y*ml
+    - projects/hipfft/*.md
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/hipFFT.yml@pipelines_repo

--- a/.azuredevops/hiprand.yml
+++ b/.azuredevops/hiprand.yml
@@ -36,7 +36,21 @@ trigger:
     - projects/hiprand/*.md
     - projects/hiprand/LICENSE.txt
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/hiprand
+    exclude:
+    - projects/hiprand/.githooks
+    - projects/hiprand/.github
+    - projects/hiprand/.jenkins
+    - projects/hiprand/docs
+    - projects/hiprand/.*.y*ml
+    - projects/hiprand/*.md
+    - projects/hiprand/LICENSE.txt
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/hipRAND.yml@pipelines_repo

--- a/.azuredevops/rocblas.yml
+++ b/.azuredevops/rocblas.yml
@@ -36,7 +36,21 @@ trigger:
     - projects/rocblas/*.md
     - projects/rocblas/*.rst
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/rocblas
+    exclude:
+    - projects/rocblas/.githooks
+    - projects/rocblas/.github
+    - projects/rocblas/.jenkins
+    - projects/rocblas/docs
+    - projects/rocblas/.*.y*ml
+    - projects/rocblas/*.md
+    - projects/rocblas/*.rst
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/rocBLAS.yml@pipelines_repo

--- a/.azuredevops/rocfft.yml
+++ b/.azuredevops/rocfft.yml
@@ -35,7 +35,20 @@ trigger:
     - projects/rocfft/.*.y*ml
     - projects/rocfft/*.md
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/rocfft
+    exclude:
+    - projects/rocfft/.githooks
+    - projects/rocfft/.github
+    - projects/rocfft/.jenkins
+    - projects/rocfft/docs
+    - projects/rocfft/.*.y*ml
+    - projects/rocfft/*.md
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/rocFFT.yml@pipelines_repo

--- a/.azuredevops/rocprim.yml
+++ b/.azuredevops/rocprim.yml
@@ -38,7 +38,22 @@ trigger:
     - projects/rocprim/LICENSE.txt
     - projects/rocprim/NOTICES.txt
 
-pr: none
+pr:
+  branches:
+    include:
+    - users/geomin12/azure-pipelines-gate
+  paths:
+    include:
+    - projects/rocprim
+    exclude:
+    - projects/rocprim/.githooks
+    - projects/rocprim/.github
+    - projects/rocprim/.gitlab
+    - projects/rocprim/.jenkins
+    - projects/rocprim/docs
+    - projects/rocprim/.*.y*ml
+    - projects/rocprim/LICENSE.txt
+    - projects/rocprim/NOTICES.txt
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/rocPRIM.yml@pipelines_repo

--- a/.azuredevops/rocprim.yml
+++ b/.azuredevops/rocprim.yml
@@ -41,7 +41,7 @@ trigger:
 pr:
   branches:
     include:
-    - users/geomin12/azure-pipelines-gate
+    - develop
   paths:
     include:
     - projects/rocprim
@@ -52,6 +52,7 @@ pr:
     - projects/rocprim/.jenkins
     - projects/rocprim/docs
     - projects/rocprim/.*.y*ml
+    - projects/rocprim/*.md
     - projects/rocprim/LICENSE.txt
     - projects/rocprim/NOTICES.txt
 

--- a/.azuredevops/rocrand.yml
+++ b/.azuredevops/rocrand.yml
@@ -36,7 +36,21 @@ trigger:
     - projects/rocrand/*.md
     - projects/rocrand/LICENSE.txt
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/rocrand
+    exclude:
+    - projects/rocrand/.githooks
+    - projects/rocrand/.github
+    - projects/rocrand/.jenkins
+    - projects/rocrand/docs
+    - projects/rocrand/.*.y*ml
+    - projects/rocrand/*.md
+    - projects/rocrand/LICENSE.txt
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/rocRAND.yml@pipelines_repo

--- a/.azuredevops/rocsolver.yml
+++ b/.azuredevops/rocsolver.yml
@@ -34,7 +34,19 @@ trigger:
     - projects/rocsolver/.*.y*ml
     - projects/rocsolver/*.md
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/rocsolver
+    exclude:
+    - projects/rocsolver/.github
+    - projects/rocsolver/.jenkins
+    - projects/rocsolver/docs
+    - projects/rocsolver/.*.y*ml
+    - projects/rocsolver/*.md
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/rocSOLVER.yml@pipelines_repo

--- a/.azuredevops/rocthrust.yml
+++ b/.azuredevops/rocthrust.yml
@@ -38,7 +38,23 @@ trigger:
     - projects/rocthrust/LICENSE
     - projects/rocthrust/NOTICES.txt
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/rocthrust
+    exclude:
+    - projects/rocthrust/.githooks
+    - projects/rocthrust/.github
+    - projects/rocthrust/.jenkins
+    - projects/rocthrust/doc
+    - projects/rocthrust/docs
+    - projects/rocthrust/.*.y*ml
+    - projects/rocthrust/*.md
+    - projects/rocthrust/LICENSE
+    - projects/rocthrust/NOTICES.txt
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/rocThrust.yml@pipelines_repo

--- a/.azuredevops/tensile.yml
+++ b/.azuredevops/tensile.yml
@@ -35,7 +35,20 @@ trigger:
     - shared/tensile/*.md
     - shared/tensile/.*.y*ml
 
-pr: none
+pr:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - shared/tensile
+    exclude:
+    - shared/tensile/.github
+    - shared/tensile/.jenkins
+    - shared/tensile/docs
+    - shared/tensile/tuning_docs
+    - shared/tensile/*.md
+    - shared/tensile/.*.y*ml
 
 jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/Tensile.yml@pipelines_repo


### PR DESCRIPTION
For Azure pipelines, this update gates pull requests until all checks pass (will apply the ruleset after this goes through)

Did a test on other branches with [this rocPRIM ruleset](https://github.com/ROCm/rocm-libraries/settings/rules/6566713), where we require `rocPRIM` Azure pipeline status check. 

In #533 , I made a markdown update in rocPRIM (purposedly allowed pipeline run for markdown files) and it ran the checks and failed, and it won't let me squash + merge!

![Screenshot 2025-07-09 064514](https://github.com/user-attachments/assets/07da974d-600e-471b-a2f2-60c9355cefaf)

In #534 , I made an update in gardening docs (not rocPRIM), and it skipped the required check (previous issue was it was "pending" and blocking PRs)

![Screenshot 2025-07-09 064605](https://github.com/user-attachments/assets/a8accacd-3bc2-44f3-90d3-b9c5d00e1a0c)

Progress on #479 