### PR TITLE
[hipblaslt] Add DTL support for TLU=1 case with pow 2 MT

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -7636,16 +7636,12 @@ class KernelWriterAssembly(KernelWriter):
                   #   numElementsPerLoad = 2
                   # elif self.states.archCaps["HasEccHalf"]:
                   #   destVgprHi = self.vgprPool.checkOut(1, 'destVgprHi')
-                  if (not tP["isM"]) and isLds and (not tP["tlu"]) and tP["glvw"]>=4 and kernel["AssertSummationElementMultiple"] % 4 == 0:
-                    if tP["glvw"] == 4:
-                      # Pack four byte values into a single load dword (for DTL only for now)
-                      numElementsPerLoad = 4
-                    elif tP["glvw"] == 16:
-                      numElementsPerLoad = 16
+                  if (not tP["isM"]) and isLds:
+                    if not kernel["NonDTLTailLoop%c"%tc]:
+                      numElementsPerLoad = kernel["GlobalReadVectorWidth%c"%tc]
                     dataIsByte = False
                   else:
                     dataIsByte = True
-
                   # Check out 3 regs once , for component 1,2,3 (r = 1,2,3)
                   if doTailOpt == 1:
                     if r == 1:
@@ -7672,7 +7668,7 @@ class KernelWriterAssembly(KernelWriter):
                   if tP["glvw"]>1 and kernel["AssertSummationElementMultiple"] % 2 == 0 and not isLds:
                   # Pack two FP16 values into a single load dword x2
                     numElementsPerLoad = 2
-                  elif isLds and kernel["AssertSummationElementMultiple"] % 2 == 0:
+                  elif isLds and not kernel["NonDTLTailLoop%c"%tc]:
                     numElementsPerLoad = kernel["GlobalReadVectorWidth%c"%tc]
                   elif self.states.archCaps["HasEccHalf"]:
                     # In some cards, loading half types into register will zero out

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -377,8 +377,8 @@ class Solution(collections.abc.Mapping):
 
     bpeA = state["ProblemType"]["DataTypeA"].numBytes()
     bpeB = state["ProblemType"]["DataTypeB"].numBytes()
-    aemA = state["AssertSummationElementMultiple"] if state["ProblemType"]["TLUA"] else state["AssertFree0ElementMultiple"]
-    aemB = state["AssertSummationElementMultiple"] if state["ProblemType"]["TLUB"] else state["AssertFree1ElementMultiple"]
+    aemA = state["AssertSummationElementMultiple"] if not state["ProblemType"]["TLUA"] else state["AssertFree0ElementMultiple"]
+    aemB = state["AssertSummationElementMultiple"] if not state["ProblemType"]["TLUB"] else state["AssertFree1ElementMultiple"]
     # For DTL, we use nonDTL loads in tail loop only if
     # a partial 32b read is required to read the last few elements of a row/col of A/B
     # i.e. ASEM * BPE % 4 != 0. In this case dword/dwordx4 DTL load will

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -377,14 +377,16 @@ class Solution(collections.abc.Mapping):
 
     bpeA = state["ProblemType"]["DataTypeA"].numBytes()
     bpeB = state["ProblemType"]["DataTypeB"].numBytes()
-    asem = state["AssertSummationElementMultiple"]
+    aemA = state["AssertSummationElementMultiple"] if state["ProblemType"]["TLUA"] else state["AssertFree0ElementMultiple"]
+    aemB = state["AssertSummationElementMultiple"] if state["ProblemType"]["TLUB"] else state["AssertFree1ElementMultiple"]
     # For DTL, we use nonDTL loads in tail loop only if
     # a partial 32b read is required to read the last few elements of a row/col of A/B
     # i.e. ASEM * BPE % 4 != 0. In this case dword/dwordx4 DTL load will
     # zero out the entire partial 32b read and cause accuracy issues.
-    if (asem * bpeA) % 4 != 0:
+    # For TLU = 0 we check AF{0,1}EM instead of ASEM.
+    if (aemA * bpeA) % 4 != 0 or not state["BufferLoad"]:
       state["NonDTLTailLoopA"] = True
