### PR TITLE
[Ex CI] remove invalid char in hipBLAS-common stage name

### DIFF
--- a/.azuredevops/hipblas-common.yml
+++ b/.azuredevops/hipblas-common.yml
@@ -33,7 +33,7 @@ trigger:
 pr: none
 
 stages:
-- stage: hipblas-common
+- stage: hipblas_common
   jobs:
   - template: ${{ variables.CI_COMPONENT_PATH }}/hipBLAS-common.yml@pipelines_repo
     parameters:


### PR DESCRIPTION
Azure stage and job names cannot have hyphens in them, so swap for underscore.