### PR TITLE
[rocPRIM] Prevent extra test output after failure

### DIFF
--- a/projects/rocprim/test/rocprim/internal/test_internal_merge_path.cpp
+++ b/projects/rocprim/test/rocprim/internal/test_internal_merge_path.cpp
@@ -58,5 +58,5 @@ TEST(RocprimInternalMergePathTests, Basic)
 
     std::sort(x.begin(), x.end());
 
-    test_utils::assert_eq(x, y);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(x, y));
 }

--- a/projects/rocprim/test/rocprim/test_arg_index_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_arg_index_iterator.cpp
@@ -210,7 +210,7 @@ TYPED_TEST(RocprimArgIndexIteratorTests, ReduceArgMinimum)
         output = d_output.load();
 
         // Check if output values are as expected
-        test_utils::assert_eq(output[0].key, expected.key);
-        test_utils::assert_eq(output[0].value, expected.value);
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[0].key, expected.key));
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[0].value, expected.value));
     }
 }

--- a/projects/rocprim/test/rocprim/test_block_discontinuity.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_discontinuity.kernels.hpp
@@ -277,10 +277,10 @@ auto test_block_discontinuity()
 
         // Reading results
         const auto heads = device_heads.load_to_unique_ptr();
-        test_utils::assert_eq(heads.get(),
-                              heads.get() + size,
-                              expected_heads.begin(),
-                              expected_heads.end());
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(heads.get(),
+                                                      heads.get() + size,
+                                                      expected_heads.begin(),
+                                                      expected_heads.end()));
     }
 }
 
@@ -362,10 +362,10 @@ auto test_block_discontinuity()
         HIP_CHECK(hipDeviceSynchronize());
 
         const auto tails = device_tails.load_to_unique_ptr();
-        test_utils::assert_eq(tails.get(),
-                              tails.get() + size,
-                              expected_tails.begin(),
-                              expected_tails.end());
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(tails.get(),
+                                                      tails.get() + size,
+                                                      expected_tails.begin(),
+                                                      expected_tails.end()));
     }
 }
 
@@ -465,14 +465,14 @@ auto test_block_discontinuity()
         const auto heads = device_heads.load_to_unique_ptr();
         const auto tails = device_tails.load_to_unique_ptr();
 
-        test_utils::assert_eq(heads.get(),
-                              heads.get() + size,
-                              expected_heads.begin(),
-                              expected_heads.end());
-        test_utils::assert_eq(tails.get(),
-                              tails.get() + size,
-                              expected_tails.begin(),
-                              expected_tails.end());
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(heads.get(),
+                                                      heads.get() + size,
+                                                      expected_heads.begin(),
+                                                      expected_heads.end()));
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(tails.get(),
+                                                      tails.get() + size,
+                                                      expected_tails.begin(),
+                                                      expected_tails.end()));
     }
 }
 

--- a/projects/rocprim/test/rocprim/test_block_histogram.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_histogram.kernels.hpp
@@ -181,7 +181,7 @@ void test_block_histogram_input_arrays()
         // Reading results back
         output_bin = device_output_bin.load();
 
-        test_utils::assert_eq(output_bin, expected_bin);
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_bin, expected_bin));
     }
 }
 

--- a/projects/rocprim/test/rocprim/test_block_reduce.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_reduce.kernels.hpp
@@ -121,7 +121,7 @@ struct static_run_algo
         // Verifying results
         if(check_equal)
         {
-            test_utils::assert_eq(output_reductions, expected_reductions);
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_reductions, expected_reductions));
         }
         else
         {
@@ -301,7 +301,7 @@ void test_block_reduce_input_arrays()
         output_reductions = device_output_reductions.load();
 
         // Verifying results
-        test_utils::assert_eq(output_reductions, expected_reductions);
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_reductions, expected_reductions));
     }
 
 }

