### PR TITLE
[hipCUB] Add fallback exclusive scan function for debian10 in `test_hipcub_block_radix_rank.cpp`

### DIFF
--- a/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -605,6 +605,25 @@ void rank_with_prefix_sum_kernel(const KeyType* keys_input,
     }
 }
 
+#if defined(_GLIBCXX_RELEASE) && (GLIBCXX_RELEASE < 9)
+
+/**
+ * name this function fall_back_exclusive_scan to prevent
+ * ambiguous name error 
+ */
+template <typename It, typename OutIt, typename T>
+void fall_back_exclusive_scan(It first, It last, OutIt out, T init)
+{
+    // Fallback implementation for exclusive scan if gcc version is < 9
+    for (; first != last; ++first)
+    {
+        *out++ = init;
+        init += *first;
+    }
+}
+
+#endif // (_GLIBCXX_RELEASE) && (GLIBCXX_RELEASE < 9)
+
 template<typename TestFixture, RadixRankAlgorithm Algorithm>
 void test_radix_rank_with_prefix_sum_output()
 {
@@ -703,10 +722,17 @@ void test_radix_rank_with_prefix_sum_output()
 
                     ++histogram[bit_rep];
                 }
-                std::exclusive_scan(histogram.begin(),
-                                    histogram.end(),
-                                    pfs_expected.begin() + pfs_offset,
-                                    0);
+                #if defined(_GLIBCXX_RELEASE) && (GLIBCXX_RELEASE >= 9)
+                    std::exclusive_scan(histogram.begin(),
+                                        histogram.end(),
+                                        pfs_expected.begin() + pfs_offset,
+                                        0);
+                #else
+                    fall_back_exclusive_scan(histogram.begin(),
+                                        histogram.end(),
+                                        pfs_expected.begin() + pfs_offset,
+                                        0);
+                #endif
             }
 
             // Preparing device


### PR DESCRIPTION
## Motivation

The test `test_hipcub_block_radix_rank` is causing compilation failures on Debian10. This is because we are using `std::exclusive_scan` which is not supported by Debian 10.

This PR aims to fix this error by adding a fallback function.

## Technical Details
We added a compile time check to see what  version of the stdc++ library is on the system. If `GLIBCXX_RELEASE` is less than 9 this means that std::exclusive_scan is not supported. If this is the case we will use the function `fall_back_exclusive_scan` instead of `std::exclusive_scan`.

## Test Plan

Run CI tests as well as run tests locally.

## Test Result
hipCUB was able to build on local debian 10 system.

