### PR TITLE
[rocsparse] add convertToInt

### DIFF
--- a/projects/rocsparse/clients/benchmarks/rocsparse_arguments_config.cpp
+++ b/projects/rocsparse/clients/benchmarks/rocsparse_arguments_config.cpp
@@ -131,6 +131,7 @@ rocsparse_arguments_config::rocsparse_arguments_config()
         this->skip_reproducibility        = false;
         this->sparsity_pattern_statistics = false;
         this->call_stage_analysis         = true;
+        this->convert_to_int              = false;
         this->filename[0]                 = '\0';
         this->function[0]                 = '\0';
         this->name[0]                     = '\0';

--- a/projects/rocsparse/clients/include/rocsparse_arguments.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_arguments.hpp
@@ -153,6 +153,7 @@ struct Arguments
     bool skip_reproducibility;
     bool sparsity_pattern_statistics;
     bool call_stage_analysis;
+    bool convert_to_int;
     char filename[128];
     char function[64];
     char name[64];
@@ -295,6 +296,7 @@ struct Arguments
         ROCSPARSE_FORMAT_CHECK(skip_reproducibility);
         ROCSPARSE_FORMAT_CHECK(sparsity_pattern_statistics);
         ROCSPARSE_FORMAT_CHECK(call_stage_analysis);
+        ROCSPARSE_FORMAT_CHECK(convert_to_int);
         ROCSPARSE_FORMAT_CHECK(filename);
         ROCSPARSE_FORMAT_CHECK(function);
         ROCSPARSE_FORMAT_CHECK(name);
@@ -510,6 +512,7 @@ private:
         print("skip_reproducibility", arg.skip_reproducibility);
         print("sparsity_pattern_statistics", arg.sparsity_pattern_statistics);
         print("call_stage_analysis", arg.call_stage_analysis);
+        print("convert_to_int", arg.convert_to_int);
         print("name", arg.name);
         print("category", arg.category);
         print("hardware", arg.hardware);

--- a/projects/rocsparse/clients/include/rocsparse_common.yaml
+++ b/projects/rocsparse/clients/include/rocsparse_common.yaml
@@ -571,6 +571,7 @@ Arguments:
   - skip_reproducibility: c_bool
   - sparsity_pattern_statistics: c_bool
   - call_stage_analysis: c_bool
+  - convert_to_int: c_bool
   - filename: c_char*128
   - function: c_char*64
   - name: c_char*64
@@ -718,6 +719,7 @@ Defaults:
   skip_reproducibility: false
   sparsity_pattern_statistics: false
   call_stage_analysis: true
+  convert_to_int: false
   workspace_size: 0
   category: nightly
   hardware: all

--- a/projects/rocsparse/clients/include/rocsparse_importer.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_importer.hpp
@@ -480,20 +480,9 @@ public:
 template <typename A>
 inline A convertToInt(A value)
 {
-    return value;
+    return static_cast<A>(static_cast<int>(value));
 }
 
-template <>
-inline float convertToInt(float value)
-{
-    return static_cast<float>(static_cast<int>(value));
-}
-
-template <>
-inline double convertToInt(double value)
-{
-    return static_cast<double>(static_cast<int>(value));
-}
 
 template <>
 inline rocsparse_float_complex convertToInt(rocsparse_float_complex value)

--- a/projects/rocsparse/clients/include/rocsparse_importer.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_importer.hpp
@@ -483,7 +483,6 @@ inline A convertToInt(A value)
     return static_cast<A>(static_cast<int>(value));
 }
 
-
 template <>
 inline rocsparse_float_complex convertToInt(rocsparse_float_complex value)
 {

--- a/projects/rocsparse/clients/include/rocsparse_importer.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_importer.hpp
@@ -477,6 +477,38 @@ public:
     }
 };
 
+template <typename A>
+inline A convertToInt(A value)
+{
+    return value;
+}
+
+template <>
+inline float convertToInt(float value)
+{
+    return static_cast<float>(static_cast<int>(value));
+}
+
+template <>
+inline double convertToInt(double value)
+{
+    return static_cast<double>(static_cast<int>(value));
+}
+
+template <>
+inline rocsparse_float_complex convertToInt(rocsparse_float_complex value)
+{
+    return rocsparse_float_complex(static_cast<float>(static_cast<int>(std::real(value))),
+                                   static_cast<float>(static_cast<int>(std::imag(value))));
+}
+
+template <>
+inline rocsparse_double_complex convertToInt(rocsparse_double_complex value)
+{
+    return rocsparse_double_complex(static_cast<double>(static_cast<int>(std::real(value))),
+                                    static_cast<double>(static_cast<int>(std::imag(value))));
+}
+
 inline void missing_file_error_message(const char* filename)
 {
     std::cerr << "#" << std::endl;

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_coo.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_coo.cpp
@@ -231,9 +231,13 @@ void testing_spmm_batched_coo(const Arguments& arg)
             hcoo_row_ind[nnz_A * i + j] = hcoo_row_ind_temp[j];
             hcoo_col_ind[nnz_A * i + j] = hcoo_col_ind_temp[j];
             if(arg.convert_to_int)
+            {
                 hcoo_val[nnz_A * i + j] = convertToInt<A>(hcoo_val_temp[j]);
+            }
             else
+            {
                 hcoo_val[nnz_A * i + j] = hcoo_val_temp[j];
+            }
         }
     }
 

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_coo.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_coo.cpp
@@ -230,7 +230,10 @@ void testing_spmm_batched_coo(const Arguments& arg)
         {
             hcoo_row_ind[nnz_A * i + j] = hcoo_row_ind_temp[j];
             hcoo_col_ind[nnz_A * i + j] = hcoo_col_ind_temp[j];
-            hcoo_val[nnz_A * i + j]     = hcoo_val_temp[j];
+            if(arg.convert_to_int)
+                hcoo_val[nnz_A * i + j] = convertToInt<A>(hcoo_val_temp[j]);
+            else
+                hcoo_val[nnz_A * i + j] = hcoo_val_temp[j];
         }
     }
 
