### PR TITLE
[ci] - Switching mi300 to mi325

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -151,5 +151,5 @@ jobs:
     with:
       project_to_test: ${{ inputs.project_to_test }}
       amdgpu_families: "gfx94X-dcgpu"
-      test_runs_on: "linux-mi300-1gpu-ossci-rocm"
+      test_runs_on: "linux-mi325-1gpu-ossci-rocm"
       platform: "linux"


### PR DESCRIPTION
As noted in [TheRock PR 1141](https://github.com/ROCm/TheRock/pull/1141), "OSSCI cluster is losing a bunch of mi300 capacity and getting more mi325 capacity for the time being"

Test run here: https://github.com/ROCm/rocm-libraries/actions/runs/16581217647