### PR TITLE
[GitHub Actions] Improvements for subtree change detection

### DIFF
--- a/.github/scripts/pr_category_label.py
+++ b/.github/scripts/pr_category_label.py
@@ -28,9 +28,10 @@ Example Usage:
 """
 
 import argparse
-import sys
-import os
+import json
 import logging
+import os
+import sys
 from pathlib import Path
 from typing import List, Optional
 from github_cli_client import GitHubCLIClient
@@ -88,7 +89,6 @@ def main(argv=None) -> None:
         logger.warning("REST API failed or returned no changed files. Falling back to SHA-based Git diff...")
         try:
             pr_data = os.popen(f"gh api repos/{args.repo}/pulls/{args.pr}").read()
-            import json
             pr = json.loads(pr_data)
             base_sha = pr["base"]["sha"]
             head_sha = pr["head"]["sha"]

--- a/.github/scripts/pr_category_label.py
+++ b/.github/scripts/pr_category_label.py
@@ -61,14 +61,8 @@ def compute_desired_labels(file_paths: list) -> set:
 
 def output_labels(existing_labels: List[str], desired_labels: List[str], dry_run: bool) -> None:
     """Output the labels to add/remove to GITHUB_OUTPUT or log them in dry-run mode."""
-    existing_auto_labels = {
-        label for label in existing_labels
-        if label.startswith("project: ") or label.startswith("shared: ")
-    }
     to_add = sorted(desired_labels - set(existing_labels))
-    to_remove = sorted(existing_auto_labels - desired_labels)
     logger.debug(f"Labels to add: {to_add}")
-    logger.debug(f"Labels to remove: {to_remove}")
     if dry_run:
         logger.info("Dry run enabled. Labels will not be applied.")
     else:
@@ -76,9 +70,7 @@ def output_labels(existing_labels: List[str], desired_labels: List[str], dry_run
         if output_file:
             with open(output_file, 'a') as f:
                 print(f"label_add={','.join(to_add)}", file=f)
-                print(f"label_remove={','.join(to_remove)}", file=f)
             logger.info(f"Wrote to GITHUB_OUTPUT: add={','.join(to_add)}")
-            logger.info(f"Wrote to GITHUB_OUTPUT: remove={','.join(to_remove)}")
         else:
             print("GITHUB_OUTPUT environment variable not set. Outputs cannot be written.")
             sys.exit(1)
@@ -93,18 +85,20 @@ def main(argv=None) -> None:
     changed_files = [file for file in client.get_changed_files(args.repo, int(args.pr))]
 
     if not changed_files:
-        logger.warning("REST API failed or returned no changed files. Falling back to Git CLI...")
+        logger.warning("REST API failed or returned no changed files. Falling back to SHA-based Git diff...")
         try:
-            # Ensure fetch is safe
-            os.system("git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/*")
-            # Get merge commit ref for this PR
-            base_ref = f"origin/{os.getenv('GITHUB_BASE_REF', 'main')}"
-            head_ref = "HEAD"  # Assumes checkout to PR merge ref
-            result = os.popen(f"git diff --name-only {base_ref}...{head_ref}").read()
+            pr_data = os.popen(f"gh api repos/{args.repo}/pulls/{args.pr}").read()
+            import json
+            pr = json.loads(pr_data)
+            base_sha = pr["base"]["sha"]
+            head_sha = pr["head"]["sha"]
+            logger.debug(f"Base SHA: {base_sha}, Head SHA: {head_sha}")
+            os.system(f"git fetch origin {base_sha} {head_sha}")
+            result = os.popen(f"git diff --name-only {base_sha} {head_sha}").read()
             changed_files = result.strip().splitlines()
-            logger.info(f"Fallback changed files: {changed_files}")
+            logger.info(f"Fallback changed files (SHA-based): {changed_files}")
         except Exception as e:
-            logger.error(f"Git CLI fallback failed: {e}")
+            logger.error(f"SHA-based Git CLI fallback failed: {e}")
             sys.exit(1)
 
     existing_labels = client.get_existing_labels_on_pr(args.repo, int(args.pr))

--- a/.github/scripts/pr_detect_changed_subtrees.py
+++ b/.github/scripts/pr_detect_changed_subtrees.py
@@ -32,9 +32,10 @@ Example Usage:
 """
 
 import argparse
-import sys
-import os
+import json
 import logging
+import os
+import sys
 from typing import List, Optional, Set
 from github_cli_client import GitHubCLIClient
 from repo_config_model import RepoEntry
@@ -118,7 +119,6 @@ def main(argv=None) -> None:
         logger.warning("REST API failed or returned no changed files. Falling back to SHA-based Git diff...")
         try:
             pr_data = os.popen(f"gh api repos/{args.repo}/pulls/{args.pr}").read()
