### PR TITLE
Performance optimization for histogram with large bin count on mi300x

### DIFF
--- a/projects/rocprim/benchmark/benchmark_device_histogram.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_histogram.cpp
@@ -214,7 +214,7 @@ void run_range_benchmark(benchmark_utils::state&& state, size_t bins)
 
     common::device_ptr<T>            d_input(input);
     common::device_ptr<level_type>   d_levels(levels);
-    common::device_ptr<counter_type> d_histogram(size);
+    common::device_ptr<counter_type> d_histogram(bins);
 
     size_t temporary_storage_bytes = 0;
     HIP_CHECK(rocprim::histogram_range(nullptr,
@@ -287,7 +287,7 @@ void run_multi_range_benchmark(benchmark_utils::state&& state, size_t bins)
     for(unsigned int channel = 0; channel < ActiveChannels; ++channel)
     {
         HIP_CHECK(hipMalloc(&d_levels[channel], num_levels_channel * sizeof(level_type)));
-        HIP_CHECK(hipMalloc(&d_histogram[channel], size * sizeof(counter_type)));
+        HIP_CHECK(hipMalloc(&d_histogram[channel], bins * sizeof(counter_type)));
     }
 
     for(unsigned int channel = 0; channel < ActiveChannels; ++channel)

--- a/projects/rocprim/benchmark/benchmark_device_histogram.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_histogram.cpp
@@ -76,7 +76,7 @@ void run_even_benchmark(benchmark_utils::state&& state,
     std::vector<T> input = generate<T>(size, entropy_reduction, lower_level, upper_level);
 
     common::device_ptr<T>            d_input(input);
-    common::device_ptr<counter_type> d_histogram(size);
+    common::device_ptr<counter_type> d_histogram(bins);
 
     size_t temporary_storage_bytes = 0;
     HIP_CHECK(rocprim::histogram_even(nullptr,

--- a/projects/rocprim/benchmark/benchmark_device_histogram.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_histogram.parallel.hpp
@@ -107,7 +107,7 @@ public:
     T* get_or_generate(const std::string& main_key, const std::string& additional_key, F gen)
     {
         // Experimentally determined maximum size, before the GPU runs out of memory.
-        static constexpr short max_default_bytes_count = 176;
+        static constexpr short max_default_bytes_count = 88;
         if(this->main_key != main_key)
         {
             // The main key (for example, data type) has been changed, clear the cache
@@ -164,7 +164,10 @@ std::string config_name()
            + ",ipt:" + std::to_string(config.histogram_config.items_per_thread)
            + ",max_grid_size:" + std::to_string(config.max_grid_size)
            + ",shared_impl_max_bins:" + std::to_string(config.shared_impl_max_bins)
-           + ",shared_impl_histograms:" + std::to_string(config.shared_impl_histograms) + "}";
+           + ",shared_impl_histograms:" + std::to_string(config.shared_impl_histograms)
+           + ",private_hist_bs:" + std::to_string(config.histogram_private_config.block_size)
+           + ",private_hist_ipt:" + std::to_string(config.histogram_private_config.items_per_thread)
+           + "}";
 }
 
 template<>
@@ -321,7 +324,8 @@ struct device_histogram_benchmark_generator
                 = rocprim::histogram_config<rocprim::kernel_config<BlockSize, ItemsPerThread>,
                                             2048,
                                             2048,
-                                            SharedImplHistograms>;
+                                            SharedImplHistograms,
+                                            rocprim::kernel_config<1024, 4>>;
 
             template<unsigned int Channels,
                      unsigned int ActiveChannels,

--- a/projects/rocprim/benchmark/benchmark_device_histogram.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_histogram.parallel.hpp
@@ -165,8 +165,8 @@ std::string config_name()
            + ",max_grid_size:" + std::to_string(config.max_grid_size)
            + ",shared_impl_max_bins:" + std::to_string(config.shared_impl_max_bins)
            + ",shared_impl_histograms:" + std::to_string(config.shared_impl_histograms)
-           + ",private_hist_bs:" + std::to_string(config.histogram_private_config.block_size)
-           + ",private_hist_ipt:" + std::to_string(config.histogram_private_config.items_per_thread)
+           + ",global_hist_bs:" + std::to_string(config.histogram_global_config.block_size)
+           + ",global_hist_ipt:" + std::to_string(config.histogram_global_config.items_per_thread)
            + "}";
 }
 

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -1320,7 +1320,8 @@ public:
     void run()
     {
         register_sorted_subset(parallel_instance, parallel_instances);
-        benchmark::RunSpecifiedBenchmarks();
+        benchmark::ConsoleReporter cr;
+        benchmark::RunSpecifiedBenchmarks(&cr);
     }
 
 private:

--- a/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
@@ -414,7 +414,7 @@ hipError_t
     hipDevice_t stream_device;
     ROCPRIM_RETURN_ON_ERROR(hipStreamGetDevice(stream, &stream_device));
 
-    // after setting device, we can't just exit on non-success
+    // After setting device, we can't just exit on non-success.
     hipError_t result = hipSetDevice(stream_device);
 
     int occupancy;
@@ -439,7 +439,7 @@ hipError_t
         result = hipDeviceGetAttribute(&num_multi_processors,
                                        hipDeviceAttribute_t::hipDeviceAttributeMultiprocessorCount,
                                        stream_device);
-        // sanity check
+        // Sanity check.
         if(num_multi_processors == 0)
         {
             result = hipErrorUnknown;
@@ -451,7 +451,7 @@ hipError_t
         grid_dim = occupancy * num_multi_processors;
     }
 
-    // always attempt to restore to default device
+    // Always attempt to restore to default device.
     hipError_t set_result = hipSetDevice(default_device);
     ROCPRIM_RETURN_ON_ERROR(result);
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_histogram.hpp
@@ -3120,7 +3120,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 16>, 2048, 2048, 3, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 16>, 2048, 2048, 3, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = double, channels = 2, active_channels = 2
@@ -3133,7 +3133,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<128, 2>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<128, 2>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = double, channels = 3, active_channels = 3
@@ -3146,7 +3146,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = double, channels = 4, active_channels = 3
@@ -3159,7 +3159,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<128, 1>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<128, 1>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = double, channels = 4, active_channels = 4
@@ -3172,7 +3172,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 1>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 1>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = float, channels = 1, active_channels = 1
@@ -3185,7 +3185,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 15>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 15>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = float, channels = 2, active_channels = 2
@@ -3198,7 +3198,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<128, 3>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<128, 3>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = float, channels = 3, active_channels = 3
@@ -3211,7 +3211,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = float, channels = 4, active_channels = 3
@@ -3224,7 +3224,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = float, channels = 4, active_channels = 4
@@ -3237,7 +3237,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::half, channels = 1, active_channels = 1
@@ -3249,7 +3249,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 1) && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 15>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 15>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::half, channels = 2, active_channels = 2
@@ -3261,7 +3261,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 2) && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::half, channels = 3, active_channels = 3
@@ -3273,7 +3273,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 3) && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::half, channels = 4, active_channels = 3
@@ -3285,7 +3285,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 4) && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::half, channels = 4, active_channels = 4
@@ -3297,7 +3297,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 4) && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 1, active_channels = 1
@@ -3310,7 +3310,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 2, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 2, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 2, active_channels = 2
@@ -3323,7 +3323,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 2, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 2, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 3, active_channels = 3
@@ -3336,7 +3336,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 4, active_channels = 3
@@ -3349,7 +3349,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 3, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 3, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 4, active_channels = 4
@@ -3362,7 +3362,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 1>, 2048, 2048, 3, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 1>, 2048, 2048, 3, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int64_t, channels = 1, active_channels = 1
@@ -3375,7 +3375,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 6>, 2048, 2048, 3, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 6>, 2048, 2048, 3, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int64_t, channels = 2, active_channels = 2
@@ -3388,7 +3388,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 3>, 2048, 2048, 3, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 3>, 2048, 2048, 3, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int64_t, channels = 3, active_channels = 3
@@ -3401,7 +3401,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int64_t, channels = 4, active_channels = 3
@@ -3414,7 +3414,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 1>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 1>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int64_t, channels = 4, active_channels = 4
@@ -3427,7 +3427,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int, channels = 1, active_channels = 1
@@ -3440,7 +3440,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 9>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 9>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int, channels = 2, active_channels = 2
@@ -3453,7 +3453,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<128, 6>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<128, 6>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int, channels = 3, active_channels = 3
@@ -3466,7 +3466,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int, channels = 4, active_channels = 3
@@ -3479,7 +3479,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int, channels = 4, active_channels = 4
@@ -3492,7 +3492,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = short, channels = 1, active_channels = 1
@@ -3505,7 +3505,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 16>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 16>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = short, channels = 2, active_channels = 2
@@ -3518,7 +3518,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = short, channels = 3, active_channels = 3
@@ -3531,7 +3531,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = short, channels = 4, active_channels = 3
@@ -3544,7 +3544,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = short, channels = 4, active_channels = 4
@@ -3557,7 +3557,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int8_t, channels = 1, active_channels = 1
@@ -3569,7 +3569,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 1) && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 12>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 12>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int8_t, channels = 2, active_channels = 2
@@ -3581,7 +3581,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 2) && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int8_t, channels = 3, active_channels = 3
@@ -3593,7 +3593,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 3) && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int8_t, channels = 4, active_channels = 3
@@ -3605,7 +3605,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 4) && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 // Based on value_type = int8_t, channels = 4, active_channels = 4
@@ -3617,7 +3617,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 4) && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 4>>
 {};
 
 } // end namespace detail

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_histogram.hpp
@@ -3120,7 +3120,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 16>, 2048, 2048, 3>
+    : histogram_config<kernel_config<256, 16>, 2048, 2048, 3, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = double, channels = 2, active_channels = 2
@@ -3133,7 +3133,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<128, 2>, 2048, 2048, 4>
+    : histogram_config<kernel_config<128, 2>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = double, channels = 3, active_channels = 3
@@ -3146,7 +3146,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = double, channels = 4, active_channels = 3
@@ -3159,7 +3159,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<128, 1>, 2048, 2048, 4>
+    : histogram_config<kernel_config<128, 1>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = double, channels = 4, active_channels = 4
@@ -3172,7 +3172,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 1>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 1>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = float, channels = 1, active_channels = 1
@@ -3185,7 +3185,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 15>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 15>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = float, channels = 2, active_channels = 2
@@ -3198,7 +3198,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<128, 3>, 2048, 2048, 4>
+    : histogram_config<kernel_config<128, 3>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = float, channels = 3, active_channels = 3
@@ -3211,7 +3211,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = float, channels = 4, active_channels = 3
@@ -3224,7 +3224,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = float, channels = 4, active_channels = 4
@@ -3237,7 +3237,7 @@ struct default_histogram_config<
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::half, channels = 1, active_channels = 1
@@ -3249,7 +3249,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 1) && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 15>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 15>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::half, channels = 2, active_channels = 2
@@ -3261,7 +3261,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 2) && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::half, channels = 3, active_channels = 3
@@ -3273,7 +3273,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 3) && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::half, channels = 4, active_channels = 3
@@ -3285,7 +3285,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 4) && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::half, channels = 4, active_channels = 4
@@ -3297,7 +3297,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (channels == 4) && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 1, active_channels = 1
@@ -3310,7 +3310,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 2>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 2, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 2, active_channels = 2
@@ -3323,7 +3323,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 2>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 2, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 3, active_channels = 3
@@ -3336,7 +3336,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 4, active_channels = 3
@@ -3349,7 +3349,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 3>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 3, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = rocprim::int128_t, channels = 4, active_channels = 4
@@ -3362,7 +3362,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 1>, 2048, 2048, 3>
+    : histogram_config<kernel_config<256, 1>, 2048, 2048, 3, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int64_t, channels = 1, active_channels = 1
@@ -3375,7 +3375,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 6>, 2048, 2048, 3>
+    : histogram_config<kernel_config<256, 6>, 2048, 2048, 3, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int64_t, channels = 2, active_channels = 2
@@ -3388,7 +3388,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 3>, 2048, 2048, 3>
+    : histogram_config<kernel_config<256, 3>, 2048, 2048, 3, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int64_t, channels = 3, active_channels = 3
@@ -3401,7 +3401,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int64_t, channels = 4, active_channels = 3
@@ -3414,7 +3414,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 1>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 1>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int64_t, channels = 4, active_channels = 4
@@ -3427,7 +3427,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 3>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int, channels = 1, active_channels = 1
@@ -3440,7 +3440,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 9>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 9>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int, channels = 2, active_channels = 2
@@ -3453,7 +3453,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<128, 6>, 2048, 2048, 4>
+    : histogram_config<kernel_config<128, 6>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int, channels = 3, active_channels = 3
@@ -3466,7 +3466,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int, channels = 4, active_channels = 3
@@ -3479,7 +3479,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int, channels = 4, active_channels = 4
@@ -3492,7 +3492,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 2>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = short, channels = 1, active_channels = 1
@@ -3505,7 +3505,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 1)
                       && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 16>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 16>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = short, channels = 2, active_channels = 2
