### PR TITLE
Add libs-common for first-party shared headers

### DIFF
--- a/shared/libs-common/.azuredevops/rocm-ci.yml
+++ b/shared/libs-common/.azuredevops/rocm-ci.yml
@@ -1,0 +1,34 @@
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - develop
+    - mainline
+  paths:
+    exclude:
+    - '*.md'
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - develop
+    - mainline
+  paths:
+    exclude:
+    - '*.md'
+  drafts: false
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/libs-common.yml@pipelines_repo

--- a/shared/libs-common/.github/CODEOWNERS
+++ b/shared/libs-common/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @bstefanuk @ellosel @bnemanich @daineAMD @TorreZuk
+
+*.md @ROCm/rocm-documentation @bstefanuk @ellosel @bnemanich @daineAMD @TorreZuk
+*.rst @ROCm/rocm-documentation @bstefnauk @ellosel @bnemanich @daineAMD @TorreZuk

--- a/shared/libs-common/CMakeLists.txt
+++ b/shared/libs-common/CMakeLists.txt
@@ -1,0 +1,85 @@
+# Copyright Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.11)
+project(libs-common VERSION 1.2.0 LANGUAGES CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+include(FetchROCmCMake)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    if(WIN32)
+        set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path prefix" FORCE)
+    else()
+        set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix" FORCE)
+    endif()
+endif()
+
+option(LIBS_COMMON_ENABLE_HIPBLAS "Enable hipBLAS common library" ON)
+option(LIBS_COMMON_ENABLE_HIPSPARSE "Enable hipSPARSE common library" ON)
+
+message(STATUS "LIBS_COMMON_ENABLE_HIPBLAS: ${LIBS_COMMON_ENABLE_HIPBLAS}")
+message(STATUS "LIBS_COMMON_ENABLE_HIPSPARSE: ${LIBS_COMMON_ENABLE_HIPSPARSE}")
+
+if(LIBS_COMMON_ENABLE_HIPBLAS)
+    message(STATUS "Building hipblas-common")
+    add_library(hipblas-common INTERFACE)
+    add_library(roc::hipblas-common ALIAS hipblas-common)
+
+    target_sources(
+        hipblas-common
+        INTERFACE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/include/hipblas-common/hipblas-common.h>
+    )
+    target_include_directories(
+        hipblas-common INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/include>
+                                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+    rocm_install_targets(
+        TARGETS hipblas-common EXPORT hipblas-common-targets INCLUDE
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/include
+    )
+    rocm_export_targets(
+        TARGETS
+        roc::hipblas-common
+        NAME
+        hipblas-common
+        EXPORT
+        hipblas-common-targets
+        NAMESPACE
+        roc::
+    )
+endif()
+
+if(LIBS_COMMON_ENABLE_HIPSPARSE)
+    message(STATUS "Building hipsparse-common")
+    add_library(hipsparse-common INTERFACE)
+    add_library(roc::hipsparse-common ALIAS hipsparse-common)
+
+    target_sources(
+        hipsparse-common
+        INTERFACE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/include/hipsparse-common/hipsparse-common.h>
+    )
+    target_include_directories(
+        hipsparse-common INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/include>
+                                   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+    rocm_install_targets(
+        TARGETS hipsparse-common EXPORT hipsparse-common-targets INCLUDE
+        ${CMAKE_CURRENT_SOURCE_DIR}/library/include
+    )
+    rocm_export_targets(
+        TARGETS
+        roc::hipsparse-common
+        NAME
+        hipsparse-common
+        EXPORT
+        hipsparse-common-targets
+        NAMESPACE
+        roc::
+    )
+endif()

--- a/shared/libs-common/CMakePresets.json
+++ b/shared/libs-common/CMakePresets.json
@@ -1,0 +1,24 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+      "major": 3,
+      "minor": 21,
+      "patch": 0
+    },
+    "configurePresets": [
+      {
+        "name": "default-release",
+        "displayName": "Release Build (Default GPU)",
+        "description": "Standard release build with default GPU target",
+        "binaryDir": "${sourceDir}/_build",
+        "cacheVariables": {
+          "CMAKE_BUILD_TYPE": "Release",
+          "CMAKE_CXX_COMPILER": "/opt/rocm/bin/amdclang++",
+          "CMAKE_PREFIX_PATH": "/opt/rocm"
+        },
+        "environment": {
+          "ROCM_PATH": "/opt/rocm"
+        }
+      }
+    ]
+  }

--- a/shared/libs-common/LICENSE.md
+++ b/shared/libs-common/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2025 AMD ROCm™ Software
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/shared/libs-common/README.rst
+++ b/shared/libs-common/README.rst
@@ -1,0 +1,83 @@
+.. highlight:: rst
+.. |project_name| replace:: libs-common
+
+==============
+|project_name|
+==============
+
+-----------------
+Quick Start Guide
+-----------------
+
+|project_name| is a header-only library that provides common files for ROCm and HIP libraries.
+
+This section describes how to configure and build the |project_name| project. It assumes the user has a
+ROCm installation, Python 3.8 or later, and CMake 3.11 or later.
+
+^^^^^^^^^^^^^^^^^^^
+Configure and build
+^^^^^^^^^^^^^^^^^^^
+
+|project_name| provides modern CMake support and relies on native CMake functionality, with the exception of
+some project specific options. As such, users are advised to consult the CMake documentation for
+general usage questions. Below are usage examples to get started. For details on all configuration
+options, see the options section.
+
+Build on fresh clone of `rocm-libraries <https://github.com/ROCm/rocm-libraries>`_
+--------------------------------------------------------------------------------
+
+   .. code-block:: cmake
+      :linenos:
+
+      cd shared/libs-common
+
+      # configure
+      cmake --preset default-release
+
+      # build
+      cmake --build _build
+
+      # install (optional)
+      cmake --install _build
+
+Options
+-------
+
+*CMake options*:
+
+* ``CMAKE_BUILD_TYPE``: Any of Release, Debug, RelWithDebInfo, MinSizeRel
+* ``CMAKE_INSTALL_PREFIX``: Base installation directory (defaults to ``/opt/rocm`` on Linux, ``C:/hipSDK`` on Windows)
+* ``CMAKE_PREFIX_PATH``: Find package search path (consider setting to ``$ROCM_PATH``)
+
+*Build control options*:
+
+* ``LIBS_COMMON_ENABLE_HIPBLAS``: Enable hipBLAS common library (default: ``ON``)
+* ``LIBS_COMMON_ENABLE_HIPSPARSE``: Enable hipSPARSE common library (default: ``ON``)
+
+
+^^^^^^^^^^^^^^^^^^^^^^^
+Using in CMake projects
+^^^^^^^^^^^^^^^^^^^^^^^
+
+To use |project_name| in your `rocm-libraries <https://github.com/ROCm/rocm-libraries>`_ CMake project,
+add the following to your ``CMakeLists.txt`` file:
+
+.. code-block:: cmake
+   :linenos:
+
+   # Add `libs-common` as a subdirectory
+   # This will build `libs-common` and add it to your build-tree
+   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/<path-to>/shared/libs-common libs-common)
+
+   # Link your target to the desired library
+   # This will propagate required include paths to your target
+   target_link_libraries(my_target PRIVATE roc::hipsparse-common)
+
+^^^^^^^^^^^^^
+CMake targets
+^^^^^^^^^^^^^
+
+*Libraries*:
+
+* ``roc::hipblas-common``
+* ``roc::hipsparse-common``

