### PR TITLE
Improve parsing of compute_type in hipblaslt-bench yamls

### DIFF
--- a/projects/hipblaslt/clients/common/hipblaslt_gentest.py
+++ b/projects/hipblaslt/clients/common/hipblaslt_gentest.py
@@ -396,11 +396,13 @@ def instantiate(test):
 
     try:
         setdefaults(test)
-
         # For enum arguments, replace name with value
         for typename in enum_args:
-            if test[typename] in datatypes:
-                test[typename] = datatypes[test[typename]]
+            dt = test[typename]
+            if typename == "compute_type" and not dt.startswith("c_"):
+                dt = "c_" + dt
+            if dt in datatypes:
+                test[typename] = datatypes[dt]
 
         known_bug_platforms = set()
 


### PR DESCRIPTION
Allows hipblaslt-bench to parse compute_type in the same format as it outputs it. Prevents it from printing f16_r when set to f32_r.