### PR TITLE
Correct GTest print check for 128-bit ints on Windows

### DIFF
--- a/projects/rocprim/test/rocprim/test_utils_assertions.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_assertions.hpp
@@ -48,17 +48,10 @@
 
 namespace test_utils {
 
-#if ROCPRIM_HAS_INT128_SUPPORT
 template<class T>
 using is_int128 = std::is_same<rocprim::int128_t, typename std::remove_cv<T>::type>;
 template<class T>
 using is_uint128 = std::is_same<rocprim::uint128_t, typename std::remove_cv<T>::type>;
-#else
-template<class T>
-using is_int128 = std::false_type;
-template<class T>
-using is_uint128 = std::false_type;
-#endif // ROCPRIM_HAS_INT128_SUPPORT
 
 template<class T>
 using is_double_custom_type = std::is_same<typename std::remove_cv<T>::type, common::custom_type<double,double,1>>;


### PR DESCRIPTION
Currently, on Windows, GTest cannot print 128-bit ints. We have a check in `test_utils::protected_assert_eq` that avoids calling `ASSERT_EQ` on 128-bit int values directly, since this will cause the values to be printed in the event of an error.

This check was relying on the `is_int128` alias, which was being set to `false_type` when `ROCPRIM_HAS_INT128_SUPPORT` was `false`. As a result, when 128-bit types were passed in, our check could not detect them and would fail to stop the printing.

In [rocprim/types.hpp](https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/rocprim/include/rocprim/types.hpp#L69), the types `rocprim::int128_t` and `rocprim::uint128_t` are now defined regardless of how `ROCPRIM_HAS_INT128_SUPPORT` is set. This means we no longer need to guard against usage of these types in our test code (we only need to use `ROCPRIM_HAS_INT128_SUPPORT` in cases where we're doing some operation that explicitly won't work on 128-bit ints).

This change removes the code that sets the `is_int128` alias to `false_type` when `ROCPRIM_HAS_INT128_SUPPORT` is not set. Doing this is enough to fix the check in `test_utils::protected_assert_eq`.