### PR TITLE
fix(rocprim): correct vsmem for select, merge, and merge_sort

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projects/rocPRIM/en/latest/](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/).
 
+## rocPRIM 4.1.0 for ROCm 7.1
+
+### Resolved issues
+
+* Fixed `device_select`, `device_merge`, and `device_merge_sort` not allocating the correct amount of virtual shared memory on the host.
+
 ## rocPRIM 4.0.0 for ROCm 7.0
 
 ### Added

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -181,7 +181,7 @@ enum class target_arch : unsigned int
 
 /**
  * \brief Checks if the first `n` characters of `rhs` are equal to `lhs`
- * 
+ *
  * \param lhs the string to compare against
  * \param rhs the string to compare with
  * \param n length of the substring of `rhs` to chceck
@@ -247,10 +247,10 @@ constexpr target_arch get_target_arch_from_name(const char* const arch_name, con
 
 /**
  * \brief Get the current architecture in device compilation.
- * 
+ *
  * This function will always return `unknown` when called from the host, host could should instead
  * call host_target_arch to query the current device from the HIP API.
- * 
+ *
  * \return target_arch the architecture currently being compiled for on the device.
  */
 constexpr target_arch device_target_arch()
@@ -300,6 +300,46 @@ auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
     }
 #endif
     return Config::template architecture_config<target_arch::unknown>::params;
+}
+
+// Wrapper that forces a Conf to use the params for ForcedArch.
+template<target_arch ForcedArch, class Conf, class PartitionConfigParams>
+struct force_arch_config
+{
+    template<target_arch Arch>
+    struct architecture_config
+    {
+        static constexpr PartitionConfigParams params
+            = Conf::template architecture_config<ForcedArch>::params;
+    };
+};
+
+template<typename F>
+inline hipError_t generic_dispatch_target_arch(detail::target_arch target_arch, F&& f)
+{
+    using ta = detail::target_arch;
+
+    switch(target_arch)
+    {
+        case ta::unknown: return f.template operator()<ta::unknown>();
+        case ta::gfx803: return f.template operator()<ta::gfx803>();
+        case ta::gfx900: return f.template operator()<ta::gfx900>();
+        case ta::gfx906: return f.template operator()<ta::gfx906>();
+        case ta::gfx908: return f.template operator()<ta::gfx908>();
+        case ta::gfx90a: return f.template operator()<ta::gfx90a>();
+        case ta::gfx942: return f.template operator()<ta::gfx942>();
+        case ta::gfx1030: return f.template operator()<ta::gfx1030>();
+        case ta::gfx1100: return f.template operator()<ta::gfx1100>();
+        case ta::gfx1102: return f.template operator()<ta::gfx1102>();
+        case ta::gfx1200: return f.template operator()<ta::gfx1200>();
+        case ta::gfx1201: return f.template operator()<ta::gfx1201>();
+        case ta::invalid:
+            assert(false && "Invalid target architecture");
+            return hipErrorInvalidValue;
+    }
+
+    assert(false && "Unhandled target_arch.");
+    return hipErrorInvalidValue;
 }
 
 template<typename Config>

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
@@ -107,13 +107,31 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block
                                 storage);
 }
 
+// Templated helper that instantiates merge_kernel_impl_ for an Arch,
+// and puts its vsmem_per_block in the vsmem_size_out member variable.
 template<class Config, class Key, class Value>
-inline size_t get_merge_vsmem_size_per_block()
+struct merge_vsmem_size_visitor
 {
-    using merge_kernel_impl_t = merge_kernel_impl_<Config, Key, Value>;
-    using MergeVSmemHelperT   = detail::vsmem_helper_impl<merge_kernel_impl_t>;
+    size_t& vsmem_size_out;
 
-    return MergeVSmemHelperT::vsmem_per_block;
+    template<target_arch Arch>
+    inline hipError_t operator()() const
+    {
+        using forced_conf_t = force_arch_config<Arch, Config, merge_config_params>;
+
+        using merge_kernel_impl_t = merge_kernel_impl_<forced_conf_t, Key, Value>;
+
+        vsmem_size_out = vsmem_helper_impl<merge_kernel_impl_t>::vsmem_per_block;
+
+        return hipSuccess;
+    }
+};
+
+template<class Config, class Key, class Value>
+inline hipError_t get_merge_vsmem_size_per_block(target_arch target_arch, size_t& vsmem_size)
+{
+    return generic_dispatch_target_arch(target_arch,
+                                        merge_vsmem_size_visitor<Config, Key, Value>{vsmem_size});
 }
 
 template<
