### PR TITLE
Clarify default Stream-K settings

### DIFF
--- a/projects/hipblaslt/docs/how-to/how-to-use-streamk.rst
+++ b/projects/hipblaslt/docs/how-to/how-to-use-streamk.rst
@@ -24,8 +24,8 @@ Set this variable to ``2`` to enable the Stream-K library or leave it set to ``0
 
 .. note::
 
-   The AMD Instinct™ MI350 series have a default ``TENSILE_SOLUTION_SELECTION_METHOD`` setting of ``2`` (Stream-K enabled).
-   To disable Stream-K, set ``TENSILE_SOLUTION_SELECTION_METHOD`` to ``0``.
+   On the AMD Instinct™ MI350 series, Stream-K is the only kernel selection strategy available.
+   There is no alternative library and the ``TENSILE_SOLUTION_SELECTION_METHOD`` variable has no effect.
 
 *  ``TENSILE_SOLUTION_SELECTION_METHOD=0`` (Standard tuned libraries)
 

--- a/projects/hipblaslt/docs/how-to/how-to-use-streamk.rst
+++ b/projects/hipblaslt/docs/how-to/how-to-use-streamk.rst
@@ -24,7 +24,7 @@ Set this variable to ``2`` to enable the Stream-K library or leave it set to ``0
 
 .. note::
 
-   The AMD Instinct™ MI350 and Instinct MI355 have a default ``TENSILE_SOLUTION_SELECTION_METHOD`` setting of ``2`` (Stream-K enabled).
+   The AMD Instinct™ MI350 series have a default ``TENSILE_SOLUTION_SELECTION_METHOD`` setting of ``2`` (Stream-K enabled).
    To disable Stream-K, set ``TENSILE_SOLUTION_SELECTION_METHOD`` to ``0``.
 
 *  ``TENSILE_SOLUTION_SELECTION_METHOD=0`` (Standard tuned libraries)

--- a/projects/hipblaslt/docs/how-to/how-to-use-streamk.rst
+++ b/projects/hipblaslt/docs/how-to/how-to-use-streamk.rst
@@ -22,7 +22,12 @@ Configuring the kernel selection strategy
 The ``TENSILE_SOLUTION_SELECTION_METHOD`` environment variable controls the hipBLASLt kernel selection strategy for GEMM operations.
 Set this variable to ``2`` to enable the Stream-K library or leave it set to ``0`` to continue to use the default settings.
 
-*  ``TENSILE_SOLUTION_SELECTION_METHOD=0`` (Default)
+.. note::
+
+   The AMD Instinct™ MI350 and Instinct MI355 have a default ``TENSILE_SOLUTION_SELECTION_METHOD`` setting of ``2`` (Stream-K enabled).
+   To disable Stream-K, set ``TENSILE_SOLUTION_SELECTION_METHOD`` to ``0``.
+
+*  ``TENSILE_SOLUTION_SELECTION_METHOD=0`` (Standard tuned libraries)
 
    *  Kernels are selected from the standard tuned libraries.
    *  The heuristic best kernel is selected from the standard tuning grid.

--- a/projects/hipblaslt/docs/reference/env-variables.rst
+++ b/projects/hipblaslt/docs/reference/env-variables.rst
@@ -99,8 +99,10 @@ For more information, see :doc:`Use Stream-K with hipBLASLt <../how-to/how-to-us
 
     * - | ``TENSILE_SOLUTION_SELECTION_METHOD``
         | Controls hipBLASLt kernel selection strategy for GEMM operations.
-      - | 0: Default (standard tuned libraries, no Stream-K)
+      - | 0: Standard tuned libraries (no Stream-K)
         | 2: Stream-K (enables Stream-K library for consistent performance)
+        | Default: Varies based on the CPU type, for instance, 0 on the Instinct™ MI300A.
+
 
     * - | ``TENSILE_STREAMK_DYNAMIC_GRID``
         | Controls Stream-K dynamic grid size selection behavior.

--- a/projects/hipblaslt/docs/reference/env-variables.rst
+++ b/projects/hipblaslt/docs/reference/env-variables.rst
@@ -99,9 +99,9 @@ For more information, see :doc:`Use Stream-K with hipBLASLt <../how-to/how-to-us
 
     * - | ``TENSILE_SOLUTION_SELECTION_METHOD``
         | Controls hipBLASLt kernel selection strategy for GEMM operations.
-      - | 0: Standard tuned libraries (no Stream-K)
+      - | 0: Default (standard tuned libraries, no Stream-K)
         | 2: Stream-K (enables Stream-K library for consistent performance)
-        | Default: Varies based on the CPU type, for instance, 0 on the Instinct™ MI300A.
+        | This variable has no effect on the AMD Instinct™ MI350 series. Stream-K is always used.
 
 
     * - | ``TENSILE_STREAMK_DYNAMIC_GRID``


### PR DESCRIPTION
This adds a note to the Stream-K documentation regarding the different defaults on the Instinct MI350/MI355 and updates the environment variables documentation.