### PR TITLE
Cherry-pick to release/rocm-rel-7.0: [rocsparse] Docs: Change GitHub links and install guides to account f…

### DIFF
--- a/projects/rocsparse/README.md
+++ b/projects/rocsparse/README.md
@@ -38,14 +38,36 @@ Optional:
 
 ## Build and install
 
-1. Build rocSPARSE using the `install.sh` script.
+1. Checkout the rocSPARSE code using either a sparse checkout or a full clone of the rocm-libraries repository.
+
+   To limit your local checkout to only the rocSPARSE project, configure ``sparse-checkout`` before cloning.
+   This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+   Use the following commands for a sparse checkout:
 
     ```bash
-    # Clone rocSPARSE using git
-    git clone https://github.com/ROCm/rocSPARSE.git
+
+    git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+    cd rocm-libraries
+    git sparse-checkout init --cone
+    git sparse-checkout set projects/rocsparse # add projects/rocprim and projects/rocblas to include dependencies
+    git checkout develop # or use the branch you want to work with
+    ```
+
+   To clone the entire rocm-libraries repository, use the following commands. This process takes more time,
+   but is recommended if you want to work with a large number of libraries.
+
+    ```bash
+
+    # Clone rocm-libraries, including rocSPARSE, using Git
+    git clone https://github.com/ROCm/rocm-libraries.git
 
     # Go to rocSPARSE directory
-    cd rocSPARSE
+    cd rocm-libraries/projects/rocsparse
+    ```
+
+2. Build rocSPARSE using the `install.sh` script.
+
+    ```bash
 
     # Run install.sh script
     # Command line options:
@@ -57,14 +79,15 @@ Optional:
     ./install.sh -dci
     ```
 
-2. Compile rocSPARSE (all compiler specifications are automatically determined).
+3. Compile rocSPARSE (all compiler specifications are automatically determined).
 
     ```bash
-    # Clone rocSPARSE using git
-    git clone https://github.com/ROCm/rocSPARSE.git
+
+    # Clone rocm-libraries, including rocSPARSE, using Git
+    git clone https://github.com/ROCm/rocm-libraries.git
 
     # Go to rocSPARSE directory, create and go to the build directory
-    cd rocSPARSE; mkdir -p build/release; cd build/release
+    cd rocm-libraries/projects/rocsparse; mkdir -p build/release; cd build/release
 
     # Configure rocSPARSE
     # Build options:
@@ -88,7 +111,7 @@ To run unit tests, you must build rocSPARSE with `-DBUILD_CLIENTS_TESTS=ON`.
 
 ```bash
 # Go to rocSPARSE build directory
-cd rocSPARSE; cd build/release
+cd rocm-libraries/projects/rocsparse; cd build/release
 
 # Run all tests
 ./clients/staging/rocsparse-test
@@ -98,7 +121,7 @@ To run benchmarks, you must build rocSPARSE with `-DBUILD_CLIENTS_BENCHMARKS=ON`
 
 ```bash
 # Go to rocSPARSE build directory
-cd rocSPARSE/build/release
+cd rocm-libraries/projects/rocsparse/build/release
 
 # Run benchmark, e.g.
 ./clients/staging/rocsparse-bench -f hybmv --laplacian-dim 2000 -i 200
@@ -106,8 +129,8 @@ cd rocSPARSE/build/release
 
 ## Issues
 
-To submit an issue, a bug, or a feature request, use the GitHub
-[issue tracker](https://github.com/ROCm/rocSPARSE/issues).
+To submit an issue, a bug, or a feature request, use the rocm-libraries GitHub
+[issue tracker](https://github.com/ROCm/rocm-libraries/issues).
 
 ## License
 

--- a/projects/rocsparse/docs/conceptual/rocsparse-design.rst
+++ b/projects/rocsparse/docs/conceptual/rocsparse-design.rst
@@ -30,7 +30,7 @@ to query for the storage buffer size, for example, :cpp:func:`rocsparse_scsrsv_b
 Library source code organization
 ================================
 
-This section discusses the structure of the rocSPARSE library in the `rocSPARSE GitHub repository <https://github.com/ROCm/rocSPARSE>`_.
+This section discusses the structure of the rocSPARSE library in the `rocSPARSE GitHub repository <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse>`_.
 
 The library/include directory
 -----------------------------

--- a/projects/rocsparse/docs/how-to/using-rocsparse.rst
+++ b/projects/rocsparse/docs/how-to/using-rocsparse.rst
@@ -828,4 +828,4 @@ hipSPARSE supports rocSPARSE and NVIDIA CUDA cuSPARSE as backends.
 
 hipSPARSE focuses on convenience and portability.
 If performance outweighs these factors, then it's best to use rocSPARSE itself.
-hipSPARSE can be found on `GitHub <https://github.com/ROCm/hipSPARSE/>`_.
+hipSPARSE can be found on `GitHub <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparse>`_.

