### PR TITLE
[rocsparse] Removing semicolon from the macro ROCSPARSE_CLIENTS_ROUTINE_TRACE and adding it when using it.

### DIFF
--- a/projects/rocsparse/clients/common/rocsparse_host.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_host.cpp
@@ -43,7 +43,7 @@ template <typename T, typename I, typename X, typename Y>
 void host_axpby(
     I size, I nnz, T alpha, const X* x_val, const I* x_ind, T beta, Y* y, rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(I i = 0; i < size; ++i)
     {
@@ -60,7 +60,7 @@ template <typename I, typename X, typename Y, typename T>
 void host_doti(
     I nnz, const X* x_val, const I* x_ind, const Y* y, T* result, rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     *result = static_cast<T>(0);
 
@@ -74,7 +74,7 @@ template <typename I, typename X, typename Y, typename T>
 void host_dotci(
     I nnz, const X* x_val, const I* x_ind, const Y* y, T* result, rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     *result = static_cast<T>(0);
 
@@ -87,7 +87,7 @@ void host_dotci(
 template <typename I, typename T>
 void host_gthr(I nnz, const T* y, T* x_val, const I* x_ind, rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(I i = 0; i < nnz; ++i)
     {
@@ -99,7 +99,7 @@ template <typename T>
 void host_gthrz(
     rocsparse_int nnz, T* y, T* x_val, const rocsparse_int* x_ind, rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(rocsparse_int i = 0; i < nnz; ++i)
     {
@@ -112,7 +112,7 @@ template <typename I, typename T>
 void host_roti(
     I nnz, T* x_val, const I* x_ind, T* y, const T* c, const T* s, rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(I i = 0; i < nnz; ++i)
     {
@@ -129,7 +129,7 @@ void host_roti(
 template <typename I, typename T>
 void host_sctr(I nnz, const T* x_val, const I* x_ind, T* y, rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(I i = 0; i < nnz; ++i)
     {
@@ -159,7 +159,7 @@ void host_bsrmv(rocsparse_direction  dir,
                 Y*                   y,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Quick return
     if(alpha == static_cast<T>(0))
@@ -378,7 +378,7 @@ void host_bsrmv(rocsparse_direction  dir,
                 Y*                   y,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     return host_bsrmv(dir,
                       trans,
@@ -416,7 +416,7 @@ void host_bsrxmv(rocsparse_direction  dir,
                  T*                   y,
                  rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(bsr_mask_ptr == nullptr)
     {
@@ -644,7 +644,7 @@ void host_gebsrmv(rocsparse_direction  dir,
                   T*                   y,
                   rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Quick return
     if(alpha == static_cast<T>(0))
@@ -1035,7 +1035,7 @@ static inline void host_bsr_lsolve(rocsparse_direction  dir,
                                    rocsparse_int*       struct_pivot,
                                    rocsparse_int*       numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -1149,7 +1149,7 @@ static inline void host_bsr_usolve(rocsparse_direction  dir,
                                    rocsparse_int*       struct_pivot,
                                    rocsparse_int*       numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -1255,7 +1255,7 @@ void host_bsrsv(rocsparse_operation  trans,
                 rocsparse_int*       struct_pivot,
                 rocsparse_int*       numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Initialize pivot
     *struct_pivot  = mb + 1;
@@ -1386,7 +1386,7 @@ void host_coomv(rocsparse_operation  trans,
                 Y*                   y,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(trans == rocsparse_operation_none)
     {
@@ -1439,7 +1439,7 @@ void host_coomv_aos(rocsparse_operation  trans,
                     Y*                   y,
                     rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(trans)
     {
@@ -1509,7 +1509,7 @@ static void host_csrmv_general(rocsparse_operation  trans,
                                rocsparse_spmv_alg   algo,
                                bool                 force_conj)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     bool conj = (trans == rocsparse_operation_conjugate_transpose || force_conj);
 
@@ -1656,7 +1656,7 @@ static void host_csrmv_symmetric(rocsparse_operation  trans,
                                  rocsparse_spmv_alg   algo,
                                  bool                 force_conj)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     bool conj = (trans == rocsparse_operation_conjugate_transpose || force_conj);
 
@@ -1812,7 +1812,7 @@ void host_csrmv(rocsparse_operation   trans,
                 rocsparse_spmv_alg    algo,
                 bool                  force_conj)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -1874,7 +1874,7 @@ void host_cscmv(rocsparse_operation trans,
                 rocsparse_matrix_type matrix_type,
                 rocsparse_spmv_alg    algo)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(trans)
     {
@@ -1949,7 +1949,7 @@ static void host_csr_lsolve(J                    M,
                             J*                   struct_pivot,
                             J*                   numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Get device properties
     int             dev;
@@ -2059,7 +2059,7 @@ static void host_csr_usolve(J                    M,
                             J*                   struct_pivot,
                             J*                   numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Get device properties
     int             dev;
@@ -2169,7 +2169,7 @@ void host_csrsv(rocsparse_operation  trans,
                 J*                   struct_pivot,
                 J*                   numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Initialize pivot
     *struct_pivot  = M + 1;
@@ -2290,7 +2290,7 @@ void host_coosv(rocsparse_operation  trans,
                 I*                   struct_pivot,
                 I*                   numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(std::is_same<I, int32_t>() && nnz < std::numeric_limits<int32_t>::max())
     {
@@ -2351,7 +2351,7 @@ void host_ellmv(rocsparse_operation  trans,
                 Y*                   y,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(trans == rocsparse_operation_none)
     {
@@ -2442,7 +2442,7 @@ void host_hybmv(rocsparse_operation  trans,
                 T*                   y,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(M == 0 || N == 0)
     {
@@ -2504,7 +2504,7 @@ void host_bsrmm(rocsparse_handle     handle,
                 rocsparse_order      order_C,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(transA != rocsparse_operation_none)
     {
@@ -2594,7 +2594,7 @@ void host_gebsrmm(rocsparse_handle          handle,
                   T*                        C,
                   int64_t                   ldc)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(transA != rocsparse_operation_none)
     {
@@ -2681,7 +2681,7 @@ void host_csrmm(J                    M,
                 rocsparse_index_base base,
                 bool                 force_conj_A)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     bool conj_A = (transA == rocsparse_operation_conjugate_transpose || force_conj_A);
     bool conj_B = (transB == rocsparse_operation_conjugate_transpose);
@@ -2809,7 +2809,7 @@ void host_csrmm_batched(J                    M,
                         rocsparse_index_base base,
                         bool                 force_conj_A)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const bool Ci_A_Bi  = (batch_count_A == 1 && batch_count_B == batch_count_C);
     const bool Ci_Ai_B  = (batch_count_B == 1 && batch_count_A == batch_count_C);
@@ -2914,7 +2914,7 @@ void host_coomm(I                    M,
                 rocsparse_order      order_C,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     bool conj_A = (transA == rocsparse_operation_conjugate_transpose);
     bool conj_B = (transB == rocsparse_operation_conjugate_transpose);
@@ -3031,7 +3031,7 @@ void host_coomm_batched(I                    M,
                         rocsparse_order      order_C,
                         rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     bool Ci_A_Bi  = (batch_count_A == 1 && batch_count_B == batch_count_C);
     bool Ci_Ai_B  = (batch_count_B == 1 && batch_count_A == batch_count_C);
@@ -3135,7 +3135,7 @@ void host_cscmm(J                   M,
                 rocsparse_order      order_C,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(transA)
     {
@@ -3231,7 +3231,7 @@ void host_cscmm_batched(J                    M,
                         rocsparse_order      order_C,
                         rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(transA)
     {
@@ -3338,7 +3338,7 @@ static inline void host_lssolve(J                    M,
                                 J*                   struct_pivot,
                                 J*                   numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -3445,7 +3445,7 @@ static inline void host_ussolve(J                    M,
                                 J*                   struct_pivot,
                                 J*                   numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -3551,7 +3551,7 @@ void host_csrsm(J                    M,
                 J*                   struct_pivot,
                 J*                   numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(nrhs == 0)
     {
@@ -3748,7 +3748,7 @@ void host_coosm(I                    M,
                 I*                   struct_pivot,
                 I*                   numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(std::is_same<I, int32_t>() && nnz < std::numeric_limits<int32_t>::max())
     {
@@ -3822,7 +3822,7 @@ void host_bsrsm(rocsparse_int       mb,
                 rocsparse_int*       struct_pivot,
                 rocsparse_int*       numeric_pivot)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Initialize pivot
     *struct_pivot  = mb + 1;
@@ -3952,7 +3952,7 @@ void host_gemvi(I                    M,
                 T*                   y,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1024)
@@ -3986,7 +3986,7 @@ void host_gemmi(rocsparse_int        M,
                 int64_t              ldc,
                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(transB == rocsparse_operation_transpose)
     {
@@ -4039,7 +4039,7 @@ void host_bsrgemm_nnzb(J                    Mb,
                        rocsparse_index_base base_C,
                        rocsparse_index_base base_D)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     return host_csrgemm_nnz(Mb,
                             Nb,
@@ -4085,7 +4085,7 @@ void host_bsrgemm(rocsparse_direction  dir,
                   rocsparse_index_base base_C,
                   rocsparse_index_base base_D)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(Mb == 0 || Nb == 0)
     {
@@ -4390,7 +4390,7 @@ void host_bsrgeam_nnzb(rocsparse_direction  dir,
                        rocsparse_index_base base_B,
                        rocsparse_index_base base_C)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     return host_csrgeam_nnz(Mb,
                             Nb,
@@ -4427,7 +4427,7 @@ void host_bsrgeam(rocsparse_direction  dir,
                   rocsparse_index_base base_B,
                   rocsparse_index_base base_C)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
 #ifdef _OPENMP
 #pragma omp parallel
@@ -4623,7 +4623,7 @@ void host_csrgeam_nnz(J                    M,
                       rocsparse_index_base base_B,
                       rocsparse_index_base base_C)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(M == 0 || N == 0)
     {
@@ -4719,7 +4719,7 @@ void host_csrgeam(J                    M,
                   rocsparse_index_base base_B,
                   rocsparse_index_base base_C)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     T alpha_val = (alpha == nullptr) ? 0 : *alpha;
     T beta_val  = (beta == nullptr) ? 0 : *beta;
@@ -4858,7 +4858,7 @@ void host_csrgemm_nnz(J                    M,
                       rocsparse_index_base base_C,
                       rocsparse_index_base base_D)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(M == 0 || N == 0)
     {
@@ -5008,7 +5008,7 @@ void host_csrgemm(J                    M,
                   rocsparse_index_base base_C,
                   rocsparse_index_base base_D)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(M == 0 || N == 0)
     {
@@ -5176,7 +5176,7 @@ void rocsparse_host<T, I, J, A, B, C>::cooddmm(rocsparse_operation  transA,
                                                C*                   coo_val_C,
                                                rocsparse_index_base base_C)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const T a = *alpha;
     const T b = *beta;
@@ -5235,7 +5235,7 @@ void rocsparse_host<T, I, J, A, B, C>::cooaosddmm(rocsparse_operation  transA,
                                                   C*                   coo_val_C,
                                                   rocsparse_index_base base_C)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const T a = *alpha;
     const T b = *beta;
@@ -5294,7 +5294,7 @@ void rocsparse_host<T, I, J, A, B, C>::csrddmm(rocsparse_operation  transA,
                                                C*                   csr_val_C,
                                                rocsparse_index_base base_C)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const T a = *alpha;
     const T b = *beta;
@@ -5357,7 +5357,7 @@ void rocsparse_host<T, I, J, A, B, C>::ellddmm(rocsparse_operation  transA,
                                                C*                   ell_val_C,
                                                rocsparse_index_base ell_base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const T a = *alpha;
     const T b = *beta;
@@ -5423,7 +5423,7 @@ void rocsparse_host<T, I, J, A, B, C>::cscddmm(rocsparse_operation  transA,
                                                C*                   csr_val_C,
                                                rocsparse_index_base base_C)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const T a = *alpha;
     const T b = *beta;
@@ -5483,7 +5483,7 @@ void host_bsric0(rocsparse_direction               direction,
                  rocsparse_int*                    numeric_pivot)
 
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_int M = Mb * block_dim;
 
@@ -5718,7 +5718,7 @@ void host_bsrilu0(rocsparse_direction               dir,
                   T                                 boost_val)
 
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Initialize pivots
     *struct_pivot  = mb + 1;
@@ -5933,7 +5933,7 @@ void host_csric0(rocsparse_int                     M,
                  rocsparse_int*                    singular_pivot,
                  double                            tol)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Initialize pivot
     *struct_pivot   = -1;
@@ -6094,7 +6094,7 @@ void host_csrilu0(rocsparse_int                     M,
                   U                                 boost_tol,
                   T                                 boost_val)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if((struct_pivot == nullptr) || (numeric_pivot == nullptr) || (singular_pivot == nullptr))
     {
@@ -6273,7 +6273,7 @@ void host_gtsv_no_pivot(rocsparse_int         m,
                         std::vector<T>&       B,
                         rocsparse_int         ldb)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     //
     // Compute BLOCKSIZE as the lowest power of 2 greater or equal than m,
@@ -6385,7 +6385,7 @@ void host_gtsv_no_pivot_strided_batch(rocsparse_int         m,
                                       rocsparse_int         batch_count,
                                       rocsparse_int         batch_stride)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     //
     // Compute BLOCKSIZE as the lowest power of 2 greater or equal than m,
@@ -6496,7 +6496,7 @@ void host_gtsv_interleaved_batch_thomas(rocsparse_int m,
                                         rocsparse_int batch_count,
                                         rocsparse_int batch_stride)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<T> c1(m * batch_count, 0);
     std::vector<T> x1(m * batch_count, 0);
@@ -6563,7 +6563,7 @@ void host_gtsv_interleaved_batch_lu(rocsparse_int m,
                                     rocsparse_int batch_count,
                                     rocsparse_int batch_stride)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<T>             l(m * batch_count, 0);
     std::vector<T>             u0(m * batch_count, 0);
@@ -6700,7 +6700,7 @@ void host_gtsv_interleaved_batch_qr(rocsparse_int m,
                                     rocsparse_int batch_count,
                                     rocsparse_int batch_stride)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<T> r0(m * batch_count, 0);
     std::vector<T> r1(m * batch_count, 0);
@@ -6808,7 +6808,7 @@ void host_gtsv_interleaved_batch(rocsparse_gtsv_interleaved_alg algo,
                                  rocsparse_int                  batch_count,
                                  rocsparse_int                  batch_stride)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(algo)
     {
@@ -6842,7 +6842,7 @@ void host_gpsv_interleaved_batch_qr(rocsparse_int m,
                                     rocsparse_int batch_count,
                                     rocsparse_int batch_stride)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<T> r3(m * batch_count, 0);
     std::vector<T> r4(m * batch_count, 0);
@@ -7061,7 +7061,7 @@ void host_gpsv_interleaved_batch(rocsparse_gpsv_interleaved_alg algo,
                                  rocsparse_int                  batch_count,
                                  rocsparse_int                  batch_stride)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(algo)
     {
@@ -7088,7 +7088,7 @@ rocsparse_status host_nnz(rocsparse_direction dirA,
                           rocsparse_int*      nnz_per_row_columns,
                           rocsparse_int*      nnz_total_dev_host_ptr)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_int mn = (dirA == rocsparse_direction_row) ? m : n;
     for(rocsparse_int j = 0; j < mn; ++j)
@@ -7135,7 +7135,7 @@ void host_prune_dense2csr(rocsparse_int               m,
                           std::vector<rocsparse_int>& csr_row_ptr,
                           std::vector<rocsparse_int>& csr_col_ind)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     csr_row_ptr.resize(m + 1, 0);
     csr_row_ptr[0] = base;
@@ -7192,7 +7192,7 @@ void host_prune_dense2csr_by_percentage(rocsparse_int               m,
                                         std::vector<rocsparse_int>& csr_row_ptr,
                                         std::vector<rocsparse_int>& csr_col_ind)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_int nnz_A = m * n;
     rocsparse_int pos   = std::ceil(nnz_A * (percentage / 100)) - 1;
@@ -7226,7 +7226,7 @@ void host_dense2csx(J                    m,
                     I*                   csx_row_col_ptr,
                     J*                   csx_col_row_ind)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     static constexpr T s_zero = {};
     J                  len    = (rocsparse_direction_row == DIRA) ? m : n;
@@ -7312,7 +7312,7 @@ void host_csx2dense(J                    m,
                     T*                   A,
                     int64_t              ld)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(order == rocsparse_order_column)
     {
@@ -7396,7 +7396,7 @@ void host_dense_to_coo(I                     m,
                        std::vector<I>&       coo_row_ind,
                        std::vector<I>&       coo_col_ind)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Find number of non-zeros in dense matrix
     int64_t nnz = 0;
@@ -7453,7 +7453,7 @@ void host_coo_to_dense(I                     m,
                        int64_t               ld,
                        rocsparse_order       order)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     I nm = order == rocsparse_order_column ? n : m;
 
@@ -7510,7 +7510,7 @@ void host_csr_to_csc(J                    M,
                      rocsparse_action     action,
                      rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Determine nnz per column
     for(I i = 0; i < nnz; ++i)
@@ -7569,7 +7569,7 @@ void host_bsr_to_csr(rocsparse_direction               direction,
                      std::vector<rocsparse_int>&       csr_col_ind,
                      rocsparse_index_base              csr_base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     return host_gebsr_to_csr(direction,
                              mb,
@@ -7602,7 +7602,7 @@ void host_csr_to_bsr(rocsparse_direction               direction,
                      std::vector<rocsparse_int>&       bsr_col_ind,
                      rocsparse_index_base              bsr_base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     return host_csr_to_gebsr(direction,
                              m,
@@ -7636,7 +7636,7 @@ void host_csr_to_gebsr(rocsparse_direction               direction,
                        std::vector<rocsparse_int>&       bsr_col_ind,
                        rocsparse_index_base              bsr_base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_int mb = (m + row_block_dim - 1) / row_block_dim;
 
@@ -7793,7 +7793,7 @@ void host_gebsr_to_gebsc(rocsparse_int                     Mb,
                          rocsparse_action                  action,
                          rocsparse_index_base              base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     bsc_row_ind.resize(nnzb);
     bsc_col_ptr.resize(Nb + 1, 0);
@@ -7861,7 +7861,7 @@ void host_gebsr_to_csr(rocsparse_direction               direction,
                        std::vector<rocsparse_int>&       csr_col_ind,
                        rocsparse_index_base              csr_base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_int m   = mb * row_block_dim;
     size_t        nnz = size_t(nnzb) * row_block_dim * col_block_dim;
@@ -7946,7 +7946,7 @@ void host_gebsr_to_gebsr(rocsparse_direction               direction,
                          rocsparse_int                     col_block_dim_C,
                          rocsparse_index_base              base_C)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_int m = mb * row_block_dim_A;
     rocsparse_int n = nb * col_block_dim_A;
@@ -8004,7 +8004,7 @@ void host_bsr_to_bsc(rocsparse_int               mb,
                      rocsparse_index_base        bsr_base,
                      rocsparse_index_base        bsc_base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     bsc_row_ind.resize(nnzb);
     bsc_col_ptr.resize(nb + 1, 0);
@@ -8075,7 +8075,7 @@ void host_csr_to_hyb(rocsparse_int                     M,
                      rocsparse_hyb_partition           part,
                      rocsparse_index_base              base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     ell_nnz = 0;
     coo_nnz = 0;
@@ -8181,7 +8181,7 @@ void host_csr_to_csr_compress(rocsparse_int                     M,
                               rocsparse_index_base              base,
                               T                                 tol)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(M <= 0 || N <= 0)
     {
@@ -8270,7 +8270,7 @@ void host_prune_csr_to_csr(rocsparse_int                     M,
                            rocsparse_index_base              csr_base_C,
                            T                                 threshold)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     csr_row_ptr_C.resize(M + 1, 0);
     csr_row_ptr_C[0] = csr_base_C;
@@ -8334,7 +8334,7 @@ void host_prune_csr_to_csr_by_percentage(rocsparse_int                     M,
                                          rocsparse_index_base              csr_base_C,
                                          T                                 percentage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_int pos = std::ceil(nnz_A * (percentage / 100)) - 1;
     pos               = std::min(pos, nnz_A - 1);
@@ -8382,7 +8382,7 @@ void host_ell_to_csr(rocsparse_int                     M,
                      rocsparse_index_base              ell_base,
                      rocsparse_index_base              csr_base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     csr_row_ptr.resize(M + 1, 0);
 
@@ -8450,7 +8450,7 @@ void host_coosort_by_column(rocsparse_int               M,
                             std::vector<rocsparse_int>& coo_col_ind,
                             std::vector<T>&             coo_val)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Permutation vector
     std::vector<rocsparse_int> perm(nnz);
@@ -8503,7 +8503,7 @@ void host_bsrpad_value(rocsparse_int m,
                        const rocsparse_int* __restrict__ bsr_col_ind,
                        rocsparse_index_base bsr_base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_int start_local_index = m % block_dim;
 

--- a/projects/rocsparse/clients/common/rocsparse_init.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_init.cpp
@@ -31,7 +31,7 @@
 template <typename I, typename J>
 void host_coo_to_csr(J M, I nnz, const J* coo_row_ind, I* csr_row_ptr, rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Resize and initialize csr_row_ptr with zeros
     for(size_t i = 0; i < M + 1; ++i)
@@ -58,7 +58,7 @@ void host_csr_to_coo(J                     M,
                      std::vector<J>&       coo_row_ind,
                      rocsparse_index_base  base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Resize coo_row_ind
     coo_row_ind.resize(nnz);
@@ -86,7 +86,7 @@ void host_csr_to_coo_aos(J                     M,
                          std::vector<I>&       coo_ind,
                          rocsparse_index_base  base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Resize coo_ind
     coo_ind.resize(2 * nnz);
@@ -118,7 +118,7 @@ void host_csr_to_ell(J                     M,
                      rocsparse_index_base  csr_base,
                      rocsparse_index_base  ell_base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Determine ELL width
     ell_width = 0;
@@ -196,7 +196,7 @@ template <typename T>
 void rocsparse_init_exact(
     T* A, size_t M, size_t N, size_t lda, size_t stride, size_t batch_count, int a, int b)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
     {
@@ -214,7 +214,7 @@ template <typename T>
 void rocsparse_init(
     T* A, size_t M, size_t N, size_t lda, size_t stride, size_t batch_count, T a, T b)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
     {
@@ -238,7 +238,7 @@ void rocsparse_init_exact(std::vector<T>& A,
                           int             a,
                           int             b)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_exact(A.data(), M, N, lda, stride, batch_count, a, b);
 }
@@ -247,7 +247,7 @@ template <typename T>
 void rocsparse_init(
     std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride, size_t batch_count, T a, T b)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init(A.data(), M, N, lda, stride, batch_count, a, b);
 }
@@ -256,7 +256,7 @@ void rocsparse_init(
 template <typename I>
 void rocsparse_init_index(std::vector<I>& x, size_t nnz, size_t start, size_t end)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<bool> check(end - start, false);
 
@@ -286,7 +286,7 @@ template <typename T>
 void rocsparse_init_alternating_sign(
     std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride, size_t batch_count)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
         for(size_t i = 0; i < M; ++i)
@@ -303,7 +303,7 @@ void rocsparse_init_alternating_sign(
 template <typename T>
 void rocsparse_init_nan(T* A, size_t N)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(size_t i = 0; i < N; ++i)
         A[i] = T(rocsparse_nan_rng());
@@ -313,7 +313,7 @@ template <typename T>
 void rocsparse_init_nan(
     std::vector<T>& A, size_t M, size_t N, size_t lda, size_t stride, size_t batch_count)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     for(size_t i_batch = 0; i_batch < batch_count; i_batch++)
         for(size_t i = 0; i < M; ++i)
@@ -334,7 +334,7 @@ void rocsparse_init_coo_matrix(std::vector<I>&      row_ind,
                                bool                 full_rank,
                                bool                 to_int)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(nnz == 0)
     {
@@ -552,7 +552,7 @@ void rocsparse_init_csr_laplace2d(std::vector<I>&      row_ptr,
                                   I&                   nnz,
                                   rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Do nothing
     if(dim_x == 0 || dim_y == 0)
@@ -627,7 +627,7 @@ void rocsparse_init_coo_laplace2d(std::vector<I>&      row_ind,
                                   int64_t&             nnz,
                                   rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Always load using int64 as we dont know ahead of time how many nnz exist in matrix
     std::vector<int64_t> row_ptr;
@@ -654,7 +654,7 @@ void rocsparse_init_gebsr_laplace2d(std::vector<I>&      row_ptr,
                                     J                    col_block_dim,
                                     rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_csr_laplace2d(row_ptr, col_ind, val, dim_x, dim_y, Mb, Nb, nnzb, base);
 
@@ -678,7 +678,7 @@ void rocsparse_init_ell_laplace2d(std::vector<I>&      col_ind,
                                   I&                   width,
                                   rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     I csr_nnz;
 
@@ -708,7 +708,7 @@ void rocsparse_init_csr_laplace3d(std::vector<I>&      row_ptr,
                                   I&                   nnz,
                                   rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Do nothing
     if(dim_x == 0 || dim_y == 0 || dim_z == 0)
@@ -793,7 +793,7 @@ void rocsparse_init_coo_laplace3d(std::vector<I>&      row_ind,
                                   int64_t&             nnz,
                                   rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Always load using int64 as we dont know ahead of time how many nnz exist in matrix
     std::vector<int64_t> row_ptr;
@@ -821,7 +821,7 @@ void rocsparse_init_gebsr_laplace3d(std::vector<I>&      row_ptr,
                                     J                    col_block_dim,
                                     rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_csr_laplace3d(row_ptr, col_ind, val, dim_x, dim_y, dim_z, Mb, Nb, nnzb, base);
 
@@ -845,7 +845,7 @@ void rocsparse_init_csr_mtx(const char*          filename,
                             I&                   nnz,
                             rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     I       coo_M, coo_N;
     int64_t coo_nnz;
@@ -885,7 +885,7 @@ void rocsparse_init_coo_mtx(const char*          filename,
                             int64_t&             nnz,
                             rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_importer_matrixmarket importer(filename);
     rocsparse_status                status
@@ -907,7 +907,7 @@ void rocsparse_init_gebsr_mtx(const char*          filename,
                               J                    col_block_dim,
                               rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // this->init_csr(bsr_row_ptr, bsr_col_ind, bsr_val, Mb, Nb, nnzb, base);
     rocsparse_init_csr_mtx(filename, bsr_row_ptr, bsr_col_ind, bsr_val, Mb, Nb, nnzb, base);
@@ -932,7 +932,7 @@ void rocsparse_init_csr_smtx(const char*          filename,
                              I&                   nnz,
                              rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_importer_mlcsr importer(filename);
     const rocsparse_status   status
@@ -958,7 +958,7 @@ void rocsparse_init_coo_smtx(const char*          filename,
                              int64_t&             nnz,
                              rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<int64_t> csr_row_ptr;
     rocsparse_init_csr_smtx<int64_t, I, T>(
@@ -981,7 +981,7 @@ void rocsparse_init_gebsr_smtx(const char*          filename,
                                J                    col_block_dim,
                                rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_importer_mlcsr importer(filename);
     const rocsparse_status   status = rocsparse_import_sparse_csr(
@@ -1010,7 +1010,7 @@ void rocsparse_init_csr_bsmtx(const char*          filename,
                               I&                   nnz,
                               rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<I> bsr_row_ptr;
     std::vector<J> bsr_col_ind;
@@ -1095,7 +1095,7 @@ void rocsparse_init_coo_bsmtx(const char*          filename,
                               int64_t&             nnz,
                               rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<int64_t> csr_row_ptr;
     rocsparse_init_csr_bsmtx<int64_t, I, T>(
@@ -1118,7 +1118,7 @@ void rocsparse_init_gebsr_bsmtx(const char*          filename,
                                 J                    col_block_dim,
                                 rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_importer_mlbsr importer(filename);
     rocsparse_direction      import_dir = {};
@@ -1153,7 +1153,7 @@ void rocsparse_init_csr_rocalution(const char*          filename,
                                    I&                   nnz,
                                    rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_importer_rocalution importer(filename);
     rocsparse_status              status
@@ -1173,7 +1173,7 @@ void rocsparse_init_coo_rocalution(const char*          filename,
                                    int64_t&             nnz,
                                    rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     I              csr_nnz = 0;
     std::vector<I> row_ptr(M + 1);
@@ -1199,7 +1199,7 @@ void rocsparse_init_gebsr_rocalution(const char*          filename,
                                      J                    col_block_dim,
                                      rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     // Temporarily the file contains a CSR matrix.
     rocsparse_init_csr_rocalution(filename, row_ptr, col_ind, val, Mb, Nb, nnzb, base);
@@ -1225,7 +1225,7 @@ void rocsparse_init_csr_rocsparseio(const char*          filename,
                                     I&                   nnz,
                                     rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_importer_rocsparseio importer(filename);
     rocsparse_status               status
@@ -1245,7 +1245,7 @@ void rocsparse_init_coo_rocsparseio(const char*          filename,
                                     int64_t&             nnz,
                                     rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_importer_rocsparseio importer(filename);
     rocsparse_status               status
@@ -1268,7 +1268,7 @@ void rocsparse_init_gebsr_rocsparseio(const char*          filename,
                                       J                    col_block_dim,
                                       rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_direction            import_dir = {};
     rocsparse_importer_rocsparseio importer(filename);
@@ -1306,7 +1306,7 @@ void rocsparse_init_csr_random(std::vector<I>&            csr_row_ptr,
                                bool                       full_rank,
                                bool                       to_int)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(init_kind)
     {
@@ -1395,7 +1395,7 @@ void rocsparse_init_coo_random(std::vector<I>&            row_ind,
                                bool                       full_rank,
                                bool                       to_int)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(init_kind)
     {
@@ -1466,7 +1466,7 @@ void rocsparse_init_gebsr_random(std::vector<I>&            row_ptr,
                                  bool                       full_rank,
                                  bool                       to_int)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_csr_random(
         row_ptr, col_ind, val, Mb, Nb, nnzb, base, init_kind, full_rank, to_int);
@@ -1502,7 +1502,7 @@ void rocsparse_init_coo_tridiagonal(std::vector<I>&      row_ind,
                                     I                    l,
                                     I                    u)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(l >= 0 || -l >= M)
     {
@@ -1572,7 +1572,7 @@ void rocsparse_init_csr_tridiagonal(std::vector<I>&      row_ptr,
                                     J                    l,
                                     J                    u)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     int64_t        coo_nnz;
     std::vector<J> row_ind;
@@ -1609,7 +1609,7 @@ void rocsparse_init_gebsr_tridiagonal(std::vector<I>&      row_ptr,
                                       J                    l,
                                       J                    u)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_csr_tridiagonal(row_ptr, col_ind, val, Mb, Nb, nnzb, base, l, u);
 
@@ -1637,7 +1637,7 @@ void rocsparse_init_coo_pentadiagonal(std::vector<I>&      row_ind,
                                       I                    u,
                                       I                    uu)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(ll >= 0 || l >= 0 || ll >= l || -l >= M || -ll >= M)
     {
@@ -1729,7 +1729,7 @@ void rocsparse_init_csr_pentadiagonal(std::vector<I>&      row_ptr,
                                       J                    u,
                                       J                    uu)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     int64_t        coo_nnz;
     std::vector<J> row_ind;
@@ -1768,7 +1768,7 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
                                         J                    u,
                                         J                    uu)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_csr_pentadiagonal(row_ptr, col_ind, val, Mb, Nb, nnzb, base, ll, l, u, uu);
     const size_t nvalues = size_t(nnzb) * row_block_dim * col_block_dim;

--- a/projects/rocsparse/clients/common/rocsparse_matrix_factory.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_matrix_factory.cpp
@@ -34,7 +34,7 @@ static void get_matrix_full_filename(const Arguments& arg_,
                                      const char*      extension_,
                                      std::string&     full_filename_)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(arg_.timing)
     {
@@ -57,7 +57,7 @@ static void get_matrix_full_filename(const Arguments& arg_,
 template <typename T, typename I, typename J>
 rocsparse_matrix_factory<T, I, J>::~rocsparse_matrix_factory()
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     if(this->m_instance)
     {
@@ -78,7 +78,7 @@ rocsparse_matrix_factory<T, I, J>::rocsparse_matrix_factory(const Arguments&    
                                                             )
     : m_arg(arg)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     //
     // FORCE REINIT.
@@ -221,7 +221,7 @@ void rocsparse_matrix_factory<T, I, J>::init_coo(std::vector<I>&      coo_row_in
                                                  int64_t&             nnz,
                                                  rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     this->m_instance->init_coo(coo_row_ind,
                                coo_col_ind,
@@ -238,7 +238,7 @@ void rocsparse_matrix_factory<T, I, J>::init_coo(std::vector<I>&      coo_row_in
 template <typename T, typename I, typename J>
 void rocsparse_matrix_factory<T, I, J>::init_coo(host_coo_matrix<T, I>& that)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     that.base = this->m_arg.baseA;
     that.m    = this->m_arg.M;
@@ -261,7 +261,7 @@ void rocsparse_matrix_factory<T, I, J>::init_coo(host_coo_matrix<T, I>& that,
                                                  I&                     N,
                                                  rocsparse_index_base   base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     that.base = base;
     that.m    = M;
@@ -283,7 +283,7 @@ void rocsparse_matrix_factory<T, I, J>::init_coo(host_coo_matrix<T, I>& that,
 template <typename T, typename I, typename J>
 void rocsparse_matrix_factory<T, I, J>::init_coo(host_coo_matrix<T, I>& that, I& M, I& N)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     this->init_coo(that, M, N, this->m_arg.baseA);
 }
@@ -300,7 +300,7 @@ void rocsparse_matrix_factory<T, I, J>::init_csr(std::vector<I>&      csr_row_pt
                                                  I&                   nnz,
                                                  rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     this->m_instance->init_csr(csr_row_ptr,
                                csr_col_ind,
@@ -317,7 +317,7 @@ void rocsparse_matrix_factory<T, I, J>::init_csr(std::vector<I>&      csr_row_pt
 template <typename T, typename I, typename J>
 void rocsparse_matrix_factory<T, I, J>::init_csr(host_csr_matrix<T, I, J>& that)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     that.base = this->m_arg.baseA;
     that.m    = this->m_arg.M;
@@ -340,7 +340,7 @@ void rocsparse_matrix_factory<T, I, J>::init_csr(host_csr_matrix<T, I, J>& that,
                                                  J&                        n,
                                                  rocsparse_index_base      base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     that.base = base;
     that.m    = m;
@@ -362,7 +362,7 @@ void rocsparse_matrix_factory<T, I, J>::init_csr(host_csr_matrix<T, I, J>& that,
 template <typename T, typename I, typename J>
 void rocsparse_matrix_factory<T, I, J>::init_csr(host_csr_matrix<T, I, J>& that, J& m, J& n)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     this->init_csr(that, m, n, this->m_arg.baseA);
 }
@@ -379,7 +379,7 @@ void rocsparse_matrix_factory<T, I, J>::init_csc(std::vector<I>&      csc_col_pt
                                                  I&                   nnz,
                                                  rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     this->m_instance->init_csr(csc_col_ptr,
                                csc_row_ind,
@@ -399,7 +399,7 @@ void rocsparse_matrix_factory<T, I, J>::init_csc(host_csc_matrix<T, I, J>& that,
                                                  J&                        n,
                                                  rocsparse_index_base      base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     that.base = base;
     this->m_instance->init_csr(that.ptr,
@@ -431,7 +431,7 @@ void rocsparse_matrix_factory<T, I, J>::init_gebsr(std::vector<I>&      bsr_row_
                                                    J&                   col_block_dim,
                                                    rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     this->m_instance->init_gebsr(bsr_row_ptr,
                                  bsr_col_ind,
@@ -458,7 +458,7 @@ void rocsparse_matrix_factory<T, I, J>::init_gebsr(host_gebsr_matrix<T, I, J>& t
                                                    J&                          col_block_dim_,
                                                    rocsparse_index_base        base_)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     that.block_direction = block_dir_;
     that.mb              = mb_;
@@ -491,7 +491,7 @@ void rocsparse_matrix_factory<T, I, J>::init_gebsr(host_gebsr_matrix<T, I, J>& t
 template <typename T, typename I, typename J>
 void rocsparse_matrix_factory<T, I, J>::init_gebsr(host_gebsr_matrix<T, I, J>& that)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     that.block_direction = this->m_arg.direction;
     that.mb              = this->m_arg.M;
@@ -523,7 +523,7 @@ void rocsparse_matrix_factory<T, I, J>::init_gebsr(host_gebsr_matrix<T, I, J>& t
                                                    J&                          col_block_dim,
                                                    rocsparse_index_base        base_)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     that.base = base_;
     that.mb   = mb;
@@ -558,7 +558,7 @@ void rocsparse_matrix_factory<T, I, J>::init_gebsr_spezial(host_gebsr_matrix<T, 
                                                            J&                          Mb,
                                                            J&                          Nb)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     I idx = 0;
 
@@ -632,7 +632,7 @@ void rocsparse_matrix_factory<T, I, J>::init_gebsc(std::vector<I>&      bsc_col_
                                                    J&                   col_block_dim,
                                                    rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     this->m_instance->init_gebsr(bsc_col_ptr,
                                  bsc_row_ind,
@@ -664,7 +664,7 @@ void rocsparse_matrix_factory<T, I, J>::init_bsr(std::vector<I>&      bsr_row_pt
                                                  J&                   block_dim,
                                                  rocsparse_index_base base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     this->m_instance->init_gebsr(bsr_row_ptr,
                                  bsr_col_ind,
@@ -713,7 +713,7 @@ struct traits_init_bsr<
                      J&                                 nb_,
                      rocsparse_index_base               base_)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         //
         // Initialize in case init_csr requires it as input.
@@ -776,7 +776,7 @@ void rocsparse_matrix_factory<T, I, J>::init_bsr(host_gebsr_matrix<T, I, J>& tha
                                                  J&                          nb_,
                                                  rocsparse_index_base        base_)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     device_gebsr_matrix<T, I, J> dB;
     this->init_bsr(that_, dB, mb_, nb_, base_);
@@ -789,7 +789,7 @@ void rocsparse_matrix_factory<T, I, J>::init_bsr(host_gebsr_matrix<T, I, J>&   t
                                                  J&                            nb_,
                                                  rocsparse_index_base          base_)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     traits_init_bsr<T, I, J>::init(*this, that_, that_on_device_, mb_, nb_, base_);
 }
@@ -822,7 +822,7 @@ struct traits_init_coo_aos<T, I, J, std::enable_if_t<std::is_same<I, J>{}>>
                      I&                                 N,
                      rocsparse_index_base               base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         host_csr_matrix<T, I, I> hA;
         factory.init_csr(hA, M, N, base);
@@ -838,7 +838,7 @@ void rocsparse_matrix_factory<T, I, J>::init_coo_aos(host_coo_aos_matrix<T, I>& 
                                                      I&                         N,
                                                      rocsparse_index_base       base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     traits_init_coo_aos<T, I, J>::init(*this, that, M, N, base);
 }
@@ -869,7 +869,7 @@ struct traits_init_ell<T, I, J, std::enable_if_t<std::is_same<I, J>{}>>
                      I&                                 N,
                      rocsparse_index_base               base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         host_csr_matrix<T, I, I> hA;
         factory.init_csr(hA, M, N, base);
@@ -886,7 +886,7 @@ void rocsparse_matrix_factory<T, I, J>::init_ell(host_ell_matrix<T, I>& that,
                                                  I&                     N,
                                                  rocsparse_index_base   base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     traits_init_ell<T, I, J>::init(*this, that, M, N, base);
 }
@@ -924,7 +924,7 @@ struct traits_init_hyb<T,
                      rocsparse_index_base               base,
                      bool&                              conform)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         conform                                = true;
         rocsparse_hyb_partition part           = factory.m_arg.part;
@@ -982,7 +982,7 @@ template <typename T, typename I, typename J>
 void rocsparse_matrix_factory<T, I, J>::init_hyb(
     rocsparse_hyb_mat that, I& M, I& N, I& nnz, rocsparse_index_base base, bool& conform)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     traits_init_hyb<T, I, J>::init(*this, that, M, N, nnz, base, conform);
 }

--- a/projects/rocsparse/clients/common/rocsparse_matrix_factory_file.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_matrix_factory_file.cpp
@@ -32,7 +32,7 @@
 template <typename T, template <typename...> class VECTOR>
 static void apply_toint(VECTOR<T>& data)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const size_t size = data.size();
     for(size_t i = 0; i < size; ++i)
@@ -44,7 +44,7 @@ static void apply_toint(VECTOR<T>& data)
 template <template <typename...> class VECTOR>
 static void apply_toint(VECTOR<_Float16>& data)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const size_t size = data.size();
     for(size_t i = 0; i < size; ++i)
@@ -56,7 +56,7 @@ static void apply_toint(VECTOR<_Float16>& data)
 template <template <typename...> class VECTOR>
 static void apply_toint(VECTOR<rocsparse_float_complex>& data)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const size_t size = data.size();
     for(size_t i = 0; i < size; ++i)
@@ -70,7 +70,7 @@ static void apply_toint(VECTOR<rocsparse_float_complex>& data)
 template <template <typename...> class VECTOR>
 static void apply_toint(VECTOR<rocsparse_double_complex>& data)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     const size_t size = data.size();
     for(size_t i = 0; i < size; ++i)
@@ -169,7 +169,7 @@ struct spec
                                       rocsparse_fill_mode    uplo,
                                       rocsparse_storage_mode storage)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         factory.init_csr(
             bsr_row_ptr, bsr_col_ind, bsr_val, Mb, Nb, nnzb, base, matrix_type, uplo, storage);
@@ -204,7 +204,7 @@ struct spec<T, rocsparse_int, rocsparse_int>
         rocsparse_fill_mode                                                          uplo,
         rocsparse_storage_mode                                                       storage)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         //
         // Initialize in case init_csr requires it as input.
@@ -279,7 +279,7 @@ void rocsparse_matrix_factory_file<MATRIX_INIT, T, I, J>::init_gebsr(
     rocsparse_fill_mode    uplo,
     rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(MATRIX_INIT)
     {
@@ -393,7 +393,7 @@ void rocsparse_matrix_factory_file<MATRIX_INIT, T, I, J>::init_csr(
     rocsparse_fill_mode    uplo,
     rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<I> row_ptr;
     std::vector<J> col_ind;
@@ -495,7 +495,7 @@ void rocsparse_matrix_factory_file<MATRIX_INIT, T, I, J>::init_coo(
     rocsparse_fill_mode    uplo,
     rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     std::vector<I> row_ind;
     std::vector<I> col_ind;

--- a/projects/rocsparse/clients/common/rocsparse_matrix_factory_laplace2d.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_matrix_factory_laplace2d.cpp
@@ -45,7 +45,7 @@ void rocsparse_matrix_factory_laplace2d<T, I, J>::init_csr(std::vector<I>&      
                                                            rocsparse_fill_mode    uplo,
                                                            rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -107,7 +107,7 @@ void rocsparse_matrix_factory_laplace2d<T, I, J>::init_coo(std::vector<I>&      
                                                            rocsparse_fill_mode    uplo,
                                                            rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -173,7 +173,7 @@ void rocsparse_matrix_factory_laplace2d<T, I, J>::init_gebsr(std::vector<I>&    
                                                              rocsparse_fill_mode    uplo,
                                                              rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_gebsr_laplace2d(bsr_row_ptr,
                                    bsr_col_ind,

--- a/projects/rocsparse/clients/common/rocsparse_matrix_factory_laplace3d.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_matrix_factory_laplace3d.cpp
@@ -49,7 +49,7 @@ void rocsparse_matrix_factory_laplace3d<T, I, J>::init_csr(std::vector<I>&      
                                                            rocsparse_fill_mode    uplo,
                                                            rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -120,7 +120,7 @@ void rocsparse_matrix_factory_laplace3d<T, I, J>::init_coo(std::vector<I>&      
                                                            rocsparse_fill_mode    uplo,
                                                            rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -194,7 +194,7 @@ void rocsparse_matrix_factory_laplace3d<T, I, J>::init_gebsr(std::vector<I>&    
                                                              rocsparse_fill_mode    uplo,
                                                              rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_gebsr_laplace3d(bsr_row_ptr,
                                    bsr_col_ind,

--- a/projects/rocsparse/clients/common/rocsparse_matrix_factory_pentadiagonal.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_matrix_factory_pentadiagonal.cpp
@@ -50,7 +50,7 @@ void rocsparse_matrix_factory_pentadiagonal<T, I, J>::init_csr(std::vector<I>&  
                                                                rocsparse_fill_mode    uplo,
                                                                rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -122,7 +122,7 @@ void rocsparse_matrix_factory_pentadiagonal<T, I, J>::init_coo(std::vector<I>&  
                                                                rocsparse_fill_mode    uplo,
                                                                rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -206,7 +206,7 @@ void rocsparse_matrix_factory_pentadiagonal<T, I, J>::init_gebsr(std::vector<I>&
                                                                  rocsparse_fill_mode    uplo,
                                                                  rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_gebsr_pentadiagonal(bsr_row_ptr,
                                        bsr_col_ind,

--- a/projects/rocsparse/clients/common/rocsparse_matrix_factory_random.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_matrix_factory_random.cpp
@@ -48,7 +48,7 @@ void rocsparse_matrix_factory_random<T, I, J>::init_csr(std::vector<I>&        c
                                                         rocsparse_fill_mode    uplo,
                                                         rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -130,7 +130,7 @@ void rocsparse_matrix_factory_random<T, I, J>::init_gebsr(std::vector<I>&       
                                                           rocsparse_fill_mode    uplo,
                                                           rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_gebsr_random(bsr_row_ptr,
                                 bsr_col_ind,
@@ -172,7 +172,7 @@ void rocsparse_matrix_factory_random<T, I, J>::init_coo(std::vector<I>&        c
                                                         rocsparse_fill_mode    uplo,
                                                         rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {

--- a/projects/rocsparse/clients/common/rocsparse_matrix_factory_tridiagonal.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_matrix_factory_tridiagonal.cpp
@@ -45,7 +45,7 @@ void rocsparse_matrix_factory_tridiagonal<T, I, J>::init_csr(std::vector<I>&    
                                                              rocsparse_fill_mode    uplo,
                                                              rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -107,7 +107,7 @@ void rocsparse_matrix_factory_tridiagonal<T, I, J>::init_coo(std::vector<I>&    
                                                              rocsparse_fill_mode    uplo,
                                                              rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(matrix_type)
     {
@@ -173,7 +173,7 @@ void rocsparse_matrix_factory_tridiagonal<T, I, J>::init_gebsr(std::vector<I>&  
                                                                rocsparse_fill_mode    uplo,
                                                                rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_gebsr_tridiagonal(bsr_row_ptr,
                                      bsr_col_ind,

--- a/projects/rocsparse/clients/common/rocsparse_matrix_factory_zero.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_matrix_factory_zero.cpp
@@ -42,7 +42,7 @@ void rocsparse_matrix_factory_zero<T, I, J>::init_csr(std::vector<I>&        csr
                                                       rocsparse_fill_mode    uplo,
                                                       rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     csr_row_ptr.resize((M > 0) ? (M + 1) : 0, static_cast<I>(base));
     csr_col_ind.resize(0);
@@ -66,7 +66,7 @@ void rocsparse_matrix_factory_zero<T, I, J>::init_gebsr(std::vector<I>&        b
                                                         rocsparse_fill_mode    uplo,
                                                         rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     bsr_row_ptr.resize((Mb > 0) ? (Mb + 1) : 0, static_cast<I>(base));
     bsr_col_ind.resize(0);
@@ -87,7 +87,7 @@ void rocsparse_matrix_factory_zero<T, I, J>::init_coo(std::vector<I>&        coo
                                                       rocsparse_fill_mode    uplo,
                                                       rocsparse_storage_mode storage)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     coo_row_ind.resize(0);
     coo_col_ind.resize(0);

--- a/projects/rocsparse/clients/include/rocsparse_clients_routine_trace.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_clients_routine_trace.hpp
@@ -44,7 +44,7 @@ namespace rocsparse_clients
             roctxRangePop();
         }
     };
-#define ROCSPARSE_CLIENTS_ROCTX_TRACE rocsparse_clients::internal_roctx roctx(__FUNCTION__);
+#define ROCSPARSE_CLIENTS_ROCTX_TRACE rocsparse_clients::internal_roctx roctx(__FUNCTION__)
 #else
 #define ROCSPARSE_CLIENTS_ROCTX_TRACE
 #endif

--- a/projects/rocsparse/clients/include/rocsparse_import.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_import.hpp
@@ -49,7 +49,7 @@ rocsparse_status rocsparse_import_sparse_gebsr(rocsparse_importer<IMPORTER>& imp
                                                J&                            col_block_dim,
                                                rocsparse_index_base          base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_direction  import_dir;
     rocsparse_index_base import_base;
@@ -109,7 +109,7 @@ rocsparse_status rocsparse_import_sparse_csr(rocsparse_importer<IMPORTER>& impor
                                              I&                            nnz,
                                              rocsparse_index_base          base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_direction  dir;
     rocsparse_index_base import_base;
@@ -167,7 +167,7 @@ rocsparse_status rocsparse_import_sparse_coo(rocsparse_importer<IMPORTER>& impor
                                              int64_t&                      nnz,
                                              rocsparse_index_base          base)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_index_base import_base;
     rocsparse_status     status = importer.import_sparse_coo(&M, &N, &nnz, &import_base);

--- a/projects/rocsparse/clients/include/rocsparse_matrix_coo.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_matrix_coo.hpp
@@ -60,7 +60,7 @@ struct coo_matrix
     explicit coo_matrix(const coo_matrix<MODE, T, I>& that_, bool transfer = true)
         : coo_matrix<MODE, T, I>(that_.m, that_.n, that_.nnz, that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -72,7 +72,7 @@ struct coo_matrix
     explicit coo_matrix(const coo_matrix<THAT_MODE, T, I>& that_, bool transfer = true)
         : coo_matrix<MODE, T, I>(that_.m, that_.n, that_.nnz, that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -83,7 +83,7 @@ struct coo_matrix
     template <memory_mode::value_t THAT_MODE>
     void transfer_from(const coo_matrix<THAT_MODE, T, I>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR((this->m == that.m && this->n == that.n && this->nnz == that.nnz
                                && this->base == that.base)
@@ -97,7 +97,7 @@ struct coo_matrix
 
     void define(I m_, I n_, int64_t nnz_, rocsparse_index_base base_)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(m_ != this->m)
         {
@@ -126,7 +126,7 @@ struct coo_matrix
     template <memory_mode::value_t THAT_MODE>
     void unit_check(const coo_matrix<THAT_MODE, T, I>& that_) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -172,7 +172,7 @@ struct coo_matrix
     void near_check(const coo_matrix<THAT_MODE, T, I>& that_,
                     floating_data_t<T>                 tol = default_tolerance<T>::value) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -215,7 +215,7 @@ struct coo_matrix
 
     void info() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         std::cout << "INFO COO " << std::endl;
         std::cout << " m    : " << this->m << std::endl;
@@ -226,7 +226,7 @@ struct coo_matrix
 
     void print() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {

--- a/projects/rocsparse/clients/include/rocsparse_matrix_coo_aos.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_matrix_coo_aos.hpp
@@ -58,7 +58,7 @@ struct coo_aos_matrix
     explicit coo_aos_matrix(const coo_aos_matrix<MODE, T, I>& that_, bool transfer = true)
         : coo_aos_matrix<MODE, T, I>(that_.m, that_.n, that_.nnz, that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -70,7 +70,7 @@ struct coo_aos_matrix
     explicit coo_aos_matrix(const coo_aos_matrix<THAT_MODE, T, I>& that_, bool transfer = true)
         : coo_aos_matrix<MODE, T, I>(that_.m, that_.n, that_.nnz, that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -81,7 +81,7 @@ struct coo_aos_matrix
     template <memory_mode::value_t THAT_MODE>
     void transfer_from(const coo_aos_matrix<THAT_MODE, T, I>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR((this->m == that.m && this->n == that.n && this->nnz == that.nnz
                                && this->base == that.base)
@@ -94,7 +94,7 @@ struct coo_aos_matrix
 
     void define(I m_, I n_, int64_t nnz_, rocsparse_index_base base_)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(m_ != this->m)
         {
@@ -123,7 +123,7 @@ struct coo_aos_matrix
     void near_check(const coo_aos_matrix<THAT_MODE, T, I>& that_,
                     floating_data_t<T>                     tol = default_tolerance<T>::value) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -165,7 +165,7 @@ struct coo_aos_matrix
 
     void info() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         std::cout << "INFO COO AOS" << std::endl;
         std::cout << " m    : " << this->m << std::endl;
@@ -176,7 +176,7 @@ struct coo_aos_matrix
 
     void print() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {

--- a/projects/rocsparse/clients/include/rocsparse_matrix_csx.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_matrix_csx.hpp
@@ -66,7 +66,7 @@ struct csx_matrix
     explicit csx_matrix(const csx_matrix<MODE, DIRECTION, T, I, J>& that_, bool transfer = true)
         : csx_matrix<MODE, DIRECTION, T, I, J>(that_.m, that_.n, that_.nnz, that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -79,7 +79,7 @@ struct csx_matrix
                         bool                                             transfer = true)
         : csx_matrix<MODE, DIRECTION, T, I, J>(that_.m, that_.n, that_.nnz, that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -89,7 +89,7 @@ struct csx_matrix
 
     rocsparse_status scale()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -130,7 +130,7 @@ struct csx_matrix
 
     void define(J m_, J n_, I nnz_, rocsparse_index_base base_)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(m_ != this->m)
         {
@@ -165,7 +165,7 @@ struct csx_matrix
 
     void info() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         std::cout << "INFO CSX " << std::endl;
         std::cout << " dir  : " << DIRECTION << std::endl;
@@ -177,7 +177,7 @@ struct csx_matrix
 
     void print() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -239,7 +239,7 @@ struct csx_matrix
 
     bool is_invalid() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(this->m < 0)
             return true;
@@ -265,7 +265,7 @@ struct csx_matrix
     template <memory_mode::value_t THAT_MODE>
     void transfer_from(const csx_matrix<THAT_MODE, DIRECTION, T, I, J>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR((this->m == that.m && this->n == that.n && this->nnz == that.nnz
                                && this->dir == that.dir && this->base == that.base)
@@ -297,7 +297,7 @@ struct csx_matrix
     template <memory_mode::value_t THAT_MODE>
     void unit_check(const csx_matrix<THAT_MODE, DIRECTION, T, I, J>& that_) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -365,7 +365,7 @@ struct csx_matrix
     void near_check(const csx_matrix<THAT_MODE, DIRECTION, T, I, J>& that_,
                     floating_data_t<T> tol = default_tolerance<T>::value) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {

--- a/projects/rocsparse/clients/include/rocsparse_matrix_dense.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_matrix_dense.hpp
@@ -111,14 +111,14 @@ public:
     template <memory_mode::value_t THAT_MODE>
     inline dense_matrix_view& operator=(const dense_matrix_view<THAT_MODE, T, I>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
         this->transfer_from(that);
         return *this;
     }
 
     inline dense_matrix_view& operator=(const dense_matrix_view& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
         this->transfer_from(that);
         return *this;
     }
@@ -151,7 +151,7 @@ public:
         , ld(ld_)
         , order(order_)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(order_)
         {
@@ -196,7 +196,7 @@ public:
 
     void info() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         std::cout << "m:    " << this->m << std::endl;
         std::cout << "n:    " << this->n << std::endl;
@@ -207,7 +207,7 @@ public:
     template <memory_mode::value_t THAT_MODE>
     void transfer_from(const dense_matrix_view<THAT_MODE, T, I>& that_)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR((this->m == that_.m && this->n == that_.n) ? hipSuccess
                                                                          : hipErrorInvalidValue);
@@ -243,7 +243,7 @@ public:
     template <memory_mode::value_t THAT_MODE>
     void unit_check(const dense_matrix_view<THAT_MODE, T, I>& that_) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -298,7 +298,7 @@ public:
     void near_check(const dense_matrix_view<THAT_MODE, T, I>& that_,
                     floating_data_t<T> tol = default_tolerance<T>::value) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -370,7 +370,7 @@ public:
     {
         if(this->data() != nullptr)
         {
-            ROCSPARSE_CLIENTS_ROUTINE_TRACE
+            ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
 #ifdef GOOGLE_TEST
             allocator::check_guards(this->data(), size_t(this->m) * size_t(this->n));
@@ -382,7 +382,7 @@ public:
     template <memory_mode::value_t THAT_MODE>
     inline dense_matrix& operator=(const dense_matrix_view<THAT_MODE, T, I>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         this->transfer_from(that);
         return *this;
@@ -396,7 +396,7 @@ public:
                                         (that.order == rocsparse_order_column) ? that.m : that.n,
                                         that.order)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -419,7 +419,7 @@ public:
                                         (that.order == rocsparse_order_column) ? that.m : that.n,
                                         that.order)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -436,7 +436,7 @@ public:
                                         (that.order == rocsparse_order_column) ? that.m : that.n,
                                         that.order)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -448,7 +448,7 @@ public:
 template <memory_mode::value_t MODE, typename T, typename I>
 void dense_matrix_view<MODE, T, I>::print() const
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(MODE)
     {

--- a/projects/rocsparse/clients/include/rocsparse_matrix_ell.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_matrix_ell.hpp
@@ -60,7 +60,7 @@ struct ell_matrix
     explicit ell_matrix(const ell_matrix<MODE, T, I>& that_, bool transfer = true)
         : ell_matrix<MODE, T, I>(that_.m, that_.n, that_.width, that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -72,7 +72,7 @@ struct ell_matrix
     explicit ell_matrix(const ell_matrix<THAT_MODE, T, I>& that_, bool transfer = true)
         : ell_matrix<MODE, T, I>(that_.m, that_.n, that_.width, that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -83,7 +83,7 @@ struct ell_matrix
     template <memory_mode::value_t THAT_MODE>
     void transfer_from(const ell_matrix<THAT_MODE, T, I>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR((this->m == that.m && this->n == that.n && this->nnz == that.nnz
                                && this->base == that.base)
@@ -96,7 +96,7 @@ struct ell_matrix
 
     void define(I m_, I n_, I width_, rocsparse_index_base base_)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(m_ != this->m)
         {
@@ -130,7 +130,7 @@ struct ell_matrix
     void near_check(const ell_matrix<THAT_MODE, T, I>& that_,
                     floating_data_t<T>                 tol = default_tolerance<T>::value) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -175,7 +175,7 @@ struct ell_matrix
 
     void info() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         std::cout << "INFO ELL" << std::endl;
         std::cout << " m     : " << this->m << std::endl;

--- a/projects/rocsparse/clients/include/rocsparse_matrix_gebsx.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_matrix_gebsx.hpp
@@ -86,7 +86,7 @@ struct gebsx_matrix
                                                   that_.col_block_dim,
                                                   that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -104,7 +104,7 @@ struct gebsx_matrix
                                                   that_.col_block_dim,
                                                   that_.base)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -115,7 +115,7 @@ struct gebsx_matrix
     void unit_check(gebsx_matrix<memory_mode::host, direction_, T, I, J>& that,
                     bool                                                  check_values = true)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         unit_check_enum(this->block_direction, that.block_direction);
         unit_check_scalar<J>(this->mb, that.mb);
@@ -161,7 +161,7 @@ struct gebsx_matrix
     void near_check(const gebsx_matrix<THAT_MODE, direction_, T, I, J>& that_,
                     floating_data_t<T> tol = default_tolerance<T>::value) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -228,7 +228,7 @@ struct gebsx_matrix
 
     void info() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         std::cout << "INFO GEBSX " << std::endl;
         std::cout << " dir            : " << direction_ << std::endl;
@@ -243,7 +243,7 @@ struct gebsx_matrix
 
     bool is_invalid() const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(this->mb < 0)
             return true;
@@ -294,7 +294,7 @@ struct gebsx_matrix
                 J                    col_block_dim_,
                 rocsparse_index_base base_)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(block_dir_ != this->block_direction)
         {
@@ -345,7 +345,7 @@ struct gebsx_matrix
     template <memory_mode::value_t THAT_MODE>
     void transfer_from(const gebsx_matrix<THAT_MODE, direction_, T, I, J>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR((this->mb == that.mb && this->nb == that.nb && this->nnzb == that.nnzb
                                && this->block_direction == that.block_direction
@@ -386,7 +386,7 @@ struct gebsx_matrix
     gebsx_matrix<MODE, direction_, T, I, J>&
         operator()(const gebsx_matrix<THAT_MODE, direction_, T, I, J>& that, bool transfer = true)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         this->define(that.block_direction,
                      that.mb,

--- a/projects/rocsparse/clients/include/rocsparse_vector.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_vector.hpp
@@ -78,7 +78,7 @@ public:
     template <memory_mode::value_t THAT_MODE>
     void unit_check(const dense_vector_t<THAT_MODE, T>& that_) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -116,7 +116,7 @@ public:
     void near_check(const dense_vector_t<THAT_MODE, T>& that_,
                     floating_data_t<T>                  tol_ = default_tolerance<T>::value) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         switch(MODE)
         {
@@ -155,7 +155,7 @@ public:
     template <memory_mode::value_t THAT_MODE>
     void transfer_from(const dense_vector_t<THAT_MODE, T>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR(this->size() == that.size() ? hipSuccess : hipErrorInvalidValue);
         auto err = hipMemcpy(this->data(),
@@ -196,7 +196,7 @@ struct host_vector : std::vector<T>
     template <memory_mode::value_t THAT_MODE>
     void transfer_from(const dense_vector_t<THAT_MODE, T>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR(this->size() == that.size() ? hipSuccess : hipErrorInvalidValue);
         CHECK_HIP_THROW_ERROR(
@@ -207,7 +207,7 @@ struct host_vector : std::vector<T>
     }
     void transfer_from(const host_vector<T>& that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR(this->size() == that.size() ? hipSuccess : hipErrorInvalidValue);
         CHECK_HIP_THROW_ERROR(
@@ -220,7 +220,7 @@ struct host_vector : std::vector<T>
     template <memory_mode::value_t THAT_MODE>
     void unit_check(const dense_vector_t<THAT_MODE, T>& that_) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         that_.unit_check(*this);
     }
@@ -229,14 +229,14 @@ struct host_vector : std::vector<T>
     void near_check(const dense_vector_t<THAT_MODE, T>& that_,
                     floating_data_t<T>                  tol_ = default_tolerance<T>::value) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         that_.near_check(*this, tol_);
     }
 
     void unit_check(const host_vector<T>& that_) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         unit_check_scalar<rocsparse_int>(this->size(), that_.size());
         unit_check_segments<T>(this->size(), this->data(), that_);
@@ -245,7 +245,7 @@ struct host_vector : std::vector<T>
     void near_check(const host_vector<T>& that_,
                     floating_data_t<T>    tol_ = default_tolerance<T>::value) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         unit_check_scalar<rocsparse_int>(this->size(), that_.size());
         near_check_segments<T>(this->size(), this->data(), that_.data(), tol_);
@@ -254,7 +254,7 @@ struct host_vector : std::vector<T>
     template <memory_mode::value_t THAT_MODE>
     void transfer_from(const T* that)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         CHECK_HIP_THROW_ERROR(
             hipMemcpy(this->data(),
@@ -265,7 +265,7 @@ struct host_vector : std::vector<T>
 
     void print(std::ostream& out) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const size_t N = this->size();
         for(size_t i = 0; i < N; ++i)
@@ -276,7 +276,7 @@ struct host_vector : std::vector<T>
 
     void print_limited(std::ostream& out, size_t bound) const
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const size_t N = this->size();
         for(size_t i = 0; i < N; ++i)
@@ -317,7 +317,7 @@ public:
 
     void resize(size_t s)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(s != this->m_size)
         {
@@ -338,7 +338,7 @@ public:
     explicit dense_vector(const host_vector<T>& that, bool transfer = true)
         : dense_vector_t<MODE, T>(that.size(), allocator::malloc(that.size()))
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -349,7 +349,7 @@ public:
     explicit dense_vector(const dense_vector<MODE, T>& that, bool transfer = true)
         : dense_vector_t<MODE, T>(that.size(), allocator::malloc(that.size()))
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -360,7 +360,7 @@ public:
     explicit dense_vector(const dense_vector_t<MODE, T>& that, bool transfer = true)
         : dense_vector_t<MODE, T>(that.size(), allocator::malloc(that.size()))
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -372,7 +372,7 @@ public:
     explicit dense_vector(const dense_vector_t<THAT_MODE, T>& that, bool transfer = true)
         : dense_vector_t<MODE, T>(that.size(), allocator::malloc(that.size()))
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(transfer)
         {
@@ -424,7 +424,7 @@ dense_vector_t<MODE, T>::~dense_vector_t()
 template <memory_mode::value_t MODE, typename T>
 void dense_vector_t<MODE, T>::unit_check(const host_vector<T>& that_) const
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(MODE)
     {
@@ -448,7 +448,7 @@ void dense_vector_t<MODE, T>::unit_check(const host_vector<T>& that_) const
 template <memory_mode::value_t MODE, typename T>
 void dense_vector_t<MODE, T>::near_check(const host_vector<T>& that_, floating_data_t<T> tol_) const
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(MODE)
     {
@@ -472,7 +472,7 @@ void dense_vector_t<MODE, T>::near_check(const host_vector<T>& that_, floating_d
 template <memory_mode::value_t MODE, typename T>
 void dense_vector_t<MODE, T>::transfer_from(const host_vector<T>& that)
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     CHECK_HIP_THROW_ERROR(this->size() == that.size() ? hipSuccess : hipErrorInvalidValue);
     auto err = hipMemcpy(this->data(),
@@ -485,7 +485,7 @@ void dense_vector_t<MODE, T>::transfer_from(const host_vector<T>& that)
 template <memory_mode::value_t MODE, typename T>
 void dense_vector_t<MODE, T>::transfer_to(std::vector<T>& that) const
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     that.resize(this->m_size);
     CHECK_HIP_THROW_ERROR(hipMemcpy(that.data(),
@@ -497,7 +497,7 @@ void dense_vector_t<MODE, T>::transfer_to(std::vector<T>& that) const
 template <memory_mode::value_t MODE, typename T>
 void dense_vector_t<MODE, T>::print() const
 {
-    ROCSPARSE_CLIENTS_ROUTINE_TRACE
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     switch(MODE)
     {

--- a/projects/rocsparse/clients/include/utility.hpp
+++ b/projects/rocsparse/clients/include/utility.hpp
@@ -209,7 +209,7 @@ public:
         : capture_started(false)
         , graph_testing(false)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_handle(&this->handle);
         if(status != rocsparse_status_success)
@@ -221,7 +221,7 @@ public:
         : capture_started(false)
         , graph_testing(arg.graph_test)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_handle(&this->handle);
         if(status != rocsparse_status_success)
@@ -231,7 +231,7 @@ public:
     }
     ~rocsparse_local_handle()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         rocsparse_destroy_handle(this->handle);
     }
@@ -248,7 +248,7 @@ public:
 
     void rocsparse_stream_begin_capture()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(!(this->graph_testing))
         {
@@ -271,7 +271,7 @@ public:
 
     void rocsparse_stream_end_capture(rocsparse_int runs = 1)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(!(this->graph_testing))
         {
@@ -323,7 +323,7 @@ class rocsparse_local_mat_descr
 public:
     rocsparse_local_mat_descr()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_mat_descr(&this->descr);
         if(status != rocsparse_status_success)
@@ -334,7 +334,7 @@ public:
 
     ~rocsparse_local_mat_descr()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         rocsparse_destroy_mat_descr(this->descr);
     }
@@ -358,7 +358,7 @@ class rocsparse_local_mat_info
 public:
     rocsparse_local_mat_info()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_mat_info(&this->info);
         if(status != rocsparse_status_success)
@@ -368,7 +368,7 @@ public:
     }
     ~rocsparse_local_mat_info()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         rocsparse_destroy_mat_info(this->info);
     }
@@ -376,7 +376,7 @@ public:
     // Sometimes useful to reset local info
     void reset()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         rocsparse_destroy_mat_info(this->info);
         const rocsparse_status status = rocsparse_create_mat_info(&this->info);
@@ -405,7 +405,7 @@ class rocsparse_local_color_info
 public:
     rocsparse_local_color_info()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_color_info(&this->info);
         if(status != rocsparse_status_success)
@@ -415,7 +415,7 @@ public:
     }
     ~rocsparse_local_color_info()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         rocsparse_destroy_color_info(this->info);
     }
@@ -423,7 +423,7 @@ public:
     // Sometimes useful to reset local info
     void reset()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         rocsparse_destroy_color_info(this->info);
         const rocsparse_status status = rocsparse_create_color_info(&this->info);
@@ -468,7 +468,7 @@ class rocsparse_local_hyb_mat
 public:
     rocsparse_local_hyb_mat()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_hyb_mat(&this->hyb);
         if(status != rocsparse_status_success)
@@ -478,7 +478,7 @@ public:
     }
     ~rocsparse_local_hyb_mat()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         rocsparse_destroy_hyb_mat(this->hyb);
     }
@@ -508,7 +508,7 @@ public:
                           rocsparse_index_base idx_base,
                           rocsparse_datatype   compute_type)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_spvec_descr(
             &this->descr, size, nnz, indices, values, idx_type, idx_base, compute_type);
@@ -519,7 +519,7 @@ public:
     }
     ~rocsparse_local_spvec()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(this->descr != nullptr)
         {
@@ -554,7 +554,7 @@ public:
                           rocsparse_index_base idx_base,
                           rocsparse_datatype   compute_type)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_coo_descr(&this->descr,
                                                                    m,
@@ -595,7 +595,7 @@ public:
                           rocsparse_index_base idx_base,
                           rocsparse_datatype   compute_type)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_coo_aos_descr(
             &this->descr, m, n, nnz, coo_ind, coo_val, idx_type, idx_base, compute_type);
@@ -624,7 +624,7 @@ public:
                           rocsparse_datatype   compute_type,
                           bool                 csc_format = false)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(csc_format == false)
         {
@@ -698,7 +698,7 @@ public:
                           rocsparse_datatype   compute_type,
                           rocsparse_format     format)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(format == rocsparse_format_bsr)
         {
@@ -755,7 +755,7 @@ public:
                           rocsparse_index_base idx_base,
                           rocsparse_datatype   compute_type)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_bell_descr(&this->descr,
                                                                     m,
@@ -783,7 +783,7 @@ public:
                           rocsparse_index_base idx_base,
                           rocsparse_datatype   compute_type)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_ell_descr(
             &this->descr, m, n, ell_col_ind, ell_val, ell_width, idx_type, idx_base, compute_type);
@@ -802,7 +802,7 @@ public:
 
     ~rocsparse_local_spmat()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(this->descr != nullptr)
             rocsparse_destroy_spmat_descr(this->descr);
@@ -827,7 +827,7 @@ class rocsparse_local_dnvec
 public:
     rocsparse_local_dnvec(int64_t size, void* values, rocsparse_datatype compute_type)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status
             = rocsparse_create_dnvec_descr(&this->descr, size, values, compute_type);
@@ -845,7 +845,7 @@ public:
 
     ~rocsparse_local_dnvec()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(this->descr != nullptr)
             rocsparse_destroy_dnvec_descr(this->descr);
@@ -875,7 +875,7 @@ public:
                           rocsparse_datatype compute_type,
                           rocsparse_order    order)
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         const rocsparse_status status = rocsparse_create_dnmat_descr(
             &this->descr, rows, cols, ld, values, compute_type, order);
@@ -893,7 +893,7 @@ public:
 
     ~rocsparse_local_dnmat()
     {
-        ROCSPARSE_CLIENTS_ROUTINE_TRACE
+        ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
         if(this->descr != nullptr)
             rocsparse_destroy_dnmat_descr(this->descr);


### PR DESCRIPTION
Code formatting from editors can be sensitive when semicolons are missing.