@@ -163,8 +181,14 @@ hipError_t merge_impl(void * temporary_storage,
     const unsigned int number_of_blocks
         = ((input1_size + input2_size) + items_per_block - 1) / items_per_block;
 
-    size_t virtual_shared_memory_size
-        = get_merge_vsmem_size_per_block<config, key_type, value_type>() * number_of_blocks;
+    size_t vsmem_size;
+    result = get_merge_vsmem_size_per_block<config, key_type, value_type>(target_arch, vsmem_size);
+    if(result != hipSuccess)
+    {
+        return result;
+    }
+
+    vsmem_size *= number_of_blocks;
 
     unsigned int* index = nullptr;
     void*         vsmem = nullptr;
@@ -175,9 +199,7 @@ hipError_t merge_impl(void * temporary_storage,
         detail::temp_storage::make_linear_partition(
             detail::temp_storage::ptr_aligned_array(&index, number_of_blocks + 1),
             // vsmem
-            detail::temp_storage::make_partition(&vsmem,
-                                                 virtual_shared_memory_size,
-                                                 cache_line_size)));
+            detail::temp_storage::make_partition(&vsmem, vsmem_size, cache_line_size)));
 
     if(partition_result != hipSuccess || temporary_storage == nullptr)
     {

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
@@ -644,53 +644,81 @@ ROCPRIM_KERNEL void device_merge_sort_compile_time_verifier()
                   "merge_mergepath_items_per_block");
 }
 
+// Templated helper that instantiates block_sort_impl and block_merge_impl for an Arch,
+// and puts its vsmem_per_block in the vsmem_size_out member variable.
 template<class BlockSortConfig, class BlockMergeConfig, typename key_type, typename value_type>
