### PR TITLE
fix(rocprim): fix device_select_predicated_flag using wrong configs

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -23,6 +23,10 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
   * 891 specializations have been improved.
   * 399 specializations have been added.
 
+### Optimizations
+
+* Improved performance of `rocprim::device_select` overload that takes flags and a predicate.
+
 ### Upcoming changes
 
 * Deprecated the `->` operator for the `zip_iterator`.

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
@@ -210,7 +210,13 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
     using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
 
-    using config = wrapped_partition_config<Config, SubAlgo, key_type, value_type>;
+    // value_type is always empty_type, except for select_unique_by_key.
+    using flag_or_value_type
+        = std::conditional_t<SubAlgo == partition_subalgo::select_predicated_flag,
+                             typename std::iterator_traits<FlagIterator>::value_type,
+                             value_type>;
+
+    using config = wrapped_partition_config<Config, SubAlgo, key_type, flag_or_value_type>;
 
     constexpr bool write_only_selected = SubAlgo == partition_subalgo::select_flag
                                          || SubAlgo == partition_subalgo::select_predicate
@@ -279,6 +285,9 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     // vsmem size
     void*  vsmem                      = nullptr;
     size_t virtual_shared_memory_size = 0;
+
+    // The flags parameter is normally an array of bools, but when the method is predicated_flag,
+    // it is an array of values (say ints) that are filtered by the predicate.
     using flag_type =
         typename std::conditional<method == select_method::predicated_flag,
                                   typename std::iterator_traits<FlagIterator>::value_type,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition_config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition_config.hpp
@@ -148,11 +148,11 @@ struct wrapped_partition_config<default_config,
     };
 };
 
-template<typename KeyType, typename ValueType>
+template<typename KeyType, typename FlagType>
 struct wrapped_partition_config<default_config,
                                 partition_subalgo::select_predicated_flag,
                                 KeyType,
-                                ValueType>
+                                FlagType>
 {
     template<target_arch Arch>
     struct architecture_config
@@ -160,7 +160,7 @@ struct wrapped_partition_config<default_config,
         static constexpr partition_config_params params
             = default_select_predicated_flag_config<static_cast<unsigned int>(Arch),
                                                     KeyType,
-                                                    ValueType>{};
+                                                    FlagType>{};
     };
 };
 


### PR DESCRIPTION
## Motivation

There is a bug where `flag_type` is ignored, meaning it'll always pick config `data_type = short, flag_type = int8_t` when `data_type=short`.

## Technical Details

This only affects the overload of `device_select()` that takes *both* flags and a predicate.

## Test Plan

The below blocks of commands can be copied directly into a terminal, so you don't need to copy the lines individually.

See the `Test Result` header in this description for the zip that contains all of the scripts that these reproduction steps use.

<details>
<summary>VS Code HIP Dev Container</summary>

`Dockerfile`:
```Dockerfile
FROM rocm/rocm-terminal:latest
```

`devcontainer.json`:
```json
{
    "build": {
        "dockerfile": "Dockerfile"
    },
    "name": "hip-minimal",
    "runArgs": [
        "--device=/dev/kfd",
        "--device=/dev/dri"
    ]
}
```

</details>

### Reproduction steps

<details>
<summary>Installing dependencies</summary>

```sh
sudo apt install -y cmake ninja-build
```

</details>

<details>
<summary>Cloning</summary>

```sh
git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git && \
cd rocm-libraries && \
git sparse-checkout init --cone && \
git sparse-checkout set projects/rocprim shared/primbench
```

</details>

<details>
<summary>Building primbench benchmarks</summary>

```sh
git checkout users/mynameistrez/fix-device-select-using-wrong-configs && \
cd projects/rocprim && \
mkdir build_benchmark_primbench && \
cd build_benchmark_primbench && \
export gfx=$(rocm_agent_enumerator | head -n1) && \
CXX=hipcc cmake -GNinja -DBUILD_BENCHMARK=ON -DGPU_TARGETS="$gfx" .. && \
ninja benchmark_host_api benchmark_device_api
```

