### PR TITLE
[ci] - Adding TheRock CI summary

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -53,37 +53,37 @@ jobs:
           repository: "ROCm/TheRock"
           path: "TheRock"
 
-      # - name: Runner Health Settings
-      #   run: |
-      #     echo "CCACHE_DIR=${CCACHE_DIR}"
-      #     df -h
-      #     ccache -z
-      #     mkdir -p $CCACHE_DIR
-      #     cmake --version
-      #     echo "Installed Python versions:"
-      #     ls -d /opt/python
-      #     echo "python: $(which python), python3: $(which python3)"
-      #     echo "Git version: $(git --version)"
-      #     git config --global --add safe.directory $PWD
-      #     git config fetch.parallel 10
+      - name: Runner Health Settings
+        run: |
+          echo "CCACHE_DIR=${CCACHE_DIR}"
+          df -h
+          ccache -z
+          mkdir -p $CCACHE_DIR
+          cmake --version
+          echo "Installed Python versions:"
+          ls -d /opt/python
+          echo "python: $(which python), python3: $(which python3)"
+          echo "Git version: $(git --version)"
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
       
-      # - name: Fetch sources
-      #   run: |
-      #     ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-math-libs
+      - name: Fetch sources
+        run: |
+          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-math-libs
 
-      # - name: Install python deps
-      #   run: |
-      #     pip install -r TheRock/requirements.txt
-      #     pip freeze
+      - name: Install python deps
+        run: |
+          pip install -r TheRock/requirements.txt
+          pip freeze
 
-      # - name: Configure Projects
-      #   env:
-      #     amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
-      #     package_version: ADHOCBUILD
-      #     extra_cmake_options: "-DTHEROCK_USE_EXTERNAL_ROCM_LIBRARIES=ON -DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=../ ${{ inputs.cmake_options }}"
-      #     BUILD_DIR: build
-      #   run: |
-      #     python3 TheRock/build_tools/github_actions/build_configure.py
+      - name: Configure Projects
+        env:
+          amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
+          package_version: ADHOCBUILD
+          extra_cmake_options: "-DTHEROCK_USE_EXTERNAL_ROCM_LIBRARIES=ON -DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=../ ${{ inputs.cmake_options }}"
+          BUILD_DIR: build
+        run: |
+          python3 TheRock/build_tools/github_actions/build_configure.py
 
       - name: Build therock-dist
         run: cmake --build TheRock/build --target therock-dist

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -53,37 +53,37 @@ jobs:
           repository: "ROCm/TheRock"
           path: "TheRock"
 
-      - name: Runner Health Settings
-        run: |
-          echo "CCACHE_DIR=${CCACHE_DIR}"
-          df -h
-          ccache -z
-          mkdir -p $CCACHE_DIR
-          cmake --version
-          echo "Installed Python versions:"
-          ls -d /opt/python
-          echo "python: $(which python), python3: $(which python3)"
-          echo "Git version: $(git --version)"
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
+      # - name: Runner Health Settings
+      #   run: |
+      #     echo "CCACHE_DIR=${CCACHE_DIR}"
+      #     df -h
+      #     ccache -z
+      #     mkdir -p $CCACHE_DIR
+      #     cmake --version
+      #     echo "Installed Python versions:"
+      #     ls -d /opt/python
+      #     echo "python: $(which python), python3: $(which python3)"
+      #     echo "Git version: $(git --version)"
+      #     git config --global --add safe.directory $PWD
+      #     git config fetch.parallel 10
       
-      - name: Fetch sources
-        run: |
-          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-math-libs
+      # - name: Fetch sources
+      #   run: |
+      #     ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-math-libs
 
-      - name: Install python deps
-        run: |
-          pip install -r TheRock/requirements.txt
-          pip freeze
+      # - name: Install python deps
+      #   run: |
+      #     pip install -r TheRock/requirements.txt
+      #     pip freeze
 
