### PR TITLE
Add origami datatype and conversion function to python bindings

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Source/lib/include/Tensile/analytical/Hardware.hpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/lib/include/Tensile/analytical/Hardware.hpp
@@ -64,6 +64,11 @@ namespace TensileLite
             None = Count
         };
 
+        inline DataType intToDataType(int dt)
+        {
+            return (DataType)dt;
+        }
+
         inline int dataTypeToBits(DataType type)
         {
             switch(type)

--- a/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/origami_module.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/origami_module.cpp
@@ -9,6 +9,31 @@ using Hardware    = TensileLite::analytical::Hardware;
 
 PYBIND11_MODULE(origami, m)
 {
+    pybind11::enum_<TensileLite::analytical::DataType>(m, "DataType")
+        .value("Float", TensileLite::analytical::DataType::Float)
+        .value("Double", TensileLite::analytical::DataType::Double)
+        .value("ComplexFloat", TensileLite::analytical::DataType::ComplexFloat)
+        .value("ComplexDouble", TensileLite::analytical::DataType::ComplexDouble)
+        .value("Half", TensileLite::analytical::DataType::Half)
+        .value("Int8x4", TensileLite::analytical::DataType::Int8x4)
+        .value("Int32", TensileLite::analytical::DataType::Int32)
+        .value("BFloat16", TensileLite::analytical::DataType::BFloat16)
+        .value("Int8", TensileLite::analytical::DataType::Int8)
+        .value("Int64", TensileLite::analytical::DataType::Int64)
+        .value("XFloat32", TensileLite::analytical::DataType::XFloat32)
+        .value("Float8_fnuz", TensileLite::analytical::DataType::Float8_fnuz)
+        .value("BFloat8_fnuz", TensileLite::analytical::DataType::BFloat8_fnuz)
+        .value("Float8BFloat8_fnuz", TensileLite::analytical::DataType::Float8BFloat8_fnuz)
+        .value("BFloat8Float8_fnuz", TensileLite::analytical::DataType::BFloat8Float8_fnuz)
+        .value("Float8", TensileLite::analytical::DataType::Float8)
+        .value("BFloat8", TensileLite::analytical::DataType::BFloat8)
+        .value("Float8BFloat8", TensileLite::analytical::DataType::Float8BFloat8)
+        .value("BFloat8Float8", TensileLite::analytical::DataType::BFloat8Float8)
+        .export_values();
+
+    m.def("intToDataType",
+          &Origami::intToDataType,
+          "Convert int to DataType.");
 
     pybind11::enum_<Hardware::Architecture>(m, "Architecture")
         .value("gfx942", Hardware::Architecture::gfx942)


### PR DESCRIPTION
Updates python bindings to work with new DataType enum for matrix instruction types.

To use it in scripts, specify DataType either using the enum like:

origami.DataType.Float

Or converting an integer with the function that casts the type:

intToDataType(0)