### PR TITLE
[hipblas] docs: Change GitHub links and install guides for mono-repo

### DIFF
--- a/projects/hipblas/README.md
+++ b/projects/hipblas/README.md
@@ -33,22 +33,43 @@ cmake -DBUILD_DOCS=ON ...
 
 ## Build and install
 
-1. Download the hipBLAS source code (clone this repository):
+1. Checkout the hipBLAS code using either a sparse checkout or a full clone of the rocm-libraries repository.
+
+   To limit your local checkout to only the rocSPARSE project, configure ``sparse-checkout`` before cloning.
+   This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+   Use the following commands for a sparse checkout:
 
     ```bash
-        git clone https://github.com/ROCmSoftwarePlatform/hipBLAS.git
+
+    git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+    cd rocm-libraries
+    git sparse-checkout init --cone
+    git sparse-checkout set projects/hipblas # add projects/rocsolver and projects/rocblas to include dependencies
+    git checkout develop # or use the branch you want to work with
+    ```
+
+   To clone the entire rocm-libraries repository, use the following commands. This process takes more time,
+   but is recommended if you want to work with a large number of libraries.
+
+    ```bash
+
+    # Clone rocm-libraries, including hipBLAS, using Git
+    git clone https://github.com/ROCm/rocm-libraries.git
+
+    # Go to rocSPARSE directory
+    cd rocm-libraries/projects/hipblas
     ```
 
     ```note
         hipBLAS requires specific versions of rocBLAS and rocSOLVER. Refer to
-        [CMakeLists.txt](https://github.com/ROCmSoftwarePlatform/hipBLAS/blob/develop/library/CMakeLists.txt)
+        [CMakeLists.txt](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipblas/library/CMakeLists.txt)
         for details.
     ```
 
-2. Build hipBLAS and install it into `/opt/rocm/hipblas`:
+2. Build hipBLAS using the `install.sh` script and install it into `/opt/rocm/hipblas`:
 
     ```bash
-        cd hipblas
+        cd rocm-libraries/projects/hipblas
         ./install.sh -i
     ```
 

--- a/projects/hipblas/README.md
+++ b/projects/hipblas/README.md
@@ -44,7 +44,7 @@ cmake -DBUILD_DOCS=ON ...
     git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
     cd rocm-libraries
     git sparse-checkout init --cone
-    git sparse-checkout set projects/hipblas # add projects/rocsolver and projects/rocblas to include dependencies
+    git sparse-checkout set projects/hipblas # add projects/rocsolver projects/rocblas projects/hipblas-common to include dependencies
     git checkout develop # or use the branch you want to work with
     ```
 
@@ -56,7 +56,7 @@ cmake -DBUILD_DOCS=ON ...
     # Clone rocm-libraries, including hipBLAS, using Git
     git clone https://github.com/ROCm/rocm-libraries.git
 
-    # Go to rocSPARSE directory
+    # Go to hipBLAS directory
     cd rocm-libraries/projects/hipblas
     ```
 

--- a/projects/hipblas/README.md
+++ b/projects/hipblas/README.md
@@ -35,7 +35,7 @@ cmake -DBUILD_DOCS=ON ...
 
 1. Checkout the hipBLAS code using either a sparse checkout or a full clone of the rocm-libraries repository.
 
-   To limit your local checkout to only the rocSPARSE project, configure ``sparse-checkout`` before cloning.
+   To limit your local checkout to only the hipBLAS project, configure ``sparse-checkout`` before cloning.
    This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
    Use the following commands for a sparse checkout:
 

--- a/projects/hipblas/docs/how-to/using-hipblas-clients.rst
+++ b/projects/hipblas/docs/how-to/using-hipblas-clients.rst
@@ -77,7 +77,7 @@ hipblas-bench supports data-driven benchmarks using a YAML-format specification 
    ./hipblas-bench --yaml <file>.yaml
 
 For example, ``hipblas_smoke.yaml`` is a YAML file used to run a smoke test.
-However, other examples can be found in the `rocBLAS <https://github.com/ROCm/rocBLAS>`_ GitHub repository.
+However, other examples can be found in the `rocBLAS <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas>`_ GitHub repository.
 
 hipblas-test
 ============
@@ -111,7 +111,7 @@ hipblas-test provides support for data-driven testing using a YAML-format test s
    ./hipblas-test --yaml <file>.yaml
 
 As an example, ``hipblas_smoke.yaml`` is a YAML file that is used to run a smoke test.
-Other examples can be found in the `rocBLAS <https://github.com/ROCm/rocBLAS>`_ GitHub repository.
+Other examples can be found in the `rocBLAS <https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas>`_ GitHub repository.
 YAML-based tests list function parameter values in the test name, which can be also used for
 test filtering using the ``gtest_filter`` argument.
 To run the provided smoke test, use this command:

