### PR TITLE
[rocBLAS] bench use hip event timing default

### DIFF
--- a/projects/rocblas/clients/common/client_utility.cpp
+++ b/projects/rocblas/clients/common/client_utility.cpp
@@ -272,20 +272,20 @@ double get_time_us_sync_device(void)
 /*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and return wall time */
 double get_time_us_sync(hipStream_t stream)
 {
-    static int oldStreamSync = [&] {
+    static bool oldStreamSync = [&] {
         // set old mode if env variable is set
         const char* str_stream_sync
-            = getenv("ROCBLAS_BENCH_STREAM_SYNC"); // windows this is fine for static init
+            = getenv("ROCBLAS_BENCH_STREAM_SYNC"); // windows getenv is fine for static init
         if(str_stream_sync)
         {
-            return (strncmp(str_stream_sync, "1", 1) == 0 ? 1 : 0);
+            return (strncmp(str_stream_sync, "1", 1) == 0 ? true : false);
         }
-        return 0;
+        return false;
     }();
 
     if(oldStreamSync)
     {
-        hipStreamSynchronize(stream);
+        THROW_IF_HIP_ERROR(hipStreamSynchronize(stream));
 
         auto now = std::chrono::steady_clock::now();
         // now.time_since_epoch() is the duration since epoch

--- a/projects/rocblas/clients/common/client_utility.cpp
+++ b/projects/rocblas/clients/common/client_utility.cpp
@@ -35,6 +35,7 @@
 #include <stdexcept>
 #include <stdlib.h>
 #include <thread>
+
 #ifdef BUILD_WITH_HIPBLASLT
 #include <hipblaslt/hipblaslt-ext.hpp>
 #endif
@@ -271,14 +272,57 @@ double get_time_us_sync_device(void)
 /*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and return wall time */
 double get_time_us_sync(hipStream_t stream)
 {
-    hipStreamSynchronize(stream);
+    static int oldStreamSync = [&] {
+        // set old mode if env variable is set
+        const char* str_stream_sync
+            = getenv("ROCBLAS_BENCH_STREAM_SYNC"); // windows this is fine for static init
+        if(str_stream_sync)
+        {
+            return (strncmp(str_stream_sync, "1", 1) == 0 ? 1 : 0);
+        }
+        return 0;
+    }();
 
-    auto now = std::chrono::steady_clock::now();
-    // now.time_since_epoch() is the duration since epoch
-    // which is converted to microseconds
-    auto duration
-        = std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
-    return (static_cast<double>(duration));
+    if(oldStreamSync)
+    {
+        hipStreamSynchronize(stream);
+
+        auto now = std::chrono::steady_clock::now();
+        // now.time_since_epoch() is the duration since epoch
+        // which is converted to microseconds
+        auto duration
+            = std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+        return (static_cast<double>(duration));
+    }
+    else
+    {
+        // avoid any stream synchronization overhead on timing
+        static thread_local hipEvent_t start{nullptr};
+        static thread_local hipEvent_t stop{nullptr};
+        if(!start)
+        {
+            THROW_IF_HIP_ERROR(hipStreamSynchronize(stream));
+            THROW_IF_HIP_ERROR(hipEventCreate(&start));
+            THROW_IF_HIP_ERROR(hipEventCreate(&stop));
+            THROW_IF_HIP_ERROR(hipEventRecord(start, stream));
+
+            return 0.0;
+        }
+        else
+        {
+            THROW_IF_HIP_ERROR(hipEventRecord(stop, stream));
+            THROW_IF_HIP_ERROR(hipStreamSynchronize(stream));
+
+            float milliseconds = 0;
+            THROW_IF_HIP_ERROR(hipEventElapsedTime(&milliseconds, start, stop));
+            THROW_IF_HIP_ERROR(hipEventDestroy(stop));
+            THROW_IF_HIP_ERROR(hipEventDestroy(start));
+            start = nullptr; // reset start event for next use
+            stop  = nullptr;
+
+            return milliseconds * 1000.0; // convert to microseconds
+        }
+    }
 };
 
 /*! \brief  CPU Timer(in microsecond): no GPU synchronization */

--- a/projects/rocblas/clients/common/client_utility.cpp
+++ b/projects/rocblas/clients/common/client_utility.cpp
@@ -301,9 +301,9 @@ double get_time_us_sync(hipStream_t stream)
         static thread_local hipEvent_t stop{nullptr};
         if(!start)
         {
-            THROW_IF_HIP_ERROR(hipStreamSynchronize(stream));
             THROW_IF_HIP_ERROR(hipEventCreate(&start));
             THROW_IF_HIP_ERROR(hipEventCreate(&stop));
+            THROW_IF_HIP_ERROR(hipStreamSynchronize(stream));
             THROW_IF_HIP_ERROR(hipEventRecord(start, stream));
 
             return 0.0;

--- a/projects/rocblas/docs/how-to/Programmers_Guide.rst
+++ b/projects/rocblas/docs/how-to/Programmers_Guide.rst
@@ -1507,6 +1507,15 @@ For the above command, instead of using the ``-r`` parameter to specify the prec
 This mixed-precision support is only available for ``gemv_batched``, ``gemv_strided_batched``, and rocBLAS extension
 functions (for example, ``axpy_ex``, ``scal_ex``, and ``gemm_ex``). For more information, see the :ref:`api-reference-guide`.
 
+
+.. _rocblas_bench_stream_sync:
+
+rocblas-bench timing
+^^^^^^^^^^^^^^^^^^^^^
+
+rocblas-bench uses ``hipEvent_t`` recording to time API calls and ignore the overhead of any ``hipStreamSynchronize`` call. 
+To switch back to the earlier timing approach that uses ``hipStreamSynchronize`` to ensure work completion, set the environment variable ``ROCBLAS_BENCH_STREAM_SYNC=1``.
+
 rocblas-gemm-tune
 -----------------
 
@@ -1542,6 +1551,7 @@ sample code showing how to use kernels directly via their indices.
 
 If the output is stored in a file, you can use the results to override the default kernel selection
 by setting the environment variable ``ROCBLAS_TENSILE_GEMM_OVERRIDE_PATH=<path>``, where ``<path>`` points to the file.
+
 
 rocblas-test
 -------------

--- a/projects/rocblas/docs/reference/env-variables.rst
+++ b/projects/rocblas/docs/reference/env-variables.rst
@@ -49,6 +49,13 @@ tables.
       - | **0**: Disable
         | **1**: Enable
 
+    * - | ``ROCBLAS_BENCH_STREAM_SYNC``
+        | Benchmark timing based on ``hipStreamSynchronize``, otherwise uses default ``hipEvent_t`` based timing.
+      - 0
+      - :ref:`rocblas_bench_stream_sync`
+      - | **0**: Disable
+        | **1**: Enable
+
 Logging environment variables
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
default to be more consistent perf. across these:
* ROCBLAS_STREAM_ORDER_ALLOC=0 ./rocblas-bench ...
* ROCBLAS_STREAM_ORDER_ALLOC=1 ./rocblas-bench

old way had significant differences:
* ROCBLAS_STREAM_ORDER_ALLOC=0 ROCBLAS_BENCH_STREAM_SYNC=1 ./rocblas-bench ...
* ROCBLAS_STREAM_ORDER_ALLOC=1 ROCBLAS_BENCH_STREAM_SYNC=1 ./rocblas-bench