### PR TITLE
feat(rocprim): add --skip_gathered flag to run_benchmarks.py

### DIFF
--- a/projects/rocprim/.gitlab/run_benchmarks.py
+++ b/projects/rocprim/.gitlab/run_benchmarks.py
@@ -28,7 +28,7 @@ import stat
 import subprocess
 import sys
 
-BenchmarkContext = namedtuple('BenchmarkContext', ['gpu_architecture', 'benchmark_output_dir', 'benchmark_dir', 'benchmark_filename_regex', 'benchmark_filter_regex', 'size', 'trials', 'seed'])
+BenchmarkContext = namedtuple('BenchmarkContext', ['gpu_architecture', 'benchmark_output_dir', 'benchmark_dir', 'benchmark_filename_regex', 'benchmark_filter_regex', 'size', 'trials', 'seed', 'skip_gathered'])
 
 def run_benchmarks(benchmark_context):
     def is_benchmark_executable(filename):
@@ -49,6 +49,9 @@ def run_benchmarks(benchmark_context):
 
         benchmark_path = os.path.join(benchmark_context.benchmark_dir, benchmark_name)
         results_json_path = os.path.join(benchmark_context.benchmark_output_dir, results_json_name)
+        if benchmark_context.skip_gathered and os.path.exists(results_json_path):
+            print(f'Skipping {benchmark_name}, because its results have already been gathered at {results_json_path}', file=sys.stderr, flush=True)
+            continue
         args = [
             benchmark_path,
             f'--benchmark_out={results_json_path}',
@@ -100,6 +103,11 @@ def main():
         help='Controls the seed for random number generation for each benchmark case',
         default='',
         required=False)
+    parser.add_argument('--skip_gathered',
+        help='Skip running benchmarks whose JSON data has already been gathered',
+        default=False,
+        action='store_true',
+        required=False)
 
     args = parser.parse_args()
 
@@ -111,7 +119,8 @@ def main():
         args.benchmark_filter_regex,
         args.size,
         args.trials,
-        args.seed)
+        args.seed,
+        args.skip_gathered)
 
     benchmark_run_successful = run_benchmarks(benchmark_context)
 

--- a/projects/rocprim/.gitlab/run_benchmarks.py
+++ b/projects/rocprim/.gitlab/run_benchmarks.py
@@ -22,6 +22,7 @@
 
 import argparse
 from collections import namedtuple
+import json
 import os
 import re
 import stat
@@ -41,6 +42,18 @@ def run_benchmarks(benchmark_context):
         # and it is a regular file (S_IFREG)
         return (st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)) and (st_mode & stat.S_IFREG)
 
+    def should_skip(results_json_path):
+        if not benchmark_context.skip_gathered:
+            return False
+
+        try:
+            with open(results_json_path) as f:
+                json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return False
+
+        return True
+
     success = True
     benchmark_names = [name for name in os.listdir(benchmark_context.benchmark_dir) if is_benchmark_executable(name)]
     print('The following benchmarks will be ran:\n{}'.format('\n'.join(benchmark_names)), file=sys.stderr, flush=True)
@@ -49,7 +62,7 @@ def run_benchmarks(benchmark_context):
 
         benchmark_path = os.path.join(benchmark_context.benchmark_dir, benchmark_name)
         results_json_path = os.path.join(benchmark_context.benchmark_output_dir, results_json_name)
-        if benchmark_context.skip_gathered and os.path.exists(results_json_path):
+        if should_skip(results_json_path):
             print(f'Skipping {benchmark_name}, because its results have already been gathered at {results_json_path}', file=sys.stderr, flush=True)
             continue
         args = [

--- a/projects/rocprim/scripts/autotune/templates/segmented_radix_sort_config_template
+++ b/projects/rocprim/scripts/autotune/templates/segmented_radix_sort_config_template
@@ -22,7 +22,7 @@ segmented_radix_sort_config<
 
 {% macro general_case() -%}
 template<unsigned int arch, class key_type, typename value_type, class enable = void>
-struct default_segmented_radix_sort_config : default_segmented_radix_sort_config_base<6, 4>::type
+struct default_segmented_radix_sort_config : default_segmented_radix_sort_config_base<6>::type
 {};
 {%- endmacro %}
 


### PR DESCRIPTION
## Scope
I am regenerating all 53 rocPRIM autotune configs, for all 7 GPU architectures, but that takes more than a single weekend to finish. And because Stream HPC colleagues need these GPUs during the weekdays, I need to stop the autotuning on Sunday.

In order to spread the work out across several nights and weekends, `run_benchmarks.py` needs to resume where it left off.

So far when I stopped `run_benchmarks.py` and started it again, it would start all over again, overwriting whatever JSON data it had already gathered.

In order to address this issue, this PR adds the optional flag `--skip_gathered`, which causes the program to skip rerunning already gathered JSON files.

## How to verify
1. Run `git checkout users/mynameistrez/skip-gathered-benchmark-data`
2. Run `rm -rf build; mkdir build; cd build`
3. Run `CXX=hipcc cmake -GNinja -DBUILD_BENCHMARK=ON -DBENCHMARK_CONFIG_TUNING=OFF -DGPU_TARGETS=gfx942 ..`
    - Replace `gfx942` with whatever `rocminfo | grep gfx` prints on your server.
4. Run `ninja benchmark_device_segmented_radix_sort_keys`
5. Run `cd ..`
6. Create `foo/benchmark_device_segmented_radix_sort_keys_gfx942.json`, and just put a valid JSON object like `{}` in it.
7. Run `python3 .gitlab/run_benchmarks.py --skip_gathered --benchmark_dir=build/benchmark --benchmark_gpu_architecture=gfx942 --benchmark_output_dir=foo --benchmark_filename_regex="^benchmark_device_segmented_radix_sort_keys"`
    - Replace `gfx942`.

## Notes for the reviewer
Because this PR just adds functionality that only gets activated when the new flag is used, these changes should not break the CI.

I also added the commit [fix(rocprim): fix invalid segmented_radix_sort config generation](https://github.com/ROCm/rocm-libraries/pull/586/commits/1b2eace095d78f2bec746afce23cb63569098e75), since it is a very small fix that I needed.