### PR TITLE
Change select offset type

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
@@ -146,7 +146,7 @@ hipError_t select(void * temporary_storage,
     using unary_predicate_type = ::rocprim::empty_type;
     // Dummy inequality operation
     using inequality_op_type = ::rocprim::empty_type;
-    using offset_type = unsigned int;
+    using offset_type                    = size_t;
     rocprim::empty_type* const no_values = nullptr; // key only
 
     using output_key_iterator_tuple = tuple<OutputIterator, ::rocprim::empty_type>;
@@ -281,7 +281,7 @@ hipError_t select(void * temporary_storage,
 {
     // Dummy flag type
     using flag_type = ::rocprim::empty_type;
-    using offset_type = unsigned int;
+    using offset_type = size_t;
     flag_type * flags = nullptr;
     // Dummy inequality operation
     using inequality_op_type = ::rocprim::empty_type;
@@ -425,7 +425,7 @@ inline hipError_t select(void*                       temporary_storage,
 {
     // Dummy inequality operation
     using inequality_op_type             = ::rocprim::empty_type;
-    using offset_type                    = unsigned int;
+    using offset_type                    = size_t;
     rocprim::empty_type* const no_values = nullptr; // key only
 
     using output_key_iterator_tuple = tuple<OutputIterator, ::rocprim::empty_type>;


### PR DESCRIPTION
### Background:
Since [NVIDIA/cccl#2400](https://github.com/NVIDIA/cccl/pull/2400), `cub::DeviceSelect` has adopted a streaming approach that processes input in chunks of up to `INT_MAX` items. As a result, it's better to use `i64` (or `size_t` on our side) offset types consistently. The key point is that there's minimal performance benefit in sticking with `i32`, and switching to `size_t` avoids redundant kernel compilation due to template specialisation differences.

Therefore [CCCL commit](https://github.com/NVIDIA/cccl/commit/16f9a1af1) dropped the 32-bit dispatch altogether.

### Scope:
This MR updates the `offset_type` used in `rocprim::select` from `unsigned int` to `size_t`, aligning with CCCL 2.8.2 changes.