### PR TITLE
[actions] fix subtree detection git CLI fallback

### DIFF
--- a/.github/scripts/pr_category_label.py
+++ b/.github/scripts/pr_category_label.py
@@ -97,10 +97,11 @@ def main(argv=None) -> None:
         try:
             # Ensure fetch is safe
             os.system("git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/*")
+            os.system("git fetch origin develop:develop")
             # Get merge commit ref for this PR
             base_ref = f"origin/{os.getenv('GITHUB_BASE_REF', 'main')}"
             head_ref = "HEAD"  # Assumes checkout to PR merge ref
-            result = os.popen(f"git diff --name-only {base_ref}...{head_ref}").read()
+            result = os.popen(f"git diff --name-only {base_ref} {head_ref}").read()
             changed_files = result.strip().splitlines()
             logger.info(f"Fallback changed files: {changed_files}")
         except Exception as e:

--- a/.github/scripts/pr_detect_changed_subtrees.py
+++ b/.github/scripts/pr_detect_changed_subtrees.py
@@ -119,10 +119,11 @@ def main(argv=None) -> None:
         try:
             # Ensure fetch is safe
             os.system("git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/*")
+            os.system("git fetch origin develop:develop")
             # Get merge commit ref for this PR
             base_ref = f"origin/{os.getenv('GITHUB_BASE_REF', 'main')}"
             head_ref = "HEAD"  # Assumes checkout to PR merge ref
-            result = os.popen(f"git diff --name-only {base_ref}...{head_ref}").read()
+            result = os.popen(f"git diff --name-only {base_ref} {head_ref}").read()
             changed_files = result.strip().splitlines()
             logger.info(f"Fallback changed files: {changed_files}")
         except Exception as e:


### PR DESCRIPTION
Fixes an error when diffing HEAD against develop in the subtree detection fallback scripts.
Sample error: https://github.com/ROCm/rocm-libraries/actions/runs/16321894737/job/46158715558#step:6:196

Steps for local test:
```
# setup
PR_NUMBER=722
mkdir test && git init
git remote add origin https://github.com/ROCm/rocm-libraries
git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --filter=blob:none --depth=1 origin +refs/pull/$PR_NUMBER/merge:refs/remotes/pull/$PR_NUMBER/merge
git sparse-checkout set .github
git checkout --progress --force refs/remotes/pull/$PR_NUMBER/merge

# previous
git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/*
git diff --name-only origin/develop...HEAD

> fatal: ambiguous argument 'origin/develop...HEAD': unknown revision or path not in the working tree.
> ...

# new
git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/*
git fetch origin develop:develop
git diff --name-only origin/develop HEAD

> projects/rocthrust/CHANGELOG.md
> ...
```