### PR TITLE
[rocRAND] Add missing include for utility header (cherry-pick)

### DIFF
--- a/projects/rocrand/library/include/rocrand/rocrand_common.h
+++ b/projects/rocrand/library/include/rocrand/rocrand_common.h
@@ -36,6 +36,7 @@
 #define ROCRAND_SQRT2_DOUBLE (1.4142135623730951)
 
 #include <hip/hip_runtime.h>
+#include <utility>
 
 #define ROCRAND_KERNEL __global__ static
 


### PR DESCRIPTION
rocrand/library/include/rocrand/rocrand_common.h was missing an include for the utility header. This header is needed for `std::declval`.