### PR TITLE
[hipsparselt] Docs: Fix data type page

### DIFF
--- a/projects/hipsparselt/docs/reference/data-type-support.rst
+++ b/projects/hipsparselt/docs/reference/data-type-support.rst
@@ -28,8 +28,8 @@ the following table.
       - Full support
 
 
-For more information about data type support for the other ROCm libraries, see 
-:doc:`Data types and precision support page <rocm:reference/precision-support>`. 
+For more information about data type support for the other ROCm libraries, see
+:doc:`Data types and precision support page <rocm:reference/precision-support>`.
 
 Supported input and output types
 ================================
@@ -88,7 +88,7 @@ List of supported input and output types:
   *
     - float32
     - HIP_R_32F
-    - ❌
+    - ✅
     - ✅
   *
     - float64


### PR DESCRIPTION
## Motivation

Fix a typo in the data type page of hipSPARSELt which mentions that float32 is not supported on AMD GPUs, when it is.

## Technical Details

Simply changed an entry in the related .rst file.

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
