### PR TITLE
Cherry-pick to release/rocm-rel-7.0: [rocBLAS] Docs: Change GitHub links and install guides to account for…

### DIFF
--- a/projects/rocblas/.github/CONTRIBUTING.rst
+++ b/projects/rocblas/.github/CONTRIBUTING.rst
@@ -34,10 +34,10 @@ Contributors wanting to submit new implementations, improvements, or bug fixes
 should follow the below mentioned guidelines.
 
 Pull requests will be reviewed by members of
-`CODEOWNERS.md <https://github.com/ROCm/rocBLAS/blob/develop/.github/CODEOWNERS>`__
+`CODEOWNERS.md <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/.github/CODEOWNERS>`__
 Continuous Integration tests will be run on the pull request. Once the pull request
 is approved and tests pass it will be merged by a member of
-`CODEOWNERS.md <https://github.com/ROCm/rocBLAS/blob/develop/.github/CODEOWNERS>`__.
+`CODEOWNERS.md <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/.github/CODEOWNERS>`__.
 Attribution for your commit will be preserved when it is merged.
 
 
@@ -63,7 +63,7 @@ Pull requests should:
 Code License
 ============
 All code contributed to this project will be licensed under the license identified in the
-`LICENSE.md <https://github.com/ROCm/rocBLAS/blob/develop/LICENSE.md>`__.
+`LICENSE.md <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/LICENSE.md>`__.
 Your contribution will be accepted under the same license.
 
 For each new file in repository, please include the licensing header
@@ -250,21 +250,21 @@ Coding Style
 
 #.  When tests are added to ``rocblas-test`` and ``rocblas-bench``,
     refer to `this
-    guide <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/clients/gtest/README.md>`__.
+    guide <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/clients/gtest/README.md>`__.
 
     The test framework is templated, and uses
     SFINAE (substitution failure is not an error) pattern and ``std::enable_if<...>`` to enable and disable certain types for
     certain tests.
 
     YAML files are used to describe tests as combinations of arguments.
-    `rocblas_gentest.py <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/clients/common/rocblas_gentest.py>`__
+    `rocblas_gentest.py <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/clients/common/rocblas_gentest.py>`__
     is used to parse the YAML files and generate tests in the form of a
     binary file of
-    `Arguments <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/clients/include/rocblas_arguments.hpp>`__
+    `Arguments <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/clients/include/rocblas_arguments.hpp>`__
     records.
 
     The ``rocblas-test`` and ``rocblas-bench`` `type dispatch
-    file <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/clients/include/type_dispatch.hpp>`__
+    file <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/clients/include/type_dispatch.hpp>`__
     is central to all tests. Basically, rather than duplicate:
 
     .. code:: cpp
@@ -280,9 +280,9 @@ Coding Style
     template argument is passed to specify which action is actually
     taken. It's fairly abstract, but it is powerful. There are examples
     of using the type dispatch in
-    `clients/gtest/*_gtest.cpp <https://github.com/ROCmSoftwarePlatform/rocBLAS/tree/develop/clients/gtest>`__
+    `clients/gtest/*_gtest.cpp <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/clients/gtest>`__
     and
-    `clients/benchmarks/client.cpp <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/clients/benchmarks/client.cpp>`__.
+    `clients/benchmarks/client.cpp <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/clients/benchmarks/client.cpp>`__.
 
 #.  Code should not be copied-and pasted, but rather, templates, macros,
     SFINAE (substitution failure is not an error) pattern and CRTP (curiously recurring template pattern),
@@ -593,11 +593,11 @@ Coding Style
 
     Note: Some blocked matrix-vector algorithms which call other BLAS
     kernels may not work if this simple transformation is used; see
-    `TRSV <https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/library/src/blas2/rocblas_trsv.cpp>`__
+    `TRSV <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/library/src/blas2/rocblas_trsv.cpp>`__
     for an example, and how it's handled there.
 
 #.  For reduction operations, the file
-    `reduction.hpp <https://github.com/ROCm/rocBLAS/blob/develop/library/src/blas1/reduction.hpp>`
+    `reduction.hpp <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/library/src/blas1/reduction.hpp>`_
     has been created to systematize reductions and perform their device
     kernels in one place. This works for ``amax``, ``amin``, ``asum``,
     ``nrm2``, and (partially) ``dot`` and ``gemv``.

--- a/projects/rocblas/docs/how-to/Contributors_Guide.rst
+++ b/projects/rocblas/docs/how-to/Contributors_Guide.rst
@@ -10,4 +10,4 @@ Contributing to rocBLAS
 
 rocBLAS encourages community contributions. For information on how to contribute to the code base,
 including information on code review guidelines, coding style, formatting, and
-acceptance criteria, see  `Contributing to rocBLAS <https://github.com/ROCm/rocBLAS/blob/develop/.github/CONTRIBUTING.rst>`_.
+acceptance criteria, see  `Contributing to rocBLAS <https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocblas/.github/CONTRIBUTING.rst>`_.

