### PR TITLE
Enable PLR when DepthU=MI_K

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -170,10 +170,12 @@ class LocalReadMFMA(LocalRead):
         tc = tP["tensorChar"]
         if tc == "A":
             writer.states.localReadDoCntA += 1
+            subTileIdx = writer.states.SubTileIdxA
         elif tc == "Metadata":
             writer.states.localReadDoCntMetadata += 1
         else:
             writer.states.localReadDoCntB += 1
+            subTileIdx = writer.states.SubTileIdxB
         tile01           = tP["tile01Idx"]
         instruction      = tP["localReadInstruction"]
         bpr              = 4 # bytes/register
@@ -185,6 +187,8 @@ class LocalReadMFMA(LocalRead):
 
         vectorWidth  = kernel["VectorWidth%s"%tc]
 
+        numSubTiles = kernel["numSubTiles%s"%tc]
+        
         MIWaveGroupShape = [ kernel["MatrixInstM"] * kernel["MatrixInstBM"] * kernel["MIWaveGroup"][0] * kernel["VectorWidthA"], \
                             kernel["MatrixInstN"] * kernel["MatrixInstBN"] * kernel["MIWaveGroup"][1] * kernel["VectorWidthB"]]
 
@@ -268,85 +272,123 @@ class LocalReadMFMA(LocalRead):
                 ds = DSModifiers(na=1, offset=offset)
                 localReadCode.add(LocalReadX(dst=destVgpr, src=srcAddr, ds=ds, comment=comment))
         else:
-            for vIdx in range(0, numVectorsPerTile):
-                for eIdx in range(0, numReadsPerVector):
+            eIdxCnt = numReadsPerVector
+            eIdxStart = 0
+            vIdxStart = 0
+            vIdxCnt = numVectorsPerTile
+            valufIdx = 0
+            if numVectorsPerTile == 1:
+                eIdxCnt = numReadsPerVector//numSubTiles
+                eIdxStart = subTileIdx * (numReadsPerVector//numSubTiles)
+            else:
+                vIdxStart = subTileIdx * (numVectorsPerTile//numSubTiles)
+                vIdxCnt = numVectorsPerTile//numSubTiles
+
+            # Calculate total number of local read instructions needed
+            totalLocalReads = numVectorsPerTile * numReadsPerVector
+            localReadsPerSubTile = totalLocalReads // numSubTiles
+            remainderReads = totalLocalReads % numSubTiles
+            
+            # Adjust for this subTile
+            if subTileIdx < remainderReads:
+                localReadsForThisSubTile = localReadsPerSubTile + 1
+            else:
+                localReadsForThisSubTile = localReadsPerSubTile
+            
+            # Calculate starting position for this subTile
+            startReadIdx = subTileIdx * localReadsPerSubTile + min(subTileIdx, remainderReads)
+            
+            # Use while loop to generate the correct number of local read instructions
+            readCount = 0
+            while readCount < localReadsForThisSubTile:
+                # Calculate current vIdx and eIdx from the global read index
+                globalReadIdx = startReadIdx + readCount
+                vIdx = globalReadIdx // numReadsPerVector
+                eIdx = globalReadIdx % numReadsPerVector
+                # Calculate valufIdx based on current vIdx and eIdx
+                if numVectorsPerTile == 1:
+                    valufIdx = eIdx * blockWidth * numReadsPerUnroll
+                else:
+                    valufIdx = (vIdx * numReadsPerVector + eIdx) * blockWidth * numReadsPerUnroll
+
+                valuiIdx = int(valufIdx)
+                baseValuiIdx = valuiIdx
+                localReadCode = imod.add(Module("LocalRead%s Valu%u"%(tc,valuiIdx)))
+                readCount += 1
+                if needPack or numSplitMetadata:
+                    packCode = pack.add(Module("packCode"))
+
+                tmpvgprHI = []
+                for rIdx in range(0, numReadsPerUnroll):
                     valuiIdx = int(valufIdx)
-                    baseValuiIdx = valuiIdx
-                    localReadCode = imod.add(Module("LocalRead%s Valu%u"%(tc,valuiIdx)))
+                    baseLRVgpr = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx), numVgpr)
+                    destVgpr = baseLRVgpr
+                    highBitsForHalf = (blockWidth == 0.5) and ((rIdx % 2) == 1) # rIdx = 1
+                    isHigh16Bits = (blockWidth == 0.25) and ( ((rIdx % 4) //2) == 1) # 2,3
+
                     if needPack or numSplitMetadata:
-                        packCode = pack.add(Module("packCode"))
+                        if kernel["UseF32XEmulation"]:
+                            if valuiIdx % 4 == 0:
+                                tmpvgprIDx = (valuiIdx % 8) // 4
+                                tmpvgprHI.append(writer.vgprPool.checkOutAligned(2, 2))
+                                numTmpForCVTSubTF32 = 4
+                                tmpvgpr =[]
+                                for i in range(numTmpForCVTSubTF32):
+                                    tmpvgpr.append(writer.vgprPool.checkOut(1))
 
-                    tmpvgprHI = []
-                    for rIdx in range(0, numReadsPerUnroll):
-                        valuiIdx = int(valufIdx)
-                        baseLRVgpr = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx), numVgpr)
-                        destVgpr = baseLRVgpr
-                        highBitsForHalf = (blockWidth == 0.5) and ((rIdx % 2) == 1) # rIdx = 1
-                        isHigh16Bits = (blockWidth == 0.25) and ( ((rIdx % 4) //2) == 1) # 2,3
+                                v0 = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx))
+                                v1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, valuiIdx))
+                                v2 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, valuiIdx))
+                                v3 = vgpr("Valu%s_X%u_I%u+%u+3"%(tc, bufferIdx, iui, valuiIdx))
 
-                        if needPack or numSplitMetadata:
-                            if kernel["UseF32XEmulation"]:
-                                if valuiIdx % 4 == 0:
-                                    tmpvgprIDx = (valuiIdx % 8) // 4
-                                    tmpvgprHI.append(writer.vgprPool.checkOutAligned(2, 2))
-                                    numTmpForCVTSubTF32 = 4
-                                    tmpvgpr =[]
-                                    for i in range(numTmpForCVTSubTF32):
-                                        tmpvgpr.append(writer.vgprPool.checkOut(1))
+                                packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]), src0=v0, src1=v1))
 
-                                    v0 = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx))
-                                    v1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, valuiIdx))
-                                    v2 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, valuiIdx))
-                                    v3 = vgpr("Valu%s_X%u_I%u+%u+3"%(tc, bufferIdx, iui, valuiIdx))
+                                packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[0]), src=vgpr(tmpvgprHI[tmpvgprIDx])))
+                                packCode.add(VSubF32(dst=v0, src0=v0, src1=vgpr(tmpvgpr[0])))
+                                packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[1]), src=vgpr(tmpvgprHI[tmpvgprIDx]), vgprMask=None, vi=1))
+                                packCode.add(VSubF32(dst=v1, src0=v1, src1=vgpr(tmpvgpr[1])))
 
-                                    packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]), src0=v0, src1=v1))
+                                packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]+1), src0=v2, src1=v3))
+                                packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1)))
+                                packCode.add(VSubF32(dst=v2, src0=v2, src1=vgpr(tmpvgpr[2])))
+                                packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1), vgprMask=None, vi=1))
+                                packCode.add(VSubF32(dst=v3, src0=v3, src1=vgpr(tmpvgpr[2])))
 
-                                    packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[0]), src=vgpr(tmpvgprHI[tmpvgprIDx])))
-                                    packCode.add(VSubF32(dst=v0, src0=v0, src1=vgpr(tmpvgpr[0])))
-                                    packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[1]), src=vgpr(tmpvgprHI[tmpvgprIDx]), vgprMask=None, vi=1))
-                                    packCode.add(VSubF32(dst=v1, src0=v1, src1=vgpr(tmpvgpr[1])))
+                                for i in range(numTmpForCVTSubTF32):
+                                    writer.vgprPool.checkIn(tmpvgpr[i])
 
-                                    packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]+1), src0=v2, src1=v3))
-                                    packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1)))
-                                    packCode.add(VSubF32(dst=v2, src0=v2, src1=vgpr(tmpvgpr[2])))
-                                    packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1), vgprMask=None, vi=1))
-                                    packCode.add(VSubF32(dst=v3, src0=v3, src1=vgpr(tmpvgpr[2])))
+                            if rIdx == numReadsPerUnroll - 1: # Last iteration
+                                if not (kernel["MatrixInstM"] == 16 and kernel["MatrixInstK"] == 16):
+                                    v0 = vgpr("Valu%s_X%u_I%u+%u+0"%(tc, bufferIdx, iui, baseValuiIdx))
+                                    v1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, baseValuiIdx))
+                                    v2 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, baseValuiIdx))
+                                    v3 = vgpr("Valu%s_X%u_I%u+%u+3"%(tc, bufferIdx, iui, baseValuiIdx))
+                                    v4 = vgpr("Valu%s_X%u_I%u+%u+4"%(tc, bufferIdx, iui, baseValuiIdx))
+                                    v5 = vgpr("Valu%s_X%u_I%u+%u+5"%(tc, bufferIdx, iui, baseValuiIdx))
+                                    v6 = vgpr("Valu%s_X%u_I%u+%u+6"%(tc, bufferIdx, iui, baseValuiIdx))
+                                    v7 = vgpr("Valu%s_X%u_I%u+%u+7"%(tc, bufferIdx, iui, baseValuiIdx))
+                                    packCode.add(VCvtPkF32toBF16(dst=v7, src0=v6, src1=v7))
+                                    packCode.add(VCvtPkF32toBF16(dst=v6, src0=v4, src1=v5))
+                                    packCode.add(VCvtPkF32toBF16(dst=v5, src0=v2, src1=v3))
+                                    packCode.add(VCvtPkF32toBF16(dst=v4, src0=v0, src1=v1))
+                                    tmpvgprHI064  = vgpr(tmpvgprHI[0], 2)
+                                    tmpvgprHI164  = vgpr(tmpvgprHI[1], 2)
+                                    valuvgprHI064 = vgpr("Valu%s_X%u_I%u+%u+0"%(tc, bufferIdx, iui, baseValuiIdx), 2)
+                                    valuvgprHI164 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, baseValuiIdx), 2)
+                                    packCode.add(VMovB64(dst=valuvgprHI064, src=tmpvgprHI064))
+                                    packCode.add(VMovB64(dst=valuvgprHI164, src=tmpvgprHI164))
+                                    for i in range(len(tmpvgprHI)):
+                                        writer.vgprPool.checkIn(tmpvgprHI[i])
 