-    if (asem * bpeB) % 4 != 0:
+    if (aemB * bpeB) % 4 != 0 or not state["BufferLoad"]:
       state["NonDTLTailLoopB"] = True
 
     if (state["ISA"] != (9, 4, 2)) or \

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -762,13 +762,16 @@ class Solution(collections.abc.Mapping):
     numBytesAB = state["ProblemType"]["DataType%s"%tc].numBytes()
     numBytesPerLoad = state["GlobalReadVectorWidth%s"%tc] * numBytesAB
 
-    # so far, numBytesAB<4 case, TLU=False only (continue with False)
-    if numBytesAB < 4 and state["ProblemType"]["TLU%c"%tc]:
-      return False
+    MT = state["MacroTile0"] if tc == 'A' else state["MacroTile1"]
+
+    if not math.log(MT,2).is_integer():
+      # so far, numBytesAB<4 case, TLU=False only (continue with False)
+      if numBytesAB < 4 and state["ProblemType"]["TLU%c"%tc]:
+        return False
 
     # x2 DTL is not supported
     if numBytesPerLoad == 8:
-      reject(state, printRejectionReason, "can't use DirectToLds with b64 buffer load")
+      printWarning("can't use DirectToLds with b64 buffer load, using non DirectToLds version instead")
       return False
 
     if numBytesPerLoad == 16 and not canDTLx4:
@@ -1532,7 +1535,7 @@ class Solution(collections.abc.Mapping):
                 ldsPadA = state["VectorWidthA"]
           else:
             if state["DirectToLdsA"]:
-              ldsPadA = max(lrvw, optPadA)
+              ldsPadA = max(lrvw, optPadA) if not state["ProblemType"]["TLUA"] else 0
             else:
               ldsPadA = max(state["GlobalReadVectorWidthA"],optPadA)
           assert(ldsPadA >= 0)
@@ -1555,7 +1558,7 @@ class Solution(collections.abc.Mapping):
                 ldsPadB = state["VectorWidthB"]
           else:
             if state["DirectToLdsB"]:
-              ldsPadB = max(lrvw, optPadB)
+              ldsPadB = max(lrvw, optPadB) if not state["ProblemType"]["TLUB"] else 0
             else:
               ldsPadB = max(state["GlobalReadVectorWidthB"],optPadB)
           assert(ldsPadB >= 0)
@@ -1577,6 +1580,10 @@ class Solution(collections.abc.Mapping):
                 ldsPadM = 0
           assert(ldsPadM >= 0)
 
+        if state["DirectToLdsA"] and state["ProblemType"]["TLUA"]:
+          ldsPadA = 0
+        if state["DirectToLdsB"] and state["ProblemType"]["TLUB"]:
+          ldsPadB = 0
         # set ldsPadA,B=0 for DirectToVgpr
         if state["DirectToVgprA"]:
           ldsPadA = 0

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -383,9 +383,9 @@ class Solution(collections.abc.Mapping):
     # i.e. ASEM * BPE % 4 != 0. In this case dword/dwordx4 DTL load will
     # zero out the entire partial 32b read and cause accuracy issues.
     if (asem * bpeA) % 4 != 0:
-      state["NonDTLTailLoopA"] = not state["ProblemType"]["TLUA"]
+      state["NonDTLTailLoopA"] = True
     if (asem * bpeB) % 4 != 0:
-      state["NonDTLTailLoopB"] = not state["ProblemType"]["TLUB"]
+      state["NonDTLTailLoopB"] = True
 
     if (state["ISA"] != (9, 4, 2)) or \
        (state["ProblemType"]["Sparse"]) or \
@@ -764,7 +764,7 @@ class Solution(collections.abc.Mapping):
 
     MT = state["MacroTile0"] if tc == 'A' else state["MacroTile1"]
 
