### PR TITLE
[Ex CI] enable hipSPARSELt pipeline and downstream

### DIFF
--- a/.azuredevops/hipsparselt.yml
+++ b/.azuredevops/hipsparselt.yml
@@ -1,0 +1,43 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: pipelinesRepoRef
+  type: string
+  default: refs/heads/develop
+- name: triggerDownstreamJobs
+  type: boolean
+  default: true
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+    ref: ${{ parameters.pipelinesRepoRef }}
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - develop
+    - release-staging/rocm-rel-7.*
+  paths:
+    include:
+    - projects/hipsparselt
+    exclude:
+    - projects/hipsparselt/.githooks
+    - projects/hipsparselt/.github
+    - projects/hipsparselt/docs
+    - projects/hipsparselt/.*.y*ml
+    - projects/hipsparselt/*.md
+
+pr: none
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/hipSPARSELt.yml@pipelines_repo
+    parameters:
+      sparseCheckoutDir: projects/hipsparselt
+      triggerDownstreamJobs: ${{ parameters.triggerDownstreamJobs }}

--- a/.github/scripts/azure_resolve_subtree_deps.py
+++ b/.github/scripts/azure_resolve_subtree_deps.py
@@ -45,15 +45,21 @@ def read_file_into_set(file_path):
 
 
 def resolve_dependencies(projects, dependencies):
-    """Resolves projects to be run by checking dependencies."""
+    """Resolves projects to be run by checking all levels of dependencies."""
+    def has_dependency(project, projects_set):
+        """Recursively checks if a project has any dependencies in the projects_set."""
+        if project not in dependencies:
+            return False
+        for dependency in dependencies[project]:
+            if dependency in projects_set or has_dependency(dependency, projects_set):
+                return True
+        return False
+
     projects_to_run = set(projects)
 
     for project in projects:
-        if project in dependencies:
-            for dependency in dependencies[project]:
-                if dependency in projects:
-                    # Skip project if its dependency is present
-                    projects_to_run.discard(project)
+        if has_dependency(project, projects_to_run):
+            projects_to_run.discard(project)
 
     return projects_to_run
 
@@ -73,12 +79,13 @@ def main(argv=None) -> None:
         "projects/hipblas-common": {},
         "projects/hipblaslt": {"projects/hipblas-common"},
         "projects/rocblas": {"projects/hipblaslt"},
-        "projects/rocsolver": {"projects/rocprim", "projects/hipblaslt"},
-        "projects/rocsparse": {"projects/rocprim", "projects/hipblaslt"},
+        "projects/rocsolver": {"projects/rocprim", "projects/rocblas"},
+        "projects/rocsparse": {"projects/rocprim", "projects/rocblas"},
         "projects/hipblas": {"projects/rocsolver"},
         "projects/hipsolver": {"projects/rocsolver", "projects/rocsparse"},
-        "projects/hipSPARSE": {"projects/rocsparse"},
-        "projects/MIOpen": {"projects/rocrand", "projects/hipblas"}
+        "projects/hipsparse": {"projects/rocsparse"},
+        "projects/hipsparselt": {"projects/hipsparse"},
+        "projects/miopen": {"projects/rocrand", "projects/hipblas"}
     }
     # Azure pipeline IDs for each project, to be populated as projects are enabled
     definition_ids = {
@@ -92,6 +99,7 @@ def main(argv=None) -> None:
         "projects/rocthrust": 276,
         "projects/hipblas-common": 300,
         "projects/hipblaslt": 301,
+        "projects/hipsparselt": 'TODO',
         "projects/rocblas": 302,
         "projects/rocsolver": 303,
     }

--- a/.github/scripts/azure_resolve_subtree_deps.py
+++ b/.github/scripts/azure_resolve_subtree_deps.py
@@ -99,7 +99,7 @@ def main(argv=None) -> None:
         "projects/rocthrust": 276,
         "projects/hipblas-common": 300,
         "projects/hipblaslt": 301,
-        "projects/hipsparselt": 'TODO',
+        "projects/hipsparselt": 309,
         "projects/rocblas": 302,
         "projects/rocsolver": 303,
     }


### PR DESCRIPTION
Depends on https://github.com/ROCm/ROCm/pull/5033

Creates a trigger file for hipSPARSELt in the monorepo. hipSPARSELt will be part of rocBLAS's downstream jobs until hipSPARSE is migrated into the monorepo.

In azure_resolve_subtree_deps.py:
- Added entry in dep tree for hipSPARSELt depending on hipSPARSE
- Added pipeline ID for new hipSPARSELt pipeline
- Fix the `resolve_dependencies()` function to fully recurse over the dependency tree instead of only checking 1 level deep
- Fix incorrect deps for rocSOLVER and rocSPARSE
- Fix inconsistent capitalization in dep tree