### PR TITLE
Correct the way to get the number of GPU

### DIFF
--- a/projects/miopen/test/test_perf.py
+++ b/projects/miopen/test/test_perf.py
@@ -71,14 +71,13 @@ class Manager(mp.Process):
 
   def get_num_gpus(self):
     """Get num_gpus"""
-    #rocminfo will have 2 lines with gfx per gpu, arch name and target id
-    cmd = "/opt/rocm/bin/rocminfo | grep gfx | wc -l"
+    cmd = "/opt/rocm/bin/rocminfo | grep 'Device Type: *GPU' | wc -l"
     proc = subprocess.Popen(cmd,
                           shell=True,
                           stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT)
     output = proc.communicate()[0]
-    return int(output.decode('utf-8').strip()) / 2
+    return int(output.decode('utf-8').strip())
 
   def set_driver_cmds(self):
     if self.override:


### PR DESCRIPTION
On some platforms, 'rocminfo | grep gfx' may report unrelated information . To resolve this, we now use "rocminfo | grep 'Device Type: *GPU'" instead.

the log of rocminfo | grep gfx:
  Name:                    gfx942
      Name:                    amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-
      Name:                    amdgcn-amd-amdhsa--gfx9-4-generic:sramecc+:xnack-
  Name:                    gfx942
      Name:                    amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-
      Name:                    amdgcn-amd-amdhsa--gfx9-4-generic:sramecc+:xnack-
...

the log of rocminfo | grep 'Device Type: *GPU':
  Device Type:             GPU
  Device Type:             GPU
  Device Type:             GPU
  Device Type:             GPU
  ...