-    if not math.log(MT,2).is_integer():
+    if (MT & (MT-1)) != 0: # Check of MT not power of 2
       # so far, numBytesAB<4 case, TLU=False only (continue with False)
       if numBytesAB < 4 and state["ProblemType"]["TLU%c"%tc]:
         return False

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -241,6 +241,47 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 128, 1,  1,   1, 1,  1,1 ]
+          - [32, 32, 64, 1,  1,   1, 1,  1,1 ]
+        - WorkGroup:
+          - [16,16,1]
+        - GlobalReadVectorWidthA: [16]
+        - GlobalReadVectorWidthB: [16]
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - NumElementsPerBatchStore: [0]
+        - DepthU: [128]
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1]
+        - MIArchVgpr: [0]
+        - LocalWritePerMfma: [-1]
+        - WorkGroupMapping: [1]
+        - ScheduleIterAlg: [3]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - StorePriorityOpt: [0]
+        - VectorStore: [-1]
+        - StoreSyncOpt: [0]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+        - 1LDSBuffer: [0]
+        - GlobalSplitU: [1]
+        - SourceSwap: [1]#[0, 1]
+        - LocalReadVectorWidth: [8]
+        - DirectToLds: [1]
+        - AssertFree0ElementMultiple: [1, 4]
+        - AssertFree1ElementMultiple: [1, 4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[16,1,32],[16,1,32],[1],[1,1,129]]
 
   ########################################
   # F8HHS TT DTL

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -5,7 +5,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   MinimumRequiredVersion: 5.0.0
   PrintLevel: 1
-  PrintSolutionRejectionReason: True
+  #PrintSolutionRejectionReason: True
   Device: 0
   CMakeBuildType: Release
   MergeFiles: False
@@ -24,7 +24,7 @@ GlobalParameters:
 
 BenchmarkProblems:
   ########################################
-  # F32
+  # F32 TN
   ########################################
   -
     - # ProblemType
@@ -55,7 +55,47 @@ BenchmarkProblems:
         - GlobalReadVectorWidthB: [1, 4]
         - LocalReadVectorWidth: [1, 4]
         - ScheduleIterAlg: [3]
-        - TransposeLDS: [1] #0,1
+        - TransposeLDS: [1]
+        - StaggerU: [0]
+        - StreamK: [0]
+        - DirectToLds: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[1,67,517], [1,93,709], [1], [1,76,865]]
+
+  ########################################
+  # F32 NT
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: S
+      DestDataType: S
+      ComputeDataType: S
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 4, 1, 1, 1, 1, 1, 1]
+          - [16, 16, 4, 1, 1, 2, 2, 2, 2]
+        - DepthU: [ 32 ]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [0]
+        - SourceSwap: [1]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1]
+        - GlobalReadVectorWidthA: [1, 4]
+        - GlobalReadVectorWidthB: [1, 4]
+        - LocalReadVectorWidth: [1, 4]
+        - ScheduleIterAlg: [3]
         - StaggerU: [0]
         - StreamK: [0]
         - DirectToLds: [1]
@@ -107,10 +147,8 @@ BenchmarkProblems:
         - LocalWritePerMfma: [-1]
         - StaggerU: [4]
         - StaggerUStride: [256]
-        #- StaggerUMapping: [2]
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
-        #- ExpandPointerSwap: [0,1]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -120,7 +158,75 @@ BenchmarkProblems:
         - LdsPadB: [0, 8]
         - 1LDSBuffer: [0]
         - GlobalSplitU: [1,2]
-        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
+        - SourceSwap: [1]#[0, 1]
+        - LocalReadVectorWidth: [8]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1, 4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[19], [19], [1], [1,3,12]]
+          - Range: [[31], [31], [1], [1,7,72]]
+          - Range: [[127], [127], [1], [128,4,140]]
+          - Range: [[13], [17], [1], [258, 3, 512]]
+          - Exact: [256, 256, 1, 64]
+          - Exact: [256, 256, 1, 128]
+          - Exact: [256, 256, 1, 320]
+
+  ########################################
+  # F8HS NT DTL
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: f8
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 128, 1,  1,   1, 1,  1,1 ]
+          - [32, 32, 64, 1,  1,   1, 1,  1,1 ]
+          - [16, 16, 128, 1,  1,   4, 4,  2,2 ]
+          - [32, 32, 64, 1,  1,   2, 2,  2,2 ]
+          - [32, 32, 64, 1,  1,   3, 2,  2,2 ]
+          - [32, 32, 64, 1,  1,   2, 3,  2,2 ]
+          - [16, 16, 128, 1,  1,   3, 2,  2,2 ]
+          - [16, 16, 128, 1,  1,   2, 3,  2,2 ]
+        - WorkGroup:
+          - [16,16,1]
+        - GlobalReadVectorWidthA: [4, 16]
+        - GlobalReadVectorWidthB: [4, 16]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2]
+        - ClusterLocalRead: [1]
+        - NumElementsPerBatchStore: [0]
+        - DepthU: [128]
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1]
+        - MIArchVgpr: [0]
+        - LocalWritePerMfma: [-1]
+        - StaggerU: [4]
+        - StaggerUStride: [256]
+        - WorkGroupMapping: [1]
+        - ScheduleIterAlg: [3]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - StorePriorityOpt: [0]
+        - VectorStore: [-1]
+        - StoreSyncOpt: [0]
+        - LdsPadA: [0, 8]
+        - LdsPadB: [0, 8]
+        - 1LDSBuffer: [0]
+        - GlobalSplitU: [1,2]
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
         - DirectToLds: [1]
