### PR TITLE
Revert "-lFortranRuntime -lFortranDecimal" and use "-lflang_rt.runtime" instead

### DIFF
--- a/projects/hipblaslt/clients/benchmarks/CMakeLists.txt
+++ b/projects/hipblaslt/clients/benchmarks/CMakeLists.txt
@@ -89,7 +89,12 @@ if (NOT WIN32)
   if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
   else()
-    list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
+    find_library(FortranRuntime NAMES FortranRuntime PATH ${HIP_CLANG_ROOT}/lib)
+    if ( ${FortranRuntime} STREQUAL "FortranRuntime-NOTFOUND" )
+      list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
+    else()
+      list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+    endif()
   endif()
 else()
   list( APPEND COMMON_LINK_LIBS "libomp")

--- a/projects/hipblaslt/clients/benchmarks/CMakeLists.txt
+++ b/projects/hipblaslt/clients/benchmarks/CMakeLists.txt
@@ -89,7 +89,7 @@ if (NOT WIN32)
   if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
   else()
-    list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+    list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
   endif()
 else()
   list( APPEND COMMON_LINK_LIBS "libomp")

--- a/projects/hipblaslt/clients/gtest/CMakeLists.txt
+++ b/projects/hipblaslt/clients/gtest/CMakeLists.txt
@@ -122,7 +122,7 @@ list( APPEND COMMON_LINK_LIBS "-lm -lstdc++fs")
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
 else()
-  list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+  list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
 endif()
 
 #if (NOT WIN32)

--- a/projects/hipblaslt/clients/gtest/CMakeLists.txt
+++ b/projects/hipblaslt/clients/gtest/CMakeLists.txt
@@ -122,7 +122,12 @@ list( APPEND COMMON_LINK_LIBS "-lm -lstdc++fs")
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
 else()
-  list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
+  find_library(FortranRuntime NAMES FortranRuntime PATH ${HIP_CLANG_ROOT}/lib)
+  if ( ${FortranRuntime} STREQUAL "FortranRuntime-NOTFOUND" )
+    list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
+  else()
+    list( APPEND COMMON_LINK_LIBS "-lFortranRuntime -lFortranDecimal") # for lapack
+  endif()
 endif()
 
 #if (NOT WIN32)


### PR DESCRIPTION
Revert "-lFortranRuntime -lFortranDecimal" and use "-lflang_rt.runtime" instead
for [SWDEV-544106](https://ontrack-internal.amd.com/browse/SWDEV-544106)