### PR TITLE
[hipblas] rewrite code coverage logic to use pure LLVM

### DIFF
--- a/projects/hipblas/.jenkins/common.groovy
+++ b/projects/hipblas/.jenkins/common.groovy
@@ -89,7 +89,7 @@ def runCoverageCommand (platform, project, String cmdDir = "release-debug")
     publishHTML([allowMissing: false,
                 alwaysLinkToLastBuild: false,
                 keepAll: false,
-                reportDir: "${project.paths.project_build_prefix}/build/${cmdDir}/lcoverage",
+                reportDir: "${project.paths.project_build_prefix}/build/${cmdDir}/coverage-report",
                 reportFiles: "index.html",
                 reportName: "Code coverage report",
                 reportTitles: "Code coverage report"])

--- a/projects/hipblas/.jenkins/common.groovy
+++ b/projects/hipblas/.jenkins/common.groovy
@@ -3,8 +3,6 @@
 
 def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
 {
-    project.paths.construct_build_prefix()
-
     def getDependenciesCommand = ""
     if (project.installLibraryDependenciesFromCI)
     {

--- a/projects/hipblas/CMakeLists.txt
+++ b/projects/hipblas/CMakeLists.txt
@@ -269,37 +269,37 @@ if(BUILD_CODE_COVERAGE)
 
   add_custom_target(coverage_analysis
     COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
-    COMMAND ${coverage_test} --gtest_filter=\"\${GTEST_FILTER}\"
+    COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage/profraw
+    COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/hipblas-coverage_%m.profraw" ${coverage_test} --gtest_filter=\"\${GTEST_FILTER}\"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 
   add_dependencies(coverage_analysis hipblas)
 
-  #
-  # Prepare coverage output
-  # This little script is generated because the option '--gcov-tool <program name>' of lcov cannot take arguments.
-  #
+  find_program(
+    LLVM_PROFDATA
+    llvm-profdata
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
 
-  # source path substitute adjustment only for CI
-  get_filename_component(PARENT_DIR ${CMAKE_SOURCE_DIR} DIRECTORY)
-  get_filename_component(GRANDPARENT_DIR ${PARENT_DIR} DIRECTORY)
-  set(base_path "/var/jenkins_home/library")
-  set(hash_path "${CMAKE_SOURCE_DIR}/library")
-  message(STATUS "BASE ${base_path} to HASHED ${hash_path}")
+  find_program(
+    LLVM_COV
+    llvm-cov
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
 
-  add_custom_target(coverage
+  add_custom_target(
+    coverage
     DEPENDS coverage_analysis
-    COMMAND mkdir -p lcoverage
-    COMMAND echo "\\#!/bin/bash" > llvm-gcov.sh
-    COMMAND echo "\\# THIS FILE HAS BEEN GENERATED" >> llvm-gcov.sh
-    COMMAND printf "exec /opt/rocm/llvm/bin/llvm-cov gcov $$\\@" >> llvm-gcov.sh
-    COMMAND chmod +x llvm-gcov.sh
-    COMMAND lcov --ignore-errors unused --directory . --base-directory "${CMAKE_SOURCE_DIR}" --gcov-tool ./llvm-gcov.sh --capture --substitute "'s#${base_path}#${hash_path}#g'" -o ./lcoverage/raw_main_coverage.info
-    COMMAND lcov --ignore-errors unused --remove ./lcoverage/raw_main_coverage.info "'/opt/*'" "'/usr/*'" -o ./lcoverage/main_coverage.info
-    COMMAND genhtml --ignore-errors source ./lcoverage/main_coverage.info --output-directory ./lcoverage --prefix ${CMAKE_SOURCE_DIR}
+    COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/hipblas-coverage_*.profraw -o ./coverage-report/hipblas.profdata
+    COMMAND ${LLVM_COV} report -object ./library/src/libhipblas.so -instr-profile=./coverage-report/hipblas.profdata
+    COMMAND ${LLVM_COV} show -object ./library/src/libhipblas.so -instr-profile=./coverage-report/hipblas.profdata -format=html -output-dir=coverage-report
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
-
+  )
 
   #
   # Coverage cleanup

--- a/projects/hipblas/CMakeLists.txt
+++ b/projects/hipblas/CMakeLists.txt
@@ -114,10 +114,6 @@ if(HIP_PLATFORM STREQUAL nvidia)
 endif()
 
 option(BUILD_CODE_COVERAGE "Build with code coverage enabled" OFF)
-if(BUILD_CODE_COVERAGE)
-  #add_compile_options(-fprofile-arcs -ftest-coverage)
-  #add_link_options(--coverage)
-endif()
 
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 if(BUILD_ADDRESS_SANITIZER)

--- a/projects/hipblas/library/src/CMakeLists.txt
+++ b/projects/hipblas/library/src/CMakeLists.txt
@@ -159,9 +159,8 @@ if (WIN32)
 endif()
 
 if(BUILD_CODE_COVERAGE)
-  #target_compile_options(-fprofile-instr-generate -fcoverage-mapping)
-  target_compile_options( hipblas PRIVATE -fprofile-arcs -ftest-coverage )
-  target_link_libraries( hipblas PRIVATE --coverage -lgcov)
+  target_compile_options(hipblas PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping)
+  target_link_options(hipblas PUBLIC -fprofile-instr-generate)
 endif()
 
 # Package that helps me set visibility for function names exported from shared library


### PR DESCRIPTION
CI was failing in monorepo.  Noticed that we are trying to use gcov and llvm-cov together, so I simplified the code to make it only use llvm-cov and did some refactoring to decouple the CMake code from Jenkins.

Also removed `construct_build_prefix` from .jenkins folder because it is not needed.  We already do that in rocJenkins before the project is loaded.

Code cov CI is passing with these changes: http://math-ci.amd.com/job/rocm-libraries/job/codecov/job/hipblas/view/change-requests/job/PR-1145/

Here is the coverage report: http://math-ci.amd.com/job/rocm-libraries/job/codecov/job/hipblas/view/change-requests/job/PR-1145/Code_20coverage_20report/

And screenshot for quick reference:
<img width="645" height="328" alt="image" src="https://github.com/user-attachments/assets/2f9455ab-26d4-45c6-9959-c1ce892d408e" />