@@ -230,10 +336,8 @@ BenchmarkProblems:
         - LocalWritePerMfma: [-1]
         - StaggerU: [4]
         - StaggerUStride: [256]
-        #- StaggerUMapping: [2]
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
-        #- ExpandPointerSwap: [0,1]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -243,8 +347,7 @@ BenchmarkProblems:
         - LdsPadB: [0, 8]
         - 1LDSBuffer: [0]
         - GlobalSplitU: [1,2]
-        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
-        - SourceSwap: [1]#[0, 1]
+        - SourceSwap: [1]
         - LocalReadVectorWidth: [8]
         - DirectToLds: [1]
         - AssertSummationElementMultiple: [1, 4]
@@ -297,10 +400,8 @@ BenchmarkProblems:
         - LocalWritePerMfma: [-1]
         - StaggerU: [4]
         - StaggerUStride: [256]
-        #- StaggerUMapping: [2]
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
-        #- ExpandPointerSwap: [0,1]
         - StorePriorityOpt: [0]
         - VectorStore: [-1]
         - StoreSyncOpt: [0]
@@ -308,7 +409,6 @@ BenchmarkProblems:
         - LdsPadB: [-1, 0, 8]
         - 1LDSBuffer: [0]
         - GlobalSplitU: [1,2]
-        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
         - DirectToLds: [1]
@@ -655,4 +755,88 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
+          - Range: [[4096], [8192], [1], [64,64,384]]
+
+
+  ########################################
+  # HHS NT DTL
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      UseBias: 0 # 1
+      Batched: True
+      Activation: False
+      ActivationHPA: False
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
+          - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
+          - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
+          - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
+          - [32, 32, 16, 1, 1, 3, 2, 2, 2 ]
+        - PrefetchGlobalRead: [1, 2]
+        - PrefetchLocalRead: [1, 2]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        #- TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1, 2]
+        - LdsPadA: [0, 8]
+        - LdsPadB: [0, 8]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1, 2]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [256, 256, 1, 64]
+          - Exact: [256, 256, 1, 128]
+          - Exact: [256, 256, 1, 256]
+          - Exact: [256, 256, 1, 512]
+          - Range: [[65], [123], [1], [1,123,512]]
+          #- Exact: [4096, 8192, 1, 128]
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
+          - [16, 16, 32, 1, 1, 8, 7, 2, 2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        #- TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1, 2]
+        - LdsPadA: [0, 8]
+        - LdsPadB: [0, 8]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[65], [123], [1], [1,123,512]]
           - Range: [[4096], [8192], [1], [64,64,384]]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -695,6 +695,33 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 512]
           - Range: [[47], [97], [1], [1,31,512]]
           - Exact: [4096, 8192, 1, 128]
+    - # ASEM/AFEM check
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1]
+        - AssertFree0ElementMultiple: [2]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[16,2,32],[16,2,32],[1],[1,1,32]]
 
   ########################################
   # HHS TT DTL


### PR DESCRIPTION
## Motivation

This PR enables DTL for certain cases with TLU=1 - namely when MT is a power of 2. Motivation is to bring DTL benefits for NT cases. 

## Technical Details
Disabled TLU=1 restriction for power of 2 MT. For non-power of 2 there are still some functional issues that are currently being investigated. LDS padding is set to zero for TLU=1, it is not needed and enabling causes some correctness issues. 

## Test Plan
Tensilelite dtl tests updated to test for NT cases. 

## Test Result
gfx950 tensilelite tests pass.

## Submission Checklist

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