-inline size_t get_merge_sort_vsmem_size(const size_t size)
+struct merge_sort_vsmem_size_visitor
 {
+    const size_t size;
+    size_t&      vsmem_size_out;
 
-    size_t                                               virtual_shared_memory_size = 0;
-    static constexpr merge_sort_block_sort_config_params bs_params
-        = device_params<BlockSortConfig>();
-    static constexpr merge_sort_block_merge_config_params bm_params
-        = device_params<BlockMergeConfig>();
-    using bs_sort_impl          = block_sort_impl<key_type,
-                                         value_type,
-                                         bs_params.block_sort_config.block_size,
-                                         bs_params.block_sort_config.items_per_thread>;
-    using bm_sort_impl          = block_merge_impl<key_type,
-                                          value_type,
-                                          bm_params.merge_mergepath_config.block_size,
-                                          bm_params.merge_mergepath_config.items_per_thread>;
-    using BlockSortVSmemHelperT = detail::vsmem_helper_impl<bs_sort_impl>;
-    using MergeSortVSmemHelperT = detail::vsmem_helper_impl<bm_sort_impl>;
-
-    // mergepath total number of blocks
-    const unsigned int merge_mergepath_items_per_block
-        = bm_params.merge_mergepath_config.block_size
-          * bm_params.merge_mergepath_config.items_per_thread;
-    const unsigned int merge_mergepath_number_of_blocks
-        = ceiling_div(size, merge_mergepath_items_per_block);
-
-    const bool use_mergepath = size > bm_params.merge_oddeven_config.size_limit;
-
-    // Check if vsmem is needed
-    if(BlockSortVSmemHelperT::vsmem_per_block + MergeSortVSmemHelperT::vsmem_per_block > 0)
+    template<target_arch Arch>
+    inline hipError_t operator()() const
     {
+        vsmem_size_out = 0;
 
-        // block sort total number of blocks
-        const unsigned int bs_items_per_block
-            = bs_params.block_sort_config.block_size * bs_params.block_sort_config.items_per_thread;
-        const unsigned int sort_number_of_blocks = ceiling_div(size, bs_items_per_block);
+        using forced_block_sort_conf_t
+            = force_arch_config<Arch, BlockSortConfig, merge_sort_block_sort_config_params>;
+        using forced_block_merge_conf_t
+            = force_arch_config<Arch, BlockMergeConfig, merge_sort_block_merge_config_params>;
 
-        // Compute amount of virtual shared memory needed
-        size_t block_sort_smem_size
-            = BlockSortVSmemHelperT::vsmem_per_block * sort_number_of_blocks;
-        size_t merge_smem_size     = use_mergepath ? MergeSortVSmemHelperT::vsmem_per_block
-                                                     * merge_mergepath_number_of_blocks
+        static constexpr merge_sort_block_sort_config_params bs_params
+            = device_params<forced_block_sort_conf_t>();
+        static constexpr merge_sort_block_merge_config_params bm_params
+            = device_params<forced_block_merge_conf_t>();
+
+        using bs_sort_impl = block_sort_impl<key_type,
+                                             value_type,
+                                             bs_params.block_sort_config.block_size,
+                                             bs_params.block_sort_config.items_per_thread>;
+        using bm_sort_impl = block_merge_impl<key_type,
+                                              value_type,
+                                              bm_params.merge_mergepath_config.block_size,
+                                              bm_params.merge_mergepath_config.items_per_thread>;
+
+        using BlockSortVSmemHelperT = detail::vsmem_helper_impl<bs_sort_impl>;
+        using MergeSortVSmemHelperT = detail::vsmem_helper_impl<bm_sort_impl>;
+
+        // mergepath total number of blocks
+        const unsigned int merge_mergepath_items_per_block
+            = bm_params.merge_mergepath_config.block_size
+              * bm_params.merge_mergepath_config.items_per_thread;
+        const unsigned int merge_mergepath_number_of_blocks
+            = ceiling_div(size, merge_mergepath_items_per_block);
+
+        const bool use_mergepath = size > bm_params.merge_oddeven_config.size_limit;
+
+        // Check if vsmem is needed
+        if(BlockSortVSmemHelperT::vsmem_per_block + MergeSortVSmemHelperT::vsmem_per_block > 0)
+        {
+
+            // block sort total number of blocks
+            const unsigned int bs_items_per_block = bs_params.block_sort_config.block_size
+                                                    * bs_params.block_sort_config.items_per_thread;
+            const unsigned int sort_number_of_blocks = ceiling_div(size, bs_items_per_block);
+
+            // Compute amount of virtual shared memory needed
+            size_t block_sort_smem_size
+                = BlockSortVSmemHelperT::vsmem_per_block * sort_number_of_blocks;
+            size_t merge_smem_size = use_mergepath ? MergeSortVSmemHelperT::vsmem_per_block
+                                                         * merge_mergepath_number_of_blocks
                                                    : 0;
-        virtual_shared_memory_size = (std::max)(block_sort_smem_size, merge_smem_size);
+            vsmem_size_out         = (std::max)(block_sort_smem_size, merge_smem_size);
+        }
+
+        return hipSuccess;
     }
-    return virtual_shared_memory_size;
+};
+
+template<class BlockSortConfig, class BlockMergeConfig, typename key_type, typename value_type>
+inline hipError_t
+    get_merge_sort_vsmem_size(const size_t size, target_arch target_arch, size_t& vsmem_size)
+{
+    return generic_dispatch_target_arch(
+        target_arch,
+        merge_sort_vsmem_size_visitor<BlockSortConfig, BlockMergeConfig, key_type, value_type>{
+            size,
+            vsmem_size});
 }
 
 template<class Config,
@@ -750,10 +778,16 @@ inline hipError_t merge_sort_impl(
         = ceiling_div(size, merge_mergepath_items_per_block);
 
     // Virtual shared memory part
-    void*  vsmem = nullptr;
-    size_t virtual_shared_memory_size
-        = get_merge_sort_vsmem_size<wrapped_bs_config, wrapped_bm_config, key_type, value_type>(
-            size);
+    void*  vsmem;
+    size_t vsmem_size;
+    result = get_merge_sort_vsmem_size<wrapped_bs_config, wrapped_bm_config, key_type, value_type>(
+        size,
+        target_arch,
+        vsmem_size);
+    if(result != hipSuccess)
+    {
+        return result;
+    }
 
     // temporary storage needed for both block merge and block sort
     size_t*     d_merge_partitions = nullptr;
@@ -772,9 +806,7 @@ inline hipError_t merge_sort_impl(
                 detail::temp_storage::ptr_aligned_array(
                     &d_merge_partitions,
                     use_mergepath ? merge_mergepath_number_of_blocks + 1 : 0),
-                detail::temp_storage::make_partition(&vsmem,
-                                                     virtual_shared_memory_size,
-                                                     cache_line_size)));
+                detail::temp_storage::make_partition(&vsmem, vsmem_size, cache_line_size)));
     }
     else
     {
@@ -785,9 +817,7 @@ inline hipError_t merge_sort_impl(
                 detail::temp_storage::ptr_aligned_array(
                     &d_merge_partitions,
                     use_mergepath ? merge_mergepath_number_of_blocks + 1 : 0),
-                detail::temp_storage::make_partition(&vsmem,
-                                                     virtual_shared_memory_size,
-                                                     cache_line_size)));
+                detail::temp_storage::make_partition(&vsmem, vsmem_size, cache_line_size)));
         keys_buffer   = keys_double_buffer;
         values_buffer = values_double_buffer;
     }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
