### PR TITLE
[ci] - Adding status check fix for `therock-ci`

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -29,6 +29,7 @@ def set_github_output(d: Mapping[str, str]):
 def retrieve_projects(args):
     # TODO(geomin12): #590 Enable TheRock CI for forked PRs
     if args.get("is_forked_pr"):
+        logging.info("Warning: not enabling any projects due to is_forked_pr. Builds/tests for forked PRs are disabled pending: https://github.com/ROCm/rocm-libraries/issues/590")
         return []
     
     if args.get("is_pull_request"):

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -25,6 +25,10 @@ def set_github_output(d: Mapping[str, str]):
         
         
 def retrieve_projects(args):
+    # TODO(geomin12): Enable TheRock CI for forked PRs
+    if args.get("is_forked_pr"):
+        return []
+    
     if args.get("is_pull_request"):
         subtrees = args.get("input_subtrees").split("\n")
     
@@ -60,11 +64,14 @@ def run(args):
 
 
 if __name__ == "__main__":
-    github_event_name = os.getenv("GITHUB_EVENT_NAME")
     args = {}
+    github_event_name = os.getenv("GITHUB_EVENT_NAME")
     args["is_pull_request"] = github_event_name == "pull_request"
     args["is_push"] = github_event_name == "push"
     args["is_workflow_dispatch"] = github_event_name == "workflow_dispatch"
+    
+    is_forked_pr = os.getenv("IS_FORKED_PR")
+    args["is_forked_pr"] = is_forked_pr
     
     input_subtrees = os.getenv("SUBTREES", "")
     args["input_subtrees"] = input_subtrees

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     args["is_workflow_dispatch"] = github_event_name == "workflow_dispatch"
     
     is_forked_pr = os.getenv("IS_FORKED_PR")
