### PR TITLE
[rocRAND] Revert PR #446 (refactor(rocrand): replace hip vector accessor macro

### DIFF
--- a/projects/rocrand/library/include/rocrand/rocrand_common.h
+++ b/projects/rocrand/library/include/rocrand/rocrand_common.h
@@ -88,6 +88,32 @@
     #define ROCRAND_DEPRECATED(msg)
 #endif
 
+// This is an accessor macro for HIP vector types (eg. int2, float4, etc.).
+// Prior to HIP 7.0, individual elements could be accessed through the
+// data member:
+//
+// int2 vec;
+// vec.data[0] = 1;
+//
+// Beginning with HIP 7.0, the data member is hidden, and individual
+// elements must be accessed like this:
+//
+// int2 vec;
+// vec[0] = 1;
+//
+// You can use the macro like this:
+//
+// int2 vec;
+// ROCRAND_HIPVEC_ACCESS(vec)[0];
+//
+#if defined(__HIP_PLATFORM_AMD__)
+    #if HIP_VERSION_MAJOR < 7
+        #define ROCRAND_HIPVEC_ACCESS(x) x.data
+    #else
+        #define ROCRAND_HIPVEC_ACCESS(x) x
+    #endif
+#endif
+
 namespace rocrand_device {
 namespace detail {
 
@@ -161,43 +187,6 @@ __forceinline__ __device__ __host__ void
 {
     lo = val;
     hi = 0;
-}
-
-template<typename T, typename = void>
-struct has_data : std::false_type
-{};
-
-template<typename T>
-struct has_data<T, decltype(std::declval<T>().data, void())> : std::true_type
-{};
-
-template<typename T>
-static constexpr bool has_data_v = has_data<T>::value;
-
-/// This is an accessor utility for HIP vector types (eg. int2, float4, etc.).
-/// Prior to HIP 7.0, individual elements could be accessed through the
-/// data member:
-///   int2 vec;
-///   vec.data[0] = 1;
-///
-/// Beginning with HIP 7.0, the data member is hidden, and individual
-/// elements can instead be accessed through the underlaying native vector.
-template<typename V, typename Index>
-__forceinline__ __device__ __host__
-auto get_element_at(V vector, Index i)
-{
-#if defined(__HIP_PLATFORM_AMD__)
-    if constexpr(has_data_v<V>)
-    {
-        return vector.data[i];
-    }
-    else
-    {
-        return get_native_vector(vector)[i];
-    }
-#else
-    return (&vector.x)[i];
-#endif
 }
 
 } // end namespace detail

--- a/projects/rocrand/library/include/rocrand/rocrand_philox4x32_10.h
+++ b/projects/rocrand/library/include/rocrand/rocrand_philox4x32_10.h
@@ -171,7 +171,11 @@ public:
 
     __forceinline__ __device__ __host__ unsigned int next()
     {
-        unsigned int ret = detail::get_element_at(m_state.result, m_state.substate);
+    #if defined(__HIP_PLATFORM_AMD__)
+        unsigned int ret = ROCRAND_HIPVEC_ACCESS(m_state.result)[m_state.substate];
+    #else
+        unsigned int ret = (&m_state.result.x)[m_state.substate];
+    #endif
 
         m_state.substate++;
         if(m_state.substate == 4)

--- a/projects/rocrand/library/include/rocrand/rocrand_threefry2_impl.h
+++ b/projects/rocrand/library/include/rocrand/rocrand_threefry2_impl.h
@@ -138,8 +138,11 @@ public:
     __forceinline__ __device__ __host__
     value next()
     {
-        value ret = detail::get_element_at(m_state.result, m_state.substate);
-
+#if defined(__HIP_PLATFORM_AMD__)
+        value ret = ROCRAND_HIPVEC_ACCESS(m_state.result)[m_state.substate];
+#else
+        value ret = (&m_state.result.x)[m_state.substate];
+#endif
         m_state.substate++;
         if(m_state.substate == 2)
         {

--- a/projects/rocrand/library/include/rocrand/rocrand_threefry4_impl.h
+++ b/projects/rocrand/library/include/rocrand/rocrand_threefry4_impl.h
@@ -152,8 +152,11 @@ public:
 
     __forceinline__ __device__ __host__ value next()
     {
-        value ret = detail::get_element_at(m_state.result, m_state.substate);
-
+#if defined(__HIP_PLATFORM_AMD__)
+        value ret = ROCRAND_HIPVEC_ACCESS(m_state.result)[m_state.substate];
+#else
+        value ret = (&m_state.result.x)[m_state.substate];
+#endif
         m_state.substate++;
         if(m_state.substate == 4)
         {


### PR DESCRIPTION
Revert PR #446 (refactor(rocrand): replace hip vector accessor macro  and use underlying native vector)

The change reverts commit 51fed3d87c40fe5b36959857750654c03f182fd4, which was causing some performance issues for the philox and threefry generators.