### PR TITLE
[rocRoller] Allow more tile sizes

### DIFF
--- a/shared/rocroller/lib/include/rocRoller/KernelGraph/Visitors.hpp
+++ b/shared/rocroller/lib/include/rocRoller/KernelGraph/Visitors.hpp
@@ -66,6 +66,14 @@ namespace rocRoller
         inline KernelGraph rewriteDimensions(KernelGraph const& k, T& visitor)
         {
             KernelGraph graph = k;
+            for(auto const& tag : k.coordinates.getNodes())
+            {
+                auto x = k.coordinates.getNode(tag);
+                auto y
+                    = std::visit([&](auto&& arg) { return visitor.visitDimension(tag, arg); }, x);
+                graph.coordinates.setElement(tag, y);
+            }
+
             if constexpr(CCoordinateEdgeVisitor<T>)
             {
                 for(auto const& tag : k.coordinates.getEdges())
@@ -77,14 +85,6 @@ namespace rocRoller
                     auto newEdge = std::visit(visB, edge);
                     graph.coordinates.setElement(tag, newEdge);
                 }
-            }
-
-            for(auto const& tag : k.coordinates.getNodes())
-            {
-                auto x = k.coordinates.getNode(tag);
-                auto y
-                    = std::visit([&](auto&& arg) { return visitor.visitDimension(tag, arg); }, x);
-                graph.coordinates.setElement(tag, y);
             }
 
             for(auto const& tag : k.control.getNodes())

--- a/shared/rocroller/lib/include/rocRoller/KernelOptions_detail.hpp
+++ b/shared/rocroller/lib/include/rocRoller/KernelOptions_detail.hpp
@@ -83,7 +83,7 @@ namespace rocRoller
          * Increasing this value could decrease SGPR pressure; decreasing it could speed up a
          * kernel if there are enough available SGPRs.
          */
