### PR TITLE
[rocBLAS] Update min CMake version

### DIFF
--- a/projects/rocblas/CMakeLists.txt
+++ b/projects/rocblas/CMakeLists.txt
@@ -22,6 +22,9 @@
 
 cmake_minimum_required( VERSION 3.16.8 )
 
+if( NOT SKIP_LIBRARY )
+  cmake_minimum_required( VERSION 3.24.4 )
+endif()
 
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE

--- a/projects/rocblas/CMakeLists.txt
+++ b/projects/rocblas/CMakeLists.txt
@@ -20,12 +20,7 @@
 #
 # ########################################################################
 
-cmake_minimum_required( VERSION 3.16.8 )
-
-# library build requires newer CMake version to build
-if( NOT SKIP_LIBRARY )
-  cmake_minimum_required( VERSION 3.24.4 )
-endif()
+cmake_minimum_required( VERSION 3.24.4 )
 
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE

--- a/projects/rocblas/CMakeLists.txt
+++ b/projects/rocblas/CMakeLists.txt
@@ -22,6 +22,7 @@
 
 cmake_minimum_required( VERSION 3.16.8 )
 
+# library build requires newer CMake version to build
 if( NOT SKIP_LIBRARY )
   cmake_minimum_required( VERSION 3.24.4 )
 endif()

--- a/projects/rocblas/install.sh
+++ b/projects/rocblas/install.sh
@@ -151,7 +151,7 @@ install_packages( )
   fi
 
   # wget and openssl are needed for cmake
-  if [ -z "$CMAKE_VERSION" ] || $(dpkg --compare-versions $CMAKE_VERSION lt 3.16.8); then
+  if [ -z "$CMAKE_VERSION" ] || $(dpkg --compare-versions $CMAKE_VERSION lt $CMAKE_MIN_VERSION); then
     if $update_cmake == true; then
       library_dependencies_ubuntu+=("wget" "libssl-dev")
       library_dependencies_centos_rhel+=("wget" "openssl-devel")
@@ -457,25 +457,27 @@ fc="gfortran"
 # #################################################
 if [[ "${install_dependencies}" == true ]]; then
   CMAKE_VERSION=$(${cmake_executable} --version | grep -oP '(?<=version )[^ ]*')
+  CMAKE_MIN_VERSION="3.24.4"
 
   install_packages
 
-  if [ -z "$CMAKE_VERSION" ] || $(dpkg --compare-versions $CMAKE_VERSION lt 3.16.8); then
+  if [ -z "$CMAKE_VERSION" ] || $(dpkg --compare-versions $CMAKE_VERSION lt $CMAKE_MIN_VERSION); then
       if $update_cmake == true; then
         pushd .
         printf "\033[32mBuilding \033[33mcmake\033[32m from source; installing into \033[33m/usr/local\033[0m\n"
-        CMAKE_REPO="https://github.com/Kitware/CMake/releases/download/v3.16.8/"
+        CMAKE_REPO="https://github.com/Kitware/CMake/releases/download"
+        CMAKE_TARGZ="cmake-${CMAKE_MIN_VERSION}.tar.gz"
         mkdir -p ${build_dir}/deps && cd ${build_dir}/deps
-        wget -nv ${CMAKE_REPO}/cmake-3.16.8.tar.gz
-        tar -xvf cmake-3.16.8.tar.gz
-        rm cmake-3.16.8.tar.gz
-        cd cmake-3.16.8
+        wget -nv ${CMAKE_REPO}/v${CMAKE_MIN_VERSION}/${CMAKE_TARGZ}
+        tar -xvf ${CMAKE_TARGZ}
+        rm ${CMAKE_TARGZ}
+        cd cmake-${CMAKE_MIN_VERSION}
         ./bootstrap --no-system-curl --parallel=16
         make -j16
         elevate_if_not_root make install
         popd
       else
-          echo "rocBLAS requires CMake version >= 3.16.8 and CMake version ${CMAKE_VERSION} is installed. Run install.sh again with --cmake_install flag and CMake version 3.16.8 will be installed to /usr/local"
+          echo "rocBLAS requires CMake version >= ${CMAKE_MIN_VERSION} and CMake version ${CMAKE_VERSION} is installed. Run install.sh again with --cmake_install flag and CMake version ${CMAKE_MIN_VERSION} will be installed to /usr/local"
           exit 2
       fi
   fi


### PR DESCRIPTION
This change updates the required minimum version of CMake to comile rocBLAS to 3.24.4. In case the option --cmake_install is provided to rocBLAS install.sh, the version 3.24.4 will be installed if an older version or no CMake is found.

The previous minimum required version of CMake (3.16.8) fails to compile Tensile with error:
```
cmake -E env: unknown option '--'
make[2]: *** [library/src/CMakeFiles/TENSILE_LIBRARY_TARGET.dir/build.make:65: Tensile/library] Error 1
make[1]: *** [CMakeFiles/Makefile2:484: library/src/CMakeFiles/TENSILE_LIBRARY_TARGET.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```