### PR TITLE
[miopen] docs: Change GitHub links and install guides for mono-repo

### DIFF
--- a/projects/miopen/README.md
+++ b/projects/miopen/README.md
@@ -2,7 +2,8 @@
 
 MIOpen is AMD's library for high-performance machine learning primitives.
 
-You can find sources and binaries in our [GitHub repository](https://github.com/ROCm/MIOpen).
+You can find sources and binaries in our [MIOpen folder](https://github.com/ROCm/rocm-libraries/tree/develop/projects/miopen)
+of the [rocm-libraries GitHub](https://github.com/ROCm/rocm-libraries) repository.
 
 > [!NOTE]
 > The published MIOpen documentation is available at [MIOpen](https://rocm.docs.amd.com/projects/MIOpen/en/latest/index.html) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the MIOpen/docs folder of this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
@@ -14,8 +15,7 @@ MIOpen supports these programming models (backends):
 
 ## Building our documentation
 
-To build the MIOpen documentation locally, run the following code from within the `docs` folder in
-our repository:
+To build the MIOpen documentation locally, run the following code from within the `docs` folder of the MIOpen project:
 
 ``` shell
 sudo apt install doxygen
@@ -33,7 +33,7 @@ To install MIOpen, you must first install these prerequisites:
 
 * A [ROCm](https://rocm.docs.amd.com/)-enabled platform
 * A base software stack that includes either:
-  *HIP (HIP and HCC libraries and header files)
+  * HIP (HIP and HCC libraries and header files)
   * OpenCL (OpenCL libraries and header files)--this is now deprecated
 * [ROCm CMake](https://github.com/ROCm/rocm-cmake): provides CMake modules for common build
   tasks needed for the ROCm software stack
@@ -44,13 +44,13 @@ To install MIOpen, you must first install these prerequisites:
     [kernel cache](https://rocm.docs.amd.com/projects/MIOpen/en/latest/cache.html)
 * [SQLite3](https://sqlite.org/index.html): A reading and writing performance database
 * lbzip2: A multi-threaded compress or decompress utility
-* [rocBLAS](https://github.com/ROCm/rocBLAS): AMD's library for Basic Linear Algebra Subprograms
+* [rocBLAS](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas): AMD's library for Basic Linear Algebra Subprograms
   (BLAS) on the ROCm platform.
   * Minimum version branch for pre-ROCm 3.5 [master-rocm-2.10](https://github.com/ROCm/rocBLAS/tree/master-rocm-2.10)
   * Minimum version branch for post-ROCm 3.5 [master-rocm-3.5](https://github.com/ROCm/rocBLAS/tree/master-rocm-3.5)
-* [hipBLASLt](https://github.com/ROCm/hipBLASLt): AMD's flexible Basic Linear Algebra Subprograms
+* [hipBLASLt](https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblaslt): AMD's flexible Basic Linear Algebra Subprograms
   (BLAS) API.
-* [hipBLAS](https://github.com/ROCm/hipBLAS): AMD's (BLAS) marshalling library.
+* [hipBLAS](https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas): AMD's (BLAS) marshalling library.
 * [Multi-Level Intermediate Representation (MLIR)](https://github.com/ROCm/rocMLIR) with its
   MIOpen dialect to support and complement kernel development
 * [Composable Kernel](https://github.com/ROCm/composable_kernel): A C++ templated device library
@@ -106,6 +106,9 @@ for more information.
 
 You can install dependencies using the `install_deps.cmake` script (`cmake -P install_deps.cmake`).
 
+>[!NOTE]
+> You can run this script from the ``rocm-libraries/projects/miopen`` directory.
+
 By default, this installs to `/usr/local`, but you can specify another location using the `--prefix`
 argument:
 
@@ -122,12 +125,12 @@ cmake -P install_deps.cmake --minimum --prefix /root/MIOpen/install_dir
 You can use this prefix to specify the dependency path during the configuration phase using
 `CMAKE_PREFIX_PATH`.
 
-MIOpen's HIP backend uses [rocBLAS](https://github.com/ROCm/rocBLAS) by default. You can install
+MIOpen's HIP backend uses [rocBLAS](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas) by default. You can install
 rocBLAS' minimum release using `apt-get install rocblas`. To disable rocBLAS, set the configuration flag
 `-DMIOPEN_USE_ROCBLAS=Off`. rocBLAS is **not** available with OpenCL.
 
-MIOpen's HIP backend can use [hipBLASLt](https://github.com/ROCm/hipBLASLt). You can install hipBLASLt's minimum
-release using ``apt-get install hipblaslt``. In addition to needing hipblaslt, you will also need to install [hipBLAS](https://github.com/ROCm/hipBLAS).
+MIOpen's HIP backend can use [hipBLASLt](https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblaslt). You can install hipBLASLt's minimum
+release using ``apt-get install hipblaslt``. In addition to needing hipblaslt, you will also need to install [hipBLAS](https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas).
 You can install hipBLAS's minimum release using ``apt-get install hipblas``.
 To disable hipBLASLt, set the configuration flag ``-DMIOPEN_USE_HIPBLASLT=Off``.
 hipBLASLt is **not** available with OpenCL.
@@ -260,7 +263,7 @@ This installs the library to the `CMAKE_INSTALL_PREFIX` path that you specified.
 
 ## Building the driver
 
-MIOpen provides an [application-driver](https://github.com/ROCm/MIOpen/tree/master/driver) that
+MIOpen provides an [application-driver](https://github.com/ROCm/rocm-libraries/tree/develop/projects/miopen/driver) that
 you can use to run any layer in isolation, and measure library performance and verification.
 
 You can build the driver using the `MIOpenDriver` target:
@@ -293,8 +296,6 @@ cd ./test/utils && python3 gtest_formating_checks.py
 
 The easiest way to format the repo is to run `make format` from your build directory.  You can also
 use the methods below if you need custom formating behaviour.
-
-Formatting Wiki Page: [Code Formatting](https://github.com/ROCm/MIOpen/wiki/How-to-format-code)  
 
 All the code is formatted using `clang-format`. To format a file, use:
 

--- a/projects/miopen/README.md
+++ b/projects/miopen/README.md
@@ -2,7 +2,7 @@
 
 MIOpen is AMD's library for high-performance machine learning primitives.
 
-You can find sources and binaries in our [MIOpen folder](https://github.com/ROCm/rocm-libraries/tree/develop/projects/miopen)
+You can find sources and binaries in the [MIOpen folder](https://github.com/ROCm/rocm-libraries/tree/develop/projects/miopen)
 of the [rocm-libraries GitHub](https://github.com/ROCm/rocm-libraries) repository.
 
 > [!NOTE]

--- a/projects/miopen/docs/index.rst
+++ b/projects/miopen/docs/index.rst
@@ -14,7 +14,12 @@ to optimize convolutions for different filter and input sizes.
 MIOpen is one of the first libraries to publicly support the ``bfloat16`` data type for convolutions, which
 allows for efficient training at lower precision without loss of accuracy.
 
-The MIOpen public repository is located at `<https://github.com/ROCm/MIOpen>`_.
+The MIOpen public repository is located at 
+`<https://github.com/ROCm/rocm-libraries/tree/develop/projects/miopen>`_.
+
+.. note::
+
+   The MIOpen repository for ROCm 6.4.3 and earlier is located at `<https://github.com/ROCm/MIOpen>`_.
 
 .. grid:: 2
   :gutter: 3
@@ -48,7 +53,7 @@ The MIOpen public repository is located at `<https://github.com/ROCm/MIOpen>`_.
 
   .. grid-item-card:: Samples
 
-    * `MIOpen samples <https://github.com/ROCm/MIOpen/tree/develop/samples>`_
+    * `MIOpen samples <https://github.com/ROCm/rocm-libraries/tree/develop/projects/miopen/samples>`_
 
   ..  grid-item-card:: Reference
 

--- a/projects/miopen/docs/install/embed.rst
+++ b/projects/miopen/docs/install/embed.rst
@@ -8,6 +8,10 @@ Build MIOpen for embedded systems
 
 Follow these steps to build and configure MIOpen for an embedded system.
 
+.. note::
+
+   You can run ``install_deps.cmake`` from the ``rocm-libraries/projects/miopen`` directory.
+
 1. Install the dependencies. The default install location is ``/usr/local``:
 
    .. code:: cpp

--- a/projects/miopen/docs/install/install.rst
+++ b/projects/miopen/docs/install/install.rst
@@ -67,6 +67,11 @@ Installing dependencies
 
 To install the MIOpen dependencies, use the ``install_deps.cmake`` command:
 
+.. note::
+
+   You can run ``install_deps.cmake`` from the ``rocm-libraries/projects/miopen`` directory.
+
+
 .. code:: shell
 
    cmake -P install_deps.cmake

--- a/projects/miopen/docs/sphinx/_toc.yml.in
+++ b/projects/miopen/docs/sphinx/_toc.yml.in
@@ -45,7 +45,7 @@ subtrees:
 
 - caption: Samples
   entries:
-  - url: https://github.com/ROCm/MIOpen/tree/develop/samples
+  - url: https://github.com/ROCm/rocm-libraries/tree/develop/projects/miopen/samples
     title: MIOpen samples
 
 - caption: Reference


### PR DESCRIPTION
This edits the install guides (Windows and Linux) and changes GitHub links in the index and on other pages. It also updates other GitHub links. It points users back to the old repository for release 6.4 and earlier.