--- a/projects/rocblas/docs/how-to/Programmers_Guide.rst
+++ b/projects/rocblas/docs/how-to/Programmers_Guide.rst
@@ -16,7 +16,8 @@ memory allocation, and other technical considerations.
 Source code organization
 ================================
 
-The rocBLAS code can be found at the `rocBLAS GitHub <https://github.com/ROCm/rocBLAS>`_.
+The rocBLAS code can be found in the `rocBLAS folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas>`_
+of the `rocm-libraries GitHub <https://github.com/ROCm/rocm-libraries>`_.
 It is split into three major parts:
 
 * The ``library`` directory contains all the source code for the library.

--- a/projects/rocblas/docs/index.rst
+++ b/projects/rocblas/docs/index.rst
@@ -12,7 +12,12 @@ rocBLAS is the ROCm Basic Linear Algebra Subprograms (BLAS) library. rocBLAS is 
 This documentation set contains instructions for installing, understanding, and using the rocBLAS library.
 To learn more, see :doc:`./what-is-rocblas`
 
-The rocBLAS public repository is located at `<https://github.com/ROCm/rocBLAS>`_.
+The rocBLAS public repository is located at 
+`<https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas>`_.
+
+.. note::
+
+   The rocBLAS repository for ROCm 6.4 and earlier is located at `<https://github.com/ROCm/rocBLAS>`_.
 
 .. grid:: 2
   :gutter: 3
@@ -37,7 +42,7 @@ The rocBLAS public repository is located at `<https://github.com/ROCm/rocBLAS>`_
 
   .. grid-item-card:: Examples
 
-    * `rocBLAS sample code <https://github.com/ROCm/rocBLAS/tree/develop/clients/samples>`_
+    * `rocBLAS sample code <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas/clients/samples>`_
 
   .. grid-item-card:: Reference
 

--- a/projects/rocblas/docs/install/Linux_Install_Guide.rst
+++ b/projects/rocblas/docs/install/Linux_Install_Guide.rst
@@ -110,10 +110,15 @@ run the following help command:
 
    ./install.sh --help
 
+.. note::
+
+   You can run the ``install.sh`` script from the ``projects/rocblas`` directory.
+
 Download rocBLAS
 ----------------
 
-The rocBLAS source code is available at the `rocBLAS GitHub page <https://github.com/ROCm/rocBLAS>`_.
+The rocBLAS source code is available from the `rocBLAS folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas>`_
+of the `rocm-libraries GitHub <https://github.com/ROCm/rocm-libraries>`_.
 Verify the ROCm version on your system. On an Ubuntu distribution, use:
 
 .. code-block:: shell
@@ -131,17 +136,35 @@ For example, the ROCm version might be ``4.0.0.40000-23``. This corresponds to m
 minor release = ``0``, patch = ``0``, and build identifier ``40000-23``.
 The GitHub branches at the rocBLAS site have names like ``rocm-major.minor.x``,
 where the major and minor releases have the same meaning as in the ROCm version.
-To download rocBLAS, use the following command:
+
+To download rocBLAS, including all projects in the rocm-libraries repository, use the following commands.
 
 .. code-block:: shell
 
-   git clone -b release/rocm-rel-x.y https://github.com/ROCm/rocBLAS.git
-   cd rocBLAS
+   git clone -b release/rocm-rel-x.y https://github.com/ROCm/rocm-libraries.git
+   cd  rocm-libraries/projects/rocblas
 
 Replace ``x.y`` in the above command with the ROCm version installed on your machine.
-For example, if you have ROCm 6.2 installed, replace ``release/rocm-rel-x.y`` with ``release/rocm-rel-6.2``.
+For example, if you have ROCm 7.0 installed, replace ``release/rocm-rel-x.y`` with ``release/rocm-rel-7.0``.
 
+To limit your local checkout to only the rocBLAS and Tensile projects, configure ``sparse-checkout`` before cloning.
+This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+Use the following commands for a sparse checkout:
 
+.. code-block:: shell
+
+   git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries
+   git sparse-checkout init --cone
+   git sparse-checkout set projects/rocblas shared/tensile
+   git checkout develop # or use the branch you want to work with
+
+.. note::
+
+   To build ROCm 6.4 and older, use the rocBLAS repository at `<https://github.com/ROCm/rocBLAS>`_.
+   For more information, see the documentation associated with the release you want to build.
+
+The rocBLAS source code is found in the ``projects/rocblas`` directory.
 The following sections list the steps to build rocBLAS using the ``install.sh`` script.
 You can build either:
 

--- a/projects/rocblas/docs/install/Windows_Install_Guide.rst
+++ b/projects/rocblas/docs/install/Windows_Install_Guide.rst
@@ -88,7 +88,9 @@ you build rocBLAS with a different Tensile logic target. See the ``--logic`` com
 Download rocBLAS
 ----------------
 