--- a/shared/libs-common/cmake/FetchROCmCMake.cmake
+++ b/shared/libs-common/cmake/FetchROCmCMake.cmake
@@ -1,0 +1,30 @@
+# Copyright Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
+# Attempt to find ROCmCMakeBuildTools in the system, if not found, fetch from source To install
+# ROCmCMakeBuildTools from source, see: https://github.com/ROCm/rocm-cmake
+
+find_package(ROCmCMakeBuildTools QUIET CONFIG)
+
+if(NOT ROCmCMakeBuildTools_FOUND)
+    message(STATUS "ROCmCMakeBuildTools not found. Fetching from source...")
+    include(FetchContent)
+    fetchcontent_declare(
+        rocm-cmake GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git GIT_TAG develop
+        GIT_SHALLOW TRUE
+    )
+
+    fetchcontent_getproperties(rocm-cmake)
+    if(NOT rocm-cmake_POPULATED)
+        fetchcontent_populate(rocm-cmake)
+        message(
+            STATUS
+                "Added ROCm CMake modules path: ${rocm-cmake_SOURCE_DIR}/share/rocmcmakebuildtools/cmake"
+        )
+        list(APPEND CMAKE_MODULE_PATH ${rocm-cmake_SOURCE_DIR}/share/rocmcmakebuildtools/cmake)
+    endif()
+endif()
+
+include(ROCMSetupVersion)
+include(ROCMInstallTargets)
+include(ROCMPackageConfigHelpers)

--- a/shared/libs-common/library/include/hipblas-common/hipblas-common.h
+++ b/shared/libs-common/library/include/hipblas-common/hipblas-common.h
@@ -1,0 +1,90 @@
+/* ************************************************************************
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * ************************************************************************ */
+
+//! HIP = Heterogeneous-compute Interface for Portability
+//!
+//! Define an extremely thin runtime layer that allows source code to be compiled unmodified
+//! through either AMD HCC or NVCC.   Key features tend to be in the spirit
+//! and terminology of CUDA, but with a portable path to other accelerators as well.
+//!
+//!  This is the master include file for hipblas-common, providing shared functionality
+//!  between hipBLAS and hipBLASLt.
+
+#ifndef HIPBLAS_COMMON_H
+#define HIPBLAS_COMMON_H
+
+/*! \brief hipblas status codes definition */
+typedef enum {
+    HIPBLAS_STATUS_SUCCESS = 0,           /**< Function succeeds */
+    HIPBLAS_STATUS_NOT_INITIALIZED = 1,   /**< HIPBLAS library not initialized */
+    HIPBLAS_STATUS_ALLOC_FAILED = 2,      /**< resource allocation failed */
+    HIPBLAS_STATUS_INVALID_VALUE = 3,     /**< unsupported numerical value was passed to function */
+    HIPBLAS_STATUS_MAPPING_ERROR = 4,     /**< access to GPU memory space failed */
+    HIPBLAS_STATUS_EXECUTION_FAILED = 5,  /**< GPU program failed to execute */
+    HIPBLAS_STATUS_INTERNAL_ERROR = 6,    /**< an internal HIPBLAS operation failed */
+    HIPBLAS_STATUS_NOT_SUPPORTED = 7,     /**< function not implemented */
+    HIPBLAS_STATUS_ARCH_MISMATCH = 8,     /**< architecture mismatch */
+    HIPBLAS_STATUS_HANDLE_IS_NULLPTR = 9, /**< hipBLAS handle is null pointer */
+    HIPBLAS_STATUS_INVALID_ENUM = 10,     /**<  unsupported enum value was passed to function */
+    HIPBLAS_STATUS_UNKNOWN = 11,          /**<  back-end returned an unsupported status code */
+} hipblasStatus_t;
+
+#ifndef HIPBLAS_OPERATION_DECLARED
+#define HIPBLAS_OPERATION_DECLARED
+/*! \brief Used to specify whether the matrix is to be transposed or not. */
+typedef enum {
+    HIPBLAS_OP_N = 111, /**<  Operate with the matrix. */
+    HIPBLAS_OP_T = 112, /**<  Operate with the transpose of the matrix. */
+    HIPBLAS_OP_C = 113  /**< Operate with the conjugate transpose of the matrix. */
+} hipblasOperation_t;
+
+#elif __cplusplus >= 201103L
+static_assert(HIPBLAS_OP_N == 111, "Inconsistent declaration of HIPBLAS_OP_N");
+static_assert(HIPBLAS_OP_T == 112, "Inconsistent declaration of HIPBLAS_OP_T");
+static_assert(HIPBLAS_OP_C == 113, "Inconsistent declaration of HIPBLAS_OP_C");
+#endif  // HIPBLAS_OPERATION_DECLARED
+
+/*! \brief The compute type to be used. Currently only used with GemmEx with the HIPBLAS_V2
+ * interface. Note that support for compute types is largely dependent on backend. */
+typedef enum {
+    // Note that these types are taken from cuBLAS. With the rocBLAS backend, currently hipBLAS will
+    // convert to rocBLAS types to get equivalent functionality where supported.
+    HIPBLAS_COMPUTE_16F = 0,           /**< compute will be at least 16-bit precision */
+    HIPBLAS_COMPUTE_16F_PEDANTIC = 1,  /**< compute will be exactly 16-bit precision */
+    HIPBLAS_COMPUTE_32F = 2,           /**< compute will be at least 32-bit precision */
+    HIPBLAS_COMPUTE_32F_PEDANTIC = 3,  /**< compute will be exactly 32-bit precision */
+    HIPBLAS_COMPUTE_32F_FAST_16F = 4,  /**< 32-bit input can use 16-bit compute */
+    HIPBLAS_COMPUTE_32F_FAST_16BF = 5, /**< 32-bit input can is bf16 compute */
+    HIPBLAS_COMPUTE_32F_FAST_TF32 = 6, /**< 32-bit input can use tensor cores w/ TF32 compute. Only
+                                          supported with cuBLAS and hipBLASLT backend currently */
+    HIPBLAS_COMPUTE_64F = 7,           /**< compute will be at least 64-bit precision */
+    HIPBLAS_COMPUTE_64F_PEDANTIC = 8,  /**< compute will be exactly 64-bit precision */
+    HIPBLAS_COMPUTE_32I = 9,           /**< compute will be at least 32-bit integer precision */
+    HIPBLAS_COMPUTE_32I_PEDANTIC = 10, /**< compute will be exactly 32-bit integer precision */
+    HIPBLAS_COMPUTE_32F_FAST_8F_FNUZ = 100,    /**< 32-bit compute using fp8 mfma instruction */
+    HIPBLAS_COMPUTE_32F_FAST_8BF_FNUZ = 101,   /**< 32-bit compute using bf8 mfma instruction */
+    HIPBLAS_COMPUTE_32F_FAST_8F8BF_FNUZ = 102, /**< 32-bit compute using f8bf8 mfma instruction */
+    HIPBLAS_COMPUTE_32F_FAST_8BF8F_FNUZ = 103, /**< 32-bit compute using bf8f8 mfma instruction */
+} hipblasComputeType_t;
+
+#endif

--- a/shared/libs-common/library/include/hipsparse-common/hipsparse-common.h
+++ b/shared/libs-common/library/include/hipsparse-common/hipsparse-common.h
@@ -1,0 +1,54 @@
+/* ************************************************************************
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * ************************************************************************ */
+
+#ifndef HIPSPARSE_COMMON_H
+#define HIPSPARSE_COMMON_H
+
+/// \cond DO_NOT_DOCUMENT
+#define DEPRECATED_CUDA_12000(warning)
+#define DEPRECATED_CUDA_11000(warning)
+#define DEPRECATED_CUDA_10000(warning)
+#define DEPRECATED_CUDA_9000(warning)
+
+#ifdef __cplusplus
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(X) 0
+#endif
+#define HIPSPARSE_HAS_DEPRECATED_MSG __has_cpp_attribute(deprecated) >= 201309L
+#else
+#ifndef __has_c_attribute
+#define __has_c_attribute(X) 0
+#endif
+#define HIPSPARSE_HAS_DEPRECATED_MSG __has_c_attribute(deprecated) >= 201904L
+#endif
+
+#if HIPSPARSE_HAS_DEPRECATED_MSG
+#define HIPSPARSE_DEPRECATED_MSG(MSG) [[deprecated(MSG)]]
+#else
+#define HIPSPARSE_DEPRECATED_MSG(MSG) HIPSPARSE_DEPRECATED  // defined in hipsparse-export.h
+#endif
+/// \endcond
+
+#include "hipsparse-generic-types.h"
+#include "hipsparse-types.h"
+
+#endif

