### PR TITLE
[rocBLAS] require env var enabled for hipblaslt batched

### DIFF
--- a/projects/rocblas/library/src/include/handle.hpp
+++ b/projects/rocblas/library/src/include/handle.hpp
@@ -297,6 +297,7 @@ public:
      * - Otherwise try when the current architecture is defaulted to hipBLASLt support
      * - Always disable for any `batched` API when the current handle is in stream
      *   capture mode (as hipblaslt batched dispatch does synchronous memory copies)
+     * - batched mode requires env variable opt in as has additional pointer copies
      ******************************************************************************/
     bool tryHipBLASLt(bool batched)
     {
@@ -316,7 +317,11 @@ public:
 
         if(status && batched)
         {
-            status = !is_stream_in_capture_mode();
+            // only use for batched when explicitly enabled by env variable
+            if(hipblasltEnvVar == 1)
+                status = !is_stream_in_capture_mode();
+            else
+                status = false;
         }
 
         return status;


### PR DESCRIPTION
* only use hipblaslt for batched GEMM if env variable ROCBLAS_USE_HIPBLASLT=1