### PR TITLE
Revert "[Workaround] "-lflang_rt.runtime" not ready so use "-lFortranRuntime … (#656)"

### DIFF
--- a/projects/hipsparselt/clients/benchmarks/CMakeLists.txt
+++ b/projects/hipsparselt/clients/benchmarks/CMakeLists.txt
@@ -81,7 +81,12 @@ if (NOT WIN32)
   if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
   else()
-    list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
+    find_library(FortranRuntime NAMES FortranRuntime PATH ${HIP_CLANG_ROOT}/lib)
+    if ( ${FortranRuntime} STREQUAL "FortranRuntime-NOTFOUND" )
+      list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
+    else()
+      list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+    endif()
   endif()
 else()
   list( APPEND COMMON_LINK_LIBS "libomp")

--- a/projects/hipsparselt/clients/benchmarks/CMakeLists.txt
+++ b/projects/hipsparselt/clients/benchmarks/CMakeLists.txt
@@ -81,7 +81,7 @@ if (NOT WIN32)
   if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
   else()
-    list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+    list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
   endif()
 else()
   list( APPEND COMMON_LINK_LIBS "libomp")

--- a/projects/hipsparselt/clients/gtest/CMakeLists.txt
+++ b/projects/hipsparselt/clients/gtest/CMakeLists.txt
@@ -90,7 +90,7 @@ list( APPEND COMMON_LINK_LIBS "-lm -lstdc++fs")
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
 else()
-  list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+  list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
 endif()
 
 #if (NOT WIN32)

--- a/projects/hipsparselt/clients/gtest/CMakeLists.txt
+++ b/projects/hipsparselt/clients/gtest/CMakeLists.txt
@@ -90,7 +90,12 @@ list( APPEND COMMON_LINK_LIBS "-lm -lstdc++fs")
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
 else()
-  list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
+  find_library(FortranRuntime NAMES FortranRuntime PATH ${HIP_CLANG_ROOT}/lib)
+  if ( ${FortranRuntime} STREQUAL "FortranRuntime-NOTFOUND" )
+    list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
+  else()
+    list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+  endif()
 endif()
 
 #if (NOT WIN32)


### PR DESCRIPTION
This reverts commit c6c0a69810f082a84513b53062b1b0b7f210ec2c.
for [SWDEV-544106](https://ontrack-internal.amd.com/browse/SWDEV-544106)