### PR TITLE
Dump (input/output) matrix to a file in hipBLASLt clients

### DIFF
--- a/projects/hipblaslt/clients/bench/src/client.cpp
+++ b/projects/hipblaslt/clients/bench/src/client.cpp
@@ -296,6 +296,7 @@ try
     bool        datafile          = hipblaslt_parse_data(argc, argv);
     bool        log_function_name = false;
     bool        any_stride        = false;
+    bool        dump_matrix       = false;
 
     int         api_method      = 0;
     std::string api_method_str  = "";
@@ -626,6 +627,10 @@ try
         ("flush",
         value<bool>(&arg.flush)->default_value(tuningEnv ? true : false),
         "Flush icache, only works for gemm.")
+
+        ("dump_matrix",
+        value<bool>(&arg.dump_matrix)->default_value(false),
+        "Dump input and output matrices to a file.")
 
         ("help,h", "produces this help message")
 

--- a/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
+++ b/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
@@ -157,6 +157,7 @@ struct Arguments
     bool                     norm_check_assert;
     bool                     swizzle_a;
     bool                     swizzle_b;
+    bool                     dump_matrix;
 
     uint32_t scaleABlockRowSize;
     uint32_t scaleABlockColSize;
@@ -266,6 +267,7 @@ struct Arguments
     OPER(norm_check_assert) SEP      \
     OPER(swizzle_a) SEP              \
     OPER(swizzle_b) SEP              \
+    OPER(dump_matrix) SEP            \
     OPER(scaleABlockRowSize) SEP     \
     OPER(scaleABlockColSize) SEP     \
     OPER(scaleBBlockRowSize) SEP     \

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -1985,6 +1985,14 @@ void testing_matmul_with_bias(const Arguments& arg,
                                         realDataTypeSize(TiB),
                                         do_swizzle_b));
             CHECK_HIP_ERROR(synchronize(hC[i], dC[i]));
+
+            const char* hipblasltDumpToFile = getenv("HIPBLASLT_DUMP_MATRICES_TO_FILE");
+            if(hipblasltDumpToFile && std::strcmp(hipblasltDumpToFile, "true") == 0)
+            {
+                hipblasltDispatchValuesToFile(transA, TiA, M[i], K[i], lda[i], hA[i].buf(), "batch_"+ std::to_string(i)+"_A_input.txt");
+                hipblasltDispatchValuesToFile(transB, TiB, K[i], N[i], ldb[i], hB[i].buf(), "batch_"+ std::to_string(i)+"_B_input.txt");
+                hipblasltDispatchValuesToFile(HIPBLAS_OP_N, To, M[i], N[i], ldc[i], hC[i].buf(), "batch_"+ std::to_string(i)+"_C_input.txt");
+            }
         }
 
         if(do_swizzle_a)
@@ -3972,6 +3980,12 @@ void testing_matmul_with_bias(const Arguments& arg,
             }
             if(arg.unit_check || arg.norm_check || arg.allclose_check)
             {
+                const char* hipblasltDumpToFile = getenv("HIPBLASLT_DUMP_MATRICES_TO_FILE");
+                if(hipblasltDumpToFile && std::strcmp(hipblasltDumpToFile, "true") == 0)
+                {
+                    hipblasltDispatchValuesToFile(HIPBLAS_OP_N, To, M[0], N[0], ldd[0], hD_1[0].buf(), "batch_0_D_output.txt");
+                    hipblasltDispatchValuesToFile(HIPBLAS_OP_N, To, M[0], N[0], ldd[0], hD_gold[0].buf(), "batch_0_D_Gold_output.txt");
+                }
                 check(stream,
                       arg,
                       gemm_count,

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -1986,8 +1986,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                                         do_swizzle_b));
             CHECK_HIP_ERROR(synchronize(hC[i], dC[i]));
 
