### PR TITLE
Add option to allow hipblaslt-bench to run duplicate problems

### DIFF
--- a/projects/hipblaslt/clients/benchmarks/client.cpp
+++ b/projects/hipblaslt/clients/benchmarks/client.cpp
@@ -302,6 +302,7 @@ try
     std::string algo_method_str = "";
 
     bool verify = 0;
+    bool allow_duplicate = false;
 
     bool                  grouped_gemm;
     std::vector<int64_t>  m, n, k;
@@ -455,6 +456,10 @@ try
         ("verify,v",
          value<bool>(&verify)->default_value(false),
          "Validate GPU results with CPU?")
+
+        ("allow_duplicate",
+         value<bool>(&allow_duplicate)->default_value(false),
+         "Allow duplicate benchmark sizes")
 
         ("iters,i",
          value<int32_t>(&arg.iters)->default_value(tuningEnv? 1000 : 10),

--- a/projects/hipblaslt/clients/common/hipblaslt_gentest.py
+++ b/projects/hipblaslt/clients/common/hipblaslt_gentest.py
@@ -119,6 +119,8 @@ Expand hipBLASLt YAML test data file into binary Arguments records
                         default=[])
     parser.add_argument('-t', '--template',
                         type=argparse.FileType('r'))
+    parser.add_argument('--allow_duplicate',
+                        action='store_true')
     return parser.parse_args()
 
 
@@ -353,7 +355,7 @@ def write_test(test):
             sys.exit("TypeError: " + str(err) + " for " + name +
                      ", which has type " + str(type(test[name])) + "\n")
     byt = bytes(param['Arguments'](*arg))
-    if byt not in testcases:
+    if byt not in testcases or args['allow_duplicate']:
         testcases.add(byt)
         write_signature(args['outfile'])
         args['outfile'].write(byt)
@@ -451,7 +453,6 @@ def instantiate(test):
         # known_bug_platforms to a space-separated list of platforms
         test['known_bug_platforms'] = ' ' . join(known_bug_platforms) if test[
             'category'] not in ('known_bug') else ''
-
         write_test(test)
 
     except KeyError as err:

--- a/projects/hipblaslt/clients/common/hipblaslt_parse_data.cpp
+++ b/projects/hipblaslt/clients/common/hipblaslt_parse_data.cpp
@@ -35,15 +35,16 @@
 #include <sys/types.h>
 
 // Parse YAML data
-static std::string hipblaslt_parse_yaml(const std::string& yaml)
+static std::string hipblaslt_parse_yaml(const std::string& yaml, bool allow_duplicate)
 {
     // TODO: This function is inherently unsafe because it returns a string vs an open
     // file handle which will block further colliding creates. See comments in
     // hipblaslt_tempname() and under no circumstances copy this to new code.
     std::string tmp     = hipblaslt_tempname();
     auto        exepath = hipblaslt_exepath();
-    auto        cmd     = exepath + "hipblaslt_gentest.py --template " + exepath
-               + "hipblaslt_template.yaml -o " + tmp + " " + yaml;
+    auto        cmd     = exepath + "hipblaslt_gentest.py "
+        + (allow_duplicate ? "--allow_duplicate " : "")
+        + "--template " + exepath + "hipblaslt_template.yaml -o " + tmp + " " + yaml;
     hipblaslt_cerr << cmd << std::endl;
 
 #ifdef _WIN32
@@ -65,6 +66,7 @@ bool hipblaslt_parse_data(int& argc, char** argv, const std::string& default_fil
     std::string filename;
     char**      argv_p = argv + 1;
     bool        help = false, yaml = false;
+    bool        allow_duplicate = false;
 
     // Scan, process and remove any --yaml or --data options
     for(int i = 1; argv[i]; ++i)
@@ -90,6 +92,8 @@ bool hipblaslt_parse_data(int& argc, char** argv, const std::string& default_fil
             }
             filename = argv[++i];
         }
+        else if(!strcmp(argv[i], "--allow_duplicate"))
+            allow_duplicate = true;
         else
         {
             *argv_p++ = argv[i];
@@ -113,7 +117,7 @@ bool hipblaslt_parse_data(int& argc, char** argv, const std::string& default_fil
         filename = default_file;
 
     if(yaml)
-        filename = hipblaslt_parse_yaml(filename);
+        filename = hipblaslt_parse_yaml(filename, allow_duplicate);
 
     if(filename != "")
     {


### PR DESCRIPTION
The new option defaults to off, so duplicate entries are filtered as normal. But can be enabled, and is useful for mimicking application benchmarks within the benchmark tool