@@ -120,28 +120,59 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block
                                         predicates...);
 }
 
+// Templated helper that instantiates partition_kernel_impl_ for an Arch,
+// and puts its vsmem_per_block in the vsmem_size_out member variable.
 template<select_method SelectMethod,
          bool          OnlySelected,
          class Config,
          class Key,
          class Value,
          class FlagType,
-         class OffsetLookbackScanState,
+         class OffsetType,
          class BlockIdWrapper>
-inline size_t get_partition_vsmem_size_per_block()
+struct partition_vsmem_size_visitor
 {
-    using offset_type             = typename OffsetLookbackScanState::value_type;
-    using partition_kernel_impl_t = partition_kernel_impl_<SelectMethod,
-                                                           OnlySelected,
-                                                           Config,
-                                                           Key,
-                                                           Value,
-                                                           FlagType,
-                                                           offset_type,
-                                                           BlockIdWrapper>;
+    size_t& vsmem_size_out;
 
-    using PartitionVSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
-    return PartitionVSmemHelperT::vsmem_per_block;
+    template<target_arch Arch>
+    inline hipError_t operator()() const
+    {
+        using forced_conf_t = force_arch_config<Arch, Config, partition_config_params>;
+
+        using partition_kernel_impl_t = partition_kernel_impl_<SelectMethod,
+                                                               OnlySelected,
+                                                               forced_conf_t,
+                                                               Key,
+                                                               Value,
+                                                               FlagType,
+                                                               OffsetType,
+                                                               BlockIdWrapper>;
+
+        vsmem_size_out = vsmem_helper_impl<partition_kernel_impl_t>::vsmem_per_block;
+
+        return hipSuccess;
+    }
+};
+
+template<select_method SelectMethod,
+         bool          OnlySelected,
+         class Config,
+         class Key,
+         class Value,
+         class FlagType,
+         class OffsetType,
+         class BlockIdWrapper>
+inline hipError_t get_partition_vsmem_size_per_block(target_arch target_arch, size_t& vsmem_size)
+{
+    return generic_dispatch_target_arch(target_arch,
+                                        partition_vsmem_size_visitor<SelectMethod,
+                                                                     OnlySelected,
+                                                                     Config,
+                                                                     Key,
+                                                                     Value,
+                                                                     FlagType,
+                                                                     OffsetType,
+                                                                     BlockIdWrapper>{vsmem_size});
 }
 
 template<partition_subalgo SubAlgo,
@@ -202,9 +233,6 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     }
     const partition_config_params params = dispatch_target_arch<config>(target_arch);
 
-    using offset_scan_state_type = detail::lookback_scan_state<offset_type>;
-    using offset_scan_state_with_sleep_type = detail::lookback_scan_state<offset_type, true>;
-
     const unsigned int block_size       = params.kernel_config.block_size;
     const unsigned int items_per_thread = params.kernel_config.items_per_thread;
     const auto         items_per_block  = block_size * items_per_thread;
@@ -221,10 +249,17 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     const unsigned int number_of_blocks
         = static_cast<unsigned int>(::rocprim::detail::ceiling_div(limited_size, items_per_block));
 
+    using block_id_wrapper_type = block_id_wrapper<uint32_t, UsingOrderedBlockId>;
+
     // Calculate required temporary storage
-    void*                           offset_scan_state_storage;
-    size_t*                         selected_count;
-    size_t*                         prev_selected_count;
+    void*                                    offset_scan_state_storage;
+    size_t*                                  selected_count;
+    size_t*                                  prev_selected_count;
+    typename block_id_wrapper_type::id_type* block_id_pool;
+    void*                                    vsmem;
+
+    using offset_scan_state_type            = detail::lookback_scan_state<offset_type>;
+    using offset_scan_state_with_sleep_type = detail::lookback_scan_state<offset_type, true>;
 
     detail::temp_storage::layout layout{};
     result = offset_scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
@@ -233,46 +268,26 @@ inline hipError_t partition_impl(void*                       temporary_storage,
         return result;
     }
 
