### PR TITLE
[rocroller] Build system clean up

### DIFF
--- a/shared/rocroller/.jenkins/precheckin.groovy
+++ b/shared/rocroller/.jenkins/precheckin.groovy
@@ -13,7 +13,7 @@ def runCI =
 
     //use docker files from this repo
     prj.repoDockerfile = true
-    prj.defaults.ccache = true
+    prj.defaults.ccache = false
 
     def uniqueTag = params?."Unique Docker image tag" ? org.apache.commons.lang.RandomStringUtils.random(9, true, true) : ""
 

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -71,7 +71,7 @@ else()
     unset(CMAKE_CXX_CPPCHECK CACHE)
 endif()
 
-find_package(fmt 11.1.3)
+find_package(fmt 11.1.3 QUIET)
 if(NOT fmt_FOUND)
     if(ROCROLLER_ENABLE_FETCH)
         set(FMT_SYSTEM_HEADERS ON)
@@ -86,7 +86,7 @@ if(NOT fmt_FOUND)
     endif()
 endif()
 
-find_package(spdlog)
+find_package(spdlog QUIET)
 if(NOT spdlog_FOUND)
     if(ROCROLLER_ENABLE_FETCH)
         FetchContent_Declare(
@@ -100,7 +100,7 @@ if(NOT spdlog_FOUND)
     endif()
 endif()
 
-find_package(libdivide)
+find_package(libdivide QUIET)
 if(NOT libdivide_FOUND)
 if(ROCROLLER_ENABLE_FETCH)
     FetchContent_Declare(
@@ -124,7 +124,7 @@ else()
     set(msgpack_libs msgpackc)
 endif()
 
-find_package(Boost 1.74.0)
+find_package(Boost 1.74.0 QUIET)
 if(NOT Boost_FOUND)
     if(ROCROLLER_ENABLE_FETCH)
         FetchContent_Declare(
@@ -256,7 +256,11 @@ target_link_libraries(rocroller
         ${llvm_libs}
 )
 
-target_include_directories(rocroller PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/include>)
+target_include_directories(rocroller 
+    PUBLIC 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/include>
+)
+
 
 target_compile_features(rocroller PUBLIC cxx_std_20)
 
@@ -287,7 +291,7 @@ rocm_install(
     TARGETS rocroller rocroller-interface
     EXPORT rocroller-targets
     INCLUDE
-        "${ROCROLLER_LIB_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/lib/include"
 )
 
 if(ROCROLLER_BUILD_TESTING OR BUILD_TESTING)

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -30,7 +30,7 @@ cmake_dependent_option(ROCROLLER_ENABLE_LLVM "Enable llvm yaml backend." ON "NOT
 option(ROCROLLER_BUILD_TESTING "Build rocRoller testing." ON)
 option(ROCROLLER_ENABLE_DOCS "Build rocRoller documentation." OFF)
 option(ROCROLLER_ENABLE_CATCH "Build rocRoller catch unit tests" ON)
-option(ROCROLLER_ENABLE_ARCH_GEN_TEST "Build rocRoller architecture generator test" ON)
+option(ROCROLLER_ENABLE_GEMM_CLIENT_TESTS "Use pytest test discovery to add gemm client tests (requires pytest-cmake)" ON)
 option(ROCROLLER_ENABLE_TEST_DISCOVERY "Use gtest and catch2 test discovery functions." ON)
 option(ROCROLLER_ENABLE_COVERAGE "Build code coverage." OFF)
 cmake_dependent_option(ROCROLLER_ENABLE_SLOW_TESTS "Disable slow running tests." ON "NOT ROCROLLER_ENABLE_COVERAGE" OFF)

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -162,6 +162,8 @@ add_library(roc::rocroller ALIAS rocroller)
 add_library(rocroller-interface INTERFACE)
 add_library(roc::rocroller-interface ALIAS rocroller-interface)
 
+target_compile_options(rocroller PUBLIC $<BUILD_INTERFACE:-fmacro-prefix-map=${PROJECT_SOURCE_DIR}=rocm-libraries/shared/rocroller>)
+
 if(ROCROLLER_ENABLE_LLD)
     find_package(LLD REQUIRED)
     target_include_directories(rocroller PRIVATE "${LLD_INCLUDES}")

--- a/shared/rocroller/GPUArchitectureGenerator/CMakeLists.txt
+++ b/shared/rocroller/GPUArchitectureGenerator/CMakeLists.txt
@@ -65,12 +65,14 @@ if(ROCROLLER_ENABLE_TIMERS)
 endif()
 
 if(NOT ROCROLLER_ENABLE_PREGENERATED_ARCH_DEF)
-    set(amd_gpu_mr_isa_zip AMD_GPU_MR_ISA_XML-2025_03_06.zip)
+    set(amd_gpu_mr_isa_zip "${ROCROLLER_MRISAS_DIR}/amd_gpu_mr_isa.zip")
+    file(DOWNLOAD https://gpuopen.com/download/machine-readable-isa/latest ${amd_gpu_mr_isa_zip})
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/amd-mrisa.stamp"
-        COMMAND wget https://gpuopen.com/download/machine-readable-isa/${amd_gpu_mr_isa_zip}
-        COMMAND unzip ${amd_gpu_mr_isa_zip} -d ${ROCROLLER_MRISAS_DIR}
-        COMMAND touch "${CMAKE_CURRENT_BINARY_DIR}/amd-mrisa.stamp"
+        DEPENDS  ${amd_gpu_mr_isa_zip}
+        COMMAND ${CMAKE_COMMAND} -E tar xzf ${amd_gpu_mr_isa_zip}
+        COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/amd-mrisa.stamp"
+        WORKING_DIRECTORY "${ROCROLLER_MRISAS_DIR}"
     )
     add_custom_target(amd-mrisa
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/amd-mrisa.stamp"

--- a/shared/rocroller/GPUArchitectureGenerator/CMakeLists.txt
+++ b/shared/rocroller/GPUArchitectureGenerator/CMakeLists.txt
@@ -65,10 +65,11 @@ if(ROCROLLER_ENABLE_TIMERS)
 endif()
 
 if(NOT ROCROLLER_ENABLE_PREGENERATED_ARCH_DEF)
+    set(amd_gpu_mr_isa_zip AMD_GPU_MR_ISA_XML-2025_03_06.zip)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/amd-mrisa.stamp"
-        COMMAND wget https://gpuopen.com/download/machine-readable-isa/AMD_GPU_MR_ISA_XML-2024_08_22.zip
-        COMMAND unzip AMD_GPU_MR_ISA_XML-2024_08_22.zip -d ${ROCROLLER_MRISAS_DIR}
+        COMMAND wget https://gpuopen.com/download/machine-readable-isa/${amd_gpu_mr_isa_zip}
+        COMMAND unzip ${amd_gpu_mr_isa_zip} -d ${ROCROLLER_MRISAS_DIR}
         COMMAND touch "${CMAKE_CURRENT_BINARY_DIR}/amd-mrisa.stamp"
     )
     add_custom_target(amd-mrisa

--- a/shared/rocroller/client/CMakeLists.txt
+++ b/shared/rocroller/client/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 find_package(BLAS REQUIRED)
 
-find_package(CLI11)
+find_package(CLI11 QUIET)
 if(NOT CLI11_FOUND)
     if(ROCROLLER_ENABLE_FETCH)
         FetchContent_Declare(

--- a/shared/rocroller/test/CMakeLists.txt
+++ b/shared/rocroller/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
-find_package(GTest)
+find_package(GTest QUIET)
 if(NOT GTest_FOUND)
     if(ROCROLLER_ENABLE_FETCH)
         FetchContent_Declare(
@@ -14,7 +14,7 @@ if(NOT GTest_FOUND)
     endif()
 endif()
 
-find_package(mxDataGenerator)
+find_package(mxDataGenerator QUIET)
 if(NOT mxDataGenerator_FOUND)
     if(ROCROLLER_ENABLE_FETCH)
         FetchContent_Declare(

--- a/shared/rocroller/test/CMakeLists.txt
+++ b/shared/rocroller/test/CMakeLists.txt
@@ -68,7 +68,7 @@ if(ROCROLLER_ENABLE_ASAN)
     )
 endif()
 
-if(ROCROLLER_ENABLE_ARCH_GEN_TEST)
+if(ROCROLLER_ENABLE_GEMM_CLIENT_TESTS)
     if(NOT ROCROLLER_ENABLE_LLD)
         # There are a few tests that require ReadELF functionality
         # which is disabled by default and on a deprecation path.
@@ -92,14 +92,15 @@ if(ROCROLLER_ENABLE_ARCH_GEN_TEST)
         PROPERTIES
             SKIP_REGULAR_EXPRESSION ${rocroller_skip_regex}
     )
-    add_executable(arch-gen-tests)
-    if(ROCROLLER_ENABLE_ASAN)
-        rocroller_target_configure_sanitizers(arch-gen-tests PRIVATE)
-        set_target_properties(arch-gen-tests
-            PROPERTIES 
-                CROSSCOMPILING_EMULATOR "${CMAKE_COMMAND};-E;env;${asan_opts}"
-        )
-    endif()
+endif()
+
+add_executable(arch-gen-tests)
+if(ROCROLLER_ENABLE_ASAN)
+    rocroller_target_configure_sanitizers(arch-gen-tests PRIVATE)
+    set_target_properties(arch-gen-tests
+        PROPERTIES
+            CROSSCOMPILING_EMULATOR "${CMAKE_COMMAND};-E;env;${asan_opts}"
+    )
 endif()
 
 find_package(BLAS REQUIRED)
@@ -142,15 +143,13 @@ if(ROCROLLER_ENABLE_TEST_DISCOVERY)
             SKIP_REGULAR_EXPRESSION "test/unit/ErrorTest.cpp:"
             ENVIRONMENT "${asan_opts}"
     )
-    if(ROCROLLER_ENABLE_ARCH_GEN_TEST)
-        gtest_discover_tests(
-            arch-gen-tests
-            XML_OUTPUT_DIR ${TEST_REPORT_DIR}
-            DISCOVERY_MODE PRE_TEST
-            PROPERTIES
-                ENVIRONMENT "${asan_opts}"
-        )
-    endif()
+    gtest_discover_tests(
+        arch-gen-tests
+        XML_OUTPUT_DIR ${TEST_REPORT_DIR}
+        DISCOVERY_MODE PRE_TEST
+        PROPERTIES
+            ENVIRONMENT "${asan_opts}"
+    )
 
     if(ROCROLLER_ENABLE_CATCH)
         if(ROCROLLER_ENABLE_FETCH)

--- a/shared/rocroller/test/CMakeLists.txt
+++ b/shared/rocroller/test/CMakeLists.txt
@@ -44,7 +44,7 @@ if(ROCROLLER_ENABLE_CATCH AND (ROCROLLER_BUILD_TESTING OR BUILD_TESTING))
     # to ensure that the command supplied to execute_process is interpreted as a list
     # of strings rather than one white space delimited string.
     if(ROCROLLER_ENABLE_ASAN)
-    rocroller_target_configure_sanitizers(rocroller-test-catch PRIVATE)
+        rocroller_target_configure_sanitizers(rocroller-test-catch PRIVATE)
         set_target_properties(rocroller-tests-catch
             PROPERTIES 
                 CROSSCOMPILING_EMULATOR "${CMAKE_COMMAND};-E;env;${asan_opts}"
@@ -130,7 +130,6 @@ if(ROCROLLER_ENABLE_TEST_DISCOVERY)
         TEST_FILTER "-*GPU_*"
         DISCOVERY_MODE PRE_TEST
         PROPERTIES
-            SKIP_REGULAR_EXPRESSION "test/unit/ErrorTest.cpp:"
             ENVIRONMENT "${asan_opts}"
     )
     gtest_discover_tests(
@@ -140,7 +139,6 @@ if(ROCROLLER_ENABLE_TEST_DISCOVERY)
         PROPERTIES "LABELS" "GPU"
         DISCOVERY_MODE PRE_TEST
         PROPERTIES
-            SKIP_REGULAR_EXPRESSION "test/unit/ErrorTest.cpp:"
             ENVIRONMENT "${asan_opts}"
     )
     gtest_discover_tests(

--- a/shared/rocroller/test/catch/CMakeLists.txt
+++ b/shared/rocroller/test/catch/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
-find_package(Catch2)
+find_package(Catch2 QUIET)
 if(NOT Catch2_FOUND)
     if(ROCROLLER_ENABLE_FETCH)
         FetchContent_Declare(

--- a/shared/rocroller/test/unit/ErrorTest.cpp
+++ b/shared/rocroller/test/unit/ErrorTest.cpp
@@ -83,7 +83,7 @@ namespace rocRollerTest
         EXPECT_THROW({ AssertFatal(IntA < IntB, ShowValue(IntB), message); }, FatalError);
 
         std::string expected = R"(
-            test/unit/ErrorTest.cpp:92: FatalError(IntA < IntB)
+            rocm-libraries/shared/rocroller/test/unit/ErrorTest.cpp:92: FatalError(IntA < IntB)
                 IntA = 5
             FatalError Test)";
 
@@ -115,7 +115,7 @@ namespace rocRollerTest
                      RecoverableError);
 
         std::string expected = R"(
-            test/unit/ErrorTest.cpp:125: RecoverableError(StrA == StrB)
+            rocm-libraries/shared/rocroller/test/unit/ErrorTest.cpp:125: RecoverableError(StrA == StrB)
                 StrA = StrA
                 StrB = StrB
             RecoverableError Test)";


### PR DESCRIPTION
- Fixes ErrorTests failures by restoring `-fmacro-prefix-map`.
- Uses latest amd-mrisa xml files.
- Uses cross platform functions for downloading and extracting mrisa data.
- Config option name change from `ROCROLLER_ENABLE_ARCH_GEN_TEST`  to `ROCROLLER_ENABLE_GEMM_CLIENT_TESTS`.
- Unconditionally adds arch-gen-tests target.