### PR TITLE
[hipfft] Add code coverage (#132)

### DIFF
--- a/projects/hipfft/README.md
+++ b/projects/hipfft/README.md
@@ -69,6 +69,15 @@ Here are some CMake build examples:
 The `-DBUILD_CLIENTS=ON` option is only allowed with the amdclang++ or HIPCC compilers.
 ```
 
+## Code Coverage
+You can generate a test coverage report with the following:
+
+```bash
+cmake -DCMAKE_CXX_COMPILER=amdclang++ -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON -DBUILD_CODE_COVERAGE=ON <optional: -DCOVERAGE_TEST_OPTIONS="cmdline args to pass to hipfft-test (default: --smoketest)"> ..
+make -j coverage
+```
+The commands above will output the coverage report to the terminal and save an html coverage report to `$PWD/coverage-report`.  Note that hipFFT uses llvm for code coverage, which only works with clang compilers.
+
 ## Porting from CUDA
 
 If you have existing CUDA code and want to transition to HIP, follow these steps:

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -222,3 +222,41 @@ if (WIN32)
     add_custom_command( TARGET hipfft-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} $<TARGET_FILE_DIR:hipfft-test> )
   endforeach( file_i )
 endif()
+
+option(BUILD_CODE_COVERAGE "Build with code coverage flags (clang only)" OFF)
+set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for hipfft-test when generating a code coverage report")
+if (BUILD_CODE_COVERAGE)
+  add_custom_target(
+    code_cov_tests
+    DEPENDS hipfft-test
+    COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
+    COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
+    COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/hipfft-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG $<TARGET_FILE:hipfft-test> --precompile=./clients/staging/hipfft-test-precompile.db ${COVERAGE_TEST_OPTIONS}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+  find_program(
+    LLVM_PROFDATA
+    llvm-profdata
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+
+  find_program(
+    LLVM_COV
+    llvm-cov
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+
+  add_custom_target(
+    coverage
+    DEPENDS code_cov_tests
+    COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
+    COMMAND ${LLVM_COV} report -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
+    COMMAND ${LLVM_COV} show -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+endif()

--- a/projects/hipfft/library/CMakeLists.txt
+++ b/projects/hipfft/library/CMakeLists.txt
@@ -179,3 +179,8 @@ if( ROCmCMakeBuildTools_FOUND )
       ${static_depends}
     NAMESPACE hip:: )
 endif()
+
+if (BUILD_CODE_COVERAGE)
+  target_compile_options( hipfft PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
+  target_link_options( hipfft PUBLIC -fprofile-instr-generate )
+endif()


### PR DESCRIPTION
Added two new targets, code_cov_tests and coverage.

To generate a coverage report, a user can add the -DBUILD_CODE_COVERAGE=ON option to cmake and then run make -j coverage. This will dump the code coverage report to the terminal and also create an html file that can be served or uploaded to Jenkins.

Default hipfft-test parameters are --smoketest, however, a user can customize their options by setting COVERAGE_TEST_OPTIONS="--arg1=value --arg2=value ...". See README for more details.

[ROCm/hipFFT commit: 0b463618d022b04d0ddee493b63c389ed48bc80c]

(cherry picked from commit 6111f96a84d8ffd52c07f6a2f6e8d57c64623dbf)