### PR TITLE
[rocFFT/hipFFT] Point to current rocm-cmake address for fallback

### DIFF
--- a/projects/hipfft/cmake/dependencies.cmake
+++ b/projects/hipfft/cmake/dependencies.cmake
@@ -72,7 +72,7 @@ if(NOT ROCmCMakeBuildTools_FOUND)
   include( FetchContent )
 
   FetchContent_Declare( rocm_cmake_local
-    GIT_REPOSITORY https://github.com/ROCm/rocm-cmake-build-tools
+    GIT_REPOSITORY https://github.com/ROCm/rocm-cmake
     GIT_TAG rocm-6.4.1
     GIT_SHALLOW ON
   )

--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -57,7 +57,7 @@ if( NOT ROCmCMakeBuildTools_FOUND )
   include( FetchContent )
 
   FetchContent_Declare( rocm_cmake_local
-    GIT_REPOSITORY https://github.com/ROCm/rocm-cmake-build-tools
+    GIT_REPOSITORY https://github.com/ROCm/rocm-cmake
     GIT_TAG rocm-6.4.1
     GIT_SHALLOW ON
   )


### PR DESCRIPTION
## Motivation

The fallback code is not currently pointing at a valid address
