### PR TITLE
[rocthrust]: Add C++ feature macros and type traits

### DIFF
--- a/projects/rocthrust/thrust/detail/config/cpp_dialect.h
+++ b/projects/rocthrust/thrust/detail/config/cpp_dialect.h
@@ -87,6 +87,25 @@
 
 #endif // !THRUST_CPP_DIALECT
 
+// Constexpr feature macros:
+#if THRUST_CPP_DIALECT >= 2023
+#    define THRUST_CONSTEXPR_SINCE_CXX23 constexpr
+#else
+#    define THRUST_CONSTEXPR_SINCE_CXX23
+#endif
+
+#if THRUST_CPP_DIALECT >= 2020
+#    define THRUST_CONSTEXPR_SINCE_CXX20 constexpr
+#else
+#    define THRUST_CONSTEXPR_SINCE_CXX20
+#endif
+
+#if THRUST_CPP_DIALECT >= 2017
+#    define THRUST_CONSTEXPR_SINCE_CXX17 constexpr
+#else
+#    define THRUST_CONSTEXPR_SINCE_CXX17
+#endif
+
 // Define THRUST_COMPILER_DEPRECATION macro:
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_NVRTC
 #  define THRUST_COMP_DEPR_IMPL(msg) THRUST_PRAGMA(message(__FILE__ ":" THRUST_TO_STRING(__LINE__) ": warning: " #msg))

--- a/projects/rocthrust/thrust/detail/type_traits.h
+++ b/projects/rocthrust/thrust/detail/type_traits.h
@@ -171,6 +171,12 @@ struct identity_
   using type = T;
 }; // end identity
 
+template <class Tp, bool>
+struct dependent_type
+{
+  using type = Tp;
+}; // end dependent_type
+
 template <bool, typename T>
 struct lazy_enable_if
 {};

--- a/projects/rocthrust/thrust/detail/type_traits.h
+++ b/projects/rocthrust/thrust/detail/type_traits.h
@@ -135,6 +135,21 @@ struct is_non_bool_integral<bool> : public false_type
 template <typename T>
 struct is_non_bool_arithmetic : public ::internal::is_arithmetic<T>
 {};
+
+template <typename T>
+struct is_unbounded_array : public thrust::detail::false_type
+{};
+template <typename T>
+struct is_unbounded_array<T[]> : public thrust::detail::true_type
+{};
+
+template <typename T>
+struct is_bounded_array : public thrust::detail::false_type
+{};
+template <typename T, size_t N>
+struct is_bounded_array<T[N]> : public thrust::detail::true_type
+{};
+
 template <>
 struct is_non_bool_arithmetic<bool> : public false_type
 {};


### PR DESCRIPTION
This PR introduces several utilities to `thrust/detail` that are prerequisites for the ongoing development of `thrust::unique_ptr` and will also be beneficial for future feature development. This PR adds the following components:

1. New Type Traits (`type_traits.h`):
 `dependent_type<T, bool>`: This utility makes an inner type dependent on a template parameter, forcing the compiler to delay name lookup until the template is instantiated, which resolves certain advanced template compilation errors.
  `is_unbounded_array<T>` and `is_bounded_array<T>`: These traits distinguish between unbounded (`T[]`) and bounded (`T[N]`)  array types
2. C++ Dialect Feature Macros (`cpp_dialect.h`):
 `THRUST_CONSTEXPR_SINCE_CXXYY`: Povides a clean, portable way to adopt `constexpr` for functions and methods as the C++ standard allows.