-      - name: Configure Projects
-        env:
-          amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
-          package_version: ADHOCBUILD
-          extra_cmake_options: "-DTHEROCK_USE_EXTERNAL_ROCM_LIBRARIES=ON -DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=../ ${{ inputs.cmake_options }}"
-          BUILD_DIR: build
-        run: |
-          python3 TheRock/build_tools/github_actions/build_configure.py
+      # - name: Configure Projects
+      #   env:
+      #     amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
+      #     package_version: ADHOCBUILD
+      #     extra_cmake_options: "-DTHEROCK_USE_EXTERNAL_ROCM_LIBRARIES=ON -DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=../ ${{ inputs.cmake_options }}"
+      #     BUILD_DIR: build
+      #   run: |
+      #     python3 TheRock/build_tools/github_actions/build_configure.py
 
       - name: Build therock-dist
         run: cmake --build TheRock/build --target therock-dist

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -64,40 +64,40 @@ jobs:
         run: |
           pip install -r TheRock/requirements.txt
 
-      - name: Install requirements
-        run: |
-          choco install --no-progress -y ccache
-          choco install --no-progress -y ninja
-          choco install --no-progress -y strawberryperl
-          echo "$PATH;C:\Strawberry\c\bin" >> $GITHUB_PATH
-          choco install --no-progress -y awscli
-          echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
+      # - name: Install requirements
+      #   run: |
+      #     choco install --no-progress -y ccache
+      #     choco install --no-progress -y ninja
+      #     choco install --no-progress -y strawberryperl
+      #     echo "$PATH;C:\Strawberry\c\bin" >> $GITHUB_PATH
+      #     choco install --no-progress -y awscli
+      #     echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
-      # After other installs, so MSVC get priority in the PATH.
-      - name: Configure MSVC
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      # # After other installs, so MSVC get priority in the PATH.
+      # - name: Configure MSVC
+      #   uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Fetch sources
-        run: |
-          git config --global core.longpaths true
-          python ./TheRock/build_tools/fetch_sources.py --jobs 96 --no-include-math-libs
+      # - name: Fetch sources
+      #   run: |
+      #     git config --global core.longpaths true
+      #     python ./TheRock/build_tools/fetch_sources.py --jobs 96 --no-include-math-libs
 
-      - name: Checkout closed source AMDGPU/ROCm interop library folder
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: nod-ai/amdgpu-windows-interop
-          path: amdgpu-windows-interop
-          lfs: true
+      # - name: Checkout closed source AMDGPU/ROCm interop library folder
+      #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      #   with:
+      #     repository: nod-ai/amdgpu-windows-interop
+      #     path: amdgpu-windows-interop
+      #     lfs: true
 
-      - name: Configure Projects
-        env:
-          amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
-          package_version: "ADHOCBUILD"
-          extra_cmake_options: "-DBUILD_TESTING=OFF -DTHEROCK_USE_EXTERNAL_ROCM_LIBRARIES=ON -DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=${{ github.workspace }} ${{ inputs.cmake_options }}"
-        run: |
-          # clear cache before build and after download
-          ccache -z
-          python3 TheRock/build_tools/github_actions/build_configure.py
+      # - name: Configure Projects
+      #   env:
+      #     amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
+      #     package_version: "ADHOCBUILD"
+      #     extra_cmake_options: "-DBUILD_TESTING=OFF -DTHEROCK_USE_EXTERNAL_ROCM_LIBRARIES=ON -DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=${{ github.workspace }} ${{ inputs.cmake_options }}"
+      #   run: |
+      #     # clear cache before build and after download
+      #     ccache -z
+      #     python3 TheRock/build_tools/github_actions/build_configure.py
 
       - name: Build therock-dist
         run: cmake --build "${{ env.BUILD_DIR }}" --target therock-dist

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -64,40 +64,40 @@ jobs:
         run: |
           pip install -r TheRock/requirements.txt
 