-                                    for i in range(numTmpForCVTSubTF32):
-                                        writer.vgprPool.checkIn(tmpvgpr[i])
-
-                                if rIdx == numReadsPerUnroll - 1: # Last iteration
-                                    if not (kernel["MatrixInstM"] == 16 and kernel["MatrixInstK"] == 16):
-                                        v0 = vgpr("Valu%s_X%u_I%u+%u+0"%(tc, bufferIdx, iui, baseValuiIdx))
-                                        v1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, baseValuiIdx))
-                                        v2 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, baseValuiIdx))
-                                        v3 = vgpr("Valu%s_X%u_I%u+%u+3"%(tc, bufferIdx, iui, baseValuiIdx))
-                                        v4 = vgpr("Valu%s_X%u_I%u+%u+4"%(tc, bufferIdx, iui, baseValuiIdx))
-                                        v5 = vgpr("Valu%s_X%u_I%u+%u+5"%(tc, bufferIdx, iui, baseValuiIdx))
-                                        v6 = vgpr("Valu%s_X%u_I%u+%u+6"%(tc, bufferIdx, iui, baseValuiIdx))
-                                        v7 = vgpr("Valu%s_X%u_I%u+%u+7"%(tc, bufferIdx, iui, baseValuiIdx))
-                                        packCode.add(VCvtPkF32toBF16(dst=v7, src0=v6, src1=v7))
-                                        packCode.add(VCvtPkF32toBF16(dst=v6, src0=v4, src1=v5))
-                                        packCode.add(VCvtPkF32toBF16(dst=v5, src0=v2, src1=v3))
-                                        packCode.add(VCvtPkF32toBF16(dst=v4, src0=v0, src1=v1))
-                                        tmpvgprHI064  = vgpr(tmpvgprHI[0], 2)
-                                        tmpvgprHI164  = vgpr(tmpvgprHI[1], 2)
-                                        valuvgprHI064 = vgpr("Valu%s_X%u_I%u+%u+0"%(tc, bufferIdx, iui, baseValuiIdx), 2)
-                                        valuvgprHI164 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, baseValuiIdx), 2)
-                                        packCode.add(VMovB64(dst=valuvgprHI064, src=tmpvgprHI064))
-                                        packCode.add(VMovB64(dst=valuvgprHI164, src=tmpvgprHI164))
-                                        for i in range(len(tmpvgprHI)):
-                                            writer.vgprPool.checkIn(tmpvgprHI[i])
-
-                                    # layout:
-                                    # Val+0: bf16 high (0,1)
-                                    # Val+1: bf16 high (2,3)
-                                    # Val+2: bf16 high (4,5)
-                                    # Val+3: bf16 high (6,7)
-                                    # Val+4: bf16 low  (0,1)
-                                    # Val+5: bf16 low  (2,3)
-                                    # Val+6: bf16 low  (4,5)
-                                    # Val+7: bf16 low  (6,7)
+                                # layout:
+                                # Val+0: bf16 high (0,1)
+                                # Val+1: bf16 high (2,3)
+                                # Val+2: bf16 high (4,5)
+                                # Val+3: bf16 high (6,7)
+                                # Val+4: bf16 low  (0,1)
+                                # Val+5: bf16 low  (2,3)
+                                # Val+6: bf16 low  (4,5)
+                                # Val+7: bf16 low  (6,7)
 
 
                             if kernel["ConvertAfterDS"] and (tP["bpe"] != tP["bpeDS"]):
@@ -625,139 +667,139 @@ class LocalReadMFMA(LocalRead):
                                         if isHigh8Bits and isHigh16Bits:
                                             packCode.add(VLShiftLeftOrB32(dst=baseLRVgpr, src0=highVgpr, shiftHex=hex(0x8), src1=baseLRVgpr, comment="pack two int8x2 Vgpr to one Vgpr"))
 
