### PR TITLE
[ci] - Adding hash refs to TheRock

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
+          ref: 5682f361d81bd53dbf677ed678539688a856a54f
 
       - name: Runner Health Settings
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
+          ref: 5682f361d81bd53dbf677ed678539688a856a54f
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
We are making updates to TheRock for particular cmake flags. It will break this repo, so adding commit hashes in order to limit breaks!

Checkout step working here: https://github.com/ROCm/rocm-libraries/actions/runs/16735941869