-    args["is_forked_pr"] = is_forked_pr
+    args["is_forked_pr"] = is_forked_pr == "true"
     
     input_subtrees = os.getenv("SUBTREES", "")
     args["input_subtrees"] = input_subtrees

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -6,26 +6,28 @@ Required environment variables:
 """
 
 import json
+import logging
 from therock_matrix import subtree_to_project_map, project_map
 from typing import Mapping
 import os
 
+logging.basicConfig(level=logging.INFO)
 
 def set_github_output(d: Mapping[str, str]):
     """Sets GITHUB_OUTPUT values.
     See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs
     """
-    print(f"Setting github output:\n{d}")
+    logging.info(f"Setting github output:\n{d}")
     step_output_file = os.environ.get("GITHUB_OUTPUT", "")
     if not step_output_file:
-        print("Warning: GITHUB_OUTPUT env var not set, can't set github outputs")
+        logging.warning("Warning: GITHUB_OUTPUT env var not set, can't set github outputs")
         return
     with open(step_output_file, "a") as f:
         f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
         
         
 def retrieve_projects(args):
-    # TODO(geomin12): Enable TheRock CI for forked PRs
+    # TODO(geomin12): #590 Enable TheRock CI for forked PRs
     if args.get("is_forked_pr"):
         return []
     
@@ -78,5 +80,7 @@ if __name__ == "__main__":
     
     input_projects = os.getenv("PROJECTS", "")
     args["input_projects"] = input_projects
+    
+    logging.info(f"Retrieved arguments {args}")
 
     run(args)

--- a/.github/workflows/azure-ci-dispatcher.yml
+++ b/.github/workflows/azure-ci-dispatcher.yml
@@ -26,6 +26,10 @@ on:
       - staging
       - main
       - release-staging/rocm-rel-7.*
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '*.md'
 
 concurrency:
   group: azure-ci-dispatcher-${{ github.event.pull_request.number || github.ref }}
@@ -37,12 +41,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 720
     steps:
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: refs/pull/${{ github.event.pull_request.number }}/merge
         sparse-checkout: .github
         sparse-checkout-cone-mode: true
+        token: ${{ steps.generate-token.outputs.token }}
 
     - name: Install dependencies
       run: |
@@ -52,7 +65,7 @@ jobs:
     - name: Detect changed subtrees
       id: detect
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
         python .github/scripts/pr_detect_changed_subtrees.py \
           --repo "${{ github.repository }}" \
@@ -63,6 +76,8 @@ jobs:
     - name: Dispatch Azure CI runs
       id: dispatch
       if: steps.detect.outputs.subtrees
+      env:
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
         echo "${{ steps.detect.outputs.subtrees }}" > changed_subtrees.txt
 

--- a/.github/workflows/azure-ci-dispatcher.yml
+++ b/.github/workflows/azure-ci-dispatcher.yml
@@ -26,10 +26,6 @@ on:
       - staging
       - main
       - release-staging/rocm-rel-7.*
-    paths-ignore:
-      - '.github/**'
-      - 'docs/**'
-      - '*.md'
 
 concurrency:
   group: azure-ci-dispatcher-${{ github.event.pull_request.number || github.ref }}
@@ -41,21 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 720
     steps:
-    - name: Generate a token
-      id: generate-token
-      uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-      with:
-        app-id: ${{ secrets.APP_ID }}
-        private-key: ${{ secrets.APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
-
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: refs/pull/${{ github.event.pull_request.number }}/merge
         sparse-checkout: .github
         sparse-checkout-cone-mode: true
-        token: ${{ steps.generate-token.outputs.token }}
 
     - name: Install dependencies
       run: |
@@ -64,8 +51,6 @@ jobs:
 
     - name: Detect changed subtrees
       id: detect
-      env:
-        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
         python .github/scripts/pr_detect_changed_subtrees.py \
           --repo "${{ github.repository }}" \
@@ -76,8 +61,6 @@ jobs:
     - name: Dispatch Azure CI runs
       id: dispatch
       if: steps.detect.outputs.subtrees
-      env:
-        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
         echo "${{ steps.detect.outputs.subtrees }}" > changed_subtrees.txt
 

--- a/.github/workflows/azure-ci-dispatcher.yml
+++ b/.github/workflows/azure-ci-dispatcher.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Detect changed subtrees
       id: detect
       env:
-        GH_TOKEN: ${{ env.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         python .github/scripts/pr_detect_changed_subtrees.py \
           --repo "${{ github.repository }}" \

--- a/.github/workflows/azure-ci-dispatcher.yml
+++ b/.github/workflows/azure-ci-dispatcher.yml
@@ -51,6 +51,8 @@ jobs:
 
     - name: Detect changed subtrees
       id: detect
+      env:
+        GH_TOKEN: ${{ env.GITHUB_TOKEN }}
       run: |
         python .github/scripts/pr_detect_changed_subtrees.py \
           --repo "${{ github.repository }}" \

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -34,21 +34,11 @@ jobs:
     outputs:
       projects: ${{ steps.projects.outputs.projects }}
     steps:
-      - name: Generate a token
-        id: generate-token
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: .github
           sparse-checkout-cone-mode: true
-          token: ${{ steps.generate-token.outputs.token }}
 
       # # will be needed for `patch_monorepo.py` but necessary now
       # - name: Checkout TheRock Repository
@@ -77,8 +67,6 @@ jobs:
       - name: Detect changed subtrees
         id: detect
         if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           python .github/scripts/pr_detect_changed_subtrees.py \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Detect changed subtrees
         id: detect
         if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: |
           python .github/scripts/pr_detect_changed_subtrees.py \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -80,8 +80,8 @@ jobs:
         env:
           SUBTREES: ${{ steps.detect.outputs.subtrees }}
           PROJECTS: ${{ inputs.projects }}
-          # TODO(geomin12): Enable TheRock CI for forked PRs
-          IS_FORKED_PR: ${{ github.event.pull_request.head.repo.fork }}
+          # TODO(geomin12): #590 Enable TheRock CI for forked PRs
+          IS_FORKED_PR: ${{ github.event.pull_request.head.repo.fork == true }}
         run: |
           python .github/scripts/therock_configure_ci.py
 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -68,7 +68,7 @@ jobs:
         id: detect
         if: github.event_name == 'pull_request'
         env:
-          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python .github/scripts/pr_detect_changed_subtrees.py \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -10,9 +10,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths-ignore:
-      - "docs/**"
-      - "*.md"
   workflow_dispatch:
     inputs:
       projects:
@@ -33,8 +30,6 @@ concurrency:
 jobs:
   setup:
     name: "Setup"
-    # TODO(geomin12): Enable TheRock CI for forked PRs
-    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-24.04
     outputs:
       projects: ${{ steps.projects.outputs.projects }}
@@ -94,6 +89,8 @@ jobs:
         env:
           SUBTREES: ${{ steps.detect.outputs.subtrees }}
           PROJECTS: ${{ inputs.projects }}
+          # TODO(geomin12): Enable TheRock CI for forked PRs
+          IS_FORKED_PR: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           python .github/scripts/therock_configure_ci.py
 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
Since `TheRock CI Linux`, `TheRock CI Windows` are required checks, some PRs were never running the status checks (particularly, forked PRs and doc updates)

Changes:
- removing ignored paths for therock-ci
- making sure forked PRs run properly
- cleanup for tokens, token is no longer needed