--- a/projects/rocprim/test/rocprim/test_block_shuffle.hpp
+++ b/projects/rocprim/test/rocprim/test_block_shuffle.hpp
@@ -82,7 +82,7 @@ typed_test_def(suite_name, name_suffix, BlockOffset)
             int offset = thread_index + distance;
             if((offset >= 0 ) && (offset < (int)block_size))
             {
-              test_utils::assert_eq(input_data[block_index*block_size + offset],output_data[block_index*block_size + thread_index]);
+              ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(input_data[block_index*block_size + offset],output_data[block_index*block_size + thread_index]));
             }
           }
         }
@@ -136,7 +136,7 @@ typed_test_def(suite_name, name_suffix, BlockRotate)
             int offset = thread_index + distance;
             if (offset >= (int)block_size)
                 offset -=      block_size;
-            test_utils::assert_eq(input_data[block_index*block_size + offset],output_data[block_index*block_size + thread_index]);
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(input_data[block_index*block_size + offset],output_data[block_index*block_size + thread_index]));
           }
         }
     }
@@ -195,7 +195,7 @@ typed_test_def(suite_name, name_suffix, BlockUp)
             {
               if(thread_index + item_index>0)
               {
-                  test_utils::assert_eq(input_data[start_offset + item_index-1],output_data[start_offset + item_index]);
+                  ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(input_data[start_offset + item_index-1],output_data[start_offset + item_index]));
               }
             }
           }
@@ -257,7 +257,7 @@ typed_test_def(suite_name, name_suffix, BlockDown)
             {
               if((thread_index!=block_size-1)&&(item_index!=ItemsPerThread-1))
               {
-                  test_utils::assert_eq(input_data[start_offset + item_index+1],output_data[start_offset + item_index]);
+                  ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(input_data[start_offset + item_index+1],output_data[start_offset + item_index]));
               }
             }
           }

--- a/projects/rocprim/test/rocprim/test_block_sort.hpp
+++ b/projects/rocprim/test/rocprim/test_block_sort.hpp
@@ -158,8 +158,8 @@ void TestSortKeyValue()
             i = j;
         }
 
-        test_utils::assert_eq(output_key, expected_key);
-        test_utils::assert_eq(output_value, expected_value);
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_key, expected_key));
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_value, expected_value));
     }
 }
 
@@ -234,7 +234,7 @@ void TestSortKey(std::vector<size_t> sizes)
             // Reading results back
             output = device_key_output.load();
 
-            test_utils::assert_eq(output, expected);
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
         }
     }
 }
@@ -329,7 +329,7 @@ void TestSortStableKey(std::vector<size_t> sizes)
                                  binary_op);
             }
 
-            test_utils::assert_eq(tuples, expected);
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(tuples, expected));
         }
     }
 }

--- a/projects/rocprim/test/rocprim/test_device_batch_memcpy.cpp
+++ b/projects/rocprim/test/rocprim/test_device_batch_memcpy.cpp
@@ -547,7 +547,7 @@ TYPED_TEST(RocprimDeviceBatchMemcpyTests, IteratorTest)
         hipMemcpy(h_data_out.data(), d_data_out, sizeof(int) * num_outputs, hipMemcpyDeviceToHost));
 
     std::vector<unsigned int> expected = {4, 4, 2, 2, 2, 7, 3, 3, 3, 1, 1, 1, 1, 1};
-    test_utils::assert_eq(expected, h_data_out);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(expected, h_data_out));
 
     // Clean up
     HIP_CHECK(hipFree(d_temp_storage));

--- a/projects/rocprim/test/rocprim/test_device_merge_inplace.cpp
+++ b/projects/rocprim/test/rocprim/test_device_merge_inplace.cpp
@@ -91,7 +91,7 @@ TEST(RocprimDeviceMergeInplaceTests, Basic)
     h_data = d_data.load();
     d_data.free_manually();
 
-    test_utils::assert_eq(h_data, h_expected);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(h_data, h_expected));
 }
 
 struct small_sizes

--- a/projects/rocprim/test/rocprim/test_device_reduce.cpp
+++ b/projects/rocprim/test/rocprim/test_device_reduce.cpp
@@ -464,8 +464,8 @@ TYPED_TEST(RocprimDeviceReduceTests, ReduceArgMinimum)
             const auto output = d_output.load();
 
             // Check if output values are as expected