-            import json
             pr = json.loads(pr_data)
             base_sha = pr["base"]["sha"]
             head_sha = pr["head"]["sha"]

--- a/.github/scripts/pr_detect_changed_subtrees.py
+++ b/.github/scripts/pr_detect_changed_subtrees.py
@@ -115,18 +115,20 @@ def main(argv=None) -> None:
     changed_files = client.get_changed_files(args.repo, int(args.pr))
 
     if not changed_files:
-        logger.warning("REST API failed or returned no changed files. Falling back to Git CLI...")
+        logger.warning("REST API failed or returned no changed files. Falling back to SHA-based Git diff...")
         try:
-            # Ensure fetch is safe
-            os.system("git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/*")
-            # Get merge commit ref for this PR
-            base_ref = f"origin/{os.getenv('GITHUB_BASE_REF', 'main')}"
-            head_ref = "HEAD"  # Assumes checkout to PR merge ref
-            result = os.popen(f"git diff --name-only {base_ref}...{head_ref}").read()
+            pr_data = os.popen(f"gh api repos/{args.repo}/pulls/{args.pr}").read()
+            import json
+            pr = json.loads(pr_data)
+            base_sha = pr["base"]["sha"]
+            head_sha = pr["head"]["sha"]
+            logger.debug(f"Base SHA: {base_sha}, Head SHA: {head_sha}")
+            os.system(f"git fetch origin {base_sha} {head_sha}")
+            result = os.popen(f"git diff --name-only {base_sha} {head_sha}").read()
             changed_files = result.strip().splitlines()
-            logger.info(f"Fallback changed files: {changed_files}")
+            logger.info(f"Fallback changed files (SHA-based): {changed_files}")
         except Exception as e:
-            logger.error(f"Git CLI fallback failed: {e}")
+            logger.error(f"SHA-based Git CLI fallback failed: {e}")
             sys.exit(1)
 
     valid_prefixes = get_valid_prefixes(config, args.require_auto_pull, args.require_auto_push)

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -89,9 +89,6 @@ jobs:
           # this env clause gets repeated, but it is safer than echo'ing secrets in the workflow
           GH_TOKEN: ${{ github.event.pull_request.head.repo.fork && secrets.GITHUB_TOKEN || steps.generate-token.outputs.token }}
         run: |
-          if [ -n "${{ steps.compute_labels.outputs.label_remove }}" ]; then
-            gh pr edit "${{ github.event.pull_request.number }}" --remove-label "${{ steps.compute_labels.outputs.label_remove }}"
-          fi
           if [ -n "${{ steps.compute_labels.outputs.label_add }}" ]; then
             gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ steps.compute_labels.outputs.label_add }}"
           fi
@@ -110,21 +107,17 @@ jobs:
 
           if [ "${{ github.event.pull_request.head.repo.fork }}" = true ]; then
             # For fork PRs: check if user has any collaborator permission on the repo
-            PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/$PR_USER/permission --jq '.permission' --silent)
+            PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/$PR_USER/permission --jq '.permission')
             if [ "$PERMISSION" = "admin" ] || [ "$PERMISSION" = "write" ] || [ "$PERMISSION" = "maintain" ]; then
               gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ env.ORG_LABEL }}"
-              gh pr edit "${{ github.event.pull_request.number }}" --remove-label "${{ env.EXTERNAL_LABEL }}"
             else
               gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ env.EXTERNAL_LABEL }}"
-              gh pr edit "${{ github.event.pull_request.number }}" --remove-label "${{ env.ORG_LABEL }}"
             fi
           else
             # For branch PRs (non-forks): check org membership via GitHub App token
             if gh api orgs/${{ env.ORG_TO_CHECK }}/members/$PR_USER --silent; then
               gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ env.ORG_LABEL }}"
-              gh pr edit "${{ github.event.pull_request.number }}" --remove-label "${{ env.EXTERNAL_LABEL }}"
             else
               gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ env.EXTERNAL_LABEL }}"
-              gh pr edit "${{ github.event.pull_request.number }}" --remove-label "${{ env.ORG_LABEL }}"
             fi
           fi


### PR DESCRIPTION
- Delete logic that removes labels as scenario where a PR decides to change which components get touched is less likely, and conflicts with users manually wanting to assign labels themselves.
- Changed fallback algorithm to use 'gh api' to determine PR base and head SHAs, which allow for replayability in the future in case of intermittent failures. refs will point to branches which may have changed.
- Tested locally with dry-runs of the python script and using large diff PRs (e.g., 598) to verify.