### PR TITLE
Remove hardcodes ignoring error from testing_matmul for gfx11/12

### DIFF
--- a/projects/hipblaslt/clients/gtest/known_bugs.yaml
+++ b/projects/hipblaslt/clients/gtest/known_bugs.yaml
@@ -4,10 +4,7 @@
 #example
 #- { function: a_type: bf16_r, b_type: bf16_r, c_type: bf16_r, d_type: bf16_r, compute_type: f32_r, transA: N, transB: N, M: 512, N: 512, K: 512, lda: 512, ldb: 512, ldc: 512, ldd: 512, alpha: 5.0, alphai: 0.0, beta: 0.0, betai: 0.0, known_bug_platforms: gfx908 }
 
-Known bugs:
-- { function: matmul, grouped_gemm: 1, known_bug_platforms: "gfx1100, gfx1101, gfx1102, gfx1200, gfx1201" }
-- { function: matmul, grouped_gemm: 2, known_bug_platforms: "gfx1100, gfx1101, gfx1102, gfx1200, gfx1201" }
-- { function: matmul, grouped_gemm: 5, known_bug_platforms: "gfx1100, gfx1101, gfx1102, gfx1200, gfx1201" }
-- { function: matmul, grouped_gemm: 7, known_bug_platforms: "gfx1100, gfx1101, gfx1102, gfx1200, gfx1201" }
-- { function: matmul, gradient: 1, known_bug_platforms: "gfx1100, gfx1101, gfx1102, gfx1200, gfx1201" }
+#Known bugs:
+#- { function: matmul, grouped_gemm: 1, known_bug_platforms: "gfx1100, gfx1101, gfx1102, gfx1200, gfx1201" }
+#- { function: matmul, gradient: 1, known_bug_platforms: "gfx1100, gfx1101, gfx1102, gfx1200, gfx1201" }
 

--- a/projects/hipblaslt/clients/gtest/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/gtest/matmul_gtest.yaml
@@ -1223,6 +1223,7 @@ Tests:
   beta: [ 0.0, 2.0 ]
   unit_check: 1
   algo_method: [2]
+  gpu_arch_exclude: '1[1-2]\d{2}'
 
 - name: matmul_groupedgemm
   category: pre_checkin
@@ -1237,6 +1238,7 @@ Tests:
   beta: [ 0.0, 2.0 ]
   unit_check: 1
   algo_method: [0, 2]
+  gpu_arch_exclude: '1[1-2]\d{2}'
 
 - name: matmul_groupedgemm_f8_fnuz
   category: pre_checkin
@@ -1297,6 +1299,7 @@ Tests:
   beta: [ 0.0, 2.0 ]
   unit_check: 1
   algo_method: [2]
+  gpu_arch_exclude: '1[1-2]\d{2}'
 
 - name: matmul_extapi_groupedgemm
   category: pre_checkin
@@ -1312,6 +1315,7 @@ Tests:
   alpha: 1
   beta: [ 0.0, 2.0 ]
   unit_check: 1
+  gpu_arch_exclude: '1[1-2]\d{2}'
 
 - name: matmul_extapi_groupedgemm
   category: pre_checkin
@@ -1328,6 +1332,7 @@ Tests:
   alpha: 1
   beta: [ 0.0, 2.0 ]
   unit_check: 1
+  gpu_arch_exclude: '1[1-2]\d{2}'
 
 - name: matmul_bias_gelu_aux_fp16
   category: pre_checkin
@@ -1465,6 +1470,7 @@ Tests:
   gradient: 1
   activation_type: gelu
   unit_check: 1
+  gpu_arch_exclude: '1[1-2]\d{2}'
 
 - name: matmul_dgelu_bias
   category: pre_checkin
@@ -1483,6 +1489,7 @@ Tests:
   bias_type: f32_r
   unit_check: 0
   norm_check: 1
+  gpu_arch_exclude: '1[1-2]\d{2}'
 
 - name: matmul_bgradb_f8_bf8_fnuz_dst_fp32
   category: pre_checkin
@@ -1518,6 +1525,7 @@ Tests:
   bias_type: f32_r
   bias_source: a
   unit_check: 1
+  gpu_arch_exclude: '1[1-2]\d{2}'
   # norm_check: 1
 
 - name: matmul_bias_gelu_aux_fp32
@@ -1641,6 +1649,7 @@ Tests:
   bias_type: [f16_r, f32_r]
   bias_source: b
   unit_check: 1
+  gpu_arch_exclude: '1[1-2]\d{2}'
 
 - name: matmul_bgradb_16_f32d_NT
   category: pre_checkin
@@ -1943,13 +1952,30 @@ Tests:
   algo_method: [2]
   use_ext: [1]
   use_ext_setproblem: [0]
-  grouped_gemm: [0, 2]
+  grouped_gemm: [0]
   wgm_vector: [[0], [4], [9], [16]]
   alpha: 1
   beta: 2.0
   unit_check: 1
 
-- name: matmul_heuristic_all_solutions_no_workspace
+- name: matmul_extapi_algo_method_grouped_gemm_tuning_wgm
+  category: pre_checkin
+  function:
+    matmul: *hpa_half_precision
+  matrix_size:
+    - { M:  4096, N:  4096, K:  40 }
+    - { M:  1024, N:  1024, K:  80 }
+  transA_transB: *transA_transB_range
+  algo_method: [2]
+  use_ext: [1]
+  use_ext_setproblem: [0]
+  grouped_gemm: [2]
+  wgm_vector: [[0], [4], [9], [16]]
+  alpha: 1
+  beta: 2.0
+  unit_check: 1
+  gpu_arch_exclude: '1[1-2]\d{2}'
+
   category: nightly
   function:
     matmul: *real_precisions

--- a/projects/hipblaslt/clients/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/include/testing_matmul.hpp
@@ -3071,22 +3071,6 @@ void testing_matmul_with_bias(const Arguments& arg,
 
     returnedAlgoCount = heuristicResult.size();
 
-    if(returnedAlgoCount == 0)
-    {
-        int             deviceId;
-        hipDeviceProp_t deviceProperties;
-        static_cast<void>(hipGetDevice(&deviceId));
-        static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
-        //workaround before known_bug work
-        if((gpu_arch_match(deviceProperties.gcnArchName, "11?")
-            || gpu_arch_match(deviceProperties.gcnArchName, "12?"))
-           && (arg.gradient || arg.grouped_gemm))
-        {
-            hipblaslt_cerr << "No Solution Found!!" << std::endl;
-            return;
-        }
-    }
-
     CHECK_SOLUTION_FOUND(returnedAlgoCount);
 
     dWorkspace = new device_vector<unsigned char>(workspace_size * block_count, 1, HMM);


### PR DESCRIPTION
use gpu_arch_exclude attribite to disable test directly

## Motivation

Remove hardcodes ignoring error from testing_matmul for gfx11/12
Tester won't see  a lot of "No solution found" errors when run the test.

## Technical Details

Don't need to run the tests that are  not actually supported

## Test Plan

Azure CI can cover the test

## Test Result

Got pass locally

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
