### PR TITLE
[Ex CI] enable MIOpen

### DIFF
--- a/.azuredevops/miopen.yml
+++ b/.azuredevops/miopen.yml
@@ -1,0 +1,47 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: pipelinesRepoRef
+  type: string
+  default: refs/heads/develop
+- name: triggerDownstreamJobs
+  type: boolean
+  default: true
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+    ref: ${{ parameters.pipelinesRepoRef }}
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - develop
+    - release-staging/rocm-rel-7.*
+  paths:
+    include:
+    - projects/miopen
+    exclude:
+    - projects/miopen/.githooks
+    - projects/miopen/.github
+    - projects/miopen/docs
+    - projects/miopen/.*.y*ml
+    - projects/miopen/*.md
+    - projects/miopen/LICENSE.txt
+
+pr: none
+
+stages:
+- stage: miopen
+  jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/MIOpen.yml@pipelines_repo
+    parameters:
+      sparseCheckoutDir: projects/miopen
+      triggerDownstreamJobs: ${{ parameters.triggerDownstreamJobs }}
+- template: templates/report-summary-check-wrapper.yml

--- a/.azuredevops/miopen.yml
+++ b/.azuredevops/miopen.yml
@@ -6,6 +6,12 @@ parameters:
 - name: pipelinesRepoRef
   type: string
   default: refs/heads/develop
+- name: mivisionxRepoRef
+  type: string
+  default: refs/heads/develop
+- name: amdmigraphxRepoRef
+  type: string
+  default: refs/heads/develop
 - name: triggerDownstreamJobs
   type: boolean
   default: true
@@ -17,6 +23,16 @@ resources:
     endpoint: ROCm
     name: ROCm/ROCm
     ref: ${{ parameters.pipelinesRepoRef }}
+  - repository: mivisionx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/MIVisionX
+    ref: ${{ parameters.mivisionxRepoRef }}
+  - repository: amdmigraphx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/AMDMIGraphX
+    ref: ${{ parameters.amdmigraphxRepoRef }}
 
 trigger:
   batch: true

--- a/.github/scripts/azure_resolve_subtree_deps.py
+++ b/.github/scripts/azure_resolve_subtree_deps.py
@@ -105,6 +105,7 @@ def main(argv=None) -> None:
         "projects/hipblas": 317,
         "projects/hipsparse": 315,
         "projects/hipsparselt": 309,
+        "projects/miopen": 320
     }
 
     args = parse_arguments(argv)


### PR DESCRIPTION
Creates a trigger file for MIOpen and adds the new pipeline ID to the subtree script.

Adds new repositories resources in the trigger file, which are needed to run downstream runs for MIVisionX and AMDMIGraphX from the MIOpen pipeline.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=40708&view=results