### PR TITLE
[hipBLAS] Fix hipBLAS SO version from bad monorepo merge

### DIFF
--- a/projects/hipblas/library/CMakeLists.txt
+++ b/projects/hipblas/library/CMakeLists.txt
@@ -20,7 +20,7 @@
 # ########################################################################
 
 # This is incremented when the ABI to the library changes
-set( hipblas_SOVERSION 3.0 )
+set( hipblas_SOVERSION 3.1 )
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 


### PR DESCRIPTION
See difference between pre-monorepo merge and post-monorepo merge: https://github.com/rocm/hipBLAS/compare/26edbf2...4189762