### PR TITLE
Add logic to handle GPU_TARGETS=all in CMake

### DIFF
--- a/projects/hipblaslt/next-cmake/CMakeLists.txt
+++ b/projects/hipblaslt/next-cmake/CMakeLists.txt
@@ -37,6 +37,7 @@ include(GenerateExportHeader)
 include(CMakeDependentOption)
 include(hipblaslt_python)
 include(hipblaslt_target_configure_sanitizers)
+include(TensileliteSupportedArchitectures)
 
 rocm_setup_version(VERSION ${PROJECT_VERSION})
 set(hipblaslt_SOVERSION 1.0)
@@ -105,6 +106,14 @@ set(TEMP_TENSILE_HOST_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../tensilelite/Ten
 set(HIPBLASLT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../library")
 set(HIPBLASLT_CLIENTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../clients")
 set(ROCBLASLT_LIB_DIR "${HIPBLASLT_LIB_DIR}/src/amd_detail/rocblaslt")
+set(GPU_TARGETS "" CACHE STRING "AMD GFX targets to cross-compile")
+
+if(NOT GPU_TARGETS OR GPU_TARGETS STREQUAL "all")
+    tensile_get_base_architectures(GPU_TARGETS)
+else()
+    tensile_validate_gpu_targets("${GPU_TARGETS}")
+endif()
+message(STATUS "Building for GPU targets: ${GPU_TARGETS}")
 
 find_package(hip REQUIRED)
 if(HIPBLASLT_ENABLE_HOST)

--- a/projects/hipblaslt/next-cmake/cmake/TensileliteSupportedArchitectures.cmake
+++ b/projects/hipblaslt/next-cmake/cmake/TensileliteSupportedArchitectures.cmake
@@ -1,0 +1,87 @@
+# ##############################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ##############################################################################
+
+# Base architectures - used when "all" is specified for GPU_TARGETS
+set(BASE_ARCHITECTURES "")
+
+# All supported architectures including xnack variants - used for validation of GPU_TARGETS
+set(SUPPORTED_ARCHITECTURES "")
+
+if(NOT BUILD_ADDRESS_SANITIZER)
+    list(APPEND BASE_ARCHITECTURES 
+        "gfx908"
+        "gfx90a"
+        "gfx942"
+        "gfx950"
+        "gfx1100"
+        "gfx1101"
+        "gfx1103"
+        "gfx1150"
+        "gfx1151"
+        "gfx1200"
+        "gfx1201")
+    
+    set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
+    list(APPEND SUPPORTED_ARCHITECTURES 
+        "gfx908:xnack+"
+        "gfx908:xnack-"
+        "gfx90a:xnack+"
+        "gfx90a:xnack-")
+
+else()
+    # For address sanitizer builds, base and supported are the same
+    list(APPEND BASE_ARCHITECTURES 
+        "gfx908:xnack+"
+        "gfx90a:xnack+"
+        "gfx942:xnack+"
+        "gfx950:xnack+")
+    set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
+endif()
+
+function(tensile_validate_gpu_targets targets)
+    set(supported_list ${SUPPORTED_ARCHITECTURES})
+    set(target_list ${targets})
+
+    string(REGEX REPLACE ";" " " supported_flat "${supported_list}")
+    string(REGEX REPLACE " +" ";" supported_list "${supported_flat}")
+    
+    string(REGEX REPLACE ";" " " target_flat "${target_list}")
+    string(REGEX REPLACE " +" ";" target_list "${target_flat}")
+
+    foreach(target IN LISTS target_list)
+        list(FIND supported_list "${target}" idx)
+        if(idx EQUAL -1)
+            message(FATAL_ERROR "Unsupported GPU target: ${target}\nSupported targets are: ${supported_list}")
+        endif()
+    endforeach()
+endfunction()
+
+function(tensile_get_base_architectures output_var)
+    set(${output_var} ${BASE_ARCHITECTURES} PARENT_SCOPE)
+endfunction()
+
+function(tensile_get_supported_architectures output_var)
+    set(${output_var} ${SUPPORTED_ARCHITECTURES} PARENT_SCOPE)
+endfunction()
+


### PR DESCRIPTION
Adds logic in the hipBLASLt new build system to correctly handle "all" as a value for -DGPU_TARGETS. Specifying `-DGPU_TARGETS=all` will automatically expand to the full set of supported GPU architectures, and this option is set as the default.