-            test_utils::assert_eq(output[0].key, expected.key);
-            test_utils::assert_eq(output[0].value, expected.value);
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[0].key, expected.key));
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[0].value, expected.value));
 
             if (TestFixture::use_graphs)
             {

--- a/projects/rocprim/test/rocprim/test_device_run_length_encode.cpp
+++ b/projects/rocprim/test/rocprim/test_device_run_length_encode.cpp
@@ -250,7 +250,7 @@ TYPED_TEST(RocprimDeviceRunLengthEncode, Encode)
 
             std::vector<count_type> runs_count_expected_2;
             runs_count_expected_2.push_back(static_cast<count_type>(runs_count_expected));
-            test_utils::assert_eq(runs_count_output, runs_count_expected_2, 1);
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(runs_count_output, runs_count_expected_2, 1));
 
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(unique_output, unique_expected, runs_count_expected));
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(counts_output, counts_expected, runs_count_expected));

--- a/projects/rocprim/test/rocprim/test_intrinsics.cpp
+++ b/projects/rocprim/test/rocprim/test_intrinsics.cpp
@@ -382,7 +382,7 @@ void test_shuffle()
                     // Read from device memory
                     const auto output = d_data.load();
 
-                    test_utils::assert_eq(output, expected);
+                    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
                 }
             }
         }
@@ -635,7 +635,7 @@ TEST(RocprimIntrinsicsTests, MaskedBitCount)
 
                 const auto output = d_output.load();
 
-                test_utils::assert_eq(output, expected);
+                ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
             }
         }
     }
@@ -751,7 +751,7 @@ void warp_any_all_test()
 
             const auto output = d_output.load();
 
-            test_utils::assert_eq(output, expected);
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
         }
     }
 }
@@ -892,7 +892,7 @@ TYPED_TEST(RocprimIntrinsicsTests, WarpPermute)
 
                 const auto output = d_output.load();
 
-                test_utils::assert_eq(output, expected);
+                ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
             }
         }
     }
@@ -1004,7 +1004,7 @@ TEST(RocprimIntrinsicsTests, MatchAny)
 
                 const auto output = d_output.load();
 
-                test_utils::assert_eq(output, expected);
+                ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
             }
         }
     }
@@ -1092,7 +1092,7 @@ TEST(RocprimIntrinsicsTests, Ballot)
 
             const auto output = d_output.load();
 
-            test_utils::assert_eq(output, expected);
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
         }
     }
 }

--- a/projects/rocprim/test/rocprim/test_radix_key_codec.cpp
+++ b/projects/rocprim/test/rocprim/test_radix_key_codec.cpp
@@ -339,7 +339,7 @@ void encode_then_decode_test(Key key, Decomposer decomposer)
     Key decoded_key = codec_t::decode(bit_key, decomposer);
     codec_t::decode_inplace(key, decomposer);
 
-    test_utils::assert_eq(decoded_key, key);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(decoded_key, key));
 }
 
 template<class Key, class Decomposer = ::rocprim::identity_decomposer>
@@ -367,7 +367,7 @@ void encode_then_extract_test(Key                key,
     const unsigned int inplace_bits
         = codec_t::extract_digit(key, start_bit, radix_bits, decomposer);
 
-    test_utils::assert_eq(bits, inplace_bits);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(bits, inplace_bits));
 }
 
 template<class Key, class Decomposer = ::rocprim::identity_decomposer>
@@ -398,7 +398,7 @@ void encode_then_extract_test_custom(Key                key,
     const unsigned int inplace_bits
         = codec_t::extract_digit(key, start_bit, radix_bits, decomposer);
 
-    test_utils::assert_eq(bits, inplace_bits);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(bits, inplace_bits));
 }
 
 template<class Key, class Decomposer = ::rocprim::identity_decomposer>

--- a/projects/rocprim/test/rocprim/test_rocprim_types.cpp
+++ b/projects/rocprim/test/rocprim/test_rocprim_types.cpp
@@ -67,19 +67,19 @@ TYPED_TEST(DoubleBufferTest, TestDoubleBuffer)
 
     // Test default construction
     rocprim::double_buffer<T> db_default;
