### PR TITLE
Do not build HostLibTests if rhel8

### DIFF
--- a/shared/tensile/.jenkins/precheckin.groovy
+++ b/shared/tensile/.jenkins/precheckin.groovy
@@ -58,6 +58,9 @@ def runCI =
         commonGroovy.runCompileCommand(platform, project, jobName, false)
     }
 
+    if (platform.os.contains("rhel8"))
+        compileCommand = null
+
     
     def testCommand =
     {

--- a/shared/tensile/.jenkins/precheckin.groovy
+++ b/shared/tensile/.jenkins/precheckin.groovy
@@ -59,7 +59,9 @@ def runCI =
     }
 
     if (platform.os.contains("rhel8"))
-        compileCommand = null
+        compileCommand = { platform, project -> 
+            // Skip compile
+        }
 
     
     def testCommand =


### PR DESCRIPTION
- A dependency on the llvm yaml library is in the rhel8 environment is causing the host lib tests to fail to build so disable when on rhel8.
- The llvm dependency should be removed in the future.