### PR TITLE
Avoid zero division in auto gsu and num enqueues

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Source/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/client/main.cpp
@@ -743,9 +743,6 @@ int main(int argc, const char* argv[])
                     if(solution == nullptr)
                         throw std::runtime_error("Could not find a solution");
 
-                    // for a new problem, autoGSU should be re-calculated
-                    solution->autoGSU = 0;
-
                     listeners.preSolution(*solution);
                     if(solutionIterator->runCurrentSolution() && runKernels)
                     {

--- a/projects/hipblaslt/tensilelite/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -261,7 +261,8 @@ namespace TensileLite
                     throw std::runtime_error(
                         "[BenchmarkTimer] Failed to cast problem to any ContractionProblem.");
                 }
-                size_t flopsInProblem = flopCount;
+                // avoid zero division
+                size_t flopsInProblem = flopCount != 0 ? flopCount : 1;
                 enqueuesByFlops       = CeilDivide(m_minFlopsPerSync, flopsInProblem);
             }
 

--- a/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -929,14 +929,7 @@ namespace TensileLite
     inline void ContractionSolution::calculateAutoGSU(Problem const&  problem,
                                                       Hardware const* hardware) const
     {
-        // Temporal remove until the cache mechanism is fixed
-        // autoGSU is already calculated
-        // if(autoGSU != 0)
-        // {
-        //     return;
-        // }
-
-        // original GSU is not -1
+        // if original GSU is not -1
         if(sizeMapping.globalSplitU != -1)
         {
             autoGSU = sizeMapping.globalSplitU;

--- a/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -929,12 +929,6 @@ namespace TensileLite
     inline void ContractionSolution::calculateAutoGSU(Problem const&  problem,
                                                       Hardware const* hardware) const
     {
-        if(problem.groupedGemm())
-        {
-            autoGSU = 1;
-            return;
-        }
-
         // Temporal remove until the cache mechanism is fixed
         // autoGSU is already calculated
         // if(autoGSU != 0)
@@ -953,6 +947,12 @@ namespace TensileLite
         assert(pAMDGPU);
         uint32_t numCUs       = pAMDGPU->computeUnitCount;
         uint32_t numWGs       = getNumWorkGroups(problem, sizeMapping);
+        // avoid zero division
+        if (numWGs == 0)
+        {
+            autoGSU = 1;
+            return;
+        }
         uint32_t MT0          = sizeMapping.macroTile.x;
         uint32_t MT1          = sizeMapping.macroTile.y;
         uint32_t MT2          = sizeMapping.depthU;

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gsu/auto_gsu_zero_dim.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gsu/auto_gsu_zero_dim.yaml
@@ -1,0 +1,74 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: 0
+  MinimumRequiredVersion: 5.0.0
+  DataInitTypeAlpha: 1
+  DataInitTypeBeta: 0
+  NewClient: 2
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  Device: 0
+  PrintSolutionRejectionReason: True
+  MinKForGSU: 2
+  CMakeBuildType: Debug
+
+BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      UseBias: 1
+      Batched: True
+      Activation: True
+      ActivationType: all
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1,  1,  2, 2,  2, 2] #64x64
+          - [32, 32, 8,  1,  1,  1, 1,  2, 2] #64x64
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [-1]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [-1]
+        - PreloadKernArgs: [1]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer","MultipleBufferSingleKernel"]
+        - GlobalSplitUCoalesced: [False,True]
+        - GlobalSplitUWorkGroupMappingRoundRobin: [False,True]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [0, 4096, 1, 4096]
+          - Exact: [0, 128, 1, 4096]
+          - Exact: [0, 128, 1, 128]
+          - Exact: [4096, 0, 1, 4096]
+          - Exact: [128, 0, 1, 4096]
+          - Exact: [128, 0, 1, 128]
+          - Exact: [4096, 4096, 0, 4096]
+          - Exact: [128, 128, 0, 4096]
+          - Exact: [128, 128, 0, 128]
+          - Exact: [4096, 4096, 1, 0]
+          - Exact: [128, 128, 1, 0]
+          - Exact: [128, 128, 1, 0]
+        - BiasTypeArgs: ['h']
+        - ActivationArgs:
+          - [Enum: relu]


### PR DESCRIPTION
This bug is triggered by zero size tuning with auto gsu. For example, [16, 0, 1, 262144], the calculated flops used by enqueuesByFlops is zero, to avoid zero division error, we should fix it to be one. In auto gsu, we will see numWGs is zero, and it should be avoided, then forcing autoGSU to be one.