-                        if kernel["ConvertAfterDS"] and kernel["UnrollMajorLDS%s"%tc]:
-                            valufIdx += blockWidth * (tP["bpe"] // tP["bpeDS"]) if (not tP["isM"]) else 1
-                        else:
-                            valufIdx += blockWidth if (not tP["isM"]) else 1
+                    if kernel["ConvertAfterDS"] and kernel["UnrollMajorLDS%s"%tc]:
+                        valufIdx += blockWidth * (tP["bpe"] // tP["bpeDS"]) if (not tP["isM"]) else 1
+                    else:
+                        valufIdx += blockWidth if (not tP["isM"]) else 1
 
-                        # load read instrution
-                        paramList = []
+                    # load read instrution
+                    paramList = []
 
-                        for oIdx in range(0, numOffsets):
-                            offset_val = (eIdx + (vIdx * numOffsets+oIdx) * MIWaveGroupShape[tile01]) * tileStride
+                    for oIdx in range(0, numOffsets):
+                        offset_val = (eIdx + (vIdx * numOffsets+oIdx) * MIWaveGroupShape[tile01]) * tileStride
 
-                            if kernel["ProblemType"]["Sparse"] != 0:
-                                if blocksPerTGroupSMFMA > 1:
-                                    blockId = (rIdx * numElementPerRead) // elementsPerBlockSMFMA  #block 0 or block 1
-                                    if kernel["UnrollMajorLDS%s"%(tc)]:
-                                        offset_val = offset_val + (blockOffsetSMFMA * blockId)
-                                    else:
-                                        offset_val = offset_val + (blockOffsetSMFMA * blockId) * UnrollStride
-                                offset_val = (rIdx * numElementPerRead * UnrollStride + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
-                            elif kernel["ProblemType"]["DataType"].is8bitFloat() and kernel["MatrixInstK"] > 32:
-                                incOffset = 0
-                                midIdx = numReadsPerUnroll // 2
-                                if rIdx >= midIdx:
-                                    if kernel["UnrollMajorLDS%s" % tP["tensorChar"]] == False:
-                                        # TODO: why are these the offsets???
-                                        if kernel["MatrixInstM"] == 32:
-                                             incOffset = midIdx * numElementPerRead * UnrollStride
-                                        elif kernel["MatrixInstM"] == 16:
-                                            incOffset = 3 * midIdx * numElementPerRead * UnrollStride
-                                    else:
-                                        if kernel["MatrixInstM"] == 32:
-                                            incOffset = 16
-                                        elif kernel["MatrixInstM"] == 16:
-                                            incOffset = 48
-                                incOffset = rIdx * numElementPerRead * UnrollStride + incOffset
-                                offset_val = (incOffset + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
-                            elif kernel["UseF32XEmulation"]:
-                                # Previously a single ds_read could be used to load all inputs for mfma
-                                # For emulated TF32, 2x ds_read is required along with a different mfma layout
-                                # so we need to adjust the offsets accordingly for the second ds_read.
-                                # Numbers here are specific to the mfma layout
-                                incOffset = 0
-                                midIdx = numReadsPerUnroll // 2
-                                if rIdx >= midIdx:
-                                    if kernel["UnrollMajorLDS%s" % tP["tensorChar"]] == False:
-                                        if kernel["MatrixInstM"] == 32:
-                                            incOffset = midIdx * numElementPerRead * UnrollStride
-                                        elif kernel["MatrixInstM"] == 16:
-                                            incOffset = 3 * midIdx * numElementPerRead * UnrollStride
-                                    else:
-                                        if kernel["MatrixInstM"] == 32 and kernel["MatrixInstK"] == 16:
-                                            incOffset = 4
-                                        elif kernel["MatrixInstM"] == 16 and kernel["MatrixInstK"] == 32:
-                                            incOffset = 12
-                                incOffset = rIdx * numElementPerRead * UnrollStride + incOffset
-                                offset_val = (incOffset + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
-                            else:
-                                offset_val = (rIdx * numElementPerRead * UnrollStride + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
-
-                            if (kernel["LdsBlockSizePerPad%s"%tc] != 0) and (kernel["LdsPad%s"%tc] != 0):
-                                offset_val = offset_val + (offset_val // kernel["LdsBlockSizePerPad%s"%tc]) * kernel["LdsPad%s"%tc] * tP["bpeDS"]
-                            offset_val = offset_val + tP["localReadSwapByteOffset"]
-                            if (kernel["DirectToLds%s" % tc] and  \
-                                kernel["GlobalReadVectorWidth%c"%tc] * tP["bpeDS"] > 4):
-                              # another address conversion for DirectToLds + NumLoadsCoalesced > 1
-                              dummy, offset_val = writer.lraOffsetConversionForDTLandNLC(kernel, tP, offset_val)
-
-                            paramList.append(int(offset_val))
-
-                        comment = "L -> Reg lro=%d swapByteOffset=%u ti=%u vIdx=%u eIdx=%u rIdx=%u oIdx=%u buffer=%u iui=%u" \
-                                % (tP["localReadOffset"], tP["localReadSwapByteOffset"], MIWaveGroupShape[tile01], vIdx, eIdx, rIdx, oIdx, bufferIdx, iui)
-
-                        highBits = 0 if writer.states.archCaps["DSLow16NotPreserve"] else highBitsForHalf or isHigh16Bits
-
-
-                        if(paramList[0] >=131072):
-                            paramList[0] = paramList[0] -131072
-                            srcAddr=vgpr("LocalReadAddr%s+2"%tc)
-                        elif (paramList[0] >=65536):
-                            paramList[0] = paramList[0] -65536
-                            srcAddr=vgpr("LocalReadAddr%s+1"%tc)
-                        else:
-                            srcAddr=vgpr("LocalReadAddr%s"%tc)
-
-                        if numOffsets == 1:
-                            ds = DSModifiers(na=1, offset=paramList[0])
-                        else:
-                            ds = DSModifiers(na=2, offset0=paramList[0], offset1=paramList[1])
-                        LocalReadX = instruction.getInst(highBits)
-                        localReadCode.add(LocalReadX(dst=destVgpr, src=srcAddr, ds=ds, comment=comment))
-                        # TODO - handle vector-load
-                        with writer.allocTmpSgpr(1) as tmpSgprInfo:
-                            tmpSgpr = tmpSgprInfo.idx
-                            if writer.db["CheckValue1%s"%tc] and not writer.inTailLoop:
-
-                                dbgVgpr = destVgpr
-                                dbgVgprList = destVgpr.split("v[")
-                                if len(dbgVgprList) == 1: # vIdx, no []
-                                    dbgVgpr = dbgVgprList[0]
+                        if kernel["ProblemType"]["Sparse"] != 0:
+                            if blocksPerTGroupSMFMA > 1:
+                                blockId = (rIdx * numElementPerRead) // elementsPerBlockSMFMA  #block 0 or block 1
+                                if kernel["UnrollMajorLDS%s"%(tc)]:
+                                    offset_val = offset_val + (blockOffsetSMFMA * blockId)
                                 else:
-                                    # We only check the first one now
-                                    # TODO: Handle vector, but need to take care the last one
-                                    dbgVgprList = (dbgVgprList[1].split("]")[0]).split(':')
-                                    dbgVgpr = "v[%s]"%dbgVgprList[0]
-                                localReadCode.add(SWaitCnt(dscnt=0, vscnt=0, comment="CheckValue1 wait for LDS read"))
+                                    offset_val = offset_val + (blockOffsetSMFMA * blockId) * UnrollStride
+                            offset_val = (rIdx * numElementPerRead * UnrollStride + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
+                        elif kernel["ProblemType"]["DataType"].is8bitFloat() and kernel["MatrixInstK"] > 32:
+                            incOffset = 0
+                            midIdx = numReadsPerUnroll // 2
+                            if rIdx >= midIdx:
+                                if kernel["UnrollMajorLDS%s" % tP["tensorChar"]] == False:
+                                    # TODO: why are these the offsets???
+                                    if kernel["MatrixInstM"] == 32:
+                                         incOffset = midIdx * numElementPerRead * UnrollStride
+                                    elif kernel["MatrixInstM"] == 16:
+                                        incOffset = 3 * midIdx * numElementPerRead * UnrollStride
+                                else:
+                                    if kernel["MatrixInstM"] == 32:
+                                        incOffset = 16
+                                    elif kernel["MatrixInstM"] == 16:
+                                        incOffset = 48
+                            incOffset = rIdx * numElementPerRead * UnrollStride + incOffset
+                            offset_val = (incOffset + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
+                        elif kernel["UseF32XEmulation"]:
+                            # Previously a single ds_read could be used to load all inputs for mfma
+                            # For emulated TF32, 2x ds_read is required along with a different mfma layout
+                            # so we need to adjust the offsets accordingly for the second ds_read.
+                            # Numbers here are specific to the mfma layout
+                            incOffset = 0
+                            midIdx = numReadsPerUnroll // 2
+                            if rIdx >= midIdx:
+                                if kernel["UnrollMajorLDS%s" % tP["tensorChar"]] == False:
+                                    if kernel["MatrixInstM"] == 32:
+                                        incOffset = midIdx * numElementPerRead * UnrollStride
+                                    elif kernel["MatrixInstM"] == 16:
+                                        incOffset = 3 * midIdx * numElementPerRead * UnrollStride
+                                else:
+                                    if kernel["MatrixInstM"] == 32 and kernel["MatrixInstK"] == 16:
+                                        incOffset = 4
+                                    elif kernel["MatrixInstM"] == 16 and kernel["MatrixInstK"] == 32:
+                                        incOffset = 12
+                            incOffset = rIdx * numElementPerRead * UnrollStride + incOffset
+                            offset_val = (incOffset + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
+                        else:
+                            offset_val = (rIdx * numElementPerRead * UnrollStride + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
 
-                                if kernel["ProblemType"]["DataType"].isHalf():
-                                    hexValue = hex(0x3c003c00)     # packed 1s
-                                    if needPack:
-                                        hexValue = hex(0x3c000000) if highBitsForHalf else hex(0x00003c00)
-                                    localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: FP16"))
+                        if (kernel["LdsBlockSizePerPad%s"%tc] != 0) and (kernel["LdsPad%s"%tc] != 0):
+                            offset_val = offset_val + (offset_val // kernel["LdsBlockSizePerPad%s"%tc]) * kernel["LdsPad%s"%tc] * tP["bpeDS"]
+                        offset_val = offset_val + tP["localReadSwapByteOffset"]
+                        if (kernel["DirectToLds%s" % tc] and  \
+                            kernel["GlobalReadVectorWidth%c"%tc] * tP["bpeDS"] > 4):
+                          # another address conversion for DirectToLds + NumLoadsCoalesced > 1
+                          dummy, offset_val = writer.lraOffsetConversionForDTLandNLC(kernel, tP, offset_val)
+
+                        paramList.append(int(offset_val))
+
+                    comment = "L -> Reg lro=%d swapByteOffset=%u ti=%u vIdx=%u eIdx=%u rIdx=%u oIdx=%u buffer=%u iui=%u" \
+                            % (tP["localReadOffset"], tP["localReadSwapByteOffset"], MIWaveGroupShape[tile01], vIdx, eIdx, rIdx, oIdx, bufferIdx, iui)
+
+                    highBits = 0 if writer.states.archCaps["DSLow16NotPreserve"] else highBitsForHalf or isHigh16Bits
+
+
+                    if(paramList[0] >=131072):
+                        paramList[0] = paramList[0] -131072
+                        srcAddr=vgpr("LocalReadAddr%s+2"%tc)
+                    elif (paramList[0] >=65536):
+                        paramList[0] = paramList[0] -65536
+                        srcAddr=vgpr("LocalReadAddr%s+1"%tc)
+                    else:
+                        srcAddr=vgpr("LocalReadAddr%s"%tc)
+
+                    if numOffsets == 1:
+                        ds = DSModifiers(na=1, offset=paramList[0])
+                    else:
+                        ds = DSModifiers(na=2, offset0=paramList[0], offset1=paramList[1])
+                    LocalReadX = instruction.getInst(highBits)
+                    localReadCode.add(LocalReadX(dst=destVgpr, src=srcAddr, ds=ds, comment=comment))
+                    # TODO - handle vector-load
+                    with writer.allocTmpSgpr(1) as tmpSgprInfo:
+                        tmpSgpr = tmpSgprInfo.idx
+
+                        if writer.db["CheckValue1%s"%tc] and not writer.inTailLoop:
+                            dbgVgpr = destVgpr
+                            dbgVgprList = destVgpr.split("v[")
+                            if len(dbgVgprList) == 1: # vIdx, no []
+                                dbgVgpr = dbgVgprList[0]
+                            else:
+                                # We only check the first one now
+                                # TODO: Handle vector, but need to take care the last one
+                                dbgVgprList = (dbgVgprList[1].split("]")[0]).split(':')
+                                dbgVgpr = "v[%s]"%dbgVgprList[0]
+                            localReadCode.add(SWaitCnt(dscnt=0, vscnt=0, comment="CheckValue1 wait for LDS read"))
+
+                            if kernel["ProblemType"]["DataType"].isHalf():
+                                hexValue = hex(0x3c003c00)     # packed 1s
+                                if needPack:
+                                    hexValue = hex(0x3c000000) if highBitsForHalf else hex(0x00003c00)
+                                localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: FP16"))
+                                localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
+
+                            elif kernel["ProblemType"]["DataType"].isBFloat16():
+                                hexValue = hex(0x3f803f80)     # packed 1s
+                                if needPack:
+                                    hexValue = hex(0x3f800000) if highBitsForHalf else hex(0x00003f80)
+                                localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: BF16"))
+                                localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
+
+                            if kernel["ProblemType"]["DataType"].isInt8():
+                                if needPack:
+                                    hexValue = hex(0x00010000) if isHigh16Bits else hex(0x00000001)
+                                    localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: INT8"))
                                     localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
 
-                                elif kernel["ProblemType"]["DataType"].isBFloat16():
-                                    hexValue = hex(0x3f803f80)     # packed 1s
-                                    if needPack:
-                                        hexValue = hex(0x3f800000) if highBitsForHalf else hex(0x00003f80)
-                                    localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: BF16"))
-                                    localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
+                            # TODO - Check if this works. But need this? MFMA would use INT8
+                            elif kernel["ProblemType"]["DataType"].isInt8x4():
+                                localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hex(0x01010101), comment="CheckValue1: INT8x4"))
+                                localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
 
-                                if kernel["ProblemType"]["DataType"].isInt8():
-                                    if needPack:
-                                        hexValue = hex(0x00010000) if isHigh16Bits else hex(0x00000001)
-                                        localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: INT8"))
-                                        localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
-
-                                # TODO - Check if this works. But need this? MFMA would use INT8
-                                elif kernel["ProblemType"]["DataType"].isInt8x4():
-                                    localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hex(0x01010101), comment="CheckValue1: INT8x4"))
-                                    localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
-
-                                elif kernel["ProblemType"]["DataType"].isSingle():
-                                    localReadCode.add(writer.assert_eq( dbgVgpr, 1.0) )
+                            elif kernel["ProblemType"]["DataType"].isSingle():
+                                localReadCode.add(writer.assert_eq( dbgVgpr, 1.0) )
         # DTV case, do not return local read code. Return pack code only.
         if (tP["isA"] or tP["isB"]) and kernel["DirectToVgpr%s"%tc]:
           imod = Module("LocalReadDo%s_I%s (Empty)" % (tP["tensorChar"],iui))

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -301,94 +301,94 @@ class LocalReadMFMA(LocalRead):
             # Use while loop to generate the correct number of local read instructions
             readCount = 0
             while readCount < localReadsForThisSubTile:
-                # Calculate current vIdx and eIdx from the global read index
-                globalReadIdx = startReadIdx + readCount
-                vIdx = globalReadIdx // numReadsPerVector
-                eIdx = globalReadIdx % numReadsPerVector
-                # Calculate valufIdx based on current vIdx and eIdx
-                if numVectorsPerTile == 1:
-                    valufIdx = eIdx * blockWidth * numReadsPerUnroll
-                else:
-                    valufIdx = (vIdx * numReadsPerVector + eIdx) * blockWidth * numReadsPerUnroll
+                    # Calculate current vIdx and eIdx from the global read index
+                    globalReadIdx = startReadIdx + readCount
+                    vIdx = globalReadIdx // numReadsPerVector
+                    eIdx = globalReadIdx % numReadsPerVector
+                    # Calculate valufIdx based on current vIdx and eIdx
+                    if numVectorsPerTile == 1:
+                        valufIdx = eIdx * blockWidth * numReadsPerUnroll
+                    else:
+                        valufIdx = (vIdx * numReadsPerVector + eIdx) * blockWidth * numReadsPerUnroll
 
-                valuiIdx = int(valufIdx)
-                baseValuiIdx = valuiIdx
-                localReadCode = imod.add(Module("LocalRead%s Valu%u"%(tc,valuiIdx)))
-                readCount += 1
-                if needPack or numSplitMetadata:
-                    packCode = pack.add(Module("packCode"))
-
-                tmpvgprHI = []
-                for rIdx in range(0, numReadsPerUnroll):
                     valuiIdx = int(valufIdx)
-                    baseLRVgpr = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx), numVgpr)
-                    destVgpr = baseLRVgpr
-                    highBitsForHalf = (blockWidth == 0.5) and ((rIdx % 2) == 1) # rIdx = 1
-                    isHigh16Bits = (blockWidth == 0.25) and ( ((rIdx % 4) //2) == 1) # 2,3
-
+                    baseValuiIdx = valuiIdx
+                    localReadCode = imod.add(Module("LocalRead%s Valu%u"%(tc,valuiIdx)))
+                    readCount += 1
                     if needPack or numSplitMetadata:
-                        if kernel["UseF32XEmulation"]:
-                            if valuiIdx % 4 == 0:
-                                tmpvgprIDx = (valuiIdx % 8) // 4
-                                tmpvgprHI.append(writer.vgprPool.checkOutAligned(2, 2))
-                                numTmpForCVTSubTF32 = 4
-                                tmpvgpr =[]
-                                for i in range(numTmpForCVTSubTF32):
-                                    tmpvgpr.append(writer.vgprPool.checkOut(1))
+                        packCode = pack.add(Module("packCode"))
 
-                                v0 = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx))
-                                v1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, valuiIdx))
-                                v2 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, valuiIdx))
-                                v3 = vgpr("Valu%s_X%u_I%u+%u+3"%(tc, bufferIdx, iui, valuiIdx))
+                    tmpvgprHI = []
+                    for rIdx in range(0, numReadsPerUnroll):
+                        valuiIdx = int(valufIdx)
+                        baseLRVgpr = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx), numVgpr)
+                        destVgpr = baseLRVgpr
+                        highBitsForHalf = (blockWidth == 0.5) and ((rIdx % 2) == 1) # rIdx = 1
+                        isHigh16Bits = (blockWidth == 0.25) and ( ((rIdx % 4) //2) == 1) # 2,3
 
-                                packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]), src0=v0, src1=v1))
+                        if needPack or numSplitMetadata:
+                            if kernel["UseF32XEmulation"]:
+                                if valuiIdx % 4 == 0:
+                                    tmpvgprIDx = (valuiIdx % 8) // 4
+                                    tmpvgprHI.append(writer.vgprPool.checkOutAligned(2, 2))
+                                    numTmpForCVTSubTF32 = 4
+                                    tmpvgpr =[]
+                                    for i in range(numTmpForCVTSubTF32):
+                                        tmpvgpr.append(writer.vgprPool.checkOut(1))
 