-    test_utils::assert_eq(db_default.current(), static_cast<T*>(nullptr));
-    test_utils::assert_eq(db_default.alternate(), static_cast<T*>(nullptr));
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(db_default.current(), static_cast<T*>(nullptr)));
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(db_default.alternate(), static_cast<T*>(nullptr)));
 
     // Test current buffer
-    test_utils::assert_eq(this->db.current(), &this->value1);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(this->db.current(), &this->value1));
 
     // Test alternate buffer
-    test_utils::assert_eq(this->db.alternate(), &this->value2);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(this->db.alternate(), &this->value2));
 
     // Test swap buffers
     this->db.swap();
-    test_utils::assert_eq(this->db.current(), &this->value2);
-    test_utils::assert_eq(this->db.alternate(), &this->value1);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(this->db.current(), &this->value2));
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(this->db.alternate(), &this->value1));
 }
 
 template<typename T>
@@ -99,18 +99,18 @@ TYPED_TEST(FutureValueTest, TestFutureValue)
 
     // Test const future value
     const auto cfv = this->fv;
-    test_utils::assert_eq(static_cast<T>(cfv), this->value);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(static_cast<T>(cfv), this->value));
 
     // Test value access
     this->value = get_random_full_range<T>();
-    test_utils::assert_eq(static_cast<TypeParam>(this->fv), this->value);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(static_cast<TypeParam>(this->fv), this->value));
 
     // Test plain input value
     T val = get_random_full_range<T>();
-    test_utils::assert_eq(rocprim::detail::get_input_value(val), val);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(rocprim::detail::get_input_value(val), val));
 
     // Test future input value
-    test_utils::assert_eq(rocprim::detail::get_input_value(this->fv), this->value);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(rocprim::detail::get_input_value(this->fv), this->value));
 }
 
 template<class K, class V>
@@ -150,8 +150,8 @@ TYPED_TEST(KeyValuePairTest, TestKeyValuePair)
     kv_type kv2{k, v};
 
     // Test value access
-    test_utils::assert_eq(kv1.key, k);
-    test_utils::assert_eq(kv1.value, v);
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(kv1.key, k));
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(kv1.value, v));
 
     K k_diff;
     V v_diff;
@@ -208,8 +208,8 @@ TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
     {
         V  val = get_random_full_range<V>();
         V& ref = this->ua.emplace(i, val); // Emplace construction
-        test_utils::assert_eq(ref, val); // Same value by reference
-        test_utils::assert_eq(this->ua.get_unsafe_array()[i], val); // Same value in array
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(ref, val)); // Same value by reference
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(this->ua.get_unsafe_array()[i], val)); // Same value in array
     }
 
     // Test memory consistency
@@ -217,8 +217,8 @@ TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
     this->ua.emplace(0, v0);
 
     auto& arr = this->ua.get_unsafe_array();
-    test_utils::assert_eq(&arr[0], &this->ua.get_unsafe_array()[0]); // Same address
-    test_utils::assert_eq(arr[0], v0); // Same content
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(&arr[0], &this->ua.get_unsafe_array()[0])); // Same address
+    ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(arr[0], v0)); // Same content
 
     for(unsigned int i = 0; i < TestFixture::Count; ++i)
     {
@@ -230,6 +230,6 @@ TYPED_TEST(UninitializedArrayTest, EmplaceConstructsCorrectValue)
     auto&                         arr_moved = moved.get_unsafe_array();
     for(unsigned int i = 0; i < TestFixture::Count; ++i)
     {
-        test_utils::assert_eq(arr_moved[i], V(i + 1));
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(arr_moved[i], V(i + 1)));
     }
 }

--- a/projects/rocprim/test/rocprim/test_utils_assertions.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_assertions.hpp
@@ -143,7 +143,7 @@ void assert_eq(const std::vector<T>& result,
         if(bit_equal(result[i], expected[i]))
             continue; // Check bitwise equality for +NaN, -NaN, +0.0, -0.0, +inf, -inf.
 
-        protected_assert_eq(result[i], expected[i], i);
+        ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result[i], expected[i], i));
     }
 }
 
