### PR TITLE
refer to HIP C++ and HIP runtime in documentation (#727)

### DIFF
--- a/projects/rocblas/docs/how-to/Programmers_Guide.rst
+++ b/projects/rocblas/docs/how-to/Programmers_Guide.rst
@@ -423,7 +423,7 @@ rocblas_sizeof_datatype function
 
     size_t rocblas_sizeof_datatype(rocblas_datatype type)
 
-Returns the size of a rocBLAS runtime data type.
+Returns the size of a rocBLAS data type.
 
 
 Answering device memory size queries in functions that do not need memory

--- a/projects/rocblas/docs/index.rst
+++ b/projects/rocblas/docs/index.rst
@@ -8,7 +8,7 @@
 rocBLAS documentation
 ********************************************************************
 
-rocBLAS is the ROCm Basic Linear Algebra Subprograms (BLAS) library. rocBLAS is implemented in the :doc:`HIP programming language <hip:index>` and optimized for AMD GPUs.
+rocBLAS is the ROCm Basic Linear Algebra Subprograms (BLAS) library. rocBLAS is implemented in :doc:`HIP C++ <hip:index>` and optimized for AMD GPUs.
 This documentation set contains instructions for installing, understanding, and using the rocBLAS library.
 To learn more, see :doc:`./what-is-rocblas`
 

--- a/projects/rocblas/docs/what-is-rocblas.rst
+++ b/projects/rocblas/docs/what-is-rocblas.rst
@@ -9,7 +9,7 @@ What is rocBLAS?
 ********************************************************************
 
 rocBLAS is the AMD library for Basic Linear Algebra Subprograms (BLAS) on the :doc:`ROCm platform <rocm:index>`.
-It is implemented in the :doc:`HIP programming language <hip:index>` and optimized for AMD GPUs.
+It is implemented in the :doc:`HIP C++ <hip:index>` and optimized for AMD GPUs.
 For more detailed component information, see :doc:`rocBLAS design notes <../conceptual/rocblas-design-notes>`.
 
 rocBLAS aims to provide the following:
@@ -17,7 +17,7 @@ rocBLAS aims to provide the following:
 * Functionality similar to legacy BLAS, adapted to run on AMD GPUs
 * A high-performance, robust implementation
 
-rocBLAS is written in C++17 and HIP and uses the AMD ROCm runtime.
+rocBLAS is written in HIP C++ (using C++17 features) and it uses the HIP runtime.
 
 The rocBLAS API is a thin C99 API that uses the hourglass pattern. It contains:
 


### PR DESCRIPTION
- cherry-pick from develop to release/rocm-rel-7.0
- in documentation refer to HIP C++ and the HIP runtime.