-    using block_id_wrapper_type = block_id_wrapper<uint32_t, UsingOrderedBlockId>;
-
-    typename block_id_wrapper_type::id_type* block_id_pool = nullptr;
-
-    bool use_sleep;
-    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleep));
-
-    // vsmem size
-    void*  vsmem                      = nullptr;
-    size_t virtual_shared_memory_size = 0;
     using flag_type =
         typename std::conditional<method == select_method::predicated_flag,
                                   typename std::iterator_traits<FlagIterator>::value_type,
                                   bool>::type;
-    if(use_sleep)
-    {
-        virtual_shared_memory_size
-            = get_partition_vsmem_size_per_block<method,
-                                                 write_only_selected,
-                                                 config,
-                                                 key_type,
-                                                 value_type,
-                                                 flag_type,
-                                                 offset_scan_state_with_sleep_type,
-                                                 block_id_wrapper_type>();
-    }
-    else
-    {
-        virtual_shared_memory_size = get_partition_vsmem_size_per_block<method,
-                                                                        write_only_selected,
-                                                                        config,
-                                                                        key_type,
-                                                                        value_type,
-                                                                        flag_type,
-                                                                        offset_scan_state_type,
-                                                                        block_id_wrapper_type>();
-    }
-    virtual_shared_memory_size *= number_of_blocks;
 
-    // temporary storage partition
+    size_t vsmem_size;
+    result = get_partition_vsmem_size_per_block<method,
+                                                write_only_selected,
+                                                config,
+                                                key_type,
+                                                value_type,
+                                                flag_type,
+                                                offset_type,
+                                                block_id_wrapper_type>(target_arch, vsmem_size);
+    if(result != hipSuccess)
+    {
+        return result;
+    }
+
+    vsmem_size *= number_of_blocks;
 
     result = detail::temp_storage::partition(
         temporary_storage,
@@ -285,12 +300,10 @@ inline hipError_t partition_impl(void*                       temporary_storage,
             // They have the same base type, so there is no padding between the types.
             detail::temp_storage::ptr_aligned_array(&selected_count, selected_count_size),
             detail::temp_storage::ptr_aligned_array(&prev_selected_count, selected_count_size),
-            detail::temp_storage::ptr_aligned_array(&block_id_pool, block_id_wrapper_type::get_storage_size()),
+            detail::temp_storage::ptr_aligned_array(&block_id_pool,
+                                                    block_id_wrapper_type::get_storage_size()),
             // vsmem
-            detail::temp_storage::make_partition(&vsmem,
-                                                 virtual_shared_memory_size,
-                                                 cache_line_size)));
-
+            detail::temp_storage::make_partition(&vsmem, vsmem_size, cache_line_size)));
     if(result != hipSuccess || temporary_storage == nullptr)
     {
         return result;
@@ -320,6 +333,9 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     {
         return result;
     }
+
+    bool use_sleep;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleep));
 
     // Call the provided function with either offset_scan_state or offset_scan_state_with_sleep based on
     // the value of use_sleep

--- a/projects/rocprim/test/rocprim/test_device_select.cpp
+++ b/projects/rocprim/test/rocprim/test_device_select.cpp
@@ -80,6 +80,7 @@ using RocprimDeviceSelectTestsParams
                        DeviceSelectParams<rocprim::half, rocprim::half>,
                        DeviceSelectParams<rocprim::bfloat16, rocprim::bfloat16>,
                        DeviceSelectParams<float, float>,
+                       DeviceSelectParams<short, char, rocprim::int128_t>,
                        DeviceSelectParams<unsigned char, float, int, true>,
                        DeviceSelectParams<double, double, int, true>,
                        DeviceSelectParams<common::custom_type<double, double, true>,


### PR DESCRIPTION
Even though in `device_select()` the host is getting the correct `block_size` and `items_per_thread` by calling `dispatch_target_arch<config>(target_arch);`, it isn't using those to calculate `vsmem_per_block`.

Instead, the host is getting an incorrect bs and ipt, because it's using the config for `target::unknown`, while the device will be using the config for say `target::gfx90a`. This results in the host not allocating enough memory for `device_select`, which causes `device_select` to go out of bounds with the newly added test `DeviceSelectParams<short, char, rocprim::int128_t>`.

The bug isn't in `select()` itself, but rather the `partition_impl()` it's using.

`device_merge()` and `device_merge_sort()` also allocate the wrong amount of vsmem on the host, so I've fixed them too, though they *do not* crash with any of the tests.

I've checked, and these fixes don't affect the performance of these three functions.