--- a/projects/hipblas/docs/index.rst
+++ b/projects/hipblas/docs/index.rst
@@ -15,7 +15,12 @@ hipBLAS exports an interface that does not require client changes, regardless of
 chosen backend. Currently, it supports :doc:`rocBLAS <rocblas:index>` and
 NVIDIA CUDA `cuBLAS <https://developer.nvidia.com/cublas>`_ as backends.
 
-The hipBLAS public repository is located at  `<https://github.com/ROCm/hipBLAS>`_.
+The hipBLAS public repository is located at 
+`<https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas>`_.
+
+.. note::
+
+   The hipBLAS repository for ROCm 6.4.3 and earlier is located at `<https://github.com/ROCm/hipBLAS>`_.
 
 .. grid:: 2
   :gutter: 3
@@ -40,7 +45,7 @@ The hipBLAS public repository is located at  `<https://github.com/ROCm/hipBLAS>`
 
   .. grid-item-card:: Examples
 
-    * `hipBLAS client examples <https://github.com/ROCm/hipBLAS/tree/develop/clients/samples>`_
+    * `hipBLAS client examples <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas/clients/samples>`_
 
   .. grid-item-card:: API Reference
 

--- a/projects/hipblas/docs/install/Linux_Install_Guide.rst
+++ b/projects/hipblas/docs/install/Linux_Install_Guide.rst
@@ -49,14 +49,14 @@ Use the following commands for a sparse checkout:
 .. note::
 
    To include the hipBLAS dependencies, set the projects for the sparse checkout using
-   ``git sparse-checkout set projects/hipblas projects/rocsolver projects/rocblas``.
+   ``git sparse-checkout set projects/hipblas projects/rocsolver projects/rocblas projects/hipblas-common``.
 
 .. code-block:: shell
 
    git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
    cd rocm-libraries
    git sparse-checkout init --cone
-   git sparse-checkout set projects/hipblas # add projects/rocsolver and projects/rocblas to include dependencies
+   git sparse-checkout set projects/hipblas # add projects/rocsolver projects/rocblas projects/hipblas-common to include dependencies
    git checkout develop # or use the branch you want to work with
 
 .. note::

--- a/projects/hipblas/docs/install/Linux_Install_Guide.rst
+++ b/projects/hipblas/docs/install/Linux_Install_Guide.rst
@@ -14,9 +14,7 @@ For a list of installation prerequisites, see :doc:`hipBLAS prerequisites <prere
 Installing prebuilt packages
 =============================
 
-You can manually download the prebuilt hipBLAS packages from the :doc:`ROCm native package manager <rocm-install-on-linux:install/quick-start>`
-or by clicking the `GitHub releases tab <https://github.com/ROCm/hipBLAS/releases>`_.
-The versions on GitHub might be more recent. Release notes are available for each release on the releases tab.
+You can manually download the prebuilt hipBLAS packages from the :doc:`ROCm native package manager <rocm-install-on-linux:install/quick-start>`.
 
 To download the prebuilt package, use this command:
 
@@ -30,6 +28,44 @@ Building hipBLAS from source
 When building hipBLAS from source, you can choose to build only the library and its dependencies or include the client and its
 dependencies.
 
+Download hipBLAS
+----------------
+
+The hipBLAS source code is available from the `hipBLAS folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas>`_
+of the `rocm-libraries GitHub <https://github.com/ROCm/rocm-libraries>`_.
+
+To download hipBLAS, including all projects in the rocm-libraries repository, use the following commands.
+
+.. code-block:: shell
+
+   git clone -b release/rocm-rel-x.y https://github.com/ROCm/rocm-libraries.git
+   cd  rocm-libraries/projects/hipblas
+
+
+To limit your local checkout to only the hipBLAS project, configure ``sparse-checkout`` before cloning.
+This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+Use the following commands for a sparse checkout:
+
+.. note::
+
+   To include the hipBLAS dependencies, set the projects for the sparse checkout using
+   ``git sparse-checkout set projects/hipblas projects/rocsolver projects/rocblas``.
+
+.. code-block:: shell
+
+   git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries
+   git sparse-checkout init --cone
+   git sparse-checkout set projects/hipblas # add projects/rocsolver and projects/rocblas to include dependencies
+   git checkout develop # or use the branch you want to work with
+
+.. note::
+
+   To build ROCm 6.4.3 and older, use the hipBLAS repository at `<https://github.com/ROCm/hipBLAS>`_.
+   For more information, see the documentation associated with the release you want to build.
+
+The hipBLAS source code is found in the ``projects/hipblas`` directory.
+
 Building the library and library dependencies
 ---------------------------------------------
 
