### PR TITLE
[hipsparse] docs: Change GitHub links and install guides for mono-repo

### DIFF
--- a/projects/hipsparse/README.md
+++ b/projects/hipsparse/README.md
@@ -4,13 +4,13 @@ hipSPARSE is a SPARSE marshalling library with multiple supported backends. It s
 application and a 'worker' SPARSE library, where it marshals inputs to the backend library and marshals
 results to your application. hipSPARSE exports an interface that doesn't require the client to change,
 regardless of the chosen backend. Currently, hipSPARSE supports
-[rocSPARSE](https://github.com/ROCmSoftwarePlatform/rocSPARSE) and
+[rocSPARSE](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse) and
 [NVIDIA CUDA cuSPARSE](https://developer.nvidia.com/cusparse) backends.
 
 ## Documentation
 
 > [!NOTE]
-> The published hipSPARSE documentation is available at [https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/](https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/index.html) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the hipSPARSE/docs folder of this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
+> The published hipSPARSE documentation is available at [https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/](https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/index.html) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the `rocm-libraries/projects/hipsparse` folder of this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
 
 To build our documentation locally, run the following code:
 
@@ -44,7 +44,8 @@ To build hipSPARSE, you can use our bash helper script (for Ubuntu only) or you 
 build (for all supported platforms).
 
 * Bash helper script (`install.sh`):
-  This script, which is located in the root of this repository, builds and installs hipSPARSE on Ubuntu
+  This script, which is located in the `rocm-libraries/projects/hipsparse` folder
+  of the rocm-libraries repository, builds and installs hipSPARSE on Ubuntu
   with a single command. Note that this option doesn't allow much customization and hard-codes
   configurations that can be specified through invoking CMake directly. Some commands in the script
   require sudo access, so it may prompt you for a password.
@@ -56,14 +57,13 @@ build (for all supported platforms).
 
 * Manual build:
     If you use a distribution other than Ubuntu, or would like more control over the build process,
-    the [hipSPARSE build wiki](https://github.com/ROCmSoftwarePlatform/hipSPARSE/wiki/Build)
+    the [hipSPARSE installation guide](https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/install/install.html)
     provides information on how to configure CMake and build hipSPARSE manually.
 
 ### Supported functions
 
-You can find a list of
-[exported functions](https://github.com/ROCmSoftwarePlatform/hipSPARSE/wiki/Exported-functions)
-on our wiki.
+See the hipSPARSE documentation for a list of
+[exported functions](https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/reference/api.html).
 
 ## Interface examples
 

--- a/projects/hipsparse/docs/index.rst
+++ b/projects/hipsparse/docs/index.rst
@@ -16,7 +16,12 @@ of the AMD ROCm runtime and toolchains and optimized for AMD discrete GPUs.
 
 For more information, see :doc:`What is hipSPARSE? <./what-is-hipsparse>`
 
-The hipSPARSE public repository is located at `<https://github.com/ROCm/hipSPARSE>`_.
+The hipSPARSE public repository is located at `<https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparse>`_.
+
+
+.. note::
+
+   The hipSPARSE repository for ROCm 6.4.2 and earlier is located at `<https://github.com/ROCm/hipSPARSE>`_.
 
 .. grid:: 2
   :gutter: 3
@@ -31,7 +36,7 @@ The hipSPARSE public repository is located at `<https://github.com/ROCm/hipSPARS
 
   .. grid-item-card:: Examples
 
-    * `Client samples <https://github.com/ROCm/hipSPARSE/tree/develop/clients/samples>`_
+    * `Client samples <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparse/clients/samples>`_
 
   .. grid-item-card:: API reference
 

--- a/projects/hipsparse/docs/install/install.rst
+++ b/projects/hipsparse/docs/install/install.rst
@@ -42,7 +42,7 @@ To build hipSPARSE from source, follow the instructions in this section.
 To compile and run hipSPARSE, the `AMD ROCm Platform <https://github.com/ROCm/ROCm>`_ is required.
 The build also requires the following compile-time dependencies:
 
-*  `rocSPARSE <https://github.com/ROCm/rocSPARSE>`_
+*  `rocSPARSE <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse>`_
 *  `git <https://git-scm.com/>`_
 *  `CMake <https://cmake.org/>`_ (Version 3.5 or later)
 *  `GoogleTest <https://github.com/google/googletest>`_ (Optional: only required to build the clients)
@@ -50,19 +50,51 @@ The build also requires the following compile-time dependencies:
 Downloading hipSPARSE
 -------------------------
 
-The hipSPARSE source code is available from the `hipSPARSE GitHub <https://github.com/ROCm/hipSPARSE>`_.
-Download the develop branch using these commands:
+The hipSPARSE source code is available from the `hipSPARSE folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparse>`_
+of the `rocm-libraries GitHub <https://github.com/ROCm/rocm-libraries>`_.
+Download the develop branch using either a sparse checkout or a full clone of the rocm-libraries repository.
+
+To limit your local checkout to only the hipSPARSE project, configure ``sparse-checkout`` before cloning.
+This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+Use the following commands for a sparse checkout:
+
+.. note::
+
+   To include the rocSPARSE dependencies, set the projects for the sparse checkout using
+   ``git sparse-checkout set projects/hipsparse projects/rocsparse``.
 
 .. code-block:: shell
 
-   git clone -b develop https://github.com/ROCm/hipSPARSE.git
-   cd hipSPARSE
+   git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries
+   git sparse-checkout init --cone
+   git sparse-checkout set projects/hipsparse # add projects/rocsparse to include dependencies
+   git checkout develop # or use the branch you want to work with
+
+
+To download the develop branch for all projects in rocm-libraries, use these commands. This process takes
+longer but is recommended for those working with a large number of libraries.
+
+.. code-block:: shell
+
+   git clone -b develop https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries/projects/hipsparse
+
+
+.. note::
+
+   To build ROCm 6.4.2 and earlier, use the hipSPARSE repository at `<https://github.com/ROCm/hipSPARSE>`_.
+   For more information, see the documentation associated with the release you want to build.
 
 Building hipSPARSE using the install script
 -------------------------------------------
 
 It's recommended to use the ``install.sh`` script to install hipSPARSE.
 Here are the steps required to build different packages of the library, including the dependencies and clients.
+
+.. note::
+
+   You can run the ``install.sh`` script from the ``projects/hipsparse`` directory.
 
 Using install.sh to build hipSPARSE with dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,6 +129,10 @@ Building hipSPARSE using individual make commands
 --------------------------------------------------
 
 You can build hipSPARSE using the following commands:
+
+.. note::
+
+   Run these commands from the ``projects/hipsparse`` directory.
 
 .. note::
 
@@ -149,7 +185,7 @@ You can test the installation by running one of the hipSPARSE examples after suc
 .. code-block:: shell
 
       # Navigate to clients binary directory
-      cd hipSPARSE/build/release/clients/staging
+      cd build/release/clients/staging
 
       # Execute hipSPARSE example
       ./example_csrmv 1000

--- a/projects/hipsparse/docs/sphinx/_toc.yml.in
+++ b/projects/hipsparse/docs/sphinx/_toc.yml.in
@@ -19,7 +19,7 @@ subtrees:
 
 - caption: Examples
   entries:
-  - url: https://github.com/ROCm/hipSPARSE/tree/develop/clients/samples
+  - url: https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparse/clients/samples
     title: Client samples
 
 - caption: Examples

--- a/projects/hipsparse/docs/what-is-hipsparse.rst
+++ b/projects/hipsparse/docs/what-is-hipsparse.rst
@@ -30,10 +30,10 @@ The hipSPARSE functionality is organized into the following categories:
 * :ref:`hipsparse_reordering_functions`: Operations on a matrix in sparse format to obtain a reordering.
 * :ref:`hipsparse_generic_functions`: Operations that manipulate sparse matrices.
 
-The source code can be found at `<https://github.com/ROCm/hipSPARSE>`_.
+The source code can be found at `<https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparse>`_.
 
 .. note::
 
    hipSPARSE focuses on convenience and portability.
    If performance outweighs these factors, it's better to use rocSPARSE directly.
-   The rocSPARSE source code can be found on the `rocSPARSE GitHub <https://github.com/ROCm/rocSPARSE>`_.
+   The rocSPARSE source code can be found on the `rocSPARSE GitHub <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse>`_.


### PR DESCRIPTION
This edits the install guide and changes GitHub links in the index and on other pages. It also updates other GitHub links. It points users back to the old repository for release 6.4.2 and earlier.