### PR TITLE
[hipsparselt] Increase the coverage from 81% to 87%

### DIFF
--- a/projects/hipsparselt/CMakeLists.txt
+++ b/projects/hipsparselt/CMakeLists.txt
@@ -405,11 +405,6 @@ if(BUILD_CODE_COVERAGE)
 
   target_compile_options(hipsparselt-test PRIVATE ${COVERAGE_CXX_FLAGS})
   target_link_options(hipsparselt-test PRIVATE ${COVERAGE_LINK_FLAGS})
-  target_include_directories(hipsparselt-test
-    PRIVATE
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/src/hcc_detail/rocsparselt/src/include>
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/src/hcc_detail/rocsparselt/include>
-  )
 
   #
   # Run coverage analysis

--- a/projects/hipsparselt/CMakeLists.txt
+++ b/projects/hipsparselt/CMakeLists.txt
@@ -391,13 +391,24 @@ if(BUILD_CODE_COVERAGE)
   find_program(LLVM_PROFDATA_EXECUTABLE llvm-profdata HINTS ${LLVM_COV_BIN_DIR} REQUIRED)
   message(STATUS "using llvm-profdata: ${LLVM_PROFDATA_EXECUTABLE}")
 
-  target_compile_options(hipsparselt PRIVATE
+  set(COVERAGE_CXX_FLAGS
     -fprofile-instr-generate
     -fcoverage-mapping
+    -fvisibility=default
+  )
+  set(COVERAGE_LINK_FLAGS
+    -fprofile-instr-generate
   )
 
-  target_link_options(hipsparselt PUBLIC
-    -fprofile-instr-generate
+  target_compile_options(hipsparselt PRIVATE ${COVERAGE_CXX_FLAGS})
+  target_link_options(hipsparselt PRIVATE ${COVERAGE_LINK_FLAGS})
+
+  target_compile_options(hipsparselt-test PRIVATE ${COVERAGE_CXX_FLAGS})
+  target_link_options(hipsparselt-test PRIVATE ${COVERAGE_LINK_FLAGS})
+  target_include_directories(hipsparselt-test
+    PRIVATE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/src/hcc_detail/rocsparselt/src/include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/library/src/hcc_detail/rocsparselt/include>
   )
 
   #
@@ -420,7 +431,7 @@ if(BUILD_CODE_COVERAGE)
   # Generate coverage output using llvm-cov
   #
   set(LLVM_COV_COMMON_ARGS
-    -object ./library/libhipsparselt.so
+    -object $<TARGET_FILE:hipsparselt>
     -instr-profile=./coverage_test.profdata
     --ignore-filename-regex=.*/build/.*
   )

--- a/projects/hipsparselt/CMakeLists.txt
+++ b/projects/hipsparselt/CMakeLists.txt
@@ -406,6 +406,13 @@ if(BUILD_CODE_COVERAGE)
   target_compile_options(hipsparselt-test PRIVATE ${COVERAGE_CXX_FLAGS})
   target_link_options(hipsparselt-test PRIVATE ${COVERAGE_LINK_FLAGS})
 
+  target_include_directories( hipsparselt-test PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/hcc_detail/rocsparselt/src/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/hcc_detail/rocsparselt/include>
+  )
+
+  target_compile_definitions( hipsparselt-test PRIVATE CODE_COVERAGE )
+
   #
   # Run coverage analysis
   #

--- a/projects/hipsparselt/clients/gtest/CMakeLists.txt
+++ b/projects/hipsparselt/clients/gtest/CMakeLists.txt
@@ -44,6 +44,8 @@ target_include_directories( hipsparselt-test
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/hcc_detail/rocsparselt/src/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/hcc_detail/rocsparselt/include>
 )
 
 # External header includes included as system files

--- a/projects/hipsparselt/clients/gtest/CMakeLists.txt
+++ b/projects/hipsparselt/clients/gtest/CMakeLists.txt
@@ -44,9 +44,15 @@ target_include_directories( hipsparselt-test
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/include>
+)
+
+if(BUILD_CODE_COVERAGE)
+target_include_directories( hipsparselt-test
+  PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/hcc_detail/rocsparselt/src/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/hcc_detail/rocsparselt/include>
 )
+endif()
 
 # External header includes included as system files
 target_include_directories( hipsparselt-test

--- a/projects/hipsparselt/clients/gtest/CMakeLists.txt
+++ b/projects/hipsparselt/clients/gtest/CMakeLists.txt
@@ -46,14 +46,6 @@ target_include_directories( hipsparselt-test
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/include>
 )
 
-if(BUILD_CODE_COVERAGE)
-target_include_directories( hipsparselt-test
-  PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/hcc_detail/rocsparselt/src/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/hcc_detail/rocsparselt/include>
-)
-endif()
-
 # External header includes included as system files
 target_include_directories( hipsparselt-test
   SYSTEM PRIVATE

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
@@ -128,6 +128,8 @@ namespace
                 testing_aux_math(arg);
             else if(!strcmp(arg.function, "aux_misc"))
                 testing_aux_misc(arg);
+            else if(!strcmp(arg.function, "aux_ostream"))
+                testing_aux_ostream(arg);
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }
@@ -177,7 +179,8 @@ namespace
                    || !strcmp(arg.function, "aux_string_helper")
                    || !strcmp(arg.function, "aux_value_mapping")
                    || !strcmp(arg.function, "aux_math")
-                   || !strcmp(arg.function, "aux_misc");
+                   || !strcmp(arg.function, "aux_misc")
+                   || !strcmp(arg.function, "aux_ostream");
         }
 
         // Google Test name suffix based on parameters

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
@@ -120,6 +120,7 @@ namespace
                 testing_aux_get_workspace_size_bad_arg(arg);
             else if(!strcmp(arg.function, "aux_get_workspace_size"))
                 testing_aux_get_workspace_size(arg);
+        #ifdef CODE_COVERAGE
             else if(!strcmp(arg.function, "aux_string_helper"))
                 testing_aux_string_helper(arg);
             else if(!strcmp(arg.function, "aux_value_mapping"))
@@ -130,6 +131,7 @@ namespace
                 testing_aux_misc(arg);
             else if(!strcmp(arg.function, "aux_ostream"))
                 testing_aux_ostream(arg);
+        #endif
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
@@ -122,8 +122,8 @@ namespace
                 testing_aux_get_workspace_size(arg);
             else if(!strcmp(arg.function, "aux_string_helper"))
                 testing_aux_string_helper(arg);
-            else if(!strcmp(arg.function, "aux_rocsparselt_ostream"))
-                testing_aux_rocsparselt_ostream(arg);
+            else if(!strcmp(arg.function, "aux_value_mapping"))
+                testing_aux_value_mapping(arg);
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }
@@ -171,7 +171,7 @@ namespace
                    || !strcmp(arg.function, "aux_get_workspace_size_bad_arg")
                    || !strcmp(arg.function, "aux_get_workspace_size")
                    || !strcmp(arg.function, "aux_string_helper")
-                   || !strcmp(arg.function, "aux_rocsparselt_ostream");
+                   || !strcmp(arg.function, "aux_value_mapping");
         }
 
         // Google Test name suffix based on parameters

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
@@ -170,7 +170,8 @@ namespace
                    || !strcmp(arg.function, "aux_matmul_plan_destroy_bad_arg")
                    || !strcmp(arg.function, "aux_get_workspace_size_bad_arg")
                    || !strcmp(arg.function, "aux_get_workspace_size")
