### PR TITLE
Reintroduce fix for spirv and unknown architecture when using lookback_scan_state

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -116,7 +116,7 @@ constexpr const int MAX_PAYLOAD_SIZE = ROCPRIM_MAX_ATOMIC_SIZE - 1;
 ///
 /// \tparam T The accumulator type of the scan operation.
 /// \tparam UseSleep [optional] If true, the execution of a wavefront is paused for a short duration, allowing other threads or processes to execute during idle periods.
-/// \tparam IsSmall [optional] Dependent on the size of `T`. If it's smaller than 16 bytes, it's set to true.
+/// \tparam IsSmall [optional] Dependent on the size of `T`. If it's smaller than 16 bytes (8 bytes if 16 byte atomics are possibly not supported), it's by default set to true.
 template<class T, bool UseSleep = false, bool IsSmall = (sizeof(T) <= MAX_PAYLOAD_SIZE)>
 struct lookback_scan_state;
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -117,7 +117,7 @@ constexpr const int MAX_PAYLOAD_SIZE = ROCPRIM_MAX_ATOMIC_SIZE - 1;
 /// \tparam T The accumulator type of the scan operation.
 /// \tparam UseSleep [optional] If true, the execution of a wavefront is paused for a short duration, allowing other threads or processes to execute during idle periods.
 /// \tparam IsSmall [optional] Dependent on the size of `T`. If it's smaller than 16 bytes, it's set to true.
-template<class T, bool UseSleep = false, bool IsSmall = (sizeof(T) <= 15)>
+template<class T, bool UseSleep = false, bool IsSmall = (sizeof(T) <= MAX_PAYLOAD_SIZE)>
 struct lookback_scan_state;
 
 /// Reduce lanes `0-valid_items` and return the result in lane 0.


### PR DESCRIPTION
In https://github.com/ROCm/rocPRIM/pull/734 a fix was introduced, something must have gone wrong with rebasing. Here we reintroduce the fix for both spirv and unknown architectures that can not use our 128-bit atomic.