### PR TITLE
[rocsparse] Uncomment spmv_csr tests that were mistakenly disabled

### DIFF
--- a/projects/rocsparse/clients/tests/test_spmv_csr.yaml
+++ b/projects/rocsparse/clients/tests/test_spmv_csr.yaml
@@ -72,6 +72,447 @@ Definitions:
     - { M: 1029843, N: 1029843 }
 
 Tests:
+- name: spmv_csr_bad_arg
+  category: pre_checkin
+  function: spmv_csr_bad_arg
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex_real
+
+#
+# general matrix type
+#
+
+- name: spmv_csr
+  category: quick
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex_real
+  M: [10, 500]
+  N: [33, 842]
+  alpha_beta: *alpha_beta_range_quick
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+
+- name: spmv_csr
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex_real
+  M: [0, 7111]
+  N: [0, 4441]
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+  call_stage_analysis: [false, true]
+
+- name: spmv_csr
+  category: nightly
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex_real
+  M: [39385, 639102]
+  N: [29348, 710341]
+  alpha_beta: *alpha_beta_range_nightly
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+
+- name: spmv_csr
+  category: nightly
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions
+  M: [39385, 639102]
+  N: [29348, 710341]
+  alpha_beta: *alpha_beta_range_nightly
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
+
+- name: spmv_csr_file
+  category: quick
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_quick
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+  filename: [mac_econ_fwd500,
+             nos2,
+             nos4]
+
+- name: spmv_csr_file
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+  filename: [rma10,
+             mc2depi,
+             ASIC_320k,
+             nos1,
+             nos3,
+             nos5,
+             nos7]
+
+- name: spmv_csr_file
+  category: nightly
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_nightly
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
+  filename: [bibd_22_8,
+             bmwcra_1,
+             amazon0312,
+             Chebyshev4,
+             sme3Dc,
+             shipsec1,
+             scircuit]
+
+- name: spmv_csr_file
+  category: quick
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *double_only_precisions_complex
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_quick
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+  filename: [Chevron2,
+             qc2534]
+
+- name: spmv_csr_file
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
+  filename: [Chevron2,
+             Chevron3]
+
+- name: spmv_csr_file
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *double_only_precisions_complex
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
+  filename: [mplate]
+
+- name: spmv_csr_file
+  category: nightly
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_nightly
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+  filename: [Chevron4]
+
+- name: spmv_csr_graph_test
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex_real
+  M: [10, 500]
+  N: [33, 842]
+  alpha_beta: *alpha_beta_range_quick
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+  graph_test: true
+  call_stage_analysis: [false, true]
+
+#
+# symmetric and triangular matrix type
+#
+
+- name: spmv_csr
+  category: quick
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex_real
+  M_N: *M_N_range_quick
+  alpha_beta: *alpha_beta_range_quick
+  transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
+  uplo: [rocsparse_fill_mode_lower]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+
+- name: spmv_csr
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex_real
+  M_N: *M_N_range_checkin
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
+  uplo: [rocsparse_fill_mode_upper]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+
+- name: spmv_csr
+  category: nightly
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex_real
+  M_N: *M_N_range_nightly
+  alpha_beta: *alpha_beta_range_nightly
+  transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_symmetric]
+  uplo: [rocsparse_fill_mode_upper]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+
+- name: spmv_csr_file
+  category: quick
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *double_only_precisions
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_quick
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
+  uplo: [rocsparse_fill_mode_lower, rocsparse_fill_mode_upper]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+  filename: [mac_econ_fwd500,
+             nos2,
+             nos4]
+
+- name: spmv_csr_file
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *double_only_precisions
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
+  uplo: [rocsparse_fill_mode_lower, rocsparse_fill_mode_upper]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+  filename: [rma10,
+             mc2depi,
+             nos1,
+             nos3,
+             nos5,
+             nos7]
+
+- name: spmv_csr_file
+  category: nightly
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *double_only_precisions
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_nightly
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
+  uplo: [rocsparse_fill_mode_lower, rocsparse_fill_mode_upper]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
+  filename: [bmwcra_1,
+             amazon0312,
+             Chebyshev4,
+             sme3Dc,
+             shipsec1,
+             scircuit]
+
+- name: spmv_csr_file
+  category: quick
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *double_only_precisions_complex
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_quick
+  transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
+  uplo: [rocsparse_fill_mode_lower, rocsparse_fill_mode_upper]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+  filename: [Chevron2,
+             qc2534]
+
+- name: spmv_csr_file
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *double_only_precisions_complex
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
+  uplo: [rocsparse_fill_mode_upper]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
+  filename: [mplate,
+             Chevron3]
+
+- name: spmv_csr_file
+  category: nightly
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *single_double_precisions_complex
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_nightly
+  transA: [rocsparse_operation_none, rocsparse_operation_transpose]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
+  uplo: [rocsparse_fill_mode_lower]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+  filename: [Chevron4]
+
+#
+# mixed precision
+#
+
+- name: spmv_csr_file
+  category: quick
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *float32_float64_float64_float64
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_quick
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
+  filename: [bmwcra_1,
+             amazon0312,
+             sme3Dc]
+
+- name: spmv_csr
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *float32_float64_float64_float64
+  M: [34, 104, 343, 5196]
+  N: [57, 109, 458, 3425]
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+
+
+- name: spmv_csr_file
+  category: quick
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *int8_int8_int32_int32_axyt_precision
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_quick
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
+  filename: [bmwcra_1,
+             amazon0312,
+             sme3Dc]
+
+- name: spmv_csr
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *int8_int8_float32_float32_axyt_precision
+  M: [34, 104, 343, 5196]
+  N: [57, 109, 458, 3425]
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+
+- name: spmv_csr
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *float16_float16_float32_float32_axyt_precision
+  M: [55, 145, 768]
+  N: [65, 210, 818]
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+
 - name: spmv_csr
   category: quick
   function: spmv_csr
