### PR TITLE
[hipSPARSELt] Docs: Change GitHub links and install guides to account for repo change

### DIFF
--- a/projects/hipsparselt/docs/index.rst
+++ b/projects/hipsparselt/docs/index.rst
@@ -11,7 +11,11 @@ hipSPARSELt documentation
 hipSPARSELt is a SPARSE marshalling library that presents a common interface for multiple supported backends.
 For more information, see :doc:`What is hipSPARSELt? <./what-is-hipsparselt>`
 
-The hipSPARSELt public repository is located at `<https://github.com/ROCm/hipSPARSELt>`_.
+The hipSPARSELt public repository is located at `<https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparselt>`_.
+
+.. note::
+
+   The hipSPARSELt repository for ROCm 6.4 and earlier is located at `<https://github.com/ROCm/hipSPARSELt>`_.
 
 .. grid:: 2
   :gutter: 3
@@ -36,7 +40,7 @@ The hipSPARSELt public repository is located at `<https://github.com/ROCm/hipSPA
 
   .. grid-item-card:: Examples
 
-    * `Client samples <https://github.com/ROCm/hipSPARSELt/tree/develop/clients/samples>`_
+    * `Client samples <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparselt/clients/samples>`_
 
   .. grid-item-card:: API Reference
 

--- a/projects/hipsparselt/docs/install/install-hipsparselt.rst
+++ b/projects/hipsparselt/docs/install/install-hipsparselt.rst
@@ -54,21 +54,43 @@ Downloading hipSPARSELt
 --------------------------------------------------------------------------------------
 
 The hipSPARSELt source code is available from the
-`hipSPARSELt GitHub <https://github.com/ROCm/hipSPARSELt>`_.
+the `hipSPARSELt <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparselt>`_ directory
+of the `rocm-libraries <https://github.com/ROCm/rocm-libraries>`_ GitHub.
 
-Download the develop branch using these commands:
+Download the develop branch for hipSPARSELt and all projects in the rocm-libraries repository
+using these commands:
 
 .. code-block:: bash
 
-   git clone -b develop https://github.com/ROCm/hipSPARSELt.git
-   cd hipSPARSELt
+   git clone -b develop https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries/projects/hipsparselt
 
+To limit your local checkout to the hipSPARSELt project, configure ``sparse-checkout`` before cloning.
+This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+Use the following commands for a sparse checkout:
+
+.. code-block:: shell
+
+   git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries
+   git sparse-checkout init --cone
+   git sparse-checkout set projects/hipsparselt
+   git checkout develop # or use the branch you want to work with
+
+.. note::
+
+   To build ROCm 6.4 and older, use the hipSPARSELt repository at `<https://github.com/ROCm/hipSPARSELt>`_.
+   For more information, see the documentation associated with the release you want to build.
 
 Building hipSPARSELt using the install script
 ----------------------------------------------
 
 It's recommended to use the ``install.sh`` script to install hipSPARSELt.
 Here are the steps required to build different packages of the library, including the dependencies and clients.
+
+.. note::
+
+   You can run the ``install.sh`` script from the ``projects/hipsparselt`` directory.
 
 Using install.sh to build hipSPARSELt with dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,6 +127,8 @@ Building hipSPARSELt using individual make commands
 You can build hipSPARSELt using the following commands:
 
 .. note::
+
+   Run these commands from the ``projects/hipsparselt`` directory.
 
    CMake 3.16.8 or later is required to build hipSPARSELt.
 
@@ -154,10 +178,14 @@ Testing the hipSPARSELt installation
 
 After successfully compiling the library with the clients, you can test the hipSPARSELt installation by running an example:
 
+.. note::
+
+   Run these commands from the ``projects/hipsparselt`` directory.
+
 .. code-block:: bash
 
    # Navigate to clients binary directory
-   cd hipSPARSELt/build/release/clients/staging
+   cd build/release/clients/staging
 
    # Execute hipSPARSELt example
    ./example_spmm_strided_batched -m 32 -n 32 -k 32 --batch_count 1
@@ -170,7 +198,7 @@ To run the benchmarks, build hipSPARSELt with the ``-DBUILD_CLIENTS_BENCHMARKS=O
 .. code-block:: bash
 
    # Go to hipSPARSELt build directory
-   cd hipSPARSELt/build/release
+   cd build/release
 
    # Run benchmark, e.g.
    ./clients/staging/hipsparselt-bench -f spmm -i 200 -m 256 -n 256 -k 256
@@ -180,7 +208,7 @@ To run the unit tests, build hipSPARSELt with the ``-DBUILD_CLIENTS_TESTS=ON`` o
 .. code-block:: bash
 
    # Go to hipSPARSELt build directory
-   cd hipSPARSELt; cd build/release
+   cd build/release
 
    # Run all tests
    ./clients/staging/hipsparselt-test

--- a/projects/hipsparselt/docs/install/quick-start-install.rst
+++ b/projects/hipsparselt/docs/install/quick-start-install.rst
@@ -8,7 +8,8 @@
 Quick start hipSPARSELt installation guide
 ****************************************************************
 
-The `hipSPARSELt GitHub <https://github.com/ROCm/hipSPARSELt>`_ root directory contains the
+The root directory of the `hipSPARSELt project <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparselt>`_
+within the `rocm-libraries GitHub <https://github.com/ROCm/rocm-libraries>`_ contains the
 helper bash script ``install.sh`` for building and installing hipSPARSELt on Ubuntu with a single command. The
 script only accepts a few options and hardcodes configuration that can be specified by invoking
 CMake directly. However, it's a great way to get started quickly and can serve as an example of how to build

--- a/projects/hipsparselt/docs/sphinx/_toc.yml.in
+++ b/projects/hipsparselt/docs/sphinx/_toc.yml.in
@@ -32,7 +32,7 @@ subtrees:
 
 - caption: Examples
   entries:
-  - url: https://github.com/ROCm/hipSPARSELt/tree/develop/clients/samples
+  - url: https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparselt/clients/samples
     title: Client samples
 
 - caption: API Reference

--- a/projects/hipsparselt/docs/what-is-hipsparselt.rst
+++ b/projects/hipsparselt/docs/what-is-hipsparselt.rst
@@ -18,5 +18,5 @@ programming language and is optimized for the latest AMD discrete GPUs.
 hipSPARSELt sits between the application and a "worker" SPARSE library, marshalling inputs into the
 backend library and results back to the application. It exports an interface that doesn't
 require the client to change, regardless of the chosen backend. The supported backends are:
-`rocSPARSELt <https://github.com/ROCm/hipSPARSELt/tree/develop/library/src/hcc_detail/rocsparselt>`_
+`rocSPARSELt <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparselt/library/src/hcc_detail/rocsparselt>`_
 and NVIDIA CUDA `cuSPARSELt v0.6.3 <https://docs.nvidia.com/cuda/cusparselt>`_.


### PR DESCRIPTION
This PR makes changes to several guides to point to the rocblas folder in the new rocm-libraries repository. It also updates some install instructions and some other links. I added a note in a few places to refer people using 6.4 or older to the previous hipSPARSELt repository.