### PR TITLE
[hipblsalt] Fix leaky hip::device dependency

### DIFF
--- a/projects/hipblaslt/next-cmake/CMakeLists.txt
+++ b/projects/hipblaslt/next-cmake/CMakeLists.txt
@@ -268,6 +268,7 @@ if(TENSILELITE_ENABLE_HOST OR HIPBLASLT_ENABLE_HOST)
     target_link_libraries(tensilelite-host 
         PUBLIC
             rocisa::rocisa-cpp
+        PRIVATE
             hip::device
     )
 
@@ -291,8 +292,8 @@ if(HIPBLASLT_ENABLE_HOST)
     target_link_libraries(hipblaslt
         PUBLIC
             roc::${hipblas_target}
-            hip::device
         PRIVATE
+            hip::device
             tensilelite-host
             ${CMAKE_DL_LIBS}
             ${rocTracer}
@@ -384,6 +385,12 @@ if(HIPBLASLT_ENABLE_HOST)
         DEPENDS PACKAGE hip
         DEPENDS PACKAGE ${hipblas_target}
         NAMESPACE roc::
+    )
+
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/hipblaslt-config.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config.cmake"
+        COPYONLY
     )
 
     if( LEGACY_HIPBLAS_DIRECT )

--- a/projects/hipblaslt/next-cmake/cmake/hipblaslt-config.cmake.in
+++ b/projects/hipblaslt/next-cmake/cmake/hipblaslt-config.cmake.in
@@ -20,9 +20,22 @@
 # THE SOFTWARE.
 #
 # ########################################################################
+
 include(CMakeFindDependencyMacro)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../share/cmake/hipblaslt")
-find_dependency(hip)
+
 find_dependency(hipblas-common)
 
 include("${CMAKE_CURRENT_LIST_DIR}/hipblaslt-targets.cmake")
+
+block(SCOPE_FOR VARIABLES)
+    if(NOT TARGET roc::hipblaslt)
+        message(FATAL_ERROR "roc::hipblaslt target is missing")
+    endif()
+
+    get_target_property(link_libraries roc::hipblaslt INTERFACE_LINK_LIBRARIES)
+
+    if(link_libraries AND "hip::device" IN_LIST link_libraries)
+        message(FATAL_ERROR "Do not export targets with hip::device as an interface link library")
+    endif()
+endblock()


### PR DESCRIPTION
- Do note use PUBLIC linkage for hip::device
- Add logic to project config to catch when hip::device is added to interface link libraries
- Fixes the regression noted in https://github.com/ROCm/rocm-libraries/pull/650#issuecomment-3120543083
- Root cause diagnosis of the issue: https://chatgpt.com/share/68841788-4564-800d-a6a1-e000c668c0fb