-                                packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[0]), src=vgpr(tmpvgprHI[tmpvgprIDx])))
-                                packCode.add(VSubF32(dst=v0, src0=v0, src1=vgpr(tmpvgpr[0])))
-                                packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[1]), src=vgpr(tmpvgprHI[tmpvgprIDx]), vgprMask=None, vi=1))
-                                packCode.add(VSubF32(dst=v1, src0=v1, src1=vgpr(tmpvgpr[1])))
+                                    v0 = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx))
+                                    v1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, valuiIdx))
+                                    v2 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, valuiIdx))
+                                    v3 = vgpr("Valu%s_X%u_I%u+%u+3"%(tc, bufferIdx, iui, valuiIdx))
 
-                                packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]+1), src0=v2, src1=v3))
-                                packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1)))
-                                packCode.add(VSubF32(dst=v2, src0=v2, src1=vgpr(tmpvgpr[2])))
-                                packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1), vgprMask=None, vi=1))
-                                packCode.add(VSubF32(dst=v3, src0=v3, src1=vgpr(tmpvgpr[2])))
+                                    packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]), src0=v0, src1=v1))
 
-                                for i in range(numTmpForCVTSubTF32):
-                                    writer.vgprPool.checkIn(tmpvgpr[i])
+                                    packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[0]), src=vgpr(tmpvgprHI[tmpvgprIDx])))
+                                    packCode.add(VSubF32(dst=v0, src0=v0, src1=vgpr(tmpvgpr[0])))
+                                    packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[1]), src=vgpr(tmpvgprHI[tmpvgprIDx]), vgprMask=None, vi=1))
+                                    packCode.add(VSubF32(dst=v1, src0=v1, src1=vgpr(tmpvgpr[1])))
 
-                            if rIdx == numReadsPerUnroll - 1: # Last iteration
-                                if not (kernel["MatrixInstM"] == 16 and kernel["MatrixInstK"] == 16):
-                                    v0 = vgpr("Valu%s_X%u_I%u+%u+0"%(tc, bufferIdx, iui, baseValuiIdx))
-                                    v1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, baseValuiIdx))
-                                    v2 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, baseValuiIdx))
-                                    v3 = vgpr("Valu%s_X%u_I%u+%u+3"%(tc, bufferIdx, iui, baseValuiIdx))
-                                    v4 = vgpr("Valu%s_X%u_I%u+%u+4"%(tc, bufferIdx, iui, baseValuiIdx))
-                                    v5 = vgpr("Valu%s_X%u_I%u+%u+5"%(tc, bufferIdx, iui, baseValuiIdx))
-                                    v6 = vgpr("Valu%s_X%u_I%u+%u+6"%(tc, bufferIdx, iui, baseValuiIdx))
-                                    v7 = vgpr("Valu%s_X%u_I%u+%u+7"%(tc, bufferIdx, iui, baseValuiIdx))
-                                    packCode.add(VCvtPkF32toBF16(dst=v7, src0=v6, src1=v7))
-                                    packCode.add(VCvtPkF32toBF16(dst=v6, src0=v4, src1=v5))
-                                    packCode.add(VCvtPkF32toBF16(dst=v5, src0=v2, src1=v3))
-                                    packCode.add(VCvtPkF32toBF16(dst=v4, src0=v0, src1=v1))
-                                    tmpvgprHI064  = vgpr(tmpvgprHI[0], 2)
-                                    tmpvgprHI164  = vgpr(tmpvgprHI[1], 2)
-                                    valuvgprHI064 = vgpr("Valu%s_X%u_I%u+%u+0"%(tc, bufferIdx, iui, baseValuiIdx), 2)
-                                    valuvgprHI164 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, baseValuiIdx), 2)
-                                    packCode.add(VMovB64(dst=valuvgprHI064, src=tmpvgprHI064))
-                                    packCode.add(VMovB64(dst=valuvgprHI164, src=tmpvgprHI164))
-                                    for i in range(len(tmpvgprHI)):
-                                        writer.vgprPool.checkIn(tmpvgprHI[i])
+                                    packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]+1), src0=v2, src1=v3))
+                                    packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1)))
+                                    packCode.add(VSubF32(dst=v2, src0=v2, src1=vgpr(tmpvgpr[2])))
+                                    packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1), vgprMask=None, vi=1))
+                                    packCode.add(VSubF32(dst=v3, src0=v3, src1=vgpr(tmpvgpr[2])))
 
-                                # layout:
-                                # Val+0: bf16 high (0,1)
-                                # Val+1: bf16 high (2,3)
-                                # Val+2: bf16 high (4,5)
-                                # Val+3: bf16 high (6,7)
-                                # Val+4: bf16 low  (0,1)
-                                # Val+5: bf16 low  (2,3)
-                                # Val+6: bf16 low  (4,5)
-                                # Val+7: bf16 low  (6,7)
+                                    for i in range(numTmpForCVTSubTF32):
+                                        writer.vgprPool.checkIn(tmpvgpr[i])
+
+                                if rIdx == numReadsPerUnroll - 1: # Last iteration
+                                    if not (kernel["MatrixInstM"] == 16 and kernel["MatrixInstK"] == 16):
+                                        v0 = vgpr("Valu%s_X%u_I%u+%u+0"%(tc, bufferIdx, iui, baseValuiIdx))
+                                        v1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, baseValuiIdx))
+                                        v2 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, baseValuiIdx))
+                                        v3 = vgpr("Valu%s_X%u_I%u+%u+3"%(tc, bufferIdx, iui, baseValuiIdx))
+                                        v4 = vgpr("Valu%s_X%u_I%u+%u+4"%(tc, bufferIdx, iui, baseValuiIdx))
+                                        v5 = vgpr("Valu%s_X%u_I%u+%u+5"%(tc, bufferIdx, iui, baseValuiIdx))
+                                        v6 = vgpr("Valu%s_X%u_I%u+%u+6"%(tc, bufferIdx, iui, baseValuiIdx))
+                                        v7 = vgpr("Valu%s_X%u_I%u+%u+7"%(tc, bufferIdx, iui, baseValuiIdx))
+                                        packCode.add(VCvtPkF32toBF16(dst=v7, src0=v6, src1=v7))
+                                        packCode.add(VCvtPkF32toBF16(dst=v6, src0=v4, src1=v5))
+                                        packCode.add(VCvtPkF32toBF16(dst=v5, src0=v2, src1=v3))
+                                        packCode.add(VCvtPkF32toBF16(dst=v4, src0=v0, src1=v1))
+                                        tmpvgprHI064  = vgpr(tmpvgprHI[0], 2)
+                                        tmpvgprHI164  = vgpr(tmpvgprHI[1], 2)
+                                        valuvgprHI064 = vgpr("Valu%s_X%u_I%u+%u+0"%(tc, bufferIdx, iui, baseValuiIdx), 2)
+                                        valuvgprHI164 = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, baseValuiIdx), 2)
+                                        packCode.add(VMovB64(dst=valuvgprHI064, src=tmpvgprHI064))
+                                        packCode.add(VMovB64(dst=valuvgprHI164, src=tmpvgprHI164))
+                                        for i in range(len(tmpvgprHI)):
+                                            writer.vgprPool.checkIn(tmpvgprHI[i])
+
+                                    # layout:
+                                    # Val+0: bf16 high (0,1)
+                                    # Val+1: bf16 high (2,3)
+                                    # Val+2: bf16 high (4,5)
+                                    # Val+3: bf16 high (6,7)
+                                    # Val+4: bf16 low  (0,1)
+                                    # Val+5: bf16 low  (2,3)
+                                    # Val+6: bf16 low  (4,5)
+                                    # Val+7: bf16 low  (6,7)
 
 
                             if kernel["ConvertAfterDS"] and (tP["bpe"] != tP["bpeDS"]):
@@ -667,139 +667,139 @@ class LocalReadMFMA(LocalRead):
                                         if isHigh8Bits and isHigh16Bits:
                                             packCode.add(VLShiftLeftOrB32(dst=baseLRVgpr, src0=highVgpr, shiftHex=hex(0x8), src1=baseLRVgpr, comment="pack two int8x2 Vgpr to one Vgpr"))
 