--- a/shared/libs-common/library/include/hipsparse-common/hipsparse-generic-types.h
+++ b/shared/libs-common/library/include/hipsparse-common/hipsparse-generic-types.h
@@ -1,0 +1,512 @@
+/*! \file */
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#ifndef HIPSPARSE_GENERIC_TYPES_H
+#define HIPSPARSE_GENERIC_TYPES_H
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a sparse vector
+ *
+ *  \details
+ *  The hipSPARSE descriptor is an opaque structure holding information for a sparse vector. It must
+ *  be initialized using hipsparseCreateSpVec() and the returned descriptor
+ *  is used in hipSPARSE generic API's involving sparse vectors. It should be destroyed at the end
+ * using hipsparseDestroySpVec().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 || \
+     (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+typedef void* hipsparseSpVecDescr_t;
+#endif
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a dense vector
+ *
+ *  \details
+ *  The hipSPARSE descriptor is an opaque structure holding information for a dense vector. It must
+ *  be initialized using hipsparseCreateDnVec() and the returned descriptor
+ *  is used in hipSPARSE generic API's involving dense vectors. It should be destroyed at the end
+ * using hipsparseDestroyDnVec().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 || \
+     (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+typedef void* hipsparseDnVecDescr_t;
+#endif
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a sparse matrix
+ *
+ *  \details
+ *  The hipSPARSE descriptor is an opaque structure holding information for a sparse matrix. It must
+ *  be initialized using either hipsparseCreateCoo() (for COO format), hipsparseCreateCooAoS() (for
+ * COO AOS format). hipsparseCreateCsr() (for CSR format), hipsparseCreateCsc() (for CSC format) or
+ * hipsparseCreateBlockedEll() (for Blocked ELL format). The returned descriptor is used in
+ * hipSPARSE generic API's involving sparse matrices. It should be destroyed at the end using
+ * hipsparseDestroySpMat().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+typedef struct hipsparseSpMatDescr_st* hipsparseSpMatDescr_t;
+#endif
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a dense matrix
+ *
+ *  \details
+ *  The hipSPARSE descriptor is an opaque structure holding information for a dense matrix. It must
+ *  be initialized using hipsparseCreateDnMat() and the returned descriptor
+ *  is used in hipSPARSE generic API's involving dense matrices. It should be destroyed at the end
+ * using hipsparseDestroyDnMat().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+typedef void* hipsparseDnMatDescr_t;
+#endif
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a sparse vector
+ *
+ *  \details
+ *  The hipSPARSE (const) descriptor is an opaque structure holding information for a sparse vector.
+ * It must be initialized using hipsparseCreateConstSpVec() and the returned descriptor is used in
+ * hipSPARSE generic API's involving sparse vectors. It should be destroyed at the end using
+ *  hipsparseDestroySpVec().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)
+typedef void const* hipsparseConstSpVecDescr_t;
+#endif
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a dense vector
+ *
+ *  \details
+ *  The hipSPARSE (const) descriptor is an opaque structure holding information for a dense vector.
+ * It must be initialized using hipsparseCreateConstDnVec() and the returned descriptor is used in
+ * hipSPARSE generic API's involving dense vectors. It should be destroyed at the end using
+ *  hipsparseDestroyDnVec().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)
+typedef void const* hipsparseConstDnVecDescr_t;
+#endif
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a sparse matrix
+ *
+ *  \details
+ *  The hipSPARSE (const) descriptor is an opaque structure holding information for a sparse matrix.
+ * It must be initialized using hipsparseCreateConstSpMat() and the returned descriptor is used in
+ * hipSPARSE generic API's involving sparse matrices. It should be destroyed at the end using
+ *  hipsparseDestroySpMat().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)
+typedef struct hipsparseSpMatDescr_st const* hipsparseConstSpMatDescr_t;
+#endif
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a dense matrix
+ *
+ *  \details
+ *  The hipSPARSE (const) descriptor is an opaque structure holding information for a dense matrix.
+ * It must be initialized using hipsparseCreateConstDnMat() and the returned descriptor is used in
+ * hipSPARSE generic API's involving dense matrices. It should be destroyed at the end using
+ *  hipsparseDestroyDnMat().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)
+typedef void const* hipsparseConstDnMatDescr_t;
+#endif
+
+/// \cond DO_NOT_DOCUMENT
+// Forward declarations
+struct hipsparseSpGEMMDescr;
+struct hipsparseSpSVDescr;
+struct hipsparseSpSMDescr;
+/// \endcond
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a SpGEMM calculations
+ *
+ *  \details
+ *  The hipSPARSE descriptor is an opaque structure holding information that is used in
+ * hipsparseSpGEMM_workEstimation(), hipsparseSpGEMMreuse_workEstimation(),
+ * hipsparseSpGEMMreuse_nnz(), hipsparseSpGEMM_compute(), hipsparseSpGEMMreuse_compute(),
+ * hipsparseSpGEMM_copy(), and hipsparseSpGEMMreuse_copy(). It must be initialized using
+ * hipsparseSpGEMM_createDescr(). It should be destroyed at the end using
+ *  hipsparseSpGEMM_destroyDescr().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+typedef struct hipsparseSpGEMMDescr* hipsparseSpGEMMDescr_t;
+#endif
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a SpSV calculations
+ *
+ *  \details
+ *  The hipSPARSE descriptor is an opaque structure holding information that is used in
+ * hipsparseSpSV_bufferSize(), hipsparseSpSV_analysis(), and hipsparseSpSV_solve(). It must be
+ * initialized using hipsparseSpSV_createDescr(). It should be destroyed at the end using
+ * hipsparseSpSV_destroyDescr().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
+typedef struct hipsparseSpSVDescr* hipsparseSpSVDescr_t;
+#endif
+
+/*! \ingroup types_module
+ *  \brief Generic API opaque structure holding information for a SpSM calculations
+ *
+ *  \details
+ *  The hipSPARSE descriptor is an opaque structure holding information that is used in
+ * hipsparseSpSM_bufferSize(), hipsparseSpSM_analysis(), and hipsparseSpSM_solve(). It must be
+ * initialized using hipsparseSpSM_createDescr(). It should be destroyed at the end using
+ * hipsparseSpSM_destroyDescr().
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+typedef struct hipsparseSpSMDescr* hipsparseSpSMDescr_t;
+#endif
+
+/* Generic API types */
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse sparse matrix formats.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseFormat_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION))
+typedef enum {
+    HIPSPARSE_FORMAT_CSR = 1,        /**< Compressed Sparse Row */
+    HIPSPARSE_FORMAT_CSC = 2,        /**< Compressed Sparse Column */
+    HIPSPARSE_FORMAT_COO = 3,        /**< Coordinate - Structure of Arrays */
+    HIPSPARSE_FORMAT_COO_AOS = 4,    /**< Coordinate - Array of Structures */
+    HIPSPARSE_FORMAT_BLOCKED_ELL = 5 /**< Blocked ELL */
+} hipsparseFormat_t;
+#else
+#if (CUDART_VERSION >= 12000)
+typedef enum {
+    HIPSPARSE_FORMAT_CSR = 1,        /**< Compressed Sparse Row */
+    HIPSPARSE_FORMAT_CSC = 2,        /**< Compressed Sparse Column */
+    HIPSPARSE_FORMAT_COO = 3,        /**< Coordinate - Structure of Arrays */
+    HIPSPARSE_FORMAT_BLOCKED_ELL = 5 /**< Blocked ELL */
+} hipsparseFormat_t;
+#elif (CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
+typedef enum {
+    HIPSPARSE_FORMAT_CSR = 1,        /**< Compressed Sparse Row */
+    HIPSPARSE_FORMAT_CSC = 2,        /**< Compressed Sparse Column */
+    HIPSPARSE_FORMAT_COO = 3,        /**< Coordinate - Structure of Arrays */
+    HIPSPARSE_FORMAT_COO_AOS = 4,    /**< Coordinate - Array of Structures */
+    HIPSPARSE_FORMAT_BLOCKED_ELL = 5 /**< Blocked ELL */
+} hipsparseFormat_t;
+#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 11021)
+typedef enum {
+    HIPSPARSE_FORMAT_CSR = 1,     /**< Compressed Sparse Row */
+    HIPSPARSE_FORMAT_COO = 3,     /**< Coordinate - Structure of Arrays */
+    HIPSPARSE_FORMAT_COO_AOS = 4, /**< Coordinate - Array of Structures */
+} hipsparseFormat_t;
+#endif
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse dense matrix memory layout ordering.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseOrder_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION))
+typedef enum {
+    HIPSPARSE_ORDER_COLUMN HIPSPARSE_DEPRECATED_MSG("Please use HIPSPARSE_ORDER_COL instead") =
+        1,                   /**< Column major */
+    HIPSPARSE_ORDER_COL = 1, /**< Column major */
+    HIPSPARSE_ORDER_ROW = 2  /**< Row major */
+} hipsparseOrder_t;
+#else
+#if (CUDART_VERSION >= 11000)
+typedef enum {
+    HIPSPARSE_ORDER_COLUMN HIPSPARSE_DEPRECATED_MSG("Please use HIPSPARSE_ORDER_COL instead") =
+        1,                   /**< Column major */
+    HIPSPARSE_ORDER_COL = 1, /**< Column major */
+    HIPSPARSE_ORDER_ROW = 2  /**< Row major */
+} hipsparseOrder_t;
+#elif (CUDART_VERSION >= 10010)
+typedef enum {
+    HIPSPARSE_ORDER_COLUMN HIPSPARSE_DEPRECATED_MSG("Please use HIPSPARSE_ORDER_COL instead") =
+        1,                  /**< Column major */
+    HIPSPARSE_ORDER_COL = 1 /**< Column major */
+} hipsparseOrder_t;
+#endif
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse index type used by sparse matrix indices.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseIndexType_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+typedef enum {
+    HIPSPARSE_INDEX_16U = 1, /**< 16 bit unsigned integer indices */
+    HIPSPARSE_INDEX_32I = 2, /**< 32 bit signed integer indices */
+    HIPSPARSE_INDEX_64I = 3  /**< 64 bit signed integer indices */
+} hipsparseIndexType_t;
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse SpMV algorithms.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseSpMVAlg_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION))
+typedef enum {
+    HIPSPARSE_MV_ALG_DEFAULT = 0,
+    HIPSPARSE_COOMV_ALG = 1,
+    HIPSPARSE_CSRMV_ALG1 = 2,
+    HIPSPARSE_CSRMV_ALG2 = 3,
+    HIPSPARSE_SPMV_ALG_DEFAULT = 0,
+    HIPSPARSE_SPMV_COO_ALG1 = 1,
+    HIPSPARSE_SPMV_CSR_ALG1 = 2,
+    HIPSPARSE_SPMV_CSR_ALG2 = 3,
+    HIPSPARSE_SPMV_COO_ALG2 = 4
+} hipsparseSpMVAlg_t;
+#else
+#if (CUDART_VERSION >= 12000)
+typedef enum {
+    HIPSPARSE_SPMV_ALG_DEFAULT = 0,
+    HIPSPARSE_SPMV_COO_ALG1 = 1,
+    HIPSPARSE_SPMV_CSR_ALG1 = 2,
+    HIPSPARSE_SPMV_CSR_ALG2 = 3,
+    HIPSPARSE_SPMV_COO_ALG2 = 4
+} hipsparseSpMVAlg_t;
+#elif (CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
+typedef enum {
+    HIPSPARSE_MV_ALG_DEFAULT = 0,
+    HIPSPARSE_COOMV_ALG = 1,
+    HIPSPARSE_CSRMV_ALG1 = 2,
+    HIPSPARSE_CSRMV_ALG2 = 3,
+    HIPSPARSE_SPMV_ALG_DEFAULT = 0,
+    HIPSPARSE_SPMV_COO_ALG1 = 1,
+    HIPSPARSE_SPMV_CSR_ALG1 = 2,
+    HIPSPARSE_SPMV_CSR_ALG2 = 3,
+    HIPSPARSE_SPMV_COO_ALG2 = 4
+} hipsparseSpMVAlg_t;
+#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 11021)
+typedef enum {
+    HIPSPARSE_MV_ALG_DEFAULT = 0,
+    HIPSPARSE_COOMV_ALG = 1,
+    HIPSPARSE_CSRMV_ALG1 = 2,
+    HIPSPARSE_CSRMV_ALG2 = 3
+} hipsparseSpMVAlg_t;
+#endif
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse SpMM algorithms.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseSpMMAlg_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION))
+typedef enum {
+    HIPSPARSE_MM_ALG_DEFAULT = 0,        /**< Default algorithm */
+    HIPSPARSE_COOMM_ALG1 = 1,            /**< COO algorithm 1 */
+    HIPSPARSE_COOMM_ALG2 = 2,            /**< COO algorithm 2 */
+    HIPSPARSE_COOMM_ALG3 = 3,            /**< COO algorithm 3 */
+    HIPSPARSE_CSRMM_ALG1 = 4,            /**< CSR algorithm 1 */
+    HIPSPARSE_SPMM_ALG_DEFAULT = 0,      /**< Default algorithm */
+    HIPSPARSE_SPMM_COO_ALG1 = 1,         /**< COO algorithm 1 */
+    HIPSPARSE_SPMM_COO_ALG2 = 2,         /**< COO algorithm 2 */
+    HIPSPARSE_SPMM_COO_ALG3 = 3,         /**< COO algorithm 3 */
+    HIPSPARSE_SPMM_COO_ALG4 = 5,         /**< COO algorithm 4 */
+    HIPSPARSE_SPMM_CSR_ALG1 = 4,         /**< CSR algorithm 1 */
+    HIPSPARSE_SPMM_CSR_ALG2 = 6,         /**< CSR algorithm 2 */
+    HIPSPARSE_SPMM_CSR_ALG3 = 12,        /**< CSR algorithm 3 */
+    HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 13 /**< Blocked ELL algorithm 1 */
+} hipsparseSpMMAlg_t;
+#else
+#if (CUDART_VERSION >= 12000)
+typedef enum {
+    HIPSPARSE_SPMM_ALG_DEFAULT = 0,      /**< Default algorithm */
+    HIPSPARSE_SPMM_COO_ALG1 = 1,         /**< COO algorithm 1 */
+    HIPSPARSE_SPMM_COO_ALG2 = 2,         /**< COO algorithm 2 */
+    HIPSPARSE_SPMM_COO_ALG3 = 3,         /**< COO algorithm 3 */
+    HIPSPARSE_SPMM_COO_ALG4 = 5,         /**< COO algorithm 4 */
+    HIPSPARSE_SPMM_CSR_ALG1 = 4,         /**< CSR algorithm 1 */
+    HIPSPARSE_SPMM_CSR_ALG2 = 6,         /**< CSR algorithm 2 */
+    HIPSPARSE_SPMM_CSR_ALG3 = 12,        /**< CSR algorithm 3 */
+    HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 13 /**< Blocked ELL algorithm 1 */
+} hipsparseSpMMAlg_t;
+#elif (CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
+typedef enum {
+    HIPSPARSE_MM_ALG_DEFAULT = 0,        /**< Default algorithm */
+    HIPSPARSE_COOMM_ALG1 = 1,            /**< COO algorithm 1 */
+    HIPSPARSE_COOMM_ALG2 = 2,            /**< COO algorithm 2 */
+    HIPSPARSE_COOMM_ALG3 = 3,            /**< COO algorithm 3 */
+    HIPSPARSE_CSRMM_ALG1 = 4,            /**< CSR algorithm 1 */
+    HIPSPARSE_SPMM_ALG_DEFAULT = 0,      /**< Default algorithm */
+    HIPSPARSE_SPMM_COO_ALG1 = 1,         /**< COO algorithm 1 */
+    HIPSPARSE_SPMM_COO_ALG2 = 2,         /**< COO algorithm 2 */
+    HIPSPARSE_SPMM_COO_ALG3 = 3,         /**< COO algorithm 3 */
+    HIPSPARSE_SPMM_COO_ALG4 = 5,         /**< COO algorithm 4 */
+    HIPSPARSE_SPMM_CSR_ALG1 = 4,         /**< CSR algorithm 1 */
+    HIPSPARSE_SPMM_CSR_ALG2 = 6,         /**< CSR algorithm 2 */
+    HIPSPARSE_SPMM_CSR_ALG3 = 12,        /**< CSR algorithm 3 */
+    HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 13 /**< Blocked ELL algorithm 1 */
+} hipsparseSpMMAlg_t;
+#elif (CUDART_VERSION >= 11003 && CUDART_VERSION < 11021)
+typedef enum {
+    HIPSPARSE_MM_ALG_DEFAULT = 0,        /**< Default algorithm */
+    HIPSPARSE_COOMM_ALG1 = 1,            /**< COO algorithm 1 */
+    HIPSPARSE_COOMM_ALG2 = 2,            /**< COO algorithm 2 */
+    HIPSPARSE_COOMM_ALG3 = 3,            /**< COO algorithm 3 */
+    HIPSPARSE_CSRMM_ALG1 = 4,            /**< CSR algorithm 1 */
+    HIPSPARSE_SPMM_ALG_DEFAULT = 0,      /**< Default algorithm */
+    HIPSPARSE_SPMM_COO_ALG1 = 1,         /**< COO algorithm 1 */
+    HIPSPARSE_SPMM_COO_ALG2 = 2,         /**< COO algorithm 2 */
+    HIPSPARSE_SPMM_COO_ALG3 = 3,         /**< COO algorithm 3 */
+    HIPSPARSE_SPMM_COO_ALG4 = 5,         /**< COO algorithm 4 */
+    HIPSPARSE_SPMM_CSR_ALG1 = 4,         /**< CSR algorithm 1 */
+    HIPSPARSE_SPMM_CSR_ALG2 = 6,         /**< CSR algorithm 2 */
+    HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 13 /**< Blocked ELL algorithm 1 */
+} hipsparseSpMMAlg_t;
+#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 11003)
+typedef enum {
+    HIPSPARSE_MM_ALG_DEFAULT = 0, /**< Default algorithm */
+    HIPSPARSE_COOMM_ALG1 = 1,     /**< COO algorithm 1 */
+    HIPSPARSE_COOMM_ALG2 = 2,     /**< COO algorithm 2 */
+    HIPSPARSE_COOMM_ALG3 = 3,     /**< COO algorithm 3 */
+    HIPSPARSE_CSRMM_ALG1 = 4      /**< CSR algorithm 1 */
+} hipsparseSpMMAlg_t;
+#endif
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse SparseToDense algorithms.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseSparseToDenseAlg_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+typedef enum {
+    HIPSPARSE_SPARSETODENSE_ALG_DEFAULT = 0,
+} hipsparseSparseToDenseAlg_t;
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse DenseToSparse algorithms.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseDenseToSparseAlg_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+typedef enum {
+    HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT = 0,
+} hipsparseDenseToSparseAlg_t;
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse SDDMM algorithms.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseSDDMMAlg_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11022)
+typedef enum { HIPSPARSE_SDDMM_ALG_DEFAULT = 0 } hipsparseSDDMMAlg_t;
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse SpSV algorithms.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseSpSVAlg_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
+typedef enum { HIPSPARSE_SPSV_ALG_DEFAULT = 0 } hipsparseSpSVAlg_t;
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse SpSM algorithms.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseSpSMAlg_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+typedef enum { HIPSPARSE_SPSM_ALG_DEFAULT = 0 } hipsparseSpSMAlg_t;
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse attributes.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseSpMatAttribute_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
+typedef enum {
+    HIPSPARSE_SPMAT_FILL_MODE = 0, /**< Fill mode attribute */
+    HIPSPARSE_SPMAT_DIAG_TYPE = 1  /**< Diag type attribute */
+} hipsparseSpMatAttribute_t;
+#endif
+
+/*! \ingroup generic_module
+ *  \brief List of hipsparse SpGEMM algorithms.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseSpGEMMAlg_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if (!defined(CUDART_VERSION))
+typedef enum {
+    HIPSPARSE_SPGEMM_DEFAULT = 0,
+    HIPSPARSE_SPGEMM_CSR_ALG_DETERMINISTIC = 1,
+    HIPSPARSE_SPGEMM_CSR_ALG_NONDETERMINISTIC = 2,
+    HIPSPARSE_SPGEMM_ALG1 = 3,
+    HIPSPARSE_SPGEMM_ALG2 = 4,
+    HIPSPARSE_SPGEMM_ALG3 = 5
+} hipsparseSpGEMMAlg_t;
+#else
+#if (CUDART_VERSION >= 12000)
+typedef enum {
+    HIPSPARSE_SPGEMM_DEFAULT = 0,
+    HIPSPARSE_SPGEMM_CSR_ALG_DETERMINISTIC = 1,
+    HIPSPARSE_SPGEMM_CSR_ALG_NONDETERMINISTIC = 2,
+    HIPSPARSE_SPGEMM_ALG1 = 3,
+    HIPSPARSE_SPGEMM_ALG2 = 4,
+    HIPSPARSE_SPGEMM_ALG3 = 5
+} hipsparseSpGEMMAlg_t;
+#elif (CUDART_VERSION >= 11031 && CUDART_VERSION < 12000)
+typedef enum {
+    HIPSPARSE_SPGEMM_DEFAULT = 0,
+    HIPSPARSE_SPGEMM_CSR_ALG_DETERMINISTIC = 1,
+    HIPSPARSE_SPGEMM_CSR_ALG_NONDETERMINISTIC = 2,
+} hipsparseSpGEMMAlg_t;
+#elif (CUDART_VERSION >= 11000)
+typedef enum { HIPSPARSE_SPGEMM_DEFAULT = 0 } hipsparseSpGEMMAlg_t;
+#endif
+#endif
+
+#endif /* HIPSPARSE_GENERIC_TYPES_H */