@@ -241,6 +244,14 @@ void testing_spmm_batched_coo(const Arguments& arg)
     // Initialize data on CPU
     rocsparse_init<B>(hB, batch_count_B * nnz_B, 1, 1);
     rocsparse_init<C>(hC_1, batch_count_C * nnz_C, 1, 1);
+
+    if(arg.convert_to_int)
+    {
+        for(I i = 0; i < batch_count_B * nnz_B; i++)
+        {
+            hB[i] = convertToInt<B>(hB[i]);
+        }
+    }
 
     host_vector<C> hC_2(hC_1);
     host_vector<C> hC_gold(hC_1);

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_csc.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_csc.cpp
@@ -249,9 +249,13 @@ void testing_spmm_batched_csc(const Arguments& arg)
         {
             hcsc_row_ind[nnz_A * i + j] = hcsc_row_ind_temp[j];
             if(arg.convert_to_int)
+            {
                 hcsc_val[nnz_A * i + j] = convertToInt<A>(hcsc_val_temp[j]);
+            }
             else
+            {
                 hcsc_val[nnz_A * i + j] = hcsc_val_temp[j];
+            }
         }
     }
 

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_csc.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_csc.cpp
@@ -248,7 +248,10 @@ void testing_spmm_batched_csc(const Arguments& arg)
         for(size_t j = 0; j < nnz_A; j++)
         {
             hcsc_row_ind[nnz_A * i + j] = hcsc_row_ind_temp[j];
-            hcsc_val[nnz_A * i + j]     = hcsc_val_temp[j];
+            if(arg.convert_to_int)
+                hcsc_val[nnz_A * i + j] = convertToInt<A>(hcsc_val_temp[j]);
+            else
+                hcsc_val[nnz_A * i + j] = hcsc_val_temp[j];
         }
     }
 
@@ -261,6 +264,14 @@ void testing_spmm_batched_csc(const Arguments& arg)
     // Initialize data on CPU
     rocsparse_init<B>(hB, batch_count_B * nnz_B, 1, 1);
     rocsparse_init<C>(hC_1, batch_count_C * nnz_C, 1, 1);
+
+    if(arg.convert_to_int)
+    {
+        for(J i = 0; i < batch_count_B * nnz_B; i++)
+        {
+            hB[i] = convertToInt<B>(hB[i]);
+        }
+    }
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_csr.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_csr.cpp
@@ -247,7 +247,14 @@ void testing_spmm_batched_csr(const Arguments& arg)
         for(size_t j = 0; j < nnz_A; j++)
         {
             hcsr_col_ind[nnz_A * i + j] = hcsr_col_ind_temp[j];
-            hcsr_val[nnz_A * i + j]     = hcsr_val_temp[j];
+            if(arg.convert_to_int)
+            {
+                hcsr_val[nnz_A * i + j] = convertToInt<A>(hcsr_val_temp[j]);
+            }
+            else
+            {
+                hcsr_val[nnz_A * i + j] = hcsr_val_temp[j];
+            }
         }
     }
 
@@ -260,6 +267,14 @@ void testing_spmm_batched_csr(const Arguments& arg)
     // Initialize data on CPU
     rocsparse_init<B>(hB, batch_count_B * nnz_B, 1, 1);
     rocsparse_init<C>(hC_1, batch_count_C * nnz_C, 1, 1);
+
+    if(arg.convert_to_int)
+    {
+        for(J i = 0; i < batch_count_B * nnz_B; i++)
+        {
+            hB[i] = convertToInt<B>(hB[i]);
+        }
+    }
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/projects/rocsparse/clients/tests/test_spmm_batched_coo.yaml
+++ b/projects/rocsparse/clients/tests/test_spmm_batched_coo.yaml
@@ -479,4 +479,5 @@ Tests:
   spmm_alg: [rocsparse_spmm_alg_coo_atomic]
   orderB: [rocsparse_order_row, rocsparse_order_column]
   orderC: [rocsparse_order_row, rocsparse_order_column]
+  convert_to_int: true
   filename: [mac_econ_fwd500]

--- a/projects/rocsparse/clients/tests/test_spmm_batched_csc.yaml
+++ b/projects/rocsparse/clients/tests/test_spmm_batched_csc.yaml
@@ -457,5 +457,6 @@ Tests:
   spmm_alg: [rocsparse_spmm_alg_csr]
   orderB: [rocsparse_order_column]
   orderC: [rocsparse_order_row, rocsparse_order_column]
+  convert_to_int: true
   filename: [mac_econ_fwd500,
              scircuit]


### PR DESCRIPTION
Some of the batched spmm stress tests fail due to accumulation of rounding errors.
Instead of comparing the results computed on host and device while using floating point values, this PR modifies these tests to use integer values while keeping them represented using floating point types. This removes rounding error accumulation as long as all the encountered integer are perfectly encodable using the used type.