-                   || !strcmp(arg.function, "aux_string_helper");
+                   || !strcmp(arg.function, "aux_string_helper")
+                   || !strcmp(arg.function, "aux_rocsparselt_ostream");
         }
 
         // Google Test name suffix based on parameters

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
@@ -120,6 +120,10 @@ namespace
                 testing_aux_get_workspace_size_bad_arg(arg);
             else if(!strcmp(arg.function, "aux_get_workspace_size"))
                 testing_aux_get_workspace_size(arg);
+            else if(!strcmp(arg.function, "aux_string_helper"))
+                testing_aux_string_helper(arg);
+            else if(!strcmp(arg.function, "aux_rocsparselt_ostream"))
+                testing_aux_rocsparselt_ostream(arg);
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }
@@ -165,7 +169,8 @@ namespace
                    || !strcmp(arg.function, "aux_matmul_plan_init")
                    || !strcmp(arg.function, "aux_matmul_plan_destroy_bad_arg")
                    || !strcmp(arg.function, "aux_get_workspace_size_bad_arg")
-                   || !strcmp(arg.function, "aux_get_workspace_size");
+                   || !strcmp(arg.function, "aux_get_workspace_size")
+                   || !strcmp(arg.function, "aux_string_helper");
         }
 
         // Google Test name suffix based on parameters

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.cpp
@@ -124,6 +124,10 @@ namespace
                 testing_aux_string_helper(arg);
             else if(!strcmp(arg.function, "aux_value_mapping"))
                 testing_aux_value_mapping(arg);
+            else if(!strcmp(arg.function, "aux_math"))
+                testing_aux_math(arg);
+            else if(!strcmp(arg.function, "aux_misc"))
+                testing_aux_misc(arg);
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }
@@ -171,7 +175,9 @@ namespace
                    || !strcmp(arg.function, "aux_get_workspace_size_bad_arg")
                    || !strcmp(arg.function, "aux_get_workspace_size")
                    || !strcmp(arg.function, "aux_string_helper")
-                   || !strcmp(arg.function, "aux_value_mapping");
+                   || !strcmp(arg.function, "aux_value_mapping")
+                   || !strcmp(arg.function, "aux_math")
+                   || !strcmp(arg.function, "aux_misc");
         }
 
         // Google Test name suffix based on parameters

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.yaml
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.yaml
@@ -173,3 +173,8 @@ Tests:
   category: pre_checkin
   function:
     - aux_misc: *hpa_half_precision
+
+- name: aux_ostream
+  category: pre_checkin
+  function:
+    - aux_ostream: *hpa_half_precision

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.yaml
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.yaml
@@ -159,7 +159,7 @@ Tests:
   function:
     - aux_string_helper: *hpa_half_precision
 
-- name: aux_rocsparselt_ostream
+- name: aux_value_mapping
   category: pre_checkin
   function:
-    - aux_rocsparselt_ostream: *hpa_half_precision
+    - aux_value_mapping: *hpa_half_precision

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.yaml
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.yaml
@@ -154,4 +154,12 @@ Tests:
   function:
     - aux_get_version: *hpa_half_precision
 
-...
+- name: aux_string_helper
+  category: pre_checkin
+  function:
+    - aux_string_helper: *hpa_half_precision
+
+- name: aux_rocsparselt_ostream
+  category: pre_checkin
+  function:
+    - aux_rocsparselt_ostream: *hpa_half_precision

--- a/projects/hipsparselt/clients/gtest/auxiliary_gtest.yaml
+++ b/projects/hipsparselt/clients/gtest/auxiliary_gtest.yaml
@@ -163,3 +163,13 @@ Tests:
   category: pre_checkin
   function:
     - aux_value_mapping: *hpa_half_precision
+
+- name: aux_math
+  category: pre_checkin
+  function:
+    - aux_math: *hpa_half_precision
+
+- name: aux_misc
+  category: pre_checkin
+  function:
+    - aux_misc: *hpa_half_precision

--- a/projects/hipsparselt/clients/include/testing_auxiliary.hpp
+++ b/projects/hipsparselt/clients/include/testing_auxiliary.hpp
@@ -33,6 +33,8 @@
 #include "hipsparselt_random.hpp"
 #include "hipsparselt_test.hpp"
 #include "hipsparselt_vector.hpp"
+#include "rocsparselt-types.h"
+#include "tensile_host.hpp"
 #include "unit.hpp"
 #include "utility.hpp"
 #include <hipsparselt/hipsparselt.h>
@@ -295,7 +297,7 @@ void testing_aux_mat_init_structured_bad_arg(const Arguments& arg)
                                                                 HIP_R_64F,
                                                                 HIPSPARSE_ORDER_COL,
                                                                 HIPSPARSELT_SPARSITY_50_PERCENT),
-                            HIPSPARSE_STATUS_NOT_SUPPORTED);     
+                            HIPSPARSE_STATUS_NOT_SUPPORTED);
 }
 
 void testing_aux_mat_dense_init(const Arguments& arg)
@@ -1829,4 +1831,156 @@ void testing_aux_get_workspace_size(const Arguments& arg)
 
     EXPECT_HIPSPARSE_STATUS(hipsparseLtMatmulGetWorkspace(handle, plan, &workspace_size),
                             HIPSPARSE_STATUS_SUCCESS);
