### PR TITLE
[rocsparse] make sure to find a correct version of rocprim and to use the correct header files even if another version is installed

### DIFF
--- a/projects/rocsparse/CMakeLists.txt
+++ b/projects/rocsparse/CMakeLists.txt
@@ -198,7 +198,7 @@ endif()
 message(STATUS "GPU_TARGETS: ${GPU_TARGETS}")
 
 # Find rocprim package
-find_package(rocprim REQUIRED)
+find_package(rocprim 4.0.0 REQUIRED)
 
 # Find rocblas package
 if (BUILD_WITH_ROCBLAS)

--- a/projects/rocsparse/library/CMakeLists.txt
+++ b/projects/rocsparse/library/CMakeLists.txt
@@ -76,7 +76,8 @@ target_compile_options(rocsparse PRIVATE -Wno-unused-command-line-argument -Wall
 
 # Target include directories
 target_include_directories(rocsparse
-                           PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include>
+                           PRIVATE ${ROCPRIM_INCLUDE_DIRS}
+                                   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include>
                                    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/library/include>
                            PUBLIC  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/rocsparse>
                                    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>


### PR DESCRIPTION
When compiling rocSPARSE on machines that have rocm preinstalled, users can run into issues where a preinstalled version of rocprim is used during the configuration/compilation.
The preinstalled version of rocprim is not necessarily consistent with the version included in the repo and used by rocSPARSE.
On top of that, even if a correct version is found, it happens that during the compilation phase the header files of the older version (installed in /opt/) are used.
This PR resolves both issues.