--- a/projects/rocsparse/docs/index.rst
+++ b/projects/rocsparse/docs/index.rst
@@ -12,7 +12,12 @@ rocSPARSE is a library that provides basic linear algebra subroutines for sparse
 It's created using the HIP programming language, implemented on top of the ROCm runtime and toolchains,
 and optimized for AMD discrete GPUs.
 
-The rocSPARSE public repository is located at `<https://github.com/ROCm/rocSPARSE>`_.
+The rocSPARSE public repository is located at `<https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse>`_.
+
+.. note::
+
+   The rocSPARSE repository for ROCm 6.4.2 and earlier is located at `<https://github.com/ROCm/rocSPARSE>`_.
+
 For ROCm code examples, see `<https://github.com/ROCm/rocm-examples>`_.
 
 .. grid:: 2
@@ -37,7 +42,7 @@ For ROCm code examples, see `<https://github.com/ROCm/rocm-examples>`_.
 
   .. grid-item-card:: Examples
 
-   * `Client samples <https://github.com/ROCm/rocSPARSE/tree/develop/clients/samples>`_
+   * `Client samples <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse/clients/samples>`_
 
   .. grid-item-card:: API reference
 

--- a/projects/rocsparse/docs/install/Linux_Install_Guide.rst
+++ b/projects/rocsparse/docs/install/Linux_Install_Guide.rst
@@ -59,8 +59,8 @@ Building rocSPARSE from source also requires the following components and depend
 
 *  `git <https://git-scm.com/>`_
 *  `CMake <https://cmake.org/>`_ (Version 3.5 or later)
-*  `rocPRIM <https://github.com/ROCm/rocPRIM>`_
-*  `rocBLAS <https://github.com/ROCm/rocBLAS>`_ (Optional: for the library)
+*  `rocPRIM <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim>`_
+*  `rocBLAS <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas>`_ (Optional: for the library)
 *  `GoogleTest <https://github.com/google/googletest>`_ (Optional: only required to build the clients)
 *  `Python <https://www.python.org/>`_
 *  `PyYAML <https://pypi.org/project/PyYAML/>`_
@@ -75,19 +75,48 @@ rocPRIM, such as 3.1.0, is not supported.
 Downloading rocSPARSE
 ----------------------
 
-The rocSPARSE source code is available from the `rocSPARSE GitHub <https://github.com/ROCm/rocSPARSE>`_.
-Download the develop branch using these commands:
+The rocSPARSE source code is available from the `rocSPARSE folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse>`_
+of the `rocm-libraries GitHub <https://github.com/ROCm/rocm-libraries>`_.
+
+To limit your local checkout to only the rocSPARSE project, configure ``sparse-checkout`` before cloning.
+This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+Use the following commands for a sparse checkout:
+
+.. note::
+
+   To include the rocPRIM and rocBLAS dependencies, set the projects for the sparse checkout using
+   ``git sparse-checkout set projects/rocsparse projects/rocprim projects/rocblas``.
 
 .. code-block:: shell
 
-   git clone -b develop https://github.com/ROCm/rocSPARSE.git
-   cd rocSPARSE
+   git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries
+   git sparse-checkout init --cone
+   git sparse-checkout set projects/rocsparse
+   git checkout develop # or use the branch you want to work with
+
+To download the develop branch for all projects in rocm-libraries, use these commands. This process takes
+longer but is recommended for those working with a large number of libraries.
+
+.. code-block:: shell
+
+   git clone -b develop https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries/projects/rocsparse
+
+.. note::
+
+   To build ROCm 6.4.2 and earlier, use the rocSPARSE repository at `<https://github.com/ROCm/rocSPARSE>`_.
+   For more information, see the documentation associated with the release you want to build.
 
 Building rocSPARSE using the install script
 -------------------------------------------
 
 It's recommended to use the ``install.sh`` script to install rocSPARSE.
 Here are the steps required to build different packages of the library, including the dependencies and clients.
+
+.. note::
+
+   You can run the ``install.sh`` script from the ``projects/rocsparse`` directory.
 
 Using install.sh to build rocSPARSE with dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,6 +158,10 @@ The rocSPARSE library contains both host and device code, therefore, the HIP com
 must be specified during the CMake configuration process.
 
 You can build rocSPARSE using the following commands:
+
+.. note::
+
+   Run these commands from the ``projects/rocsparse`` directory.
 
 .. note::
 
@@ -192,7 +225,7 @@ after successfully compiling the library with the clients.
 .. code-block:: shell
 
       # Navigate to clients binary directory
-      cd rocSPARSE/build/release/clients/staging
+      cd build/release/clients/staging
 
       # Execute rocSPARSE example
       ./example_csrmv 1000