</details>

<details>
<summary>Running primbench benchmarks</summary>

#### HIP

```sh
benchmark/benchmark_device_api \
  --json-out benchmark_rocrand_device_api.json \
  --csv-out benchmark_rocrand_device_api.csv
```

</details>

<details>
<summary>Building develop benchmarks</summary>

#### Setup

```sh
git checkout TODO:ADD && \
cd projects/rocrand && \
mkdir build_benchmark_develop && \
cd build_benchmark_develop && \
export gfx=$(rocm_agent_enumerator | head -n1) && \
CXX=hipcc cmake -GNinja -DBUILD_BENCHMARK=ON -DGPU_TARGETS="$gfx" .. && \
ninja benchmark_rocrand_host_api benchmark_rocrand_device_api
```

</details>

<details>
<summary>Running develop benchmarks</summary>

#### HIP

```sh
benchmark/benchmark_rocrand_device_api \
  --benchmark_out=benchmark_rocrand_device_api.json
```

</details>

<details>
<summary>Converting develop JSON results to primbench CSVs</summary>

The script `gbench2primbench.py` converts a directory of old Google Benchmark JSON files, to a directory of new primbench CSV files.

<details><summary><code>--help</code> options</summary>

```
usage: gbench2primbench.py [-h] --project {rocprim,rocrand} --noise-threshold-percentage NOISE_THRESHOLD_PERCENTAGE input_dir output_dir

Convert Google Benchmark JSON to primbench CSV format

positional arguments:
  input_dir             Directory containing Google Benchmark JSON files
  output_dir            Output directory for primbench CSV files

options:
  -h, --help            show this help message and exit
  --project {rocprim,rocrand}
                        Project name
  --noise-threshold-percentage NOISE_THRESHOLD_PERCENTAGE
                        The noise threshold percentage, past which benchmark specializations are considered to be too noisy
```

</details>

```sh
python3 gbench2primbench.py \
  --project rocrand \
  --noise-threshold-percentage 1 \
  build_benchmark_develop/results \
  converted
```

</details>

<details>
<summary>Generating graphs</summary>

The script `grapher.py` takes primbench JSON and CSV files, and generates a relative or absolute graph.

In the previous step `gbench2primbench.py` was used to convert old Google Benchmark JSON files to primbench CSV files.

The zip of the results contains both relative and absolute graphs, where the absolute graphs were generated by passing `--absolute` to `grapher.py`.

<details><summary><code>--help</code> options</summary>

```
Usage: grapher.py [-h] --output OUTPUT [--algo ALGO] [--arch ARCH] [--filter FILTER] [--absolute] input_files [input_files ...]

Positional Arguments:
  input_files      paths to input .json or .csv primbench files

Options:
  -h, --help       show this help message and exit
  --output OUTPUT  path to output .svg graph (default: None)
  --algo ALGO      algorithm name for the chart title (required if only CSV files are passed) (default: None)
  --arch ARCH      GPU arch name for the chart title (required if only CSV files are passed) (default: None)
  --filter FILTER  regex pattern of specializations to include (default: None)
  --absolute       perform absolute instead of relative comparison (default: False)
```

</details>

```sh
python3 -m pip install pygal pandas rich_argparse && \
for csv in converted/*.csv; do
  b=$(basename "$csv" .csv)
  python3 grapher.py \
    --output "graphs/$b.svg" \
    "converted/$b.csv" \
    "build_benchmark_primbench/results/json/$b.json"
done
```

</details>

## Test Result

TODO: ADD!!!

TODO: ADD ZIP OF RESULT DATA AND SCRIPTS!

TODO: UPDATE THIS: There is a big performance gain (at least on gfx90a) when `flag_type` is large (like `int128_t`), and `data_type` is small (like `int8_t`):

![rocprim__int128_t](https://github.com/user-attachments/assets/edaa36cb-121e-45f0-81f0-a8e8cb9ccb28)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
