### PR TITLE
[GitHub Actions] Format Patch Usage for Modified Files

### DIFF
--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -149,10 +149,13 @@ def generate_file_level_patches(prefix: str, merge_sha: str, output_dir: Path) -
         elif status == 'M':
             file_path = parts[1]
             patch_path = output_dir / (file_path.replace("/", "_") + ".patch")
-            diff_text = _run_git([
-                "diff", f"{merge_sha}^!", "--", file_path
+            _run_git([
+                "format-patch",
+                "-1", merge_sha,
+                f"--relative={prefix}",
+                "--output", str(patch_path),
+                "--", file_path
             ])
-            patch_path.write_text(diff_text, encoding="utf-8")
             patch_files.append(patch_path)
         elif status == 'D':
             deleted_files.append(parts[1])

--- a/.github/workflows/pr-merge-sync-patches-manual.yml
+++ b/.github/workflows/pr-merge-sync-patches-manual.yml
@@ -97,7 +97,6 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
-
       - name: Generate and apply patches
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -107,3 +106,4 @@ jobs:
             --pr "${{ github.event.inputs.pr }}" \
             --subtrees "${{ steps.detect.outputs.subtrees }}" \
             --config ".github/repos-config.json"
+            --debug

--- a/.github/workflows/pr-merge-sync-patches.yml
+++ b/.github/workflows/pr-merge-sync-patches.yml
@@ -124,3 +124,4 @@ jobs:
             --pr "${{ steps.pr-check.outputs.pr }}" \
             --subtrees "${{ steps.detect.outputs.subtrees }}" \
             --config ".github/repos-config.json"
+            --debug


### PR DESCRIPTION
- For the individual modified files, go back to using format-patch as this was working last week before this endeavour on supporting large files. (Commit 43e4a8a8873fecc3041c1e5a2fa5098f968b255a)
- Now that we stripped out patches for file adds, deletes, and moves, the patch file sizes should be manageable.
- Added debug logging as default behaviour to the GitHub workflows.