--- a/projects/rocsparse/docs/install/Windows_Install_Guide.rst
+++ b/projects/rocsparse/docs/install/Windows_Install_Guide.rst
@@ -31,7 +31,7 @@ Add the SDK installation location to your ``CMAKE_PREFIX_PATH``.
 
 .. code-block:: shell
 
-   -DCMAKE_PREFIX_PATH="C:\Program Files\AMD\ROCm\5.5"
+   -DCMAKE_PREFIX_PATH="C:\Program Files\AMD\ROCm\7.0"
 
 In your ``CMakeLists.txt`` file, use these lines:
 
@@ -65,8 +65,8 @@ Building rocSPARSE from source also requires the following components and depend
 
 *  `git <https://git-scm.com/>`_
 *  `CMake <https://cmake.org/>`_ (Version 3.5 or later)
-*  `rocPRIM <https://github.com/ROCm/rocPRIM>`_
-*  `rocBLAS <https://github.com/ROCm/rocBLAS>`_ (Optional: for the library)
+*  `rocPRIM <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim>`_
+*  `rocBLAS <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas>`_ (Optional: for the library)
 *  `vcpkg <https://github.com/Microsoft/vcpkg.git>`_
 *  `GoogleTest <https://github.com/google/googletest>`_ (Optional: only required to build the clients)
 *  `Python <https://www.python.org/>`_
@@ -83,7 +83,8 @@ Downloading rocSPARSE
 ----------------------
 
 The rocSPARSE source code for Windows, which is the same as for Linux, is available
-at the `rocSPARSE GitHub <https://github.com/ROCm/rocSPARSE>`_.
+from the `rocSPARSE folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse>`_
+of the `rocm-libraries GitHub <https://github.com/ROCm/rocm-libraries>`_.
 The ROCm HIP SDK version might be shown in the default installation path, but
 you can run the HIP SDK compiler from the ``bin/`` folder to display the version using this command:
 
@@ -96,15 +97,40 @@ For example, the HIP version might be ``5.4.22880-135e1ab4``.
 This corresponds to major release ``5``, minor release ``4``, patch ``22880``, and build identifier ``135e1ab4``.
 The rocSPARSE GitHub includes branches with names like ``release/rocm-rel-major.minor``,
 where major and minor have the same meaning as the HIP version.
-For example, use the following command to download rocSPARSE:
+
+To limit your local checkout to only the rocSPARSE project, configure ``sparse-checkout`` before cloning.
+This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+Use the following commands for a sparse checkout:
+
+.. note::
+
+   To include the rocPRIM and rocBLAS dependencies, set the projects for the sparse checkout using
+   ``git sparse-checkout set projects/rocsparse projects/rocprim projects/rocblas``.
 
 .. code-block:: shell
 
-   git clone -b release/rocm-rel-x.y https://github.com/ROCm/rocSPARSE.git
-   cd rocSPARSE
+   git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries
+   git sparse-checkout init --cone
+   git sparse-checkout set projects/rocsparse
+   git checkout release/rocm-rel-x.y  # or use the branch you want to work with
 
 Replace ``x.y`` in the above command with the version of HIP SDK installed on your machine.
-For example, if you have HIP 5.5 installed, use ``-b release/rocm-rel-5.5``.
+For example, if you have HIP 7.0 installed, use ``-b release/rocm-rel-7.0``.
+
+To download all projects in rocm-libraries, use these commands. This process takes
+longer but is recommended for those working with a large number of libraries.
+
+.. code-block:: shell
+
+   git clone -b release/rocm-rel-x.y https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries/projects/rocsparse
+
+.. note::
+
+   To build ROCm 6.4.2 and earlier, use the rocSPARSE repository at `<https://github.com/ROCm/rocSPARSE>`_.
+   For more information, see the documentation associated with the release you want to build.
+
 Add the SDK tools to your path with an entry like the following:
 
 .. code-block:: shell
@@ -127,6 +153,10 @@ Building the library from source
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following table lists the common ways to use ``rmake.py`` to build the rocSPARSE library only.
+
+.. note::
+
+   You can run ``rmake.py`` from the ``projects\rocsparse`` directory.
 
 .. csv-table::
    :header: "Command","Description"

--- a/projects/rocsparse/docs/sphinx/_toc.yml.in
+++ b/projects/rocsparse/docs/sphinx/_toc.yml.in
@@ -22,6 +22,11 @@ subtrees:
   - file: how-to/contribute
     title: Contribute to rocSPARSE
 
+- caption: Examples
+  entries:
+  - url: https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse/clients/samples
+    title: Client samples
+
 - caption: API reference
   entries:
   - file: reference/reference.rst


### PR DESCRIPTION
…or mono-repo (#749)

This edits the install guides (Windows and Linux) and changes GitHub links in the index and on other pages. It also updates other GitHub links. It points users back to the old repository for release 6.4 and earlier.

(cherry picked from commit a98c39b201a4448b7b80e84485b1e16cba373602)