-            const char* hipblasltDumpToFile = getenv("HIPBLASLT_DUMP_MATRICES_TO_FILE");
-            if(hipblasltDumpToFile && std::strcmp(hipblasltDumpToFile, "true") == 0)
+            if(arg.dump_matrix)
             {
                 hipblasltDispatchValuesToFile(transA, TiA, M[i], K[i], lda[i], hA[i].buf(), "batch_"+ std::to_string(i)+"_A_input.txt");
                 hipblasltDispatchValuesToFile(transB, TiB, K[i], N[i], ldb[i], hB[i].buf(), "batch_"+ std::to_string(i)+"_B_input.txt");
@@ -3980,8 +3979,7 @@ void testing_matmul_with_bias(const Arguments& arg,
             }
             if(arg.unit_check || arg.norm_check || arg.allclose_check)
             {
-                const char* hipblasltDumpToFile = getenv("HIPBLASLT_DUMP_MATRICES_TO_FILE");
-                if(hipblasltDumpToFile && std::strcmp(hipblasltDumpToFile, "true") == 0)
+                if(arg.dump_matrix)
                 {
                     hipblasltDispatchValuesToFile(HIPBLAS_OP_N, To, M[0], N[0], ldd[0], hD_1[0].buf(), "batch_0_D_output.txt");
                     hipblasltDispatchValuesToFile(HIPBLAS_OP_N, To, M[0], N[0], ldd[0], hD_gold[0].buf(), "batch_0_D_Gold_output.txt");

--- a/projects/hipblaslt/clients/common/include/utility.hpp
+++ b/projects/hipblaslt/clients/common/include/utility.hpp
@@ -529,3 +529,9 @@ typename std::enable_if<!std::is_same<int8_t, T>::value, T>::type saturate_cast(
 std::vector<void*> benchmark_allocation();
 int32_t            hipblaslt_get_arch_major();
 void hipblaslt_print_version();
+
+/* ==================================================================== */
+/*! \brief write a matrix to file. */
+void hipblasltDispatchValuesToFile(hipblasOperation_t transA, hipDataType TiA,
+                                   int row, int col, int lda, void *hA,
+                                   std::string ADataFile);

--- a/projects/hipblaslt/clients/common/src/utility.cpp
+++ b/projects/hipblaslt/clients/common/src/utility.cpp
@@ -368,7 +368,8 @@ void hipblaslt_print_version()
 /*! \brief write a matrix to file. */
 template <typename T>
 void hipblasltStoreValuesToFile(hipblasOperation_t transA, int row, int col,
-                                int lda, T *A, std::string ADataFile) {
+                                int lda, T *A, std::string ADataFile) 
+{
   const int A_row = transA == HIPBLAS_OP_N ? row : col;
   const int A_col = transA == HIPBLAS_OP_N ? col : row;
 
@@ -387,7 +388,8 @@ void hipblasltStoreValuesToFile(hipblasOperation_t transA, int row, int col,
 /*! \brief call hipblasltStoreValuesToFile with appropriate datatype. */
 void hipblasltDispatchValuesToFile(hipblasOperation_t transA, hipDataType T,
                                    int row, int col, int lda, void *hA,
-                                   std::string ADataFile) {
+                                   std::string ADataFile) 
+{
   if (T == HIP_R_32F)
     hipblasltStoreValuesToFile(transA, row, col, lda, static_cast<float *>(hA),
                                ADataFile);
@@ -400,6 +402,18 @@ void hipblasltDispatchValuesToFile(hipblasOperation_t transA, hipDataType T,
   else if (T == HIP_R_16BF)
     hipblasltStoreValuesToFile(transA, row, col, lda,
                                static_cast<hip_bfloat16 *>(hA), ADataFile);
+  else if (T == HIP_R_8F_E4M3_FNUZ)
+    hipblasltStoreValuesToFile(transA, row, col, lda,
+                               static_cast<hipblaslt_f8_fnuz *>(hA), ADataFile);
+  else if (T == HIP_R_8F_E5M2_FNUZ)
+    hipblasltStoreValuesToFile(transA, row, col, lda,
+                               static_cast<hipblaslt_bf8_fnuz *>(hA), ADataFile);
+  else if (T == HIP_R_8F_E4M3)
+    hipblasltStoreValuesToFile(transA, row, col, lda,
+                               static_cast<hipblaslt_f8 *>(hA), ADataFile);
+  else if (T == HIP_R_8F_E5M2)
+    hipblasltStoreValuesToFile(transA, row, col, lda,
+                               static_cast<hipblaslt_bf8 *>(hA), ADataFile);
   else
     hipblaslt_cout << "This datatype " << T
                    << " is Unsupported and could be added to the if-else "

--- a/projects/hipblaslt/clients/common/src/utility.cpp
+++ b/projects/hipblaslt/clients/common/src/utility.cpp
@@ -363,3 +363,46 @@ void hipblaslt_print_version()
     hipblaslt_cout << "hipBLASLt version: " << version << std::endl;
     hipblaslt_cout << "hipBLASLt git version: " << git_version << std::endl;
 }
+
+/* ==================================================================== */
+/*! \brief write a matrix to file. */
+template <typename T>
+void hipblasltStoreValuesToFile(hipblasOperation_t transA, int row, int col,
+                                int lda, T *A, std::string ADataFile) {
+  const int A_row = transA == HIPBLAS_OP_N ? row : col;
+  const int A_col = transA == HIPBLAS_OP_N ? col : row;
+
+  std::ofstream FILE(ADataFile);
+
+  for (int i = 0; i < A_row; i++) {
+    for (int j = 0; j < A_col; j++)
+      FILE << std::left << std::setw(12) << static_cast<double>(A[j * lda + i]);
+    FILE << std::endl;
+  }
+
+  FILE.close();
+}
+
+/* ==================================================================== */
+/*! \brief write a matrix to file. */
+void hipblasltDispatchValuesToFile(hipblasOperation_t transA, hipDataType T,
+                                   int row, int col, int lda, void *hA,
+                                   std::string ADataFile) {
+  if (T == HIP_R_32F)
+    hipblasltStoreValuesToFile(transA, row, col, lda, static_cast<float *>(hA),
+                               ADataFile);
+  else if (T == HIP_R_64F)
+    hipblasltStoreValuesToFile(transA, row, col, lda, static_cast<double *>(hA),
+                               ADataFile);
+  else if (T == HIP_R_16F)
+    hipblasltStoreValuesToFile(transA, row, col, lda,
+                               static_cast<hipblasLtHalf *>(hA), ADataFile);
+  else if (T == HIP_R_16BF)
+    hipblasltStoreValuesToFile(transA, row, col, lda,
+                               static_cast<hip_bfloat16 *>(hA), ADataFile);
+  else
+    hipblaslt_cout << "This datatype " << T
+                   << " is Unsupported and could be added to the if-else "
+                      "condition to write to file"
+                   << std::endl;
+}

--- a/projects/hipblaslt/clients/common/src/utility.cpp
+++ b/projects/hipblaslt/clients/common/src/utility.cpp
@@ -374,10 +374,11 @@ void hipblasltStoreValuesToFile(hipblasOperation_t transA, int row, int col,
   const int A_col = transA == HIPBLAS_OP_N ? col : row;
 
   std::ofstream FILE(ADataFile);
-
+  
+  FILE << std::scientific << std::setprecision(6);
   for (int i = 0; i < A_row; i++) {
     for (int j = 0; j < A_col; j++)
-      FILE << std::left << std::setw(12) << static_cast<double>(A[j * lda + i]);
+      FILE  << std::setw(15) << std::right << static_cast<double>(A[j * lda + i]);
     FILE << std::endl;
   }
 

--- a/projects/hipblaslt/clients/common/src/utility.cpp
+++ b/projects/hipblaslt/clients/common/src/utility.cpp
@@ -384,7 +384,7 @@ void hipblasltStoreValuesToFile(hipblasOperation_t transA, int row, int col,
 }
 
 /* ==================================================================== */
-/*! \brief write a matrix to file. */
+/*! \brief call hipblasltStoreValuesToFile with appropriate datatype. */
 void hipblasltDispatchValuesToFile(hipblasOperation_t transA, hipDataType T,
                                    int row, int col, int lda, void *hA,
                                    std::string ADataFile) {

--- a/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
+++ b/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
@@ -567,6 +567,7 @@ Arguments:
   - norm_check_assert: c_bool
   - swizzle_a: c_bool
   - swizzle_b: c_bool
+  - dump_matrix: c_bool
   - scaleABlockRowSize: c_uint32
   - scaleABlockColSize: c_uint32
   - scaleBBlockRowSize: c_uint32
@@ -676,6 +677,7 @@ Defaults:
   norm_check_assert: true
   swizzle_a: false
   swizzle_b: false
+  dump_matrix: false
   scaleABlockRowSize: 32
   scaleABlockColSize: 1
   scaleBBlockRowSize: 1


### PR DESCRIPTION
1. Added a routine `hipblasltStoreValuesToFile` to store (input/output) matrix values to a file from the clients.
2. This feature can be enabled by setting the client arg `--dump_matrix`.
3. Example command to use this feature: `./hipblaslt-bench -f matmul -v --dump_matrix`