+}
+
+void testing_aux_string_helper(const Arguments& arg)
+{
+    struct StrToEnumTestCase
+    {
+        const char* input;
+        int expected;
+    };
+
+    constexpr int invalid_enum = -1;
+
+    const StrToEnumTestCase hip_datatype_cases[] = {
+        {"f32_r", HIP_R_32F},
+        {"s", HIP_R_32F},
+        {"f16_r", HIP_R_16F},
+        {"h", HIP_R_16F},
+        {"bf16_r", HIP_R_16BF},
+        {"i8_r", HIP_R_8I},
+#if defined(HIP_FP8_TYPE_OCP) || defined(__HIP_PLATFORM_NVIDIA__)
+        {"f8_r", HIP_R_8F_E4M3},
+        {"bf8_r", HIP_R_8F_E5M2},
+#endif
+        {"invalid", invalid_enum},
+        {"", invalid_enum},
+        {"f64_r", invalid_enum},
+        {"unknown", invalid_enum},
+        {"F32_R", invalid_enum},
+    };
+
+    for(const auto& test : hip_datatype_cases)
+    {
+        EXPECT_EQ(string_to_hip_datatype(test.input), test.expected);
+    }
+
+    const StrToEnumTestCase compute_type_cases[] = {
+        {"f32_r", HIPSPARSELT_COMPUTE_32F},
+        {"s", HIPSPARSELT_COMPUTE_32F},
+        {"i32_r", HIPSPARSELT_COMPUTE_32I},
+        {"f16_r", HIPSPARSELT_COMPUTE_16F},
+        {"h", HIPSPARSELT_COMPUTE_16F},
+        {"tf32_r", HIPSPARSELT_COMPUTE_TF32},
+        {"tf32f_r", HIPSPARSELT_COMPUTE_TF32_FAST},
+        {"invalid", invalid_enum},
+        {"", invalid_enum},
+        {"unknown", invalid_enum},
+    };
+
+    for(const auto& test : compute_type_cases)
+    {
+        EXPECT_EQ(string_to_hipsparselt_computetype(test.input), test.expected);
+    }
+
+    const std::pair<const char*, hipsparselt_activation_type> activation_type_cases[] = {
+        {"abs", hipsparselt_activation_type::abs},
+        {"clippedrelu", hipsparselt_activation_type::clippedrelu},
+        {"exp", hipsparselt_activation_type::exp},
+        {"gelu", hipsparselt_activation_type::gelu},
+        {"leakyrelu", hipsparselt_activation_type::leakyrelu},
+        {"relu", hipsparselt_activation_type::relu},
+        {"sigmoid", hipsparselt_activation_type::sigmoid},
+        {"tanh", hipsparselt_activation_type::tanh},
+        {"all", hipsparselt_activation_type::all},
+        {"none", hipsparselt_activation_type::none},
+        {"invalid", static_cast<hipsparselt_activation_type>(invalid_enum)},
+    };
+
+    for(const auto& test : activation_type_cases)
+    {
+        EXPECT_EQ(string_to_hipsparselt_activation_type(test.first), test.second);
+        EXPECT_STREQ(hipsparselt_activation_type_to_string(test.second), test.first);
+    }
+}
+
+// Test for RocsparseltContractionProblem operator<< function
+void testing_rocsparselt_contraction_problem_ostream(const Arguments& arg)
+{
+    // using Ti = float;
+    // using To = float;
+    // using Tc = float;
+
+    // // Create a mock handle
+    // _rocsparselt_handle handle;
+
+    // // Test data - use different values to ensure all branches are covered
+    // constexpr size_t m = 128, n = 64, k = 32;
+    // constexpr size_t batch_count = 2;
+
+    // // Create test arrays
+    // std::vector<Ti> A_data(m * k * batch_count, Ti(1.5));
+    // std::vector<Ti> B_data(k * n * batch_count, Ti(2.5));
+    // std::vector<To> C_data(m * n * batch_count, To(3.5));
+    // std::vector<To> D_data(m * n * batch_count, To(0.0));
+    // std::vector<unsigned char> metadata(m * k / 2, 0xFF);
+    // std::vector<float> bias_data(m, 1.0f);
+
+    // Tc alpha = Tc(1.0);
+    // Tc beta = Tc(0.5);
+
+    // // Test case 2: Problem with bias and activation to cover different branches
+    // {
+    //     RocsparseltContractionProblem<Ti, To> prob(
+    //         &handle,
+    //         rocsparselt_operation_transpose,  // trans_a
+    //         rocsparselt_operation_none,       // trans_b
+    //         rocsparselt_order_row,           // order
+    //         m, n, k,                         // dimensions
+    //         &alpha,                          // alpha
+    //         A_data.data(), nullptr,          // A, batch_A
+    //         k, 0, 0,                        // ld_a, batch_stride_a, offset_a
+    //         B_data.data(), nullptr,          // B, batch_B
+    //         n, 0, 0,                        // ld_b, batch_stride_b, offset_b
+    //         &beta,                           // beta
+    //         C_data.data(), nullptr,          // C, batch_C
+    //         n, 0, 0,                        // ld_c, batch_stride_c, offset_c
+    //         D_data.data(), nullptr,          // D, batch_D
+    //         n, 0, 0,                        // ld_d, batch_stride_d, offset_d
+    //         batch_count,                     // batch_count
+    //         true,                           // strided_batch
+    //         false,                          // sparseA
+    //         nullptr,                        // metadata
+    //         hipsparselt_activation_type::relu, // act_type
+    //         0.1f, 6.0f,                     // act_arg0, act_arg1
+    //         bias_data.data(),               // bias_vector (not nullptr)
+    //         1,                              // bias_stride
+    //         HIP_R_16F,                      // bias_type
+    //         true,                           // alpha_vector_scaling
+    //         nullptr,                        // workspace
+    //         1024,                           // workspaceSize
+    //         nullptr,                        // streams
+    //         1                               // numStreams
+    //     );
+
+    //     hipsparselt_internal_ostream hoss;
+
+    //     // This should cover the bias_vector != nullptr branch
+    //     //hoss << prob;
+    //     printRCP(hoss, prob);
+
+    //     std::string output = hoss.str();
+
+    //     // Verify bias-related output
+    //     EXPECT_TRUE(output.find("relu") != std::string::npos); // activation type
+    //     EXPECT_TRUE(output.find("true") != std::string::npos);  // has_bias should be true
+    //     EXPECT_TRUE(output.find("0.1") != std::string::npos);   // activation_arg0
+    //     EXPECT_TRUE(output.find("6") != std::string::npos);     // activation_arg1
+    // }
+}
+
+void testing_aux_rocsparselt_ostream(const Arguments& arg)
+{
+    testing_rocsparselt_contraction_problem_ostream(arg);
 }

--- a/projects/hipsparselt/clients/include/testing_auxiliary.hpp
+++ b/projects/hipsparselt/clients/include/testing_auxiliary.hpp
@@ -2037,3 +2037,34 @@ void testing_aux_value_mapping(const Arguments& arg)
     EXPECT_EQ(get_rocsparselt_status_for_hip_status(static_cast<hipError_t>(invalid_enum)),
               rocsparselt_status_internal_error);
 }
+
+void testing_aux_math(const Arguments& arg)
+{
+    __half_raw v_raw;
+    v_raw.x = 0x7C01; // NaN
+    EXPECT_TRUE(hipsparselt_isnan(__half(v_raw)));
+
+    v_raw.x = 0x3C00;
+    EXPECT_FALSE(hipsparselt_isnan(__half(v_raw)));
+
+    v_raw.x = 0x7C00; // Inf
+    EXPECT_TRUE(hipsparselt_isinf(__half(v_raw))); // Inf
+
+    __hip_fp8_e4m3 v_fp8_e4m3;
+    v_fp8_e4m3.__x = 0x7E;
+    EXPECT_TRUE(hipsparselt_isnan(v_fp8_e4m3)); // NaN
+
+    v_fp8_e4m3.__x = 0x82;
+    EXPECT_FALSE(hipsparselt_isnan(v_fp8_e4m3));
+
+    __hip_fp8_e5m2 v_fp8_e5m2;
+    v_fp8_e5m2.__x = 0x82;
+    EXPECT_FALSE(hipsparselt_isnan(v_fp8_e5m2));
+}
+
+void testing_aux_misc(const Arguments& arg)
+{
+    std::string arch = "gfx950";
+    std::string_view empty;
+    EXPECT_TRUE(gpu_arch_match(arch, empty));
+}

--- a/projects/hipsparselt/clients/include/testing_auxiliary.hpp
+++ b/projects/hipsparselt/clients/include/testing_auxiliary.hpp
@@ -34,6 +34,7 @@
 #include "hipsparselt_test.hpp"
 #include "hipsparselt_vector.hpp"
 #include "rocsparselt-types.h"
+#include "status.h"
 #include "tensile_host.hpp"
 #include "unit.hpp"
 #include "utility.hpp"
