### PR TITLE
Environment variable to override WGM value at run-time for experiments

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
@@ -228,6 +228,7 @@ namespace TensileLite
         int         computeUnitCount = 0;
         int         skDynamicGrid    = 6;
         int         skDynamicWGM     = 0;
+        int         fixedWGM         = std::numeric_limits<int>::max();
         int         skMaxCUs         = 0;
         int         skGridMultiplier = 1;
         int         skFixedGrid      = 0;
@@ -260,6 +261,13 @@ namespace TensileLite
         {
             static const char* envStr = std::getenv("TENSILE_STREAMK_DYNAMIC_WGM");
             static const int   value  = (envStr == NULL ? 0 : std::atoi(envStr));
+            return value;
+        }
+
+        const int getFixedWGM() const
+        {
+            static const char* envStr = std::getenv("TENSILE_FIXED_WGM");
+            static const int   value  = (envStr == NULL ? std::numeric_limits<int>::max() : std::atoi(envStr));
             return value;
         }
 

--- a/projects/hipblaslt/tensilelite/src/AMDGPU.cpp
+++ b/projects/hipblaslt/tensilelite/src/AMDGPU.cpp
@@ -53,6 +53,7 @@ namespace TensileLite
         , deviceName(name)
         , skDynamicGrid(getSKDynamicGrid())
         , skDynamicWGM(getSKDynamicWGM())
+        , fixedWGM(getFixedWGM())
         , skMaxCUs(getSKMaxCUs())
         , skGridMultiplier(getSKGridMultiplier())
         , skFixedGrid(getSKFixedGrid())

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -1204,7 +1204,11 @@ namespace TensileLite
             if(sizeMapping.streamK != 0)
             {
                 AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
-                if(pAMDGPU->skDynamicWGM == 1)
+                if(pAMDGPU->fixedWGM >= -1024 && pAMDGPU->fixedWGM <= 1024)
+                {
+                    defaultWGM = pAMDGPU->fixedWGM;
+                }
+                else if(pAMDGPU->skDynamicWGM == 1)
                 {
                     hip::HipAMDGPU const* hipAMDGPU
                         = dynamic_cast<hip::HipAMDGPU const*>(&hardware);


### PR DESCRIPTION
To override WGM value set the environment variable TENSILE_FIXED_WGM. Default is off. This option is meant for easier debugging and performance experiments.