@@ -38,6 +74,10 @@ hipBLAS with a single command. It accepts several options but has a hard-coded c
 that you can override by invoking ``cmake`` directly. However, it's a great way to get started quickly and
 serves as an example of how to build and install hipBLAS.
 A few commands in the script require ``sudo`` access, which might prompt you for a password.
+
+.. note::
+
+   You can run the ``rmake.py`` script from the ``projects/hipblas`` directory.
 
 The install script determines the build platform by querying ``hipconfig --platform``. This value can be explicitly defined
 by setting the environment variable ``HIP_PLATFORM`` to ``HIP_PLATFORM=amd`` or ``HIP_PLATFORM=nvidia``.
@@ -129,7 +169,7 @@ Build the library, tests, benchmarks, and samples using individual commands
 ----------------------------------------------------------------------------
 
 The repository contains source code for clients that serve as samples, tests, and benchmarks. These source code files can be
-found in the `clients subdirectory <https://github.com/ROCm/hipBLAS/tree/develop/clients>`_ of the hipBLAS GitHub.
+found in the `clients subdirectory <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas/clients>`_ of the hipBLAS GitHub.
 
 Dependencies (only necessary for hipBLAS clients)
 -------------------------------------------------

--- a/projects/hipblas/docs/install/Windows_Install_Guide.rst
+++ b/projects/hipblas/docs/install/Windows_Install_Guide.rst
@@ -78,14 +78,14 @@ Use the following commands for a sparse checkout:
 .. note::
 
    To include the hipBLAS dependencies, set the projects for the sparse checkout using
-   ``git sparse-checkout set projects/hipblas projects/rocsolver projects/rocblas``.
+   ``git sparse-checkout set projects/hipblas projects/rocsolver projects/rocblas projects/hipblas-common``.
 
 .. code-block:: shell
 
    git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
    cd rocm-libraries
    git sparse-checkout init --cone
-   git sparse-checkout set projects/hipblas # add projects/rocsolver and projects/rocblas to include dependencies
+   git sparse-checkout set projects/hipblas # add projects/rocsolver projects/rocblas, projects/hipblas-common to include dependencies
    git checkout develop # or use the branch you want to work with
 
 .. note::

--- a/projects/hipblas/docs/install/Windows_Install_Guide.rst
+++ b/projects/hipblas/docs/install/Windows_Install_Guide.rst
@@ -41,8 +41,8 @@ If necessary, users can follow these instructions to build hipBLAS from source.
 Download the hipBLAS source code
 --------------------------------
 
-The hipBLAS source code is available on the `hipBLAS GitHub <https://github.com/ROCm/hipBLAS>`_.
-The ROCm HIP SDK version might be shown in the default installation path,
+The hipBLAS source code is available from the `hipBLAS folder <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas>`_
+of the `rocm-libraries GitHub <https://github.com/ROCm/rocm-libraries>`_.The ROCm HIP SDK version might be shown in the default installation path,
 but you can run the HIP SDK compiler to display the version from the ``bin/`` folder:
 
 ::
@@ -52,21 +52,46 @@ but you can run the HIP SDK compiler to display the version from the ``bin/`` fo
 The HIP version includes the major, minor, and patch fields, and possibly a build-specific identifier.
 As an example, the HIP version might be ``5.4.22880-135e1ab4``.
 This corresponds to major release = ``5``, minor release = ``4``, patch = ``22880``, and the build identifier ``135e1ab4``.
-The hipBLAS GitHub contains branches with names like ``release/rocm-rel-major.minor``. Select the branch where the major and minor
+The rocm-libraries GitHub contains branches with names like ``release/rocm-rel-major.minor``. Select the branch where the major and minor
 fields correspond to the HIP version.
-For example, use the following command format to download hipBLAS:
+
+To download hipBLAS, including all projects in the rocm-libraries repository, use the following commands.
 
 ::
 
-    git clone -b release/rocm-rel-x.y https://github.com/ROCm/hipBLAS.git
+   git clone -b release/rocm-rel-x.y https://github.com/ROCm/rocm-libraries.git
+   cd  rocm-libraries/projects/hipblas
 
 Replace ``x.y`` in this command with the version of the HIP SDK installed on your machine.
-For example, if you have HIP 6.2 installed, then use ``-b release/rocm-rel-6.2``.
+For example, if you have HIP 7.0 installed, then use ``-b release/rocm-rel-7.0``.
 You can add the SDK tools to your path with an entry such as:
 
 ::
 
     %HIP_PATH%\bin