@@ -1835,15 +1836,9 @@ void testing_aux_get_workspace_size(const Arguments& arg)
 
 void testing_aux_string_helper(const Arguments& arg)
 {
-    struct StrToEnumTestCase
-    {
-        const char* input;
-        int expected;
-    };
-
     constexpr int invalid_enum = -1;
 
-    const StrToEnumTestCase hip_datatype_cases[] = {
+    const std::pair<const char*, int> hip_datatype_cases[] = {
         {"f32_r", HIP_R_32F},
         {"s", HIP_R_32F},
         {"f16_r", HIP_R_16F},
@@ -1863,10 +1858,10 @@ void testing_aux_string_helper(const Arguments& arg)
 
     for(const auto& test : hip_datatype_cases)
     {
-        EXPECT_EQ(string_to_hip_datatype(test.input), test.expected);
+        EXPECT_EQ(string_to_hip_datatype(test.first), test.second);
     }
 
-    const StrToEnumTestCase compute_type_cases[] = {
+    const std::pair<const char*, int> str_to_compute_type_cases[] = {
         {"f32_r", HIPSPARSELT_COMPUTE_32F},
         {"s", HIPSPARSELT_COMPUTE_32F},
         {"i32_r", HIPSPARSELT_COMPUTE_32I},
@@ -1879,9 +1874,9 @@ void testing_aux_string_helper(const Arguments& arg)
         {"unknown", invalid_enum},
     };
 
-    for(const auto& test : compute_type_cases)
+    for(const auto& test : str_to_compute_type_cases)
     {
-        EXPECT_EQ(string_to_hipsparselt_computetype(test.input), test.expected);
+        EXPECT_EQ(string_to_hipsparselt_computetype(test.first), test.second);
     }
 
     const std::pair<const char*, hipsparselt_activation_type> activation_type_cases[] = {
@@ -1903,182 +1898,142 @@ void testing_aux_string_helper(const Arguments& arg)
         EXPECT_EQ(string_to_hipsparselt_activation_type(test.first), test.second);
         EXPECT_STREQ(hipsparselt_activation_type_to_string(test.second), test.first);
     }
+
+    const std::pair<rocsparselt_operation, const char*> roc_operation_cases[] = {
+        {rocsparselt_operation_conjugate_transpose, "conjugate_transpose"},
+    };
+
+    for(const auto& test : roc_operation_cases)
+    {
+        EXPECT_STREQ(rocsparselt_operation_to_string(test.first), test.second);
+    }
+
+    const std::pair<rocsparselt_matrix_type, const char*> mat_type_cases[] = {
+        {rocsparselt_matrix_type_unknown, "unknown"},
+    };
+    for(const auto& test : mat_type_cases)
+    {
+        EXPECT_STREQ(rocsparselt_matrix_type_to_string(test.first), test.second);
+    }
+
+    const std::pair<rocsparselt_layer_mode , const char*> layer_mode_cases[] = {
+        {rocsparselt_layer_mode_none, "None"},
+        {rocsparselt_layer_mode_log_error, "Error"},
+        {rocsparselt_layer_mode_log_hints, "Hints"},
+        {rocsparselt_layer_mode_log_info, "Info"},
+        {static_cast<rocsparselt_layer_mode>(-1), "Invalid"},
+    };
+
+    for(const auto& test : layer_mode_cases)
+    {
+        EXPECT_STREQ(rocsparselt_layer_mode2string(test.first), test.second);
+    }
+
+    const std::pair<rocsparselt_matmul_descr_attribute, const char*> mat_attr_cases[] = {
+        {rocsparselt_matmul_activation_abs, "abs"},
+        {rocsparselt_matmul_activation_gelu, "gelu"},
+        {rocsparselt_matmul_activation_leakyrelu, "leakyrelu"},
+        {rocsparselt_matmul_activation_tanh, "tanh"},
+    };
+
+    for(const auto& test : mat_attr_cases)
+    {
+        EXPECT_STREQ(rocsparselt_activation_type_to_string(test.first), test.second);
+    }
+
+    const std::pair<hipsparseStatus_t, const char*> status_cases[] = {
+        {HIPSPARSE_STATUS_SUCCESS, "HIPSPARSE_STATUS_SUCCESS"},
+        {HIPSPARSE_STATUS_NOT_INITIALIZED, "HIPSPARSE_STATUS_NOT_INITIALIZED"},
+        {HIPSPARSE_STATUS_ALLOC_FAILED, "HIPSPARSE_STATUS_ALLOC_FAILED"},
+        {HIPSPARSE_STATUS_INVALID_VALUE, "HIPSPARSE_STATUS_INVALID_VALUE"},
+        {HIPSPARSE_STATUS_ARCH_MISMATCH, "HIPSPARSE_STATUS_ARCH_MISMATCH"},
+        {HIPSPARSE_STATUS_MAPPING_ERROR, "HIPSPARSE_STATUS_MAPPING_ERROR"},
+        {HIPSPARSE_STATUS_EXECUTION_FAILED, "HIPSPARSE_STATUS_EXECUTION_FAILED"},
+        {HIPSPARSE_STATUS_INTERNAL_ERROR, "HIPSPARSE_STATUS_INTERNAL_ERROR"},
+        {HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED, "HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED"},
+        {HIPSPARSE_STATUS_ZERO_PIVOT, "HIPSPARSE_STATUS_ZERO_PIVOT"},
+        {HIPSPARSE_STATUS_NOT_SUPPORTED, "HIPSPARSE_STATUS_NOT_SUPPORTED"},
+    };
+
+    for(const auto& test : status_cases)
+    {
+        EXPECT_STREQ(hipsparse_status_to_string(test.first), test.second);
+    }
+
+    const std::pair<hipsparseOperation_t, const char*> operation_cases[] = {
+        {HIPSPARSE_OPERATION_NON_TRANSPOSE, "N"},
+        {HIPSPARSE_OPERATION_TRANSPOSE, "T"},
+        {HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE, "C"},
+        {static_cast<hipsparseOperation_t>(invalid_enum), "invalid"},
+    };
+
+    for(const auto& test : operation_cases)
+    {
+        EXPECT_STREQ(hipsparselt_operation_to_string(test.first), test.second);
+    }
+
+    const std::pair<char, hipsparseOperation_t> operation_char_cases[] = {
+        {'N', HIPSPARSE_OPERATION_NON_TRANSPOSE},
+        {'n', HIPSPARSE_OPERATION_NON_TRANSPOSE},
+        {'T', HIPSPARSE_OPERATION_TRANSPOSE},
+        {'t', HIPSPARSE_OPERATION_TRANSPOSE},
+        {'C', HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE},
+        {'c', HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE},
+        {'X', static_cast<hipsparseOperation_t>(invalid_enum)},
+    };
+
+    for(const auto& test : operation_char_cases)
+    {
+        EXPECT_EQ(char_to_hipsparselt_operation(test.first), test.second);
+    }
+
+    const std::pair<char, hipsparseOrder_t> order_cases[] = {
+        {'C', HIPSPARSE_ORDER_COL},
+        {'c', HIPSPARSE_ORDER_COL},
+        {'R', HIPSPARSE_ORDER_ROW},
+        {'r', HIPSPARSE_ORDER_ROW},
+        {'X', static_cast<hipsparseOrder_t>(invalid_enum)},
+    };
+
+    for(const auto& test : order_cases)
+    {
+        EXPECT_EQ(char_to_hipsparselt_order(test.first), test.second);
+    }
+
+    const std::pair<hipsparseLtComputetype_t, const char*> compute_type_cases[] = {
+        {HIPSPARSELT_COMPUTE_16F, "f16_r"},
+        {HIPSPARSELT_COMPUTE_32I, "i32_r"},
+        {HIPSPARSELT_COMPUTE_32F, "f32_r"},
+        {static_cast<hipsparseLtComputetype_t>(invalid_enum), "invalid"},
+    };
+
+    for(const auto& test : compute_type_cases)
+    {
+        EXPECT_STREQ(hipsparselt_computetype_to_string(test.first), test.second);
+    }
 }
 
-template <typename Ti, typename To, typename Tc>
-std::ostringstream& operator<<(std::ostringstream& os, const RocsparseltContractionProblem<Ti, To, Tc>& prob)
+void testing_aux_value_mapping(const Arguments& arg)
 {
-    hipsparselt_internal_ostream hos;
-    hos << prob;  // Delegate to internal stream
-    os << hos.str();  // Append the internal stream's content to the output stream
-    return os;
-}
+    constexpr int invalid_enum = -1;
 
-// Test for RocsparseltContractionProblem operator<< function
+    const std::pair<rocsparselt_status, hipError_t> status_mapping[] = {
+        {rocsparselt_status_success, hipSuccess},
+        {rocsparselt_status_memory_error, hipErrorMemoryAllocation},
+        {rocsparselt_status_memory_error, hipErrorLaunchOutOfResources},
+        {rocsparselt_status_invalid_pointer, hipErrorInvalidDevicePointer},
+        {rocsparselt_status_invalid_handle, hipErrorInvalidDevice},
+        {rocsparselt_status_invalid_handle, hipErrorInvalidResourceHandle},
+        {rocsparselt_status_internal_error, hipErrorInvalidValue},
+        {rocsparselt_status_internal_error, hipErrorNoDevice},
+        {rocsparselt_status_internal_error, hipErrorUnknown},
+    };
 
-template <typename Ti, typename To, typename Tc>
-std::string testing_aux_rocsparselt_ostream_helper(const Arguments& arg)
-{
-    // Create a mock handle
-    _rocsparselt_handle handle;
+    for(const auto& pair : status_mapping)
+    {
+        EXPECT_EQ(get_rocsparselt_status_for_hip_status(pair.second), pair.first);
+    }
 
-    // Test data - use different values to ensure all branches are covered
-    constexpr size_t m = 2, n = 4, k = 1;
-    constexpr size_t batch_count = 2;
-
-    // Create test arrays
-    std::vector<Ti> A_data(m * k * batch_count, Ti(0));
-    std::vector<Ti> B_data(k * n * batch_count, Ti(0));
-    std::vector<To> C_data(m * n * batch_count, To(0));
-    std::vector<To> D_data(m * n * batch_count, To(0));
-    std::vector<unsigned char> metadata(m * k / 2, 0xFF);
-    std::vector<float> bias_data(m, 1.0f);
-
-    Tc alpha = Tc(1.0);
-    Tc beta = Tc(0.5);
-
-    RocsparseltContractionProblem<Ti, To, Tc> prob(
-        &handle,
-        rocsparselt_operation_transpose,  // trans_a
-        rocsparselt_operation_none,       // trans_b
-        rocsparselt_order_row,           // order
-        m, n, k,                         // dimensions
-        &alpha,                          // alpha
-        A_data.data(), nullptr,          // A, batch_A
-        k, 0, 0,                        // ld_a, batch_stride_a, offset_a
-        B_data.data(), nullptr,          // B, batch_B
-        n, 0, 0,                        // ld_b, batch_stride_b, offset_b
-        &beta,                           // beta
-        C_data.data(), nullptr,          // C, batch_C
-        n, 0, 0,                        // ld_c, batch_stride_c, offset_c
-        D_data.data(), nullptr,          // D, batch_D
-        n, 0, 0,                        // ld_d, batch_stride_d, offset_d
-        batch_count,                     // batch_count
-        true,                           // strided_batch
-        false,                          // sparseA
-        nullptr,                        // metadata
-        hipsparselt_activation_type::relu, // act_type
-        0.1f, 6.0f,                     // act_arg0, act_arg1
-        bias_data.data(),               // bias_vector (not nullptr)
-        1,                              // bias_stride
-        HIP_R_16F,                      // bias_type
-        true,                           // alpha_vector_scaling
-        nullptr,                        // workspace
-        1024,                           // workspaceSize
-        nullptr,                        // streams
-        1                               // numStreams
-    );
-
-    hipsparselt_internal_ostream hos;
-
-    hos << prob;
-    return hos.str();
-}
-
-void testing_aux_rocsparselt_ostream(const Arguments& arg)
-{
-    using Ti = float;
-    using To = float;
-    using Tc = float;
-
-    // Create a mock handle
-    _rocsparselt_handle handle;
-
-    // Test data - use different values to ensure all branches are covered
-    constexpr size_t m = 2, n = 4, k = 1;
-    constexpr size_t batch_count = 2;
-
-    // Create test arrays
-    std::vector<Ti> A_data(m * k * batch_count, Ti(1.5));
-    std::vector<Ti> B_data(k * n * batch_count, Ti(2.5));
-    std::vector<To> C_data(m * n * batch_count, To(3.5));
-    std::vector<To> D_data(m * n * batch_count, To(0.0));
-    std::vector<unsigned char> metadata(m * k / 2, 0xFF);
-    std::vector<float> bias_data(m, 1.0f);
-
-    Tc alpha = Tc(1.0);
-    Tc beta = Tc(0.5);
-
-    RocsparseltContractionProblem<Ti, To> prob(
-        &handle,
-        rocsparselt_operation_transpose,  // trans_a
-        rocsparselt_operation_none,       // trans_b
-        rocsparselt_order_row,           // order
-        m, n, k,                         // dimensions
-        &alpha,                          // alpha
-        A_data.data(), nullptr,          // A, batch_A
-        k, 0, 0,                        // ld_a, batch_stride_a, offset_a
-        B_data.data(), nullptr,          // B, batch_B
-        n, 0, 0,                        // ld_b, batch_stride_b, offset_b
-        &beta,                           // beta
-        C_data.data(), nullptr,          // C, batch_C
-        n, 0, 0,                        // ld_c, batch_stride_c, offset_c
-        D_data.data(), nullptr,          // D, batch_D
-        n, 0, 0,                        // ld_d, batch_stride_d, offset_d
-        batch_count,                     // batch_count
-        true,                           // strided_batch
-        false,                          // sparseA
-        nullptr,                        // metadata
-        hipsparselt_activation_type::relu, // act_type
-        0.1f, 6.0f,                     // act_arg0, act_arg1
-        bias_data.data(),               // bias_vector (not nullptr)
-        1,                              // bias_stride
-        HIP_R_16F,                      // bias_type
-        true,                           // alpha_vector_scaling
-        nullptr,                        // workspace
-        1024,                           // workspaceSize
-        nullptr,                        // streams
-        1                               // numStreams
-    );
-
-    hipsparselt_internal_ostream hos;
-
-    hos << prob;
-
-    // Verify bias-related output
-    const char* answer_str =
-        "{ a_type: \"f32_r\","
-        " b_type: \"f32_r\","
-        " c_type: \"f32_r\","
-        " d_type: \"f32_r\","
-        " compute_type: \"f32_r\","
-        " transA: \"T\","
-        " transB: \"N\","
-        " M: 2,"
-        " N: 4,"
-        " K: 1,"
-        " alpha: 1,"
-        " row_stride_a: 1,"
-        " col_stride_a: 1,"
-        " row_stride_b: 1,"
-        " col_stride_b: 4,"
-        " row_stride_c: 1,"
-        " col_stride_c: 4,"
-        " row_stride_d: 1,"
-        " col_stride_d: 4,"
-        " beta: 0.5,"
-        " batch_count: 2,"
-        " strided_batch: true,"
-        " stride_a: 0,"
-        " stride_b: 0,"
-        " stride_c: 0,"
-        " stride_d: 0,"
-        " activation: \"relu\","
-        " activation_argument_0: 0.1,"
-        " activation_argument_1: 6,"
-        " has_bias: true,"
-        " bias_stride: 1,"
-        " bias_type: \"f16_r\","
-        " alpha_vector_scaling: true }\n";
-
-    EXPECT_STREQ(hos.str().c_str(), answer_str);
-
-    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<half, half, float>(arg);
-    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<hip_bfloat16, hip_bfloat16, float>(arg);
-
-    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<char, char, float>(arg);
-    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<char, half, float>(arg);
-    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<char, hip_bfloat16, float>(arg);
-    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<__hip_fp8_e4m3, float, float>(arg);
-    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<__hip_fp8_e4m3, float, float>(arg);
+    EXPECT_EQ(get_rocsparselt_status_for_hip_status(static_cast<hipError_t>(invalid_enum)),
+              rocsparselt_status_internal_error);
 }

--- a/projects/hipsparselt/clients/include/testing_auxiliary.hpp
+++ b/projects/hipsparselt/clients/include/testing_auxiliary.hpp
@@ -2068,3 +2068,112 @@ void testing_aux_misc(const Arguments& arg)
     std::string_view empty;
     EXPECT_TRUE(gpu_arch_match(arch, empty));
 }
+
+template <typename Ti, typename To, typename Tc>
+std::ostringstream& operator<<(std::ostringstream& os, const RocsparseltContractionProblem<Ti, To, Tc>& prob)
+{
+    hipsparselt_internal_ostream hos;
+    hos << prob;
+    os << hos.str();
+    return os;
+}
+
+template <typename Ti, typename To, typename Tc>
+std::string testing_aux_rocsparselt_ostream_helper(const Arguments& arg)
+{
+    _rocsparselt_handle handle;
+
+    // Test data - use different values to ensure all branches are covered
+    constexpr size_t m = 2, n = 4, k = 1;
+    constexpr size_t batch_count = 2;
+
+    // Create test arrays
+    std::vector<Ti> A_data(m * k * batch_count, Ti(1.5));
+    std::vector<Ti> B_data(k * n * batch_count, Ti(2.5));
+    std::vector<To> C_data(m * n * batch_count, To(3.5));
+    std::vector<To> D_data(m * n * batch_count, To(0.0));
+    std::vector<unsigned char> metadata(m * k / 2, 0xFF);
+    std::vector<float> bias_data(m, 1.0f);
+
+    Tc alpha = Tc(1.0);
+    Tc beta = Tc(0.5);
+
+    RocsparseltContractionProblem<Ti, To, Tc> prob(
+        &handle,
+        rocsparselt_operation_transpose, // trans_a
+        rocsparselt_operation_none,      // trans_b
+        rocsparselt_order_row,           // order
+        m, n, k,                         // dimensions
+        &alpha,                          // alpha
+        A_data.data(), nullptr,          // A, batch_A
+        k, 0, 0,                         // ld_a, batch_stride_a, offset_a
+        B_data.data(), nullptr,          // B, batch_B
+        n, 0, 0,                         // ld_b, batch_stride_b, offset_b
+        &beta,                           // beta
+        C_data.data(), nullptr,          // C, batch_C
+        n, 0, 0,                         // ld_c, batch_stride_c, offset_c
+        D_data.data(), nullptr,          // D, batch_D
+        n, 0, 0,                         // ld_d, batch_stride_d, offset_d
+        batch_count,                     // batch_count
+        true,                            // strided_batch
+        false,                           // sparseA
+        nullptr,                         // metadata
+        hipsparselt_activation_type::relu, // act_type
+        0.1f, 6.0f,                      // act_arg0, act_arg1
+        bias_data.data(),                // bias_vector (not nullptr)
+        1,                               // bias_stride
+        HIP_R_32F,                       // bias_type
+        true,                            // alpha_vector_scaling
+        nullptr,                         // workspace
+        1024,                            // workspaceSize
+        nullptr,                         // streams
+        1                                // numStreams
+    );
+
+    hipsparselt_internal_ostream hos;
+
+    hos << prob;
+    return hos.str();
+}
+
+void testing_aux_ostream(const Arguments& arg)
+{
+    const char* expected =
+        "{ a_type: \"f16_r\","
+        " b_type: \"f16_r\","
+        " c_type: \"f16_r\","
+        " d_type: \"f16_r\","
+        " compute_type: \"f32_r\","
+        " transA: \"T\","
+        " transB: \"N\","
+        " M: 2,"
+        " N: 4,"
+        " K: 1,"
+        " alpha: 1,"
+        " row_stride_a: 1,"
+        " col_stride_a: 1,"
+        " row_stride_b: 1,"
+        " col_stride_b: 4,"
+        " row_stride_c: 1,"
+        " col_stride_c: 4,"
+        " row_stride_d: 1,"
+        " col_stride_d: 4,"
+        " beta: 0.5,"
+        " batch_count: 2,"
+        " strided_batch: true,"
+        " stride_a: 0,"
+        " stride_b: 0,"
+        " stride_c: 0,"
+        " stride_d: 0,"
+        " activation: \"relu\","
+        " activation_argument_0: 0.1,"
+        " activation_argument_1: 6,"
+        " has_bias: true,"
+        " bias_stride: 1,"
+        " bias_type: \"f32_r\","
+        " alpha_vector_scaling: true }\n";
+
+    std::string output = testing_aux_rocsparselt_ostream_helper<__half, __half, float>(arg);
+
+    EXPECT_STREQ(output.c_str(), expected);
+}

--- a/projects/hipsparselt/clients/include/testing_auxiliary.hpp
+++ b/projects/hipsparselt/clients/include/testing_auxiliary.hpp
@@ -1905,82 +1905,180 @@ void testing_aux_string_helper(const Arguments& arg)
     }
 }
 