@@ -81,523 +522,68 @@ Tests:
   N: [76, 478, 586]
   alpha_beta: *alpha_beta_range_quick
   transA: [rocsparse_operation_none]
-  baseA: [rocsparse_index_base_zero]
+  baseA: [rocsparse_index_base_one]
   matrix: [rocsparse_matrix_random]
   matrix_type: [rocsparse_matrix_type_general]
   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
 
-# - name: spmv_csr_bad_arg
-#   category: pre_checkin
-#   function: spmv_csr_bad_arg
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex_real
+- name: spmv_csr
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *cmplx32_cmplx64_cmplx64_cmplx64
+  M: [16, 78, 294, 482, 68302]
+  N: [16, 93, 297, 657, 46342]
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
 
-# #
-# # general matrix type
-# #
+- name: spmv_csr_file
+  category: nightly
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *cmplx32_cmplx64_cmplx64_cmplx64
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_nightly
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+  filename: [Chebyshev4,
+             shipsec1,
+             scircuit]
 
-# - name: spmv_csr
-#   category: quick
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex_real
-#   M: [10, 500]
-#   N: [33, 842]
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
+- name: spmv_csr
+  category: pre_checkin
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *float32_cmplx32_cmplx32_cmplx32_axyt_precision
+  M: [16, 78, 294, 482, 68302]
+  N: [16, 93, 297, 657, 46342]
+  alpha_beta: *alpha_beta_range_checkin
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_zero]
+  matrix: [rocsparse_matrix_random]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
 