@@ -3518,7 +3518,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 2)
                       && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = short, channels = 3, active_channels = 3
@@ -3531,7 +3531,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 3)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = short, channels = 4, active_channels = 3
@@ -3544,7 +3544,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 4)
                       && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = short, channels = 4, active_channels = 4
@@ -3557,7 +3557,7 @@ struct default_histogram_config<
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1) && (channels == 4)
                       && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int8_t, channels = 1, active_channels = 1
@@ -3569,7 +3569,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 1) && (active_channels == 1))>>
-    : histogram_config<kernel_config<256, 12>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 12>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int8_t, channels = 2, active_channels = 2
@@ -3581,7 +3581,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 2) && (active_channels == 2))>>
-    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 8>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int8_t, channels = 3, active_channels = 3
@@ -3593,7 +3593,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 3) && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 5>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int8_t, channels = 4, active_channels = 3
@@ -3605,7 +3605,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 4) && (active_channels == 3))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 // Based on value_type = int8_t, channels = 4, active_channels = 4
@@ -3617,7 +3617,7 @@ struct default_histogram_config<
     active_channels,
     std::enable_if_t<(!bool(rocprim::is_floating_point<value_type>::value)
                       && (sizeof(value_type) <= 1) && (channels == 4) && (active_channels == 4))>>
-    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4>
+    : histogram_config<kernel_config<256, 4>, 2048, 2048, 4, kernel_config<1024, 32>>
 {};
 
 } // end namespace detail

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -807,7 +807,7 @@ struct histogram_config_params
     unsigned int shared_impl_max_bins   = 0;
     unsigned int shared_impl_histograms = 0;
 
-    kernel_config_params histogram_private_config = {0, 0};
+    kernel_config_params histogram_global_config = {0, 0};
 };
 
 } // namespace detail
@@ -821,11 +821,13 @@ struct histogram_config_params
 /// when exceeded the global memory implementation is used (samples -> global memory bins).
 /// \tparam SharedImplHistograms number of histograms in the shared memory to reduce bank conflicts
 /// for atomic operations with narrow sample distributions. Sweetspot for 9xx and 10xx is 3.
+/// \tparam HistogramGlobalConfig configuration of currently only used for the private global kernel.
+/// Must be \p kernel_config.
 template<class HistogramConfig,
          unsigned int MaxGridSize          = 1024,
          unsigned int SharedImplMaxBins    = 2048,
          unsigned int SharedImplHistograms = 3,
-         class HistogramPrivateConfig      = HistogramConfig>
+         class HistogramGlobalConfig       = HistogramConfig>
 struct histogram_config : detail::histogram_config_params
 {
     /// \brief Identifies the algorithm associated to the config.
@@ -842,7 +844,7 @@ struct histogram_config : detail::histogram_config_params
                                           MaxGridSize,
                                           SharedImplMaxBins,
                                           SharedImplHistograms,
-                                          HistogramPrivateConfig{}} {};
+                                          HistogramGlobalConfig{}} {};
 #endif
 };
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -806,6 +806,8 @@ struct histogram_config_params
     unsigned int max_grid_size          = 0;
     unsigned int shared_impl_max_bins   = 0;
     unsigned int shared_impl_histograms = 0;
+
+    kernel_config_params histogram_private_config = {0, 0};
 };
 
 } // namespace detail
@@ -822,7 +824,8 @@ struct histogram_config_params
 template<class HistogramConfig,
          unsigned int MaxGridSize          = 1024,
          unsigned int SharedImplMaxBins    = 2048,
-         unsigned int SharedImplHistograms = 3>
+         unsigned int SharedImplHistograms = 3,
+         class HistogramPrivateConfig      = HistogramConfig>
 struct histogram_config : detail::histogram_config_params
 {
     /// \brief Identifies the algorithm associated to the config.
@@ -835,8 +838,11 @@ struct histogram_config : detail::histogram_config_params
     static constexpr unsigned int shared_impl_histograms = SharedImplHistograms;
 
     constexpr histogram_config()
-        : detail::histogram_config_params{
-            HistogramConfig{}, MaxGridSize, SharedImplMaxBins, SharedImplHistograms} {};
+        : detail::histogram_config_params{HistogramConfig{},
+                                          MaxGridSize,
+                                          SharedImplMaxBins,
+                                          SharedImplHistograms,
+                                          HistogramPrivateConfig{}} {};
 #endif
 };
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -463,17 +463,34 @@ void histogram_global(SampleIterator                                   samples,
                       unsigned int                                     row_stride,
                       fixed_array<Counter*, ActiveChannels>            histogram,
                       const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                      const fixed_array<unsigned int, ActiveChannels>  bins_bits)
