### PR TITLE
Users/umfranzw/hipcub exclusive scan fallback

### DIFF
--- a/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -608,7 +608,7 @@ void rank_with_prefix_sum_kernel(const KeyType* keys_input,
 #if defined(_GLIBCXX_RELEASE) && (GLIBCXX_RELEASE < 9)
 
 template <typename It, typename OutIt, typename T>
-void exclusive_scan(It first, It last, OutIt out, T init)
+void fall_back_exclusive_scan(It first, It last, OutIt out, T init)
 {
     // Fallback implementation for exclusive scan if gcc version is < 9
     for (; first != last; ++first)
@@ -725,7 +725,7 @@ void test_radix_rank_with_prefix_sum_output()
                                         pfs_expected.begin() + pfs_offset,
                                         0);
                 #else
-                    exclusive_scan(histogram.begin(),
+                    fall_back_exclusive_scan(histogram.begin(),
                                         histogram.end(),
                                         pfs_expected.begin() + pfs_offset,
                                         0);

--- a/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -607,6 +607,10 @@ void rank_with_prefix_sum_kernel(const KeyType* keys_input,
 
 #if defined(_GLIBCXX_RELEASE) && (GLIBCXX_RELEASE < 9)
 
+/**
+ * name this function fall_back_exclusive_scan to prevent
+ * ambiguous name error 
+ */
 template <typename It, typename OutIt, typename T>
 void fall_back_exclusive_scan(It first, It last, OutIt out, T init)
 {

--- a/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -605,6 +605,21 @@ void rank_with_prefix_sum_kernel(const KeyType* keys_input,
     }
 }
 
+#if defined(_GLIBCXX_RELEASE) && (GLIBCXX_RELEASE < 9)
+
+template <typename It, typename OutIt, typename T>
+void exclusive_scan(It first, It last, OutIt out, T init)
+{
+    // Fallback implementation for exclusive scan if gcc version is < 9
+    for (; first != last; ++first)
+    {
+        *out++ = init;
+        init += *first;
+    }
+}
+
+#endif
+
 template<typename TestFixture, RadixRankAlgorithm Algorithm>
 void test_radix_rank_with_prefix_sum_output()
 {
@@ -703,10 +718,19 @@ void test_radix_rank_with_prefix_sum_output()
 
                     ++histogram[bit_rep];
                 }
-                std::exclusive_scan(histogram.begin(),
-                                    histogram.end(),
-                                    pfs_expected.begin() + pfs_offset,
-                                    0);
+
+                #if defined(_GLIBCXX_RELEASE) && (GLIBCXX_RELEASE >= 9)
+                    std::exclusive_scan(histogram.begin(),
+                                        histogram.end(),
+                                        pfs_expected.begin() + pfs_offset,
+                                        0);
+                #else
+                    exclusive_scan(histogram.begin(),
+                                        histogram.end(),
+                                        pfs_expected.begin() + pfs_offset,
+                                        0);
+                #endif
+
             }
 
             // Preparing device


### PR DESCRIPTION
## Motivation

Debian 10 does not provide full c++17 support - in particular, support for std::exclusive_scan is missing. We use std::exclusive scan in one of our hipCUB unit tests.

## Technical Details

Add an implementation of exclusive scan that we can fallback to when we detect that glibcxx is too old. Support for std::exclusive scan was added in glibcxx version 9.

## Test Plan

Built and ran the affected test target ( `test_hipcub_block_radix_rank` ) on the affected OS (Debian 10) as well as an unaffected OS (Ubuntu 22.04) to ensure that both execution paths (fallback and normal) are working.
Will wait for CI test checks to pass as well.

## Test Result

The tests pass in both cases.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
