### PR TITLE
[rocsparse] Move very long running pre_checkin tests to stress test category

### DIFF
--- a/projects/rocsparse/clients/tests/test_bsric0.yaml
+++ b/projects/rocsparse/clients/tests/test_bsric0.yaml
@@ -163,8 +163,7 @@ Tests:
   baseA: [rocsparse_index_base_zero]
   direction: [rocsparse_direction_column]
   matrix: [rocsparse_matrix_file_rocalution]
-  filename: [ASIC_320k,
-             Chebyshev4]
+  filename: [Chebyshev4]
   skip_hardware: gfx940, gfx941
 
 - name: bsric0_file
@@ -230,3 +229,19 @@ Tests:
   direction: [rocsparse_direction_row, rocsparse_direction_column]
   matrix: [rocsparse_matrix_random]
   graph_test: true
+
+- name: bsric0_file
+  category: stress
+  function: bsric0
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  block_dim: [3]
+  transA: [rocsparse_operation_none]
+  apol: [rocsparse_analysis_policy_reuse]
+  spol: [rocsparse_solve_policy_auto]
+  baseA: [rocsparse_index_base_zero]
+  direction: [rocsparse_direction_column]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [ASIC_320k]
+  skip_hardware: gfx940, gfx941

--- a/projects/rocsparse/clients/tests/test_csric0.yaml
+++ b/projects/rocsparse/clients/tests/test_csric0.yaml
@@ -163,8 +163,7 @@ Tests:
   spol: [rocsparse_solve_policy_auto]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   matrix: [rocsparse_matrix_file_rocalution]
-  filename: [ASIC_320k,
-             Chebyshev4]
+  filename: [Chebyshev4]
   skip_hardware: gfx940, gfx941
 
 - name: csric0_file
@@ -221,3 +220,17 @@ Tests:
 - name: csric0_extra
   category: pre_checkin
   function: csric0_extra
+
+- name: csric0_file
+  category: stress
+  function: csric0
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  transA: [rocsparse_operation_none]
+  apol: [rocsparse_analysis_policy_reuse, rocsparse_analysis_policy_force]
+  spol: [rocsparse_solve_policy_auto]
+  baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [ASIC_320k]
+  skip_hardware: gfx940, gfx941

--- a/projects/rocsparse/clients/tests/test_csrilu0.yaml
+++ b/projects/rocsparse/clients/tests/test_csrilu0.yaml
@@ -143,20 +143,6 @@ Tests:
              nos7]
 
 - name: csrilu0_file
-  category: pre_checkin
-  function: csrilu0
-  precision: *single_double_precisions
-  M: 1
-  N: 1
-  transA: [rocsparse_operation_none]
-  apol: [rocsparse_analysis_policy_reuse, rocsparse_analysis_policy_force]
-  spol: [rocsparse_solve_policy_auto]
-  baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
-  matrix: [rocsparse_matrix_file_rocalution]
-  filename: [ASIC_320k]
-  skip_hardware: gfx940, gfx941
-
-- name: csrilu0_file
   category: nightly
   function: csrilu0
   precision: *single_double_precisions
@@ -243,3 +229,17 @@ Tests:
 - name: csrilu0_extra
   category: pre_checkin
   function: csrilu0_extra
+
+- name: csrilu0_file
+  category: stress
+  function: csrilu0
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  transA: [rocsparse_operation_none]
+  apol: [rocsparse_analysis_policy_reuse, rocsparse_analysis_policy_force]
+  spol: [rocsparse_solve_policy_auto]
+  baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [ASIC_320k]
+  skip_hardware: gfx940, gfx941

--- a/projects/rocsparse/clients/tests/test_csrilusv.yaml
+++ b/projects/rocsparse/clients/tests/test_csrilusv.yaml
@@ -53,7 +53,6 @@ Tests:
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [mc2depi,
-             ASIC_320k,
              nos1,
              nos3,
              nos7]
@@ -108,3 +107,15 @@ Tests:
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [Chevron4]
+
+- name: csrilusv_file
+  category: stress
+  function: csrilusv
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  apol: [rocsparse_analysis_policy_reuse, rocsparse_analysis_policy_force]
+  spol: [rocsparse_solve_policy_auto]
+  baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  filename: [ASIC_320k]


### PR DESCRIPTION
Summary of proposed changes:
- Move some very long running pre_checkin tests (involving the ASIC_320k matrix with preconditioning routines) to stress test category
- These tests can take 10k or even 100k ms where as most of the other tests in this category take 10 or 100 ms. 
- It therefore makes sense for the preconditioning routines to mark these tests as stress tests.