-                    if kernel["ConvertAfterDS"] and kernel["UnrollMajorLDS%s"%tc]:
-                        valufIdx += blockWidth * (tP["bpe"] // tP["bpeDS"]) if (not tP["isM"]) else 1
-                    else:
-                        valufIdx += blockWidth if (not tP["isM"]) else 1
-
-                    # load read instrution
-                    paramList = []
-
-                    for oIdx in range(0, numOffsets):
-                        offset_val = (eIdx + (vIdx * numOffsets+oIdx) * MIWaveGroupShape[tile01]) * tileStride
-
-                        if kernel["ProblemType"]["Sparse"] != 0:
-                            if blocksPerTGroupSMFMA > 1:
-                                blockId = (rIdx * numElementPerRead) // elementsPerBlockSMFMA  #block 0 or block 1
-                                if kernel["UnrollMajorLDS%s"%(tc)]:
-                                    offset_val = offset_val + (blockOffsetSMFMA * blockId)
-                                else:
-                                    offset_val = offset_val + (blockOffsetSMFMA * blockId) * UnrollStride
-                            offset_val = (rIdx * numElementPerRead * UnrollStride + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
-                        elif kernel["ProblemType"]["DataType"].is8bitFloat() and kernel["MatrixInstK"] > 32:
-                            incOffset = 0
-                            midIdx = numReadsPerUnroll // 2
-                            if rIdx >= midIdx:
-                                if kernel["UnrollMajorLDS%s" % tP["tensorChar"]] == False:
-                                    # TODO: why are these the offsets???
-                                    if kernel["MatrixInstM"] == 32:
-                                         incOffset = midIdx * numElementPerRead * UnrollStride
-                                    elif kernel["MatrixInstM"] == 16:
-                                        incOffset = 3 * midIdx * numElementPerRead * UnrollStride
-                                else:
-                                    if kernel["MatrixInstM"] == 32:
-                                        incOffset = 16
-                                    elif kernel["MatrixInstM"] == 16:
-                                        incOffset = 48
-                            incOffset = rIdx * numElementPerRead * UnrollStride + incOffset
-                            offset_val = (incOffset + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
-                        elif kernel["UseF32XEmulation"]:
-                            # Previously a single ds_read could be used to load all inputs for mfma
-                            # For emulated TF32, 2x ds_read is required along with a different mfma layout
-                            # so we need to adjust the offsets accordingly for the second ds_read.
-                            # Numbers here are specific to the mfma layout
-                            incOffset = 0
-                            midIdx = numReadsPerUnroll // 2
-                            if rIdx >= midIdx:
-                                if kernel["UnrollMajorLDS%s" % tP["tensorChar"]] == False:
-                                    if kernel["MatrixInstM"] == 32:
-                                        incOffset = midIdx * numElementPerRead * UnrollStride
-                                    elif kernel["MatrixInstM"] == 16:
-                                        incOffset = 3 * midIdx * numElementPerRead * UnrollStride
-                                else:
-                                    if kernel["MatrixInstM"] == 32 and kernel["MatrixInstK"] == 16:
-                                        incOffset = 4
-                                    elif kernel["MatrixInstM"] == 16 and kernel["MatrixInstK"] == 32:
-                                        incOffset = 12
-                            incOffset = rIdx * numElementPerRead * UnrollStride + incOffset
-                            offset_val = (incOffset + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
+                        if kernel["ConvertAfterDS"] and kernel["UnrollMajorLDS%s"%tc]:
+                            valufIdx += blockWidth * (tP["bpe"] // tP["bpeDS"]) if (not tP["isM"]) else 1
                         else:
-                            offset_val = (rIdx * numElementPerRead * UnrollStride + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
+                            valufIdx += blockWidth if (not tP["isM"]) else 1
 
-                        if (kernel["LdsBlockSizePerPad%s"%tc] != 0) and (kernel["LdsPad%s"%tc] != 0):
-                            offset_val = offset_val + (offset_val // kernel["LdsBlockSizePerPad%s"%tc]) * kernel["LdsPad%s"%tc] * tP["bpeDS"]
-                        offset_val = offset_val + tP["localReadSwapByteOffset"]
-                        if (kernel["DirectToLds%s" % tc] and  \
-                            kernel["GlobalReadVectorWidth%c"%tc] * tP["bpeDS"] > 4):
-                          # another address conversion for DirectToLds + NumLoadsCoalesced > 1
-                          dummy, offset_val = writer.lraOffsetConversionForDTLandNLC(kernel, tP, offset_val)
+                        # load read instrution
+                        paramList = []
 
-                        paramList.append(int(offset_val))
+                        for oIdx in range(0, numOffsets):
+                            offset_val = (eIdx + (vIdx * numOffsets+oIdx) * MIWaveGroupShape[tile01]) * tileStride
 
-                    comment = "L -> Reg lro=%d swapByteOffset=%u ti=%u vIdx=%u eIdx=%u rIdx=%u oIdx=%u buffer=%u iui=%u" \
-                            % (tP["localReadOffset"], tP["localReadSwapByteOffset"], MIWaveGroupShape[tile01], vIdx, eIdx, rIdx, oIdx, bufferIdx, iui)
-
-                    highBits = 0 if writer.states.archCaps["DSLow16NotPreserve"] else highBitsForHalf or isHigh16Bits
-
-
-                    if(paramList[0] >=131072):
-                        paramList[0] = paramList[0] -131072
-                        srcAddr=vgpr("LocalReadAddr%s+2"%tc)
-                    elif (paramList[0] >=65536):
-                        paramList[0] = paramList[0] -65536
-                        srcAddr=vgpr("LocalReadAddr%s+1"%tc)
-                    else:
-                        srcAddr=vgpr("LocalReadAddr%s"%tc)
-
-                    if numOffsets == 1:
-                        ds = DSModifiers(na=1, offset=paramList[0])
-                    else:
-                        ds = DSModifiers(na=2, offset0=paramList[0], offset1=paramList[1])
-                    LocalReadX = instruction.getInst(highBits)
-                    localReadCode.add(LocalReadX(dst=destVgpr, src=srcAddr, ds=ds, comment=comment))
-                    # TODO - handle vector-load
-                    with writer.allocTmpSgpr(1) as tmpSgprInfo:
-                        tmpSgpr = tmpSgprInfo.idx
-
-                        if writer.db["CheckValue1%s"%tc] and not writer.inTailLoop:
-                            dbgVgpr = destVgpr
-                            dbgVgprList = destVgpr.split("v[")
-                            if len(dbgVgprList) == 1: # vIdx, no []
-                                dbgVgpr = dbgVgprList[0]
+                            if kernel["ProblemType"]["Sparse"] != 0:
+                                if blocksPerTGroupSMFMA > 1:
+                                    blockId = (rIdx * numElementPerRead) // elementsPerBlockSMFMA  #block 0 or block 1
+                                    if kernel["UnrollMajorLDS%s"%(tc)]:
+                                        offset_val = offset_val + (blockOffsetSMFMA * blockId)
+                                    else:
+                                        offset_val = offset_val + (blockOffsetSMFMA * blockId) * UnrollStride
+                                offset_val = (rIdx * numElementPerRead * UnrollStride + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
+                            elif kernel["ProblemType"]["DataType"].is8bitFloat() and kernel["MatrixInstK"] > 32:
+                                incOffset = 0
+                                midIdx = numReadsPerUnroll // 2
+                                if rIdx >= midIdx:
+                                    if kernel["UnrollMajorLDS%s" % tP["tensorChar"]] == False:
+                                        # TODO: why are these the offsets???
+                                        if kernel["MatrixInstM"] == 32:
+                                             incOffset = midIdx * numElementPerRead * UnrollStride
+                                        elif kernel["MatrixInstM"] == 16:
+                                            incOffset = 3 * midIdx * numElementPerRead * UnrollStride
+                                    else:
+                                        if kernel["MatrixInstM"] == 32:
+                                            incOffset = 16
+                                        elif kernel["MatrixInstM"] == 16:
+                                            incOffset = 48
+                                incOffset = rIdx * numElementPerRead * UnrollStride + incOffset
+                                offset_val = (incOffset + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
+                            elif kernel["UseF32XEmulation"]:
+                                # Previously a single ds_read could be used to load all inputs for mfma
+                                # For emulated TF32, 2x ds_read is required along with a different mfma layout
+                                # so we need to adjust the offsets accordingly for the second ds_read.
+                                # Numbers here are specific to the mfma layout
+                                incOffset = 0
+                                midIdx = numReadsPerUnroll // 2
+                                if rIdx >= midIdx:
+                                    if kernel["UnrollMajorLDS%s" % tP["tensorChar"]] == False:
+                                        if kernel["MatrixInstM"] == 32:
+                                            incOffset = midIdx * numElementPerRead * UnrollStride
+                                        elif kernel["MatrixInstM"] == 16:
+                                            incOffset = 3 * midIdx * numElementPerRead * UnrollStride
+                                    else:
+                                        if kernel["MatrixInstM"] == 32 and kernel["MatrixInstK"] == 16:
+                                            incOffset = 4
+                                        elif kernel["MatrixInstM"] == 16 and kernel["MatrixInstK"] == 32:
+                                            incOffset = 12
+                                incOffset = rIdx * numElementPerRead * UnrollStride + incOffset
+                                offset_val = (incOffset + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
                             else:
-                                # We only check the first one now
-                                # TODO: Handle vector, but need to take care the last one
-                                dbgVgprList = (dbgVgprList[1].split("]")[0]).split(':')
-                                dbgVgpr = "v[%s]"%dbgVgprList[0]
-                            localReadCode.add(SWaitCnt(dscnt=0, vscnt=0, comment="CheckValue1 wait for LDS read"))
+                                offset_val = (rIdx * numElementPerRead * UnrollStride + offset_val + tP["localReadOffset"]) * tP["bpeDS"]
 
-                            if kernel["ProblemType"]["DataType"].isHalf():
-                                hexValue = hex(0x3c003c00)     # packed 1s
-                                if needPack:
-                                    hexValue = hex(0x3c000000) if highBitsForHalf else hex(0x00003c00)
-                                localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: FP16"))
-                                localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
+                            if (kernel["LdsBlockSizePerPad%s"%tc] != 0) and (kernel["LdsPad%s"%tc] != 0):
+                                offset_val = offset_val + (offset_val // kernel["LdsBlockSizePerPad%s"%tc]) * kernel["LdsPad%s"%tc] * tP["bpeDS"]
+                            offset_val = offset_val + tP["localReadSwapByteOffset"]
+                            if (kernel["DirectToLds%s" % tc] and  \
+                                kernel["GlobalReadVectorWidth%c"%tc] * tP["bpeDS"] > 4):
+                              # another address conversion for DirectToLds + NumLoadsCoalesced > 1
+                              dummy, offset_val = writer.lraOffsetConversionForDTLandNLC(kernel, tP, offset_val)
 
-                            elif kernel["ProblemType"]["DataType"].isBFloat16():
-                                hexValue = hex(0x3f803f80)     # packed 1s
-                                if needPack:
-                                    hexValue = hex(0x3f800000) if highBitsForHalf else hex(0x00003f80)
-                                localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: BF16"))
-                                localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
+                            paramList.append(int(offset_val))
 
-                            if kernel["ProblemType"]["DataType"].isInt8():
-                                if needPack:
-                                    hexValue = hex(0x00010000) if isHigh16Bits else hex(0x00000001)
-                                    localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: INT8"))
+                        comment = "L -> Reg lro=%d swapByteOffset=%u ti=%u vIdx=%u eIdx=%u rIdx=%u oIdx=%u buffer=%u iui=%u" \
+                                % (tP["localReadOffset"], tP["localReadSwapByteOffset"], MIWaveGroupShape[tile01], vIdx, eIdx, rIdx, oIdx, bufferIdx, iui)
+
+                        highBits = 0 if writer.states.archCaps["DSLow16NotPreserve"] else highBitsForHalf or isHigh16Bits
+
+
+                        if(paramList[0] >=131072):
+                            paramList[0] = paramList[0] -131072
+                            srcAddr=vgpr("LocalReadAddr%s+2"%tc)
+                        elif (paramList[0] >=65536):
+                            paramList[0] = paramList[0] -65536
+                            srcAddr=vgpr("LocalReadAddr%s+1"%tc)
+                        else:
+                            srcAddr=vgpr("LocalReadAddr%s"%tc)
+
+                        if numOffsets == 1:
+                            ds = DSModifiers(na=1, offset=paramList[0])
+                        else:
+                            ds = DSModifiers(na=2, offset0=paramList[0], offset1=paramList[1])
+                        LocalReadX = instruction.getInst(highBits)
+                        localReadCode.add(LocalReadX(dst=destVgpr, src=srcAddr, ds=ds, comment=comment))
+                        # TODO - handle vector-load
+                        with writer.allocTmpSgpr(1) as tmpSgprInfo:
+                            tmpSgpr = tmpSgprInfo.idx
+                            if writer.db["CheckValue1%s"%tc] and not writer.inTailLoop:
+
+                                dbgVgpr = destVgpr
+                                dbgVgprList = destVgpr.split("v[")
+                                if len(dbgVgprList) == 1: # vIdx, no []
+                                    dbgVgpr = dbgVgprList[0]
+                                else:
+                                    # We only check the first one now
+                                    # TODO: Handle vector, but need to take care the last one
+                                    dbgVgprList = (dbgVgprList[1].split("]")[0]).split(':')
+                                    dbgVgpr = "v[%s]"%dbgVgprList[0]
+                                localReadCode.add(SWaitCnt(dscnt=0, vscnt=0, comment="CheckValue1 wait for LDS read"))
+
+                                if kernel["ProblemType"]["DataType"].isHalf():
+                                    hexValue = hex(0x3c003c00)     # packed 1s
+                                    if needPack:
+                                        hexValue = hex(0x3c000000) if highBitsForHalf else hex(0x00003c00)
+                                    localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: FP16"))
                                     localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
 
-                            # TODO - Check if this works. But need this? MFMA would use INT8
-                            elif kernel["ProblemType"]["DataType"].isInt8x4():
-                                localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hex(0x01010101), comment="CheckValue1: INT8x4"))
-                                localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
+                                elif kernel["ProblemType"]["DataType"].isBFloat16():
+                                    hexValue = hex(0x3f803f80)     # packed 1s
+                                    if needPack:
+                                        hexValue = hex(0x3f800000) if highBitsForHalf else hex(0x00003f80)
+                                    localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: BF16"))
+                                    localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
 
-                            elif kernel["ProblemType"]["DataType"].isSingle():
-                                localReadCode.add(writer.assert_eq( dbgVgpr, 1.0) )
+                                if kernel["ProblemType"]["DataType"].isInt8():
+                                    if needPack:
+                                        hexValue = hex(0x00010000) if isHigh16Bits else hex(0x00000001)
+                                        localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hexValue, comment="CheckValue1: INT8"))
+                                        localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
+
+                                # TODO - Check if this works. But need this? MFMA would use INT8
+                                elif kernel["ProblemType"]["DataType"].isInt8x4():
+                                    localReadCode.add(SMovB32(dst=sgpr(tmpSgpr), src=hex(0x01010101), comment="CheckValue1: INT8x4"))
+                                    localReadCode.add(writer.assert_eq( dbgVgpr, sgpr(tmpSgpr)))
+
+                                elif kernel["ProblemType"]["DataType"].isSingle():
+                                    localReadCode.add(writer.assert_eq( dbgVgpr, 1.0) )
         # DTV case, do not return local read code. Return pack code only.
         if (tP["isA"] or tP["isB"]) and kernel["DirectToVgpr%s"%tc]:
           imod = Module("LocalReadDo%s_I%s (Empty)" % (tP["tensorChar"],iui))

--- a/projects/hipblaslt/tensilelite/Tensile/Components/SIA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/SIA.py
@@ -33,7 +33,7 @@ from ..Component import SIA
 
 from copy import deepcopy
 from typing import Tuple
-
+import math
 PRECISION = 100
 class SIA3(SIA):
     kernel = {"ScheduleIterAlg": 3}
@@ -55,8 +55,9 @@ class SIA3(SIA):
             numLocalWriteModPerMfma = roundUp(kernel["LocalWritePerMfma"]*PRECISION)
 
         writer.states.numGlobalReadInsPerMfma, writer.states.numLocalWriteModPerMfma = calculateGRPMandLWPM(writer, kernel, numLocalWriteModPerMfma)
-        localWriteEndIter = fixLocalWriteEndMfmaIndex(writer, kernel, tensorParametersA, tensorParametersB, \
-            globalReadIncACode, globalReadIncBCode, numMfmaBetweenLWandBarrier, lastLoop)
+        if not kernel["ForceUnrollSubIter"]:
+            localWriteEndIter = fixLocalWriteEndMfmaIndex(writer, kernel, tensorParametersA, tensorParametersB, \
+                globalReadIncACode, globalReadIncBCode, numMfmaBetweenLWandBarrier, lastLoop)
         numGlobalReadInsPerIter, numLocalWriteModPerIter, numEmptyGlobalReadIncCode = getScheduleParamMfma(writer)
         numLocalWritesPerSched = writer.states.numLocalWriteModPerMfma
         # Schedule global read
@@ -258,6 +259,16 @@ def getLocalWriteMFMAEnd(writer, kernel, tensorParametersA, tensorParametersB):
     # final index definition
     writer.states.numMfmaForNextLoopLR = min(writer.states.numMfmaForNextLoopLR,numMfmaPerIter-1)
     writer.states.syncPlrMfmaIndex = numMfmaPerIter*(kernel["LoopIters"]-writer.states.numItersPLR+1) - writer.states.numMfmaForNextLoopLR - 1 if writer.states.numItersPLR else 0
+    if kernel["ForceUnrollSubIter"]:
+        mfmaiter0 =  math.ceil(kernel["MIWaveTile"][0]/2) * math.ceil(kernel["MIWaveTile"][1]/2)
+        mfmaiter1 = math.floor(kernel["MIWaveTile"][0]/2) * math.ceil(kernel["MIWaveTile"][1]/2)
+        mfmaiter2 = math.ceil(kernel["MIWaveTile"][0]/2) * math.floor(kernel["MIWaveTile"][1]/2)
+        writer.states.syncPlrMfmaIndex = (mfmaiter0 + mfmaiter1 + mfmaiter2)
+        if ( kernel["UseF32XEmulation"]) :
+            writer.states.syncPlrMfmaIndex = writer.states.syncPlrMfmaIndex *3   # TF32
+        elif ( kernel["ProblemType"]["DataType"].isComplex()):
+            writer.states.syncPlrMfmaIndex = writer.states.syncPlrMfmaIndex *4   # Complex
+
     numMfmaBetweenLWandBarrier = 2 if kernel["MatrixInstM"] == 32 else 3
     writer.states.lwEndMfmaIndex = max(writer.states.syncPlrMfmaIndex - numMfmaBetweenLWandBarrier,0) if writer.states.numItersPLR else numMfmaPerIter*kernel["LoopIters"] - 1
     if kernel["DirectToLds"] and kernel["PrefetchGlobalRead"] == 2:
@@ -731,6 +742,8 @@ def assignLWSchedIndexSIA3(writer, kernel, numLocalWritesPerSched, localWriteEnd
     if kernel["1LDSBuffer"] or kernel["DirectToLds"]:
         writer.states.sync1LdsMfmaIndex = max(writer.states.lwStartMfmaIndex - 1, 0)
     startIter = writer.states.lwStartMfmaIndex//numMfmaPerIter
+    if kernel["ForceUnrollSubIter"]:
+        startIter = min(1,startIter) # if ForceUnrollSubIter, startIter should be 0 or 1
     assert startIter < localWriteEndIter+1 # startIter should be at or before the endIter
     return startIter
 

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -51,6 +51,7 @@ from .Common import printWarning, roundUp, print2, DebugConfig, DataDirection, \
 from Tensile.SolutionStructs.Naming import getKernelNameMin
 from Tensile.Toolchain.Component import Assembler
 
+import math
 import abc
 import sys
 import collections
@@ -176,7 +177,9 @@ class StateValues:
   lrvwUnrollMetadata: int                       = 0 # For Sparse Metadat
 
   numMfmaPerIter: int                    = 0
-
+  SubTileIdxA: int                       = 0
+  SubTileIdxB: int                       = 0
+  mfmaIndex: int                         = -1  # For MFMA, index of the current mfma instruction
   numReadsIterCoalescedA: int            = 0
   numReadsIterCoalescedB: int            = 0
   numReadsIterCoalescedMetadata: int     = 0
@@ -767,6 +770,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       isBarrier = kernel["LoopIters"] - self.states.numItersPLR
       writeItems = list(localWriteCode.items())
       macIterItems = macIterCode.flatitems()
+      numMfmaPerIter = len(macIterItems)
       skipLocalWriteWaitcnt = 0
       localReadsWaitcnt = 0
       localReadsIssuedInThisIter = 0
@@ -1284,6 +1288,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
                 skipLocalWriteWaitcnt += countLocalWrite(writeItem) + countDSStoreB256(writeItem)
               if not localReadItemsThisLoop:
                 self.states.perIterLocalWriteCanSkip[iteration] += countLocalWrite(writeItem) + countDSStoreB256(writeItem)
+          if kernel["ForceUnrollSubIter"] and (writeItems and i == (numMfmaPerIter - 1)):
+            # if ForceUnrollSubIter, we need to schedule all localWrite in last mfma
+            while writeItems:      
+              writeItem = writeItems.pop(0)
+              iterCode.add(writeItem)
         if mfmaIndex == self.states.lwEndMfmaIndex:
           while writeItems:
             localWriteCodeCounts.pop(0)
@@ -1748,7 +1757,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
           if ((iteration < numReadsIterB and not dataAtIterB < max(dataAtIterA,dataAtIterB)) or numPrefetchIter) and (not kernel["DirectToVgprB"]):
             localReads -= self.states.numReadsPerIterB
           localReads += localReadsWaitcnt
-          if iteration == 0 and kernel["UnrollMajorLDSB"] and not (kernel["ProblemType"]["DataTypeB"].isAnyFloat8() and kernel["ConvertAfterDS"]):
+          if iteration == 0 and kernel["UnrollMajorLDSB"] and not (kernel["ForceUnrollSubIter"] or (kernel["ProblemType"]["DataTypeB"].isAnyFloat8() and kernel["ConvertAfterDS"])):
             # We issued LR with A[0]->B[0]->A[1:]->B[1:] order.
             # We need to calculate how many B[N:] needed by 1st mfma.
             # If not UnrollMajorLDSB, we have packB which will be issued ahead.
@@ -2096,12 +2105,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
           self.makeSchedule(kernel, tensorParametersA, tensorParametersB, localWriteEndIter, skipGlobalReadInc=False, lastLoop=NLLlast, isNGLL=isNGLL)
           module.add(self.codes.unrollLoopHeader)
 
+      if kernel["ForceUnrollSubIter"]:
+        self.states.lwStartMfmaIndex = math.floor((kernel["MIWaveTile"][1] + kernel["MIWaveTile"][0])/2) -1
+
       # which loop iteration to reset the LRO,
       # note if PLR=0, isResetLroIter is False for all u
-      isResetLroIter = (u == localWriteEndIter)
+      isResetLroIter = 1 if kernel["ForceUnrollSubIter"] else (u == localWriteEndIter)
       isSwapAndResetLwoIter = isResetLroIter
       isSwapLroIter = isResetLroIter
       if kernel["ScheduleIterAlg"] == 3:
+        if kernel["ForceUnrollSubIter"]:
+          isSwapAndResetLwoIter = 1
+        else:
           isSwapAndResetLwoIter = (u == self.states.lwEndMfmaIndex//(self.states.numMfmaPerIter))
 
       extraComment = ""
@@ -2114,8 +2129,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
             extraComment += " (swap and reset local write pointers iteration) "
         if isSwapLroIter:
             extraComment += " (swap local read pointers iteration) "
-
-      module.addComment1("iter %u%s"%(u,extraComment))
+      if kernel["ForceUnrollSubIter"]:
+        module.addComment1("subiter %u"%(u))
+      else:
+        module.addComment1("iter %u%s"%(u,extraComment))
       plrIdx = (u+pflr) % self.states.numVgprBuffer
       plrIdxDTV = (u+pflr) % kernel["LoopIters"]
       localReads = Module()
@@ -2152,6 +2169,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
       doReadA = (u < kernel["LoopIters"]/self.states.numIterPerCoalescedReadA - self.states.numItersPLR)
       doReadB = (u < kernel["LoopIters"]/self.states.numIterPerCoalescedReadB - self.states.numItersPLR)
       doReadM = (u < kernel["LoopIters"]/self.states.numIterPerCoalescedReadMetadata - self.states.numItersPLR)
+      if kernel["ForceUnrollSubIter"]:
+        doReadA = 1 if u == 0 else 0
+        doReadB = 1 if u == 0 else 0
+        doReadM = 1 if u == 0 else 0
       # reads for next loop
       doReadA = doReadA or (hasLiveLdsData and u > localWriteEndIter)
       doReadB = doReadB or (hasLiveLdsData and u > localWriteEndIter)
@@ -2171,6 +2192,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
           if needNextBufLR:
             localReads.add(localReadCodeA)
           pack[plrIdx*self.states.numIterPerCoalescedReadA].add(packCodeA)
+          if kernel["ForceUnrollSubIter"]:
+            pack[1] = Module()
+            pack[1].add(packCodeA)
         if doReadM:
           localReads.addComment1("local read metadata")
           localReadCodeM, packCodeM = self.localReadDo(kernel, plrIdx*self.states.numIterPerCoalescedReadMetadata, iui*self.states.numReadsIterCoalescedMetadata, 0, tPM)
@@ -2184,6 +2208,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
             # DTV + pack or input conversion case, offset bufferIdx for local read packing instructions
             bufferIdx = plrIdxDTV*self.states.numIterPerCoalescedReadB + vregSetIdxLR * kernel["LoopIters"]
           localReadCodeB, packCodeB = self.localReadDo(kernel, bufferIdx, iui*self.states.numReadsIterCoalescedB, 0, tensorParametersB)
+          if kernel["ForceUnrollSubIter"]:
+            pack[1].add(packCodeB)
           if needNextBufLR:
             localReads.add(localReadCodeB)
           pack[plrIdx*self.states.numIterPerCoalescedReadB].add(packCodeB)
@@ -2222,10 +2248,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
             # Swap, reset, or increment the LRO:
             # force internalPointerSwap = False in NGLL case
             internalPointerSwap = expand and not isNGLL
-            pointerLRCode.addComment1("local read swap offsets a")
-            pointerLRCode.add(self.localReadSwapOffsets(kernel, internalPointerSwap, tensorParametersA))
-            pointerLRCode.addComment1("local read swap offsets b")
-            pointerLRCode.add(self.localReadSwapOffsets(kernel, internalPointerSwap, tensorParametersB))
+            if not kernel["ForceUnrollSubIter"] or (doReadA and (u<localWriteEndIter)):
+              pointerLRCode.addComment1("local read swap offsets a")
+              pointerLRCode.add(self.localReadSwapOffsets(kernel, internalPointerSwap, tensorParametersA))
+            if not kernel["ForceUnrollSubIter"] or (doReadB and (u<localWriteEndIter)):
+              pointerLRCode.addComment1("local read swap offsets b")
+              pointerLRCode.add(self.localReadSwapOffsets(kernel, internalPointerSwap, tensorParametersB))
             if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
               pointerLRCode.addComment1("local read swap offsets metadata")
               pointerLRCode.add(self.localReadSwapOffsets(kernel, internalPointerSwap, tPM))
@@ -2254,6 +2282,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
           module.add(self.getWaitcntCodeForDirectToVgpr(kernel, tensorParametersA, tensorParametersB, localWriteEndIter, u, isNLL=(not isNGLL), NLLlast=NLLlast))
 
       luIdx = u % self.states.numVgprBuffer # local to use for MACs
+      if kernel["ForceUnrollSubIter"]:
+        luIdx = u
       if kernel["EnableMatrixInstruction"]:
         macIterCode.add(self.mfmaIter(kernel, tensorParametersA, tensorParametersB, u, kernel["InnerUnroll"], vregSetIdxMFMA, unrollIdx = u))
       else:
@@ -2265,6 +2295,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
       subIterCode = self._makeSubIterSchedule(kernel, tensorParametersA, tensorParametersB, localReads, \
                       u, pointerLWCode, pointerLRCode, waitCode, macIterCode, waitLWCode, syncCode, pack[luIdx], module, NLLlast)
       module.add(subIterCode)
+      self.states.SubTileIdxA = (self.states.SubTileIdxA + 1) % kernel["numSubTilesA"]
+      self.states.SubTileIdxB = (self.states.SubTileIdxB + 1) % kernel["numSubTilesB"]
       pack[luIdx] = Module()
     return module
 
@@ -2501,11 +2533,17 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
       # which loop iteration to reset the LRO,
       # note if PLR=0, isResetLroIter is False for all u
-      isResetLroIter = (u == localWriteEndIter)
+      if kernel["ForceUnrollSubIter"]:
+        self.states.lwStartMfmaIndex = math.floor((kernel["MIWaveTile"][1] + kernel["MIWaveTile"][0])/2) -1
+                
+      isResetLroIter = 1 if kernel["ForceUnrollSubIter"] else (u == localWriteEndIter)
       isSwapAndResetLwoIter = isResetLroIter
       isSwapLroIter = isResetLroIter
       if kernel["ScheduleIterAlg"] == 3:
-        isSwapAndResetLwoIter = (u == self.states.lwEndMfmaIndex//(self.states.numMfmaPerIter))
+        if kernel["ForceUnrollSubIter"]:
+          isSwapAndResetLwoIter = 1
+        else:
+          isSwapAndResetLwoIter = (u == self.states.lwEndMfmaIndex//(self.states.numMfmaPerIter))
       extraComment = ""
       if isResetLroIter:
         extraComment += " (reset local read pointers iteration) "
@@ -2514,7 +2552,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
       if isSwapLroIter:
         extraComment += " (swap local read pointers iteration) "
 
-      module.addComment1("iter %u%s"%(u,extraComment))
+      if kernel["ForceUnrollSubIter"]:
+        module.addComment1("subiter %u"%(u))
+      else:
+        module.addComment1("iter %u%s"%(u,extraComment))
+
       plrIdx = (u+pflr) % self.states.numVgprBuffer
       plrIdxDTV = (u+pflr) % kernel["LoopIters"]
 
@@ -2550,6 +2592,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
       doReadA = (u < kernel["LoopIters"]/self.states.numIterPerCoalescedReadA - self.states.numItersPLR)
       doReadB = (u < kernel["LoopIters"]/self.states.numIterPerCoalescedReadB - self.states.numItersPLR)
       doReadM = (u < kernel["LoopIters"]/self.states.numIterPerCoalescedReadMetadata - self.states.numItersPLR)
+
+      if kernel["ForceUnrollSubIter"]:
+        doReadA = 1 if u == 0 else 0
+        doReadB = 1 if u == 0 else 0
+        doReadM = 1 if u == 0 else 0
+
       # reads for next loop
       doReadA = doReadA or (hasLiveLdsData and u > localWriteEndIter)
       doReadB = doReadB or (hasLiveLdsData and u > localWriteEndIter)
@@ -2569,6 +2617,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
           localReads.add(localReadCodeA)
           localReadsA.add(localReadCodeA)
           pack[plrIdx*self.states.numIterPerCoalescedReadA].add(packCodeA)
+          if kernel["ForceUnrollSubIter"]:
+            pack[1] = Module()
+            pack[1].add(packCodeA)
         if doReadM:
           localReads.addComment1("local read metadata")
           localReadCodeM, packCodeM = self.localReadDo(kernel, plrIdx*self.states.numIterPerCoalescedReadMetadata, iui*self.states.numReadsIterCoalescedMetadata, 0, tPM)
@@ -2585,6 +2636,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
           localReads.add(localReadCodeB)
           localReadsB.add(localReadCodeB)
           pack[plrIdx*self.states.numIterPerCoalescedReadB].add(packCodeB)
+          if kernel["ForceUnrollSubIter"]:
+            pack[1].add(packCodeB)
+
         # Don't increment the LRO if we are going to reset them below:
         if not isResetLroIter or iui != kernel["InnerUnroll"]-1:
           if doReadA:
@@ -2630,13 +2684,15 @@ class KernelWriter(metaclass=abc.ABCMeta):
           if kernel["ExpertSchedulingMode"] > 0:
             pointerLRCode.add(SWaitAlu(vm_vsrc=0, comment="wait for local read to vgpr complete"))
           # Swap, reset, or increment the LRO:
-          pointerLRCode.addComment1("local read swap offsets a")
-          pointerLRCode.add(self.localReadSwapOffsets(kernel, expand, tensorParametersA))
+          if not kernel["ForceUnrollSubIter"] or (doReadA and (u<localWriteEndIter)):
+            pointerLRCode.addComment1("local read swap offsets a")
+            pointerLRCode.add(self.localReadSwapOffsets(kernel, expand, tensorParametersA))
           if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
             pointerLRCode.addComment1("local read swap offsets metadata")
             pointerLRCode.add(self.localReadSwapOffsets(kernel, expand, tPM))
-          pointerLRCode.addComment1("local read swap offsets b")
-          pointerLRCode.add(self.localReadSwapOffsets(kernel, expand, tensorParametersB))
+          if not kernel["ForceUnrollSubIter"] or (doReadB and (u<localWriteEndIter)):
+            pointerLRCode.addComment1("local read swap offsets b")
+            pointerLRCode.add(self.localReadSwapOffsets(kernel, expand, tensorParametersB))
 
       if isResetLroIter: # ResetLroIter
         pointerLRCode.addComment1("local read init pointers a")
@@ -2678,9 +2734,13 @@ class KernelWriter(metaclass=abc.ABCMeta):
       # Is this test necessary because of the global variable this if was previously always true
       # after removing the global variable it is always false...
       # if self.states.numItersPLR:
+      if kernel["ForceUnrollSubIter"]:
+        luIdx = u
       subIterCode = self._makeSubIterSchedule(kernel, tensorParametersA, tensorParametersB, localReads, \
                       u, pointerLWCode, pointerLRCode, waitCode, macIterCode, waitLWCode, syncCode, pack[luIdx], module)
       module.add(subIterCode) # add scheduled "other", local reads, local writes
+      self.states.SubTileIdxA = (self.states.SubTileIdxA + 1) % kernel["numSubTilesA"]
+      self.states.SubTileIdxB = (self.states.SubTileIdxB + 1) % kernel["numSubTilesB"]
       pack[luIdx] = Module()
 
     # close unrolled loop
@@ -2729,8 +2789,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     if self.do["executeToPrefetchEnd"]:
       module.add(self.functionEnd(kernel, addLabel=False))
-
-    pack = [ Module() for i in range (self.states.numVgprBuffer) ]
+    if kernel["ForceUnrollSubIter"]:
+      pack = [ Module() for i in range (4) ] # 4 buffers for ForceUnrollSubIter
+    else:
+      pack = [ Module() for i in range (self.states.numVgprBuffer) ]
     self.preLoopLocalWriteCode = None
 
     if kernel["PrefetchGlobalRead"]:
@@ -2803,6 +2865,14 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
         module.add(self.closePrefetchGlobalRead2())
 
+      self.states.subTileIdxA = 0
+      self.states.subTileIdxB = 0
+
+      if kernel["ForceUnrollSubIter"]:
+        kernel["LoopIters"] = kernel["numSubTilesA"] * kernel["numSubTilesA"]
+        self.states.numMfmaPerIter = self.states.numMfmaPerIter//kernel["LoopIters"]
+        self.states.numItersPLR = 1
+
       # prefetch-local
       if self.states.numItersPLR:
         # not generate wait for local write if LDS write code is not generated
@@ -2831,16 +2901,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
                 localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx*self.states.numIterPerCoalescedReadB, iui*self.states.numReadsIterCoalescedB, espi, tensorParametersB)
                 module.add(localReadCodeB)
                 pack[plrIdx].add(packCodeB)
-              if iui*self.states.numReadsIterCoalescedA < kernel["InnerUnroll"]:
+              if not kernel["ForceUnrollSubIter"] and (iui*self.states.numReadsIterCoalescedA < kernel["InnerUnroll"]):
                 module.addComment1("local read inc a")
                 module.add(self.localReadInc(kernel, iui, tensorParametersA))
-              if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
+              if not kernel["ForceUnrollSubIter"] and (kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]):
                 if iui*self.states.numReadsIterCoalescedMetadata < kernel["InnerUnroll"]: # no local read code if DirectToVgpr is enabled
                   module.addComment1("local read inc metadata")
                   module.add(self.localReadInc(kernel, iui, tPM))
-              if iui*self.states.numReadsIterCoalescedB < kernel["InnerUnroll"]:
+              if not kernel["ForceUnrollSubIter"] and (iui*self.states.numReadsIterCoalescedB < kernel["InnerUnroll"]):
                 module.addComment1("local read inc b")
                 module.add(self.localReadInc(kernel, iui, tensorParametersB))
+        self.states.SubTileIdxA = (self.states.SubTileIdxA + 1) % kernel["numSubTilesA"]
+        self.states.SubTileIdxB = (self.states.SubTileIdxB + 1) % kernel["numSubTilesB"]
       module.add(self.closeSumAtLeastUnroll(kernel, tensorParametersA, tensorParametersB, prefetch=True, isOptNLL=False, isNGLL=False))
 
     loopCopies = 2 if expand else 1

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -6778,8 +6778,26 @@ class KernelWriterAssembly(KernelWriter):
         outer = 0
         loopSwap = True
       inner = 1 - outer # inner is the opposite of outer
-      for idxOuter in range(0, kernel["MIWaveTile"][outer]):
-        for idxInner in range(0, kernel["MIWaveTile"][inner]):
+
+      idxOuter_start = 0
+      idxInner_start = 0
+      idxOuter_stop = kernel["MIWaveTile"][outer]
+      idxInner_stop = kernel["MIWaveTile"][inner]
+      numSubTiles = kernel["numSubTilesA"]
+      if numSubTiles > 1:
+        outerBy2=(kernel["MIWaveTile"][outer]//numSubTiles)
+        innerBy2=(kernel["MIWaveTile"][inner]//numSubTiles)
+        outerMod2=(kernel["MIWaveTile"][outer]%numSubTiles)
+        innerMod2=(kernel["MIWaveTile"][inner]%numSubTiles)
+        idxHalfO = u//numSubTiles
+        idxHalfI = u % numSubTiles
+        idxOuter_start = (outerBy2 + outerMod2)*idxHalfO 
+        idxInner_start = (innerBy2 + innerMod2)*idxHalfI 
+        idxOuter_stop = kernel["MIWaveTile"][outer] - (1-idxHalfO)* outerBy2
+        idxInner_stop = kernel["MIWaveTile"][inner] - (1-idxHalfI)* innerBy2
+
+      for idxOuter in range(idxOuter_start, idxOuter_stop):
+        for idxInner in range(idxInner_start, idxInner_stop):
           idx0 = idxInner
           idx1 = idxOuter
           if loopSwap:

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1314,6 +1314,27 @@ class Solution(collections.abc.Mapping):
         reject(state, printRejectionReason, "MIWaveTile0(%u) should be multiple of VectorWidthB(%u)" % (state["MIWaveTile"][1], state["VectorWidthB"]))
         return
 
+    if (
+      state["DepthU"] == state["MatrixInstK"] and state["PrefetchGlobalRead"] and not state["1LDSBuffer"]
+      and (state["MIWaveTile"][0] > 2  and state["MIWaveTile"][1] > 2)
+      and (state["MIWaveTile"][0] % 2 == 0 and state["MIWaveTile"][1] % 2 == 0)
+    ):
+      state["ForceUnrollSubIter"] = True
+      #ToDo: Formula for numSubTilesA and numSubTilesB
+      # numSubTilesA and numSubTilesB are used to calculate the number of sub-tiles
+      # in the case of D_U_iseqMI_K=True, numSubTilesA and numSubTilesB are set to 2
+      # This is because the number of sub-tiles is determined by the number of
+      # sub-tiles in the A and B dimensions.
+      # since we are currently breaking A into A0 A1 and B into B0 B1 as we have MI[5:6] as [2,2]
+      # and we are using 2x2 sub-tiles for A and B.
+      state["numSubTilesA"] = 2 
+      state["numSubTilesB"] = 2 
+    else:
+      state["ForceUnrollSubIter"] = False
+      state["numSubTilesA"] = 1 
+      state["numSubTilesB"] = 1 
+
+      
     if len(problemType["IndicesSummation"]) > 1:
       # not supported with multiple summations, bug is maybe something with
       # how stagger iteration is wrapped when unroll loop exits

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f16_plr.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f16_plr.yaml
@@ -1,0 +1,143 @@
+GlobalParameters:
+  MergeFiles: False
+  NumElementsToValidate: -1
+
+  NumWarmups: 1000
+  EnqueuesPerSync: 10000
+
+  NumBenchmarks: 1
+  SyncsPerBenchmark: 1
+  SleepPercent: 0
+  DataInitTypeA: 12
+  DataInitTypeB: 13
+  # DataInitTypeC: 0
+  # DataInitTypeD: 3
+  DataInitTypeBeta: 0
+  DataInitTypeAlpha: 1
+  # DataInitTypeBias: 0
+  DataInitTypeScaleAlphaVec: 1
+  DataInitTypeScaleA: 1
+  DataInitTypeScaleB: 1
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  #Device: 0
+  MinKForGSU: 1
+  #MaxWorkspaceSize: 3355443200
+  MaxFileName: 256
+  KernelTime: True
+  #RotatingBufferSize: 512
+  MaxLDS: 163840
+  DeviceLDS: 163840
+  #GenerateSourcesAndExit: True
+
+  PrintSolutionRejectionReason: True
+  #Device: 3
+
+  RotatingBufferSize: 512
+  KeepBuildTmp: True
+
+
+BenchmarkProblems:
+  ########################################
+  # NN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      #DataTypeA: f8
+      #DataTypeB: h
+      #UseScaleAB: True
+
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+
+      #UseBias: True
+      #Activation: True
+      #UseScaleAlphaVec: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1,  8,  8 , 2,2 ]
+          - [16, 16, 32, 1,  1,  8,  7 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  8,  6 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  8,  5 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  8,  4 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  8,  2 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  7,  8 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  7,  7 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  7,  6 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  7,  5 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  7,  4 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  7,  3 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  7,  2 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  6,  8 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  6,  7 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  6,  6 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  6,  5 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  6,  4 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  6,  3 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  6,  2 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  5,  8 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  5,  7 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  5,  6 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  5,  5 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  5,  4 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  5,  3 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  5,  2 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  4,  8 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  4,  7 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  4,  6 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  4,  5 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  4,  4 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  4,  3 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  4,  2 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  3,  8 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  3,  7 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  3,  6 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  3,  5 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  3,  4 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  3,  3 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  3,  2 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  2,  8 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  2,  7 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  2,  6 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  2,  5 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  2,  4 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  2,  3 , 2,2 ] 
+          - [16, 16, 32, 1,  1,  2,  2 , 2,2 ] 
+
+
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [32]
+        - TransposeLDS: [1]
+        #- DirectToLds: [1]
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - LocalReadVectorWidth: [8]
+        #- GlobalSplitU: [3]   #disable GSU
+        - SourceSwap: [1]
+        # - NonTemporalA: [4]
+        # - NonTemporalB: [0,1]
+        # - NonTemporalC: [3]
+        # - NonTemporalD: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [4096, 4096, 1, 16384]
+          #- Exact: [256, 256, 1, 384]
+        #- BiasTypeArgs: ['s']
+        #- ActivationArgs:
+        #  - [Enum: none]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f8_plr.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/f8_plr.yaml
@@ -1,0 +1,159 @@
+GlobalParameters:
+  MergeFiles: False
+  NumElementsToValidate: -1
+
+  NumWarmups: 1000
+  EnqueuesPerSync: 10000
+
+  NumBenchmarks: 1
+  SyncsPerBenchmark: 1
+  SleepPercent: 0
+  DataInitTypeA: 12
+  DataInitTypeB: 13
+  # DataInitTypeC: 0
+  # DataInitTypeD: 3
+  DataInitTypeBeta: 0
+  DataInitTypeAlpha: 1
+  # DataInitTypeBias: 0
+  DataInitTypeScaleAlphaVec: 1
+  DataInitTypeScaleA: 1
+  DataInitTypeScaleB: 1
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  #Device: 0
+  MinKForGSU: 1
+  #MaxWorkspaceSize: 3355443200
+  MaxFileName: 256
+  KernelTime: True
+  #RotatingBufferSize: 512
+  MaxLDS: 163840
+  DeviceLDS: 163840
+  #GenerateSourcesAndExit: True
+
+  PrintSolutionRejectionReason: True
+  #Device: 3
+
+  RotatingBufferSize: 512
+  KeepBuildTmp: True
+
+
+BenchmarkProblems:
+  ########################################
+  # NN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      #DataTypeA: f8
+      #DataTypeB: h
+      #UseScaleAB: True
+
+      DataType: f8
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+
+      #UseBias: True
+      #Activation: True
+      #UseScaleAlphaVec: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 128, 1,  1,  8,  8 , 2,2 ]
+          - [16, 16, 128, 1,  1,  8,  7 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  8,  6 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  8,  5 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  8,  4 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  8,  2 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  8,  1 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  7,  8 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  7,  7 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  7,  6 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  7,  5 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  7,  4 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  7,  3 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  7,  2 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  7,  1 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  6,  8 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  6,  7 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  6,  6 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  6,  5 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  6,  4 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  6,  3 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  6,  2 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  6,  1 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  5,  8 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  5,  7 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  5,  6 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  5,  5 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  5,  4 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  5,  3 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  5,  2 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  5,  1 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  4,  8 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  4,  7 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  4,  6 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  4,  5 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  4,  4 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  4,  3 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  4,  2 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  4,  1 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  3,  8 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  3,  7 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  3,  6 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  3,  5 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  3,  4 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  3,  3 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  3,  2 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  3,  1 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  2,  8 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  2,  7 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  2,  6 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  2,  5 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  2,  4 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  2,  3 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  2,  2 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  2,  1 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  1,  8 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  1,  7 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  1,  6 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  1,  5 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  1,  4 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  1,  3 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  1,  2 , 2,2 ] 
+          - [16, 16, 128, 1,  1,  1,  1 , 2,2 ] 
+
+        - AssertSummationElementMultiple: [128]
+        - AssertFree0ElementMultiple: [16]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [128]
+        - TransposeLDS: [1]
+        #- DirectToLds: [1]
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - GlobalReadVectorWidthA: [16]
+        - GlobalReadVectorWidthB: [16]
+        - LocalReadVectorWidth: [16]
+        #- GlobalSplitU: [3]   #disable GSU
+        - SourceSwap: [1]
+        # - NonTemporalA: [4]
+        # - NonTemporalB: [0,1]
+        # - NonTemporalC: [3]
+        # - NonTemporalD: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [4096, 4096, 1, 16384]
+          #- Exact: [256, 256, 1, 384]
+        #- BiasTypeArgs: ['s']
+        #- ActivationArgs:
+        #  - [Enum: none]


### PR DESCRIPTION
## Motivation

For High rate MFMAs in the newer architecture because of insufficient vgprs we can not unroll the loop. This  leads to exposed memory operations reducing efficiency. Here we break A and B into two equal parts and divide loop into 4 subiters by reordering MFMAs such as A0B0 ,A0B1,A1B0,A1B1. This helps us to separate dependencies and hide exposed reads. 

## Technical Details
Rigid schedule is imposed on the instructions in order to get following desired code. 

Prefetch phase : read A0,B0
 MainLoop:
sub-iter0: MFMA (A0,B0) read(A1,B1)
sub-iter1: MFMA (A0,B1) write(A,B) Global Read(A,B)
sub-iter2: MFMA (A1,B0) 
sub-iter3:MFMA (A1,B1) read(A0,B0)

NoLoadLoop:
sub-iter0: MFMA (A0,B0) read(A1,B1)
sub-iter1: MFMA (A0,B1) write(A,B) 
sub-iter2: MFMA (A1,B0) 
sub-iter3:MFMA (A1,B1) read(A0,B0)


## Test Plan

Added Two .yaml files to test the changes. 
Currently supported only for even wave tile sizes>2 f8 and f16 using  double LDS buffer. 

## Test Result

For supported configurations , .s is generated with 4 sub-iters along with prefetch. 3-5% improvement in the performance 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
