### PR TITLE
[hipBLASLt] Fixed memory leak in hipblaslt-test 

### DIFF
--- a/projects/hipblaslt/clients/common/utility.cpp
+++ b/projects/hipblaslt/clients/common/utility.cpp
@@ -71,7 +71,14 @@ static std::string get_self_path()
         result.resize(result.size() * 2);
     }
 #else
-    return std::string(realpath("/proc/self/exe", 0));
+    char result[PATH_MAX] = {};
+
+    if(realpath("/proc/self/exe", result))
+    {
+        return std::string(result);
+    }
+
+    return std::string();
 #endif
 }
 


### PR DESCRIPTION
## Motivation

Fix memory leak in hipblaslt-test.

## Technical Details

There's leaking return value of `realpath(...)`.

## Test Plan

Test `hipblaslt-test` with `valgrind --leak-check=full`.

## Test Result

No definitely leak observed with this PR. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
