### PR TITLE
[Ex CI] enable hipSOLVER

### DIFF
--- a/.azuredevops/hipsolver.yml
+++ b/.azuredevops/hipsolver.yml
@@ -1,0 +1,47 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: pipelinesRepoRef
+  type: string
+  default: refs/heads/develop
+- name: triggerDownstreamJobs
+  type: boolean
+  default: true
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+    ref: ${{ parameters.pipelinesRepoRef }}
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - develop
+    - release-staging/rocm-rel-7.*
+  paths:
+    include:
+    - projects/hipsolver
+    exclude:
+    - projects/hipsolver/.githooks
+    - projects/hipsolver/.github
+    - projects/hipsolver/.jenkins
+    - projects/hipsolver/docs
+    - projects/hipsolver/.*.y*ml
+    - projects/hipsolver/*.md
+
+pr: none
+
+stages:
+- stage: hipsolver
+  jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/hipSOLVER.yml@pipelines_repo
+    parameters:
+      sparseCheckoutDir: projects/hipsolver
+      triggerDownstreamJobs: ${{ parameters.triggerDownstreamJobs }}
+- template: templates/report-summary-check-wrapper.yml

--- a/.github/scripts/azure_resolve_subtree_deps.py
+++ b/.github/scripts/azure_resolve_subtree_deps.py
@@ -103,6 +103,7 @@ def main(argv=None) -> None:
         "projects/rocsolver": 303,
         "projects/rocsparse": 314,
         "projects/hipblas": 317,
+        "projects/hipsolver": 322,
         "projects/hipsparse": 315,
         "projects/hipsparselt": 309,
     }


### PR DESCRIPTION
Creates a trigger file for hipSOLVER and adds the new pipeline ID to the subtree script.

Sample run:
https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=40959&view=results