### PR TITLE
[rocBLAS] collect rocblas tip commit

### DIFF
--- a/projects/rocblas/library/CMakeLists.txt
+++ b/projects/rocblas/library/CMakeLists.txt
@@ -202,10 +202,11 @@ find_package(Git REQUIRED)
 
 # Get the git hash of the rocBLAS branch
 execute_process(
-          COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
-          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+          COMMAND "${GIT_EXECUTABLE}" log -1 --format=%H . # was rev-parse HEAD
+          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} # top rocBLAS directory
           OUTPUT_VARIABLE GIT_HASH_ROCBLAS
-          OUTPUT_STRIP_TRAILING_WHITESPACE)
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
 
 #set the rocBLAS commit hash
 set(rocblas_VERSION_COMMIT_ID "${GIT_HASH_ROCBLAS}")


### PR DESCRIPTION
Need to discuss, as packaging commit would be general one for rocm-libraries, vs. one related to rocBLAS. e.g. below:

rocBLAS version: 5.1.0.d263a37c12-dirty
rocBLAS-commit-hash: 8f685a3acf013a31522fa5a8ce9bf6029a58bb69
Tensile-commit-hash: N/A, as rocBLAS was built without Tensile
hipBLASLt: N/A, as rocBLAS was built without hipBLASLt

So the -dirty you can see is different commit.