-      # - name: Install requirements
-      #   run: |
-      #     choco install --no-progress -y ccache
-      #     choco install --no-progress -y ninja
-      #     choco install --no-progress -y strawberryperl
-      #     echo "$PATH;C:\Strawberry\c\bin" >> $GITHUB_PATH
-      #     choco install --no-progress -y awscli
-      #     echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
+      - name: Install requirements
+        run: |
+          choco install --no-progress -y ccache
+          choco install --no-progress -y ninja
+          choco install --no-progress -y strawberryperl
+          echo "$PATH;C:\Strawberry\c\bin" >> $GITHUB_PATH
+          choco install --no-progress -y awscli
+          echo "$PATH;C:\Program Files\Amazon\AWSCLIV2" >> $GITHUB_PATH
 
-      # # After other installs, so MSVC get priority in the PATH.
-      # - name: Configure MSVC
-      #   uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      # After other installs, so MSVC get priority in the PATH.
+      - name: Configure MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      # - name: Fetch sources
-      #   run: |
-      #     git config --global core.longpaths true
-      #     python ./TheRock/build_tools/fetch_sources.py --jobs 96 --no-include-math-libs
+      - name: Fetch sources
+        run: |
+          git config --global core.longpaths true
+          python ./TheRock/build_tools/fetch_sources.py --jobs 96 --no-include-math-libs
 
-      # - name: Checkout closed source AMDGPU/ROCm interop library folder
-      #   uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      #   with:
-      #     repository: nod-ai/amdgpu-windows-interop
-      #     path: amdgpu-windows-interop
-      #     lfs: true
+      - name: Checkout closed source AMDGPU/ROCm interop library folder
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: nod-ai/amdgpu-windows-interop
+          path: amdgpu-windows-interop
+          lfs: true
 
-      # - name: Configure Projects
-      #   env:
-      #     amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
-      #     package_version: "ADHOCBUILD"
-      #     extra_cmake_options: "-DBUILD_TESTING=OFF -DTHEROCK_USE_EXTERNAL_ROCM_LIBRARIES=ON -DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=${{ github.workspace }} ${{ inputs.cmake_options }}"
-      #   run: |
-      #     # clear cache before build and after download
-      #     ccache -z
-      #     python3 TheRock/build_tools/github_actions/build_configure.py
+      - name: Configure Projects
+        env:
+          amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
+          package_version: "ADHOCBUILD"
+          extra_cmake_options: "-DBUILD_TESTING=OFF -DTHEROCK_USE_EXTERNAL_ROCM_LIBRARIES=ON -DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=${{ github.workspace }} ${{ inputs.cmake_options }}"
+        run: |
+          # clear cache before build and after download
+          ccache -z
+          python3 TheRock/build_tools/github_actions/build_configure.py
 
       - name: Build therock-dist
         run: cmake --build "${{ env.BUILD_DIR }}" --target therock-dist

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -120,3 +120,24 @@ jobs:
       cmake_options: ${{ matrix.projects.cmake_options }}
       project_to_test: ${{ matrix.projects.project_to_test }}
       subtree_checkout: ${{ matrix.projects.subtree_checkout }}
+
+  therock_ci_summary:
+    name: TheRock CI Summary
+    if: always()
+    needs:
+      - setup
+      - therock-ci-linux
+      - therock-ci-windows
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Output failed jobs
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi


### PR DESCRIPTION
(i need to add the segment where it triggers all TheRock jobs based on ci* changes), but after this PR lands, we will be able to lock down TheRock CI and add the "required" rule

Changes: 
- Adding basic TheRock CI summary check, to ensure we lock down TheRock CI and no hanging checks

This is fairly basic, but will make it more sophisticated as needed

Test runs:
- [TheRock CI skip](https://github.com/ROCm/rocm-libraries/actions/runs/16481241365)
- [TheRock CI success](https://github.com/ROCm/rocm-libraries/actions/runs/16481288434)
- [TheRock CI failure](https://github.com/ROCm/rocm-libraries/actions/runs/16482468087)