### PR TITLE
Set default rocroller scheduler to Priority

### DIFF
--- a/shared/rocroller/lib/include/rocRoller/Utilities/Settings.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Utilities/Settings.hpp
@@ -146,7 +146,7 @@ namespace rocRoller
         static inline const SettingsOption<Scheduling::SchedulerProcedure> Scheduler{
             "ROCROLLER_SCHEDULER",
             "Scheduler used when scheduling independent instruction streams.",
-            Scheduling::SchedulerProcedure::Sequential,
+            Scheduling::SchedulerProcedure::Priority,
             -1};
 
         static inline const SettingsOption<Scheduling::CostFunction> SchedulerCost{


### PR DESCRIPTION
Change the default rocRoller scheduler from Sequential to Priority.