+                      const fixed_array<unsigned int, ActiveChannels>  bins_bits,
+                      const fixed_array<unsigned int, ActiveChannels>  bins,
+                      unsigned int*                                    private_histograms)
 {
     using sample_type        = typename std::iterator_traits<SampleIterator>::value_type;
     using sample_vector_type = sample_vector<sample_type, Channels>;
 
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
-    const unsigned int flat_id      = ::rocprim::detail::block_thread_id<0>();
-    const unsigned int block_id0    = ::rocprim::detail::block_id<0>();
-    const unsigned int block_id1    = ::rocprim::detail::block_id<1>();
-    const unsigned int block_offset = block_id0 * items_per_block;
+    const unsigned int flat_id       = ::rocprim::detail::block_thread_id<0>();
+    const unsigned int block_id0     = ::rocprim::detail::block_id<0>();
+    const unsigned int block_id1     = ::rocprim::detail::block_id<1>();
+    const unsigned int flat_block_id = ::rocprim::flat_block_id();
+    const unsigned int block_offset  = block_id0 * items_per_block;
+
+    // starts of the first histogram for each channel
+    unsigned int* block_histogram[ActiveChannels];
+    unsigned int  total_bins = 0;
+    for(unsigned int channel = 0; channel < ActiveChannels; channel++)
+    {
+        block_histogram[channel] = private_histograms + total_bins;
+        total_bins += bins[channel];
+    }
+
+    for(unsigned int channel = 0; channel < ActiveChannels; channel++)
+    {
+        block_histogram[channel] += flat_block_id * total_bins;
+    }
 
     samples += block_id1 * row_stride + Channels * block_offset;
 
@@ -506,9 +523,23 @@ void histogram_global(SampleIterator                                   samples,
                 {
                     // Write the number of lanes having this bin,
                     // if the current lane is the first (and maybe only) lane with this bin.
-                    ::rocprim::detail::atomic_add(&histogram[channel][bin],
+                    ::rocprim::detail::atomic_add(&block_histogram[channel][bin],
                                                   ::rocprim::bit_count(same_bin_lanes_mask));
                 }
+            }
+        }
+    }
+
+    ::rocprim::syncthreads();
+
+    for(unsigned int channel = 0; channel < ActiveChannels; channel++)
+    {
+        for(unsigned int bin = flat_id; bin < bins[channel]; bin += BlockSize)
+        {
+            unsigned int total = block_histogram[channel][bin];
+            if(total > 0)
+            {
+                ::rocprim::detail::atomic_add(&histogram[channel][bin], total);
             }
         }
     }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -460,23 +460,28 @@ template<unsigned int BlockSize,
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void histogram_global(SampleIterator                                   samples,
                       unsigned int                                     columns,
+                      unsigned int                                     rows,
                       unsigned int                                     row_stride,
                       fixed_array<Counter*, ActiveChannels>            histogram,
                       const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
                       const fixed_array<unsigned int, ActiveChannels>  bins_bits,
                       const fixed_array<unsigned int, ActiveChannels>  bins,
-                      unsigned int*                                    private_histograms)
+                      unsigned int*                                    private_histograms,
+                      unsigned int                                     max_blocks,
+                      unsigned int                                     virtual_max_blocks,
+                      unsigned int*                                    block_id_count)
 {
     using sample_type        = typename std::iterator_traits<SampleIterator>::value_type;
     using sample_vector_type = sample_vector<sample_type, Channels>;
 
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
-    const unsigned int flat_id       = ::rocprim::detail::block_thread_id<0>();
-    const unsigned int block_id0     = ::rocprim::detail::block_id<0>();
-    const unsigned int block_id1     = ::rocprim::detail::block_id<1>();
+    const unsigned int flat_id       = ::rocprim::flat_block_thread_id();
     const unsigned int flat_block_id = ::rocprim::flat_block_id();
-    const unsigned int block_offset  = block_id0 * items_per_block;
+    const unsigned int total_items   = rows * columns;
+
+    __shared__
+    unsigned int       block_id_count_shared;
 
     // starts of the first histogram for each channel
     unsigned int* block_histogram[ActiveChannels];
@@ -492,39 +497,62 @@ void histogram_global(SampleIterator                                   samples,
         block_histogram[channel] += flat_block_id * total_bins;
     }
 
-    samples += block_id1 * row_stride + Channels * block_offset;
-
-    sample_vector_type values[ItemsPerThread];
-    unsigned int       valid_count;
-    if(block_offset + items_per_block <= columns)
+    unsigned int virtual_block_id = 0;
+    while(virtual_block_id < virtual_max_blocks)
     {
-        valid_count = items_per_block;
-        load_samples<BlockSize>(flat_id, samples, values);
-    }
-    else
-    {
-        valid_count = columns - block_offset;
-        load_samples<BlockSize>(flat_id, samples, values, valid_count);
-    }
-
-    ROCPRIM_UNROLL
-    for(unsigned int i = 0; i < ItemsPerThread; i++)
-    {
-        for(unsigned int channel = 0; channel < ActiveChannels; channel++)
+        if(flat_id == 0)
         {
-            unsigned int bin;
-            if(sample_to_bin_op[channel](values[i].values[channel], bin))
-            {
-                const unsigned int pos = flat_id * ItemsPerThread + i;
-                lane_mask_type     same_bin_lanes_mask
-                    = ::rocprim::match_any(bin, bins_bits[channel], pos < valid_count);
+            block_id_count_shared = ::rocprim::detail::atomic_add(block_id_count, 1u);
+        }
 
-                if(::rocprim::group_elect(same_bin_lanes_mask))
+        ::rocprim::syncthreads();
+
+        virtual_block_id = block_id_count_shared;
+
+        if (virtual_block_id >= virtual_max_blocks)
+        {
+            break;
+        }
+
+        const unsigned int row_id       = virtual_block_id % rows;
+        const unsigned int col_id       = virtual_block_id / rows;
+        const unsigned int block_offset = col_id * items_per_block;
+
+        SampleIterator samples_block = samples + row_id * row_stride + block_offset * Channels;
+
+        sample_vector_type values[ItemsPerThread];
+        unsigned int       valid_count;
+
+        if(block_offset + items_per_block <= columns)
+        {
+            valid_count = items_per_block;
+            load_samples<BlockSize>(flat_id, samples_block, values);
+        }
+        else
+        {
+            valid_count = columns - block_offset;
+            load_samples<BlockSize>(flat_id, samples_block, values, valid_count);
+        }
+
+        ROCPRIM_UNROLL
+        for(unsigned int i = 0; i < ItemsPerThread; i++)
+        {
+            for(unsigned int channel = 0; channel < ActiveChannels; channel++)
+            {
+                unsigned int bin;
+                if(sample_to_bin_op[channel](values[i].values[channel], bin))
                 {
-                    // Write the number of lanes having this bin,
-                    // if the current lane is the first (and maybe only) lane with this bin.
-                    ::rocprim::detail::atomic_add(&block_histogram[channel][bin],
-                                                  ::rocprim::bit_count(same_bin_lanes_mask));
+                    const unsigned int pos = flat_id * ItemsPerThread + i;
+                    lane_mask_type     same_bin_lanes_mask
+                        = ::rocprim::match_any(bin, bins_bits[channel], pos < valid_count);
+
+                    if(::rocprim::group_elect(same_bin_lanes_mask))
+                    {
+                        // Write the number of lanes having this bin,
+                        // if the current lane is the first (and maybe only) lane with this bin.
+                        ::rocprim::detail::atomic_add(&block_histogram[channel][bin],
+                                                      ::rocprim::bit_count(same_bin_lanes_mask));
+                    }
                 }
             }
         }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -41,7 +41,7 @@ namespace detail
 {
 
 // Special wrapper for passing fixed-length arrays (i.e. T values[Size]) into kernels
-template<class T, unsigned int Size>
+template<class T, size_t Size>
 class fixed_array
 {
 private:
@@ -56,12 +56,12 @@ public:
         }
     }
 
-    ROCPRIM_HOST_DEVICE T& operator[](unsigned int index)
+    ROCPRIM_HOST_DEVICE T& operator[](size_t index)
     {
         return values[index];
     }
 
-    ROCPRIM_HOST_DEVICE const T& operator[](unsigned int index) const
+    ROCPRIM_HOST_DEVICE const T& operator[](size_t index) const
     {
         return values[index];
     }
@@ -70,14 +70,17 @@ public:
 template<class Level, class Enable = void>
 struct sample_to_bin_even
 {
-    unsigned int bins;
-    Level        lower_level;
-    Level        upper_level;
-    Level        scale;
+    size_t bins;
+    Level  lower_level;
+    Level  upper_level;
+    Level  scale;
 
-    ROCPRIM_HOST_DEVICE sample_to_bin_even() = default;
+    ROCPRIM_HOST_DEVICE
+    sample_to_bin_even()
+        = default;
 
-    ROCPRIM_HOST_DEVICE sample_to_bin_even(unsigned int bins, Level lower_level, Level upper_level)
+    ROCPRIM_HOST_DEVICE
+    sample_to_bin_even(size_t bins, Level lower_level, Level upper_level)
         : bins(bins)
         , lower_level(lower_level)
         , upper_level(upper_level)
@@ -85,12 +88,12 @@ struct sample_to_bin_even
     {}
 
     template<class Sample>
-    ROCPRIM_HOST_DEVICE bool operator()(Sample sample, unsigned int& bin) const
+    ROCPRIM_HOST_DEVICE bool operator()(Sample sample, size_t& bin) const
     {
         const Level s = static_cast<Level>(sample);
         if(s >= lower_level && s < upper_level)
         {
-            bin = static_cast<unsigned int>((s - lower_level) / scale);
+            bin = static_cast<size_t>((s - lower_level) / scale);
             return true;
         }
         return false;
@@ -103,16 +106,17 @@ struct sample_to_bin_even<
     Level,
     typename std::enable_if<std::is_integral<Level>::value && (sizeof(Level) <= 4)>::type>
 {
-    unsigned int  bins;
+    size_t        bins;
     Level         lower_level;
     Level         upper_level;
     uint_fast_div scale;
 
-    ROCPRIM_HOST_DEVICE inline sample_to_bin_even() = default;
+    ROCPRIM_HOST_DEVICE
+    inline sample_to_bin_even()
+        = default;
 
-    ROCPRIM_HOST_DEVICE inline sample_to_bin_even(unsigned int bins,
-                                                  Level        lower_level,
-                                                  Level        upper_level)
+    ROCPRIM_HOST_DEVICE
+    inline sample_to_bin_even(size_t bins, Level lower_level, Level upper_level)
         : bins(bins)
         , lower_level(lower_level)
         , upper_level(upper_level)
@@ -120,12 +124,13 @@ struct sample_to_bin_even<
     {}
 
     template<class Sample>
-    ROCPRIM_HOST_DEVICE inline bool operator()(Sample sample, unsigned int& bin) const
+    ROCPRIM_HOST_DEVICE
+    inline bool operator()(Sample sample, size_t& bin) const
     {
         const Level s = static_cast<Level>(sample);
         if(s >= lower_level && s < upper_level)
         {
-            bin = static_cast<unsigned int>(s - lower_level) / scale;
+            bin = static_cast<size_t>(s - lower_level) / scale;
             return true;
         }
         return false;
@@ -137,16 +142,17 @@ template<class Level>
 struct sample_to_bin_even<Level,
                           typename std::enable_if<rocprim::is_floating_point<Level>::value>::type>
 {
-    unsigned int bins;
-    Level        lower_level;
-    Level        upper_level;
-    Level        inv_scale;
+    size_t bins;
+    Level  lower_level;
+    Level  upper_level;
+    Level  inv_scale;
 
-    ROCPRIM_HOST_DEVICE inline sample_to_bin_even() = default;
+    ROCPRIM_HOST_DEVICE
+    inline sample_to_bin_even()
+        = default;
 
-    ROCPRIM_HOST_DEVICE inline sample_to_bin_even(unsigned int bins,
-                                                  Level        lower_level,
-                                                  Level        upper_level)
+    ROCPRIM_HOST_DEVICE
+    inline sample_to_bin_even(size_t bins, Level lower_level, Level upper_level)
         : bins(bins)
         , lower_level(lower_level)
         , upper_level(upper_level)
@@ -154,12 +160,13 @@ struct sample_to_bin_even<Level,
     {}
 
     template<class Sample>
-    ROCPRIM_HOST_DEVICE inline bool operator()(Sample sample, unsigned int& bin) const
+    ROCPRIM_HOST_DEVICE
+    inline bool operator()(Sample sample, size_t& bin) const
     {
         const Level s = static_cast<Level>(sample);
         if(s >= lower_level && s < upper_level)
         {
-            bin = static_cast<unsigned int>((s - lower_level) * inv_scale);
+            bin = static_cast<size_t>((s - lower_level) * inv_scale);
             return true;
         }
         return false;
@@ -191,17 +198,21 @@ ROCPRIM_HOST_DEVICE inline unsigned int upper_bound(const T* values, unsigned in
 template<class Level>
 struct sample_to_bin_range
 {
-    unsigned int bins;
+    size_t       bins;
     const Level* level_values;
 
-    ROCPRIM_HOST_DEVICE inline sample_to_bin_range() = default;
+    ROCPRIM_HOST_DEVICE
+    inline sample_to_bin_range()
+        = default;
 
-    ROCPRIM_HOST_DEVICE inline sample_to_bin_range(unsigned int bins, const Level* level_values)
+    ROCPRIM_HOST_DEVICE
+    inline sample_to_bin_range(size_t bins, const Level* level_values)
         : bins(bins), level_values(level_values)
     {}
 
     template<class Sample>
-    ROCPRIM_HOST_DEVICE inline bool operator()(Sample sample, unsigned int& bin) const
+    ROCPRIM_HOST_DEVICE
+    inline bool operator()(Sample sample, size_t& bin) const
     {
         const Level s = static_cast<Level>(sample);
         bin           = upper_bound(level_values, bins + 1, s) - 1;
@@ -307,13 +318,13 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void
 
 template<unsigned int BlockSize, unsigned int ActiveChannels, class Counter>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-void init_histogram(fixed_array<Counter*, ActiveChannels>           histogram,
-                    const fixed_array<unsigned int, ActiveChannels> bins)
+void init_histogram(fixed_array<Counter*, ActiveChannels>     histogram,
+                    const fixed_array<size_t, ActiveChannels> bins)
 {
     const unsigned int flat_id  = ::rocprim::detail::block_thread_id<0>();
     const unsigned int block_id = ::rocprim::detail::block_id<0>();
 
-    const unsigned int index = block_id * BlockSize + flat_id;
+    const size_t index = block_id * BlockSize + flat_id;
     for(unsigned int channel = 0; channel < ActiveChannels; channel++)
     {
         if(index < bins[channel])
@@ -339,7 +350,7 @@ void histogram_shared(SampleIterator                                   samples,
                       unsigned int                                     shared_histograms,
                       fixed_array<Counter*, ActiveChannels>            histogram,
                       const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                      const fixed_array<unsigned int, ActiveChannels>  bins,
+                      const fixed_array<size_t, ActiveChannels>        bins,
                       unsigned int*                                    block_histogram_start)
 {
     using sample_type        = typename std::iterator_traits<SampleIterator>::value_type;
@@ -392,7 +403,7 @@ void histogram_shared(SampleIterator                                   samples,
                 {
                     for(unsigned int channel = 0; channel < ActiveChannels; channel++)
                     {
-                        unsigned int bin;
+                        size_t bin;
                         if(sample_to_bin_op[channel](values[i].values[channel], bin))
                         {
                             ::rocprim::detail::atomic_add(block_histogram[channel] + bin
@@ -416,7 +427,7 @@ void histogram_shared(SampleIterator                                   samples,
                     {
                         for(unsigned int channel = 0; channel < ActiveChannels; channel++)
                         {
-                            unsigned int bin;
+                            size_t bin;
                             if(sample_to_bin_op[channel](values[i].values[channel], bin))
                             {
                                 ::rocprim::detail::atomic_add(block_histogram[channel] + bin
@@ -458,18 +469,17 @@ template<unsigned int BlockSize,
          class Counter,
          class SampleToBinOp>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-void histogram_global(SampleIterator                             samples,
-                      unsigned int                               columns,
-                      unsigned int                               rows,
-                      unsigned int                               row_stride,
-                      fixed_array<Counter*, ActiveChannels>      histogram,
+void histogram_global(SampleIterator                                   samples,
+                      unsigned int                                     columns,
+                      unsigned int                                     rows,
+                      unsigned int                                     row_stride,
+                      fixed_array<Counter*, ActiveChannels>            histogram,
                       const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                      const fixed_array<unsigned int, ActiveChannels>  bins_bits,
-                      const fixed_array<unsigned int, ActiveChannels>  bins,
-                      unsigned int*                              private_histograms,
-                      const unsigned int                         max_blocks,
-                      const unsigned int                         virtual_max_blocks,
-                      unsigned int*                              block_id_count)
+                      const fixed_array<size_t, ActiveChannels>        bins_bits,
+                      const fixed_array<size_t, ActiveChannels>        bins,
+                      Counter*                                         private_histograms,
+                      const unsigned int                               virtual_max_blocks,
+                      unsigned int*                                    block_id_count)
 {
     using sample_type        = typename std::iterator_traits<SampleIterator>::value_type;
     using sample_vector_type = sample_vector<sample_type, Channels>;
@@ -478,14 +488,13 @@ void histogram_global(SampleIterator                             samples,
 
     const unsigned int flat_id       = ::rocprim::flat_block_thread_id();
     const unsigned int flat_block_id = ::rocprim::flat_block_id();
-    const unsigned int total_items   = rows * columns;
 
     __shared__
     unsigned int       block_id_count_shared;
 
     // starts of the first histogram for each channel
-    unsigned int* block_histogram[ActiveChannels];
-    unsigned int  total_bins = 0;
+    Counter* block_histogram[ActiveChannels];
+    size_t  total_bins = 0;
     for(unsigned int channel = 0; channel < ActiveChannels; channel++)
     {
         block_histogram[channel] = private_histograms + total_bins;
@@ -526,7 +535,7 @@ void histogram_global(SampleIterator                             samples,
         {
             for(unsigned int channel = 0; channel < ActiveChannels; channel++)
             {
-                unsigned int bin;
+                size_t bin;
                 if(sample_to_bin_op[channel](values[i].values[channel], bin))
                 {
                     const unsigned int pos = flat_id * ItemsPerThread + i;
@@ -558,9 +567,9 @@ void histogram_global(SampleIterator                             samples,
 
     for(unsigned int channel = 0; channel < ActiveChannels; channel++)
     {
-        for(unsigned int bin = flat_id; bin < bins[channel]; bin += BlockSize)
+        for(size_t bin = flat_id; bin < bins[channel]; bin += BlockSize)
         {
-            unsigned int total = block_histogram[channel][bin];
+            Counter total = block_histogram[channel][bin];
             if(total > 0)
             {
                 ::rocprim::detail::atomic_add(&histogram[channel][bin], total);

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -458,18 +458,18 @@ template<unsigned int BlockSize,
          class Counter,
          class SampleToBinOp>
 ROCPRIM_DEVICE ROCPRIM_INLINE
-void histogram_global(SampleIterator                                   samples,
-                      unsigned int                                     columns,
-                      unsigned int                                     rows,
-                      unsigned int                                     row_stride,
-                      fixed_array<Counter*, ActiveChannels>            histogram,
+void histogram_global(SampleIterator                             samples,
+                      unsigned int                               columns,
+                      unsigned int                               rows,
+                      unsigned int                               row_stride,
+                      fixed_array<Counter*, ActiveChannels>      histogram,
                       const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
                       const fixed_array<unsigned int, ActiveChannels>  bins_bits,
                       const fixed_array<unsigned int, ActiveChannels>  bins,
-                      unsigned int*                                    private_histograms,
-                      unsigned int                                     max_blocks,
-                      unsigned int                                     virtual_max_blocks,
-                      unsigned int*                                    block_id_count)
+                      unsigned int*                              private_histograms,
+                      const unsigned int                         max_blocks,
+                      const unsigned int                         virtual_max_blocks,
+                      unsigned int*                              block_id_count)
 {
     using sample_type        = typename std::iterator_traits<SampleIterator>::value_type;
     using sample_vector_type = sample_vector<sample_type, Channels>;
@@ -497,23 +497,10 @@ void histogram_global(SampleIterator                                   samples,
         block_histogram[channel] += flat_block_id * total_bins;
     }
 
-    unsigned int virtual_block_id = 0;
+    unsigned int virtual_block_id = flat_block_id;
+
     while(virtual_block_id < virtual_max_blocks)
     {
-        if(flat_id == 0)
-        {
-            block_id_count_shared = ::rocprim::detail::atomic_add(block_id_count, 1u);
-        }
-
-        ::rocprim::syncthreads();
-
-        virtual_block_id = block_id_count_shared;
-
-        if (virtual_block_id >= virtual_max_blocks)
-        {
-            break;
-        }
-
         const unsigned int row_id       = virtual_block_id % rows;
         const unsigned int col_id       = virtual_block_id / rows;
         const unsigned int block_offset = col_id * items_per_block;
@@ -556,9 +543,18 @@ void histogram_global(SampleIterator                                   samples,
                 }
             }
         }
-    }
 
-    ::rocprim::syncthreads();
+        if(flat_id == 0)
+        {
+            block_id_count_shared = ::rocprim::detail::atomic_add(block_id_count, 1u);
+        }
+
+        ::rocprim::syncthreads();
+
+        virtual_block_id = block_id_count_shared;
+
+        ::rocprim::syncthreads();
+    }
 
     for(unsigned int channel = 0; channel < ActiveChannels; channel++)
     {

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -471,15 +471,79 @@ template<unsigned int BlockSize,
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void histogram_global(SampleIterator                                   samples,
                       unsigned int                                     columns,
-                      unsigned int                                     rows,
                       unsigned int                                     row_stride,
                       fixed_array<Counter*, ActiveChannels>            histogram,
                       const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                      const fixed_array<size_t, ActiveChannels>        bins_bits,
-                      const fixed_array<size_t, ActiveChannels>        bins,
-                      Counter*                                         private_histograms,
-                      const unsigned int                               virtual_max_blocks,
-                      unsigned int*                                    block_id_count)
+                      const fixed_array<size_t, ActiveChannels>        bins_bits)
+{
+    using sample_type        = typename std::iterator_traits<SampleIterator>::value_type;
+    using sample_vector_type = sample_vector<sample_type, Channels>;
+
+    constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
+
+    const unsigned int flat_id      = ::rocprim::detail::block_thread_id<0>();
+    const unsigned int block_id0    = ::rocprim::detail::block_id<0>();
+    const unsigned int block_id1    = ::rocprim::detail::block_id<1>();
+    const unsigned int block_offset = block_id0 * items_per_block;
+
+    samples += block_id1 * row_stride + Channels * block_offset;
+
+    sample_vector_type values[ItemsPerThread];
+    unsigned int       valid_count;
+    if(block_offset + items_per_block <= columns)
+    {
+        valid_count = items_per_block;
+        load_samples<BlockSize>(flat_id, samples, values);
+    }
+    else
+    {
+        valid_count = columns - block_offset;
+        load_samples<BlockSize>(flat_id, samples, values, valid_count);
+    }
+
+    ROCPRIM_UNROLL
+    for(unsigned int i = 0; i < ItemsPerThread; i++)
+    {
+        for(unsigned int channel = 0; channel < ActiveChannels; channel++)
+        {
+            size_t bin;
+            if(sample_to_bin_op[channel](values[i].values[channel], bin))
+            {
+                const unsigned int pos = flat_id * ItemsPerThread + i;
+                lane_mask_type     same_bin_lanes_mask
+                    = ::rocprim::match_any(bin, bins_bits[channel], pos < valid_count);
+
+                if(::rocprim::group_elect(same_bin_lanes_mask))
+                {
+                    // Write the number of lanes having this bin,
+                    // if the current lane is the first (and maybe only) lane with this bin.
+                    ::rocprim::detail::atomic_add(&histogram[channel][bin],
+                                                  ::rocprim::bit_count(same_bin_lanes_mask));
+                }
+            }
+        }
+    }
+}
+
+template<unsigned int BlockSize,
+         unsigned int ItemsPerThread,
+         unsigned int Channels,
+         unsigned int ActiveChannels,
+         class SampleIterator,
+         class Counter,
+         class SampleToBinOp>
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void histogram_private_global(SampleIterator                                   samples,
+                              unsigned int                                     columns,
+                              unsigned int                                     rows,
+                              unsigned int                                     row_stride,
+                              fixed_array<Counter*, ActiveChannels>            histogram,
+                              const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
+                              const fixed_array<size_t, ActiveChannels>        bins_bits,
+                              const fixed_array<size_t, ActiveChannels>        bins,
+                              Counter*                                         private_histograms,
+                              const unsigned int                               virtual_max_blocks,
+                              unsigned int*                                    block_id_count)
 {
     using sample_type        = typename std::iterator_traits<SampleIterator>::value_type;
     using sample_vector_type = sample_vector<sample_type, Channels>;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -365,7 +365,7 @@ void histogram_shared(SampleIterator                                   samples,
     const unsigned int block_id1  = ::rocprim::detail::block_id<1>();
     const unsigned int grid_size0 = ::rocprim::detail::grid_size<0>();
 
-    // starts of the first histogram for each channel
+    // Store the start of the first histogram for each channel
     unsigned int* block_histogram[ActiveChannels];
     unsigned int  total_bins = 0;
     for(unsigned int channel = 0; channel < ActiveChannels; channel++)
@@ -557,7 +557,7 @@ void histogram_private_global(SampleIterator                                   s
 
     __shared__ unsigned int block_id_count_shared;
 
-    // starts of the first histogram for each channel
+    // Store the start of the first histogram for each channel
     Counter* block_histogram[ActiveChannels];
     size_t   total_bins = 0;
     for(unsigned int channel = 0; channel < ActiveChannels; channel++)

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -56,12 +56,15 @@ public:
         }
     }
 
-    ROCPRIM_HOST_DEVICE T& operator[](size_t index)
+    ROCPRIM_HOST_DEVICE
+    T& operator[](size_t index)
     {
         return values[index];
     }
 
-    ROCPRIM_HOST_DEVICE const T& operator[](size_t index) const
+    ROCPRIM_HOST_DEVICE
+    const T&
+        operator[](size_t index) const
     {
         return values[index];
     }
@@ -75,12 +78,11 @@ struct sample_to_bin_even
     Level  upper_level;
     Level  scale;
 
-    ROCPRIM_HOST_DEVICE
-    sample_to_bin_even()
-        = default;
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE sample_to_bin_even() = default;
 
-    ROCPRIM_HOST_DEVICE
-    sample_to_bin_even(size_t bins, Level lower_level, Level upper_level)
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE sample_to_bin_even(size_t bins,
+                                                         Level  lower_level,
+                                                         Level  upper_level)
         : bins(bins)
         , lower_level(lower_level)
         , upper_level(upper_level)
@@ -88,7 +90,8 @@ struct sample_to_bin_even
     {}
 
     template<class Sample>
-    ROCPRIM_HOST_DEVICE bool operator()(Sample sample, size_t& bin) const
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE
+    bool operator()(Sample sample, size_t& bin) const
     {
         const Level s = static_cast<Level>(sample);
         if(s >= lower_level && s < upper_level)
@@ -111,12 +114,11 @@ struct sample_to_bin_even<
     Level         upper_level;
     uint_fast_div scale;
 
-    ROCPRIM_HOST_DEVICE
-    inline sample_to_bin_even()
-        = default;
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE sample_to_bin_even() = default;
 
-    ROCPRIM_HOST_DEVICE
-    inline sample_to_bin_even(size_t bins, Level lower_level, Level upper_level)
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE sample_to_bin_even(size_t bins,
+                                                         Level  lower_level,
+                                                         Level  upper_level)
         : bins(bins)
         , lower_level(lower_level)
         , upper_level(upper_level)
@@ -125,7 +127,8 @@ struct sample_to_bin_even<
 
     template<class Sample>
     ROCPRIM_HOST_DEVICE
-    inline bool operator()(Sample sample, size_t& bin) const
+    ROCPRIM_INLINE
+    bool operator()(Sample sample, size_t& bin) const
     {
         const Level s = static_cast<Level>(sample);
         if(s >= lower_level && s < upper_level)
@@ -147,12 +150,11 @@ struct sample_to_bin_even<Level,
     Level  upper_level;
     Level  inv_scale;
 
-    ROCPRIM_HOST_DEVICE
-    inline sample_to_bin_even()
-        = default;
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE sample_to_bin_even() = default;
 
-    ROCPRIM_HOST_DEVICE
-    inline sample_to_bin_even(size_t bins, Level lower_level, Level upper_level)
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE sample_to_bin_even(size_t bins,
+                                                         Level  lower_level,
+                                                         Level  upper_level)
         : bins(bins)
         , lower_level(lower_level)
         , upper_level(upper_level)
@@ -161,7 +163,8 @@ struct sample_to_bin_even<Level,
 
     template<class Sample>
     ROCPRIM_HOST_DEVICE
-    inline bool operator()(Sample sample, size_t& bin) const
+    ROCPRIM_INLINE
+    bool operator()(Sample sample, size_t& bin) const
     {
         const Level s = static_cast<Level>(sample);
         if(s >= lower_level && s < upper_level)
@@ -175,7 +178,8 @@ struct sample_to_bin_even<Level,
 
 // Returns index of the first element in values that is greater than value, or count if no such element is found.
 template<class T>
-ROCPRIM_HOST_DEVICE inline unsigned int upper_bound(const T* values, unsigned int count, T value)
+ROCPRIM_HOST_DEVICE ROCPRIM_INLINE
+unsigned int upper_bound(const T* values, unsigned int count, T value)
 {
     unsigned int current = 0;
     while(count > 0)
@@ -198,21 +202,19 @@ ROCPRIM_HOST_DEVICE inline unsigned int upper_bound(const T* values, unsigned in
 template<class Level>
 struct sample_to_bin_range
 {
-    size_t       bins;
+    size_t bins;
     const Level* level_values;
 
-    ROCPRIM_HOST_DEVICE
-    inline sample_to_bin_range()
-        = default;
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE sample_to_bin_range() = default;
 
-    ROCPRIM_HOST_DEVICE
-    inline sample_to_bin_range(size_t bins, const Level* level_values)
+    ROCPRIM_HOST_DEVICE ROCPRIM_INLINE sample_to_bin_range(size_t bins, const Level* level_values)
         : bins(bins), level_values(level_values)
     {}
 
     template<class Sample>
     ROCPRIM_HOST_DEVICE
-    inline bool operator()(Sample sample, size_t& bin) const
+    ROCPRIM_INLINE
+    bool operator()(Sample sample, size_t& bin) const
     {
         const Level s = static_cast<Level>(sample);
         bin           = upper_bound(level_values, bins + 1, s) - 1;
@@ -550,15 +552,14 @@ void histogram_private_global(SampleIterator                                   s
 
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
-    const unsigned int flat_id       = ::rocprim::flat_block_thread_id();
+    const unsigned int flat_id = ::rocprim::flat_block_thread_id();
     const unsigned int flat_block_id = ::rocprim::flat_block_id();
 
-    __shared__
-    unsigned int       block_id_count_shared;
+    __shared__ unsigned int block_id_count_shared;
 
     // starts of the first histogram for each channel
     Counter* block_histogram[ActiveChannels];
-    size_t  total_bins = 0;
+    size_t   total_bins = 0;
     for(unsigned int channel = 0; channel < ActiveChannels; channel++)
     {
         block_histogram[channel] = private_histograms + total_bins;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -143,11 +143,8 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     using config = wrapped_histogram_config<Config, sample_type, Channels, ActiveChannels>;
 
     detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+    HIP_CHECK(host_target_arch(stream, target_arch));
+
     const histogram_config_params params = dispatch_target_arch<config>(target_arch);
 
     const unsigned int block_size           = params.histogram_config.block_size;
@@ -177,11 +174,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         std::cout << "columns " << columns << '\n';
         std::cout << "rows " << rows << '\n';
         std::cout << "blocks_x " << blocks_x << '\n';
-        hipError_t error = hipStreamSynchronize(stream);
-        if(error != hipSuccess)
-        {
-            return error;
-        }
+        HIP_CHECK(hipStreamSynchronize(stream));
     }
 
     unsigned int bins[ActiveChannels];
@@ -199,19 +192,19 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         max_bins = std::max(max_bins, bins[channel]);
     }
 
+
     std::chrono::steady_clock::time_point start;
 
     if(debug_synchronous)
     {
         start = std::chrono::steady_clock::now();
     }
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(init_histogram_kernel<config, ActiveChannels>),
-                       dim3(::rocprim::detail::ceiling_div(max_bins, block_size)),
-                       dim3(block_size),
-                       0,
-                       stream,
-                       fixed_array<Counter*, ActiveChannels>(histogram),
-                       fixed_array<unsigned int, ActiveChannels>(bins));
+    init_histogram_kernel<config, ActiveChannels>
+        <<<dim3(::rocprim::detail::ceiling_div(max_bins, block_size)),
+           dim3(block_size),
+           0,
+           stream>>>(fixed_array<Counter*, ActiveChannels>(histogram),
+                     fixed_array<unsigned int, ActiveChannels>(bins));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_histogram", max_bins, start);
 
     if(columns == 0 || rows == 0)
@@ -242,16 +235,12 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         int          max_blocks_per_mp        = 0;
         for(unsigned int n = params.shared_impl_histograms; n >= 1; n--)
         {
-            int        blocks_per_mp;
-            hipError_t error
-                = hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_mp,
-                                                               kernel,
-                                                               block_size,
-                                                               n * block_histogram_bytes);
-            if(error != hipSuccess)
-            {
-                return error;
-            }
+            int blocks_per_mp;
+            HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_mp,
+                                                                   kernel,
+                                                                   block_size,
+                                                                   n * block_histogram_bytes));
+
             if(blocks_per_mp > max_blocks_per_mp)
             {
                 chosen_shared_histograms = n;
@@ -261,16 +250,12 @@ inline hipError_t histogram_impl(void*          temporary_storage,
 
         // Choose minimum grid size needed to achieve the best occupancy
         int        min_grid_size, max_block_size;
-        hipError_t error
-            = hipOccupancyMaxPotentialBlockSize(&min_grid_size,
+        HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&min_grid_size,
                                                 &max_block_size,
                                                 kernel,
                                                 chosen_shared_histograms * block_histogram_bytes,
-                                                int(block_size));
-        if(error != hipSuccess)
-        {
-            return error;
-        }
+                                                int(block_size)));
+
         const unsigned int chosen_grid_size
             = std::min(static_cast<unsigned int>(min_grid_size), params.max_grid_size);
 
@@ -278,12 +263,10 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         grid_size.x = std::min(chosen_grid_size, blocks_x);
         grid_size.y = std::min(rows, ::rocprim::detail::ceiling_div(chosen_grid_size, grid_size.x));
         const unsigned int rows_per_block = ::rocprim::detail::ceiling_div(rows, grid_size.y);
-        hipLaunchKernelGGL(kernel,
-                           grid_size,
-                           dim3(block_size, 1),
-                           chosen_shared_histograms * block_histogram_bytes,
-                           stream,
-                           samples,
+        kernel<<<grid_size,
+                 dim3(block_size, 1),
+                 chosen_shared_histograms * block_histogram_bytes,
+                 stream>>>(samples,
                            columns,
                            rows,
                            row_stride,
@@ -302,18 +285,14 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         {
             start = std::chrono::steady_clock::now();
         }
-        hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(histogram_global_kernel<config, Channels, ActiveChannels>),
-            dim3(blocks_x, rows),
-            dim3(block_size, 1),
-            0,
-            stream,
-            samples,
-            columns,
-            row_stride,
-            fixed_array<Counter*, ActiveChannels>(histogram),
-            fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-            fixed_array<unsigned int, ActiveChannels>(bins_bits));
+        histogram_global_kernel<config, Channels, ActiveChannels>
+            <<<dim3(blocks_x, rows), dim3(block_size, 1), 0, stream>>>(
+                samples,
+                columns,
+                row_stride,
+                fixed_array<Counter*, ActiveChannels>(histogram),
+                fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
+                fixed_array<unsigned int, ActiveChannels>(bins_bits));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global",
                                                     blocks_x * block_size * rows,
                                                     start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -102,12 +102,16 @@ template<class Config,
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
     histogram_global_kernel(SampleIterator                                   samples,
                             unsigned int                                     columns,
+                            unsigned int                                     rows,
                             unsigned int                                     row_stride,
                             fixed_array<Counter*, ActiveChannels>            histogram,
                             const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
                             const fixed_array<unsigned int, ActiveChannels>  bins_bits,
                             const fixed_array<unsigned int, ActiveChannels>  bins,
-                            unsigned int*                                    private_histograms)
+                            unsigned int*                                    private_histograms,
+                            unsigned int                                     max_blocks,
+                            unsigned int                                     virtual_max_blocks,
+                            unsigned int*                                    block_id_count)
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
@@ -116,12 +120,16 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.bl
                      Channels,
                      ActiveChannels>(samples,
                                      columns,
+                                     rows,
                                      row_stride,
                                      histogram,
                                      sample_to_bin_op,
                                      bins_bits,
                                      bins,
-                                     private_histograms);
+                                     private_histograms,
+                                     max_blocks,
+                                     virtual_max_blocks,
+                                     block_id_count);
 }
 
 template<unsigned int Channels,
@@ -147,7 +155,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     using config = wrapped_histogram_config<Config, sample_type, Channels, ActiveChannels>;
 
     detail::target_arch target_arch;
-    HIP_CHECK(host_target_arch(stream, target_arch));
+    ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
 
     const histogram_config_params params = dispatch_target_arch<config>(target_arch);
 
@@ -184,8 +192,10 @@ inline hipError_t histogram_impl(void*          temporary_storage,
 
     const bool use_shared_mem = total_shared_bins <= shared_impl_max_bins;
 
-
     unsigned int* private_histograms = nullptr;
+    unsigned int* block_id_count = nullptr;
+    int global_histogram_grid_size = 0;
+    unsigned int virtual_max_blocks = 0;
 
     if(use_shared_mem)
     {
@@ -199,22 +209,41 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     }
     else
     {
-        const unsigned size_private_histograms = total_bins * blocks_x * rows;
-        const hipError_t partition_result = detail::temp_storage::partition(
+        auto kernel = HIP_KERNEL_NAME(histogram_global_kernel<config,
+                                                              Channels,
+                                                              ActiveChannels,
+                                                              SampleIterator,
+                                                              Counter,
+                                                              SampleToBinOp>);
+                            
+        ROCPRIM_RETURN_ON_ERROR(detail::grid_dim_for_max_active_blocks(global_histogram_grid_size,
+                                                                       block_size,
+                                                                       kernel,
+                                                                       stream));
+
+        virtual_max_blocks = ::rocprim::detail::ceiling_div(columns, items_per_block) * rows;
+        global_histogram_grid_size
+            = rocprim::min(static_cast<unsigned int>(global_histogram_grid_size),
+                           virtual_max_blocks);
+
+        const unsigned   size_private_histograms = total_bins * global_histogram_grid_size;
+        const hipError_t partition_result        = detail::temp_storage::partition(
             temporary_storage,
             storage_size,
             detail::temp_storage::make_linear_partition(
                 detail::temp_storage::ptr_aligned_array(&private_histograms,
-                                                        total_bins * blocks_x * rows)));
+                                                        size_private_histograms),
+                detail::temp_storage::ptr_aligned_array(&block_id_count, 1)));
         if(partition_result != hipSuccess || temporary_storage == nullptr)
         {
             return partition_result;
         }
 
-        HIP_CHECK(hipMemsetAsync(private_histograms,
-                                 0u,
-                                 size_private_histograms * sizeof(unsigned int),
-                                 stream));
+        ROCPRIM_RETURN_ON_ERROR(hipMemsetAsync(private_histograms,
+                                               0u,
+                                               size_private_histograms * sizeof(unsigned int),
+                                               stream));
+        ROCPRIM_RETURN_ON_ERROR(hipMemsetAsync(block_id_count, 0u, sizeof(unsigned int), stream));
     }
 
     if(debug_synchronous)
@@ -222,7 +251,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         std::cout << "columns " << columns << '\n';
         std::cout << "rows " << rows << '\n';
         std::cout << "blocks_x " << blocks_x << '\n';
-        HIP_CHECK(hipStreamSynchronize(stream));
+        ROCPRIM_RETURN_ON_ERROR(hipStreamSynchronize(stream));
     }
 
     std::chrono::steady_clock::time_point start;
@@ -268,7 +297,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         for(unsigned int n = params.shared_impl_histograms; n >= 1; n--)
         {
             int blocks_per_mp;
-            HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_mp,
+            ROCPRIM_RETURN_ON_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_mp,
                                                                    kernel,
                                                                    block_size,
                                                                    n * block_histogram_bytes));
@@ -282,11 +311,12 @@ inline hipError_t histogram_impl(void*          temporary_storage,
 
         // Choose minimum grid size needed to achieve the best occupancy
         int        min_grid_size, max_block_size;
-        HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&min_grid_size,
-                                                &max_block_size,
-                                                kernel,
-                                                chosen_shared_histograms * block_histogram_bytes,
-                                                int(block_size)));
+        ROCPRIM_RETURN_ON_ERROR(
+            hipOccupancyMaxPotentialBlockSize(&min_grid_size,
+                                              &max_block_size,
+                                              kernel,
+                                              chosen_shared_histograms * block_histogram_bytes,
+                                              int(block_size)));
 
         const unsigned int chosen_grid_size
             = std::min(static_cast<unsigned int>(min_grid_size), params.max_grid_size);
@@ -318,15 +348,18 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             start = std::chrono::steady_clock::now();
         }
         histogram_global_kernel<config, Channels, ActiveChannels>
-            <<<dim3(blocks_x, rows), dim3(block_size, 1), 0, stream>>>(
+            <<<dim3(global_histogram_grid_size), dim3(block_size), 0, stream>>>(
                 samples,
                 columns,
+                rows,
                 row_stride,
                 fixed_array<Counter*, ActiveChannels>(histogram),
                 fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
                 fixed_array<unsigned int, ActiveChannels>(bins_bits),
                 fixed_array<unsigned int, ActiveChannels>(bins),
-                private_histograms);
+                private_histograms,
+                global_histogram_grid_size,
+                virtual_max_blocks, block_id_count);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global",
                                                     blocks_x * block_size * rows,
                                                     start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -105,7 +105,9 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.bl
                             unsigned int                                     row_stride,
                             fixed_array<Counter*, ActiveChannels>            histogram,
                             const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                            const fixed_array<unsigned int, ActiveChannels>  bins_bits)
+                            const fixed_array<unsigned int, ActiveChannels>  bins_bits,
+                            const fixed_array<unsigned int, ActiveChannels>  bins,
+                            unsigned int*                                    private_histograms)
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
@@ -117,7 +119,9 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.bl
                                      row_stride,
                                      histogram,
                                      sample_to_bin_op,
-                                     bins_bits);
+                                     bins_bits,
+                                     bins,
+                                     private_histograms);
 }
 
 template<unsigned int Channels,
@@ -161,12 +165,56 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     const unsigned int blocks_x   = ::rocprim::detail::ceiling_div(columns, items_per_block);
     const unsigned int row_stride = row_stride_bytes / sizeof(sample_type);
 
-    if(temporary_storage == nullptr)
+    unsigned int bins[ActiveChannels];
+    unsigned int bins_bits[ActiveChannels];
+    unsigned int total_shared_bins = 0;
+    unsigned int max_bins          = 0;
+    unsigned int total_bins        = 0;
+    for(unsigned int channel = 0; channel < ActiveChannels; channel++)
     {
-        // Make sure user won't try to allocate 0 bytes memory, because
-        // hipMalloc will return nullptr.
-        storage_size = 4;
-        return hipSuccess;
+        bins[channel] = levels[channel] - 1;
+        bins_bits[channel]
+            = static_cast<unsigned int>(std::log2(detail::next_power_of_two(bins[channel])));
+        const unsigned int size = bins[channel];
+        // Prevent LDS bank conflicts
+        total_shared_bins += rocprim::detail::is_power_of_two(size) ? size + 1 : size;
+        total_bins += size;
+        max_bins = std::max(max_bins, bins[channel]);
+    }
+
+    const bool use_shared_mem = total_shared_bins <= shared_impl_max_bins;
+
+
+    unsigned int* private_histograms = nullptr;
+
+    if(use_shared_mem)
+    {
+        if(temporary_storage == nullptr)
+        {
+            // Make sure user won't try to allocate 0 bytes memory, because
+            // hipMalloc will return nullptr.
+            storage_size = 4;
+            return hipSuccess;
+        }
+    }
+    else
+    {
+        const unsigned size_private_histograms = total_bins * blocks_x * rows;
+        const hipError_t partition_result = detail::temp_storage::partition(
+            temporary_storage,
+            storage_size,
+            detail::temp_storage::make_linear_partition(
+                detail::temp_storage::ptr_aligned_array(&private_histograms,
+                                                        total_bins * blocks_x * rows)));
+        if(partition_result != hipSuccess || temporary_storage == nullptr)
+        {
+            return partition_result;
+        }
+
+        HIP_CHECK(hipMemsetAsync(private_histograms,
+                                 0u,
+                                 size_private_histograms * sizeof(unsigned int),
+                                 stream));
     }
 
     if(debug_synchronous)
@@ -176,22 +224,6 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         std::cout << "blocks_x " << blocks_x << '\n';
         HIP_CHECK(hipStreamSynchronize(stream));
     }
-
-    unsigned int bins[ActiveChannels];
-    unsigned int bins_bits[ActiveChannels];
-    unsigned int total_shared_bins = 0;
-    unsigned int max_bins          = 0;
-    for(unsigned int channel = 0; channel < ActiveChannels; channel++)
-    {
-        bins[channel] = levels[channel] - 1;
-        bins_bits[channel]
-            = static_cast<unsigned int>(std::log2(detail::next_power_of_two(bins[channel])));
-        const unsigned int size = bins[channel];
-        // Prevent LDS bank conflicts
-        total_shared_bins += rocprim::detail::is_power_of_two(size) ? size + 1 : size;
-        max_bins = std::max(max_bins, bins[channel]);
-    }
-
 
     std::chrono::steady_clock::time_point start;
 
@@ -212,7 +244,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         return hipSuccess;
     }
 
-    if(total_shared_bins <= shared_impl_max_bins)
+    if(use_shared_mem)
     {
         if(debug_synchronous)
         {
@@ -292,7 +324,9 @@ inline hipError_t histogram_impl(void*          temporary_storage,
                 row_stride,
                 fixed_array<Counter*, ActiveChannels>(histogram),
                 fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                fixed_array<unsigned int, ActiveChannels>(bins_bits));
+                fixed_array<unsigned int, ActiveChannels>(bins_bits),
+                fixed_array<unsigned int, ActiveChannels>(bins),
+                private_histograms);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global",
                                                     blocks_x * block_size * rows,
                                                     start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -269,15 +269,20 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             return partition_result;
         }
 
-        // When using graphs, private_histograms and block_id_count both returned a nullptr.
-        // That is why a memset is directly done on temporary_storage.
-        ROCPRIM_RETURN_ON_ERROR(hipMemsetAsync(temporary_storage, 0, storage_size, stream));
+        // It will not run the kernel if columns or rows are 0.
+        if(global_histogram_grid_size > 0)
+        {
+            ROCPRIM_RETURN_ON_ERROR(hipMemsetAsync(private_histograms,
+                                                   0,
+                                                   size_private_histograms * sizeof(Counter),
+                                                   stream));
 
-        ROCPRIM_RETURN_ON_ERROR(hipMemcpyAsync(block_id_count,
-                                               &global_histogram_grid_size,
-                                               sizeof(unsigned int),
-                                               hipMemcpyHostToDevice,
-                                               stream));
+            ROCPRIM_RETURN_ON_ERROR(hipMemcpyAsync(block_id_count,
+                                                   &global_histogram_grid_size,
+                                                   sizeof(unsigned int),
+                                                   hipMemcpyHostToDevice,
+                                                   stream));
+        }
     }
 
     if(debug_synchronous)

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -240,32 +240,14 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         const auto items_per_block = params.histogram_global_config.block_size
                                      * params.histogram_global_config.items_per_thread;
 
-        hipDevice_t default_device;
-        ROCPRIM_RETURN_ON_ERROR(hipStreamGetDevice(0, &default_device));
+        int device_id = hipGetStreamDeviceId(stream);
 
-        hipDevice_t stream_device;
-        ROCPRIM_RETURN_ON_ERROR(hipStreamGetDevice(stream, &stream_device));
-
-        // After setting device, we can't just exit on non-success.
-        hipError_t result = hipSetDevice(stream_device);
-
-        int num_multi_processors;
-        if(result == hipSuccess)
-        {
-            result
-                = hipDeviceGetAttribute(&num_multi_processors,
-                                        hipDeviceAttribute_t::hipDeviceAttributeMultiprocessorCount,
-                                        stream_device);
-            // Sanity check.
-            if(num_multi_processors == 0)
-            {
-                result = hipErrorUnknown;
-            }
-        }
-        // Always attempt to restore to default device.
-        hipError_t set_result = hipSetDevice(default_device);
-        ROCPRIM_RETURN_ON_ERROR(set_result);
-        ROCPRIM_RETURN_ON_ERROR(result);
+        // Get the number of multiprocessors
+        int num_multi_processors{};
+        ROCPRIM_RETURN_ON_ERROR(
+            hipDeviceGetAttribute(&num_multi_processors,
+                                  hipDeviceAttribute_t::hipDeviceAttributeMultiprocessorCount,
+                                  device_id));
 
         global_histogram_grid_size = num_multi_processors;
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -128,7 +128,7 @@ template<class Config,
          class Counter,
          class SampleToBinOp>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>()
-                                         .histogram_private_config.block_size) void
+                                         .histogram_global_config.block_size) void
     histogram_private_global_kernel(SampleIterator                             samples,
                                     unsigned int                               columns,
                                     unsigned int                               rows,
@@ -143,8 +143,8 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>()
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
-    histogram_private_global<params.histogram_private_config.block_size,
-                             params.histogram_private_config.items_per_thread,
+    histogram_private_global<params.histogram_global_config.block_size,
+                             params.histogram_global_config.items_per_thread,
                              Channels,
                              ActiveChannels>(samples,
                                              columns,
@@ -237,8 +237,8 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     }
     else
     {
-        const auto items_per_block = params.histogram_private_config.block_size
-                                     * params.histogram_private_config.items_per_thread;
+        const auto items_per_block = params.histogram_global_config.block_size
+                                     * params.histogram_global_config.items_per_thread;
 
         hipDevice_t default_device;
         ROCPRIM_RETURN_ON_ERROR(hipStreamGetDevice(0, &default_device));
@@ -406,7 +406,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             }
             histogram_private_global_kernel<config, Channels, ActiveChannels>
                 <<<dim3(global_histogram_grid_size),
-                   dim3(params.histogram_private_config.block_size),
+                   dim3(params.histogram_global_config.block_size),
                    0,
                    stream>>>(samples,
                              columns,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -44,13 +44,8 @@ namespace detail
 
 template<class Config, unsigned int ActiveChannels, class Counter>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
-<<<<<<< HEAD
-    init_histogram_kernel(fixed_array<Counter*, ActiveChannels>           histogram,
-                          const fixed_array<unsigned int, ActiveChannels> bins)
-=======
     init_histogram_kernel(fixed_array<Counter*, ActiveChannels>     histogram,
-                          fixed_array<size_t, ActiveChannels> bins)
->>>>>>> 86d06adef9 (Change types of private histogram and indexing of bins)
+                          const fixed_array<size_t, ActiveChannels> bins)
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
@@ -104,7 +99,8 @@ template<class Config,
          class SampleIterator,
          class Counter,
          class SampleToBinOp>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
+ROCPRIM_KERNEL
+ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_private_config.block_size) void
     histogram_global_kernel(SampleIterator                                   samples,
                             unsigned int                                     columns,
                             unsigned int                                     rows,
@@ -119,8 +115,8 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.bl
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
-    histogram_global<params.histogram_config.block_size,
-                     params.histogram_config.items_per_thread,
+    histogram_global<params.histogram_private_config.block_size,
+                     params.histogram_private_config.items_per_thread,
                      Channels,
                      ActiveChannels>(samples,
                                      columns,
@@ -211,6 +207,9 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     }
     else
     {
+
+        const auto items_per_block = params.histogram_private_config.block_size
+                                     * params.histogram_private_config.items_per_thread;
         auto kernel = HIP_KERNEL_NAME(histogram_global_kernel<config,
                                                               Channels,
                                                               ActiveChannels,
@@ -352,18 +351,20 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             start = std::chrono::steady_clock::now();
         }
         histogram_global_kernel<config, Channels, ActiveChannels>
-            <<<dim3(global_histogram_grid_size), dim3(block_size), 0, stream>>>(
-                samples,
-                columns,
-                rows,
-                row_stride,
-                fixed_array<Counter*, ActiveChannels>(histogram),
-                fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                fixed_array<size_t, ActiveChannels>(bins_bits),
-                fixed_array<size_t, ActiveChannels>(bins),
-                private_histograms,
-                virtual_max_blocks,
-                block_id_count);
+            <<<dim3(global_histogram_grid_size),
+               dim3(params.histogram_private_config.block_size),
+               0,
+               stream>>>(samples,
+                         columns,
+                         rows,
+                         row_stride,
+                         fixed_array<Counter*, ActiveChannels>(histogram),
+                         fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
+                         fixed_array<size_t, ActiveChannels>(bins_bits),
+                         fixed_array<size_t, ActiveChannels>(bins),
+                         private_histograms,
+                         virtual_max_blocks,
+                         block_id_count);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global",
                                                     blocks_x * block_size * rows,
                                                     start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -31,6 +31,7 @@
 #include "../detail/various.hpp"
 #include "../functional.hpp"
 
+#include "config_types.hpp"
 #include "detail/device_histogram.hpp"
 #include "device_histogram_config.hpp"
 
@@ -99,36 +100,63 @@ template<class Config,
          class SampleIterator,
          class Counter,
          class SampleToBinOp>
-ROCPRIM_KERNEL
-ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_private_config.block_size) void
+ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
     histogram_global_kernel(SampleIterator                                   samples,
                             unsigned int                                     columns,
-                            unsigned int                                     rows,
                             unsigned int                                     row_stride,
                             fixed_array<Counter*, ActiveChannels>            histogram,
                             const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                            const fixed_array<size_t, ActiveChannels>        bins_bits,
-                            const fixed_array<size_t, ActiveChannels>        bins,
-                            Counter*                                         private_histograms,
-                            unsigned int                                     virtual_max_blocks,
-                            unsigned int*                                    block_id_count)
+                            const fixed_array<size_t, ActiveChannels>        bins_bits)
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
-    histogram_global<params.histogram_private_config.block_size,
-                     params.histogram_private_config.items_per_thread,
+    histogram_global<params.histogram_config.block_size,
+                     params.histogram_config.items_per_thread,
                      Channels,
                      ActiveChannels>(samples,
                                      columns,
-                                     rows,
                                      row_stride,
                                      histogram,
                                      sample_to_bin_op,
-                                     bins_bits,
-                                     bins,
-                                     private_histograms,
-                                     virtual_max_blocks,
-                                     block_id_count);
+                                     bins_bits);
+}
+
+template<class Config,
+         unsigned int Channels,
+         unsigned int ActiveChannels,
+         class SampleIterator,
+         class Counter,
+         class SampleToBinOp>
+ROCPRIM_KERNEL
+ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_private_config.block_size) void
+    histogram_private_global_kernel(SampleIterator                             samples,
+                                    unsigned int                               columns,
+                                    unsigned int                               rows,
+                                    unsigned int                               row_stride,
+                                    fixed_array<Counter*, ActiveChannels>      histogram,
+                                    fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
+                                    fixed_array<size_t, ActiveChannels>        bins_bits,
+                                    fixed_array<size_t, ActiveChannels>        bins,
+                                    Counter*                                   private_histograms,
+                                    unsigned int                               virtual_max_blocks,
+                                    unsigned int*                              block_id_count)
+{
+    static constexpr histogram_config_params params = device_params<Config>();
+
+    histogram_private_global<params.histogram_private_config.block_size,
+                             params.histogram_private_config.items_per_thread,
+                             Channels,
+                             ActiveChannels>(samples,
+                                             columns,
+                                             rows,
+                                             row_stride,
+                                             histogram,
+                                             sample_to_bin_op,
+                                             bins_bits,
+                                             bins,
+                                             private_histograms,
+                                             virtual_max_blocks,
+                                             block_id_count);
 }
 
 template<unsigned int Channels,
@@ -190,12 +218,14 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     }
 
     const bool use_shared_mem = total_shared_bins <= shared_impl_max_bins;
-    Counter* private_histograms = nullptr;
-    unsigned int* block_id_count = nullptr;
-    int global_histogram_grid_size = 0;
-    unsigned int virtual_max_blocks = 0;
+    const bool use_private_histogram = target_arch == target_arch::gfx942;
 
-    if(use_shared_mem)
+    Counter*      private_histograms         = nullptr;
+    unsigned int* block_id_count             = nullptr;
+    int           global_histogram_grid_size = 0;
+    unsigned int  virtual_max_blocks         = 0;
+
+    if(use_shared_mem || !use_private_histogram)
     {
         if(temporary_storage == nullptr)
         {
@@ -207,16 +237,15 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     }
     else
     {
-
         const auto items_per_block = params.histogram_private_config.block_size
                                      * params.histogram_private_config.items_per_thread;
-        auto kernel = HIP_KERNEL_NAME(histogram_global_kernel<config,
-                                                              Channels,
-                                                              ActiveChannels,
-                                                              SampleIterator,
-                                                              Counter,
-                                                              SampleToBinOp>);
-                            
+        auto kernel = HIP_KERNEL_NAME(histogram_private_global_kernel<config,
+                                                                      Channels,
+                                                                      ActiveChannels,
+                                                                      SampleIterator,
+                                                                      Counter,
+                                                                      SampleToBinOp>);
+
         ROCPRIM_RETURN_ON_ERROR(detail::grid_dim_for_max_active_blocks(global_histogram_grid_size,
                                                                        block_size,
                                                                        kernel,
@@ -227,7 +256,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             = rocprim::min(static_cast<unsigned int>(global_histogram_grid_size),
                            virtual_max_blocks);
 
-        const size_t size_private_histograms = total_bins * global_histogram_grid_size;
+        const size_t     size_private_histograms = total_bins * global_histogram_grid_size;
         const hipError_t partition_result        = detail::temp_storage::partition(
             temporary_storage,
             storage_size,
@@ -242,11 +271,13 @@ inline hipError_t histogram_impl(void*          temporary_storage,
 
         // When using graphs private_histograms and block_id_count both returned a nullptr,
         // that is why a memset is directly done on temporary_storage.
-        ROCPRIM_RETURN_ON_ERROR(
-            hipMemsetAsync(temporary_storage, 0, storage_size, stream));
+        ROCPRIM_RETURN_ON_ERROR(hipMemsetAsync(temporary_storage, 0, storage_size, stream));
 
-        ROCPRIM_RETURN_ON_ERROR(
-            hipMemcpyAsync(block_id_count, &global_histogram_grid_size, sizeof(unsigned int), hipMemcpyHostToDevice, stream));
+        ROCPRIM_RETURN_ON_ERROR(hipMemcpyAsync(block_id_count,
+                                               &global_histogram_grid_size,
+                                               sizeof(unsigned int),
+                                               hipMemcpyHostToDevice,
+                                               stream));
     }
 
     if(debug_synchronous)
@@ -346,28 +377,51 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     }
     else
     {
-        if(debug_synchronous)
+
+        if(use_private_histogram)
         {
-            start = std::chrono::steady_clock::now();
+
+            if(debug_synchronous)
+            {
+                start = std::chrono::steady_clock::now();
+            }
+            histogram_private_global_kernel<config, Channels, ActiveChannels>
+                <<<dim3(global_histogram_grid_size),
+                   dim3(params.histogram_private_config.block_size),
+                   0,
+                   stream>>>(samples,
+                             columns,
+                             rows,
+                             row_stride,
+                             fixed_array<Counter*, ActiveChannels>(histogram),
+                             fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
+                             fixed_array<size_t, ActiveChannels>(bins_bits),
+                             fixed_array<size_t, ActiveChannels>(bins),
+                             private_histograms,
+                             virtual_max_blocks,
+                             block_id_count);
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_private_global",
+                                                        blocks_x * block_size * rows,
+                                                        start);
         }
-        histogram_global_kernel<config, Channels, ActiveChannels>
-            <<<dim3(global_histogram_grid_size),
-               dim3(params.histogram_private_config.block_size),
-               0,
-               stream>>>(samples,
-                         columns,
-                         rows,
-                         row_stride,
-                         fixed_array<Counter*, ActiveChannels>(histogram),
-                         fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                         fixed_array<size_t, ActiveChannels>(bins_bits),
-                         fixed_array<size_t, ActiveChannels>(bins),
-                         private_histograms,
-                         virtual_max_blocks,
-                         block_id_count);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global",
-                                                    blocks_x * block_size * rows,
-                                                    start);
+        else
+        {
+            if(debug_synchronous)
+            {
+                start = std::chrono::steady_clock::now();
+            }
+            histogram_global_kernel<config, Channels, ActiveChannels>
+                <<<dim3(blocks_x, rows), dim3(block_size, 1), 0, stream>>>(
+                    samples,
+                    columns,
+                    row_stride,
+                    fixed_array<Counter*, ActiveChannels>(histogram),
+                    fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
+                    fixed_array<size_t, ActiveChannels>(bins_bits));
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global",
+                                                        blocks_x * block_size * rows,
+                                                        start);
+        }
     }
 
     return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -127,8 +127,8 @@ template<class Config,
          class SampleIterator,
          class Counter,
          class SampleToBinOp>
-ROCPRIM_KERNEL
-ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_private_config.block_size) void
+ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>()
+                                         .histogram_private_config.block_size) void
     histogram_private_global_kernel(SampleIterator                             samples,
                                     unsigned int                               columns,
                                     unsigned int                               rows,
@@ -217,7 +217,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         max_bins = std::max(max_bins, bins[channel]);
     }
 
-    const bool use_shared_mem = total_shared_bins <= shared_impl_max_bins;
+    const bool use_shared_mem        = total_shared_bins <= shared_impl_max_bins;
     const bool use_private_histogram = target_arch == target_arch::gfx942;
 
     Counter*      private_histograms         = nullptr;
@@ -349,10 +349,11 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         for(unsigned int n = params.shared_impl_histograms; n >= 1; n--)
         {
             int blocks_per_mp;
-            ROCPRIM_RETURN_ON_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_mp,
-                                                                   kernel,
-                                                                   block_size,
-                                                                   n * block_histogram_bytes));
+            ROCPRIM_RETURN_ON_ERROR(
+                hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_mp,
+                                                             kernel,
+                                                             block_size,
+                                                             n * block_histogram_bytes));
 
             if(blocks_per_mp > max_blocks_per_mp)
             {

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -246,7 +246,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         hipDevice_t stream_device;
         ROCPRIM_RETURN_ON_ERROR(hipStreamGetDevice(stream, &stream_device));
 
-        // after setting device, we can't just exit on non-success
+        // After setting device, we can't just exit on non-success.
         hipError_t result = hipSetDevice(stream_device);
 
         int num_multi_processors;
@@ -256,13 +256,13 @@ inline hipError_t histogram_impl(void*          temporary_storage,
                 = hipDeviceGetAttribute(&num_multi_processors,
                                         hipDeviceAttribute_t::hipDeviceAttributeMultiprocessorCount,
                                         stream_device);
-            // sanity check
+            // Sanity check.
             if(num_multi_processors == 0)
             {
                 result = hipErrorUnknown;
             }
         }
-        // always attempt to restore to default device
+        // Always attempt to restore to default device.
         hipError_t set_result = hipSetDevice(default_device);
         ROCPRIM_RETURN_ON_ERROR(set_result);
         ROCPRIM_RETURN_ON_ERROR(result);
@@ -287,8 +287,8 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             return partition_result;
         }
 
-        // When using graphs private_histograms and block_id_count both returned a nullptr,
-        // that is why a memset is directly done on temporary_storage.
+        // When using graphs, private_histograms and block_id_count both returned a nullptr.
+        // That is why a memset is directly done on temporary_storage.
         ROCPRIM_RETURN_ON_ERROR(hipMemsetAsync(temporary_storage, 0, storage_size, stream));
 
         ROCPRIM_RETURN_ON_ERROR(hipMemcpyAsync(block_id_count,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -243,6 +243,9 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         // that is why a memset is directly done on temporary_storage.
         ROCPRIM_RETURN_ON_ERROR(
             hipMemsetAsync(temporary_storage, 0, storage_size * sizeof(char), stream));
+
+        ROCPRIM_RETURN_ON_ERROR(
+            hipMemcpyAsync(block_id_count, &global_histogram_grid_size, sizeof(unsigned int), hipMemcpyHostToDevice, stream));
     }
 
     if(debug_synchronous)

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -44,8 +44,13 @@ namespace detail
 
 template<class Config, unsigned int ActiveChannels, class Counter>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
+<<<<<<< HEAD
     init_histogram_kernel(fixed_array<Counter*, ActiveChannels>           histogram,
                           const fixed_array<unsigned int, ActiveChannels> bins)
+=======
+    init_histogram_kernel(fixed_array<Counter*, ActiveChannels>     histogram,
+                          fixed_array<size_t, ActiveChannels> bins)
+>>>>>>> 86d06adef9 (Change types of private histogram and indexing of bins)
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
@@ -67,7 +72,7 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.bl
                             unsigned int                                     shared_histograms,
                             fixed_array<Counter*, ActiveChannels>            histogram,
                             const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                            const fixed_array<unsigned int, ActiveChannels>  bins)
+                            const fixed_array<size_t, ActiveChannels>        bins)
 {
     static constexpr histogram_config_params params = device_params<Config>();
 
@@ -106,10 +111,9 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.bl
                             unsigned int                                     row_stride,
                             fixed_array<Counter*, ActiveChannels>            histogram,
                             const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                            const fixed_array<unsigned int, ActiveChannels>  bins_bits,
-                            const fixed_array<unsigned int, ActiveChannels>  bins,
-                            unsigned int*                                    private_histograms,
-                            unsigned int                                     max_blocks,
+                            const fixed_array<size_t, ActiveChannels>        bins_bits,
+                            const fixed_array<size_t, ActiveChannels>        bins,
+                            Counter*                                         private_histograms,
                             unsigned int                                     virtual_max_blocks,
                             unsigned int*                                    block_id_count)
 {
@@ -127,7 +131,6 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.bl
                                      bins_bits,
                                      bins,
                                      private_histograms,
-                                     max_blocks,
                                      virtual_max_blocks,
                                      block_id_count);
 }
@@ -173,17 +176,17 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     const unsigned int blocks_x   = ::rocprim::detail::ceiling_div(columns, items_per_block);
     const unsigned int row_stride = row_stride_bytes / sizeof(sample_type);
 
-    unsigned int bins[ActiveChannels];
-    unsigned int bins_bits[ActiveChannels];
-    unsigned int total_shared_bins = 0;
-    unsigned int max_bins          = 0;
-    unsigned int total_bins        = 0;
+    size_t bins[ActiveChannels];
+    size_t bins_bits[ActiveChannels];
+    size_t total_shared_bins = 0;
+    size_t max_bins          = 0;
+    size_t total_bins        = 0;
     for(unsigned int channel = 0; channel < ActiveChannels; channel++)
     {
         bins[channel] = levels[channel] - 1;
         bins_bits[channel]
             = static_cast<unsigned int>(std::log2(detail::next_power_of_two(bins[channel])));
-        const unsigned int size = bins[channel];
+        const size_t size = bins[channel];
         // Prevent LDS bank conflicts
         total_shared_bins += rocprim::detail::is_power_of_two(size) ? size + 1 : size;
         total_bins += size;
@@ -191,8 +194,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     }
 
     const bool use_shared_mem = total_shared_bins <= shared_impl_max_bins;
-
-    unsigned int* private_histograms = nullptr;
+    Counter* private_histograms = nullptr;
     unsigned int* block_id_count = nullptr;
     int global_histogram_grid_size = 0;
     unsigned int virtual_max_blocks = 0;
@@ -226,7 +228,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             = rocprim::min(static_cast<unsigned int>(global_histogram_grid_size),
                            virtual_max_blocks);
 
-        const unsigned   size_private_histograms = total_bins * global_histogram_grid_size;
+        const size_t size_private_histograms = total_bins * global_histogram_grid_size;
         const hipError_t partition_result        = detail::temp_storage::partition(
             temporary_storage,
             storage_size,
@@ -242,7 +244,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         // When using graphs private_histograms and block_id_count both returned a nullptr,
         // that is why a memset is directly done on temporary_storage.
         ROCPRIM_RETURN_ON_ERROR(
-            hipMemsetAsync(temporary_storage, 0, storage_size * sizeof(char), stream));
+            hipMemsetAsync(temporary_storage, 0, storage_size, stream));
 
         ROCPRIM_RETURN_ON_ERROR(
             hipMemcpyAsync(block_id_count, &global_histogram_grid_size, sizeof(unsigned int), hipMemcpyHostToDevice, stream));
@@ -267,7 +269,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
            dim3(block_size),
            0,
            stream>>>(fixed_array<Counter*, ActiveChannels>(histogram),
-                     fixed_array<unsigned int, ActiveChannels>(bins));
+                     fixed_array<size_t, ActiveChannels>(bins));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_histogram", max_bins, start);
 
     if(columns == 0 || rows == 0)
@@ -338,7 +340,7 @@ inline hipError_t histogram_impl(void*          temporary_storage,
                            chosen_shared_histograms,
                            fixed_array<Counter*, ActiveChannels>(histogram),
                            fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                           fixed_array<unsigned int, ActiveChannels>(bins));
+                           fixed_array<size_t, ActiveChannels>(bins));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_shared",
                                                     grid_size.x * grid_size.y * block_size,
                                                     start);
@@ -357,11 +359,11 @@ inline hipError_t histogram_impl(void*          temporary_storage,
                 row_stride,
                 fixed_array<Counter*, ActiveChannels>(histogram),
                 fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                fixed_array<unsigned int, ActiveChannels>(bins_bits),
-                fixed_array<unsigned int, ActiveChannels>(bins),
+                fixed_array<size_t, ActiveChannels>(bins_bits),
+                fixed_array<size_t, ActiveChannels>(bins),
                 private_histograms,
-                global_histogram_grid_size,
-                virtual_max_blocks, block_id_count);
+                virtual_max_blocks,
+                block_id_count);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global",
                                                     blocks_x * block_size * rows,
                                                     start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -239,17 +239,35 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     {
         const auto items_per_block = params.histogram_private_config.block_size
                                      * params.histogram_private_config.items_per_thread;
-        auto kernel = HIP_KERNEL_NAME(histogram_private_global_kernel<config,
-                                                                      Channels,
-                                                                      ActiveChannels,
-                                                                      SampleIterator,
-                                                                      Counter,
-                                                                      SampleToBinOp>);
 
-        ROCPRIM_RETURN_ON_ERROR(detail::grid_dim_for_max_active_blocks(global_histogram_grid_size,
-                                                                       block_size,
-                                                                       kernel,
-                                                                       stream));
+        hipDevice_t default_device;
+        ROCPRIM_RETURN_ON_ERROR(hipStreamGetDevice(0, &default_device));
+
+        hipDevice_t stream_device;
+        ROCPRIM_RETURN_ON_ERROR(hipStreamGetDevice(stream, &stream_device));
+
+        // after setting device, we can't just exit on non-success
+        hipError_t result = hipSetDevice(stream_device);
+
+        int num_multi_processors;
+        if(result == hipSuccess)
+        {
+            result
+                = hipDeviceGetAttribute(&num_multi_processors,
+                                        hipDeviceAttribute_t::hipDeviceAttributeMultiprocessorCount,
+                                        stream_device);
+            // sanity check
+            if(num_multi_processors == 0)
+            {
+                result = hipErrorUnknown;
+            }
+        }
+        // always attempt to restore to default device
+        hipError_t set_result = hipSetDevice(default_device);
+        ROCPRIM_RETURN_ON_ERROR(set_result);
+        ROCPRIM_RETURN_ON_ERROR(result);
+
+        global_histogram_grid_size = num_multi_processors;
 
         virtual_max_blocks = ::rocprim::detail::ceiling_div(columns, items_per_block) * rows;
         global_histogram_grid_size

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -239,11 +239,10 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             return partition_result;
         }
 
-        ROCPRIM_RETURN_ON_ERROR(hipMemsetAsync(private_histograms,
-                                               0u,
-                                               size_private_histograms * sizeof(unsigned int),
-                                               stream));
-        ROCPRIM_RETURN_ON_ERROR(hipMemsetAsync(block_id_count, 0u, sizeof(unsigned int), stream));
+        // When using graphs private_histograms and block_id_count both returned a nullptr,
+        // that is why a memset is directly done on temporary_storage.
+        ROCPRIM_RETURN_ON_ERROR(
+            hipMemsetAsync(temporary_storage, 0, storage_size * sizeof(char), stream));
     }
 
     if(debug_synchronous)

--- a/projects/rocprim/scripts/autotune/templates/histogram_config_template
+++ b/projects/rocprim/scripts/autotune/templates/histogram_config_template
@@ -5,7 +5,7 @@ ROCPRIM_DEVICE_DETAIL_CONFIG_DEVICE_HISTOGRAM_HPP_
 {%- endmacro %}
 
 {% macro kernel_configuration(measurement) -%}
-histogram_config<kernel_config<{{ measurement['cfg']['bs'] }}, {{ measurement['cfg']['ipt'] }}>, {{ measurement['cfg']['max_grid_size'] }}, {{ measurement['cfg']['shared_impl_max_bins'] }}, {{ measurement['cfg']['shared_impl_histograms'] }}> { };
+histogram_config<kernel_config<{{ measurement['cfg']['bs'] }}, {{ measurement['cfg']['ipt'] }}>, {{ measurement['cfg']['max_grid_size'] }}, {{ measurement['cfg']['shared_impl_max_bins'] }}, {{ measurement['cfg']['shared_impl_histograms'] }}, kernel_config<{{ measurement['cfg']['private_hist_bs'] }}, {{ measurement['cfg']['private_hist_ipt'] }}>> { };
 {%- endmacro %}
 
 {% macro general_case() -%}

--- a/projects/rocprim/scripts/autotune/templates/histogram_config_template
+++ b/projects/rocprim/scripts/autotune/templates/histogram_config_template
@@ -5,7 +5,7 @@ ROCPRIM_DEVICE_DETAIL_CONFIG_DEVICE_HISTOGRAM_HPP_
 {%- endmacro %}
 
 {% macro kernel_configuration(measurement) -%}
-histogram_config<kernel_config<{{ measurement['cfg']['bs'] }}, {{ measurement['cfg']['ipt'] }}>, {{ measurement['cfg']['max_grid_size'] }}, {{ measurement['cfg']['shared_impl_max_bins'] }}, {{ measurement['cfg']['shared_impl_histograms'] }}, kernel_config<{{ measurement['cfg']['private_hist_bs'] }}, {{ measurement['cfg']['private_hist_ipt'] }}>> { };
+histogram_config<kernel_config<{{ measurement['cfg']['bs'] }}, {{ measurement['cfg']['ipt'] }}>, {{ measurement['cfg']['max_grid_size'] }}, {{ measurement['cfg']['shared_impl_max_bins'] }}, {{ measurement['cfg']['shared_impl_histograms'] }}, kernel_config<{{ measurement['cfg']['global_hist_bs'] }}, {{ measurement['cfg']['global_hist_ipt'] }}>> { };
 {%- endmacro %}
 
 {% macro general_case() -%}


### PR DESCRIPTION
# Context
A performance optimization for bins that do not fit in shared memory on mi300x. It also includes some cleaning up of the code and some bug fixes for the benchmarks. The graph also includes the other cases where it does fit in shared memory.

It also includes a commit to make the human output better readable, https://github.com/ROCm/rocm-libraries/pull/719/commits/1cbdf1d23844ff0e038712d7aadd34b4dc4fb1f1.

Results:
![graph_device_histogram_rocprim_mi300x](https://github.com/user-attachments/assets/99c78b4c-2550-4946-b57b-5c4c44f8bdbe)