-// Test for RocsparseltContractionProblem operator<< function
-void testing_rocsparselt_contraction_problem_ostream(const Arguments& arg)
+template <typename Ti, typename To, typename Tc>
+std::ostringstream& operator<<(std::ostringstream& os, const RocsparseltContractionProblem<Ti, To, Tc>& prob)
 {
-    // using Ti = float;
-    // using To = float;
-    // using Tc = float;
+    hipsparselt_internal_ostream hos;
+    hos << prob;  // Delegate to internal stream
+    os << hos.str();  // Append the internal stream's content to the output stream
+    return os;
+}
 
-    // // Create a mock handle
-    // _rocsparselt_handle handle;
+// Test for RocsparseltContractionProblem operator<< function
 
-    // // Test data - use different values to ensure all branches are covered
-    // constexpr size_t m = 128, n = 64, k = 32;
-    // constexpr size_t batch_count = 2;
+template <typename Ti, typename To, typename Tc>
+std::string testing_aux_rocsparselt_ostream_helper(const Arguments& arg)
+{
+    // Create a mock handle
+    _rocsparselt_handle handle;
 
-    // // Create test arrays
-    // std::vector<Ti> A_data(m * k * batch_count, Ti(1.5));
-    // std::vector<Ti> B_data(k * n * batch_count, Ti(2.5));
-    // std::vector<To> C_data(m * n * batch_count, To(3.5));
-    // std::vector<To> D_data(m * n * batch_count, To(0.0));
-    // std::vector<unsigned char> metadata(m * k / 2, 0xFF);
-    // std::vector<float> bias_data(m, 1.0f);
+    // Test data - use different values to ensure all branches are covered
+    constexpr size_t m = 2, n = 4, k = 1;
+    constexpr size_t batch_count = 2;
 
-    // Tc alpha = Tc(1.0);
-    // Tc beta = Tc(0.5);
+    // Create test arrays
+    std::vector<Ti> A_data(m * k * batch_count, Ti(0));
+    std::vector<Ti> B_data(k * n * batch_count, Ti(0));
+    std::vector<To> C_data(m * n * batch_count, To(0));
+    std::vector<To> D_data(m * n * batch_count, To(0));
+    std::vector<unsigned char> metadata(m * k / 2, 0xFF);
+    std::vector<float> bias_data(m, 1.0f);
 
-    // // Test case 2: Problem with bias and activation to cover different branches
-    // {
-    //     RocsparseltContractionProblem<Ti, To> prob(
-    //         &handle,
-    //         rocsparselt_operation_transpose,  // trans_a
-    //         rocsparselt_operation_none,       // trans_b
-    //         rocsparselt_order_row,           // order
-    //         m, n, k,                         // dimensions
-    //         &alpha,                          // alpha
-    //         A_data.data(), nullptr,          // A, batch_A
-    //         k, 0, 0,                        // ld_a, batch_stride_a, offset_a
-    //         B_data.data(), nullptr,          // B, batch_B
-    //         n, 0, 0,                        // ld_b, batch_stride_b, offset_b
-    //         &beta,                           // beta
-    //         C_data.data(), nullptr,          // C, batch_C
-    //         n, 0, 0,                        // ld_c, batch_stride_c, offset_c
-    //         D_data.data(), nullptr,          // D, batch_D
-    //         n, 0, 0,                        // ld_d, batch_stride_d, offset_d
-    //         batch_count,                     // batch_count
-    //         true,                           // strided_batch
-    //         false,                          // sparseA
-    //         nullptr,                        // metadata
-    //         hipsparselt_activation_type::relu, // act_type
-    //         0.1f, 6.0f,                     // act_arg0, act_arg1
-    //         bias_data.data(),               // bias_vector (not nullptr)
-    //         1,                              // bias_stride
-    //         HIP_R_16F,                      // bias_type
-    //         true,                           // alpha_vector_scaling
-    //         nullptr,                        // workspace
-    //         1024,                           // workspaceSize
-    //         nullptr,                        // streams
-    //         1                               // numStreams
-    //     );
+    Tc alpha = Tc(1.0);
+    Tc beta = Tc(0.5);
 
-    //     hipsparselt_internal_ostream hoss;
+    RocsparseltContractionProblem<Ti, To, Tc> prob(
+        &handle,
+        rocsparselt_operation_transpose,  // trans_a
+        rocsparselt_operation_none,       // trans_b
+        rocsparselt_order_row,           // order
+        m, n, k,                         // dimensions
+        &alpha,                          // alpha
+        A_data.data(), nullptr,          // A, batch_A
+        k, 0, 0,                        // ld_a, batch_stride_a, offset_a
+        B_data.data(), nullptr,          // B, batch_B
+        n, 0, 0,                        // ld_b, batch_stride_b, offset_b
+        &beta,                           // beta
+        C_data.data(), nullptr,          // C, batch_C
+        n, 0, 0,                        // ld_c, batch_stride_c, offset_c
+        D_data.data(), nullptr,          // D, batch_D
+        n, 0, 0,                        // ld_d, batch_stride_d, offset_d
+        batch_count,                     // batch_count
+        true,                           // strided_batch
+        false,                          // sparseA
+        nullptr,                        // metadata
+        hipsparselt_activation_type::relu, // act_type
+        0.1f, 6.0f,                     // act_arg0, act_arg1
+        bias_data.data(),               // bias_vector (not nullptr)
+        1,                              // bias_stride
+        HIP_R_16F,                      // bias_type
+        true,                           // alpha_vector_scaling
+        nullptr,                        // workspace
+        1024,                           // workspaceSize
+        nullptr,                        // streams
+        1                               // numStreams
+    );
 
-    //     // This should cover the bias_vector != nullptr branch
-    //     //hoss << prob;
-    //     printRCP(hoss, prob);
+    hipsparselt_internal_ostream hos;
 
-    //     std::string output = hoss.str();
-
-    //     // Verify bias-related output
-    //     EXPECT_TRUE(output.find("relu") != std::string::npos); // activation type
-    //     EXPECT_TRUE(output.find("true") != std::string::npos);  // has_bias should be true
-    //     EXPECT_TRUE(output.find("0.1") != std::string::npos);   // activation_arg0
-    //     EXPECT_TRUE(output.find("6") != std::string::npos);     // activation_arg1
-    // }
+    hos << prob;
+    return hos.str();
 }
 
 void testing_aux_rocsparselt_ostream(const Arguments& arg)
 {
-    testing_rocsparselt_contraction_problem_ostream(arg);
+    using Ti = float;
+    using To = float;
+    using Tc = float;
+
+    // Create a mock handle
+    _rocsparselt_handle handle;
+
+    // Test data - use different values to ensure all branches are covered
+    constexpr size_t m = 2, n = 4, k = 1;
+    constexpr size_t batch_count = 2;
+
+    // Create test arrays
+    std::vector<Ti> A_data(m * k * batch_count, Ti(1.5));
+    std::vector<Ti> B_data(k * n * batch_count, Ti(2.5));
+    std::vector<To> C_data(m * n * batch_count, To(3.5));
+    std::vector<To> D_data(m * n * batch_count, To(0.0));
+    std::vector<unsigned char> metadata(m * k / 2, 0xFF);
+    std::vector<float> bias_data(m, 1.0f);
+
+    Tc alpha = Tc(1.0);
+    Tc beta = Tc(0.5);
+
+    RocsparseltContractionProblem<Ti, To> prob(
+        &handle,
+        rocsparselt_operation_transpose,  // trans_a
+        rocsparselt_operation_none,       // trans_b
+        rocsparselt_order_row,           // order
+        m, n, k,                         // dimensions
+        &alpha,                          // alpha
+        A_data.data(), nullptr,          // A, batch_A
+        k, 0, 0,                        // ld_a, batch_stride_a, offset_a
+        B_data.data(), nullptr,          // B, batch_B
+        n, 0, 0,                        // ld_b, batch_stride_b, offset_b
+        &beta,                           // beta
+        C_data.data(), nullptr,          // C, batch_C
+        n, 0, 0,                        // ld_c, batch_stride_c, offset_c
+        D_data.data(), nullptr,          // D, batch_D
+        n, 0, 0,                        // ld_d, batch_stride_d, offset_d
+        batch_count,                     // batch_count
+        true,                           // strided_batch
+        false,                          // sparseA
+        nullptr,                        // metadata
+        hipsparselt_activation_type::relu, // act_type
+        0.1f, 6.0f,                     // act_arg0, act_arg1
+        bias_data.data(),               // bias_vector (not nullptr)
+        1,                              // bias_stride
+        HIP_R_16F,                      // bias_type
+        true,                           // alpha_vector_scaling
+        nullptr,                        // workspace
+        1024,                           // workspaceSize
+        nullptr,                        // streams
+        1                               // numStreams
+    );
+
+    hipsparselt_internal_ostream hos;
+
+    hos << prob;
+
+    // Verify bias-related output
+    const char* answer_str =
+        "{ a_type: \"f32_r\","
+        " b_type: \"f32_r\","
+        " c_type: \"f32_r\","
+        " d_type: \"f32_r\","
+        " compute_type: \"f32_r\","
+        " transA: \"T\","
+        " transB: \"N\","
+        " M: 2,"
+        " N: 4,"
+        " K: 1,"
+        " alpha: 1,"
+        " row_stride_a: 1,"
+        " col_stride_a: 1,"
+        " row_stride_b: 1,"
+        " col_stride_b: 4,"
+        " row_stride_c: 1,"
+        " col_stride_c: 4,"
+        " row_stride_d: 1,"
+        " col_stride_d: 4,"
+        " beta: 0.5,"
+        " batch_count: 2,"
+        " strided_batch: true,"
+        " stride_a: 0,"
+        " stride_b: 0,"
+        " stride_c: 0,"
+        " stride_d: 0,"
+        " activation: \"relu\","
+        " activation_argument_0: 0.1,"
+        " activation_argument_1: 6,"
+        " has_bias: true,"
+        " bias_stride: 1,"
+        " bias_type: \"f16_r\","
+        " alpha_vector_scaling: true }\n";
+
+    EXPECT_STREQ(hos.str().c_str(), answer_str);
+
+    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<half, half, float>(arg);
+    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<hip_bfloat16, hip_bfloat16, float>(arg);
+
+    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<char, char, float>(arg);
+    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<char, half, float>(arg);
+    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<char, hip_bfloat16, float>(arg);
+    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<__hip_fp8_e4m3, float, float>(arg);
+    hipsparselt_cout << testing_aux_rocsparselt_ostream_helper<__hip_fp8_e4m3, float, float>(arg);
 }