-The rocBLAS source code, which is the same as the ROCm Linux version, is available from the `rocBLAS GitHub page <https://github.com/ROCm/rocBLAS>`_.
+The rocBLAS source code, which is the same as the ROCm Linux version, is available from the
+`rocBLAS folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas>`_
+of the `rocm-libraries GitHub <https://github.com/ROCm/rocm-libraries>`_.
 The ROCm HIP SDK version might appear in the default installation path,
 but you can run the HIP SDK compiler to display the version from the ``bin/`` folder:
 
@@ -101,20 +103,39 @@ For example, the HIP version might be ``5.4.22880-135e1ab4``.
 This corresponds to major release = ``5``, minor release = ``4``, patch = ``22880``, and build identifier ``135e1ab4``.
 The GitHub branches at the rocBLAS site have names like ``release/rocm-rel-major.minor``,
 where the major and minor releases have the same meaning as in the ROCm version.
-To download rocBLAS, use the following command:
+
+
+To download rocBLAS, including all projects in the rocm-libraries repository, use the following commands.
 
 ::
 
-   git clone -b release/rocm-rel-x.y https://github.com/ROCm/rocBLAS.git
-   cd rocBLAS
+   git clone -b release/rocm-rel-x.y https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries/projects/rocblas
 
 Replace ``x.y`` in the above command with the version of HIP SDK installed on your machine.
-For example, if you have HIP 5.5 installed, then use ``-b release/rocm-rel-5.5``.
+For example, if you have HIP 7.0 installed, use ``-b release/rocm-rel-7.0``.
 You can add the SDK tools to your path using an entry like this:
 
 ::
 
    %HIP_PATH%\bin
+
+To limit your local checkout to only the rocBLAS and Tensile projects, configure ``sparse-checkout`` before cloning.
+This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+Use the following commands for a sparse checkout:
+
+::
+
+   git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries
+   git sparse-checkout init --cone
+   git sparse-checkout set projects/rocblas shared/tensile
+   git checkout develop # or use the branch you want to work with
+
+.. note::
+
+   To build ROCm 6.4 and older, use the rocBLAS repository at `<https://github.com/ROCm/rocBLAS>`_.
+   For more information, see the documentation associated with the release you want to build.
 
 Building rocBLAS
 ----------------
@@ -169,6 +190,9 @@ Building the library dependencies and library
 Common examples of how to use ``rmake.py`` to build the library dependencies and library are
 shown in the table below:
 
+.. note::
+
+   You can run ``rmake.py`` from the ``projects\rocblas`` directory.
 
 .. csv-table::
    :header: "Command","Description"
@@ -212,7 +236,7 @@ The rocBLAS clients can be built on their own by using ``rmake.py`` with a pre-e
 
 The version of the rocBLAS clients being built should match the version of the installed rocBLAS.
 You can determine the version of the installed rocBLAS in the HIP SDK directory
-from the file ``include\rocblas\internal\rocblas-version.h``.
+from the file ``projects\rocblas\include\rocblas\internal\rocblas-version.h``.
 If you have installed the ``grep`` utility, you can find the version of rocBLAS being built
 by running the ``grep "VERSION_STRING" CMakeLists.txt`` command in the
 rocBLAS directory where you are building the clients.

--- a/projects/rocblas/docs/install/Windows_Install_Guide.rst
+++ b/projects/rocblas/docs/install/Windows_Install_Guide.rst
@@ -236,7 +236,7 @@ The rocBLAS clients can be built on their own by using ``rmake.py`` with a pre-e
 
 The version of the rocBLAS clients being built should match the version of the installed rocBLAS.
 You can determine the version of the installed rocBLAS in the HIP SDK directory
-from the file ``projects\rocblas\include\rocblas\internal\rocblas-version.h``.
+from the file ``include\rocblas\internal\rocblas-version.h``.
 If you have installed the ``grep`` utility, you can find the version of rocBLAS being built
 by running the ``grep "VERSION_STRING" CMakeLists.txt`` command in the
 rocBLAS directory where you are building the clients.

--- a/projects/rocblas/docs/sphinx/_toc.yml.in
+++ b/projects/rocblas/docs/sphinx/_toc.yml.in
@@ -30,7 +30,7 @@ subtrees:
 
 - caption: Examples
   entries:
-  - url: https://github.com/ROCm/rocBLAS/tree/develop/clients/samples
+  - url: https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas/clients/samples
     title: rocBLAS sample code
 
 - caption: API Reference


### PR DESCRIPTION
… repo change (#541)

This PR makes changes to several guides to point to the rocblas folder in the new rocm-libraries repository. It also updates some install instructions and some other links. I added a note in a few places to refer people using 6.4 or older to the previous rocBLAS repository.

(cherry picked from commit 43f328c6d0a96fab1a4b792560220ca3465730df)