### PR TITLE
[rocThrust] Add check for 128-bit integer support (cherry-pick)

### DIFF
--- a/projects/rocthrust/benchmarks/bench/transform/basic.cu
+++ b/projects/rocthrust/benchmarks/bench/transform/basic.cu
@@ -257,7 +257,9 @@ void add_benchmarks(const std::string& name, std::vector<benchmark::internal::Be
     BENCHMARK_BABELSTREAM_TYPE(int16_t),
     BENCHMARK_BABELSTREAM_TYPE(float),
     BENCHMARK_BABELSTREAM_TYPE(double),
+#if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
     BENCHMARK_BABELSTREAM_TYPE(int128_t),
+#endif
   };
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());


### PR DESCRIPTION
This change adds a missing 128-bit integer support check to the benchmark code.