--- a/projects/hipsparselt/clients/include/testing_auxiliary.hpp
+++ b/projects/hipsparselt/clients/include/testing_auxiliary.hpp
@@ -1834,6 +1834,7 @@ void testing_aux_get_workspace_size(const Arguments& arg)
                             HIPSPARSE_STATUS_SUCCESS);
 }
 
+#ifdef CODE_COVERAGE
 void testing_aux_string_helper(const Arguments& arg)
 {
     constexpr int invalid_enum = -1;
@@ -2177,3 +2178,4 @@ void testing_aux_ostream(const Arguments& arg)
 
     EXPECT_STREQ(output.c_str(), expected);
 }
+#endif

--- a/projects/hipsparselt/library/CMakeLists.txt
+++ b/projects/hipsparselt/library/CMakeLists.txt
@@ -59,19 +59,6 @@ include(src/CMakeLists.txt)
 add_library(hipsparselt ${hipsparselt_source} ${hipsparselt_headers_public})
 add_library(roc::hipsparselt ALIAS hipsparselt)
 
-if( BUILD_CODE_COVERAGE )
-  set(COVERAGE_CXX_FLAGS
-    -fprofile-instr-generate
-    -fcoverage-mapping
-  )
-  set(COVERAGE_LINK_FLAGS
-    -fprofile-instr-generate
-  )
-
-  target_compile_options(hipsparselt PRIVATE ${COVERAGE_CXX_FLAGS})
-  target_link_libraries(hipsparselt PRIVATE ${COVERAGE_LINK_FLAGS})
-endif()
-
 # Target compile definitions
 if(NOT BUILD_CUDA)
   target_compile_options(hipsparselt PRIVATE -Wno-unused-command-line-argument -Wall)