-        int minLaunchTimeExpressionComplexity = 10;
+        int minLaunchTimeExpressionComplexity = 20;
 
         /**
          * The maximum number of concurrent subexpressions given at once to the scheduler when

--- a/shared/rocroller/lib/source/CodeGen/Arithmetic/Multiply.cpp
+++ b/shared/rocroller/lib/source/CodeGen/Arithmetic/Multiply.cpp
@@ -78,6 +78,9 @@ namespace rocRoller
         AssertFatal(lhs != nullptr);
         AssertFatal(rhs != nullptr);
 
+        if(rhs->regType() == Register::Type::Literal
+           && !m_context->targetArchitecture().isSupportedConstantValue(rhs))
+            co_yield m_context->copier()->ensureType(rhs, rhs, Register::Type::Vector);
         co_yield_(Instruction("v_mul_lo_u32", {dest}, {lhs, rhs}, {}, ""));
     }
 

--- a/shared/rocroller/lib/source/CodeGen/Arithmetic/MultiplyHigh.cpp
+++ b/shared/rocroller/lib/source/CodeGen/Arithmetic/MultiplyHigh.cpp
@@ -73,6 +73,9 @@ namespace rocRoller
             {
                 if(dataTypeInfoDest.isSigned)
                 {
+                    if(rhs->regType() == Register::Type::Literal
+                       && !m_context->targetArchitecture().isSupportedConstantValue(rhs))
+                        co_yield m_context->copier()->ensureType(rhs, rhs, Register::Type::Vector);
                     co_yield_(Instruction("v_mul_hi_i32", {dest}, {lhs, rhs}, {}, ""));
                 }
                 else

--- a/shared/rocroller/lib/source/CodeGen/Arithmetic/MultiplyHigh.cpp
+++ b/shared/rocroller/lib/source/CodeGen/Arithmetic/MultiplyHigh.cpp
@@ -73,9 +73,6 @@ namespace rocRoller
             {
                 if(dataTypeInfoDest.isSigned)
                 {
-                    if(rhs->regType() == Register::Type::Literal
-                       && !m_context->targetArchitecture().isSupportedConstantValue(rhs))
-                        co_yield m_context->copier()->ensureType(rhs, rhs, Register::Type::Vector);
                     co_yield_(Instruction("v_mul_hi_i32", {dest}, {lhs, rhs}, {}, ""));
                 }
                 else

--- a/shared/rocroller/lib/source/KernelGraph/Utils.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Utils.cpp
@@ -1137,11 +1137,11 @@ namespace rocRoller
 
         Expression::ExpressionPtr tileCeilDivide(Expression::ExpressionPtr sdSize, int tileSize)
         {
-            auto tileSizeExpr = std::has_single_bit(static_cast<uint>(tileSize)) ?
-                                        Expression::literal(static_cast<uint>(tileSize)) :
-                                        Expression::literal(static_cast<int64_t>(tileSize));
-            
-            auto one          = Expression::literal(1u);
+            auto tileSizeExpr = std::has_single_bit(static_cast<uint>(tileSize))
+                                    ? Expression::literal(static_cast<uint>(tileSize))
+                                    : Expression::literal(static_cast<int64_t>(tileSize));
+
+            auto one = Expression::literal(1u);
 
             return (sdSize + tileSizeExpr - one) / tileSizeExpr;
         }

--- a/shared/rocroller/lib/source/KernelGraph/Utils.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Utils.cpp
@@ -1137,7 +1137,10 @@ namespace rocRoller
 
         Expression::ExpressionPtr tileCeilDivide(Expression::ExpressionPtr sdSize, int tileSize)
         {
-            auto tileSizeExpr = Expression::literal(static_cast<uint>(tileSize));
+            auto tileSizeExpr = std::has_single_bit(static_cast<uint>(tileSize)) ?
+                                        Expression::literal(static_cast<uint>(tileSize)) :
+                                        Expression::literal(static_cast<int64_t>(tileSize));
+            
             auto one          = Expression::literal(1u);
 
             return (sdSize + tileSizeExpr - one) / tileSizeExpr;

--- a/shared/rocroller/test/unit/GEMMTest.cpp
+++ b/shared/rocroller/test/unit/GEMMTest.cpp
@@ -3583,7 +3583,7 @@ namespace GEMMDriverTest
 
         basicGEMM<Half>(gemm);
     }
-    
+
     TEST_P(GEMMTestGPU, GPU_BasicGEMMStoreDWave)
     {
         REQUIRE_ARCH_CAP(GPUCapability::HasMFMA);

--- a/shared/rocroller/test/unit/GEMMTest.cpp
+++ b/shared/rocroller/test/unit/GEMMTest.cpp
@@ -2445,6 +2445,8 @@ namespace GEMMDriverTest
         gemm.swizzleScale  = true;
         gemm.prefetchScale = true;
 
+        gemm.workgroupMapping = {0, 2};
+
         gemm.scaleBlockSize
             = m_context->targetArchitecture().GetCapability(GPUCapability::DefaultScaleBlockSize);
 
@@ -2457,6 +2459,62 @@ namespace GEMMDriverTest
         // 1x4 wave config: NumAScaleLoadTiles = 256/64 = 4 and NumBScaleLoadTiles = 256/4/64 = 1
         // prefetched scale: 2 * 5 = 10
         EXPECT_EQ(countSubstring(generatedCode, "buffer_load_dwordx2 "), 10);
+    }
+
+    TEST_P(GEMMTestGPU, GPU_SwizzleScaledPrefetchD2LGEMMMXF4TN_192x256)
+    {
+        REQUIRE_ARCH_CAP(GPUCapability::HasMFMA_f8f6f4);
+        REQUIRE_ARCH_CAP(GPUCapability::HasBlockScaling32);
+
+        auto gemm = setup_GEMMF8F6F4(32, 32, 64);
+
+        gemm.macM = 192;
+        gemm.macN = 256;
+        gemm.macK = 128;
+
+        gemm.m = 2 * gemm.macM;
+        gemm.n = 3 * gemm.macN;
+        gemm.k = 4 * gemm.macK;
+
+        gemm.workgroupSizeX = 1 * gemm.wavefrontSize;
+        gemm.workgroupSizeY = 4;
+
+        gemm.loadLDSA      = true;
+        gemm.loadLDSB      = true;
+        gemm.loadLDSScaleA = false;
+        gemm.loadLDSScaleB = false;
+        gemm.direct2LDSA   = true;
+        gemm.direct2LDSB   = true;
+
+        gemm.unrollK           = 2;
+        gemm.prefetch          = true;
+        gemm.prefetchInFlight  = 2;
+        gemm.prefetchLDSFactor = 1;
+        gemm.prefetchMixMemOps = true;
+
+        gemm.scaleAMode = Operations::ScaleMode::Separate;
+        gemm.scaleBMode = Operations::ScaleMode::Separate;
+
+        gemm.scaleTypeA = DataType::E8M0;
+        gemm.scaleTypeB = DataType::E8M0;
+
+        gemm.swizzleScale  = true;
+        gemm.prefetchScale = true;
+
+        gemm.workgroupMapping = {0, 2};
+
+        gemm.scaleBlockSize
+            = m_context->targetArchitecture().GetCapability(GPUCapability::DefaultScaleBlockSize);
+
+        basicGEMM<FP4, FP4, float>(gemm);
+
+        std::string generatedCode = m_context->instructions()->toString();
+        EXPECT_EQ(countSubstring(generatedCode, "ds_write"), 0);
+        EXPECT_EQ(countSubstring(generatedCode, "buffer_load_ubyte "), 0);
+        EXPECT_EQ(countSubstring(generatedCode, "buffer_load_dword "), 0);
+        // 1x4 wave config: NumAScaleLoadTiles = 192/64 = 3 and NumBScaleLoadTiles = 256/4/64 = 1
+        // prefetched scale: 2 * 4 = 8
+        EXPECT_EQ(countSubstring(generatedCode, "buffer_load_dwordx2 "), 8);
     }
 
     TEST_P(GEMMF8F6F4TestGPU, GPU_SwizzleScaled_Prefetch_GEMMF8F6F4)
@@ -3501,6 +3559,31 @@ namespace GEMMDriverTest
         basicGEMM<Half>(gemm);
     }
 
+    TEST_P(GEMMTestGPU, GPU_BasicGEMMFP16_96x256)
+    {
+        REQUIRE_ARCH_CAP(GPUCapability::HasMFMA);
+        GEMMProblem gemm;
+
+        gemm.m = 192;
+        gemm.n = 512;
+        gemm.k = 64;
+
+        gemm.macM = 96;
+        gemm.macN = 256;
+        gemm.macK = 16;
+
+        gemm.waveK = 8;
+
+        gemm.workgroupSizeX = 1 * gemm.wavefrontSize;
+        gemm.workgroupSizeY = 4;
+
+        gemm.loadLDSA  = true;
+        gemm.loadLDSB  = true;
+        gemm.storeLDSD = true;
+
+        basicGEMM<Half>(gemm);
+    }
+    
     TEST_P(GEMMTestGPU, GPU_BasicGEMMStoreDWave)
     {
         REQUIRE_ARCH_CAP(GPUCapability::HasMFMA);


### PR DESCRIPTION
Enable more tile sizes in rocRoller. Also made a few changes to reduce sgpr usage (only reduces it by a small amount, but enough to get the new GEMM test working).

Changes to enable 192X256 tile size:
1. Change `tileCeilDivide` to convert the tile size to 64bit integer when not a power of 2. This keeps the current behavior for all power of 2 sizes, but allows other sizes to work.
2. Fix multiply operation to copy literal values to vgprs when literal size is not allowed.

Changes to reduce sgpr usage:
1. Change order that `cleanArguments` finds arguments within the coordinate graph. This modifiers the `Visitor` class, but `cleanArguments` is the only section of code using this part of the `Visitor` class.
2. Increase the default `minLaunchTimeExpressionComplexity` value.