### PR TITLE
Add cmake-format with pre-commit

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,23 @@
+with section("parse"):
+    additional_commands = {
+        "rocm_create_package": {
+            "kwargs": {"NAME": 1, "DESCRIPTION": 1, "MAINTAINER": 1, "LDCONFIG_DIR": 1},
+            "flags": ["LDCONFIG", "HEADER_ONLY"],
+        }
+    }
+
+with section("format"):
+    line_width = 100
+    tab_size = 4
+    dangle_parens = True
+    command_case = "lower"
+    enable_sort = True
+    max_subgroups_hwrap = 4
+    max_pargs_hwrap = 6
+    max_lines_hwrap = 2
+
+with section("markup"):
+    first_comment_is_literal = True
+
+with section("lint"):
+    disabled_codes = ["C0301", "W0106"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__
+
+# Build directories
+_build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,9 @@ repos:
         name: clang-format (C/C++/ObjC)
         entry: clang-format -i -style=file
         files: '\.(c|cpp|cc|h|hpp|m|mm)$'
+
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.10
+    hooks:
+      - id: cmake-format
+      - id: cmake-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
 exclude: |
-  third_party/
+    third_party/
+    build/
+    build-.*/
+    _build/
+    projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/projects/hipblas-common/CMakeLists.txt
+++ b/projects/hipblas-common/CMakeLists.txt
@@ -1,26 +1,5 @@
-# ########################################################################
-#
-# MIT License
-#
-# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
-# ies of the Software, and to permit persons to whom the Software is furnished
-# to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
-# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
-# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-# ########################################################################
+# Copyright Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.11)
 project(hipblas-common VERSION 1.2.0 LANGUAGES CXX)
@@ -33,36 +12,30 @@ include(CMakePackageConfigHelpers)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     if(WIN32)
-      set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path prefix" FORCE)
+        set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path prefix" FORCE)
     else()
-      set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix" FORCE)
+        set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix" FORCE)
     endif()
 endif()
 
 add_library(hipblas-common INTERFACE)
 add_library(roc::hipblas-common ALIAS hipblas-common)
 
-target_sources(hipblas-common 
+target_sources(
+    hipblas-common
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/include/hipblas-common/hipblas-common.h>
 )
-target_include_directories(hipblas-common
-    INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/include>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+target_include_directories(
+    hipblas-common INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/include>
+                             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-rocm_install_targets(
-  TARGETS hipblas-common
-  INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/library/include
-)
+rocm_install_targets(TARGETS hipblas-common INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/library/include)
 
-rocm_export_targets(
-    TARGETS roc::hipblas-common
-    NAMESPACE roc::
-)
+rocm_export_targets(TARGETS roc::hipblas-common NAMESPACE roc::)
 
-if (WIN32)
+if(WIN32)
     set(CPACK_SOURCE_GENERATOR "ZIP")
     set(CPACK_GENERATOR "ZIP")
     set(CPACK_SET_DESTDIR FALSE)
@@ -72,7 +45,9 @@ elseif(NOT CPACK_PACKAGING_INSTALL_PREFIX)
 endif()
 
 set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}")
-set(HIPBLAS_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file")
+set(HIPBLAS_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+    CACHE PATH "Path placed into ldconfig file"
+)
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md")
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 


### PR DESCRIPTION
Add cmakelang checks to the pre-commit spec. If pre-commit is enabled, cmake-format and cmake-lint will be called and block the commit if errors are encountered.