-# - name: spmv_csr
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex_real
-#   M: [0, 7111]
-#   N: [0, 4441]
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
-#   call_stage_analysis: [false, true]
-
-# - name: spmv_csr
-#   category: nightly
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex_real
-#   M: [39385, 639102]
-#   N: [29348, 710341]
-#   alpha_beta: *alpha_beta_range_nightly
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-
-# - name: spmv_csr
-#   category: nightly
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions
-#   M: [39385, 639102]
-#   N: [29348, 710341]
-#   alpha_beta: *alpha_beta_range_nightly
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-
-# - name: spmv_csr_file
-#   category: quick
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
-#   filename: [mac_econ_fwd500,
-#              nos2,
-#              nos4]
-
-# - name: spmv_csr_file
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-#   filename: [rma10,
-#              mc2depi,
-#              ASIC_320k,
-#              nos1,
-#              nos3,
-#              nos5,
-#              nos7]
-
-# - name: spmv_csr_file
-#   category: nightly
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_nightly
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-#   filename: [bibd_22_8,
-#              bmwcra_1,
-#              amazon0312,
-#              Chebyshev4,
-#              sme3Dc,
-#              shipsec1,
-#              scircuit]
-
-# - name: spmv_csr_file
-#   category: quick
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *double_only_precisions_complex
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
-#   filename: [Chevron2,
-#              qc2534]
-
-# - name: spmv_csr_file
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-#   filename: [Chevron2,
-#              Chevron3]
-
-# - name: spmv_csr_file
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *double_only_precisions_complex
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-#   filename: [mplate]
-
-# - name: spmv_csr_file
-#   category: nightly
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_nightly
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-#   filename: [Chevron4]
-
-# - name: spmv_csr_graph_test
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex_real
-#   M: [10, 500]
-#   N: [33, 842]
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
-#   graph_test: true
-#   call_stage_analysis: [false, true]
-
-# #
-# # symmetric and triangular matrix type
-# #
-
-# - name: spmv_csr
-#   category: quick
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex_real
-#   M_N: *M_N_range_quick
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
-#   uplo: [rocsparse_fill_mode_lower]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
-
-# - name: spmv_csr
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex_real
-#   M_N: *M_N_range_checkin
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
-#   uplo: [rocsparse_fill_mode_upper]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
-
-# - name: spmv_csr
-#   category: nightly
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex_real
-#   M_N: *M_N_range_nightly
-#   alpha_beta: *alpha_beta_range_nightly
-#   transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_symmetric]
-#   uplo: [rocsparse_fill_mode_upper]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
-
-# - name: spmv_csr_file
-#   category: quick
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *double_only_precisions
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
-#   uplo: [rocsparse_fill_mode_lower, rocsparse_fill_mode_upper]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
-#   filename: [mac_econ_fwd500,
-#              nos2,
-#              nos4]
-
-# - name: spmv_csr_file
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *double_only_precisions
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
-#   uplo: [rocsparse_fill_mode_lower, rocsparse_fill_mode_upper]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-#   filename: [rma10,
-#              mc2depi,
-#              nos1,
-#              nos3,
-#              nos5,
-#              nos7]
-
-# - name: spmv_csr_file
-#   category: nightly
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *double_only_precisions
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_nightly
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
-#   uplo: [rocsparse_fill_mode_lower, rocsparse_fill_mode_upper]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-#   filename: [bmwcra_1,
-#              amazon0312,
-#              Chebyshev4,
-#              sme3Dc,
-#              shipsec1,
-#              scircuit]
-
-# - name: spmv_csr_file
-#   category: quick
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *double_only_precisions_complex
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
-#   uplo: [rocsparse_fill_mode_lower, rocsparse_fill_mode_upper]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_rowsplit]
-#   filename: [Chevron2,
-#              qc2534]
-
-# - name: spmv_csr_file
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *double_only_precisions_complex
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
-#   uplo: [rocsparse_fill_mode_upper]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-#   filename: [mplate,
-#              Chevron3]
-
-# - name: spmv_csr_file
-#   category: nightly
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *single_double_precisions_complex
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_nightly
-#   transA: [rocsparse_operation_none, rocsparse_operation_transpose]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_symmetric, rocsparse_matrix_type_triangular]
-#   uplo: [rocsparse_fill_mode_lower]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-#   filename: [Chevron4]
-
-# #
-# # mixed precision
-# #
-
-# - name: spmv_csr_file
-#   category: quick
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *float32_float64_float64_float64
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-#   filename: [bmwcra_1,
-#              amazon0312,
-#              sme3Dc]
-
-# - name: spmv_csr
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *float32_float64_float64_float64
-#   M: [34, 104, 343, 5196]
-#   N: [57, 109, 458, 3425]
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-
-
-# - name: spmv_csr_file
-#   category: quick
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *int8_int8_int32_int32_axyt_precision
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-#   filename: [bmwcra_1,
-#              amazon0312,
-#              sme3Dc]
-
-# - name: spmv_csr
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *int8_int8_float32_float32_axyt_precision
-#   M: [34, 104, 343, 5196]
-#   N: [57, 109, 458, 3425]
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-
-# - name: spmv_csr
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *float16_float16_float32_float32_axyt_precision
-#   M: [55, 145, 768]
-#   N: [65, 210, 818]
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-
-# - name: spmv_csr
-#   category: quick
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *bfloat16_bfloat16_float32_float32_axyt_precision
-#   M: [65, 475, 827]
-#   N: [76, 478, 586]
-#   alpha_beta: *alpha_beta_range_quick
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-
-# - name: spmv_csr
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *cmplx32_cmplx64_cmplx64_cmplx64
-#   M: [16, 78, 294, 482, 68302]
-#   N: [16, 93, 297, 657, 46342]
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-
-# - name: spmv_csr_file
-#   category: nightly
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *cmplx32_cmplx64_cmplx64_cmplx64
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_nightly
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-#   filename: [Chebyshev4,
-#              shipsec1,
-#              scircuit]
-
-# - name: spmv_csr
-#   category: pre_checkin
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *float32_cmplx32_cmplx32_cmplx32_axyt_precision
-#   M: [16, 78, 294, 482, 68302]
-#   N: [16, 93, 297, 657, 46342]
-#   alpha_beta: *alpha_beta_range_checkin
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_zero]
-#   matrix: [rocsparse_matrix_random]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_rowsplit, rocsparse_spmv_alg_csr_lrb]
-
-# - name: spmv_csr_file
-#   category: nightly
-#   function: spmv_csr
-#   indextype: *i32i32_i64i32_i64i64
-#   precision: *float64_cmplx64_cmplx64_cmplx64_axyt_precision
-#   M: 1
-#   N: 1
-#   alpha_beta: *alpha_beta_range_nightly
-#   transA: [rocsparse_operation_none]
-#   baseA: [rocsparse_index_base_one]
-#   matrix: [rocsparse_matrix_file_rocalution]
-#   matrix_type: [rocsparse_matrix_type_general]
-#   spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
-#   filename: [Chebyshev4,
-#              shipsec1]
+- name: spmv_csr_file
+  category: nightly
+  function: spmv_csr
+  indextype: *i32i32_i64i32_i64i64
+  precision: *float64_cmplx64_cmplx64_cmplx64_axyt_precision
+  M: 1
+  N: 1
+  alpha_beta: *alpha_beta_range_nightly
+  transA: [rocsparse_operation_none]
+  baseA: [rocsparse_index_base_one]
+  matrix: [rocsparse_matrix_file_rocalution]
+  matrix_type: [rocsparse_matrix_type_general]
+  spmv_alg: [rocsparse_spmv_alg_csr_adaptive, rocsparse_spmv_alg_csr_lrb]
+  filename: [Chebyshev4,
+             shipsec1]


### PR DESCRIPTION
The spmv_csr tests were mistakenly disabled in https://github.com/ROCm/rocm-libraries/commit/bfad6133e92b81352303632e27eeeadfbb210526 