@@ -161,7 +161,7 @@ void assert_eq(const std::vector<common::custom_type<T, T, true>>& result,
         if(bit_equal(result[i].x, expected[i].x) && bit_equal(result[i].y, expected[i].y))
             continue; // Check bitwise equality for +NaN, -NaN, +0.0, -0.0, +inf, -inf.
 
-        protected_assert_eq(result[i], expected[i], i);
+        ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result[i], expected[i], i));
     }
 }
 
@@ -202,7 +202,7 @@ void assert_eq(const T& result, const T& expected)
     if(bit_equal(result, expected))
         return; // Check bitwise equality for +NaN, -NaN, +0.0, -0.0, +inf, -inf.
 
-    protected_assert_eq(result, expected);
+    ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result, expected));
 }
 
 template<class T>
@@ -211,7 +211,7 @@ void assert_eq(const common::custom_type<T, T, true>& result,
 {
     if(bit_equal(result.x, expected.x) && bit_equal(result.y, expected.y))
         return; // Check bitwise equality for +NaN, -NaN, +0.0, -0.0, +inf, -inf.
-    protected_assert_eq(result, expected);
+    ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result, expected));
 }
 
 template<>
@@ -271,7 +271,7 @@ auto assert_near(const std::vector<T>& result, const std::vector<T>& expected, c
     ASSERT_EQ(result.size(), expected.size());
     for(size_t i = 0; i < result.size(); i++)
     {
-        protected_assert_eq(result[i], expected[i], i);
+        ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result[i], expected[i], i));
     }
 }
 
@@ -312,8 +312,8 @@ auto assert_near(const std::vector<common::custom_type<T, T, true>>& result,
     ASSERT_EQ(result.size(), expected.size());
     for(size_t i = 0; i < result.size(); i++)
     {
-        protected_assert_eq(result[i].x, expected[i].x, i);
-        protected_assert_eq(result[i].y, expected[i].y, i);
+        ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result[i].x, expected[i].x, i));
+        ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result[i].y, expected[i].y, i));
     }
 }
 
@@ -352,7 +352,7 @@ template<class T>
 auto assert_near(const T& result, const T& expected, const float)
     -> typename std::enable_if<std::is_integral<T>::value>::type
 {
-    protected_assert_eq(result, expected);
+    ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result, expected));
 }
 
 template<class T, std::enable_if_t<std::is_same<T, rocprim::bfloat16>::value ||
@@ -381,8 +381,8 @@ auto assert_near(const common::custom_type<T, T, true>& result,
                  const common::custom_type<T, T, true>& expected,
                  const float) -> typename std::enable_if<std::is_integral<T>::value>::type
 {
-    protected_assert_eq(result.x, expected.x);
-    protected_assert_eq(result.y, expected.y);
+    ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result.x, expected.x));
+    ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result.y, expected.y));
 }
 
 template<class T>

--- a/projects/rocprim/test/rocprim/test_warp_sort.hpp
+++ b/projects/rocprim/test/rocprim/test_warp_sort.hpp
@@ -114,7 +114,7 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, Sort)
         // Read from device memory
         output = d_output.load();
 
-        test_utils::assert_eq(output, expected);
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
     }
 
 }
@@ -230,7 +230,7 @@ typed_test_def(RocprimWarpSortShuffleBasedTests, name_suffix, SortKeyInt)
             i = j;
         }
 
-        test_utils::assert_eq(output_key, expected_key);
-        test_utils::assert_eq(output_value, expected_value);
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_key, expected_key));
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output_value, expected_value));
     }
 }


### PR DESCRIPTION
Recent refactoring changes have created new calls to test_utils::assert_eq and added test_utils::protected_assert (called by assert_eq).

By default, when GTest encounters a test failure, it only aborts the currently executing function. This means that tests that call test_utils::assert_eq in a loop may continue on to the next iteration after a test failure. This can result in large amounts of output for a single problem.

This change wraps calls to test_utils::assert_eq in GTests's ASSERT_NO_FATAL_FAILURE macro. This macro aborts the current function if any failure occur in the subroutine call it wraps.

The change also adds ASSERT_NO_FATAL_FAILURE calls in test_utils::assert_eq's calls to test_utils::protected_assert to prevent the same problem.