--- a/projects/hipsparselt/library/src/hcc_detail/hipsparselt.cpp
+++ b/projects/hipsparselt/library/src/hcc_detail/hipsparselt.cpp
@@ -114,6 +114,21 @@ rocsparselt_operation_ HIPOperationToHCCOperation(hipsparseOperation_t op)
     }
 }
 
+hipsparseOperation_t HCCOperationToHIPOperation(rocsparselt_operation_ op)
+{
+    switch(op)
+    {
+    case rocsparselt_operation_none:
+        return HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    case rocsparselt_operation_transpose:
+        return HIPSPARSE_OPERATION_TRANSPOSE;
+    case rocsparselt_operation_conjugate_transpose:
+        return HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
+    default:
+        throw HIPSPARSE_STATUS_INVALID_VALUE;
+    }
+}
+
 rocsparselt_order_ HIPOrderToHCCOrder(hipsparseOrder_t op)
 {
     switch(op)

--- a/projects/hipsparselt/library/src/hcc_detail/hipsparselt.cpp
+++ b/projects/hipsparselt/library/src/hcc_detail/hipsparselt.cpp
@@ -114,21 +114,6 @@ rocsparselt_operation_ HIPOperationToHCCOperation(hipsparseOperation_t op)
     }
 }
 
-hipsparseOperation_t HCCOperationToHIPOperation(rocsparselt_operation_ op)
-{
-    switch(op)
-    {
-    case rocsparselt_operation_none:
-        return HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    case rocsparselt_operation_transpose:
-        return HIPSPARSE_OPERATION_TRANSPOSE;
-    case rocsparselt_operation_conjugate_transpose:
-        return HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
-    default:
-        throw HIPSPARSE_STATUS_INVALID_VALUE;
-    }
-}
-
 rocsparselt_order_ HIPOrderToHCCOrder(hipsparseOrder_t op)
 {
     switch(op)

--- a/projects/hipsparselt/library/src/hcc_detail/rocsparselt/src/include/utility.hpp
+++ b/projects/hipsparselt/library/src/hcc_detail/rocsparselt/src/include/utility.hpp
@@ -41,22 +41,6 @@
 extern "C" {
 #endif
 hipsparseOperation_t     HCCOperationToHIPOperation(rocsparselt_operation_ op);
-
-inline hipsparseOperation_t HCCOperationToHIPOperation(rocsparselt_operation_ op)
-{
-    switch(op)
-    {
-    case rocsparselt_operation_none:
-        return HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    case rocsparselt_operation_transpose:
-        return HIPSPARSE_OPERATION_TRANSPOSE;
-    case rocsparselt_operation_conjugate_transpose:
-        return HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
-    default:
-        throw HIPSPARSE_STATUS_INVALID_VALUE;
-    }
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/projects/hipsparselt/library/src/hcc_detail/rocsparselt/src/include/utility.hpp
+++ b/projects/hipsparselt/library/src/hcc_detail/rocsparselt/src/include/utility.hpp
@@ -41,6 +41,22 @@
 extern "C" {
 #endif
 hipsparseOperation_t     HCCOperationToHIPOperation(rocsparselt_operation_ op);
+
+inline hipsparseOperation_t HCCOperationToHIPOperation(rocsparselt_operation_ op)
+{
+    switch(op)
+    {
+    case rocsparselt_operation_none:
+        return HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    case rocsparselt_operation_transpose:
+        return HIPSPARSE_OPERATION_TRANSPOSE;
+    case rocsparselt_operation_conjugate_transpose:
+        return HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
+    default:
+        throw HIPSPARSE_STATUS_INVALID_VALUE;
+    }
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Build hipsparselt-test with coverage flags, otherwise we will lose the statistics for header defined functions
- Add test coverage for string helpers, value mapping, math utils, and output streams

Line coverage:  81% (4424/5438) -> 87% (4688/5341)
Function Coverage: 76% (200/263) -> 87% (217/249)

Two header files cause the differences in total counts:

```
Before:   
                                  Function Coverage    Line Coverage
include/auxiliary.hpp             18.18% (2/11)        18.25% (23/126)
include/hipsparselt_ostream.hpp	  40.54% (15/37)       36.61% (67/183)

This patch:
                                  Function Coverage    Line Coverage
include/auxiliary.hpp             75.00% (3/4)         70.00% (42/60)
include/hipsparselt_ostream.hpp	  66.67% (20/30)       57.24% (87/152)

```

This is the similar issue reported in https://github.com/llvm/llvm-project/issues/72786 when dealing with header defined functions.