### PR TITLE
[Ex CI] add MIVisionX and MIGraphX repo resources to MIOpen's upstream triggers

### DIFF
--- a/.azuredevops/hipblas-common.yml
+++ b/.azuredevops/hipblas-common.yml
@@ -6,6 +6,12 @@ parameters:
 - name: pipelinesRepoRef
   type: string
   default: refs/heads/develop
+- name: mivisionxRepoRef
+  type: string
+  default: refs/heads/develop
+- name: amdmigraphxRepoRef
+  type: string
+  default: refs/heads/develop
 - name: triggerDownstreamJobs
   type: boolean
   default: true

--- a/.azuredevops/hipblas-common.yml
+++ b/.azuredevops/hipblas-common.yml
@@ -17,6 +17,16 @@ resources:
     endpoint: ROCm
     name: ROCm/ROCm
     ref: ${{ parameters.pipelinesRepoRef }}
+  - repository: mivisionx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/MIVisionX
+    ref: ${{ parameters.mivisionxRepoRef }}
+  - repository: amdmigraphx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/AMDMIGraphX
+    ref: ${{ parameters.amdmigraphxRepoRef }}
 
 trigger:
   batch: true

--- a/.azuredevops/hipblas.yml
+++ b/.azuredevops/hipblas.yml
@@ -6,6 +6,12 @@ parameters:
 - name: pipelinesRepoRef
   type: string
   default: refs/heads/develop
+- name: mivisionxRepoRef
+  type: string
+  default: refs/heads/develop
+- name: amdmigraphxRepoRef
+  type: string
+  default: refs/heads/develop
 - name: triggerDownstreamJobs
   type: boolean
   default: true

--- a/.azuredevops/hipblas.yml
+++ b/.azuredevops/hipblas.yml
@@ -17,6 +17,16 @@ resources:
     endpoint: ROCm
     name: ROCm/ROCm
     ref: ${{ parameters.pipelinesRepoRef }}
+  - repository: mivisionx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/MIVisionX
+    ref: ${{ parameters.mivisionxRepoRef }}
+  - repository: amdmigraphx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/AMDMIGraphX
+    ref: ${{ parameters.amdmigraphxRepoRef }}
 
 trigger:
   batch: true

--- a/.azuredevops/hipblaslt.yml
+++ b/.azuredevops/hipblaslt.yml
@@ -6,6 +6,12 @@ parameters:
 - name: pipelinesRepoRef
   type: string
   default: refs/heads/develop
+- name: mivisionxRepoRef
+  type: string
+  default: refs/heads/develop
+- name: amdmigraphxRepoRef
+  type: string
+  default: refs/heads/develop
 - name: triggerDownstreamJobs
   type: boolean
   default: true

--- a/.azuredevops/hipblaslt.yml
+++ b/.azuredevops/hipblaslt.yml
@@ -17,6 +17,16 @@ resources:
     endpoint: ROCm
     name: ROCm/ROCm
     ref: ${{ parameters.pipelinesRepoRef }}
+  - repository: mivisionx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/MIVisionX
+    ref: ${{ parameters.mivisionxRepoRef }}
+  - repository: amdmigraphx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/AMDMIGraphX
+    ref: ${{ parameters.amdmigraphxRepoRef }}
 
 trigger:
   batch: true

--- a/.azuredevops/rocblas.yml
+++ b/.azuredevops/rocblas.yml
@@ -6,6 +6,12 @@ parameters:
 - name: pipelinesRepoRef
   type: string
   default: refs/heads/develop
+- name: mivisionxRepoRef
+  type: string
+  default: refs/heads/develop
+- name: amdmigraphxRepoRef
+  type: string
+  default: refs/heads/develop
 - name: triggerDownstreamJobs
   type: boolean
   default: true

--- a/.azuredevops/rocblas.yml
+++ b/.azuredevops/rocblas.yml
@@ -17,6 +17,16 @@ resources:
     endpoint: ROCm
     name: ROCm/ROCm
     ref: ${{ parameters.pipelinesRepoRef }}
+  - repository: mivisionx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/MIVisionX
+    ref: ${{ parameters.mivisionxRepoRef }}
+  - repository: amdmigraphx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/AMDMIGraphX
+    ref: ${{ parameters.amdmigraphxRepoRef }}
 
 trigger:
   batch: true

--- a/.azuredevops/rocprim.yml
+++ b/.azuredevops/rocprim.yml
@@ -6,6 +6,12 @@ parameters:
 - name: pipelinesRepoRef
   type: string
   default: refs/heads/develop
+- name: mivisionxRepoRef
+  type: string
+  default: refs/heads/develop
+- name: amdmigraphxRepoRef
+  type: string
+  default: refs/heads/develop
 - name: triggerDownstreamJobs
   type: boolean
   default: true

--- a/.azuredevops/rocprim.yml
+++ b/.azuredevops/rocprim.yml
@@ -17,6 +17,16 @@ resources:
     endpoint: ROCm
     name: ROCm/ROCm
     ref: ${{ parameters.pipelinesRepoRef }}
+  - repository: mivisionx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/MIVisionX
+    ref: ${{ parameters.mivisionxRepoRef }}
+  - repository: amdmigraphx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/AMDMIGraphX
+    ref: ${{ parameters.amdmigraphxRepoRef }}
 
 trigger:
   batch: true

--- a/.azuredevops/rocrand.yml
+++ b/.azuredevops/rocrand.yml
@@ -6,6 +6,12 @@ parameters:
 - name: pipelinesRepoRef
   type: string
   default: refs/heads/develop
+- name: mivisionxRepoRef
+  type: string
+  default: refs/heads/develop
+- name: amdmigraphxRepoRef
+  type: string
+  default: refs/heads/develop
 - name: triggerDownstreamJobs
   type: boolean
   default: true

--- a/.azuredevops/rocrand.yml
+++ b/.azuredevops/rocrand.yml
@@ -17,6 +17,16 @@ resources:
     endpoint: ROCm
     name: ROCm/ROCm
     ref: ${{ parameters.pipelinesRepoRef }}
+  - repository: mivisionx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/MIVisionX
+    ref: ${{ parameters.mivisionxRepoRef }}
+  - repository: amdmigraphx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/AMDMIGraphX
+    ref: ${{ parameters.amdmigraphxRepoRef }}
 
 trigger:
   batch: true

--- a/.azuredevops/rocsolver.yml
+++ b/.azuredevops/rocsolver.yml
@@ -6,6 +6,12 @@ parameters:
 - name: pipelinesRepoRef
   type: string
   default: refs/heads/develop
+- name: mivisionxRepoRef
+  type: string
+  default: refs/heads/develop
+- name: amdmigraphxRepoRef
+  type: string
+  default: refs/heads/develop
 - name: triggerDownstreamJobs
   type: boolean
   default: true

--- a/.azuredevops/rocsolver.yml
+++ b/.azuredevops/rocsolver.yml
@@ -17,6 +17,16 @@ resources:
     endpoint: ROCm
     name: ROCm/ROCm
     ref: ${{ parameters.pipelinesRepoRef }}
+  - repository: mivisionx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/MIVisionX
+    ref: ${{ parameters.mivisionxRepoRef }}
+  - repository: amdmigraphx_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/AMDMIGraphX
+    ref: ${{ parameters.amdmigraphxRepoRef }}
 
 trigger:
   batch: true


### PR DESCRIPTION
Adds MIVisionX and MIGraphX in `resources.repositories` for every pipeline that calls MIOpen as a downstream job. These resources are required in order to checkout MIVisionX and MIGraphX repositories.