+
+
+To limit your local checkout to only the hipBLAS project, configure ``sparse-checkout`` before cloning.
+This uses the Git partial clone feature (``--filter=blob:none``) to reduce how much data is downloaded.
+Use the following commands for a sparse checkout:
+
+.. note::
+
+   To include the hipBLAS dependencies, set the projects for the sparse checkout using
+   ``git sparse-checkout set projects/hipblas projects/rocsolver projects/rocblas``.
+
+.. code-block:: shell
+
+   git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git
+   cd rocm-libraries
+   git sparse-checkout init --cone
+   git sparse-checkout set projects/hipblas # add projects/rocsolver and projects/rocblas to include dependencies
+   git checkout develop # or use the branch you want to work with
+
+.. note::
+
+   To build ROCm 6.4.3 and older, use the hipBLAS repository at `<https://github.com/ROCm/hipBLAS>`_.
+   For more information, see the documentation associated with the release you want to build.
 
 Building the library and library dependencies
 ---------------------------------------------
@@ -76,6 +101,10 @@ with a single command. It accepts several options but has a hard-coded configura
 that you can override by invoking ``cmake`` directly. However, it's a great way to get started quickly and serves
 as an example of how to build and install hipBLAS.
 A few commands in the script require administrator access, so you might be prompted for a password.
+
+.. note::
+
+   You can run the ``rmake.py`` script from the ``projects/hipblas`` directory.
 
 Common examples showing how to use ``rmake.py`` to build the library dependencies and library are listed
 in this table:

--- a/projects/hipblas/docs/install/prerequisites.rst
+++ b/projects/hipblas/docs/install/prerequisites.rst
@@ -19,7 +19,7 @@ The hipBLAS prerequisites are different than the :doc:`rocBLAS <rocblas:index>` 
 *  The prerequisites required to use the rocBLAS backend with AMD components are as follows:
 
    * A ROCm-enabled platform. For more information, see the :doc:`Linux system requirements <rocm-install-on-linux:reference/system-requirements>`.
-   * A compatible version of `hipblas-common <https://github.com/ROCm/hipBLAS-common>`_.
+   * A compatible version of `hipblas-common <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common>`_.
    * A compatible version of rocBLAS.
    * For full functionality, optionally install a compatible version of :doc:`rocSOLVER <rocsolver:index>` and its :doc:`rocSPARSE <rocsparse:index>`
      and :doc:`rocPRIM <rocprim:index>` dependencies.
@@ -35,7 +35,7 @@ Prerequisites for Microsoft Windows
 *  Here are the prerequisites required to use the rocBLAS backend with AMD components:
 
    * An AMD HIP SDK-enabled platform. For more information, see :doc:`Windows system requirements <rocm-install-on-windows:reference/system-requirements>`.
-   * A compatible version of hipblas-common.
+   * A compatible version of `hipblas-common <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common>`_.
    * A compatible version of rocBLAS.
    * For full functionality, a compatible version of :doc:`rocSOLVER <rocsolver:index>` and its :doc:`rocSPARSE <rocsparse:index>`
      and :doc:`rocPRIM <rocprim:index>` dependencies.

--- a/projects/hipblas/docs/reference/hipblas-api-functions.rst
+++ b/projects/hipblas/docs/reference/hipblas-api-functions.rst
@@ -147,7 +147,7 @@ hipBLAS types
 *************
 
 For information about the ``hipblasStatus_t``, ``hipblasComputeType_t``, and ``hipblasOperation_t`` enumerations,
-see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/hipBLAS-common>`_ repository.
+see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common>`_ repository.
 
 Definitions
 ===========
@@ -181,13 +181,13 @@ hipblasStatus_t
 -----------------
 
 For information about ``hipblasStatus_t``,
-see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/hipBLAS-common>`_ repository.
+see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common>`_ repository.
 
 hipblasOperation_t
 ------------------
 
 For information about ``hipblasOperation_t``,
-see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/hipBLAS-common>`_ repository.
+see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common>`_ repository.
 
 
 hipblasPointerMode_t
@@ -210,7 +210,7 @@ hipblasComputeType_t
 --------------------
 
 For information about ``hipblasComputeType_t``,
-see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/hipBLAS-common>`_ repository.
+see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common>`_ repository.
 
 
 hipblasGemmAlgo_t

--- a/projects/hipblas/docs/sphinx/_toc.yml.in
+++ b/projects/hipblas/docs/sphinx/_toc.yml.in
@@ -22,7 +22,7 @@ subtrees:
       title: Contribute to hipBLAS
 - caption: Examples
   entries:
-  - url: https://github.com/ROCm/hipBLAS/tree/develop/clients/samples
+  - url: https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas/clients/samples
     title: hipBLAS client examples
 - caption: API Reference
   entries:


### PR DESCRIPTION
This edits the install guides (Windows and Linux) and changes GitHub links in the index and on other pages. It also updates other GitHub links. It points users back to the old repository for release 6.4 and earlier.