### PR TITLE
Revert "Bump aws-actions/configure-aws-credentials from 4.1.0 to 4.2.1 in the github-actions group"

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: always()
-        uses: aws-actions/configure-aws-credentials@59b441846ad109fa4a1549b73ef4e149c4bfb53b # v4.3.0
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: always()
-        uses: aws-actions/configure-aws-credentials@59b441846ad109fa4a1549b73ef4e149c4bfb53b # v4.3.0
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           aws-region: us-east-2
           role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external


### PR DESCRIPTION
Reverts ROCm/rocm-libraries#341

This failed on postsubmit: https://github.com/ROCm/rocm-libraries/actions/runs/16753710906
```
Run aws-actions/configure-aws-credentials@59b441846ad109fa4a1549b73ef4e149c4bfb53b
/usr/bin/docker exec  bc7d587afdf7bf843ca5bcb112898946df18556c9c3e39cca26728790a4a4fc2 sh -c "cat /etc/*release | grep ^ID"
Configuring proxy handler for STS client
Error: Invalid URL
```