--- a/shared/libs-common/library/include/hipsparse-common/hipsparse-types.h
+++ b/shared/libs-common/library/include/hipsparse-common/hipsparse-types.h
@@ -1,0 +1,472 @@
+/*! \file */
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+#ifndef HIPSPARSE_TYPES_H
+#define HIPSPARSE_TYPES_H
+
+/// \cond DO_NOT_DOCUMENT
+// Forward declarations
+struct bsrsv2Info;
+struct bsrsm2Info;
+struct bsrilu02Info;
+struct bsric02Info;
+struct csrsv2Info;
+struct csrsm2Info;
+struct csrilu02Info;
+struct csric02Info;
+struct csrgemm2Info;
+struct pruneInfo;
+struct csru2csrInfo;
+/// \endcond
+
+/*! \ingroup types_module
+ *  \brief Handle to the hipSPARSE library context queue.
+ *
+ *  \details
+ *  The hipSPARSE handle is a structure holding the hipSPARSE library context. It must
+ *  be initialized using hipsparseCreate() and the returned handle must be passed to all
+ *  subsequent library function calls. It should be destroyed at the end using
+ *  hipsparseDestroy().
+ */
+typedef void* hipsparseHandle_t;
+
+/*! \ingroup types_module
+ *  \brief Descriptor of the matrix.
+ *
+ *  \details
+ *  The hipSPARSE matrix descriptor is a structure holding all properties of a matrix.
+ *  It must be initialized using hipsparseCreateMatDescr() and the returned descriptor
+ *  must be passed to all subsequent library calls that involve the matrix. It should be
+ *  destroyed at the end using hipsparseDestroyMatDescr().
+ */
+typedef void* hipsparseMatDescr_t;
+
+/*! \ingroup types_module
+ *  \brief HYB matrix storage format.
+ *
+ *  \details
+ *  The hipSPARSE HYB matrix structure holds the HYB matrix. It must be initialized using
+ *  hipsparseCreateHybMat() and the returned HYB matrix must be passed to all subsequent
+ *  library calls that involve the matrix. It should be destroyed at the end using
+ *  hipsparseDestroyHybMat().
+ */
+typedef void* hipsparseHybMat_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding coloring info.
+ *
+ *  \details
+ *  The hipSPARSE ColorInfo structure holds the coloring information. It must be
+ *  initialized using hipsparseCreateColorInfo() and the returned structure must be
+ *  passed to all subsequent library calls that involve the coloring. It should be
+ *  destroyed at the end using hipsparseDestroyColorInfo().
+ */
+typedef void* hipsparseColorInfo_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding bsrsv2 info.
+ *
+ *  \details
+ *  The hipSPARSE bsrsv2 structure holds the information used by hipsparseXbsrsv2_zeroPivot(),
+ *  \ref hipsparseSbsrsv2_bufferSize "hipsparseXbsrsv2_bufferSize()", \ref
+ * hipsparseSbsrsv2_bufferSizeExt "hipsparseXbsrsv2_bufferSizeExt()", \ref hipsparseSbsrsv2_analysis
+ * "hipsparseXbsrsv2_analysis()", and \ref hipsparseSbsrsv2_solve "hipsparseXbsrsv2_solve()". It
+ * must be initialized using hipsparseCreateBsrsv2Info() and the returned structure must be passed
+ * to all subsequent library calls that involve bsrsv2. It should be destroyed at the end using
+ * hipsparseDestroyBsrsv2Info().
+ */
+typedef struct bsrsv2Info* bsrsv2Info_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding bsrsm2 info.
+ *
+ *  \details
+ *  The hipSPARSE bsrsm2 structure holds the information used by hipsparseXbsrsm2_zeroPivot(),
+ *  \ref hipsparseSbsrsm2_bufferSize "hipsparseXbsrsm2_bufferSize()", \ref hipsparseSbsrsm2_analysis
+ *  "hipsparseXbsrsm2_analysis()", and \ref hipsparseSbsrsm2_solve "hipsparseXbsrsm2_solve()". It
+ *  must be initialized using hipsparseCreateBsrsm2Info() and the returned structure must be
+ *  passed to all subsequent library calls that involve bsrsm2. It should be
+ *  destroyed at the end using hipsparseDestroyBsrsm2Info().
+ */
+typedef struct bsrsm2Info* bsrsm2Info_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding bsrilu02 info.
+ *
+ *  \details
+ *  The hipSPARSE bsrilu02 structure holds the information used by hipsparseXbsrilu02_zeroPivot(),
+ *  \ref hipsparseSbsrilu02_numericBoost "hipsparseXbsrilu02_numericBoost()", \ref
+ * hipsparseSbsrilu02_bufferSize "hipsparseXbsrilu02_bufferSize()", \ref hipsparseSbsrilu02_analysis
+ * "hipsparseXbsrilu02_analysis()", and \ref hipsparseSbsrilu02 "hipsparseXbsrilu02()". It must be
+ * initialized using hipsparseCreateBsrilu02Info() and the returned structure must be passed to all
+ * subsequent library calls that involve bsrilu02. It should be destroyed at the end using
+ * hipsparseDestroyBsrilu02Info().
+ */
+typedef struct bsrilu02Info* bsrilu02Info_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding bsric02 info.
+ *
+ *  \details
+ *  The hipSPARSE bsric02 structure holds the information used by hipsparseXbsric02_zeroPivot(),
+ *  \ref hipsparseSbsric02_bufferSize "hipsparseXbsric02_bufferSize()", \ref
+ * hipsparseSbsric02_analysis "hipsparseXbsric02_analysis()", and \ref hipsparseSbsric02
+ * "hipsparseXbsric02()". It must be initialized using hipsparseCreateBsric02Info() and the returned
+ * structure must be passed to all subsequent library calls that involve bsric02. It should be
+ * destroyed at the end using hipsparseDestroyBsric02Info().
+ */
+typedef struct bsric02Info* bsric02Info_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding csrsv2 info.
+ *
+ *  \details
+ *  The hipSPARSE csrsv2 structure holds the information used by hipsparseXcsrsv2_zeroPivot(),
+ *  \ref hipsparseScsrsv2_bufferSize "hipsparseXcsrsv2_bufferSize()", \ref hipsparseScsrsv2_analysis
+ *  "hipsparseXcsrsv2_analysis()", and \ref hipsparseScsrsv2_solve "hipsparseXcsrsv2_solve()". It
+ * must be initialized using hipsparseCreateCsrsv2Info() and the returned structure must be passed
+ * to all subsequent library calls that involve csrsv2. It should be destroyed at the end using
+ * hipsparseDestroyCsrsv2Info().
+ */
+typedef struct csrsv2Info* csrsv2Info_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding csrsm2 info.
+ *
+ *  \details
+ *  The hipSPARSE csrsm2 structure holds the information used by hipsparseXcsrsm2_zeroPivot(),
+ *  \ref hipsparseScsrsm2_bufferSizeExt "hipsparseXcsrsm2_bufferSizeExt()", \ref
+ * hipsparseScsrsm2_analysis "hipsparseXcsrsm2_analysis()", and \ref hipsparseScsrsm2_solve
+ * "hipsparseXcsrsm2_solve()". It must be initialized using hipsparseCreateCsrsm2Info() and the
+ * returned structure must be passed to all subsequent library calls that involve csrsm2. It should
+ * be destroyed at the end using hipsparseDestroyCsrsm2Info().
+ */
+typedef struct csrsm2Info* csrsm2Info_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding csrilu02 info.
+ *
+ *  \details
+ *  The hipSPARSE csrilu02 structure holds the information used by hipsparseXcsrilu02_zeroPivot(),
+ *  \ref hipsparseScsrilu02_numericBoost "hipsparseXcsrilu02_numericBoost()", \ref
+ * hipsparseScsrilu02_bufferSize "hipsparseXcsrilu02_bufferSize()", \ref hipsparseScsrilu02_analysis
+ * "hipsparseXcsrilu02_analysis()", and \ref hipsparseScsrilu02 "hipsparseXcsrilu02()". It must be
+ * initialized using hipsparseCreateCsrilu02Info() and the returned structure must be passed to all
+ * subsequent library calls that involve csrilu02. It should be destroyed at the end using
+ * hipsparseDestroyCsrilu02Info().
+ */
+typedef struct csrilu02Info* csrilu02Info_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding csric02 info.
+ *
+ *  \details
+ *  The hipSPARSE csric02 structure holds the information used by hipsparseXcsric02_zeroPivot(),
+ *  \ref hipsparseScsric02_bufferSize "hipsparseXcsric02_bufferSize()", \ref
+ * hipsparseScsric02_analysis "hipsparseXcsric02_analysis()", and \ref hipsparseScsric02
+ * "hipsparseXcsric02()". It must be initialized using hipsparseCreateCsric02Info() and the returned
+ * structure must be passed to all subsequent library calls that involve csric02. It should be
+ * destroyed at the end using hipsparseDestroyCsric02Info().
+ */
+typedef struct csric02Info* csric02Info_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding csrgemm2 info.
+ *
+ *  \details
+ *  The hipSPARSE csrgemm2 structure holds the information used by \ref
+ * hipsparseScsrgemm2_bufferSizeExt "hipsparseXcsrgemm2_bufferSizeExt()", hipsparseXcsrgemm2Nnz(),
+ * and \ref hipsparseScsrgemm2 "hipsparseXcsrgemm2()". It must be initialized using
+ * hipsparseCreateCsrgemm2Info() and the returned structure must be passed to all subsequent library
+ * calls that involve csrgemm2. It should be destroyed at the end using
+ *  hipsparseDestroyCsrgemm2Info().
+ */
+typedef struct csrgemm2Info* csrgemm2Info_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding prune info.
+ *
+ *  \details
+ *  The hipSPARSE prune structure holds the information used by \ref
+ * hipsparseSpruneDense2csrByPercentage_bufferSize
+ *  "hipsparseXpruneDense2csrByPercentage_bufferSize()", \ref
+ * hipsparseSpruneDense2csrByPercentage_bufferSizeExt
+ *  "hipsparseXpruneDense2csrByPercentage_bufferSizeExt()", \ref
+ * hipsparseSpruneCsr2csrByPercentage_bufferSize "hipsparseXpruneCsr2csrByPercentage_bufferSize()",
+ * \ref hipsparseSpruneCsr2csrByPercentage_bufferSizeExt
+ *  "hipsparseXpruneCsr2csrByPercentage_bufferSizeExt()", \ref
+ * hipsparseSpruneDense2csrNnzByPercentage "hipsparseXpruneDense2csrNnzByPercentage()", \ref
+ * hipsparseSpruneCsr2csrNnzByPercentage "hipsparseXpruneCsr2csrNnzByPercentage()", \ref
+ * hipsparseSpruneDense2csrByPercentage "hipsparseXpruneDense2csrByPercentage()", and \ref
+ * hipsparseSpruneCsr2csrByPercentage "hipsparseXpruneCsr2csrByPercentage()". It must be initialized
+ * using hipsparseCreatePruneInfo() and the returned structure must be passed to all subsequent
+ * library calls that involve prune. It should be destroyed at the end using
+ * hipsparseDestroyPruneInfo().
+ */
+typedef struct pruneInfo* pruneInfo_t;
+
+/*! \ingroup types_module
+ *  \brief Pointer type to opaque structure holding csru2csr info.
+ *
+ *  \details
+ *  The hipSPARSE csru2csr structure holds the information used by \ref
+ * hipsparseScsru2csr_bufferSizeExt "hipsparseXcsru2csr_bufferSizeExt()", \ref hipsparseScsru2csr
+ * "hipsparseXcsru2csr()", and \ref hipsparseScsr2csru "hipsparseXcsr2csru()". It must be
+ * initialized using hipsparseCreateCsru2csrInfo() and the returned structure must be passed to all
+ * subsequent library calls that involve csru2csr. It should be destroyed at the end using
+ * hipsparseDestroyCsru2csrInfo().
+ */
+typedef struct csru2csrInfo* csru2csrInfo_t;
+
+// clang-format off
+
+/*! \ingroup types_module
+ *  \brief List of hipsparse status codes definition.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseStatus_t types that are used by the hipSPARSE
+ *  library.
+ */
+#if(!defined(CUDART_VERSION))
+typedef enum {
+    HIPSPARSE_STATUS_SUCCESS                   = 0, /**< Function succeeds */
+    HIPSPARSE_STATUS_NOT_INITIALIZED           = 1, /**< hipSPARSE was not initialized */
+    HIPSPARSE_STATUS_ALLOC_FAILED              = 2, /**< Resource allocation failed */
+    HIPSPARSE_STATUS_INVALID_VALUE             = 3, /**< Unsupported value was passed to the function */
+    HIPSPARSE_STATUS_ARCH_MISMATCH             = 4, /**< Device architecture not supported */
+    HIPSPARSE_STATUS_MAPPING_ERROR             = 5, /**< Access to GPU memory space failed */
+    HIPSPARSE_STATUS_EXECUTION_FAILED          = 6, /**< GPU program failed to execute */
+    HIPSPARSE_STATUS_INTERNAL_ERROR            = 7, /**< An internal hipSPARSE operation failed */
+    HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED = 8, /**< Matrix type not supported */
+    HIPSPARSE_STATUS_ZERO_PIVOT                = 9, /**< Zero pivot was computed */
+    HIPSPARSE_STATUS_NOT_SUPPORTED             = 10, /**< Operation is not supported */
+    HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES    = 11 /**< Resources are insufficient */
+} hipsparseStatus_t;
+#else
+#if(CUDART_VERSION >= 11003)
+typedef enum {
+    HIPSPARSE_STATUS_SUCCESS                   = 0, /**< Function succeeds */
+    HIPSPARSE_STATUS_NOT_INITIALIZED           = 1, /**< hipSPARSE was not initialized */
+    HIPSPARSE_STATUS_ALLOC_FAILED              = 2, /**< Resource allocation failed */
+    HIPSPARSE_STATUS_INVALID_VALUE             = 3, /**< Unsupported value was passed to the function */
+    HIPSPARSE_STATUS_ARCH_MISMATCH             = 4, /**< Device architecture not supported */
+    HIPSPARSE_STATUS_MAPPING_ERROR             = 5, /**< Access to GPU memory space failed */
+    HIPSPARSE_STATUS_EXECUTION_FAILED          = 6, /**< GPU program failed to execute */
+    HIPSPARSE_STATUS_INTERNAL_ERROR            = 7, /**< An internal hipSPARSE operation failed */
+    HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED = 8, /**< Matrix type not supported */
+    HIPSPARSE_STATUS_ZERO_PIVOT                = 9, /**< Zero pivot was computed */
+    HIPSPARSE_STATUS_NOT_SUPPORTED             = 10, /**< Operation is not supported */
+    HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES    = 11 /**< Resources are insufficient */
+} hipsparseStatus_t;
+#elif(CUDART_VERSION >= 10010)
+typedef enum {
+    HIPSPARSE_STATUS_SUCCESS                   = 0, /**< Function succeeds */
+    HIPSPARSE_STATUS_NOT_INITIALIZED           = 1, /**< hipSPARSE was not initialized */
+    HIPSPARSE_STATUS_ALLOC_FAILED              = 2, /**< Resource allocation failed */
+    HIPSPARSE_STATUS_INVALID_VALUE             = 3, /**< Unsupported value was passed to the function */
+    HIPSPARSE_STATUS_ARCH_MISMATCH             = 4, /**< Device architecture not supported */
+    HIPSPARSE_STATUS_MAPPING_ERROR             = 5, /**< Access to GPU memory space failed */
+    HIPSPARSE_STATUS_EXECUTION_FAILED          = 6, /**< GPU program failed to execute */
+    HIPSPARSE_STATUS_INTERNAL_ERROR            = 7, /**< An internal hipSPARSE operation failed */
+    HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED = 8, /**< Matrix type not supported */
+    HIPSPARSE_STATUS_ZERO_PIVOT                = 9, /**< Zero pivot was computed */
+    HIPSPARSE_STATUS_NOT_SUPPORTED             = 10 /**< Operation is not supported */
+} hipsparseStatus_t;
+#endif
+#endif
+
+/*! \ingroup types_module
+ *  \brief Indicates if the pointer is device pointer or host pointer.
+ *
+ *  \details
+ *  The \ref hipsparsePointerMode_t indicates whether scalar values are passed by
+ *  reference on the host or device. The \ref hipsparsePointerMode_t can be changed by
+ *  hipsparseSetPointerMode(). The currently used pointer mode can be obtained by
+ *  hipsparseGetPointerMode().
+ */
+typedef enum {
+    HIPSPARSE_POINTER_MODE_HOST   = 0, /**< Scalar pointers are in host memory */
+    HIPSPARSE_POINTER_MODE_DEVICE = 1 /**< Scalar pointers are in device memory */
+} hipsparsePointerMode_t;
+
+/*! \ingroup types_module
+ *  \brief Specify where the operation is performed on.
+ *
+ *  \details
+ *  The \ref hipsparseAction_t indicates whether the operation is performed on the full
+ *  matrix, or only on the sparsity pattern of the matrix.
+ */
+typedef enum {
+    HIPSPARSE_ACTION_SYMBOLIC = 0, /**< Operate only on indices */
+    HIPSPARSE_ACTION_NUMERIC  = 1 /**< Operate on data and indices */
+} hipsparseAction_t;
+
+/*! \ingroup types_module
+ *  \brief Specify the matrix type.
+ *
+ *  \details
+ *  The \ref hipsparseMatrixType_t indices the type of a matrix. For a given
+ *  \ref hipsparseMatDescr_t, the \ref hipsparseMatrixType_t can be set using
+ *  hipsparseSetMatType(). The current \ref hipsparseMatrixType_t of a matrix can be
+ *  obtained by hipsparseGetMatType().
+ */
+typedef enum {
+    HIPSPARSE_MATRIX_TYPE_GENERAL    = 0, /**< General matrix type */
+    HIPSPARSE_MATRIX_TYPE_SYMMETRIC  = 1, /**< Symmetric matrix type */
+    HIPSPARSE_MATRIX_TYPE_HERMITIAN  = 2, /**< Hermitian matrix type */
+    HIPSPARSE_MATRIX_TYPE_TRIANGULAR = 3 /**< Triangular matrix type */
+} hipsparseMatrixType_t;
+
+/*! \ingroup types_module
+ *  \brief Specify the matrix fill mode.
+ *
+ *  \details
+ *  The \ref hipsparseFillMode_t indicates whether the lower or the upper part is stored
+ *  in a sparse triangular matrix. For a given \ref hipsparseMatDescr_t, the
+ *  \ref hipsparseFillMode_t can be set using hipsparseSetMatFillMode(). The current
+ *  \ref hipsparseFillMode_t of a matrix can be obtained by hipsparseGetMatFillMode().
+ */
+typedef enum {
+    HIPSPARSE_FILL_MODE_LOWER = 0, /**< Lower triangular part is stored */
+    HIPSPARSE_FILL_MODE_UPPER = 1 /**< Upper triangular part is stored */
+} hipsparseFillMode_t;
+
+/*! \ingroup types_module
+ *  \brief Indicates if the diagonal entries are unity.
+ *
+ *  \details
+ *  The \ref hipsparseDiagType_t indicates whether the diagonal entries of a matrix are
+ *  unity or not. If \ref HIPSPARSE_DIAG_TYPE_UNIT is specified, all present diagonal
+ *  values will be ignored. For a given \ref hipsparseMatDescr_t, the
+ *  \ref hipsparseDiagType_t can be set using hipsparseSetMatDiagType(). The current
+ *  \ref hipsparseDiagType_t of a matrix can be obtained by hipsparseGetMatDiagType().
+ */
+typedef enum {
+    HIPSPARSE_DIAG_TYPE_NON_UNIT = 0, /**< Diagonal entries are non-unity */
+    HIPSPARSE_DIAG_TYPE_UNIT     = 1  /**< Diagonal entries are unity */
+} hipsparseDiagType_t;
+
+/*! \ingroup types_module
+ *  \brief Specify the matrix index base.
+ *
+ *  \details
+ *  The \ref hipsparseIndexBase_t indicates the index base of the indices. For a
+ *  given \ref hipsparseMatDescr_t, the \ref hipsparseIndexBase_t can be set using
+ *  hipsparseSetMatIndexBase(). The current \ref hipsparseIndexBase_t of a matrix
+ *  can be obtained by hipsparseGetMatIndexBase().
+ */
+typedef enum {
+    HIPSPARSE_INDEX_BASE_ZERO = 0, /**< Zero based indexing */
+    HIPSPARSE_INDEX_BASE_ONE  = 1  /**< One based indexing */
+} hipsparseIndexBase_t;
+
+/*! \ingroup types_module
+ *  \brief Specify whether the matrix is to be transposed or not.
+ *
+ *  \details
+ *  The \ref hipsparseOperation_t indicates the operation performed with the given matrix.
+ */
+typedef enum {
+    HIPSPARSE_OPERATION_NON_TRANSPOSE       = 0, /**< Operate with matrix */
+    HIPSPARSE_OPERATION_TRANSPOSE           = 1, /**< Operate with transpose */
+    HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE = 2  /**< Operate with conj. transpose */
+} hipsparseOperation_t;
+
+/*! \ingroup types_module
+ *  \brief HYB matrix partitioning type.
+ *
+ *  \details
+ *  The \ref hipsparseHybPartition_t type indicates how the hybrid format partitioning
+ *  between COO and ELL storage formats is performed.
+ */
+typedef enum {
+    HIPSPARSE_HYB_PARTITION_AUTO = 0, /**< Automatically decide on ELL nnz per row */
+    HIPSPARSE_HYB_PARTITION_USER = 1, /**< User given ELL nnz per row */
+    HIPSPARSE_HYB_PARTITION_MAX  = 2  /**< Max ELL nnz per row, no COO part */
+} hipsparseHybPartition_t;
+
+/*! \ingroup types_module
+ *  \brief Specify policy in triangular solvers and factorizations.
+ *
+ *  \details
+ *  The \ref hipsparseSolvePolicy_t type indicates the solve policy for the triangular
+ *  solve.
+ */
+typedef enum {
+    HIPSPARSE_SOLVE_POLICY_NO_LEVEL  = 0, /**< No level information generated */
+    HIPSPARSE_SOLVE_POLICY_USE_LEVEL = 1  /**< Generate level information */
+} hipsparseSolvePolicy_t;
+
+/// \cond DO_NOT_DOCUMENT
+// Note: Add back to types.rst if we get documentation for this in the future
+typedef enum {
+    HIPSPARSE_SIDE_LEFT  = 0,
+    HIPSPARSE_SIDE_RIGHT = 1
+} hipsparseSideMode_t;
+/// \endcond
+
+/*! \ingroup types_module
+ *  \brief Specify the matrix direction.
+ *
+ *  \details
+ *  The \ref hipsparseDirection_t indicates whether a dense matrix should be parsed by
+ *  rows or by columns, assuming column-major storage.
+ */
+typedef enum {
+    HIPSPARSE_DIRECTION_ROW = 0, /**< Parse the matrix by rows */
+    HIPSPARSE_DIRECTION_COLUMN = 1 /**< Parse the matrix by columns */
+} hipsparseDirection_t;
+
+/*! \ingroup types_module
+ *  \brief List of hipsparse csr2csc algorithms.
+ *
+ *  \details
+ *  This is a list of the \ref hipsparseCsr2CscAlg_t algorithms that can be used by the hipSPARSE
+ *  library routines \ref hipsparseCsr2cscEx2_bufferSize and \ref hipsparseCsr2cscEx2.
+ */
+#if(!defined(CUDART_VERSION))
+typedef enum
+{
+    HIPSPARSE_CSR2CSC_ALG_DEFAULT = 0,
+    HIPSPARSE_CSR2CSC_ALG1        = 1,
+    HIPSPARSE_CSR2CSC_ALG2        = 2
+} hipsparseCsr2CscAlg_t;
+#else
+#if(CUDART_VERSION >= 12000)
+typedef enum
+{
+    HIPSPARSE_CSR2CSC_ALG_DEFAULT = 0,
+    HIPSPARSE_CSR2CSC_ALG1        = 1
+} hipsparseCsr2CscAlg_t;
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+typedef enum
+{
+    HIPSPARSE_CSR2CSC_ALG1 = 1,
+    HIPSPARSE_CSR2CSC_ALG2 = 2
+} hipsparseCsr2CscAlg_t;
+#endif
+#endif
+
+// clang-format on
+
+#endif /* HIPSPARSE_TYPES_H */

--- a/shared/libs-common/tests/CMakeLists.txt
+++ b/shared/libs-common/tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ########################################################################
+#
+# MIT License
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+
+cmake_minimum_required(VERSION 3.11.0)
+project(installation-tests LANGUAGES CXX)
+
+find_package(hipblas-common REQUIRED)
+
+add_executable(hello-roc main.cpp)
+target_link_libraries(hello-roc PRIVATE roc::hipblas-common)

--- a/shared/libs-common/tests/main.cpp
+++ b/shared/libs-common/tests/main.cpp
@@ -1,0 +1,31 @@
+// ########################################################################
+//
+// MIT License
+//
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+// ies of the Software, and to permit persons to whom the Software is furnished
+// to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+// PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+// CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ########################################################################
+
+#include <iostream>
+
+#include "hipblas-common/hipblas-common.h"
+
+int main() {
+    std::puts("Hello hipblas-common");
+}


### PR DESCRIPTION
Proposal to add a libs-common directory to collect shared header files for various ROCm and HIP components. If approved, a follow-up PR will be issued to update projects dependent on these headers those currently in hipblas-common.

If consensus rejects this proposal, this PR will be closed.