### PR TITLE
[hipfftw] Enabling hipfftw basic plans and testing thereof + paving the way for future developments on both sides

### DIFF
--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -324,7 +324,7 @@ public:
         if(!hipfftw_log_trace || std::atoi(hipfftw_log_trace) <= 0)
         {
 #ifdef WIN32
-            active = SetEnvironmentVariable("HIPFFTW_LOG_EXCEPTIONS", "1") != 0;
+            active = SetEnvironmentVariable("HIPFFTW_LOG_EXCEPTIONS", "1");
 #else
             active = setenv("HIPFFTW_LOG_EXCEPTIONS", "1", 1) == EXIT_SUCCESS;
 #endif
@@ -341,9 +341,9 @@ public:
         if(active)
         {
 #ifdef WIN32
-            SetEnvironmentVariable("HIPFFTW_LOG_EXCEPTIONS", "0");
+            (void)SetEnvironmentVariable("HIPFFTW_LOG_EXCEPTIONS", "0");
 #else
-            setenv("HIPFFTW_LOG_EXCEPTIONS", "0", 1);
+            (void)setenv("HIPFFTW_LOG_EXCEPTIONS", "0", 1);
 #endif
             // restore cerr to its original state
             std::cerr.rdbuf(original_cerr_rdbuf);
@@ -1042,7 +1042,7 @@ public:
             ret << "real_inverse";
             break;
         default:
-            std::runtime_error("unknown type of transform");
+            throw std::runtime_error("unknown type of transform");
         }
 
         // report rank if invalid
@@ -1162,7 +1162,7 @@ public:
         }
         else
         {
-            std::runtime_error("New-array execution functions not implemented yet.");
+            throw std::runtime_error("New-array execution functions not implemented yet.");
         }
     }
 

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -22,7 +22,6 @@
 #define HIPFFTW_HELPER_H
 
 #include "../shared/fft_params.h"
-#include "fftw3.h"
 #include <algorithm>
 #include <fftw3.h>
 #include <memory>

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -21,6 +21,7 @@
 #ifndef HIPFFTW_HELPER_H
 #define HIPFFTW_HELPER_H
 
+#include "../shared/environment.h"
 #include "../shared/fft_params.h"
 #include <algorithm>
 #include <fftw3.h>
@@ -314,28 +315,23 @@ struct hipfftw_exception_logger
     std::stringstream     buffer;
     std::streambuf* const original_cerr_rdbuf = nullptr;
 
+    std::unique_ptr<EnvironmentSetTemp> hipfftw_temp_logger_env;
+
 public:
     hipfftw_exception_logger()
         : active(false)
         , original_cerr_rdbuf(std::cerr.rdbuf())
     {
-#ifdef WIN32
-        // no more than 8*sizeof(size_t) + 3 characters for valid values
-        // (if variable defined in binary representation "0b[...]")
-        char       hipfftw_log_trace[8 * sizeof(size_t) + 3];
-        const auto sz = GetEnvironmentVariableA(
-            "HIPFFTW_LOG_EXCEPTIONS", hipfftw_log_trace, sizeof(hipfftw_log_trace));
-        if(sz == 0 || (sz <= sizeof(hipfftw_log_trace) && std::stoull(hipfftw_log_trace) == 0))
+        const auto env_val = rocfft_getenv("HIPFFTW_LOG_EXCEPTIONS");
+        // activate temporary redirection only if not already used otherwise
+        // (e.g., in test user's environment )
+        if(env_val.empty() || std::stoull(env_val) == 0)
         {
-            active = SetEnvironmentVariable("HIPFFTW_LOG_EXCEPTIONS", "1");
+            hipfftw_temp_logger_env
+                = std::make_unique<EnvironmentSetTemp>("HIPFFTW_LOG_EXCEPTIONS", "1");
+            const auto temp_env_val = rocfft_getenv("HIPFFTW_LOG_EXCEPTIONS");
+            active                  = !temp_env_val.empty() && std::stoull(temp_env_val) != 0;
         }
-#else
-        const char* hipfftw_log_trace = std::getenv("HIPFFTW_LOG_EXCEPTIONS");
-        if(!hipfftw_log_trace || std::stoull(hipfftw_log_trace) == 0)
-        {
-            active = setenv("HIPFFTW_LOG_EXCEPTIONS", "1", 1) == EXIT_SUCCESS;
-        }
-#endif
         if(active)
             std::cerr.rdbuf(buffer.rdbuf());
     }
@@ -347,11 +343,6 @@ public:
     {
         if(active)
         {
-#ifdef WIN32
-            (void)SetEnvironmentVariable("HIPFFTW_LOG_EXCEPTIONS", "0");
-#else
-            (void)setenv("HIPFFTW_LOG_EXCEPTIONS", "0", 1);
-#endif
             // restore cerr to its original state
             std::cerr.rdbuf(original_cerr_rdbuf);
         }

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -75,13 +75,17 @@ private:
 
     dynamically_loaded_hipfftw()
     {
+#ifdef __HIP_PLATFORM_AMD__
         const std::string lib_basename = "hipfftw";
+#else
+        const std::string lib_basename = "cufftw";
+#endif
 #ifdef WIN32
         const std::string lib_fullame = lib_basename + ".dll";
         lib_handle                    = LoadLibraryA(lib_fullame.c_str());
 #else
-        const std::string lib_fullame = "lib" + lib_basename + ".so";
-        lib_handle                    = dlopen(lib_fullame.c_str(), RTLD_LAZY);
+        const std::string lib_fullame  = "lib" + lib_basename + ".so";
+        lib_handle                     = dlopen(lib_fullame.c_str(), RTLD_LAZY);
 #endif
         load_error_info.clear();
         if(!lib_handle)
@@ -322,6 +326,7 @@ public:
         : active(false)
         , original_cerr_rdbuf(std::cerr.rdbuf())
     {
+#ifdef __HIP_PLATFORM_AMD__
         const auto env_val = rocfft_getenv("HIPFFTW_LOG_EXCEPTIONS");
         // activate temporary redirection only if not already used otherwise
         // (e.g., in test user's environment )
@@ -332,6 +337,7 @@ public:
             const auto temp_env_val = rocfft_getenv("HIPFFTW_LOG_EXCEPTIONS");
             active                  = !temp_env_val.empty() && std::stoull(temp_env_val) != 0;
         }
+#endif
         if(active)
             std::cerr.rdbuf(buffer.rdbuf());
     }

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -569,7 +569,7 @@ private:
                 // creation will be considered "valid". If there exists one (usable) candidate s.t.
                 // creation_options == candidate however, this choice is considered "enforced"
                 // (e.g. for function-specific argument validation testing purposes)
-                if(creation_options == candidate || is_supported_for_creation_with(candidate))
+                if(creation_options == candidate || can_create_plan_with(candidate))
                     valid_candidates.push_back(candidate);
             }
         }
@@ -991,34 +991,40 @@ public:
         return is_valid_for_creation_with(hipfftw_plan_creation_func::ANY);
     }
     // check expected support by (any of) the given option(s)
-    bool is_supported_for_creation_with(hipfftw_plan_creation_func creation_options) const
+    bool has_unsupported_args_for(hipfftw_plan_creation_func creation_options) const
     {
-        if(!hipfftw_creation_options_are_well_defined(creation_options))
-            throw std::invalid_argument(
-                "invalid creation_option for is_supported_for_creation_with");
-
-        if(!is_valid_for_creation_with(creation_options))
-            return false;
         // extra conditions for configurations supported by hipfftw:
-        if(rank < 1 || rank > 3)
-            return false;
+        if(rank > 3)
+            return true;
         if(flags & FFTW_WISDOM_ONLY)
-            return false;
+            return true;
         if(dft_kind == fft_transform_type_real_inverse && rank > 1 && (flags & FFTW_PRESERVE_INPUT))
-            return false;
-        if(!(creation_options & hipfftw_plan_creation_func::PLAN_GURU64))
+            return true;
+        if(!(creation_options & hipfftw_plan_creation_func::PLAN_GURU64) && has_valid_rank()
+           && has_valid_lengths())
         {
             // cannot handle data sizes involving more elements than the
             // largest representable int value
             if(get_num_elements_in(fft_io_in) > std::numeric_limits<int>::max()
                || get_num_elements_in(fft_io_out) > std::numeric_limits<int>::max())
-                return false;
+                return true;
         }
+        return false;
+    }
+    bool can_create_plan_with(hipfftw_plan_creation_func creation_options) const
+    {
+        if(!hipfftw_creation_options_are_well_defined(creation_options))
+            throw std::invalid_argument("invalid creation_option for can_create_plan_with");
+
+        if(!is_valid_for_creation_with(creation_options))
+            return false;
+        if(has_unsupported_args_for(creation_options))
+            return false;
         return true;
     }
-    bool is_supported_for_creation() const
+    bool can_create_plan() const
     {
-        return is_supported_for_creation_with(hipfftw_plan_creation_func::ANY);
+        return can_create_plan_with(hipfftw_plan_creation_func::ANY);
     }
     // create a token consistent with other tests to enable kernel precompilation
     // for valid cases, and/or capturing all required details about members otherwise
@@ -1044,7 +1050,7 @@ public:
         }
 
         // report rank if invalid
-        if(!has_valid_rank())
+        if(!has_valid_rank() || lengths.empty())
             ret << "_invalid_rank" << (rank < 0 ? "_negative_" : "_") << std::abs(rank);
         ret << "_len";
         if(lengths.empty())

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -1,0 +1,1228 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef HIPFFTW_HELPER_H
+#define HIPFFTW_HELPER_H
+
+#include "../shared/fft_params.h"
+#include "fftw3.h"
+#include <algorithm>
+#include <fftw3.h>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+#ifdef WIN32
+#include <windows.h>
+// psapi.h requires windows.h to be included first
+#include <psapi.h>
+typedef HMODULE LIB_HANDLE_T;
+#else
+#include <dlfcn.h>
+#include <link.h>
+typedef void* LIB_HANDLE_T;
+#endif
+
+template <fft_precision prec>
+struct hipfftw_trait;
+template <>
+struct hipfftw_trait<fft_precision_single>
+{
+    using plan_t    = fftwf_plan;
+    using complex_t = fftwf_complex;
+    using real_t    = float;
+};
+template <>
+struct hipfftw_trait<fft_precision_double>
+{
+    using plan_t    = fftw_plan;
+    using complex_t = fftw_complex;
+    using real_t    = double;
+};
+
+template <fft_precision prec>
+using hipfftw_real_t = typename hipfftw_trait<prec>::real_t;
+template <fft_precision prec>
+using hipfftw_complex_t = typename hipfftw_trait<prec>::complex_t;
+template <fft_precision prec>
+using hipfftw_plan_t = typename hipfftw_trait<prec>::plan_t;
+
+// singleton class encapsulating the dynamically-loaded hipfftw library
+class dynamically_loaded_hipfftw
+{
+private:
+    LIB_HANDLE_T       lib_handle;
+    std::ostringstream load_error_info;
+
+    dynamically_loaded_hipfftw()
+    {
+        const std::string lib_basename = "hipfftw";
+#ifdef WIN32
+        const std::string lib_fullame = lib_basename + ".dll";
+        lib_handle                    = LoadLibraryA(lib_fullame.c_str());
+#else
+        const std::string lib_fullame = "lib" + lib_basename + ".so";
+        lib_handle                    = dlopen(lib_fullame.c_str(), RTLD_LAZY);
+#endif
+        load_error_info.clear();
+        if(!lib_handle)
+        {
+            load_error_info << "failed to open library " << lib_fullame;
+#ifdef WIN32
+            load_error_info << ". System's error code = " << GetLastError();
+#else
+            load_error_info << ". System's error message = " << dlerror();
+#endif
+            // do not throw from here to ease exception handling
+        }
+    }
+    /* disable copies and moves */
+    dynamically_loaded_hipfftw(const dynamically_loaded_hipfftw&) = delete;
+    dynamically_loaded_hipfftw(dynamically_loaded_hipfftw&&)      = delete;
+    dynamically_loaded_hipfftw& operator=(const dynamically_loaded_hipfftw&) = delete;
+    dynamically_loaded_hipfftw& operator=(dynamically_loaded_hipfftw&&) = delete;
+
+    static const dynamically_loaded_hipfftw& get_instance()
+    {
+        static dynamically_loaded_hipfftw singleton_instance;
+        return singleton_instance;
+    }
+
+public:
+    static LIB_HANDLE_T get_lib()
+    {
+        return get_instance().lib_handle;
+    }
+    static std::string get_load_error_info()
+    {
+        return get_instance().load_error_info.str();
+    }
+    ~dynamically_loaded_hipfftw()
+    {
+        if(lib_handle)
+        {
+#ifdef WIN32
+            (void)FreeLibrary(lib_handle);
+#else
+            (void)dlclose(lib_handle);
+#endif
+        }
+        lib_handle = nullptr;
+    }
+};
+
+// exception specific to issues when loading hipfftw and/or when fetching
+// the address of the supposedly-available functions therefrom
+struct hipfftw_undefined_function_ptr : std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
+// helper struct for retrieving a function's return type
+template <class T>
+struct func_ret;
+template <typename R, class... Args>
+struct func_ret<R(Args...)>
+{
+    using type = R;
+};
+template <class T>
+using func_ret_t = typename func_ret<T>::type;
+
+template <typename func_type, std::enable_if_t<std::is_function_v<func_type>, bool> = true>
+struct dynamically_loaded_function_t
+{
+private:
+    // address of the desired function, to be fetched from a dynamically loaded shared library
+    func_type* func_ptr;
+    // address of the reference function (from linked fftw3)
+    func_type* const reference_func_ptr;
+    // symbol of said function
+    std::string func_symbol;
+
+public:
+    dynamically_loaded_function_t(const char* symbol, func_type* ref_func_address)
+        : func_ptr(nullptr)
+        , reference_func_ptr(ref_func_address)
+        , func_symbol(symbol)
+    {
+    }
+
+    // forwarding functional calls
+    template <typename... Args>
+    func_ret_t<func_type> operator()(Args... args) const
+    {
+        if(!may_be_used())
+            throw hipfftw_undefined_function_ptr(dynamically_loaded_hipfftw::get_load_error_info());
+        return func_ptr(args...);
+    }
+    template <bool call_reference, typename... Args>
+    func_ret_t<func_type> call(Args... args) const
+    {
+        if constexpr(!call_reference)
+        {
+            return this->operator()(args...);
+        }
+        else
+        {
+            if(!reference_func_ptr)
+                throw hipfftw_undefined_function_ptr(
+                    "Ill-defined reference function pointer for symbol " + func_symbol);
+            return reference_func_ptr(args...);
+        }
+        // unreachable
+    }
+    void load_implementation()
+    {
+        const auto hipfftw_lib = dynamically_loaded_hipfftw::get_lib();
+        if(!hipfftw_lib)
+        {
+            // make func_ptr unambiguously unset to force the dedicated exception
+            // to be thrown at forwarded functional call(s)
+            func_ptr = nullptr;
+            return;
+        }
+#ifdef WIN32
+        func_ptr = reinterpret_cast<func_type*>(GetProcAddress(hipfftw_lib, func_symbol.c_str()));
+#else
+        func_ptr = reinterpret_cast<func_type*>(dlsym(hipfftw_lib, func_symbol.c_str()));
+#endif
+    }
+    bool may_be_used() const
+    {
+        return func_ptr != nullptr;
+    }
+    std::string get_symbol() const
+    {
+        return func_symbol;
+    }
+};
+
+template <typename T, typename... Args>
+static void load_implementations(dynamically_loaded_function_t<T>& first, Args&... others)
+{
+    first.load_implementation();
+    if constexpr(sizeof...(others) > 0)
+        load_implementations(others...);
+}
+
+// define singleton structures encapsulating all the hipfftw function
+// pointers (one specialization per supported precision)
+template <fft_precision prec>
+struct hipfftw_funcs;
+
+#define HIPFFTW_STRINGIFY(x) #x
+#define HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, func)                        \
+    dynamically_loaded_function_t<decltype(prefix##func)> func                                   \
+        = dynamically_loaded_function_t<decltype(prefix##func)>(HIPFFTW_STRINGIFY(prefix##func), \
+                                                                &(prefix##func));
+
+#define HIPFFTW_FUNCS_SPECIALIZATION(prefix, specialization)                         \
+    template <>                                                                      \
+    struct hipfftw_funcs<specialization>                                             \
+    {                                                                                \
+    private:                                                                         \
+        hipfftw_funcs()                                                              \
+        {                                                                            \
+            load_implementations(malloc,                                             \
+                                 alloc_real,                                         \
+                                 alloc_complex,                                      \
+                                 free,                                               \
+                                 destroy_plan,                                       \
+                                 cleanup,                                            \
+                                 execute,                                            \
+                                 plan_dft_1d,                                        \
+                                 plan_dft_2d,                                        \
+                                 plan_dft_3d,                                        \
+                                 plan_dft,                                           \
+                                 plan_dft_r2c_1d,                                    \
+                                 plan_dft_r2c_2d,                                    \
+                                 plan_dft_r2c_3d,                                    \
+                                 plan_dft_r2c,                                       \
+                                 plan_dft_c2r_1d,                                    \
+                                 plan_dft_c2r_2d,                                    \
+                                 plan_dft_c2r_3d,                                    \
+                                 plan_dft_c2r,                                       \
+                                 print_plan,                                         \
+                                 set_timelimit,                                      \
+                                 cost,                                               \
+                                 flops);                                             \
+        }                                                                            \
+        /* disable copies and moves */                                               \
+        hipfftw_funcs(const hipfftw_funcs&) = delete;                                \
+        hipfftw_funcs& operator=(const hipfftw_funcs&) = delete;                     \
+        hipfftw_funcs(hipfftw_funcs&&)                 = delete;                     \
+        hipfftw_funcs& operator=(hipfftw_funcs&&) = delete;                          \
+                                                                                     \
+    public:                                                                          \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, malloc)          \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, alloc_real)      \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, alloc_complex)   \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, free)            \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, destroy_plan)    \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, cleanup)         \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, execute)         \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_1d)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_2d)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_3d)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft)        \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c_1d) \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c_2d) \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c_3d) \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c)    \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r_1d) \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r_2d) \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r_3d) \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r)    \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, print_plan)      \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, set_timelimit)   \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, cost)            \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, flops)           \
+        static const hipfftw_funcs& get_instance()                                   \
+        {                                                                            \
+            static const hipfftw_funcs instance;                                     \
+            return instance;                                                         \
+        }                                                                            \
+    }
+
+HIPFFTW_FUNCS_SPECIALIZATION(fftwf_, fft_precision_single);
+HIPFFTW_FUNCS_SPECIALIZATION(fftw_, fft_precision_double);
+
+// structure enabling verbosity for hipfftw's exception handler and redirecting std::cerr
+// to a runtime buffer throughout its lifetime (unless it was already enabled prior/externally)
+struct hipfftw_exception_logger
+{
+    bool                  active;
+    std::stringstream     buffer;
+    std::streambuf* const original_cerr_rdbuf = nullptr;
+
+public:
+    hipfftw_exception_logger()
+        : active(false)
+        , original_cerr_rdbuf(std::cerr.rdbuf())
+    {
+        const char* hipfftw_log_trace = std::getenv("HIPFFTW_LOG_EXCEPTIONS");
+        if(!hipfftw_log_trace || std::atoi(hipfftw_log_trace) <= 0)
+        {
+#ifdef WIN32
+            active = SetEnvironmentVariable("HIPFFTW_LOG_EXCEPTIONS", "1") != 0;
+#else
+            active = setenv("HIPFFTW_LOG_EXCEPTIONS", "1", 1) == EXIT_SUCCESS;
+#endif
+        }
+        if(active)
+            std::cerr.rdbuf(buffer.rdbuf());
+    }
+    hipfftw_exception_logger(const hipfftw_exception_logger&) = delete;
+    hipfftw_exception_logger(hipfftw_exception_logger&&)      = delete;
+    hipfftw_exception_logger& operator=(const hipfftw_exception_logger&) = delete;
+    hipfftw_exception_logger& operator=(hipfftw_exception_logger&&) = delete;
+    ~hipfftw_exception_logger()
+    {
+        if(active)
+        {
+#ifdef WIN32
+            SetEnvironmentVariable("HIPFFTW_LOG_EXCEPTIONS", "0");
+#else
+            setenv("HIPFFTW_LOG_EXCEPTIONS", "0", 1);
+#endif
+            // restore cerr to its original state
+            std::cerr.rdbuf(original_cerr_rdbuf);
+        }
+    }
+    bool is_active() const
+    {
+        return active;
+    }
+    std::string get_log() const
+    {
+        return buffer.str();
+    }
+};
+
+// bit-flagging enum used for representing (combinations of) plan creation
+// function(s) to consider
+enum hipfftw_plan_creation_func : unsigned
+{
+    NONE        = 0x0, // not to be used (exceptfor validating values)
+    PLAN_DFT_ND = 0x1 << 0,
+    PLAN_DFT    = 0x1 << 1,
+    PLAN_MANY   = 0x1 << 2,
+    PLAN_GURU   = 0x1 << 3,
+    PLAN_GURU64 = 0x1 << 4,
+    ANY         = PLAN_DFT_ND | PLAN_DFT | PLAN_MANY | PLAN_GURU | PLAN_GURU64
+};
+static const std::vector<hipfftw_plan_creation_func> hipfftw_plan_creation_func_candidates
+    = {hipfftw_plan_creation_func::PLAN_DFT_ND,
+       hipfftw_plan_creation_func::PLAN_DFT,
+       hipfftw_plan_creation_func::PLAN_MANY,
+       hipfftw_plan_creation_func::PLAN_GURU,
+       hipfftw_plan_creation_func::PLAN_GURU64};
+
+static bool hipfftw_creation_options_are_well_defined(hipfftw_plan_creation_func creation_options)
+{
+    return creation_options == (creation_options & hipfftw_plan_creation_func::ANY);
+}
+
+static std::string hipfftw_creation_options_to_string(hipfftw_plan_creation_func creation_options,
+                                                      fft_transform_type         dft_type,
+                                                      int                        intended_rank)
+{
+    if(!hipfftw_creation_options_are_well_defined(creation_options))
+        throw std::invalid_argument(
+            "invalid creation_options for hipfftw_creation_options_to_string");
+    if(creation_options == hipfftw_plan_creation_func::NONE)
+        return "none";
+    if(creation_options == hipfftw_plan_creation_func::ANY)
+        return "any";
+    if(std::find(hipfftw_plan_creation_func_candidates.begin(),
+                 hipfftw_plan_creation_func_candidates.end(),
+                 creation_options)
+       == hipfftw_plan_creation_func_candidates.end())
+    {
+        // 2 or more qualifying candidates flagged in creation_options
+        std::string ret;
+        for(auto candidate : hipfftw_plan_creation_func_candidates)
+        {
+            if(creation_options & candidate)
+            {
+                if(!ret.empty())
+                    ret += "_or_";
+                ret += hipfftw_creation_options_to_string(candidate, dft_type, intended_rank);
+            }
+        }
+        return ret;
+    }
+    // creation_options is one unique qualifying candidate
+    std::ostringstream ret;
+    const std::string  real_or_empty_qualifier
+        = is_real(dft_type) ? (is_fwd(dft_type) ? "_r2c" : "_c2r") : "";
+    switch(creation_options)
+    {
+    case hipfftw_plan_creation_func::PLAN_DFT_ND:
+        ret << "plan_dft" << real_or_empty_qualifier << "_" << (intended_rank < 0 ? "negative" : "")
+            << std::abs(intended_rank) << "d";
+        break;
+    case hipfftw_plan_creation_func::PLAN_DFT:
+        ret << "plan_dft" << real_or_empty_qualifier;
+        break;
+    case hipfftw_plan_creation_func::PLAN_MANY:
+        ret << "plan_many_dft" << real_or_empty_qualifier;
+        break;
+    case hipfftw_plan_creation_func::PLAN_GURU:
+        ret << "plan_guru_dft" << real_or_empty_qualifier;
+        break;
+    case hipfftw_plan_creation_func::PLAN_GURU64:
+        ret << "plan_guru64_dft" << real_or_empty_qualifier;
+        break;
+    default:
+        throw std::runtime_error("hipfftw_creation_options_to_string: internal error encountered "
+                                 "(unexpected value for creation_options)");
+        break;
+    }
+    return ret.str();
+}
+
+template <
+    fft_precision prec,
+    std::enable_if_t<prec == fft_precision_single || prec == fft_precision_double, bool> = true>
+struct hipfftw_plan_bundle_t
+{
+private:
+    const decltype(hipfftw_funcs<prec>::destroy_plan)& plan_destructor;
+
+public:
+    hipfftw_plan_t<prec>       plan;
+    std::pair<void*, void*>    creation_io; // not owned
+    hipfftw_plan_creation_func creation_func;
+    std::string                plan_token; // <-- plan details, except for creation io data pointers
+    hipfftw_plan_bundle_t(decltype(plan_destructor) plan_destructor_func)
+        : plan_destructor(plan_destructor_func)
+        , plan(nullptr)
+        , creation_io({nullptr, nullptr})
+        , creation_func(hipfftw_plan_creation_func::NONE)
+        , plan_token("")
+    {
+    }
+    ~hipfftw_plan_bundle_t()
+    {
+        // make sure the plan destructor may be used to avoid
+        // throwing from the hipfftw_plan_bundle_t destructor
+        if(plan_destructor.may_be_used())
+        {
+            // should be stable even if plan == nullptr;
+            plan_destructor(plan);
+        }
+        else if(plan)
+        {
+            std::cerr << "WARNING: A " << (prec == fft_precision_single ? "single" : "double")
+                      << "-precision plan was seemingly created but its destructor cannot be used "
+                      << std::endl;
+        }
+    }
+    // disable copies and moves
+    hipfftw_plan_bundle_t(const hipfftw_plan_bundle_t&) = delete;
+    hipfftw_plan_bundle_t& operator=(const hipfftw_plan_bundle_t&) = delete;
+    hipfftw_plan_bundle_t(hipfftw_plan_bundle_t&&)                 = delete;
+    hipfftw_plan_bundle_t& operator=(hipfftw_plan_bundle_t&&) = delete;
+};
+
+static bool rank_is_valid_for_hipfftw(int r)
+{
+    return r > 0;
+}
+template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+static bool lengths_are_valid_for_hipfftw_as(const std::vector<ptrdiff_t> len, int intended_rank)
+{
+    if(!rank_is_valid_for_hipfftw(intended_rank))
+        return false; // impossible to validate lengths for an invalid rank
+    // check that lengths are all strictly positive and representable with
+    // type T without data loss
+    return len.size() == intended_rank
+           && std::all_of(len.begin(), len.end(), [](const decltype(len)::value_type& val) {
+                  return val > 0 && val <= std::numeric_limits<T>::max();
+              });
+}
+static bool sign_is_valid_for_hipfftw(int s, const fft_transform_type& dft_kind)
+{
+    if(is_real(dft_kind))
+        return true; // sign is irrelevant for real transforms
+    return s == (is_fwd(dft_kind) ? FFTW_FORWARD : FFTW_BACKWARD);
+}
+static constexpr unsigned hipfftw_valid_flags_mask
+    = FFTW_WISDOM_ONLY | FFTW_MEASURE | FFTW_DESTROY_INPUT | FFTW_UNALIGNED | FFTW_CONSERVE_MEMORY
+      | FFTW_EXHAUSTIVE | FFTW_PRESERVE_INPUT | FFTW_PATIENT | FFTW_ESTIMATE;
+static bool flags_are_valid_for_hipfftw(unsigned f)
+{
+    return (f & hipfftw_valid_flags_mask) == f;
+}
+
+template <
+    fft_precision prec,
+    std::enable_if_t<prec == fft_precision_single || prec == fft_precision_double, bool> = true>
+struct hipfftw_helper
+{
+private:
+    // plan_bundle stores information about the latest plan possibly created by this
+    // object. A shard_ptr is used to make hipfftw_helper safe w.r.t. shallow
+    // copies (as required by gtest for parameterized tests).
+    // This member is also made mutable so we can release/create it even from a
+    // const-qualified objects (e.g., to release owned resources upon test completion,
+    // or to re-create the plan at execution if needed or found necessary)
+    mutable std::shared_ptr<hipfftw_plan_bundle_t<prec>> plan_bundle;
+
+    fft_transform_type     dft_kind;
+    int                    rank = 0;
+    std::vector<ptrdiff_t> lengths;
+    fft_result_placement   plan_placement;
+    int                    sign  = 0;
+    unsigned               flags = std::numeric_limits<unsigned>::max();
+
+    template <typename T>
+    void reset_member_value(T& member, const T& new_value)
+    {
+        if(new_value != member)
+        {
+            member = new_value;
+            plan_bundle.reset();
+        }
+    }
+
+    hipfftw_plan_creation_func get_creation_func(hipfftw_plan_creation_func creation_options) const
+    {
+        if(!hipfftw_creation_options_are_well_defined(creation_options))
+            throw std::invalid_argument("invalid creation_options for get_creation_func");
+        if(!can_use_creation_options(creation_options))
+        {
+            // e.g., rank < 0 with creation_options == hipfftw_plan_creation_func::PLAN_DFT_ND
+            throw std::invalid_argument(
+                "The plan creation options "
+                + hipfftw_creation_options_to_string(creation_options, dft_kind, rank)
+                + " cannot be used with this object");
+        }
+        std::vector<hipfftw_plan_creation_func> valid_candidates;
+        for(auto candidate : hipfftw_plan_creation_func_candidates)
+        {
+            if(!(creation_options & candidate))
+                continue; // candidate is not in given creation_options
+            if(can_use_creation_options(candidate))
+            {
+                // If creation_options != candidate for all candidates, creation_optionsactually
+                // combines 2 or more candidates --> only the candidates actually supporting plan
+                // creation will be considered "valid". If there exists one (usable) candidate s.t.
+                // creation_options == candidate however, this choice is considered "enforced"
+                // (e.g. for function-specific argument validation testing purposes)
+                if(creation_options == candidate || is_supported_for_creation_with(candidate))
+                    valid_candidates.push_back(candidate);
+            }
+        }
+        if(valid_candidates.empty())
+            return hipfftw_plan_creation_func::NONE;
+        // "randomly" (yet reproducibly) choose
+        return valid_candidates[std::hash<std::string>()(token()) % valid_candidates.size()];
+    }
+
+    template <bool make_reference_plan = false>
+    hipfftw_plan_t<prec>
+        make_plan(void* in, void* out, hipfftw_plan_creation_func chosen_creation) const
+    {
+        if(std::find(hipfftw_plan_creation_func_candidates.begin(),
+                     hipfftw_plan_creation_func_candidates.end(),
+                     chosen_creation)
+           == hipfftw_plan_creation_func_candidates.end())
+        {
+            throw std::invalid_argument("Invalid chosen_creation for hipfftw_helper::make_plan");
+        }
+
+        // fetch/infer plan creation function arguments
+        const auto& hipfftw_impl = hipfftw_funcs<prec>::get_instance();
+        const auto  int_len      = get_length_as<int>();
+        const int*  int_len_ptr  = int_len.empty() ? nullptr : int_len.data();
+
+        switch(chosen_creation)
+        {
+        case hipfftw_plan_creation_func::PLAN_DFT_ND:
+        {
+            if(!can_use_creation_options(hipfftw_plan_creation_func::PLAN_DFT_ND))
+                throw std::runtime_error("hipfftw_plan_creation_func::PLAN_DFT_ND cannot be used.");
+            if(rank == 1)
+            {
+                if(dft_kind == fft_transform_type_real_forward)
+                {
+                    return hipfftw_impl.plan_dft_r2c_1d.template call<make_reference_plan>(
+                        int_len_ptr[0],
+                        static_cast<hipfftw_real_t<prec>*>(in),
+                        static_cast<hipfftw_complex_t<prec>*>(out),
+                        flags);
+                }
+                else if(dft_kind == fft_transform_type_real_inverse)
+                {
+                    return hipfftw_impl.plan_dft_c2r_1d.template call<make_reference_plan>(
+                        int_len_ptr[0],
+                        static_cast<hipfftw_complex_t<prec>*>(in),
+                        static_cast<hipfftw_real_t<prec>*>(out),
+                        flags);
+                }
+                else
+                {
+
+                    return hipfftw_impl.plan_dft_1d.template call<make_reference_plan>(
+                        int_len_ptr[0],
+                        static_cast<hipfftw_complex_t<prec>*>(in),
+                        static_cast<hipfftw_complex_t<prec>*>(out),
+                        sign,
+                        flags);
+                }
+            }
+            else if(rank == 2)
+            {
+                if(dft_kind == fft_transform_type_real_forward)
+                {
+                    return hipfftw_impl.plan_dft_r2c_2d.template call<make_reference_plan>(
+                        int_len_ptr[0],
+                        int_len_ptr[1],
+                        static_cast<hipfftw_real_t<prec>*>(in),
+                        static_cast<hipfftw_complex_t<prec>*>(out),
+                        flags);
+                }
+                else if(dft_kind == fft_transform_type_real_inverse)
+                {
+
+                    return hipfftw_impl.plan_dft_c2r_2d.template call<make_reference_plan>(
+                        int_len_ptr[0],
+                        int_len_ptr[1],
+                        static_cast<hipfftw_complex_t<prec>*>(in),
+                        static_cast<hipfftw_real_t<prec>*>(out),
+                        flags);
+                }
+                else
+                {
+                    return hipfftw_impl.plan_dft_2d.template call<make_reference_plan>(
+                        int_len_ptr[0],
+                        int_len_ptr[1],
+                        static_cast<hipfftw_complex_t<prec>*>(in),
+                        static_cast<hipfftw_complex_t<prec>*>(out),
+                        sign,
+                        flags);
+                }
+            }
+            else
+            {
+                if(dft_kind == fft_transform_type_real_forward)
+                {
+                    return hipfftw_impl.plan_dft_r2c_3d.template call<make_reference_plan>(
+                        int_len_ptr[0],
+                        int_len_ptr[1],
+                        int_len_ptr[2],
+                        static_cast<hipfftw_real_t<prec>*>(in),
+                        static_cast<hipfftw_complex_t<prec>*>(out),
+                        flags);
+                }
+                else if(dft_kind == fft_transform_type_real_inverse)
+                {
+                    return hipfftw_impl.plan_dft_c2r_3d.template call<make_reference_plan>(
+                        int_len_ptr[0],
+                        int_len_ptr[1],
+                        int_len_ptr[2],
+                        static_cast<hipfftw_complex_t<prec>*>(in),
+                        static_cast<hipfftw_real_t<prec>*>(out),
+                        flags);
+                }
+                else
+                {
+                    return hipfftw_impl.plan_dft_3d.template call<make_reference_plan>(
+                        int_len_ptr[0],
+                        int_len_ptr[1],
+                        int_len_ptr[2],
+                        static_cast<hipfftw_complex_t<prec>*>(in),
+                        static_cast<hipfftw_complex_t<prec>*>(out),
+                        sign,
+                        flags);
+                }
+            }
+        }
+        break;
+        case hipfftw_plan_creation_func::PLAN_DFT:
+        {
+            if(!can_use_creation_options(hipfftw_plan_creation_func::PLAN_DFT))
+                throw std::runtime_error("hipfftw_plan_creation_func::PLAN_DFT cannot be used.");
+
+            if(dft_kind == fft_transform_type_real_forward)
+            {
+                return hipfftw_impl.plan_dft_r2c.template call<make_reference_plan>(
+                    rank,
+                    int_len_ptr,
+                    static_cast<hipfftw_real_t<prec>*>(in),
+                    static_cast<hipfftw_complex_t<prec>*>(out),
+                    flags);
+            }
+            else if(dft_kind == fft_transform_type_real_inverse)
+            {
+                return hipfftw_impl.plan_dft_c2r.template call<make_reference_plan>(
+                    rank,
+                    int_len_ptr,
+                    static_cast<hipfftw_complex_t<prec>*>(in),
+                    static_cast<hipfftw_real_t<prec>*>(out),
+                    flags);
+            }
+            else
+            {
+                return hipfftw_impl.plan_dft.template call<make_reference_plan>(
+                    rank,
+                    int_len_ptr,
+                    static_cast<hipfftw_complex_t<prec>*>(in),
+                    static_cast<hipfftw_complex_t<prec>*>(out),
+                    sign,
+                    flags);
+            }
+        }
+        break;
+        case hipfftw_plan_creation_func::PLAN_MANY:
+            [[fallthrough]];
+        case hipfftw_plan_creation_func::PLAN_GURU:
+            [[fallthrough]];
+        case hipfftw_plan_creation_func::PLAN_GURU64:
+            throw std::runtime_error("Enforced plan creation is not implemented yet");
+            break;
+        default:
+            throw std::runtime_error("Unknown kind of plan creation");
+            break;
+        }
+        // unreachable
+    }
+
+public:
+    hipfftw_helper()                       = default;
+    ~hipfftw_helper()                      = default;
+    hipfftw_helper(hipfftw_helper&& other) = default;
+    hipfftw_helper& operator=(hipfftw_helper&& other) = default;
+    hipfftw_helper(const hipfftw_helper& other)       = default;
+    hipfftw_helper& operator=(const hipfftw_helper& rhs) = default;
+
+    void set_creation_args(fft_transform_type            dft_kind_to_set,
+                           int                           rank_to_set,
+                           const std::vector<ptrdiff_t>& lengths_to_set,
+                           fft_result_placement          placement_to_set,
+                           int                           sign_to_set,
+                           unsigned                      flags_to_set)
+    {
+        reset_member_value(dft_kind, dft_kind_to_set);
+        reset_member_value(rank, rank_to_set);
+        reset_member_value(lengths, lengths_to_set);
+        reset_member_value(plan_placement, placement_to_set);
+        reset_member_value(sign, sign_to_set);
+        reset_member_value(flags, flags_to_set);
+    }
+    // getters
+    fft_transform_type get_dft_kind() const
+    {
+        return dft_kind;
+    }
+    int get_rank() const
+    {
+        return rank;
+    }
+    // returns the lengths as an std::vector<T> if they may all be safely converted to T
+    // (the returned vector is empty otherwise)
+    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+    std::vector<T> get_length_as() const
+    {
+        if constexpr(std::is_same_v<T, typename decltype(lengths)::value_type>)
+            return lengths;
+        std::vector<T> ret;
+        if(std::any_of(lengths.begin(),
+                       lengths.end(),
+                       [](const typename decltype(lengths)::value_type& val) {
+                           return val < std::numeric_limits<T>::lowest()
+                                  || val > std::numeric_limits<T>::max();
+                       }))
+        {
+            // not a safe conversion, return empty lengths
+            return ret;
+        }
+        ret.assign(lengths.begin(), lengths.end());
+        return ret;
+    }
+    fft_result_placement get_placement() const
+    {
+        return plan_placement;
+    }
+    int get_sign() const
+    {
+        return sign;
+    }
+    unsigned get_flags() const
+    {
+        return flags;
+    }
+    std::shared_ptr<hipfftw_plan_bundle_t<prec>> get_plan_bundle() const
+    {
+        return plan_bundle;
+    }
+    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+    std::vector<T> get_strides_as(fft_io io) const
+    {
+        if(!rank_is_valid_for_hipfftw(rank) || !has_valid_lengths())
+            throw std::runtime_error(
+                "cannot calculate default strides with invalid rank or invalid lengths");
+        // only default strides for now
+        std::vector<ptrdiff_t> strides(rank, 1);
+        if(rank > 1)
+        {
+            if(is_complex(dft_kind))
+                strides[rank - 2] = lengths.back();
+            else
+            {
+                if(is_fwd(dft_kind) == (io == fft_io::fft_io_out))
+                    strides[rank - 2] = lengths.back() / 2 + 1;
+                else
+                {
+                    if(plan_placement == fft_placement_inplace)
+                        strides[rank - 2] = 2 * (lengths.back() / 2 + 1);
+                    else
+                        strides[rank - 2] = lengths.back();
+                }
+            }
+        }
+        for(auto dim = rank - 3; dim >= 0; dim--)
+            strides[dim] = strides[dim + 1] * lengths[dim + 1];
+
+        std::vector<T> ret;
+        if(std::any_of(strides.begin(),
+                       strides.end(),
+                       [](const typename decltype(strides)::value_type& val) {
+                           return val < std::numeric_limits<T>::lowest()
+                                  || val > std::numeric_limits<T>::max();
+                       }))
+        {
+            // not a safe conversion, return empty lengths
+            return ret;
+        }
+        ret.assign(strides.begin(), strides.end());
+        return ret;
+    }
+    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+    T get_dist_as(fft_io io) const
+    {
+        if(!rank_is_valid_for_hipfftw(rank) || !has_valid_lengths())
+            throw std::runtime_error(
+                "cannot calculate default distance(s) with invalid rank or invalid lengths");
+        // only default distances for now
+        ptrdiff_t dist = 0;
+        if(rank == 1)
+        {
+            if(is_complex(dft_kind))
+                dist = lengths.back();
+            else
+            {
+                if(is_fwd(dft_kind) == (io == fft_io::fft_io_out))
+                    dist = lengths.back() / 2 + 1;
+                else
+                {
+                    if(plan_placement == fft_placement_inplace)
+                        dist = 2 * (lengths.back() / 2 + 1);
+                    else
+                        dist = lengths.back();
+                }
+            }
+        }
+        else
+        {
+            const auto strides = get_strides_as<ptrdiff_t>(io);
+            dist               = strides.front() * lengths.front();
+        }
+        if(dist < std::numeric_limits<T>::lowest() || dist > std::numeric_limits<T>::max())
+            throw std::runtime_error("distance cannot be safely converted to the desired type");
+        return static_cast<T>(dist);
+    }
+    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+    T get_nbatch_as(fft_io io) const
+    {
+        // only unbatched for now
+        T ret = 1;
+        return ret;
+    }
+
+    // validity checks
+    bool has_valid_rank() const
+    {
+        return rank_is_valid_for_hipfftw(rank);
+    }
+    bool has_valid_lengths() const
+    {
+        return lengths_are_valid_for_hipfftw_as<ptrdiff_t>(lengths, rank);
+    }
+    bool has_valid_sign() const
+    {
+        return sign_is_valid_for_hipfftw(sign, dft_kind);
+    }
+    bool has_valid_flags() const
+    {
+        return flags_are_valid_for_hipfftw(flags);
+    }
+    // checks if the current parameters can be used with (any of) the given option(s) of
+    // plan creation (NOT whether they're valid or not). For instance, one cannot possibly
+    // communicate rank > 3 with hipfftw_plan_creation_func::PLAN_DFT_ND, or communicate
+    // non-default strides with hipfftw_plan_creation_func::PLAN_DFT_ND or
+    // hipfftw_plan_creation_func::PLAN_DFT...
+    // TODO: expand logic when extra configuration parameters are added (e.g. batch sizes,
+    // strides, etc.)
+    bool can_use_creation_options(hipfftw_plan_creation_func creation_options) const
+    {
+        if(!hipfftw_creation_options_are_well_defined(creation_options))
+            throw std::invalid_argument(
+                "ill-defined creation_options used in can_use_creation_options");
+        if(creation_options == hipfftw_plan_creation_func::NONE)
+            return false;
+        if(std::find(hipfftw_plan_creation_func_candidates.begin(),
+                     hipfftw_plan_creation_func_candidates.end(),
+                     creation_options)
+           == hipfftw_plan_creation_func_candidates.end())
+        {
+            // creation_options combines several candidates in hipfftw_plan_creation_func_candidates
+            // --> parse them individually and find out if any applicable can be used
+            return std::any_of(hipfftw_plan_creation_func_candidates.begin(),
+                               hipfftw_plan_creation_func_candidates.end(),
+                               [=](const hipfftw_plan_creation_func& candidate) {
+                                   return (creation_options & candidate)
+                                          && can_use_creation_options(candidate);
+                               });
+        }
+        // "creation_options" actually is an individual value in hipfftw_plan_creation_func_candidates
+        switch(creation_options)
+        {
+        case hipfftw_plan_creation_func::PLAN_DFT_ND:
+            // rank is not passed as an argument but dictated by the called function,
+            // (must be 1, 2, or 3), and as many lengths must be passed as individual
+            // integer values
+            return (rank == 1 || rank == 2 || rank == 3) && get_length_as<int>().size() == rank;
+            break;
+        case hipfftw_plan_creation_func::PLAN_DFT:
+            // the lengths must be representable as integers, if not empty (supposedly
+            // intentionally, e.g., for input validation testing purposes)
+            return lengths.empty() || get_length_as<int>().size() == rank;
+            break;
+        case hipfftw_plan_creation_func::PLAN_MANY:
+            [[fallthrough]];
+        case hipfftw_plan_creation_func::PLAN_GURU:
+            [[fallthrough]];
+        case hipfftw_plan_creation_func::PLAN_GURU64:
+            return false;
+            break;
+        default:
+            throw std::runtime_error("hipfftw_helper: internal error encountered (unexpected value "
+                                     "for creation_options)");
+            break;
+        }
+        // unreachable
+    }
+
+    // checks validity of configuration parameters and whether creation can be
+    // attempted via (any of) the given option(s)
+    bool is_valid_for_creation_with(hipfftw_plan_creation_func creation_options) const
+    {
+        if(!hipfftw_creation_options_are_well_defined(creation_options))
+            throw std::invalid_argument("invalid creation_options for is_valid_for_creation_with");
+
+        // TODO: expand the global validity checks below when this struct is
+        // expanded to cover more configurations (e.g., batching, srides, etc.)
+        return has_valid_rank() && has_valid_lengths() && has_valid_sign() && has_valid_flags()
+               && can_use_creation_options(creation_options);
+    }
+    bool is_valid_for_creation() const
+    {
+        return is_valid_for_creation_with(hipfftw_plan_creation_func::ANY);
+    }
+    // check expected support by (any of) the given option(s)
+    bool is_supported_for_creation_with(hipfftw_plan_creation_func creation_options) const
+    {
+        if(!hipfftw_creation_options_are_well_defined(creation_options))
+            throw std::invalid_argument(
+                "invalid creation_option for is_supported_for_creation_with");
+
+        if(!is_valid_for_creation_with(creation_options))
+            return false;
+        // extra conditions for configurations supported by hipfftw:
+        if(rank < 1 || rank > 3)
+            return false;
+        if(flags & FFTW_WISDOM_ONLY)
+            return false;
+        if(dft_kind == fft_transform_type_real_inverse && rank > 1 && (flags & FFTW_PRESERVE_INPUT))
+            return false;
+        if(!(creation_options & hipfftw_plan_creation_func::PLAN_GURU64))
+        {
+            // cannot handle data sizes involving more elements than the
+            // largest representable int value
+            if(get_num_elements_in(fft_io_in) > std::numeric_limits<int>::max()
+               || get_num_elements_in(fft_io_out) > std::numeric_limits<int>::max())
+                return false;
+        }
+        return true;
+    }
+    bool is_supported_for_creation() const
+    {
+        return is_supported_for_creation_with(hipfftw_plan_creation_func::ANY);
+    }
+    // create a token consistent with other tests to enable kernel precompilation
+    // for valid cases, and/or capturing all required details about members otherwise
+    std::string token() const
+    {
+        std::ostringstream ret;
+        switch(dft_kind)
+        {
+        case fft_transform_type_complex_forward:
+            ret << "complex_forward";
+            break;
+        case fft_transform_type_complex_inverse:
+            ret << "complex_inverse";
+            break;
+        case fft_transform_type_real_forward:
+            ret << "real_forward";
+            break;
+        case fft_transform_type_real_inverse:
+            ret << "real_inverse";
+            break;
+        default:
+            std::runtime_error("unknown type of transform");
+        }
+
+        // report rank if invalid
+        if(!has_valid_rank())
+            ret << "_invalid_rank" << (rank < 0 ? "_negative_" : "_") << std::abs(rank);
+        ret << "_len";
+        if(lengths.empty())
+            ret << "_none";
+        else
+        {
+            for(const auto& len : lengths)
+                ret << (len < 0 ? "_negative_" : "_") << std::abs(len);
+        }
+        if constexpr(prec == fft_precision_single)
+            ret << "_single";
+        else
+            ret << "_double";
+        ret << (plan_placement == fft_placement_inplace ? "_ip" : "_op");
+        // only supporting unbatched cases as of now
+        ret << "_batch_1";
+        if(has_valid_rank() && has_valid_lengths())
+        {
+            ret << "_istride";
+            for(const auto& stride : get_strides_as<size_t>(fft_io::fft_io_in))
+                ret << "_" << stride;
+            if(!is_real(dft_kind))
+                ret << "_CI";
+            else if(dft_kind == fft_transform_type_real_forward)
+                ret << "_R";
+            else
+                ret << "_HI";
+            ret << "_ostride";
+            for(const auto& stride : get_strides_as<size_t>(fft_io::fft_io_out))
+                ret << "_" << stride;
+            if(!is_real(dft_kind))
+                ret << "_CI";
+            else if(dft_kind == fft_transform_type_real_forward)
+                ret << "_HI";
+            else
+                ret << "_R";
+            ret << "_idist_" << get_dist_as<size_t>(fft_io::fft_io_in);
+            ret << "_odist_" << get_dist_as<size_t>(fft_io::fft_io_out);
+            ret << "_ioffset_0_0_ooffset_0_0";
+        }
+        if(!has_valid_sign())
+            ret << "_invalid_sign" << (sign < 0 ? "_negative_" : "_") << std::abs(sign);
+        ret << "_flags_" << flags;
+        return ret.str();
+    }
+    // create_plan invokes an hipfftw plan creation function for the object's configuration
+    // parameters, the corresponding plan pointer returned by hipfftw is stored internally.
+    // IMPORTANT NOTE: if one wants to target a specific creation function (as represented
+    // by any value in hipfftw_plan_creation_func_candidates), setting the creation_options
+    // argument to that specific value effectively bypasses the verification that the
+    // object's configuration is actually (expected to be) supported and attempts the plan
+    // creation anyways (unless it simply cannot be done, e.g., attempting
+    // creation_options = hipfftw_plan_creation_func::PLAN_DFT_ND herein on an object
+    // holding a value for rank > 3 simply cannot be done)
+    void create_plan(void*                      in,
+                     void*                      out,
+                     hipfftw_plan_creation_func creation_options
+                     = hipfftw_plan_creation_func::ANY) const
+    {
+        const auto&                      hipfftw_impl  = hipfftw_funcs<prec>::get_instance();
+        const hipfftw_plan_creation_func chosen_option = get_creation_func(creation_options);
+        if(chosen_option == hipfftw_plan_creation_func::NONE)
+        {
+            plan_bundle = std::make_shared<hipfftw_plan_bundle_t<prec>>(hipfftw_impl.destroy_plan);
+            plan_bundle->creation_io   = {in, out};
+            plan_bundle->plan          = nullptr;
+            plan_bundle->creation_func = chosen_option;
+            plan_bundle->plan_token    = "";
+            return;
+        }
+        // early return if there is no need to (re)build
+        if(plan_bundle && plan_bundle->plan_token == token() && plan_bundle->creation_io.first == in
+           && plan_bundle->creation_io.second == out && plan_bundle->creation_func == chosen_option)
+            return;
+
+        // create the desired plan
+        plan_bundle = std::make_shared<hipfftw_plan_bundle_t<prec>>(hipfftw_impl.destroy_plan);
+        plan_bundle->plan          = make_plan(in, out, chosen_option);
+        plan_bundle->creation_io   = {in, out};
+        plan_bundle->creation_func = chosen_option;
+        plan_bundle->plan_token    = token();
+    }
+
+    // returns a reference FFTW plan for the current configuration
+    // The returned plan is NOT owned by this object!
+    hipfftw_plan_t<prec> get_reference_plan(void*                      in,
+                                            void*                      out,
+                                            hipfftw_plan_creation_func creation_options
+                                            = hipfftw_plan_creation_func::ANY) const
+    {
+        const hipfftw_plan_creation_func chosen_option = get_creation_func(creation_options);
+        if(chosen_option == hipfftw_plan_creation_func::NONE)
+        {
+            return nullptr;
+        }
+        constexpr bool make_reference_plan = true;
+        return make_plan<make_reference_plan>(in, out, chosen_option);
+    }
+
+    void execute(void* execute_in, void* execute_out) const
+    {
+        if(!plan_bundle || plan_bundle->plan_token != token())
+        {
+            // plan is not created or possibly not up-to-date
+            create_plan(execute_in, execute_out);
+        }
+
+        const auto& hipfftw_impl = hipfftw_funcs<prec>::get_instance();
+        if(execute_in == plan_bundle->creation_io.first
+           && execute_out == plan_bundle->creation_io.second)
+        {
+            hipfftw_impl.execute(plan_bundle->plan);
+        }
+        else
+        {
+            std::runtime_error("New-array execution functions not implemented yet.");
+        }
+    }
+
+    // TODO: revise/expand logic below when the structure is expanded for more cases (batches,
+    // non-default strides, etc.)
+    size_t get_num_elements_in(fft_io in_or_out) const
+    {
+        if(in_or_out != fft_io_in && in_or_out != fft_io_out)
+            throw std::invalid_argument("invalid in_or_out for get_num_elements_in");
+        if(!has_valid_rank() || !has_valid_lengths())
+            throw std::runtime_error("get_num_elements_in requires valid rank and lengths");
+        const auto tmp = get_length_as<size_t>();
+        if(tmp.empty() || tmp.size() != rank)
+        {
+            throw std::runtime_error(
+                "get_num_elements_in failed to correctly convert lengths to size_t values");
+        }
+        size_t num_elems = 1;
+        if(is_complex(dft_kind))
+        {
+            num_elems *= tmp[rank - 1];
+        }
+        else
+        {
+            const size_t cmplx_len = tmp[rank - 1] / 2 + 1;
+            if(is_fwd(dft_kind) == (in_or_out == fft_io_out))
+                num_elems *= cmplx_len;
+            else
+                num_elems
+                    *= plan_placement == fft_placement_inplace ? 2 * cmplx_len : tmp[rank - 1];
+        }
+        num_elems *= product(tmp.begin(), tmp.begin() + rank - 1);
+        return num_elems;
+    }
+
+    size_t get_data_byte_size(fft_io in_or_out) const
+    {
+        if(in_or_out != fft_io_in && in_or_out != fft_io_out)
+            throw std::invalid_argument("invalid in_or_out for get_data_byte_size");
+        // for in-place, input and output data sizes are enforced equal
+        std::vector<fft_io> io_range_to_consider = {in_or_out};
+        if(plan_placement == fft_placement_inplace)
+            io_range_to_consider.push_back(in_or_out == fft_io::fft_io_in ? fft_io::fft_io_out
+                                                                          : fft_io::fft_io_in);
+
+        size_t ret = 0;
+        for(auto io : io_range_to_consider)
+        {
+            const size_t num_elems = get_num_elements_in(io);
+            if(is_complex(dft_kind) || (is_fwd(dft_kind) == (io == fft_io_out)))
+                ret = std::max(ret, num_elems * sizeof(hipfftw_complex_t<prec>));
+            else
+                ret = std::max(ret, num_elems * sizeof(hipfftw_real_t<prec>));
+        }
+        return ret;
+    }
+    void release_plan() const
+    {
+        plan_bundle.reset();
+    }
+};
+
+#endif

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -320,15 +320,23 @@ public:
         : active(false)
         , original_cerr_rdbuf(std::cerr.rdbuf())
     {
-        const char* hipfftw_log_trace = std::getenv("HIPFFTW_LOG_EXCEPTIONS");
-        if(!hipfftw_log_trace || std::atoi(hipfftw_log_trace) <= 0)
-        {
 #ifdef WIN32
+        // no more than 8*sizeof(size_t) + 3 characters for valid values
+        // (if variable defined in binary representation "0b[...]")
+        char       hipfftw_log_trace[8 * sizeof(size_t) + 3];
+        const auto sz = GetEnvironmentVariableA(
+            "HIPFFTW_LOG_EXCEPTIONS", hipfftw_log_trace, sizeof(hipfftw_log_trace));
+        if(sz == 0 || (sz <= sizeof(hipfftw_log_trace) && std::stoull(hipfftw_log_trace) == 0))
+        {
             active = SetEnvironmentVariable("HIPFFTW_LOG_EXCEPTIONS", "1");
-#else
-            active = setenv("HIPFFTW_LOG_EXCEPTIONS", "1", 1) == EXIT_SUCCESS;
-#endif
         }
+#else
+        const char* hipfftw_log_trace = std::getenv("HIPFFTW_LOG_EXCEPTIONS");
+        if(!hipfftw_log_trace || std::stoull(hipfftw_log_trace) == 0)
+        {
+            active = setenv("HIPFFTW_LOG_EXCEPTIONS", "1", 1) == EXIT_SUCCESS;
+        }
+#endif
         if(active)
             std::cerr.rdbuf(buffer.rdbuf());
     }

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ set( hipfft-test_source
   accuracy_test_2D.cpp
   accuracy_test_3D.cpp
   accuracy_test_callback.cpp
+  hipfftw_test.cpp
   multi_device_test.cpp
   multi_stream_test.cpp
   ../../shared/array_validator.cpp
@@ -250,6 +251,11 @@ target_link_libraries( hipfft-test
   Threads::Threads
   )
 
+# hipfft-test will opens the hipfftw library but does not link to it
+if( TARGET hipfftw )
+  add_dependencies( hipfft-test hipfftw )
+endif()
+
 if (WIN32)
 
   # Ensure tests run with HIP DLLs and not anything the driver owns
@@ -301,8 +307,8 @@ if (BUILD_CODE_COVERAGE)
     coverage
     DEPENDS code_cov_tests
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
-    COMMAND ${LLVM_COV} report -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
-    COMMAND ${LLVM_COV} show -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
+    COMMAND ${LLVM_COV} report -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
+    COMMAND ${LLVM_COV} show -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 endif()

--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -61,6 +61,9 @@ double real_prob_factor;
 double complex_planar_prob_factor;
 // Modifier for probability of running tests with callbacks
 double callback_prob_factor;
+// Constraints for the hipfftw tests
+size_t max_length_for_hipfftw_test;
+size_t max_io_gb_for_hipfftw_test;
 
 // Transform parameters for manual test:
 hipfft_params manual_params;
@@ -306,6 +309,16 @@ int main(int argc, char* argv[])
                    "Probability multiplier for running individual callback transforms")
         ->default_val(0.1)
         ->check(CLI::NonNegativeNumber);
+    app.add_option("--max_hipfftw_test_len",
+                   max_length_for_hipfftw_test,
+                   "Maximum length to be considered in hipfftw tests")
+        ->default_val(8192)
+        ->check(CLI::PositiveNumber);
+    app.add_option("--max_io_gb_for_hipfftw_test",
+                   max_io_gb_for_hipfftw_test,
+                   "Maximum size of I/O to be considered in hipfftw tests in GiB")
+        ->default_val(1) /* 1 GiB */
+        ->check(CLI::PositiveNumber);
 
     app.add_option("--fftw_compare", fftw_compare, "Compare to FFTW in accuracy tests")
         ->default_val(true);

--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -172,13 +172,10 @@ void precompile_test_kernels(const std::string& precompile_file)
                 continue;
 
             // only care about accuracy tests
-            if(name.find("vs_fftw/") != std::string::npos)
+            const auto pos = name.find("vs_fftw/");
+            if(pos != std::string::npos)
             {
-                // [possible TODO] move above check to nesting loop's scope as a
-                // check on the test suite's name (i.e., if it includes "accuracy_test").
-                // That would allow other (hypothetical) accuracy test instances than
-                // "vs_fftw/" to be considered as well...
-                name.erase(0, 8);
+                name.erase(0, pos + 8);
 
                 // change batch to 1, so we don't waste time creating
                 // multiple plans that differ only by batch
@@ -201,7 +198,7 @@ void precompile_test_kernels(const std::string& precompile_file)
     std::mt19937       dist(dev());
     std::shuffle(tokens.begin(), tokens.end(), dist);
     auto precompile_begin = std::chrono::steady_clock::now();
-    std::cout << "precompiling " << tokens.size() << " FFT plans...\n";
+    std::cout << "precompiling kernels for " << tokens.size() << " tokens...\n";
 
     for(auto&& t : tokens)
         tokenQueue.push(std::move(t));
@@ -224,6 +221,13 @@ void precompile_test_kernels(const std::string& precompile_file)
                     params.from_token(token);
                     params.validate();
                     params.create_plan();
+                    if(params.is_forward())
+                    {
+                        hipfft_params inverse_params;
+                        inverse_params.inverse_from_forward(params);
+                        inverse_params.validate();
+                        inverse_params.create_plan();
+                    }
                 }
                 catch(fft_params::work_buffer_alloc_failure&)
                 {

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -1733,7 +1733,7 @@ namespace
                 }
                 const auto contiguous_idist = val;
                 set_input<hostbuf, hipfftw_real_t<prec>>(verification_input,
-                                                         fft_input_generator_host,
+                                                         fft_input_random_generator_host,
                                                          params.get_array_type(fft_io::fft_io_in),
                                                          params.get_lengths(),
                                                          ilength,
@@ -1978,7 +1978,7 @@ namespace
                                            {0} /* offset */,
                                            {0} /* offset */);
                 EXPECT_LE(diff.l_inf, linf_cutoff);
-                EXPECT_LT(diff.l_2 / ref_norm.l_2, sqrt(log2(total_length)) * test_epsilon);
+                EXPECT_LE(diff.l_2 / ref_norm.l_2, sqrt(log2(total_length)) * test_epsilon);
                 if constexpr(prec == fft_precision_single)
                 {
                     max_linf_eps_single = std::max(max_linf_eps_single,

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -52,11 +52,33 @@ namespace
     //---------------------------------------------------------------------------------------------
     //
 
-    // byte size limit used for I/O data sizes (arbitrarily decided)
-    const std::vector<size_t> max_byte_size_for_unbatched_hipfftw_tests
-        = {1ULL << 16, 1ULL << 24, 1ULL << 29};
-    //             1D          2D       >= 3D
-    //         64 KiB,     16 MiB,    512 MiB
+    size_t max_byte_size_for_hipfftw_tests()
+    {
+        auto get_io_byte_size_limit = []() {
+            size_t tmp = vramgb * ONE_GiB;
+            if(tmp == 0)
+            {
+                size_t free = 0, total = 0;
+                if(hipMemGetInfo(&free, &total) == hipSuccess)
+                    tmp = total / 8;
+            }
+            tmp = std::min(tmp, ramgb * ONE_GiB);
+            tmp = std::min(tmp, max_io_gb_for_hipfftw_test * ONE_GiB);
+            if(verbose > 0)
+            {
+                std::cout << "Limit for the size of I/O data used in hipfftw tests: ";
+                if(tmp >= ONE_GiB)
+                    std::cout << float(tmp) / ONE_GiB << " GiB." << std ::endl;
+                else if(tmp >= ONE_MiB)
+                    std::cout << float(tmp) / ONE_MiB << " MiB." << std ::endl;
+                else
+                    std::cout << float(tmp) / ONE_KiB << " KiB." << std ::endl;
+            }
+            return tmp;
+        };
+        static const size_t io_byte_size_limit = get_io_byte_size_limit();
+        return io_byte_size_limit;
+    }
 
     std::ranlux24_base& get_pseudo_rng()
     {
@@ -1036,12 +1058,12 @@ namespace
                     {
                         const bool is_real_inplace
                             = is_real(dft_kind) && placement == fft_placement_inplace;
-                        const auto max_byte_size
-                            = max_byte_size_for_unbatched_hipfftw_tests[std::min(rank - 1, 2)];
-                        const ptrdiff_t allocatable_len_threshold = get_len_threshold(
-                            max_num_elems_for_data_size<prec>(max_byte_size, dft_kind),
-                            rank,
-                            is_real_inplace);
+                        const ptrdiff_t allocatable_len_threshold = std::min(
+                            get_len_threshold(max_num_elems_for_data_size<prec>(
+                                                  max_byte_size_for_hipfftw_tests(), dft_kind),
+                                              rank,
+                                              is_real_inplace),
+                            static_cast<ptrdiff_t>(max_length_for_hipfftw_test));
                         const auto valid_int_lengths
                             = get_random_lengths<valid_value, int>(rank, allocatable_len_threshold);
                         // always add valid integer lengths for valid ranks
@@ -1105,12 +1127,11 @@ namespace
         {
             // do not allocate for the lengths designed to trigger an overflow
             // (allocation sizes would be ridiculously large)
-            const bool test_may_allocate
-                = helper.has_valid_rank() && helper.has_valid_lengths()
-                  && helper.get_data_byte_size(fft_io::fft_io_in)
-                         <= max_byte_size_for_unbatched_hipfftw_tests[helper.get_rank() - 1]
-                  && helper.get_data_byte_size(fft_io::fft_io_out)
-                         <= max_byte_size_for_unbatched_hipfftw_tests[helper.get_rank() - 1];
+            const bool test_may_allocate = helper.has_valid_rank() && helper.has_valid_lengths()
+                                           && helper.get_data_byte_size(fft_io::fft_io_in)
+                                                  <= max_byte_size_for_hipfftw_tests()
+                                           && helper.get_data_byte_size(fft_io::fft_io_out)
+                                                  <= max_byte_size_for_hipfftw_tests();
             for(auto creation : hipfftw_plan_creation_func_candidates)
             {
                 // full range considered for creation_io_is_null and execution_io
@@ -2025,12 +2046,15 @@ namespace
             to_add.execution_io = hipfftw_execution_io_args::use_creation_io;
             const auto dft_kind
                 = trans_type_range_full[get_random_idx(trans_type_range_full.size())];
-            const auto rank               = get_random_rank<valid_value, 1, 3>();
-            const auto placement          = place_range[get_random_idx(place_range.size())];
-            const bool is_real_inplace    = is_real(dft_kind) && placement == fft_placement_inplace;
-            const auto max_byte_size      = max_byte_size_for_unbatched_hipfftw_tests[rank - 1];
-            const ptrdiff_t len_threshold = get_len_threshold(
-                max_num_elems_for_data_size<prec>(max_byte_size, dft_kind), rank, is_real_inplace);
+            const auto rank            = get_random_rank<valid_value, 1, 3>();
+            const auto placement       = place_range[get_random_idx(place_range.size())];
+            const bool is_real_inplace = is_real(dft_kind) && placement == fft_placement_inplace;
+            const ptrdiff_t len_threshold
+                = std::min(get_len_threshold(max_num_elems_for_data_size<prec>(
+                                                 max_byte_size_for_hipfftw_tests(), dft_kind),
+                                             rank,
+                                             is_real_inplace),
+                           static_cast<ptrdiff_t>(max_length_for_hipfftw_test));
             to_add.plan_helper.set_creation_args(
                 dft_kind,
                 rank,

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -27,6 +27,7 @@
 #include "../../shared/test_params.h"
 
 #include <cstdint>
+#include <cstring>
 #include <fftw3.h>
 #include <future>
 #include <gtest/gtest.h>
@@ -1442,14 +1443,12 @@ namespace
                                                          hipfftw_data_memory_type::device};
 #ifndef WIN32
             // "managed" may or may not be supported
-            int managed_mem_is_supported = 0;
-            if(hipDeviceGetAttribute(&managed_mem_is_supported,
-                                     hipDeviceAttributeManagedMemory,
-                                     get_current_device_id())
-                   == hipSuccess
-               && managed_mem_is_supported)
+            hipDeviceProp_t props;
+            if(hipGetDeviceProperties(&props, get_current_device_id()) == hipSuccess)
             {
-                ret.push_back(hipfftw_data_memory_type::managed);
+                // explicitly ruling out gfx908 (MI100)
+                if(std::strstr(props.gcnArchName, "gfx908") == nullptr && props.managedMemory == 1)
+                    ret.push_back(hipfftw_data_memory_type::managed);
             }
 #endif
             return ret;

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -122,15 +122,6 @@ namespace
         }
         return ret;
     }
-    int get_random_integer(const int min_val, const int max_val)
-    {
-        if(min_val > max_val)
-            throw std::invalid_argument("invalid bounds for get_random_integer");
-        std::uniform_int_distribution<int> int_rng(min_val, max_val);
-
-        return int_rng(get_pseudo_rng());
-    }
-
     template <bool validity_flag, typename type_to_consider_for_validity>
     std::vector<ptrdiff_t>
         get_random_lengths(int       desired_rank,
@@ -1471,12 +1462,6 @@ namespace
         }
     };
 
-    hipfftw_data_memory_type get_random_data_mem_type()
-    {
-        const auto& options = get_possible_data_mem_types();
-        return options[get_random_idx(options.size())];
-    };
-
     template <fft_precision prec>
     struct hipfftw_functional_validation_params
     {
@@ -2125,13 +2110,21 @@ TEST(hipfftw_test, utility_functions)
 }
 
 INSTANTIATE_TEST_SUITE_P(
+#ifdef __HIP_PLATFORM_AMD__
     hipfftw_test,
+#else
+    DISABLED_hipfftw_test,
+#endif
     allocation_sp,
     ::testing::ValuesIn(params_for_testing_hipfftw_malloc<fft_precision_single>()),
     allocation_sp::TestName);
 
 INSTANTIATE_TEST_SUITE_P(
+#ifdef __HIP_PLATFORM_AMD__
     hipfftw_test,
+#else
+    DISABLED_hipfftw_test,
+#endif
     allocation_dp,
     ::testing::ValuesIn(params_for_testing_hipfftw_malloc<fft_precision_double>()),
     allocation_dp::TestName);
@@ -2148,12 +2141,21 @@ TEST_P(argument_validation_dp, creation_and_execution)
 }
 
 INSTANTIATE_TEST_SUITE_P(
+#ifdef __HIP_PLATFORM_AMD__
     hipfftw_test,
+#else
+    DISABLED_hipfftw_test,
+#endif
     argument_validation_sp,
     ::testing::ValuesIn(params_for_testing_input_validation_params<fft_precision_single>()),
     argument_validation_sp::TestName);
+
 INSTANTIATE_TEST_SUITE_P(
+#ifdef __HIP_PLATFORM_AMD__
     hipfftw_test,
+#else
+    DISABLED_hipfftw_test,
+#endif
     argument_validation_dp,
     ::testing::ValuesIn(params_for_testing_input_validation_params<fft_precision_double>()),
     argument_validation_dp::TestName);

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -287,13 +287,24 @@ namespace
     template <fft_precision prec>
     void test_existence_of_utility_functions()
     {
-        // call utility functions - they need to exist but don't need to work
-        const auto& hipfftw_ = hipfftw_funcs<prec>::get_instance();
-        hipfftw_.print_plan(nullptr);
-        hipfftw_.set_timelimit(0.0);
-        hipfftw_.cost(nullptr);
-        hipfftw_.flops(nullptr, nullptr, nullptr, nullptr);
-        hipfftw_.cleanup();
+        try
+        {
+            // call utility functions - they need to exist but don't need to work
+            const auto& hipfftw_ = hipfftw_funcs<prec>::get_instance();
+            hipfftw_.print_plan(nullptr);
+            hipfftw_.set_timelimit(0.0);
+            hipfftw_.cost(nullptr);
+            hipfftw_.flops(nullptr, nullptr, nullptr, nullptr);
+            hipfftw_.cleanup();
+        }
+        catch(const hipfftw_undefined_function_ptr& e)
+        {
+            GTEST_FAIL() << "Undefined function pointers detected. Error info: " << e.what();
+        }
+        catch(...)
+        {
+            GTEST_FAIL() << "Unexpected failure";
+        }
     }
 
     //
@@ -2452,19 +2463,8 @@ namespace
 
 TEST(hipfftw_test, utility_functions)
 {
-    try
-    {
-        test_existence_of_utility_functions<fft_precision_single>();
-        test_existence_of_utility_functions<fft_precision_double>();
-    }
-    catch(const hipfftw_undefined_function_ptr& e)
-    {
-        GTEST_FAIL() << "Undefined function pointers detected. Error info: " << e.what();
-    }
-    catch(...)
-    {
-        GTEST_FAIL() << "Unexpected failure";
-    }
+    test_existence_of_utility_functions<fft_precision_single>();
+    test_existence_of_utility_functions<fft_precision_double>();
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -20,6 +20,7 @@
 
 #include "../hipfftw_helper.h"
 
+#include "../../shared/environment.h"
 #include "../../shared/gpubuf.h"
 #include "../../shared/hostbuf.h"
 #include "../../shared/params_gen.h"
@@ -336,9 +337,6 @@ namespace
 
     const std::vector<hipfftw_alloc_memkind> hipfftw_possible_memkinds
         = {pinned_host, pageable_host};
-    const std::string env_hipfftw_pageable_alloc_limit
-        = "HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC";
-    const std::string env_hipfftw_pinned_alloc_limit = "HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC";
 
     bool hipfftw_alloc_kind_is_valid(hipfftw_alloc_memkind kind)
     {
@@ -380,85 +378,6 @@ namespace
             break;
         }
         // unreachable
-    }
-
-    size_t get_hipfftw_allocation_byte_size_limit(hipfftw_alloc_memkind kind)
-    {
-        // kind must be in hipfftw_possible_memkinds
-        if(std::find(hipfftw_possible_memkinds.begin(), hipfftw_possible_memkinds.end(), kind)
-           == hipfftw_possible_memkinds.end())
-        {
-            throw std::invalid_argument("get_hipfftw_allocation_byte_size_limit: invalid kind");
-        }
-        // kind is a well-defined value in hipfftw_possible_memkinds
-        const char* dedicated_env_var_cstr = nullptr;
-        switch(kind)
-        {
-        case hipfftw_alloc_memkind::pinned_host:
-            dedicated_env_var_cstr = env_hipfftw_pinned_alloc_limit.c_str();
-            break;
-        case hipfftw_alloc_memkind::pageable_host:
-            dedicated_env_var_cstr = env_hipfftw_pageable_alloc_limit.c_str();
-            break;
-        default:
-            break;
-        }
-        if(!dedicated_env_var_cstr)
-            throw std::runtime_error(
-                "get_hipfftw_allocation_byte_size_limit: internal error encountered "
-                "(unexpected value for kind)");
-#ifdef WIN32
-        // no more than 8*sizeof(size_t) + 3 characters for valid values
-        // (if variable defined in binary representation "0b[...]")
-        char       tmp[8 * sizeof(size_t) + 3];
-        const auto sz = GetEnvironmentVariableA(dedicated_env_var_cstr, tmp, sizeof(tmp));
-        if(sz == 0 || sz > sizeof(tmp))
-            return std::numeric_limits<size_t>::max();
-#else
-        const char* tmp = std::getenv(dedicated_env_var_cstr);
-        if(!tmp)
-            return std::numeric_limits<size_t>::max();
-#endif
-        return std::stoull(tmp);
-    }
-
-    // self-explanatory
-    // returned bool is true if the limit was successfully set
-    bool set_hipfftw_allocation_byte_size_limit(hipfftw_alloc_memkind kind, size_t limit_to_set)
-    {
-        // kind must be in hipfftw_possible_memkinds
-        if(std::find(hipfftw_possible_memkinds.begin(), hipfftw_possible_memkinds.end(), kind)
-           == hipfftw_possible_memkinds.end())
-        {
-            throw std::invalid_argument("set_hipfftw_allocation_byte_size_limit: invalid kind");
-        }
-        // kind is a well-defined value in hipfftw_possible_memkinds
-        bool       ret        = false;
-        const auto limit_str  = std::to_string(limit_to_set);
-        const auto limit_cstr = limit_str.c_str();
-        switch(kind)
-        {
-        case hipfftw_alloc_memkind::pinned_host:
-#ifdef WIN32
-            ret = SetEnvironmentVariable(env_hipfftw_pinned_alloc_limit.c_str(), limit_cstr);
-#else
-            ret = setenv(env_hipfftw_pinned_alloc_limit.c_str(), limit_cstr, 1) == EXIT_SUCCESS;
-#endif
-            break;
-        case hipfftw_alloc_memkind::pageable_host:
-#ifdef WIN32
-            ret = SetEnvironmentVariable(env_hipfftw_pageable_alloc_limit.c_str(), limit_cstr);
-#else
-            ret = setenv(env_hipfftw_pageable_alloc_limit.c_str(), limit_cstr, 1) == EXIT_SUCCESS;
-#endif
-            break;
-        default:
-            throw std::runtime_error(
-                "set_hipfftw_allocation_byte_size_limit: internal error encountered "
-                "(unexpected value for kind)");
-            break;
-        }
-        return ret;
     }
 
     template <fft_precision prec>
@@ -563,8 +482,7 @@ namespace
     protected:
         void* test_allocation = nullptr;
         bool  expect_no_allocation;
-
-        std::map<hipfftw_alloc_memkind, size_t> limits_to_reset_upon_test_completion;
+        std::map<hipfftw_alloc_memkind, std::unique_ptr<EnvironmentSetTemp>> temp_alloc_limit_env;
 
         void SetUp() override
         {
@@ -580,22 +498,39 @@ namespace
             size_t limit_for_alloc_kind = 0;
             for(auto alloc_kind_candidate : hipfftw_possible_memkinds)
             {
+                if(alloc_kind_candidate != hipfftw_alloc_memkind::pinned_host
+                   && alloc_kind_candidate != hipfftw_alloc_memkind::pageable_host)
+                {
+                    throw std::runtime_error("unexpected memory allocation kind "
+                                             + hipfftw_alloc_kind_to_string(alloc_kind_candidate));
+                }
+                const std::string control_env_var
+                    = alloc_kind_candidate == hipfftw_alloc_memkind::pinned_host
+                          ? "HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC"
+                          : "HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC";
+
                 if(alloc_kind_candidate & params.alloc_kind)
                 {
+                    const auto test_user_limit = rocfft_getenv(control_env_var.c_str());
                     limit_for_alloc_kind
                         = std::max(limit_for_alloc_kind,
-                                   get_hipfftw_allocation_byte_size_limit(alloc_kind_candidate));
+                                   test_user_limit.empty() ? std::numeric_limits<size_t>::max()
+                                                           : size_t(std::stoull(test_user_limit)));
                 }
                 else
                 {
-                    limits_to_reset_upon_test_completion[alloc_kind_candidate]
-                        = get_hipfftw_allocation_byte_size_limit(alloc_kind_candidate);
                     // disable the other possible allocation kind(s) by temporarily
                     // setting the corresponding byte size limit to 0
-                    if(!set_hipfftw_allocation_byte_size_limit(alloc_kind_candidate, 0))
+                    temp_alloc_limit_env[alloc_kind_candidate]
+                        = std::make_unique<EnvironmentSetTemp>(control_env_var.c_str(), "0");
+                    // skip if temporary limit(s) was(were) not successfully set
+                    const auto tmp_limit = rocfft_getenv(control_env_var.c_str());
+                    if(tmp_limit.empty() || std::stoull(tmp_limit) != 0)
+                    {
                         GTEST_SKIP() << "failed to set environment variable disabling "
                                      << hipfftw_alloc_kind_to_string(alloc_kind_candidate)
                                      << " allocation(s) by hipFFTW";
+                    }
                 }
             }
             const size_t req_byte_size = params.get_byte_size();
@@ -604,11 +539,7 @@ namespace
         }
         void TearDown() override
         {
-            for(auto limit_to_reset : limits_to_reset_upon_test_completion)
-            {
-                // reset all temporarily-modified allocation limits
-                set_hipfftw_allocation_byte_size_limit(limit_to_reset.first, limit_to_reset.second);
-            }
+            temp_alloc_limit_env.clear();
             const hipfftw_funcs<prec>& hipfftw_impl = hipfftw_funcs<prec>::get_instance();
             if(test_allocation && !hipfftw_impl.free.may_be_used())
                 GTEST_FAIL() << "An allocation was created but it can't be freed";

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -302,43 +302,177 @@ namespace
     //---------------------------------------------------------------------------------------------
     //
 
-    enum class alloc_func_type
+    enum class hipfftw_alloc_func_type
     {
         unspecified,
         real,
         complex
     };
-    bool alloc_func_type_is_valid(alloc_func_type func)
+    bool hipfftw_alloc_func_type_is_valid(hipfftw_alloc_func_type func)
     {
-        return func == alloc_func_type::unspecified || func == alloc_func_type::real
-               || func == alloc_func_type::complex;
+        return func == hipfftw_alloc_func_type::unspecified || func == hipfftw_alloc_func_type::real
+               || func == hipfftw_alloc_func_type::complex;
     }
-    // bit mask to prevent allocation kind(s)
-    enum alloc_kind_disabler : unsigned
+    // bit mask to prevent allocation kind(s), by increasing "rank" to enable meaningful
+    // comparison operators (implicitly defined based on the underlying type)
+    enum hipfftw_alloc_memkind : unsigned
     {
         none          = 0x0,
-        pinned_host   = 0x1 << 0,
-        pageable_host = 0x1 << 1,
-        all           = pinned_host | pageable_host
+        pageable_host = 0x1 << 0,
+        pinned_host   = 0x1 << 1,
+        any           = pageable_host | pinned_host
     };
-    bool alloc_disabler_is_valid(alloc_kind_disabler disabler)
+
+    const std::vector<hipfftw_alloc_memkind> hipfftw_possible_memkinds
+        = {pinned_host, pageable_host};
+    const std::string env_hipfftw_pageable_alloc_limit
+        = "HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC";
+    const std::string env_hipfftw_pinned_alloc_limit = "HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC";
+
+    bool hipfftw_alloc_kind_is_valid(hipfftw_alloc_memkind kind)
     {
-        return disabler == (disabler & alloc_kind_disabler::all);
+        return kind == (kind & hipfftw_alloc_memkind::any);
     }
+    std::string hipfftw_alloc_kind_to_string(hipfftw_alloc_memkind kind)
+    {
+        if(!hipfftw_alloc_kind_is_valid(kind))
+            throw std::invalid_argument("alloc_kind_to_string: invalid kind");
+        if(kind == hipfftw_alloc_memkind::none)
+            return "none";
+        if(std::find(hipfftw_possible_memkinds.begin(), hipfftw_possible_memkinds.end(), kind)
+           == hipfftw_possible_memkinds.end())
+        {
+            // several values enabled
+            std::string ret;
+            for(auto to_consider : hipfftw_possible_memkinds)
+            {
+                if(!(kind & to_consider))
+                    continue;
+                if(!ret.empty())
+                    ret += "_or_";
+                ret += hipfftw_alloc_kind_to_string(to_consider);
+            }
+            return ret;
+        }
+        // kind is a well-defined value in hipfftw_possible_memkinds
+        switch(kind)
+        {
+        case hipfftw_alloc_memkind::pinned_host:
+            return "pinned_host";
+            break;
+        case hipfftw_alloc_memkind::pageable_host:
+            return "pageable_host";
+            break;
+        default:
+            throw std::runtime_error("alloc_kind_to_string: internal error encountered "
+                                     "(unexpected value for kind)");
+            break;
+        }
+        // unreachable
+    }
+
+    size_t get_hipfftw_allocation_byte_size_limit(hipfftw_alloc_memkind kind)
+    {
+        // kind must be in hipfftw_possible_memkinds
+        if(std::find(hipfftw_possible_memkinds.begin(), hipfftw_possible_memkinds.end(), kind)
+           == hipfftw_possible_memkinds.end())
+        {
+            throw std::invalid_argument("get_hipfftw_allocation_byte_size_limit: invalid kind");
+        }
+        // kind is a well-defined value in hipfftw_possible_memkinds
+        const char* dedicated_env_var_cstr = nullptr;
+        switch(kind)
+        {
+        case hipfftw_alloc_memkind::pinned_host:
+            dedicated_env_var_cstr = env_hipfftw_pinned_alloc_limit.c_str();
+            break;
+        case hipfftw_alloc_memkind::pageable_host:
+            dedicated_env_var_cstr = env_hipfftw_pageable_alloc_limit.c_str();
+            break;
+        default:
+            break;
+        }
+        if(!dedicated_env_var_cstr)
+            throw std::runtime_error(
+                "get_hipfftw_allocation_byte_size_limit: internal error encountered "
+                "(unexpected value for kind)");
+#ifdef WIN32
+        // no more than 8*sizeof(size_t) + 3 characters for valid values
+        // (if variable defined in binary representation "0b[...]")
+        char       tmp[8 * sizeof(size_t) + 3];
+        const auto sz = GetEnvironmentVariableA(dedicated_env_var_cstr, tmp, sizeof(tmp));
+        if(sz == 0 || sz > sizeof(tmp))
+            return std::numeric_limits<size_t>::max();
+#else
+        const char* tmp = std::getenv(dedicated_env_var_cstr);
+        if(!tmp)
+            return std::numeric_limits<size_t>::max();
+#endif
+        return std::stoull(tmp);
+    }
+
+    // self-explanatory
+    // returned bool is true if the limit was successfully set
+    bool set_hipfftw_allocation_byte_size_limit(hipfftw_alloc_memkind kind, size_t limit_to_set)
+    {
+        // kind must be in hipfftw_possible_memkinds
+        if(std::find(hipfftw_possible_memkinds.begin(), hipfftw_possible_memkinds.end(), kind)
+           == hipfftw_possible_memkinds.end())
+        {
+            throw std::invalid_argument("set_hipfftw_allocation_byte_size_limit: invalid kind");
+        }
+        // kind is a well-defined value in hipfftw_possible_memkinds
+        bool       ret        = false;
+        const auto limit_str  = std::to_string(limit_to_set);
+        const auto limit_cstr = limit_str.c_str();
+        switch(kind)
+        {
+        case hipfftw_alloc_memkind::pinned_host:
+#ifdef WIN32
+            ret = SetEnvironmentVariable(env_hipfftw_pinned_alloc_limit.c_str(), limit_cstr);
+#else
+            ret = setenv(env_hipfftw_pinned_alloc_limit.c_str(), limit_cstr, 1) == EXIT_SUCCESS;
+#endif
+            break;
+        case hipfftw_alloc_memkind::pageable_host:
+#ifdef WIN32
+            ret = SetEnvironmentVariable(env_hipfftw_pageable_alloc_limit.c_str(), limit_cstr);
+#else
+            ret = setenv(env_hipfftw_pageable_alloc_limit.c_str(), limit_cstr, 1) == EXIT_SUCCESS;
+#endif
+            break;
+        default:
+            throw std::runtime_error(
+                "set_hipfftw_allocation_byte_size_limit: internal error encountered "
+                "(unexpected value for kind)");
+            break;
+        }
+        return ret;
+    }
+
     template <fft_precision prec>
     struct hipfftw_malloc_params
     {
-        size_t              alloc_arg;
-        alloc_func_type     alloc_func;
-        alloc_kind_disabler avoid_alloc_kind;
+        size_t                  alloc_arg;
+        hipfftw_alloc_func_type alloc_func;
+        hipfftw_alloc_memkind   alloc_kind;
+
+        size_t get_byte_size() const
+        {
+            return alloc_arg
+                   * (alloc_func == hipfftw_alloc_func_type::unspecified
+                          ? sizeof(char)
+                          : (alloc_func == hipfftw_alloc_func_type::real
+                                 ? sizeof(hipfftw_real_t<prec>)
+                                 : sizeof(hipfftw_complex_t<prec>)));
+        }
 
         std::string to_string() const
         {
-            if(alloc_func != alloc_func_type::unspecified && alloc_func != alloc_func_type::real
-               && alloc_func != alloc_func_type::complex)
-                throw std::runtime_error("unknown type of allocation function");
-            if(!alloc_disabler_is_valid(avoid_alloc_kind))
-                throw std::runtime_error("unknown allocation kind(s) to disable");
+            if(!hipfftw_alloc_func_type_is_valid(alloc_func))
+                throw std::runtime_error("invalid type of allocation function");
+            if(!hipfftw_alloc_kind_is_valid(alloc_kind))
+                throw std::runtime_error("invalid allocation kind(s)");
 
             std::string ret;
             if constexpr(prec == fft_precision_single)
@@ -346,17 +480,14 @@ namespace
             else
                 ret += "fftw_";
 
-            if(alloc_func == alloc_func_type::unspecified)
+            if(alloc_func == hipfftw_alloc_func_type::unspecified)
                 ret += "malloc_";
-            else if(alloc_func == alloc_func_type::real)
+            else if(alloc_func == hipfftw_alloc_func_type::real)
                 ret += "alloc_real_";
             else
                 ret += "alloc_complex_";
             ret += std::to_string(alloc_arg);
-            if(avoid_alloc_kind & alloc_kind_disabler::pinned_host)
-                ret += "_disabling_pinned_host";
-            if(avoid_alloc_kind & alloc_kind_disabler::pageable_host)
-                ret += "_disabling_pageable_host";
+            ret += "_alloc_kind_" + hipfftw_alloc_kind_to_string(alloc_kind);
             return ret;
         }
         // for using with insert_into_unique_sorted_params
@@ -377,29 +508,37 @@ namespace
         // testing argument value 0 and a randomly chosen one (max 64MiB in byte size, arbitrarily chosen)
         constexpr size_t max_test_alloc_size = 1ULL << 26;
 
-        const std::vector<alloc_func_type> func_range
-            = {alloc_func_type::unspecified, alloc_func_type::real, alloc_func_type::complex};
-        const std::vector<alloc_kind_disabler> disabler_range = {alloc_kind_disabler::none,
-                                                                 alloc_kind_disabler::pinned_host,
-                                                                 alloc_kind_disabler::pageable_host,
-                                                                 alloc_kind_disabler::all};
+        const std::vector<hipfftw_alloc_func_type> func_range
+            = {hipfftw_alloc_func_type::unspecified,
+               hipfftw_alloc_func_type::real,
+               hipfftw_alloc_func_type::complex};
+        std::vector<hipfftw_alloc_memkind> memkind_range;
+        // add all possible combinations of memory kinds:
+        for(auto kind = static_cast<std::underlying_type<hipfftw_alloc_memkind>::type>(
+                hipfftw_alloc_memkind::none);
+            kind <= static_cast<std::underlying_type<hipfftw_alloc_memkind>::type>(
+                hipfftw_alloc_memkind::any);
+            kind++)
+        {
+            memkind_range.push_back(static_cast<hipfftw_alloc_memkind>(kind));
+        }
 
         hipfftw_malloc_params<prec> to_add;
         for(auto func : func_range)
         {
             size_t max_arg = max_test_alloc_size;
-            if(func == alloc_func_type::real)
+            if(func == hipfftw_alloc_func_type::real)
                 max_arg /= sizeof(hipfftw_real_t<prec>);
-            else if(func == alloc_func_type::complex)
+            else if(func == hipfftw_alloc_func_type::complex)
                 max_arg /= sizeof(hipfftw_complex_t<prec>);
             std::uniform_int_distribution<size_t> arg_rng(1, max_arg);
-            for(auto disabler : disabler_range)
+            for(auto kind : memkind_range)
             {
                 for(auto arg : {size_t(0), arg_rng(get_pseudo_rng())})
                 {
-                    to_add.alloc_arg        = arg;
-                    to_add.alloc_func       = func;
-                    to_add.avoid_alloc_kind = disabler;
+                    to_add.alloc_arg  = arg;
+                    to_add.alloc_func = func;
+                    to_add.alloc_kind = kind;
                     insert_into_unique_sorted_params(ret, to_add);
                 }
             }
@@ -412,81 +551,54 @@ namespace
     {
     protected:
         void* test_allocation = nullptr;
-        bool  pinned_host_alloc_was_disabled;
-        bool  pageable_host_alloc_was_disabled;
+        bool  expect_no_allocation;
+
+        std::map<hipfftw_alloc_memkind, size_t> limits_to_reset_upon_test_completion;
 
         void SetUp() override
         {
             if(test_allocation)
                 GTEST_FAIL() << "Starting from an unclean slate (test_allocation is not nullptr)";
-            pinned_host_alloc_was_disabled   = false;
-            pageable_host_alloc_was_disabled = false;
-
             const hipfftw_malloc_params<prec>& params = this->GetParam();
             // check validity of params
-            if(!alloc_disabler_is_valid(params.avoid_alloc_kind))
-                GTEST_FAIL() << "invalid value for allocation disabler";
-
-            if(!alloc_func_type_is_valid(params.alloc_func))
+            if(!hipfftw_alloc_kind_is_valid(params.alloc_kind))
+                GTEST_FAIL() << "invalid value for allocation kind";
+            if(!hipfftw_alloc_func_type_is_valid(params.alloc_func))
                 GTEST_FAIL() << "unknown allocation function";
 
-            // enable allocation limits, if relevant for the targeted test
-            if(params.avoid_alloc_kind & alloc_kind_disabler::pinned_host)
+            size_t limit_for_alloc_kind = 0;
+            for(auto alloc_kind_candidate : hipfftw_possible_memkinds)
             {
-#ifdef WIN32
-                pinned_host_alloc_was_disabled
-                    = SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", "0");
-#else
-                pinned_host_alloc_was_disabled
-                    = setenv("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", "0", 1) == EXIT_SUCCESS;
-#endif
-                if(!pinned_host_alloc_was_disabled)
+                if(alloc_kind_candidate & params.alloc_kind)
                 {
-                    GTEST_SKIP()
-                        << "failed to set environment variable disabling pinned host allocation";
+                    limit_for_alloc_kind
+                        = std::max(limit_for_alloc_kind,
+                                   get_hipfftw_allocation_byte_size_limit(alloc_kind_candidate));
+                }
+                else
+                {
+                    limits_to_reset_upon_test_completion[alloc_kind_candidate]
+                        = get_hipfftw_allocation_byte_size_limit(alloc_kind_candidate);
+                    // disable the other possible allocation kind(s) by temporarily
+                    // setting the corresponding byte size limit to 0
+                    if(!set_hipfftw_allocation_byte_size_limit(alloc_kind_candidate, 0))
+                        GTEST_SKIP() << "failed to set environment variable disabling "
+                                     << hipfftw_alloc_kind_to_string(alloc_kind_candidate)
+                                     << " allocation(s) by hipFFTW";
                 }
             }
-            if(params.avoid_alloc_kind & alloc_kind_disabler::pageable_host)
-            {
-#ifdef WIN32
-                pageable_host_alloc_was_disabled
-                    = SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", "0");
-#else
-                pageable_host_alloc_was_disabled
-                    = setenv("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", "0", 1) == EXIT_SUCCESS;
-#endif
-                if(!pageable_host_alloc_was_disabled)
-                {
-                    GTEST_SKIP()
-                        << "failed to set environment variable disabling pageable host allocation";
-                }
-            }
+            const size_t req_byte_size = params.get_byte_size();
+            expect_no_allocation       = params.alloc_kind == hipfftw_alloc_memkind::none
+                                   || req_byte_size == 0 || req_byte_size > limit_for_alloc_kind;
         }
         void TearDown() override
         {
+            for(auto limit_to_reset : limits_to_reset_upon_test_completion)
+            {
+                // reset all temporarily-modified allocation limits
+                set_hipfftw_allocation_byte_size_limit(limit_to_reset.first, limit_to_reset.second);
+            }
             const hipfftw_funcs<prec>& hipfftw_impl = hipfftw_funcs<prec>::get_instance();
-            // reenable disabled allocation kinds (ignoring returned values below)
-            const std::string no_limit_str = std::to_string(std::numeric_limits<size_t>::max());
-            if(pinned_host_alloc_was_disabled)
-            {
-#ifdef WIN32
-                (void)SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC",
-                                             no_limit_str.c_str());
-#else
-                (void)setenv("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", no_limit_str.c_str(), 1);
-#endif
-            }
-            if(pageable_host_alloc_was_disabled)
-            {
-#ifdef WIN32
-                (void)SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC",
-                                             no_limit_str.c_str());
-#else
-                (void)setenv(
-                    "HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", no_limit_str.c_str(), 1);
-#endif
-            }
-
             if(test_allocation && !hipfftw_impl.free.may_be_used())
                 GTEST_FAIL() << "An allocation was created but it can't be freed";
             // note: free should be stable even with nullptr
@@ -537,33 +649,59 @@ namespace
                     = sum_of_cycles
                       + (tail_sz > 0 ? sum_of_integers(max_elem, max_elem + 1 - tail_sz) : 0);
                 if(expected_result_r > max_representable_result
-                   || (params.alloc_func == alloc_func_type::complex
+                   || (params.alloc_func == hipfftw_alloc_func_type::complex
                        && expected_result_i > max_representable_result))
                     throw allocation_test_to_be_skipped("Test cannot reliably check for argument "
                                                         + std::to_string(params.alloc_arg));
 
-                if(params.alloc_func == alloc_func_type::unspecified)
+                if(params.alloc_func == hipfftw_alloc_func_type::unspecified)
                     test_allocation = hipfftw_impl.malloc(params.alloc_arg);
-                else if(params.alloc_func == alloc_func_type::real)
+                else if(params.alloc_func == hipfftw_alloc_func_type::real)
                     test_allocation = hipfftw_impl.alloc_real(params.alloc_arg);
                 else
                     test_allocation = hipfftw_impl.alloc_complex(params.alloc_arg);
 
                 // check that the allocation behaved as expected
-                if(params.avoid_alloc_kind == alloc_kind_disabler::all || params.alloc_arg == 0)
+                if(expect_no_allocation)
                 {
                     if(!test_allocation)
                         throw allocation_test_success();
                     else
                         // no allocation should have happened, nullptr should have been returned
                         throw allocation_test_failed(
-                            "allocation misbehaved for zero-size request or "
-                            "fully-disabled hipfftw allocation");
+                            "An allocation was unexpectedly produced for this test");
                 }
                 if(!test_allocation)
                 {
                     throw allocation_test_failed("allocation failed");
                 }
+                // check that the allocation is of the expected type
+                hipPointerAttribute_t attributes;
+                auto hip_status = hipPointerGetAttributes(&attributes, test_allocation);
+                if(hip_status != hipSuccess)
+                {
+                    ++n_hip_failures;
+                    std::ostringstream gtest_info;
+                    gtest_info << "hipPointerGetAttributes failure with error " << hip_status;
+                    if(skip_runtime_fails)
+                        GTEST_SKIP() << gtest_info.str();
+                    else
+                        GTEST_FAIL() << gtest_info.str();
+                }
+                switch(attributes.type)
+                {
+                case hipMemoryType::hipMemoryTypeHost:
+                    EXPECT_NE(params.alloc_kind & hipfftw_alloc_memkind::pinned_host, 0);
+                    break;
+                case hipMemoryType::hipMemoryTypeUnregistered:
+                    EXPECT_NE(params.alloc_kind & hipfftw_alloc_memkind::pageable_host, 0);
+                    break;
+                default:
+                    GTEST_FAIL() << "Unexpected kind of memory created: attributes.type = "
+                                 << attributes.type;
+                    break;
+                }
+
                 // check that the host can write to the entire allocation
 #ifdef _OPENMP
 #pragma omp parallel for
@@ -571,9 +709,11 @@ namespace
                 for(size_t idx = 0; idx < params.alloc_arg; idx++)
                 {
                     uint8_t val = static_cast<uint8_t>(idx % cycle_sz);
-                    if(params.alloc_func == alloc_func_type::unspecified) // write as uint8_t
+                    if(params.alloc_func
+                       == hipfftw_alloc_func_type::unspecified) // write as uint8_t
                         static_cast<uint8_t*>(test_allocation)[idx] = val;
-                    else if(params.alloc_func == alloc_func_type::real) // write as float/double
+                    else if(params.alloc_func
+                            == hipfftw_alloc_func_type::real) // write as float/double
                         static_cast<hipfftw_real_t<prec>*>(test_allocation)[idx] = val;
                     else // write as complex value of req. precision
                     {
@@ -589,12 +729,12 @@ namespace
 #endif
                 for(size_t idx = 0; idx < params.alloc_arg; idx++)
                 {
-                    if(params.alloc_func == alloc_func_type::unspecified)
+                    if(params.alloc_func == hipfftw_alloc_func_type::unspecified)
                     {
                         // read as uint8_t, accumulate as double
                         result[0] += static_cast<uint8_t*>(test_allocation)[idx];
                     }
-                    else if(params.alloc_func == alloc_func_type::real)
+                    else if(params.alloc_func == hipfftw_alloc_func_type::real)
                     {
                         // read as float/double, accumulate as double
                         result[0] += static_cast<hipfftw_real_t<prec>*>(test_allocation)[idx];
@@ -609,7 +749,8 @@ namespace
                 // validity checks
                 if(result[0] != expected_result_r)
                     throw allocation_test_failed("incorrect result for accumulated real parts");
-                if(params.alloc_func == alloc_func_type::complex && result[1] != expected_result_i)
+                if(params.alloc_func == hipfftw_alloc_func_type::complex
+                   && result[1] != expected_result_i)
                     throw allocation_test_failed(
                         "incorrect result for accumulated imaginary parts");
             }
@@ -646,18 +787,30 @@ namespace
 
             // pinned host allocation is the first-ranked choice of hipfftw
             // check that the execution flow was redirected if disabled
-            if(pinned_host_alloc_was_disabled && params.alloc_arg > 0
-               && exception_logger.is_active())
+            for(auto possible_memkind : hipfftw_possible_memkinds)
             {
-                const auto log_content = exception_logger.get_log();
-                if(log_content.find(
-                       hipfftw_expected_log_instance<hipfftw_internal_exception::flow_redirection>)
-                   == std::string::npos)
+                if(possible_memkind <= params.alloc_kind)
+                    continue;
+                // possible_memkind is higher ranked than the test's targeted kind
+                // flow re-direction must have happened
+                if(test_allocation && exception_logger.is_active())
                 {
-                    GTEST_FAIL() << "No instance of \"" << hipfftw_expected_log_instance<hipfftw_internal_exception::flow_redirection>
-                                 << "\" in log despite disabling pinned host allocation via "
-                                    "environment variable.\nContent of log:\n"
-                                 << log_content;
+                    const auto log_content = exception_logger.get_log();
+                    if(log_content.find(hipfftw_expected_log_instance<
+                                        hipfftw_internal_exception::flow_redirection>)
+                       == std::string::npos)
+                    {
+                        GTEST_FAIL() << "No instance of \""
+                                     << hipfftw_expected_log_instance<
+                                            hipfftw_internal_exception::
+                                                flow_redirection> << "\" in log despite "
+                                     << hipfftw_alloc_kind_to_string(possible_memkind)
+                                     << " allocation kind supposedly "
+                                        "disabled via environment variable.\nContent of log:\n"
+                                     << log_content;
+                    }
+                    else
+                        break;
                 }
             }
         }
@@ -2371,3 +2524,9 @@ INSTANTIATE_TEST_SUITE_P(
     hipfftw_functional_validation_dp,
     ::testing::ValuesIn(params_for_functional_tests<fft_precision_double>(full_suite_size)),
     hipfftw_functional_validation_dp::TestName);
+
+// params_for_functional_tests may return empty vectors for low test probabilities.
+// The following ensures such cases do not make gtest report an error due to uninstantiated
+// hipfftw_functional_validation_{sp,dp}.
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hipfftw_functional_validation_sp);
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(hipfftw_functional_validation_dp);

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -1,0 +1,2375 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "../hipfftw_helper.h"
+
+#include "../../shared/gpubuf.h"
+#include "../../shared/hostbuf.h"
+#include "../../shared/params_gen.h"
+#include "../../shared/test_params.h"
+
+#include <cstdint>
+#include <fftw3.h>
+#include <future>
+#include <gtest/gtest.h>
+#include <memory>
+#include <numeric>
+
+#ifdef WIN32
+#include <windows.h>
+#else
+#include <cstdlib>
+#endif
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+// test details
+namespace
+{
+    //
+    //---------------------------------------------------------------------------------------------
+    //                                  COMMONS AND HELPERS
+    //---------------------------------------------------------------------------------------------
+    //
+
+    // byte size limit used for I/O data sizes (arbitrarily decided)
+    const std::vector<size_t> max_byte_size_for_unbatched_hipfftw_tests
+        = {1ULL << 16, 1ULL << 24, 1ULL << 29};
+    //             1D          2D       >= 3D
+    //         64 KiB,     16 MiB,    512 MiB
+
+    std::ranlux24_base& get_pseudo_rng()
+    {
+        static std::ranlux24_base gen(random_seed);
+        return gen;
+    }
+
+    // NOTE: this function makes use of comparison operator < and != which must be defined for the
+    // specialization type T
+    template <typename T>
+    void insert_into_unique_sorted_params(std::vector<T>& unique_sorted_params,
+                                          const T&        param_to_insert)
+    {
+        auto it = std::lower_bound(
+            unique_sorted_params.begin(), unique_sorted_params.end(), param_to_insert);
+        if(it != unique_sorted_params.end() && *it == param_to_insert)
+            return; // it's already in there generated
+        unique_sorted_params.insert(it, param_to_insert);
+    }
+
+    enum class hipfftw_internal_exception
+    {
+        flow_redirection,
+        invalid_args,
+        unsupported_args
+    };
+
+    template <hipfftw_internal_exception>
+    constexpr std::string_view hipfftw_expected_log_instance;
+    template <>
+    constexpr std::string_view hipfftw_expected_log_instance<
+        hipfftw_internal_exception::invalid_args> = R"(Invalid argument reported)";
+    template <>
+    constexpr std::string_view hipfftw_expected_log_instance<
+        hipfftw_internal_exception::unsupported_args> = R"(Unsupported usage reported)";
+    template <>
+    constexpr std::string_view hipfftw_expected_log_instance<
+        hipfftw_internal_exception::flow_redirection> = R"(Redirecting execution flow)";
+
+    // bit-flagging enum used for configuring tests's execution I/O
+    enum hipfftw_execution_io_args : unsigned
+    {
+        use_creation_io       = 0x0,
+        non_null_new_in       = 0x1 << 1,
+        non_null_new_out      = 0x1 << 2,
+        new_io_same_placement = 0x1 << 3,
+        // all flags must be up to be generally clean with new I/O
+        clean_new_io = non_null_new_in | non_null_new_out | new_io_same_placement
+    };
+
+    // randomizers
+    // Note: albeit not supported, ranks > 3 are "valid" rank argument
+    // --> limiting rank value to max of 10 by default to avoid ridiculously long
+    // lengths possibly created in automated parameter generations;
+    template <bool validity_flag,
+              int  min_rank          = validity_flag ? 1 : std::numeric_limits<int>::lowest(),
+              int  max_rank          = validity_flag ? 10 : 0,
+              std::enable_if_t<(min_rank <= max_rank) && (!validity_flag || min_rank > 0)
+                                   && (validity_flag || max_rank <= 0),
+                               bool> = true>
+    int get_random_rank()
+    {
+        static std::uniform_int_distribution<int> rank_rng(min_rank, max_rank);
+
+        auto ret = rank_rng(get_pseudo_rng());
+        if(rank_is_valid_for_hipfftw(ret) != validity_flag)
+        {
+            throw std::runtime_error(
+                "failed to generate a rank value of desired validity randomly");
+        }
+        return ret;
+    }
+    int get_random_integer(const int min_val, const int max_val)
+    {
+        if(min_val > max_val)
+            throw std::invalid_argument("invalid bounds for get_random_integer");
+        std::uniform_int_distribution<int> int_rng(min_val, max_val);
+
+        return int_rng(get_pseudo_rng());
+    }
+
+    template <bool validity_flag, typename type_to_consider_for_validity>
+    std::vector<ptrdiff_t>
+        get_random_lengths(int       desired_rank,
+                           ptrdiff_t max_abs_len
+                           = std::numeric_limits<type_to_consider_for_validity>::max(),
+                           ptrdiff_t min_abs_len = 0)
+    {
+        std::vector<ptrdiff_t> ret;
+        // cannot generate lengths for invalid ranks --> return empty lengths in that case
+        if(!rank_is_valid_for_hipfftw(desired_rank))
+            return ret;
+        if(min_abs_len < 0 || min_abs_len > max_abs_len)
+            throw std::invalid_argument("invalid bounds used for get_random_lengths");
+        // generate values that are all representable as integers
+        auto&                                    pseudo_rng = get_pseudo_rng();
+        std::uniform_int_distribution<ptrdiff_t> length_rng(min_abs_len, max_abs_len);
+        // setter lambda
+        auto set_random_len = [&]() {
+            for(auto& l : ret)
+            {
+                const ptrdiff_t val = length_rng(pseudo_rng);
+                if constexpr(validity_flag)
+                    l = val;
+                else
+                {
+                    if(pseudo_rng() % 2)
+                        l = -val;
+                    else
+                        l = val;
+                }
+            }
+        };
+
+        ret.resize(desired_rank);
+        set_random_len();
+        while(lengths_are_valid_for_hipfftw_as<type_to_consider_for_validity>(ret, desired_rank)
+              != validity_flag)
+            set_random_len();
+
+        return ret;
+    }
+    template <bool validity_flag>
+    int get_random_sign(fft_transform_type intended_dft_kind)
+    {
+        if(!validity_flag && is_real(intended_dft_kind))
+            throw std::invalid_argument("An invalid sign cannot be generated for real transforms "
+                                        "(sign is ignored in that case)");
+        std::uniform_int_distribution<int> sign_rng(std::numeric_limits<int>::lowest(),
+                                                    std::numeric_limits<int>::max());
+
+        int tmp = validity_flag && is_complex(intended_dft_kind)
+                      ? (is_fwd(intended_dft_kind) ? FFTW_FORWARD : FFTW_BACKWARD)
+                      : sign_rng(get_pseudo_rng());
+
+        while(sign_is_valid_for_hipfftw(tmp, intended_dft_kind) != validity_flag)
+            tmp = sign_rng(get_pseudo_rng());
+        return tmp;
+    }
+    template <bool validity_flag>
+    unsigned get_random_flags()
+    {
+        std::uniform_int_distribution<unsigned> flags_rng(std::numeric_limits<unsigned>::lowest(),
+                                                          std::numeric_limits<unsigned>::max());
+
+        auto tmp = flags_rng(get_pseudo_rng());
+        if constexpr(validity_flag)
+        {
+            tmp &= hipfftw_valid_flags_mask;
+            if(!flags_are_valid_for_hipfftw(tmp))
+                throw std::runtime_error("failed to create random valid flags");
+            return tmp;
+        }
+        while(flags_are_valid_for_hipfftw(tmp))
+            tmp = flags_rng(get_pseudo_rng());
+        return tmp;
+    }
+    size_t get_random_idx(size_t upper_bound)
+    {
+        if(upper_bound == 0)
+            throw std::invalid_argument("upper_bound must be strictly positive for get_random_idx");
+        std::uniform_int_distribution<size_t> idx_rng(0, upper_bound - 1);
+        return idx_rng(get_pseudo_rng());
+    }
+
+    // calculates the threshold value X such that max_data_idx is no greater
+    // (resp. larger) than num_elems, if all elements of lengths are all no greater
+    // (resp. larger) than X, and lengths.size() == rank [using bisection]
+    ptrdiff_t get_len_threshold(size_t num_elems, int rank, bool is_real_inplace)
+    {
+        if(rank < 1)
+            throw std::invalid_argument("invalid rank used in get_len_threshold");
+        if(num_elems == 0)
+            return 1;
+        constexpr ptrdiff_t X_max = std::numeric_limits<ptrdiff_t>::max();
+        // we need to find X in [0, X_max] s.t.
+        // largest_idx(X) <= num_elems && largest_idx(X + 1) > num_elems
+        auto largest_idx = [&](ptrdiff_t X) {
+            size_t ret = rank > 1 && is_real_inplace ? 2 * (X / 2 + 1) : X;
+            for(auto i = 1; i < rank; i++)
+                ret *= X;
+            return ret;
+        };
+        // initialization
+        ptrdiff_t X_down
+            = rank == 1 ? static_cast<ptrdiff_t>(num_elems)
+                        : static_cast<ptrdiff_t>(std::floor(std::pow(num_elems, 1.0 / rank)));
+        ptrdiff_t diff = 1;
+        ptrdiff_t X_up = X_down;
+        while(largest_idx(X_up) <= num_elems && X_up < X_max)
+        {
+            X_down = X_up;
+            X_up   = X_up <= X_max - diff ? X_up + diff : X_max;
+            diff *= 2;
+        }
+        diff = 1;
+        while(largest_idx(X_down) > num_elems && X_down > 0)
+        {
+            X_up   = X_down;
+            X_down = X_down >= diff ? X_down - diff : 0;
+            diff *= 2;
+        }
+        // bisection
+        while(X_up - X_down > 1)
+        {
+            const auto tmp = (X_up + X_down) / 2;
+            if(largest_idx(tmp) <= num_elems)
+                X_down = tmp;
+            else
+                X_up = tmp;
+        }
+        return X_down;
+    }
+
+    template <fft_precision prec>
+    size_t max_num_elems_for_data_size(size_t data_byte_size, fft_transform_type dft_kind)
+    {
+        return data_byte_size
+               / (is_real(dft_kind) ? sizeof(hipfftw_real_t<prec>)
+                                    : sizeof(hipfftw_complex_t<prec>));
+    }
+
+    //
+    //---------------------------------------------------------------------------------------------
+    //                             EXISTENCE OF UTILITY FUNCTIONS
+    //---------------------------------------------------------------------------------------------
+    //
+
+    template <fft_precision prec>
+    void test_existence_of_utility_functions()
+    {
+        // call utility functions - they need to exist but don't need to work
+        const auto& hipfftw_ = hipfftw_funcs<prec>::get_instance();
+        hipfftw_.print_plan(nullptr);
+        hipfftw_.set_timelimit(0.0);
+        hipfftw_.cost(nullptr);
+        hipfftw_.flops(nullptr, nullptr, nullptr, nullptr);
+        hipfftw_.cleanup();
+    }
+
+    //
+    //---------------------------------------------------------------------------------------------
+    //                                   ALLOCATION AND FREE
+    //---------------------------------------------------------------------------------------------
+    //
+
+    enum class alloc_func_type
+    {
+        unspecified,
+        real,
+        complex
+    };
+    bool alloc_func_type_is_valid(alloc_func_type func)
+    {
+        return func == alloc_func_type::unspecified || func == alloc_func_type::real
+               || func == alloc_func_type::complex;
+    }
+    // bit mask to prevent allocation kind(s)
+    enum alloc_kind_disabler : unsigned
+    {
+        none          = 0x0,
+        pinned_host   = 0x1 << 0,
+        pageable_host = 0x1 << 1,
+        all           = pinned_host | pageable_host
+    };
+    bool alloc_disabler_is_valid(alloc_kind_disabler disabler)
+    {
+        return disabler == (disabler & alloc_kind_disabler::all);
+    }
+    template <fft_precision prec>
+    struct hipfftw_malloc_params
+    {
+        size_t              alloc_arg;
+        alloc_func_type     alloc_func;
+        alloc_kind_disabler avoid_alloc_kind;
+
+        std::string to_string() const
+        {
+            if(alloc_func != alloc_func_type::unspecified && alloc_func != alloc_func_type::real
+               && alloc_func != alloc_func_type::complex)
+                throw std::runtime_error("unknown type of allocation function");
+            if(!alloc_disabler_is_valid(avoid_alloc_kind))
+                throw std::runtime_error("unknown allocation kind(s) to disable");
+
+            std::string ret;
+            if constexpr(prec == fft_precision_single)
+                ret += "fftwf_";
+            else
+                ret += "fftw_";
+
+            if(alloc_func == alloc_func_type::unspecified)
+                ret += "malloc_";
+            else if(alloc_func == alloc_func_type::real)
+                ret += "alloc_real_";
+            else
+                ret += "alloc_complex_";
+            ret += std::to_string(alloc_arg);
+            if(avoid_alloc_kind & alloc_kind_disabler::pinned_host)
+                ret += "_disabling_pinned_host";
+            if(avoid_alloc_kind & alloc_kind_disabler::pageable_host)
+                ret += "_disabling_pageable_host";
+            return ret;
+        }
+        // for using with insert_into_unique_sorted_params
+        bool operator<(const hipfftw_malloc_params& other) const
+        {
+            return to_string() < other.to_string();
+        }
+        bool operator==(const hipfftw_malloc_params& other) const
+        {
+            return to_string() == other.to_string();
+        }
+    };
+
+    template <fft_precision prec>
+    std::vector<hipfftw_malloc_params<prec>> params_for_testing_hipfftw_malloc()
+    {
+        std::vector<hipfftw_malloc_params<prec>> ret;
+        // testing argument value 0 and a randomly chosen one (max 64MiB in byte size, arbitrarily chosen)
+        constexpr size_t max_test_alloc_size = 1ULL << 26;
+
+        const std::vector<alloc_func_type> func_range
+            = {alloc_func_type::unspecified, alloc_func_type::real, alloc_func_type::complex};
+        const std::vector<alloc_kind_disabler> disabler_range = {alloc_kind_disabler::none,
+                                                                 alloc_kind_disabler::pinned_host,
+                                                                 alloc_kind_disabler::pageable_host,
+                                                                 alloc_kind_disabler::all};
+
+        hipfftw_malloc_params<prec> to_add;
+        for(auto func : func_range)
+        {
+            size_t max_arg = max_test_alloc_size;
+            if(func == alloc_func_type::real)
+                max_arg /= sizeof(hipfftw_real_t<prec>);
+            else if(func == alloc_func_type::complex)
+                max_arg /= sizeof(hipfftw_complex_t<prec>);
+            std::uniform_int_distribution<size_t> arg_rng(1, max_arg);
+            for(auto disabler : disabler_range)
+            {
+                for(auto arg : {size_t(0), arg_rng(get_pseudo_rng())})
+                {
+                    to_add.alloc_arg        = arg;
+                    to_add.alloc_func       = func;
+                    to_add.avoid_alloc_kind = disabler;
+                    insert_into_unique_sorted_params(ret, to_add);
+                }
+            }
+        }
+        return ret;
+    }
+
+    template <fft_precision prec>
+    class hipfftw_allocation_test : public ::testing::TestWithParam<hipfftw_malloc_params<prec>>
+    {
+    protected:
+        void* test_allocation = nullptr;
+        bool  pinned_host_alloc_was_disabled;
+        bool  pageable_host_alloc_was_disabled;
+
+        void SetUp() override
+        {
+            if(test_allocation)
+                GTEST_FAIL() << "Starting from an unclean slate (test_allocation is not nullptr)";
+            pinned_host_alloc_was_disabled   = false;
+            pageable_host_alloc_was_disabled = false;
+
+            const hipfftw_malloc_params<prec>& params = this->GetParam();
+            // check validity of params
+            if(!alloc_disabler_is_valid(params.avoid_alloc_kind))
+                GTEST_FAIL() << "invalid value for allocation disabler";
+
+            if(!alloc_func_type_is_valid(params.alloc_func))
+                GTEST_FAIL() << "unknown allocation function";
+
+            // enable allocation limits, if relevant for the targeted test
+            if(params.avoid_alloc_kind & alloc_kind_disabler::pinned_host)
+            {
+#ifdef WIN32
+                pinned_host_alloc_was_disabled
+                    = SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", "0") != 0;
+#else
+                pinned_host_alloc_was_disabled
+                    = setenv("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", "0", 1) == EXIT_SUCCESS;
+#endif
+                if(!pinned_host_alloc_was_disabled)
+                {
+                    GTEST_SKIP()
+                        << "failed to set environment variable disabling pinned host allocation";
+                }
+            }
+            if(params.avoid_alloc_kind & alloc_kind_disabler::pageable_host)
+            {
+#ifdef WIN32
+                pageable_host_alloc_was_disabled                          = SetEnvironmentVariable(
+                    "HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", "0") ! = 0;
+#else
+                pageable_host_alloc_was_disabled
+                    = setenv("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", "0", 1) == EXIT_SUCCESS;
+#endif
+                if(!pageable_host_alloc_was_disabled)
+                {
+                    GTEST_SKIP()
+                        << "failed to set environment variable disabling pageable host allocation";
+                }
+            }
+        }
+        void TearDown() override
+        {
+            const hipfftw_funcs<prec>& hipfftw_impl = hipfftw_funcs<prec>::get_instance();
+            // reenable disabled allocation kinds (ignoring returned values below)
+            const std::string no_limit_str = std::to_string(std::numeric_limits<size_t>::max());
+            if(pinned_host_alloc_was_disabled)
+            {
+#ifdef WIN32
+                (void)SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC",
+                                             no_limit_str.c_str());
+#else
+                (void)setenv("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", no_limit_str.c_str(), 1);
+#endif
+            }
+            if(pageable_host_alloc_was_disabled)
+            {
+#ifdef WIN32
+                (void)SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC",
+                                             no_limit_str.c_str());
+#else
+                (void)setenv(
+                    "HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", no_limit_str.c_str(), 1);
+#endif
+            }
+
+            if(test_allocation && !hipfftw_impl.free.may_be_used())
+                GTEST_FAIL() << "An allocation was created but it can't be freed";
+            // note: free should be stable even with nullptr
+            if(hipfftw_impl.free.may_be_used())
+                hipfftw_impl.free(test_allocation);
+        }
+
+        void test_malloc_write_and_read()
+        {
+            const hipfftw_malloc_params<prec>& params       = this->GetParam();
+            const hipfftw_funcs<prec>&         hipfftw_impl = hipfftw_funcs<prec>::get_instance();
+            hipfftw_exception_logger           exception_logger;
+
+            struct allocation_test_to_be_skipped : std::runtime_error
+            {
+                using std::runtime_error::runtime_error;
+            };
+            struct allocation_test_failed : std::runtime_error
+            {
+                using std::runtime_error::runtime_error;
+            };
+            struct allocation_test_success
+            {
+            }; // used to cut test execution short when applicable
+
+            try
+            {
+                // The test
+                // - fills values in the allocated arrays as 0, 1, ..., max_elem, 0, 1, ..., max_elem, 0, 1, etc.
+                //   (max_elem, max_elem-1, ..., 1, 0, max_elem, max_elem-1, ..., for imaginary values)
+                // - reads the values thereafter and accumulates them as a sum of doubles
+                // - checks the result.
+                // --> the expected_result's must be exactly representable as double values
+                const size_t max_elem = static_cast<size_t>(std::numeric_limits<uint8_t>::max());
+                const size_t cycle_sz = max_elem + 1;
+                const size_t max_representable_result = 1ULL << std::numeric_limits<double>::digits;
+                auto         sum_of_integers          = [](size_t to, size_t from = 0) {
+                    if(from > to)
+                        throw std::invalid_argument("invalid argument for sum_of_integers lambda");
+                    return (to + from) * (to - from + 1) / 2;
+                };
+                const size_t sum_of_cycles
+                    = (params.alloc_arg / cycle_sz) * sum_of_integers(max_elem);
+                const size_t tail_sz = params.alloc_arg % cycle_sz;
+                const size_t expected_result_r
+                    = sum_of_cycles + (tail_sz > 0 ? sum_of_integers(tail_sz - 1) : 0);
+                const size_t expected_result_i
+                    = sum_of_cycles
+                      + (tail_sz > 0 ? sum_of_integers(max_elem, max_elem + 1 - tail_sz) : 0);
+                if(expected_result_r > max_representable_result
+                   || (params.alloc_func == alloc_func_type::complex
+                       && expected_result_i > max_representable_result))
+                    throw allocation_test_to_be_skipped("Test cannot reliably check for argument "
+                                                        + std::to_string(params.alloc_arg));
+
+                if(params.alloc_func == alloc_func_type::unspecified)
+                    test_allocation = hipfftw_impl.malloc(params.alloc_arg);
+                else if(params.alloc_func == alloc_func_type::real)
+                    test_allocation = hipfftw_impl.alloc_real(params.alloc_arg);
+                else
+                    test_allocation = hipfftw_impl.alloc_complex(params.alloc_arg);
+
+                // check that the allocation behaved as expected
+                if(params.avoid_alloc_kind == alloc_kind_disabler::all || params.alloc_arg == 0)
+                {
+                    if(!test_allocation)
+                        throw allocation_test_success();
+                    else
+                        // no allocation should have happened, nullptr should have been returned
+                        throw allocation_test_failed(
+                            "allocation misbehaved for zero-size request or "
+                            "fully-disabled hipfftw allocation");
+                }
+                if(!test_allocation)
+                {
+                    throw allocation_test_failed("allocation failed");
+                }
+                // check that the host can write to the entire allocation
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+                for(size_t idx = 0; idx < params.alloc_arg; idx++)
+                {
+                    uint8_t val = static_cast<uint8_t>(idx % cycle_sz);
+                    if(params.alloc_func == alloc_func_type::unspecified) // write as uint8_t
+                        static_cast<uint8_t*>(test_allocation)[idx] = val;
+                    else if(params.alloc_func == alloc_func_type::real) // write as float/double
+                        static_cast<hipfftw_real_t<prec>*>(test_allocation)[idx] = val;
+                    else // write as complex value of req. precision
+                    {
+                        static_cast<hipfftw_complex_t<prec>*>(test_allocation)[idx][0] = val;
+                        static_cast<hipfftw_complex_t<prec>*>(test_allocation)[idx][1]
+                            = max_elem - val;
+                    }
+                }
+                // check that the host can read from the entire allocation
+                double result[2] = {0, 0};
+#ifdef _OPENMP
+#pragma omp parallel for reduction(+ : result)
+#endif
+                for(size_t idx = 0; idx < params.alloc_arg; idx++)
+                {
+                    if(params.alloc_func == alloc_func_type::unspecified)
+                    {
+                        // read as uint8_t, accumulate as double
+                        result[0] += static_cast<uint8_t*>(test_allocation)[idx];
+                    }
+                    else if(params.alloc_func == alloc_func_type::real)
+                    {
+                        // read as float/double, accumulate as double
+                        result[0] += static_cast<hipfftw_real_t<prec>*>(test_allocation)[idx];
+                    }
+                    else // write as complex value of req. precision
+                    {
+                        // read as complex value of req. precision, accumulate as doubles
+                        result[0] += static_cast<hipfftw_complex_t<prec>*>(test_allocation)[idx][0];
+                        result[1] += static_cast<hipfftw_complex_t<prec>*>(test_allocation)[idx][1];
+                    }
+                }
+                // validity checks
+                if(result[0] != expected_result_r)
+                    throw allocation_test_failed("incorrect result for accumulated real parts");
+                if(params.alloc_func == alloc_func_type::complex && result[1] != expected_result_i)
+                    throw allocation_test_failed(
+                        "incorrect result for accumulated imaginary parts");
+            }
+            catch(const allocation_test_success&)
+            {
+                // so far so good
+            }
+            catch(const hipfftw_undefined_function_ptr& e)
+            {
+                GTEST_FAIL() << "undefined function pointers detected. Error info: " << e.what();
+            }
+            catch(const allocation_test_to_be_skipped& e)
+            {
+                GTEST_SKIP() << e.what();
+            }
+            catch(const allocation_test_failed& e)
+            {
+                std::ostringstream gtest_info;
+                gtest_info << e.what();
+                const auto log_content = exception_logger.get_log();
+                if(!log_content.empty())
+                    gtest_info << "\nContent of error log :\n " << log_content;
+                GTEST_FAIL() << gtest_info.str();
+            }
+            catch(...)
+            {
+                std::ostringstream gtest_info;
+                gtest_info << "unidentified exception caught during test.";
+                const auto log_content = exception_logger.get_log();
+                if(!log_content.empty())
+                    gtest_info << "\nContent of error log :\n " << log_content;
+                GTEST_FAIL() << gtest_info.str();
+            }
+
+            // pinned host allocation is the first-ranked choice of hipfftw
+            // check that the execution flow was redirected if disabled
+            if(pinned_host_alloc_was_disabled && params.alloc_arg > 0
+               && exception_logger.is_active())
+            {
+                const auto log_content = exception_logger.get_log();
+                if(log_content.find(
+                       hipfftw_expected_log_instance<hipfftw_internal_exception::flow_redirection>)
+                   == std::string::npos)
+                {
+                    GTEST_FAIL() << "No instance of \"" << hipfftw_expected_log_instance<hipfftw_internal_exception::flow_redirection>
+                                 << "\" in log despite disabling pinned host allocation via "
+                                    "environment variable.\nContent of log:\n"
+                                 << log_content;
+                }
+            }
+        }
+
+    public:
+        static std::string TestName(
+            const testing::TestParamInfo<typename hipfftw_allocation_test::ParamType>& info)
+        {
+            return info.param.to_string();
+        }
+    };
+
+    using allocation_sp = hipfftw_allocation_test<fft_precision_single>;
+    TEST_P(allocation_sp, malloc_write_and_read)
+    {
+        test_malloc_write_and_read();
+    }
+    using allocation_dp = hipfftw_allocation_test<fft_precision_double>;
+    TEST_P(allocation_dp, malloc_write_and_read)
+    {
+        test_malloc_write_and_read();
+    }
+
+    //
+    //---------------------------------------------------------------------------------------------
+    //                    INPUT VALIDATION FOR PLAN CREATION AND EXECUTION
+    //---------------------------------------------------------------------------------------------
+    //
+
+    static bool hipfftw_execution_io_args_are_well_defined(hipfftw_execution_io_args args)
+    {
+        return args == (args & hipfftw_execution_io_args::clean_new_io);
+    }
+
+    enum class hipfftw_step
+    {
+        plan_creation,
+        plan_execution
+    };
+
+    template <fft_precision prec>
+    struct hipfftw_input_validation_params
+    {
+        hipfftw_plan_creation_func creation_options;
+        std::pair<bool, bool>      creation_io_is_null;
+        hipfftw_execution_io_args  execution_io;
+        hipfftw_helper<prec>       plan_helper;
+
+        // NOTE: placement is to be respected by tests' choice of I/O at plan creation!
+        fft_result_placement creation_placement() const
+        {
+            return plan_helper.get_placement();
+        }
+
+        fft_result_placement execution_placement() const
+        {
+            auto ret = creation_placement();
+            if(!use_creation_io_at_execution()
+               && !(execution_io & hipfftw_execution_io_args::new_io_same_placement))
+            {
+                if(ret == fft_placement_inplace)
+                    ret = fft_placement_notinplace;
+                else
+                    ret = fft_placement_inplace;
+            }
+            return ret;
+        }
+
+        bool use_creation_io_at_execution() const
+        {
+            return execution_io == hipfftw_execution_io_args::use_creation_io;
+        }
+
+        bool is_execution_arg_null(fft_io io_label) const
+        {
+            if(io_label != fft_io::fft_io_in && io_label != fft_io::fft_io_out)
+                throw std::invalid_argument(
+                    "invalid io_label for hipfftw_input_validation_params::is_execution_io_null");
+            if(use_creation_io_at_execution())
+                return io_label == fft_io::fft_io_in ? creation_io_is_null.first
+                                                     : creation_io_is_null.second;
+            const auto non_null_io_mask = io_label == fft_io::fft_io_in
+                                              ? hipfftw_execution_io_args::non_null_new_in
+                                              : hipfftw_execution_io_args::non_null_new_out;
+            return !(execution_io & non_null_io_mask);
+        }
+
+        bool can_be_tested() const
+        {
+            if(!use_creation_io_at_execution())
+                return false; // cannot be done yet
+            if(!hipfftw_execution_io_args_are_well_defined(execution_io))
+                return false;
+            if(!plan_helper.can_use_creation_options(creation_options))
+                return false;
+            if(creation_placement() == fft_placement_inplace)
+            {
+                if(creation_io_is_null.first != creation_io_is_null.second)
+                    return false;
+            }
+            else
+            {
+                if(creation_io_is_null.first && creation_io_is_null.second)
+                    return false;
+            }
+            if(execution_placement() == fft_placement_inplace)
+            {
+                if(is_execution_arg_null(fft_io::fft_io_in)
+                   != is_execution_arg_null(fft_io::fft_io_out))
+                    return false; // woudl be out-of-place at execution
+            }
+            else
+            {
+                if(is_execution_arg_null(fft_io::fft_io_in)
+                   && is_execution_arg_null(fft_io::fft_io_out))
+                    return false; // would be in-place at execution
+            }
+            return true;
+        }
+
+        bool has_valid_io_for(hipfftw_step step) const
+        {
+            if(step != hipfftw_step::plan_creation && step != hipfftw_step::plan_execution)
+                throw std::invalid_argument("Invalid step for has_valid_io_for");
+            if(step == hipfftw_step::plan_creation)
+            {
+                // anything goes if using FFTW_ESTIMATE or FFTW_WISDOM_ONLY in flags
+                const auto flags = plan_helper.get_flags();
+                if(flags & FFTW_ESTIMATE || flags & FFTW_WISDOM_ONLY)
+                    return true;
+                return !creation_io_is_null.first
+                       && (creation_placement() == fft_placement_inplace
+                           || !creation_io_is_null.second);
+            }
+            if(!hipfftw_execution_io_args_are_well_defined(execution_io))
+                throw std::runtime_error("invalid plan execution args");
+            if(use_creation_io_at_execution())
+                return !creation_io_is_null.first
+                       && (creation_placement() == fft_placement_inplace
+                           || !creation_io_is_null.second);
+
+            return execution_io == hipfftw_execution_io_args::clean_new_io;
+        }
+
+        bool expects_internal_exception_for(hipfftw_step               step,
+                                            hipfftw_internal_exception expected_exception) const
+        {
+            if(step != hipfftw_step::plan_creation && step != hipfftw_step::plan_execution)
+                throw std::invalid_argument("Invalid step in expects_internal_exception_for");
+
+            if(expected_exception != hipfftw_internal_exception::invalid_args
+               && expected_exception != hipfftw_internal_exception::unsupported_args)
+                throw std::invalid_argument(
+                    "Invalid expected exception in expects_internal_exception_for");
+
+            if(expected_exception != hipfftw_internal_exception::invalid_args
+               && step == hipfftw_step::plan_execution)
+                throw std::invalid_argument("Cannot expect anything else than invalid argument for "
+                                            "failures at plan execution");
+
+            if(!can_be_tested())
+                throw std::runtime_error(
+                    hipfftw_creation_options_to_string(
+                        creation_options, plan_helper.get_dft_kind(), plan_helper.get_rank())
+                    + " cannot be tested for these parameters");
+
+            // any i/o is fine is using FFTW_ESTIMATE or FFTW_WISDOM_ONLY in the plan's flags
+            const bool valid_args_for_plan_creation
+                = plan_helper.is_valid_for_creation_with(creation_options)
+                  && has_valid_io_for(hipfftw_step::plan_creation);
+            const bool supported_args_for_plan_creation
+                = valid_args_for_plan_creation
+                  && plan_helper.is_supported_for_creation_with(creation_options);
+            if(step == hipfftw_step::plan_creation)
+            {
+                if(expected_exception == hipfftw_internal_exception::invalid_args)
+                    return !valid_args_for_plan_creation;
+                else // must be valid but not supported
+                    return valid_args_for_plan_creation && !supported_args_for_plan_creation;
+            }
+            else
+            {
+                return !valid_args_for_plan_creation || !supported_args_for_plan_creation
+                       || !has_valid_io_for(hipfftw_step::plan_execution);
+            }
+        }
+
+        std::string to_string() const
+        {
+            std::ostringstream ret;
+            ret << plan_helper.token();
+            ret << "_creation_func_"
+                << hipfftw_creation_options_to_string(
+                       creation_options, plan_helper.get_dft_kind(), plan_helper.get_rank());
+            ret << "_creation_in_ptr" << (creation_io_is_null.first ? "_" : "_not_") << "nullptr";
+            ret << "_creation_out_ptr" << (creation_io_is_null.second ? "_" : "_not_") << "nullptr";
+            if(!hipfftw_execution_io_args_are_well_defined(execution_io))
+                throw std::runtime_error("invalid plan execution args");
+            if(!use_creation_io_at_execution())
+            {
+                ret << "_execution_new_in_ptr"
+                    << (is_execution_arg_null(fft_io::fft_io_in) ? "_" : "_not_") << "nullptr";
+                ret << "_execution_out_ptr"
+                    << (is_execution_arg_null(fft_io::fft_io_out) ? "_" : "_not_") << "nullptr";
+                ret << "_execution_placement"
+                    << ((execution_io & hipfftw_execution_io_args::new_io_same_placement)
+                            ? "_same_"
+                            : "_different_than_")
+                    << "creation_placement";
+            }
+            return ret.str();
+        }
+
+        // for using with insert_into_unique_sorted_params
+        bool operator<(const hipfftw_input_validation_params& other) const
+        {
+            return to_string() < other.to_string();
+        }
+        bool operator==(const hipfftw_input_validation_params& other) const
+        {
+            return to_string() == other.to_string();
+        }
+    };
+
+    template <fft_precision prec>
+    std::vector<hipfftw_input_validation_params<prec>> params_for_testing_input_validation_params()
+    {
+        // constexpr used for readability of template specialization values below
+        constexpr bool valid_value          = true;
+        constexpr int  min_unsupported_rank = 4;
+
+        // create a full-scope map containing all the generated test; the map keys capture the
+        // hipfftw's function name the tests would target
+        // --> ease for guaranteeing coverage even with low test probability in the end
+        std::map<std::string, std::vector<hipfftw_input_validation_params<prec>>> full_scope_tests;
+        hipfftw_input_validation_params<prec>                                     to_add;
+
+        // generate broad scope for plan creation and/or default plan
+        // execution (i.e., reusing plan creation's IO at execution)
+        for(auto internal_except : {hipfftw_internal_exception::invalid_args,
+                                    hipfftw_internal_exception::unsupported_args})
+        {
+            for(auto creation_option : hipfftw_plan_creation_func_candidates)
+            {
+                for(auto dft_kind : trans_type_range_full)
+                {
+                    std::vector<int> rank_range = {1, 2, 3};
+                    if(internal_except == hipfftw_internal_exception::invalid_args)
+                        rank_range.push_back(get_random_rank<!valid_value>());
+                    else if(internal_except == hipfftw_internal_exception::unsupported_args)
+                        rank_range.push_back(get_random_rank<valid_value, min_unsupported_rank>());
+                    for(auto rank : rank_range)
+                    {
+                        for(auto placement : place_range)
+                        {
+                            std::vector<std::vector<ptrdiff_t>> range_of_lengths;
+                            // most creation funcs take lengths as pointers
+                            // --> test for empty lengths (re-interpreted as a nullptr
+                            // arg by hipfftw_helper)
+                            range_of_lengths.emplace_back(std::vector<ptrdiff_t>());
+
+                            const bool is_real_inplace
+                                = is_real(dft_kind) && placement == fft_placement_inplace;
+                            const auto max_byte_size
+                                = max_byte_size_for_unbatched_hipfftw_tests[std::min(
+                                    std::max(rank - 1, 0), 2)];
+                            const ptrdiff_t allocatable_len_threshold = get_len_threshold(
+                                max_num_elems_for_data_size<prec>(max_byte_size, dft_kind),
+                                std::max(rank, 1),
+                                is_real_inplace);
+                            if(rank > 0)
+                            {
+                                const auto valid_int_lengths = get_random_lengths<valid_value, int>(
+                                    rank, allocatable_len_threshold);
+                                // always add valid integer lengths for valid ranks
+                                range_of_lengths.emplace_back(valid_int_lengths);
+                                if(internal_except == hipfftw_internal_exception::invalid_args)
+                                {
+                                    const auto invalid_int_lengths
+                                        = get_random_lengths<!valid_value, int>(
+                                            rank, allocatable_len_threshold);
+                                    auto invalid_int_lengths_due_to_some_zero = valid_int_lengths;
+                                    invalid_int_lengths_due_to_some_zero[get_random_idx(rank)] = 0;
+                                    // invalid integer lengths (most likely nonzero)
+                                    range_of_lengths.emplace_back(invalid_int_lengths);
+                                    // invalid integer lengths (some zero)
+                                    range_of_lengths.emplace_back(
+                                        invalid_int_lengths_due_to_some_zero);
+                                }
+                                else if(rank > 1 && rank < min_unsupported_rank
+                                        && creation_option
+                                               != hipfftw_plan_creation_func::PLAN_GURU64)
+                                {
+                                    // no support for layouts that trigger an int overflow for
+                                    // any relevant element index
+                                    const auto min_overflowing_len = get_len_threshold(
+                                        std::numeric_limits<int>::max(), rank, is_real_inplace);
+
+                                    const auto unsupported_lengths
+                                        = get_random_lengths<valid_value, int>(
+                                            rank,
+                                            std::numeric_limits<int>::max(),
+                                            min_overflowing_len + 1);
+                                    range_of_lengths.emplace_back(unsupported_lengths);
+                                }
+                            }
+                            for(const auto& lengths : range_of_lengths)
+                            {
+                                // do not allocate for the lengths designed to trigger an overflow
+                                const bool test_may_allocate = std::all_of(
+                                    lengths.begin(), lengths.end(), [&](const ptrdiff_t& val) {
+                                        return val <= allocatable_len_threshold;
+                                    });
+                                std::vector<std::pair<bool, bool>> creation_io_is_null_range;
+                                if(test_may_allocate)
+                                    creation_io_is_null_range.push_back({false, false});
+                                if(placement == fft_placement_inplace)
+                                    creation_io_is_null_range.push_back({true, true});
+                                else if(test_may_allocate)
+                                {
+                                    creation_io_is_null_range.push_back({true, false});
+                                    creation_io_is_null_range.push_back({false, true});
+                                }
+                                for(auto set_creation_io_as_null : creation_io_is_null_range)
+                                {
+                                    std::vector<int> sign_range;
+                                    sign_range.push_back(get_random_sign<valid_value>(dft_kind));
+                                    if(is_complex(dft_kind))
+                                        sign_range.push_back(
+                                            get_random_sign<!valid_value>(dft_kind));
+                                    for(auto sign : sign_range)
+                                    {
+                                        std::vector<unsigned> flags_range;
+                                        flags_range.push_back(get_random_flags<valid_value>());
+                                        if(internal_except
+                                           == hipfftw_internal_exception::invalid_args)
+                                            flags_range.push_back(get_random_flags<!valid_value>());
+                                        else
+                                        {
+                                            // FFTW_WISDOM_ONLY is not supported
+                                            flags_range.push_back(
+                                                FFTW_WISDOM_ONLY | get_random_flags<valid_value>());
+                                            // FFTW_PRESERVE_INPUT is not supported for multi-dimensional c2r
+                                            if(rank > 1 && rank < min_unsupported_rank
+                                               && dft_kind == fft_transform_type_real_inverse)
+                                                flags_range.push_back(
+                                                    FFTW_PRESERVE_INPUT
+                                                    | get_random_flags<valid_value>());
+                                        }
+
+                                        for(auto flags : flags_range)
+                                        {
+                                            to_add.creation_options    = creation_option;
+                                            to_add.creation_io_is_null = set_creation_io_as_null;
+                                            to_add.execution_io
+                                                = hipfftw_execution_io_args::use_creation_io;
+                                            to_add.plan_helper.set_creation_args(
+                                                dft_kind, rank, lengths, placement, sign, flags);
+                                            // skip params if they can't be used anyways
+                                            if(!to_add.can_be_tested())
+                                                continue;
+                                            // skip params if they're supposed to be fine even for execution
+                                            if(!to_add.expects_internal_exception_for(
+                                                   hipfftw_step::plan_execution,
+                                                   hipfftw_internal_exception::invalid_args))
+                                                continue;
+                                            // skip params if they're not triggering the kind of exception
+                                            // we'd want at plan creation
+                                            if(!to_add.expects_internal_exception_for(
+                                                   hipfftw_step::plan_creation, internal_except))
+                                                continue;
+                                            insert_into_unique_sorted_params(
+                                                full_scope_tests[hipfftw_creation_options_to_string(
+                                                    creation_option, dft_kind, rank)],
+                                                to_add);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Add some supported plans for which creation is expected to succeed
+        // but execution is expected to fail
+        // TODO: add messed up (new) I/O arguments when new-array executes are enabled
+        for(auto dft_kind : trans_type_range_full)
+        {
+            std::vector<int> supported_rank_range = {1, 2, 3};
+            for(auto supported_rank : supported_rank_range)
+            {
+                for(auto placement : place_range)
+                {
+                    const bool is_real_inplace
+                        = is_real(dft_kind) && placement == fft_placement_inplace;
+                    const ptrdiff_t allocatable_len_threshold = get_len_threshold(
+                        max_num_elems_for_data_size<prec>(
+                            max_byte_size_for_unbatched_hipfftw_tests[supported_rank - 1],
+                            dft_kind),
+                        supported_rank,
+                        is_real_inplace);
+                    const auto supported_int_lengths = get_random_lengths<valid_value, int>(
+                        supported_rank, allocatable_len_threshold);
+                    std::vector<std::pair<bool, bool>> creation_io_is_null_range;
+                    if(placement == fft_placement_inplace)
+                        creation_io_is_null_range.push_back({true, true});
+                    else
+                    {
+                        creation_io_is_null_range.push_back({true, false});
+                        creation_io_is_null_range.push_back({false, true});
+                    }
+                    for(auto set_creation_io_as_null : creation_io_is_null_range)
+                    {
+                        const auto valid_sign = get_random_sign<valid_value>(dft_kind);
+                        // using FFTW_ESTIMATE so that nullptr may be used at creation
+                        const auto valid_flags     = FFTW_ESTIMATE;
+                        to_add.creation_options    = hipfftw_plan_creation_func::ANY;
+                        to_add.creation_io_is_null = set_creation_io_as_null;
+                        to_add.execution_io        = hipfftw_execution_io_args::use_creation_io;
+                        to_add.plan_helper.set_creation_args(dft_kind,
+                                                             supported_rank,
+                                                             supported_int_lengths,
+                                                             placement,
+                                                             valid_sign,
+                                                             valid_flags);
+                        // skip params if they can't be used anyways
+                        if(!to_add.can_be_tested())
+                            continue;
+                        // skip params if they're not expected to trigger an exception at execution
+                        if(!to_add.expects_internal_exception_for(
+                               hipfftw_step::plan_execution,
+                               hipfftw_internal_exception::invalid_args))
+                            continue;
+
+                        insert_into_unique_sorted_params(full_scope_tests["execute"], to_add);
+                    }
+                }
+            }
+        }
+        std::vector<hipfftw_input_validation_params<prec>> ret;
+        for(auto pair : full_scope_tests)
+        {
+            const auto& targeted_func  = pair.first;
+            auto&       targeted_tests = pair.second;
+            if(targeted_tests.empty())
+            {
+                throw std::runtime_error("params_for_testing_input_validation_params: empty list "
+                                         "of (supposedly broad-spectrum) tests for "
+                                         + targeted_func);
+            }
+            // add one randomly-chosen one to guarantee coverage for the targeted function
+            const auto forced_coverage_idx = get_random_idx(targeted_tests.size());
+            ret.emplace_back(targeted_tests[forced_coverage_idx]);
+            targeted_tests.erase(targeted_tests.begin() + forced_coverage_idx);
+            // consider all other probabilistically
+            for(const auto& test : targeted_tests)
+            {
+                const double roll = hash_prob(random_seed, test.to_string());
+                // not distinguishing between real/complex for this list generation
+                if(roll > test_prob)
+                {
+                    if(verbose > 4)
+                    {
+                        std::cout << "Test skipped: (roll=" << roll << " > " << test_prob << ")\n";
+                    }
+                    continue;
+                }
+                ret.emplace_back(test);
+            }
+        }
+        return ret;
+    }
+
+    template <fft_precision prec>
+    class hipfftw_argument_validation
+        : public ::testing::TestWithParam<hipfftw_input_validation_params<prec>>
+    {
+    protected:
+        void SetUp() override
+        {
+            const hipfftw_input_validation_params<prec>& params = this->GetParam();
+
+            if(!params.can_be_tested())
+                GTEST_FAIL() << "invalid parameters which cannot be tested";
+
+            // get_data_byte_size requires valid ranks and lengths to be calculated (of course)
+            // --> make sure the I/O data sizes are not zero for test consistency w.r.t. testing
+            // for nullptr data args I/O
+            const size_t input_data_size
+                = params.plan_helper.has_valid_rank() && params.plan_helper.has_valid_lengths()
+                      ? params.plan_helper.get_data_byte_size(fft_io_in)
+                      : sizeof(hipfftw_complex_t<prec>);
+            const size_t output_data_size
+                = params.plan_helper.has_valid_rank() && params.plan_helper.has_valid_lengths()
+                      ? params.plan_helper.get_data_byte_size(fft_io_out)
+                      : sizeof(hipfftw_complex_t<prec>);
+
+            if(params.creation_io_is_null.first)
+                plan_creation_input.free();
+            else
+                plan_creation_input.alloc(input_data_size);
+
+            if(params.creation_placement() == fft_placement_inplace
+               || params.creation_io_is_null.second)
+                plan_creation_output.free();
+            else
+                plan_creation_output.alloc(output_data_size);
+
+            if(params.use_creation_io_at_execution())
+            {
+                plan_execution_input.free();
+                plan_execution_output.free();
+            }
+            else
+            {
+                if(!params.is_execution_arg_null(fft_io::fft_io_in))
+                    plan_execution_input.alloc(input_data_size);
+                else
+                    plan_execution_input.free();
+
+                if(params.execution_placement() == fft_placement_inplace
+                   || params.is_execution_arg_null(fft_io::fft_io_out))
+                    plan_execution_output.free();
+                else
+                    plan_execution_output.alloc(output_data_size);
+            }
+        }
+        void TearDown() override
+        {
+            plan_creation_input.free();
+            plan_creation_output.free();
+            plan_execution_input.free();
+            plan_execution_output.free();
+            this->GetParam().plan_helper.release_plan();
+        }
+        hostbuf plan_creation_input;
+        hostbuf plan_creation_output;
+        hostbuf plan_execution_input;
+        hostbuf plan_execution_output;
+
+        void expect_failure(hipfftw_step               step_target,
+                            hipfftw_internal_exception internal_exception_target)
+        {
+            if(step_target == hipfftw_step::plan_creation)
+            {
+                if(internal_exception_target != hipfftw_internal_exception::invalid_args
+                   && internal_exception_target != hipfftw_internal_exception::unsupported_args)
+                {
+                    throw std::invalid_argument(
+                        "unexpected internal_exception_target when testing "
+                        "argument validation for plan creation function(s)");
+                }
+            }
+            else if(step_target == hipfftw_step::plan_execution)
+            {
+                if(internal_exception_target != hipfftw_internal_exception::invalid_args)
+                {
+                    throw std::invalid_argument(
+                        "unexpected internal_exception_target when testing "
+                        "argument validation for plan execution function(s)");
+                }
+            }
+            else
+            {
+                throw std::invalid_argument(
+                    "unexpected step_target when testing argument validation");
+            }
+            // exception-logging-related variables
+            const auto expected_log_instance
+                = internal_exception_target == hipfftw_internal_exception::invalid_args
+                      ? hipfftw_expected_log_instance<hipfftw_internal_exception::invalid_args>
+                      : hipfftw_expected_log_instance<hipfftw_internal_exception::unsupported_args>;
+            const hipfftw_input_validation_params<prec>& params = this->GetParam();
+            std::unique_ptr<hipfftw_exception_logger>    exception_logger;
+            bool                                         check_log_content = false;
+            std::string                                  log_content;
+            try
+            {
+                if(step_target == hipfftw_step::plan_creation)
+                {
+                    exception_logger  = std::make_unique<hipfftw_exception_logger>();
+                    check_log_content = exception_logger->is_active();
+                }
+                params.plan_helper.create_plan(plan_creation_input.data(),
+                                               params.creation_placement() == fft_placement_inplace
+                                                   ? plan_creation_input.data()
+                                                   : plan_creation_output.data(),
+                                               params.creation_options);
+                if(step_target == hipfftw_step::plan_creation)
+                {
+                    log_content = exception_logger->get_log();
+                    exception_logger.reset();
+                    const std::shared_ptr<hipfftw_plan_bundle_t<prec>> plan_bundle
+                        = params.plan_helper.get_plan_bundle();
+                    if(!plan_bundle)
+                        throw std::runtime_error(
+                            "the plan bundle could not be retrieved from the parameters");
+                    if(plan_bundle->plan)
+                        throw std::runtime_error(
+                            hipfftw_creation_options_to_string(plan_bundle->creation_func,
+                                                               params.plan_helper.get_dft_kind(),
+                                                               params.plan_helper.get_rank())
+                            + " actually created a plan for these parameters");
+                }
+                else
+                {
+                    // intentionally do not check that hipfftw_test_plan != nullptr as that's
+                    // kind of the point of this test: even if it doesn't report error codes,
+                    // execution must not misbehave (e.g. must not segfault) with invalid argument
+                    // (if hipfftw's exception handler is made verbose, it should print failure
+                    //  info to the log, and that's verified in the end)
+                    exception_logger  = std::make_unique<hipfftw_exception_logger>();
+                    check_log_content = exception_logger->is_active();
+                    if(params.use_creation_io_at_execution())
+                    {
+                        params.plan_helper.execute(plan_creation_input.data(),
+                                                   params.creation_placement()
+                                                           == fft_placement_inplace
+                                                       ? plan_creation_input.data()
+                                                       : plan_creation_output.data(), );
+                    }
+                    else
+                    {
+                        params.plan_helper.execute(plan_execution_input.data(),
+                                                   params.execution_placement()
+                                                           == fft_placement_inplace
+                                                       ? plan_execution_input.data()
+                                                       : plan_execution_output.data());
+                    }
+                    log_content = exception_logger->get_log();
+                    exception_logger.reset();
+                }
+            }
+            catch(const hipfftw_undefined_function_ptr& e)
+            {
+                GTEST_FAIL() << "undefined function pointers detected. Error info: " << e.what();
+            }
+            catch(const std::runtime_error e)
+            {
+                if(log_content.empty() && exception_logger)
+                    log_content = exception_logger->get_log();
+                std::ostringstream gtest_info;
+                gtest_info << e.what();
+                if(!log_content.empty())
+                    gtest_info << "\nContent of error log:\n" << log_content;
+                GTEST_FAIL() << gtest_info.str();
+            }
+            catch(...)
+            {
+                if(log_content.empty() && exception_logger)
+                    log_content = exception_logger->get_log();
+                std::ostringstream gtest_info;
+                gtest_info << "unidentified exception caught during test.";
+                if(!log_content.empty())
+                    gtest_info << "\nContent of error log:\n" << log_content;
+                GTEST_FAIL() << gtest_info.str();
+            }
+
+            if(log_content.empty() && exception_logger)
+                log_content = exception_logger->get_log();
+            if(check_log_content && log_content.find(expected_log_instance) == std::string::npos)
+            {
+                GTEST_FAIL() << "No instance of \"" << expected_log_instance
+                             << "\" detected in error log when testing for plan "
+                             << (step_target == hipfftw_step::plan_creation ? "creation."
+                                                                            : "execution.")
+                             << "\nContent of error log:\n"
+                             << log_content;
+            }
+        }
+
+        void input_validation_test()
+        {
+            const auto& param     = this->GetParam();
+            bool        done_some = false;
+            if(param.expects_internal_exception_for(hipfftw_step::plan_creation,
+                                                    hipfftw_internal_exception::invalid_args))
+            {
+                expect_failure(hipfftw_step::plan_creation,
+                               hipfftw_internal_exception::invalid_args);
+                done_some = true;
+            }
+            else if(param.expects_internal_exception_for(
+                        hipfftw_step::plan_creation, hipfftw_internal_exception::unsupported_args))
+            {
+                expect_failure(hipfftw_step::plan_creation,
+                               hipfftw_internal_exception::unsupported_args);
+                done_some = true;
+            }
+            if(param.expects_internal_exception_for(hipfftw_step::plan_execution,
+                                                    hipfftw_internal_exception::invalid_args))
+            {
+                expect_failure(hipfftw_step::plan_execution,
+                               hipfftw_internal_exception::invalid_args);
+                done_some = true;
+            }
+            if(!done_some)
+            {
+                GTEST_FAIL()
+                    << "No test actually executed for these parameters (no internal exception "
+                       "expected at creation or execution)";
+            }
+        }
+
+    public:
+        static std::string TestName(
+            const testing::TestParamInfo<typename hipfftw_argument_validation::ParamType>& info)
+        {
+            return info.param.to_string();
+        }
+    };
+
+    //
+    //---------------------------------------------------------------------------------------------
+    //                                 FUNCTIONAL VALIDATION
+    //---------------------------------------------------------------------------------------------
+    //
+
+    enum class hipfftw_data_memory_type
+    {
+        pageable_host,
+        pinned_host,
+#ifndef WIN32
+        // linux-only
+        managed,
+        managed_other_device, // for new-array executes, only
+#endif
+        current_device,
+        other_device // for new-array executes, only
+    };
+
+    const std::vector<hipfftw_data_memory_type>& get_possible_data_mem_types()
+    {
+        auto create_possible_cases = []() {
+            // always testable
+            std::vector<hipfftw_data_memory_type> ret = {hipfftw_data_memory_type::pageable_host,
+                                                         hipfftw_data_memory_type::pinned_host,
+                                                         hipfftw_data_memory_type::current_device};
+            // "other_device" needs several devices to be available
+            int num_devices = 1;
+            if(hipGetDeviceCount(&num_devices) == hipSuccess && num_devices > 1)
+            {
+                ret.push_back(hipfftw_data_memory_type::other_device);
+            }
+#ifndef WIN32
+            // "managed" may or may not be supported
+            int deviceId = hipInvalidDeviceId;
+            if(hipGetDevice(&deviceId) != hipSuccess || deviceId == hipInvalidDeviceId)
+                return ret;
+            int managed_mem_is_supported = 0;
+            if(hipDeviceGetAttribute(
+                   &managed_mem_is_supported, hipDeviceAttributeManagedMemory, deviceId)
+                   == hipSuccess
+               && managed_mem_is_supported)
+            {
+                ret.push_back(hipfftw_data_memory_type::managed);
+                if(num_devices > 1)
+                    ret.push_back(hipfftw_data_memory_type::managed_other_device);
+            }
+            return ret;
+#endif
+        };
+        const static std::vector<hipfftw_data_memory_type> possible_cases = create_possible_cases();
+        return possible_cases;
+    };
+
+    std::string hipfftw_data_mem_type_to_string(hipfftw_data_memory_type mem_type)
+    {
+        switch(mem_type)
+        {
+        case hipfftw_data_memory_type::pageable_host:
+            return "pageable_host";
+            break;
+        case hipfftw_data_memory_type::pinned_host:
+            return "pinned_host";
+            break;
+#ifndef WIN32
+        case hipfftw_data_memory_type::managed:
+            return "managed";
+            break;
+        case hipfftw_data_memory_type::managed_other_device:
+            return "managed_other_device";
+            break;
+#endif
+        case hipfftw_data_memory_type::current_device:
+            return "current_device";
+            break;
+        case hipfftw_data_memory_type::other_device:
+            return "other_device";
+            break;
+        default:
+            throw std::runtime_error("internal error: unexpected value of mem_tye in "
+                                     "hipfftw_data_mem_type_to_string");
+            break;
+        }
+    };
+
+    bool is_attached_to_other_device(hipfftw_data_memory_type mem_type)
+    {
+        bool ret = mem_type == hipfftw_data_memory_type::other_device;
+#ifndef WIN32
+        ret = ret || mem_type == hipfftw_data_memory_type::managed_other_device;
+#endif
+        return ret;
+    }
+
+    hipfftw_data_memory_type get_random_data_mem_type()
+    {
+        const auto& options = get_possible_data_mem_types();
+        return options[get_random_idx(options.size())];
+    };
+
+    template <fft_precision prec>
+    struct hipfftw_functional_validation_params
+    {
+        // define type of I/O argument memory to be tested at a given step (creation/execution)
+        // by a map: mem_type[{step_label, io_label}] represents the test's target memory type to consider
+        // for the "io_label" I/O argument at step "step_label"
+        std::map<std::pair<hipfftw_step, fft_io>, hipfftw_data_memory_type> mem_type;
+        hipfftw_execution_io_args                                           execution_io;
+        hipfftw_helper<prec>                                                plan_helper;
+
+        fft_transform_type get_dft_kind() const
+        {
+            return plan_helper.get_dft_kind();
+        }
+        fft_result_placement get_placement() const
+        {
+            return plan_helper.get_placement();
+        }
+        bool use_creation_io_at_execution() const
+        {
+            return execution_io == hipfftw_execution_io_args::use_creation_io;
+        }
+        fft_array_type get_array_type(fft_io io) const
+        {
+            if(io != fft_io::fft_io_in && io != fft_io::fft_io_out)
+                throw std::invalid_argument("invalid io argument for "
+                                            "hipfftw_functional_validation_params::get_array_type");
+            const auto dft_kind = plan_helper.get_dft_kind();
+            if(is_complex(dft_kind))
+                return fft_array_type_complex_interleaved;
+            else if(is_fwd(dft_kind) == (io == fft_io::fft_io_in))
+                return fft_array_type_real;
+            else
+                return fft_array_type_hermitian_interleaved;
+        }
+        std::vector<size_t> get_lengths() const
+        {
+            return plan_helper.template get_length_as<size_t>();
+        }
+        std::vector<size_t> get_ilengths() const
+        {
+            auto ilengths = get_lengths();
+            if(plan_helper.get_dft_kind() == fft_transform_type_real_inverse)
+                ilengths.back() = ilengths.back() / 2 + 1;
+            return ilengths;
+        }
+        int get_rank() const
+        {
+            return plan_helper.get_rank();
+        }
+        std::vector<size_t> get_istride() const
+        {
+            return plan_helper.template get_strides_as<size_t>(fft_io::fft_io_in);
+        }
+        std::vector<size_t> get_ostride() const
+        {
+            return plan_helper.template get_strides_as<size_t>(fft_io::fft_io_out);
+        }
+        size_t get_idist() const
+        {
+            return plan_helper.template get_dist_as<size_t>(fft_io::fft_io_in);
+        }
+        size_t get_odist() const
+        {
+            return plan_helper.template get_dist_as<size_t>(fft_io::fft_io_out);
+        }
+        size_t get_nbatch() const
+        {
+            return plan_helper.template get_nbatch_as<size_t>(fft_io::fft_io_in);
+        }
+        std::vector<size_t> get_contiguous_istride() const
+        {
+            // equivalent to plan's strides for now, to be reconsidered once more general
+            // configurations are enabled
+            return plan_helper.template get_strides_as<size_t>(fft_io::fft_io_in);
+        }
+        size_t get_contiguous_idist() const
+        {
+            // equivalent to plan's strides for now, to be reconsidered once more general
+            // configurations are enabled
+            return plan_helper.template get_dist_as<size_t>(fft_io::fft_io_in);
+        }
+
+        bool can_be_tested() const
+        {
+            for(auto step : {hipfftw_step::plan_creation, hipfftw_step::plan_execution})
+            {
+                for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+                {
+                    const std::pair<hipfftw_step, fft_io> key = {step, io};
+                    if(mem_type.find(key) == mem_type.end())
+                    {
+                        // incomplete mem_type map
+                        return false;
+                    }
+                }
+            }
+            // "*_other_device" types only for execution as they mean other "than creation's" types
+            if(is_attached_to_other_device(
+                   mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_in}))
+               || is_attached_to_other_device(
+                   mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_out})))
+            {
+                // Inconsistent data memory type for I/O data at plan creation:
+                // "*_other_device" values cannot be used for creation arguments
+                return false;
+            }
+            // if using new I/O at execution, they must be clean
+            // TODO: enabled clean_new_io when new-array executes are implemented
+            if(execution_io != hipfftw_execution_io_args::use_creation_io
+               /* && execution_io != hipfftw_execution_io_args::clean_new_io*/)
+            {
+                return false;
+            }
+            if(!plan_helper.is_supported_for_creation())
+                return false;
+            const auto placement = plan_helper.get_placement();
+            if(placement == fft_placement_inplace)
+            {
+                if(mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_in})
+                   != mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_out}))
+                    return false;
+                if(mem_type.at({hipfftw_step::plan_execution, fft_io::fft_io_in})
+                   != mem_type.at({hipfftw_step::plan_execution, fft_io::fft_io_out}))
+                    return false;
+            }
+            if(execution_io == hipfftw_execution_io_args::use_creation_io)
+            {
+                if(mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_in})
+                       != mem_type.at({hipfftw_step::plan_execution, fft_io::fft_io_in})
+                   || mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_out})
+                          != mem_type.at({hipfftw_step::plan_execution, fft_io::fft_io_out}))
+                    return false;
+            }
+            return true;
+        }
+
+        std::string to_string() const
+        {
+            for(auto step : {hipfftw_step::plan_creation, hipfftw_step::plan_execution})
+            {
+                for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+                {
+                    const std::pair<hipfftw_step, fft_io> key = {step, io};
+                    if(mem_type.find(key) == mem_type.end())
+                        throw std::runtime_error("incomplete mem_type map");
+                }
+            }
+            std::ostringstream ret;
+            ret << plan_helper.token();
+            ret << "_creation_input_mem_type_"
+                << hipfftw_data_mem_type_to_string(
+                       mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_in}));
+            if(plan_helper.get_placement() == fft_placement_notinplace)
+            {
+                ret << "_creation_output_mem_type_"
+                    << hipfftw_data_mem_type_to_string(
+                           mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_out}));
+            }
+            if(execution_io == hipfftw_execution_io_args::clean_new_io)
+            {
+                ret << "_execution_input_mem_type_"
+                    << hipfftw_data_mem_type_to_string(
+                           mem_type.at({hipfftw_step::plan_execution, fft_io::fft_io_in}));
+                if(plan_helper.get_placement() == fft_placement_notinplace)
+                {
+                    ret << "_execution_output_mem_type_"
+                        << hipfftw_data_mem_type_to_string(
+                               mem_type.at({hipfftw_step::plan_execution, fft_io::fft_io_out}));
+                }
+            }
+            return ret.str();
+        }
+
+        // for using with insert_into_unique_sorted_params
+        bool operator<(const hipfftw_functional_validation_params& other) const
+        {
+            return to_string() < other.to_string();
+        }
+        bool operator==(const hipfftw_functional_validation_params& other) const
+        {
+            return to_string() == other.to_string();
+        }
+    };
+
+    template <fft_precision prec>
+    class hipfftw_functional_validation
+        : public ::testing::TestWithParam<hipfftw_functional_validation_params<prec>>
+    {
+    protected:
+        void SetUp() override
+        {
+            const hipfftw_functional_validation_params<prec>& params = this->GetParam();
+
+            if(!params.can_be_tested())
+                GTEST_FAIL() << "invalid parameters, cannot be tested";
+            if(reference_plan)
+                GTEST_FAIL() << "Starting from an unclean slate (reference plan is not nullptr)";
+
+            execution_results_on_host.resize(1);
+            execution_results_on_host[0].alloc(
+                params.plan_helper.get_data_byte_size(fft_io::fft_io_out));
+
+            std::vector<fft_io> io_range = {fft_io::fft_io_in};
+            if(params.get_placement() == fft_placement_notinplace)
+                io_range.push_back(fft_io::fft_io_out);
+            std::vector<hipfftw_step> step_range = {hipfftw_step::plan_creation};
+            if(!params.use_creation_io_at_execution())
+                step_range.push_back(hipfftw_step::plan_execution);
+            std::ostringstream gtest_info;
+            for(auto io : io_range)
+            {
+                const size_t data_size = params.plan_helper.get_data_byte_size(io);
+                auto&        io_verification_vec
+                    = io == fft_io::fft_io_in ? verification_input : verification_output;
+                io_verification_vec.resize(1);
+                io_verification_vec[0].alloc(data_size);
+
+                for(auto step : step_range)
+                {
+                    const std::pair<hipfftw_step, fft_io> map_key  = {step, io};
+                    const auto                            mem_type = params.mem_type.at(map_key);
+                    if(mem_type == hipfftw_data_memory_type::pageable_host
+                       || mem_type == hipfftw_data_memory_type::pinned_host)
+                    {
+                        host_io_buffer[map_key].alloc(
+                            data_size, mem_type == hipfftw_data_memory_type::pinned_host);
+                    }
+                    else
+                    {
+                        auto original_device_id = hipInvalidDeviceId;
+                        auto hip_status         = hipGetDevice(&original_device_id);
+                        if(hip_status != hipSuccess)
+                        {
+                            ++n_hip_failures;
+                            gtest_info << "hipGetDevice failure with error " << hip_status;
+                            if(skip_runtime_fails)
+                                GTEST_SKIP() << gtest_info.str();
+                            else
+                                GTEST_FAIL() << gtest_info.str();
+                        }
+                        auto other_device_id = hipInvalidDeviceId;
+                        if(mem_type == hipfftw_data_memory_type::managed_other_device
+                           || mem_type == hipfftw_data_memory_type::other_device)
+                        {
+                            int num_devices = 0;
+                            hip_status      = hipGetDeviceCount(&num_devices);
+                            if(hip_status != hipSuccess)
+                            {
+                                ++n_hip_failures;
+                                gtest_info << "hipGetDeviceCount failure with error " << hip_status;
+                                if(skip_runtime_fails)
+                                    GTEST_SKIP() << gtest_info.str();
+                                else
+                                    GTEST_FAIL() << gtest_info.str();
+                            }
+                            if(num_devices <= 1)
+                                throw std::runtime_error("Cannot attach memory to another "
+                                                         "device than the current one "
+                                                         "(only one available)");
+                            while((other_device_id = get_random_integer(0, num_devices - 1))
+                                  == original_device_id)
+                            {
+                                // do it again
+                            }
+                            hip_status = hipSetDevice(other_device_id);
+                            if(hip_status != hipSuccess)
+                            {
+                                ++n_hip_failures;
+                                gtest_info << "hipSetDevice failure with error " << hip_status
+                                           << ": couldn't change device id from "
+                                           << original_device_id << " to " << other_device_id;
+                                if(skip_runtime_fails)
+                                    GTEST_SKIP() << gtest_info.str();
+                                else
+                                    GTEST_FAIL() << gtest_info.str();
+                            }
+                        }
+#ifndef WIN32
+                        hip_status = gpu_io_buffer[map_key].alloc(
+                            data_size, mem_type == hipfftw_data_memory_type::managed);
+#else
+                        hip_status = gpu_io_buffer[map_key].alloc(data_size);
+#endif
+                        if(hip_status != hipSuccess)
+                        {
+                            gtest_info << "failed to allocate a buffer of type "
+                                       << hipfftw_data_mem_type_to_string(mem_type)
+                                       << " and byte size " << std::to_string(data_size)
+                                       << ". Original device ID is " << original_device_id;
+                            if(is_attached_to_other_device(mem_type))
+                                gtest_info << ", other device ID is" << other_device_id;
+                            ++n_hip_failures;
+                            if(skip_runtime_fails)
+                                GTEST_SKIP() << gtest_info.str();
+                            else
+                                GTEST_FAIL() << gtest_info.str();
+                        }
+
+                        if(mem_type == hipfftw_data_memory_type::managed_other_device
+                           || mem_type == hipfftw_data_memory_type::other_device)
+                        {
+                            hip_status = hipSetDevice(original_device_id);
+                            if(hip_status != hipSuccess)
+                            {
+                                ++n_hip_failures;
+                                gtest_info << "hipSetDevice failure with error " << hip_status
+                                           << ": couldn't reset device id from " << other_device_id
+                                           << " to " << original_device_id;
+                                if(skip_runtime_fails)
+                                    GTEST_SKIP() << gtest_info.str();
+                                else
+                                    GTEST_FAIL() << gtest_info.str();
+                            }
+                        }
+                    }
+                }
+            }
+            if(verification_input.size() != 1
+               || (params.get_placement() != fft_placement_inplace
+                   && verification_output.size() != 1))
+                GTEST_FAIL() << "Verification IO buffer incorrectly initialized";
+            // generate input data
+            const std::vector<size_t> field_lower(params.get_rank(), 0);
+            const auto                ilength = params.get_ilengths();
+            std::vector<size_t>       contiguous_istride(params.get_rank());
+            size_t                    val = 1;
+            for(int dim = params.get_rank() - 1; dim >= 0; dim--)
+            {
+                contiguous_istride[dim] = val;
+                val *= ilength[dim];
+            }
+            const auto contiguous_idist = val;
+            set_input<hostbuf, hipfftw_real_t<prec>>(verification_input,
+                                                     fft_input_generator_host,
+                                                     params.get_array_type(fft_io::fft_io_in),
+                                                     params.get_lengths(),
+                                                     ilength,
+                                                     params.get_istride(),
+                                                     params.get_idist(),
+                                                     params.get_nbatch(),
+                                                     get_curr_device_prop(),
+                                                     field_lower,
+                                                     0 /* field_lower_batch */,
+                                                     contiguous_istride,
+                                                     contiguous_idist);
+            // create the reference plan (systematically using the most general guru64 creation)
+            reference_plan = params.plan_helper.get_reference_plan(
+                verification_input[0].data(),
+                params.get_placement() == fft_placement_inplace ? verification_input[0].data()
+                                                                : verification_output[0].data());
+
+            if(!reference_plan)
+            {
+                GTEST_FAIL() << "could not create a reference plan";
+            }
+        }
+        void TearDown() override
+        {
+            verification_input.clear();
+            verification_output.clear();
+            execution_results_on_host.clear();
+            host_io_buffer.clear();
+            gpu_io_buffer.clear();
+            if constexpr(prec == fft_precision_single)
+                fftwf_destroy_plan(reference_plan);
+            else
+                fftw_destroy_plan(reference_plan);
+            this->GetParam().plan_helper.release_plan();
+        }
+        // verification buffers (set_input and other common routines require std::vector's of size 1 for these)
+        std::vector<hostbuf> verification_input;
+        std::vector<hostbuf> verification_output;
+        std::vector<hostbuf> execution_results_on_host;
+        // possible host buffers (pageable or pinned host allocation)
+        std::map<std::pair<hipfftw_step, fft_io>, hostbuf> host_io_buffer;
+        // possible nonhost buffers (may be current/other device or runtime-managed)
+        std::map<std::pair<hipfftw_step, fft_io>, gpubuf> gpu_io_buffer;
+        // reference plan
+        hipfftw_plan_t<prec> reference_plan = nullptr;
+
+        void functional_test() const
+        {
+            const hipfftw_functional_validation_params<prec>& params = this->GetParam();
+            try
+            {
+                std::ostringstream gtest_info;
+                if(verification_input.size() != 1
+                   || (params.get_placement() != fft_placement_inplace
+                       && verification_output.size() != 1))
+                    GTEST_FAIL() << "The verification I/O buffer(s) were not initialized as "
+                                    "needed; host buffer(s) are required";
+                if(execution_results_on_host.size() != 1)
+                    GTEST_FAIL() << "Improper test initialization: no host buffer to copy the "
+                                    "execution results";
+                // get/define raw pointers as needed
+                std::map<std::pair<hipfftw_step, fft_io>, void*>                    test_io_ptr;
+                std::map<std::pair<hipfftw_step, fft_io>, hipfftw_data_memory_type> test_io_type;
+                for(auto step : {hipfftw_step::plan_creation, hipfftw_step::plan_execution})
+                {
+                    if(step == hipfftw_step::plan_execution
+                       && params.use_creation_io_at_execution())
+                    {
+                        for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+                        {
+                            const std::pair<hipfftw_step, fft_io> map_key = {step, io};
+                            const std::pair<hipfftw_step, fft_io> creation_key
+                                = {hipfftw_step::plan_creation, io};
+                            test_io_ptr[map_key]  = test_io_ptr[creation_key];
+                            test_io_type[map_key] = test_io_type[creation_key];
+                        }
+                        continue;
+                    }
+                    for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+                    {
+                        const std::pair<hipfftw_step, fft_io> map_key = {step, io};
+                        if(io == fft_io::fft_io_out
+                           && params.get_placement() == fft_placement_inplace)
+                        {
+                            const std::pair<hipfftw_step, fft_io> input_key
+                                = {step, fft_io::fft_io_in};
+                            test_io_ptr[map_key]  = test_io_ptr[input_key];
+                            test_io_type[map_key] = test_io_type[input_key];
+                            continue;
+                        }
+                        if(params.mem_type.find(map_key) == params.mem_type.end())
+                            GTEST_FAIL() << "incomplete mem_type map in test parameters";
+                        test_io_type[map_key] = params.mem_type.at(map_key);
+                        if(test_io_type[map_key] == hipfftw_data_memory_type::pageable_host
+                           || test_io_type[map_key] == hipfftw_data_memory_type::pinned_host)
+                        {
+                            const auto host_buf_it = host_io_buffer.find(map_key);
+                            if(host_buf_it == host_io_buffer.end()
+                               || host_buf_it->second.size()
+                                      < params.plan_helper.get_data_byte_size(io))
+                            {
+                                GTEST_FAIL()
+                                    << "The test " << (io == fft_io::fft_io_in ? "input" : "output")
+                                    << " buffer was not initialized (host buffer required)";
+                            }
+                            else
+                            {
+                                test_io_ptr[map_key] = host_buf_it->second.data();
+                            }
+                        }
+                        else
+                        {
+                            const auto gpu_buf_it = gpu_io_buffer.find(map_key);
+                            if(gpu_buf_it == gpu_io_buffer.end()
+                               || gpu_buf_it->second.size()
+                                      < params.plan_helper.get_data_byte_size(io))
+                            {
+                                GTEST_FAIL()
+                                    << "The test " << (io == fft_io::fft_io_in ? "input" : "output")
+                                    << " buffer was not initialized (GPU buffer required)";
+                            }
+                            else
+                            {
+                                test_io_ptr[map_key] = gpu_buf_it->second.data();
+                            }
+                        }
+                    }
+                }
+                // copy input data to hipfftw's input
+                const std::pair<hipfftw_step, fft_io> exec_in_key
+                    = {hipfftw_step::plan_execution, fft_io::fft_io_in};
+                if(test_io_type.at(exec_in_key) == hipfftw_data_memory_type::current_device
+                   || test_io_type.at(exec_in_key) == hipfftw_data_memory_type::other_device)
+                {
+                    int  test_device_id = hipInvalidDeviceId;
+                    auto hip_status     = hipGetDevice(&test_device_id);
+                    if(hip_status != hipSuccess)
+                    {
+                        ++n_hip_failures;
+                        gtest_info << "hipGetDevice failure with error " << hip_status;
+                        if(skip_runtime_fails)
+                            GTEST_SKIP() << gtest_info.str();
+                        else
+                            GTEST_FAIL() << gtest_info.str();
+                    }
+                    if(test_io_type.at(exec_in_key) == hipfftw_data_memory_type::other_device)
+                    {
+                        hipPointerAttribute_t ptr_attributes;
+                        hip_status
+                            = hipPointerGetAttributes(&ptr_attributes, test_io_ptr.at(exec_in_key));
+                        if(hip_status != hipSuccess)
+                        {
+                            ++n_hip_failures;
+                            gtest_info << "hipPointerGetAttributes failure with error "
+                                       << hip_status;
+                            if(skip_runtime_fails)
+                                GTEST_SKIP() << gtest_info.str();
+                            else
+                                GTEST_FAIL() << gtest_info.str();
+                        }
+                        EXPECT_NE(ptr_attributes.device, test_device_id);
+
+                        hip_status = hipSetDevice(ptr_attributes.device);
+                        if(hip_status != hipSuccess)
+                        {
+                            ++n_hip_failures;
+                            gtest_info << "hipSetDevice failure with error " << hip_status;
+                            if(skip_runtime_fails)
+                                GTEST_SKIP() << gtest_info.str();
+                            else
+                                GTEST_FAIL() << gtest_info.str();
+                        }
+                    }
+                    hip_status = hipMemcpy(test_io_ptr.at(exec_in_key),
+                                           verification_input[0].data(),
+                                           params.plan_helper.get_data_byte_size(fft_io::fft_io_in),
+                                           hipMemcpyHostToDevice);
+                    if(hip_status != hipSuccess)
+                    {
+                        ++n_hip_failures;
+                        gtest_info << "hipMemcpy failure with error " << hip_status;
+                        if(skip_runtime_fails)
+                            GTEST_SKIP() << gtest_info.str();
+                        else
+                            GTEST_FAIL() << gtest_info.str();
+                    }
+                    if(test_io_type.at(exec_in_key) == hipfftw_data_memory_type::other_device)
+                    {
+                        // reset device id
+                        hip_status = hipSetDevice(test_device_id);
+                        if(hip_status != hipSuccess)
+                        {
+                            ++n_hip_failures;
+                            gtest_info << "hipSetDevice failure with error " << hip_status;
+                            if(skip_runtime_fails)
+                                GTEST_SKIP() << gtest_info.str();
+                            else
+                                GTEST_FAIL() << gtest_info.str();
+                        }
+                    }
+                }
+                else
+                {
+                    std::memcpy(test_io_ptr.at(exec_in_key),
+                                verification_input[0].data(),
+                                params.plan_helper.get_data_byte_size(fft_io::fft_io_in));
+                }
+
+                std::shared_future<void> reference_cpu_dft = std::async(std::launch::async, [&]() {
+                    if constexpr(prec == fft_precision_single)
+                        fftwf_execute(reference_plan);
+                    else
+                        fftw_execute(reference_plan);
+                });
+
+                auto exception_logger = std::make_unique<hipfftw_exception_logger>();
+                params.plan_helper.create_plan(
+                    test_io_ptr.at({hipfftw_step::plan_creation, fft_io::fft_io_in}),
+                    test_io_ptr.at({hipfftw_step::plan_creation, fft_io::fft_io_out}));
+                params.plan_helper.execute(
+                    test_io_ptr.at({hipfftw_step::plan_execution, fft_io::fft_io_in}),
+                    test_io_ptr.at({hipfftw_step::plan_execution, fft_io::fft_io_out}));
+                if(exception_logger->is_active())
+                {
+                    const auto log_content = exception_logger->get_log();
+                    if(!log_content.empty())
+                    {
+                        GTEST_FAIL() << "Non-empty log content detected:\n" << log_content;
+                    }
+                }
+                exception_logger.reset();
+
+                // copy hipfftw results back into the execution_results_on_host[0] buffer
+                // for verification purposes
+                const std::pair<hipfftw_step, fft_io> exec_out_key
+                    = {hipfftw_step::plan_execution, fft_io::fft_io_out};
+                if(test_io_type.at(exec_out_key) == hipfftw_data_memory_type::current_device
+                   || test_io_type.at(exec_out_key) == hipfftw_data_memory_type::other_device)
+                {
+                    int  test_device_id = hipInvalidDeviceId;
+                    auto hip_status     = hipGetDevice(&test_device_id);
+                    if(hip_status != hipSuccess)
+                    {
+                        ++n_hip_failures;
+                        gtest_info << "hipGetDevice failure with error " << hip_status;
+                        if(skip_runtime_fails)
+                            GTEST_SKIP() << gtest_info.str();
+                        else
+                            GTEST_FAIL() << gtest_info.str();
+                    }
+                    if(test_io_type.at(exec_out_key) == hipfftw_data_memory_type::other_device)
+                    {
+                        hipPointerAttribute_t ptr_attributes;
+                        hip_status = hipPointerGetAttributes(&ptr_attributes,
+                                                             test_io_ptr.at(exec_out_key));
+                        if(hip_status != hipSuccess)
+                        {
+                            ++n_hip_failures;
+                            gtest_info << "hipPointerGetAttributes failure with error "
+                                       << hip_status;
+                            if(skip_runtime_fails)
+                                GTEST_SKIP() << gtest_info.str();
+                            else
+                                GTEST_FAIL() << gtest_info.str();
+                        }
+                        EXPECT_NE(ptr_attributes.device, test_device_id);
+
+                        hip_status = hipSetDevice(ptr_attributes.device);
+                        if(hip_status != hipSuccess)
+                        {
+                            ++n_hip_failures;
+                            gtest_info << "hipSetDevice failure with error " << hip_status;
+                            if(skip_runtime_fails)
+                                GTEST_SKIP() << gtest_info.str();
+                            else
+                                GTEST_FAIL() << gtest_info.str();
+                        }
+                    }
+                    const size_t out_data_size
+                        = params.plan_helper.get_data_byte_size(fft_io::fft_io_out);
+                    hip_status = hipMemcpy(execution_results_on_host[0].data(),
+                                           test_io_ptr.at(exec_out_key),
+                                           out_data_size,
+                                           hipMemcpyDeviceToHost);
+                    if(hip_status != hipSuccess)
+                    {
+                        ++n_hip_failures;
+                        gtest_info << "hipMemcpy failure with error " << hip_status;
+                        if(skip_runtime_fails)
+                            GTEST_SKIP() << gtest_info.str();
+                        else
+                            GTEST_FAIL() << gtest_info.str();
+                    }
+                    if(test_io_type.at(exec_out_key) == hipfftw_data_memory_type::other_device)
+                    {
+                        // reset device id
+                        hip_status = hipSetDevice(test_device_id);
+                        if(hip_status != hipSuccess)
+                        {
+                            ++n_hip_failures;
+                            gtest_info << "hipSetDevice failure with error " << hip_status;
+                            if(skip_runtime_fails)
+                                GTEST_SKIP() << gtest_info.str();
+                            else
+                                GTEST_FAIL() << gtest_info.str();
+                        }
+                    }
+                }
+                else
+                {
+                    std::memcpy(execution_results_on_host[0].data(),
+                                test_io_ptr.at(exec_out_key),
+                                params.plan_helper.get_data_byte_size(fft_io::fft_io_out));
+                }
+                // compare results
+                if(reference_cpu_dft.valid())
+                    reference_cpu_dft.get();
+                const auto test_lengths  = params.get_lengths();
+                auto       test_olengths = test_lengths;
+                if(params.get_dft_kind() == fft_transform_type_real_forward)
+                    test_olengths.back() = test_olengths.back() / 2 + 1;
+                const auto  total_length     = product(test_lengths.begin(), test_lengths.end());
+                const auto& reference_output = params.get_placement() == fft_placement_inplace
+                                                   ? verification_input
+                                                   : verification_output;
+
+                const auto   ref_norm = norm(reference_output,
+                                           test_olengths,
+                                           params.get_nbatch(),
+                                           prec,
+                                           params.get_array_type(fft_io::fft_io_out),
+                                           params.get_ostride(),
+                                           params.get_odist(),
+                                           {0} /* offset */);
+                const double test_epsilon
+                    = prec == fft_precision_single ? single_epsilon : double_epsilon;
+                const double linf_cutoff = test_epsilon * ref_norm.l_inf * log(total_length);
+                // compare results
+                const auto diff = distance(reference_output,
+                                           execution_results_on_host,
+                                           test_olengths,
+                                           params.get_nbatch(),
+                                           prec,
+                                           params.get_array_type(fft_io::fft_io_out),
+                                           params.get_ostride(),
+                                           params.get_odist(),
+                                           params.get_array_type(fft_io::fft_io_out),
+                                           params.get_ostride(),
+                                           params.get_odist(),
+                                           nullptr,
+                                           linf_cutoff,
+                                           {0} /* offset */,
+                                           {0} /* offset */);
+                EXPECT_LE(diff.l_inf, linf_cutoff);
+                EXPECT_LT(diff.l_2 / ref_norm.l_2, sqrt(log2(total_length)) * test_epsilon);
+                if constexpr(prec == fft_precision_single)
+                {
+                    max_linf_eps_single = std::max(max_linf_eps_single,
+                                                   diff.l_inf / ref_norm.l_inf / log(total_length));
+                    max_l2_eps_single   = std::max(
+                        max_l2_eps_single, diff.l_2 / ref_norm.l_2 * sqrt(log2(total_length)));
+                }
+                else
+                {
+                    max_linf_eps_double = std::max(max_linf_eps_double,
+                                                   diff.l_inf / ref_norm.l_inf / log(total_length));
+                    max_l2_eps_double   = std::max(
+                        max_l2_eps_double, diff.l_2 / ref_norm.l_2 * sqrt(log2(total_length)));
+                }
+            }
+            catch(const hipfftw_undefined_function_ptr& e)
+            {
+                GTEST_FAIL() << "undefined function pointers detected. Error info: " << e.what();
+            }
+            catch(const std::runtime_error e)
+            {
+                GTEST_FAIL() << e.what();
+            }
+            catch(...)
+            {
+                GTEST_FAIL() << "unidentified exception caught during test.";
+            }
+        }
+
+    public:
+        static std::string TestName(
+            const testing::TestParamInfo<typename hipfftw_functional_validation::ParamType>& info)
+        {
+            return info.param.to_string();
+        }
+    };
+
+    template <fft_precision prec>
+    std::vector<hipfftw_functional_validation_params<prec>>
+        params_for_functional_tests(size_t desired_full_suite_size)
+    {
+        std::vector<hipfftw_functional_validation_params<prec>> full_list;
+        hipfftw_functional_validation_params<prec>              to_add;
+        constexpr bool                                          valid_value
+            = true; // for readability of template specialization values below
+        const auto& possible_mem_types = get_possible_data_mem_types();
+        while(full_list.size() < desired_full_suite_size)
+        {
+            // TODO: randomly alternate between hipfftw_execution_io_args::use_creation_io and
+            // hipfftw_execution_io_args::clean_new_io when the latter is available
+            to_add.execution_io = hipfftw_execution_io_args::use_creation_io;
+            const auto dft_kind
+                = trans_type_range_full[get_random_idx(trans_type_range_full.size())];
+            const auto rank               = get_random_rank<valid_value, 1, 3>();
+            const auto placement          = place_range[get_random_idx(place_range.size())];
+            const bool is_real_inplace    = is_real(dft_kind) && placement == fft_placement_inplace;
+            const auto max_byte_size      = max_byte_size_for_unbatched_hipfftw_tests[rank - 1];
+            const ptrdiff_t len_threshold = get_len_threshold(
+                max_num_elems_for_data_size<prec>(max_byte_size, dft_kind), rank, is_real_inplace);
+            to_add.plan_helper.set_creation_args(
+                dft_kind,
+                rank,
+                get_random_lengths<valid_value, int>(rank, len_threshold),
+                placement,
+                is_fwd(dft_kind) ? FFTW_FORWARD : FFTW_BACKWARD,
+                FFTW_ESTIMATE);
+            for(auto step : {hipfftw_step::plan_creation, hipfftw_step::plan_execution})
+            {
+                if(step == hipfftw_step::plan_execution
+                   && to_add.execution_io == hipfftw_execution_io_args::use_creation_io)
+                {
+                    for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+                    {
+                        const std::pair<hipfftw_step, fft_io> key = {step, io};
+                        const std::pair<hipfftw_step, fft_io> creation_key
+                            = {hipfftw_step::plan_creation, io};
+                        to_add.mem_type[key] = to_add.mem_type[creation_key];
+                    }
+                    continue;
+                }
+                for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+                {
+                    const std::pair<hipfftw_step, fft_io> key = {step, io};
+                    if(placement == fft_placement_inplace && io == fft_io::fft_io_out)
+                    {
+                        auto input_key       = key;
+                        input_key.second     = fft_io::fft_io_in;
+                        to_add.mem_type[key] = to_add.mem_type[input_key];
+                    }
+                    else
+                    {
+                        to_add.mem_type[key]
+                            = possible_mem_types[get_random_idx(possible_mem_types.size())];
+                        while(step == hipfftw_step::plan_creation
+                              && is_attached_to_other_device(to_add.mem_type[key]))
+                        {
+                            // pick another one
+                            to_add.mem_type[key]
+                                = possible_mem_types[get_random_idx(possible_mem_types.size())];
+                        }
+                    }
+                }
+            }
+            // skip params if they can't be tested for some reason
+            if(!to_add.can_be_tested())
+                continue;
+            insert_into_unique_sorted_params(full_list, to_add);
+        }
+        if(test_prob == 1.0 && real_prob_factor == 1.0)
+            return full_list;
+        std::vector<hipfftw_functional_validation_params<prec>> ret;
+        for(const auto& test : full_list)
+        {
+            const double roll = hash_prob(random_seed, test.to_string());
+            const double run_prob
+                = test_prob * (is_real(test.plan_helper.get_dft_kind()) ? real_prob_factor : 1.0);
+
+            if(roll > run_prob)
+            {
+                if(verbose > 4)
+                {
+                    std::cout << "Test skipped: (roll=" << roll << " > " << run_prob << ")\n";
+                }
+                continue;
+            }
+            ret.emplace_back(test);
+        }
+        return ret;
+    }
+
+} // hipfftw test details' anonymous namespace
+
+//
+//---------------------------------------------------------------------------------------------
+//                                    INSTANTIATION OF TESTS
+//---------------------------------------------------------------------------------------------
+//
+
+TEST(hipfftw_test, utility_functions)
+{
+    try
+    {
+        test_existence_of_utility_functions<fft_precision_single>();
+        test_existence_of_utility_functions<fft_precision_double>();
+    }
+    catch(const hipfftw_undefined_function_ptr& e)
+    {
+        GTEST_FAIL() << "Undefined function pointers detected. Error info: " << e.what();
+    }
+    catch(...)
+    {
+        GTEST_FAIL() << "Unexpected failure";
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    hipfftw_test,
+    allocation_sp,
+    ::testing::ValuesIn(params_for_testing_hipfftw_malloc<fft_precision_single>()),
+    allocation_sp::TestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    hipfftw_test,
+    allocation_dp,
+    ::testing::ValuesIn(params_for_testing_hipfftw_malloc<fft_precision_double>()),
+    allocation_dp::TestName);
+
+using argument_validation_sp = hipfftw_argument_validation<fft_precision_single>;
+TEST_P(argument_validation_sp, creation_and_execution)
+{
+    input_validation_test();
+}
+using argument_validation_dp = hipfftw_argument_validation<fft_precision_double>;
+TEST_P(argument_validation_dp, creation_and_execution)
+{
+    input_validation_test();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    hipfftw_test,
+    argument_validation_sp,
+    ::testing::ValuesIn(params_for_testing_input_validation_params<fft_precision_single>()),
+    argument_validation_sp::TestName);
+INSTANTIATE_TEST_SUITE_P(
+    hipfftw_test,
+    argument_validation_dp,
+    ::testing::ValuesIn(params_for_testing_input_validation_params<fft_precision_double>()),
+    argument_validation_dp::TestName);
+
+using hipfftw_functional_validation_sp = hipfftw_functional_validation<fft_precision_single>;
+TEST_P(hipfftw_functional_validation_sp, accuracy_vs_fftw)
+{
+    functional_test();
+}
+
+using hipfftw_functional_validation_dp = hipfftw_functional_validation<fft_precision_double>;
+TEST_P(hipfftw_functional_validation_dp, accuracy_vs_fftw)
+{
+    functional_test();
+}
+
+static constexpr size_t full_suite_size = 1024; // per precision
+INSTANTIATE_TEST_SUITE_P(
+    hipfftw_test,
+    hipfftw_functional_validation_sp,
+    ::testing::ValuesIn(params_for_functional_tests<fft_precision_single>(full_suite_size)),
+    hipfftw_functional_validation_sp::TestName);
+INSTANTIATE_TEST_SUITE_P(
+    hipfftw_test,
+    hipfftw_functional_validation_dp,
+    ::testing::ValuesIn(params_for_functional_tests<fft_precision_double>(full_suite_size)),
+    hipfftw_functional_validation_dp::TestName);

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -1278,7 +1278,7 @@ namespace
                                                    params.creation_placement()
                                                            == fft_placement_inplace
                                                        ? plan_creation_input.data()
-                                                       : plan_creation_output.data(), );
+                                                       : plan_creation_output.data());
                     }
                     else
                     {

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -79,11 +79,15 @@ namespace
 
     enum class hipfftw_internal_exception
     {
+        none,
         flow_redirection,
         invalid_args,
-        unsupported_args
+        unsupported_args,
+        ill_defined
     };
 
+    // for well-defined internal exceptions, we may expect a specific report thereof
+    // in the hipfftw exception log (if logging is activated)
     template <hipfftw_internal_exception>
     constexpr std::string_view hipfftw_expected_log_instance;
     template <>
@@ -95,17 +99,6 @@ namespace
     template <>
     constexpr std::string_view hipfftw_expected_log_instance<
         hipfftw_internal_exception::flow_redirection> = R"(Redirecting execution flow)";
-
-    // bit-flagging enum used for configuring tests's execution I/O
-    enum hipfftw_execution_io_args : unsigned
-    {
-        use_creation_io       = 0x0,
-        non_null_new_in       = 0x1 << 1,
-        non_null_new_out      = 0x1 << 2,
-        new_io_same_placement = 0x1 << 3,
-        // all flags must be up to be generally clean with new I/O
-        clean_new_io = non_null_new_in | non_null_new_out | new_io_same_placement
-    };
 
     // randomizers
     // Note: albeit not supported, ranks > 3 are "valid" rank argument
@@ -277,6 +270,26 @@ namespace
         return data_byte_size
                / (is_real(dft_kind) ? sizeof(hipfftw_real_t<prec>)
                                     : sizeof(hipfftw_complex_t<prec>));
+    }
+
+    // exception for hip runtime error(s) specifically
+    struct hip_runtime_error : public std::runtime_error
+    {
+        const hipError_t hip_error;
+        hip_runtime_error(const std::string& info, hipError_t hip_status)
+            : std::runtime_error::runtime_error(info)
+            , hip_error(hip_status)
+
+        {
+        }
+    };
+    int get_current_device_id()
+    {
+        int        ret        = hipInvalidDeviceId;
+        const auto hip_status = hipGetDevice(&ret);
+        if(hip_status != hipSuccess)
+            throw hip_runtime_error("hipGetDevice failed.", hip_status);
+        return ret;
     }
 
     //
@@ -621,15 +634,7 @@ namespace
                 hipPointerAttribute_t attributes;
                 auto hip_status = hipPointerGetAttributes(&attributes, test_allocation);
                 if(hip_status != hipSuccess)
-                {
-                    ++n_hip_failures;
-                    std::ostringstream gtest_info;
-                    gtest_info << "hipPointerGetAttributes failure with error " << hip_status;
-                    if(skip_runtime_fails)
-                        GTEST_SKIP() << gtest_info.str();
-                    else
-                        GTEST_FAIL() << gtest_info.str();
-                }
+                    throw hip_runtime_error("hipPointerGetAttributes failed.", hip_status);
                 switch(attributes.type)
                 {
                 case hipMemoryType::hipMemoryTypeHost:
@@ -703,6 +708,14 @@ namespace
             catch(const hipfftw_undefined_function_ptr& e)
             {
                 GTEST_FAIL() << "undefined function pointers detected. Error info: " << e.what();
+            }
+            catch(const hip_runtime_error& e)
+            {
+                ++n_hip_failures;
+                if(skip_runtime_fails)
+                    GTEST_SKIP() << e.what() << "\nError code: " << e.hip_error << ".";
+                else
+                    GTEST_FAIL() << e.what() << "\nError code: " << e.hip_error << ".";
             }
             catch(const allocation_test_to_be_skipped& e)
             {
@@ -782,6 +795,17 @@ namespace
     //---------------------------------------------------------------------------------------------
     //
 
+    // bit-flagging enum used for configuring tests's execution I/O
+    enum hipfftw_execution_io_args : unsigned
+    {
+        use_creation_io       = 0x0,
+        non_null_new_in       = 0x1 << 1,
+        non_null_new_out      = 0x1 << 2,
+        new_io_same_placement = 0x1 << 3,
+        // all flags must be up to be generally clean with new I/O
+        clean_new_io = non_null_new_in | non_null_new_out | new_io_same_placement
+    };
+
     static bool hipfftw_execution_io_args_are_well_defined(hipfftw_execution_io_args args)
     {
         return args == (args & hipfftw_execution_io_args::clean_new_io);
@@ -840,7 +864,9 @@ namespace
             return !(execution_io & non_null_io_mask);
         }
 
-        bool can_be_tested() const
+        // checks consistency between values for test parameters that may have
+        // overlapping scopes/meaning, in some specific cases
+        bool can_be_tested(bool io_allocation_is_allowed = true) const
         {
             if(!use_creation_io_at_execution())
                 return false; // cannot be done yet
@@ -870,6 +896,20 @@ namespace
                    && is_execution_arg_null(fft_io::fft_io_out))
                     return false; // would be in-place at execution
             }
+            if(!io_allocation_is_allowed)
+            {
+                // do not tolerate allow SetUp to allocate
+                bool ret = creation_io_is_null.first
+                           && (creation_placement() == fft_placement_inplace
+                               || creation_io_is_null.second);
+                if(!use_creation_io_at_execution() && ret)
+                {
+                    ret = is_execution_arg_null(fft_io::fft_io_in)
+                          && (execution_placement() == fft_placement_inplace
+                              || is_execution_arg_null(fft_io::fft_io_out));
+                }
+                return ret;
+            }
             return true;
         }
 
@@ -897,21 +937,13 @@ namespace
             return execution_io == hipfftw_execution_io_args::clean_new_io;
         }
 
-        bool expects_internal_exception_for(hipfftw_step               step,
-                                            hipfftw_internal_exception expected_exception) const
+        // helper to determine if an internal exception may reliably be expected
+        // for the given step (creation/execution) and, if yes, which kind of
+        // internal exception
+        hipfftw_internal_exception expected_internal_exception_for(hipfftw_step step) const
         {
             if(step != hipfftw_step::plan_creation && step != hipfftw_step::plan_execution)
-                throw std::invalid_argument("Invalid step in expects_internal_exception_for");
-
-            if(expected_exception != hipfftw_internal_exception::invalid_args
-               && expected_exception != hipfftw_internal_exception::unsupported_args)
-                throw std::invalid_argument(
-                    "Invalid expected exception in expects_internal_exception_for");
-
-            if(expected_exception != hipfftw_internal_exception::invalid_args
-               && step == hipfftw_step::plan_execution)
-                throw std::invalid_argument("Cannot expect anything else than invalid argument for "
-                                            "failures at plan execution");
+                throw std::invalid_argument("Invalid step in expected_internal_exception_for");
 
             if(!can_be_tested())
                 throw std::runtime_error(
@@ -919,24 +951,33 @@ namespace
                         creation_options, plan_helper.get_dft_kind(), plan_helper.get_rank())
                     + " cannot be tested for these parameters");
 
-            // any i/o is fine is using FFTW_ESTIMATE or FFTW_WISDOM_ONLY in the plan's flags
             const bool valid_args_for_plan_creation
                 = plan_helper.is_valid_for_creation_with(creation_options)
                   && has_valid_io_for(hipfftw_step::plan_creation);
-            const bool supported_args_for_plan_creation
-                = valid_args_for_plan_creation
-                  && plan_helper.is_supported_for_creation_with(creation_options);
+            const bool plan_can_be_created = valid_args_for_plan_creation
+                                             && plan_helper.can_create_plan_with(creation_options);
             if(step == hipfftw_step::plan_creation)
             {
-                if(expected_exception == hipfftw_internal_exception::invalid_args)
-                    return !valid_args_for_plan_creation;
-                else // must be valid but not supported
-                    return valid_args_for_plan_creation && !supported_args_for_plan_creation;
+                if(plan_can_be_created)
+                    return hipfftw_internal_exception::none;
+                // plan cannot be created
+                if(valid_args_for_plan_creation)
+                    return hipfftw_internal_exception::unsupported_args;
+                // plan cannot be created and arguments were invalid...
+                // We may however have a mixed bag of some invalid and other unsupported args.
+                // In such cases, the specific exception to expect would be ill-defined
+                if(!plan_helper.has_unsupported_args_for(creation_options))
+                    return hipfftw_internal_exception::invalid_args;
+                else
+                    return hipfftw_internal_exception::ill_defined;
             }
             else
             {
-                return !valid_args_for_plan_creation || !supported_args_for_plan_creation
-                       || !has_valid_io_for(hipfftw_step::plan_execution);
+                if(!plan_can_be_created || !has_valid_io_for(hipfftw_step::plan_execution))
+                {
+                    return hipfftw_internal_exception::invalid_args;
+                }
+                return hipfftw_internal_exception::none;
             }
         }
 
@@ -959,7 +1000,7 @@ namespace
                     << (is_execution_arg_null(fft_io::fft_io_out) ? "_" : "_not_") << "nullptr";
                 ret << "_execution_placement"
                     << ((execution_io & hipfftw_execution_io_args::new_io_same_placement)
-                            ? "_same_"
+                            ? "_same_as_"
                             : "_different_than_")
                     << "creation_placement";
             }
@@ -983,212 +1024,144 @@ namespace
         // constexpr used for readability of template specialization values below
         constexpr bool valid_value          = true;
         constexpr int  min_unsupported_rank = 4;
-
-        // create a full-scope map containing all the generated test; the map keys capture the
-        // hipfftw's function name the tests would target
-        // --> ease for guaranteeing coverage even with low test probability in the end
-        std::map<std::string, std::vector<hipfftw_input_validation_params<prec>>> full_scope_tests;
-        hipfftw_input_validation_params<prec>                                     to_add;
-
-        // generate broad scope for plan creation and/or default plan
-        // execution (i.e., reusing plan creation's IO at execution)
-        for(auto internal_except : {hipfftw_internal_exception::invalid_args,
-                                    hipfftw_internal_exception::unsupported_args})
+        // scope of plan hipfftw_helpers configured with (zero or possibly many)
+        // invalid/unsupported parameter value(s)
+        std::vector<hipfftw_helper<prec>> helper_scope;
+        for(auto dft_kind : trans_type_range_full)
         {
-            for(auto creation_option : hipfftw_plan_creation_func_candidates)
+            std::vector<int> rank_range = {1, 2, 3};
+            rank_range.push_back(get_random_rank<!valid_value>());
+            rank_range.push_back(get_random_rank<valid_value, min_unsupported_rank>());
+            for(auto rank : rank_range)
             {
-                for(auto dft_kind : trans_type_range_full)
+                for(auto placement : place_range)
                 {
-                    std::vector<int> rank_range = {1, 2, 3};
-                    if(internal_except == hipfftw_internal_exception::invalid_args)
-                        rank_range.push_back(get_random_rank<!valid_value>());
-                    else if(internal_except == hipfftw_internal_exception::unsupported_args)
-                        rank_range.push_back(get_random_rank<valid_value, min_unsupported_rank>());
-                    for(auto rank : rank_range)
+                    std::vector<std::vector<ptrdiff_t>> range_of_lengths;
+                    // most creation funcs take lengths as pointers
+                    // --> test for empty lengths (re-interpreted as a nullptr
+                    // arg by hipfftw_helper)
+                    range_of_lengths.emplace_back(std::vector<ptrdiff_t>());
+                    if(rank > 0)
                     {
-                        for(auto placement : place_range)
+                        const bool is_real_inplace
+                            = is_real(dft_kind) && placement == fft_placement_inplace;
+                        const auto max_byte_size
+                            = max_byte_size_for_unbatched_hipfftw_tests[std::min(rank - 1, 2)];
+                        const ptrdiff_t allocatable_len_threshold = get_len_threshold(
+                            max_num_elems_for_data_size<prec>(max_byte_size, dft_kind),
+                            rank,
+                            is_real_inplace);
+                        const auto valid_int_lengths
+                            = get_random_lengths<valid_value, int>(rank, allocatable_len_threshold);
+                        // always add valid integer lengths for valid ranks
+                        range_of_lengths.emplace_back(valid_int_lengths);
+                        // invalid integer lengths (most likely nonzero)
+                        const auto invalid_int_lengths = get_random_lengths<!valid_value, int>(
+                            rank, allocatable_len_threshold);
+                        range_of_lengths.emplace_back(invalid_int_lengths);
+                        // invalid integer lengths (some zero)
+                        auto invalid_int_lengths_due_to_some_zero = valid_int_lengths;
+                        invalid_int_lengths_due_to_some_zero[get_random_idx(rank)] = 0;
+                        range_of_lengths.emplace_back(invalid_int_lengths_due_to_some_zero);
+                        if(rank > 1 && rank < min_unsupported_rank)
                         {
-                            std::vector<std::vector<ptrdiff_t>> range_of_lengths;
-                            // most creation funcs take lengths as pointers
-                            // --> test for empty lengths (re-interpreted as a nullptr
-                            // arg by hipfftw_helper)
-                            range_of_lengths.emplace_back(std::vector<ptrdiff_t>());
-
-                            const bool is_real_inplace
-                                = is_real(dft_kind) && placement == fft_placement_inplace;
-                            const auto max_byte_size
-                                = max_byte_size_for_unbatched_hipfftw_tests[std::min(
-                                    std::max(rank - 1, 0), 2)];
-                            const ptrdiff_t allocatable_len_threshold = get_len_threshold(
-                                max_num_elems_for_data_size<prec>(max_byte_size, dft_kind),
-                                std::max(rank, 1),
-                                is_real_inplace);
-                            if(rank > 0)
+                            // no support for layouts that trigger an int overflow for any relevant
+                            // element index (unless GURU64 creation functions are used)
+                            const auto min_overflowing_len = get_len_threshold(
+                                std::numeric_limits<int>::max(), rank, is_real_inplace);
+                            const auto unsupported_int_lengths
+                                = get_random_lengths<valid_value, int>(
+                                    rank, std::numeric_limits<int>::max(), min_overflowing_len + 1);
+                            range_of_lengths.emplace_back(unsupported_int_lengths);
+                        }
+                    }
+                    for(const auto& lengths : range_of_lengths)
+                    {
+                        std::vector<int> sign_range = {get_random_sign<valid_value>(dft_kind)};
+                        if(is_complex(dft_kind))
+                            sign_range.push_back(get_random_sign<!valid_value>(dft_kind));
+                        for(auto sign : sign_range)
+                        {
+                            // FFTW_ESTIMATE is always supported
+                            std::vector<unsigned> flags_range = {FFTW_ESTIMATE};
+                            // some invalid flags
+                            flags_range.push_back(get_random_flags<!valid_value>());
+                            // unsupported FFTW_WISDOM_ONLY
+                            flags_range.push_back(FFTW_WISDOM_ONLY
+                                                  | get_random_flags<valid_value>());
+                            // unsupported FFTW_PRESERVE_INPUT for multi-dimensional c2r
+                            flags_range.push_back(FFTW_PRESERVE_INPUT
+                                                  | get_random_flags<valid_value>());
+                            for(auto flags : flags_range)
                             {
-                                const auto valid_int_lengths = get_random_lengths<valid_value, int>(
-                                    rank, allocatable_len_threshold);
-                                // always add valid integer lengths for valid ranks
-                                range_of_lengths.emplace_back(valid_int_lengths);
-                                if(internal_except == hipfftw_internal_exception::invalid_args)
-                                {
-                                    const auto invalid_int_lengths
-                                        = get_random_lengths<!valid_value, int>(
-                                            rank, allocatable_len_threshold);
-                                    auto invalid_int_lengths_due_to_some_zero = valid_int_lengths;
-                                    invalid_int_lengths_due_to_some_zero[get_random_idx(rank)] = 0;
-                                    // invalid integer lengths (most likely nonzero)
-                                    range_of_lengths.emplace_back(invalid_int_lengths);
-                                    // invalid integer lengths (some zero)
-                                    range_of_lengths.emplace_back(
-                                        invalid_int_lengths_due_to_some_zero);
-                                }
-                                else if(rank > 1 && rank < min_unsupported_rank
-                                        && creation_option
-                                               != hipfftw_plan_creation_func::PLAN_GURU64)
-                                {
-                                    // no support for layouts that trigger an int overflow for
-                                    // any relevant element index
-                                    const auto min_overflowing_len = get_len_threshold(
-                                        std::numeric_limits<int>::max(), rank, is_real_inplace);
-
-                                    const auto unsupported_lengths
-                                        = get_random_lengths<valid_value, int>(
-                                            rank,
-                                            std::numeric_limits<int>::max(),
-                                            min_overflowing_len + 1);
-                                    range_of_lengths.emplace_back(unsupported_lengths);
-                                }
-                            }
-                            for(const auto& lengths : range_of_lengths)
-                            {
-                                // do not allocate for the lengths designed to trigger an overflow
-                                const bool test_may_allocate = std::all_of(
-                                    lengths.begin(), lengths.end(), [&](const ptrdiff_t& val) {
-                                        return val <= allocatable_len_threshold;
-                                    });
-                                std::vector<std::pair<bool, bool>> creation_io_is_null_range;
-                                if(test_may_allocate)
-                                    creation_io_is_null_range.push_back({false, false});
-                                if(placement == fft_placement_inplace)
-                                    creation_io_is_null_range.push_back({true, true});
-                                else if(test_may_allocate)
-                                {
-                                    creation_io_is_null_range.push_back({true, false});
-                                    creation_io_is_null_range.push_back({false, true});
-                                }
-                                for(auto set_creation_io_as_null : creation_io_is_null_range)
-                                {
-                                    std::vector<int> sign_range;
-                                    sign_range.push_back(get_random_sign<valid_value>(dft_kind));
-                                    if(is_complex(dft_kind))
-                                        sign_range.push_back(
-                                            get_random_sign<!valid_value>(dft_kind));
-                                    for(auto sign : sign_range)
-                                    {
-                                        std::vector<unsigned> flags_range;
-                                        flags_range.push_back(get_random_flags<valid_value>());
-                                        if(internal_except
-                                           == hipfftw_internal_exception::invalid_args)
-                                            flags_range.push_back(get_random_flags<!valid_value>());
-                                        else
-                                        {
-                                            // FFTW_WISDOM_ONLY is not supported
-                                            flags_range.push_back(
-                                                FFTW_WISDOM_ONLY | get_random_flags<valid_value>());
-                                            // FFTW_PRESERVE_INPUT is not supported for multi-dimensional c2r
-                                            if(rank > 1 && rank < min_unsupported_rank
-                                               && dft_kind == fft_transform_type_real_inverse)
-                                                flags_range.push_back(
-                                                    FFTW_PRESERVE_INPUT
-                                                    | get_random_flags<valid_value>());
-                                        }
-
-                                        for(auto flags : flags_range)
-                                        {
-                                            to_add.creation_options    = creation_option;
-                                            to_add.creation_io_is_null = set_creation_io_as_null;
-                                            to_add.execution_io
-                                                = hipfftw_execution_io_args::use_creation_io;
-                                            to_add.plan_helper.set_creation_args(
-                                                dft_kind, rank, lengths, placement, sign, flags);
-                                            // skip params if they can't be used anyways
-                                            if(!to_add.can_be_tested())
-                                                continue;
-                                            // skip params if they're supposed to be fine even for execution
-                                            if(!to_add.expects_internal_exception_for(
-                                                   hipfftw_step::plan_execution,
-                                                   hipfftw_internal_exception::invalid_args))
-                                                continue;
-                                            // skip params if they're not triggering the kind of exception
-                                            // we'd want at plan creation
-                                            if(!to_add.expects_internal_exception_for(
-                                                   hipfftw_step::plan_creation, internal_except))
-                                                continue;
-                                            insert_into_unique_sorted_params(
-                                                full_scope_tests[hipfftw_creation_options_to_string(
-                                                    creation_option, dft_kind, rank)],
-                                                to_add);
-                                        }
-                                    }
-                                }
+                                hipfftw_helper<prec> helper_to_add;
+                                helper_to_add.set_creation_args(
+                                    dft_kind, rank, lengths, placement, sign, flags);
+                                helper_scope.emplace_back(helper_to_add);
                             }
                         }
                     }
                 }
             }
         }
-        // Add some supported plans for which creation is expected to succeed
-        // but execution is expected to fail
+        // create a full-scope map containing all the generated test parameters; the map keys
+        // capture the hipfftw's function name that the tests would target
+        // --> ease for guaranteeing coverage even with low test probability in the end
         // TODO: add messed up (new) I/O arguments when new-array executes are enabled
-        for(auto dft_kind : trans_type_range_full)
+        std::map<std::string, std::vector<hipfftw_input_validation_params<prec>>> full_scope_tests;
+        hipfftw_input_validation_params<prec>                                     test_to_add;
+        for(const auto& helper : helper_scope)
         {
-            std::vector<int> supported_rank_range = {1, 2, 3};
-            for(auto supported_rank : supported_rank_range)
+            // do not allocate for the lengths designed to trigger an overflow
+            // (allocation sizes would be ridiculously large)
+            const bool test_may_allocate
+                = helper.has_valid_rank() && helper.has_valid_lengths()
+                  && helper.get_data_byte_size(fft_io::fft_io_in)
+                         <= max_byte_size_for_unbatched_hipfftw_tests[helper.get_rank() - 1]
+                  && helper.get_data_byte_size(fft_io::fft_io_out)
+                         <= max_byte_size_for_unbatched_hipfftw_tests[helper.get_rank() - 1];
+            for(auto creation : hipfftw_plan_creation_func_candidates)
             {
-                for(auto placement : place_range)
+                // full range considered for creation_io_is_null and execution_io
+                // parameters: some might be ruled out later on because they can't
+                // be tested (e.g., "not_inplace" required yet using nullptr for
+                // creation input and output would be nonsensical)
+                const std::vector<std::pair<bool, bool>> creation_io_is_null_range
+                    = {{false, false}, {true, false}, {false, true}, {true, true}};
+                for(auto set_creation_io_as_null : creation_io_is_null_range)
                 {
-                    const bool is_real_inplace
-                        = is_real(dft_kind) && placement == fft_placement_inplace;
-                    const ptrdiff_t allocatable_len_threshold = get_len_threshold(
-                        max_num_elems_for_data_size<prec>(
-                            max_byte_size_for_unbatched_hipfftw_tests[supported_rank - 1],
-                            dft_kind),
-                        supported_rank,
-                        is_real_inplace);
-                    const auto supported_int_lengths = get_random_lengths<valid_value, int>(
-                        supported_rank, allocatable_len_threshold);
-                    std::vector<std::pair<bool, bool>> creation_io_is_null_range;
-                    if(placement == fft_placement_inplace)
-                        creation_io_is_null_range.push_back({true, true});
-                    else
+                    for(std::underlying_type_t<hipfftw_execution_io_args> exec_io
+                        = hipfftw_execution_io_args::use_creation_io;
+                        exec_io <= hipfftw_execution_io_args::clean_new_io;
+                        exec_io++)
                     {
-                        creation_io_is_null_range.push_back({true, false});
-                        creation_io_is_null_range.push_back({false, true});
-                    }
-                    for(auto set_creation_io_as_null : creation_io_is_null_range)
-                    {
-                        const auto valid_sign = get_random_sign<valid_value>(dft_kind);
-                        // using FFTW_ESTIMATE so that nullptr may be used at creation
-                        const auto valid_flags     = FFTW_ESTIMATE;
-                        to_add.creation_options    = hipfftw_plan_creation_func::ANY;
-                        to_add.creation_io_is_null = set_creation_io_as_null;
-                        to_add.execution_io        = hipfftw_execution_io_args::use_creation_io;
-                        to_add.plan_helper.set_creation_args(dft_kind,
-                                                             supported_rank,
-                                                             supported_int_lengths,
-                                                             placement,
-                                                             valid_sign,
-                                                             valid_flags);
-                        // skip params if they can't be used anyways
-                        if(!to_add.can_be_tested())
+                        test_to_add.creation_options    = creation;
+                        test_to_add.creation_io_is_null = set_creation_io_as_null;
+                        test_to_add.execution_io = static_cast<hipfftw_execution_io_args>(exec_io);
+                        test_to_add.plan_helper  = helper;
+                        // skip params if they can't/shouldn't be used anyways
+                        if(!test_to_add.can_be_tested(test_may_allocate))
                             continue;
-                        // skip params if they're not expected to trigger an exception at execution
-                        if(!to_add.expects_internal_exception_for(
-                               hipfftw_step::plan_execution,
-                               hipfftw_internal_exception::invalid_args))
+                        // tests expect a failure at execution at least
+                        if(test_to_add.expected_internal_exception_for(hipfftw_step::plan_execution)
+                           == hipfftw_internal_exception::none)
                             continue;
-
-                        insert_into_unique_sorted_params(full_scope_tests["execute"], to_add);
+                        if(test_to_add.expected_internal_exception_for(hipfftw_step::plan_creation)
+                               == hipfftw_internal_exception::invalid_args
+                           || test_to_add.expected_internal_exception_for(
+                                  hipfftw_step::plan_creation)
+                                  == hipfftw_internal_exception::unsupported_args)
+                        {
+                            insert_into_unique_sorted_params(
+                                full_scope_tests[hipfftw_creation_options_to_string(
+                                    creation, helper.get_dft_kind(), helper.get_rank())],
+                                test_to_add);
+                        }
+                        else
+                        {
+                            insert_into_unique_sorted_params(full_scope_tests["execute"],
+                                                             test_to_add);
+                        }
                     }
                 }
             }
@@ -1294,42 +1267,21 @@ namespace
         hostbuf plan_execution_input;
         hostbuf plan_execution_output;
 
-        void expect_failure(hipfftw_step               step_target,
-                            hipfftw_internal_exception internal_exception_target)
+        void expect_failure(hipfftw_step step_target)
         {
-            if(step_target == hipfftw_step::plan_creation)
-            {
-                if(internal_exception_target != hipfftw_internal_exception::invalid_args
-                   && internal_exception_target != hipfftw_internal_exception::unsupported_args)
-                {
-                    throw std::invalid_argument(
-                        "unexpected internal_exception_target when testing "
-                        "argument validation for plan creation function(s)");
-                }
-            }
-            else if(step_target == hipfftw_step::plan_execution)
-            {
-                if(internal_exception_target != hipfftw_internal_exception::invalid_args)
-                {
-                    throw std::invalid_argument(
-                        "unexpected internal_exception_target when testing "
-                        "argument validation for plan execution function(s)");
-                }
-            }
-            else
-            {
-                throw std::invalid_argument(
-                    "unexpected step_target when testing argument validation");
-            }
-            // exception-logging-related variables
-            const auto expected_log_instance
-                = internal_exception_target == hipfftw_internal_exception::invalid_args
-                      ? hipfftw_expected_log_instance<hipfftw_internal_exception::invalid_args>
-                      : hipfftw_expected_log_instance<hipfftw_internal_exception::unsupported_args>;
             const hipfftw_input_validation_params<prec>& params = this->GetParam();
             std::unique_ptr<hipfftw_exception_logger>    exception_logger;
             bool                                         check_log_content = false;
             std::string                                  log_content;
+            const auto expected_exception = params.expected_internal_exception_for(step_target);
+            if(expected_exception != hipfftw_internal_exception::invalid_args
+               && expected_exception != hipfftw_internal_exception::unsupported_args)
+                GTEST_FAIL() << "invalid expected_exception to be tested for: only invalid or "
+                                "unsupported arguments may be tested";
+            const auto expected_log_instance
+                = expected_exception == hipfftw_internal_exception::invalid_args
+                      ? hipfftw_expected_log_instance<hipfftw_internal_exception::invalid_args>
+                      : hipfftw_expected_log_instance<hipfftw_internal_exception::unsupported_args>;
             try
             {
                 if(step_target == hipfftw_step::plan_creation)
@@ -1360,29 +1312,24 @@ namespace
                 }
                 else
                 {
+                    exception_logger  = std::make_unique<hipfftw_exception_logger>();
+                    check_log_content = exception_logger->is_active();
+                    void* exec_in     = params.use_creation_io_at_execution()
+                                            ? plan_creation_input.data()
+                                            : plan_execution_input.data();
+                    void* exec_out    = params.use_creation_io_at_execution()
+                                            ? (params.creation_placement() == fft_placement_inplace
+                                                   ? plan_creation_input.data()
+                                                   : plan_creation_output.data())
+                                            : (params.execution_placement() == fft_placement_inplace
+                                                   ? plan_execution_input.data()
+                                                   : plan_execution_output.data());
                     // intentionally do not check that hipfftw_test_plan != nullptr as that's
                     // kind of the point of this test: even if it doesn't report error codes,
                     // execution must not misbehave (e.g. must not segfault) with invalid argument
                     // (if hipfftw's exception handler is made verbose, it should print failure
                     //  info to the log, and that's verified in the end)
-                    exception_logger  = std::make_unique<hipfftw_exception_logger>();
-                    check_log_content = exception_logger->is_active();
-                    if(params.use_creation_io_at_execution())
-                    {
-                        params.plan_helper.execute(plan_creation_input.data(),
-                                                   params.creation_placement()
-                                                           == fft_placement_inplace
-                                                       ? plan_creation_input.data()
-                                                       : plan_creation_output.data());
-                    }
-                    else
-                    {
-                        params.plan_helper.execute(plan_execution_input.data(),
-                                                   params.execution_placement()
-                                                           == fft_placement_inplace
-                                                       ? plan_execution_input.data()
-                                                       : plan_execution_output.data());
-                    }
+                    params.plan_helper.execute(exec_in, exec_out);
                     log_content = exception_logger->get_log();
                     exception_logger.reset();
                 }
@@ -1427,35 +1374,26 @@ namespace
 
         void input_validation_test()
         {
-            const auto& param     = this->GetParam();
-            bool        done_some = false;
-            if(param.expects_internal_exception_for(hipfftw_step::plan_creation,
-                                                    hipfftw_internal_exception::invalid_args))
+            const auto& param = this->GetParam();
+            if(param.expected_internal_exception_for(hipfftw_step::plan_execution)
+               == hipfftw_internal_exception::none)
             {
-                expect_failure(hipfftw_step::plan_creation,
-                               hipfftw_internal_exception::invalid_args);
-                done_some = true;
+                GTEST_FAIL() << "Invalid parameters for testing input validation (no internal "
+                                "exception expected up to execution)";
             }
-            else if(param.expects_internal_exception_for(
-                        hipfftw_step::plan_creation, hipfftw_internal_exception::unsupported_args))
+            // only one well-defined kind of exception should be expected at plan creation
+            // for reliable testing: if plan creation arguments are a mixed bags of invalid
+            // and unsupported values, implementation details may trigger one kind of
+            // exception or the other (internally)
+            const auto expected_plan_creation_exception
+                = param.expected_internal_exception_for(hipfftw_step::plan_creation);
+            if(expected_plan_creation_exception == hipfftw_internal_exception::invalid_args
+               || expected_plan_creation_exception == hipfftw_internal_exception::unsupported_args)
             {
-                expect_failure(hipfftw_step::plan_creation,
-                               hipfftw_internal_exception::unsupported_args);
-                done_some = true;
+                expect_failure(hipfftw_step::plan_creation);
             }
-            if(param.expects_internal_exception_for(hipfftw_step::plan_execution,
-                                                    hipfftw_internal_exception::invalid_args))
-            {
-                expect_failure(hipfftw_step::plan_execution,
-                               hipfftw_internal_exception::invalid_args);
-                done_some = true;
-            }
-            if(!done_some)
-            {
-                GTEST_FAIL()
-                    << "No test actually executed for these parameters (no internal exception "
-                       "expected at creation or execution)";
-            }
+            // always test for execution
+            expect_failure(hipfftw_step::plan_execution);
         }
 
     public:
@@ -1479,10 +1417,8 @@ namespace
 #ifndef WIN32
         // linux-only
         managed,
-        managed_other_device, // for new-array executes, only
 #endif
-        current_device,
-        other_device // for new-array executes, only
+        device
     };
 
     const std::vector<hipfftw_data_memory_type>& get_possible_data_mem_types()
@@ -1491,27 +1427,17 @@ namespace
             // always testable
             std::vector<hipfftw_data_memory_type> ret = {hipfftw_data_memory_type::pageable_host,
                                                          hipfftw_data_memory_type::pinned_host,
-                                                         hipfftw_data_memory_type::current_device};
-            // "other_device" needs several devices to be available
-            int num_devices = 1;
-            if(hipGetDeviceCount(&num_devices) == hipSuccess && num_devices > 1)
-            {
-                ret.push_back(hipfftw_data_memory_type::other_device);
-            }
+                                                         hipfftw_data_memory_type::device};
 #ifndef WIN32
             // "managed" may or may not be supported
-            int deviceId = hipInvalidDeviceId;
-            if(hipGetDevice(&deviceId) != hipSuccess || deviceId == hipInvalidDeviceId)
-                return ret;
             int managed_mem_is_supported = 0;
-            if(hipDeviceGetAttribute(
-                   &managed_mem_is_supported, hipDeviceAttributeManagedMemory, deviceId)
+            if(hipDeviceGetAttribute(&managed_mem_is_supported,
+                                     hipDeviceAttributeManagedMemory,
+                                     get_current_device_id())
                    == hipSuccess
                && managed_mem_is_supported)
             {
                 ret.push_back(hipfftw_data_memory_type::managed);
-                if(num_devices > 1)
-                    ret.push_back(hipfftw_data_memory_type::managed_other_device);
             }
 #endif
             return ret;
@@ -1534,15 +1460,9 @@ namespace
         case hipfftw_data_memory_type::managed:
             return "managed";
             break;
-        case hipfftw_data_memory_type::managed_other_device:
-            return "managed_other_device";
-            break;
 #endif
-        case hipfftw_data_memory_type::current_device:
-            return "current_device";
-            break;
-        case hipfftw_data_memory_type::other_device:
-            return "other_device";
+        case hipfftw_data_memory_type::device:
+            return "device";
             break;
         default:
             throw std::runtime_error("internal error: unexpected value of mem_tye in "
@@ -1550,15 +1470,6 @@ namespace
             break;
         }
     };
-
-    bool is_attached_to_other_device(hipfftw_data_memory_type mem_type)
-    {
-        bool ret = mem_type == hipfftw_data_memory_type::other_device;
-#ifndef WIN32
-        ret = ret || mem_type == hipfftw_data_memory_type::managed_other_device;
-#endif
-        return ret;
-    }
 
     hipfftw_data_memory_type get_random_data_mem_type()
     {
@@ -1663,16 +1574,6 @@ namespace
                     }
                 }
             }
-            // "*_other_device" types only for execution as they mean other "than creation's" types
-            if(is_attached_to_other_device(
-                   mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_in}))
-               || is_attached_to_other_device(
-                   mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_out})))
-            {
-                // Inconsistent data memory type for I/O data at plan creation:
-                // "*_other_device" values cannot be used for creation arguments
-                return false;
-            }
             // if using new I/O at execution, they must be clean
             // TODO: enabled clean_new_io when new-array executes are implemented
             if(execution_io != hipfftw_execution_io_args::use_creation_io
@@ -1680,7 +1581,7 @@ namespace
             {
                 return false;
             }
-            if(!plan_helper.is_supported_for_creation())
+            if(!plan_helper.can_create_plan())
                 return false;
             const auto placement = plan_helper.get_placement();
             if(placement == fft_placement_inplace)
@@ -1758,167 +1659,111 @@ namespace
     protected:
         void SetUp() override
         {
-            const hipfftw_functional_validation_params<prec>& params = this->GetParam();
-
-            if(!params.can_be_tested())
-                GTEST_FAIL() << "invalid parameters, cannot be tested";
-            if(reference_plan)
-                GTEST_FAIL() << "Starting from an unclean slate (reference plan is not nullptr)";
-
-            execution_results_on_host.resize(1);
-            execution_results_on_host[0].alloc(
-                params.plan_helper.get_data_byte_size(fft_io::fft_io_out));
-
-            std::vector<fft_io> io_range = {fft_io::fft_io_in};
-            if(params.get_placement() == fft_placement_notinplace)
-                io_range.push_back(fft_io::fft_io_out);
-            std::vector<hipfftw_step> step_range = {hipfftw_step::plan_creation};
-            if(!params.use_creation_io_at_execution())
-                step_range.push_back(hipfftw_step::plan_execution);
-            std::ostringstream gtest_info;
-            for(auto io : io_range)
+            try
             {
-                const size_t data_size = params.plan_helper.get_data_byte_size(io);
-                auto&        io_verification_vec
-                    = io == fft_io::fft_io_in ? verification_input : verification_output;
-                io_verification_vec.resize(1);
-                io_verification_vec[0].alloc(data_size);
+                const hipfftw_functional_validation_params<prec>& params = this->GetParam();
 
-                for(auto step : step_range)
+                if(!params.can_be_tested())
+                    GTEST_FAIL() << "invalid parameters, cannot be tested";
+                if(reference_plan)
+                    GTEST_FAIL()
+                        << "Starting from an unclean slate (reference plan is not nullptr)";
+
+                execution_results_on_host.resize(1);
+                execution_results_on_host[0].alloc(
+                    params.plan_helper.get_data_byte_size(fft_io::fft_io_out));
+
+                std::vector<fft_io> io_range = {fft_io::fft_io_in};
+                if(params.get_placement() == fft_placement_notinplace)
+                    io_range.push_back(fft_io::fft_io_out);
+                std::vector<hipfftw_step> step_range = {hipfftw_step::plan_creation};
+                if(!params.use_creation_io_at_execution())
+                    step_range.push_back(hipfftw_step::plan_execution);
+                for(auto io : io_range)
                 {
-                    const std::pair<hipfftw_step, fft_io> map_key  = {step, io};
-                    const auto                            mem_type = params.mem_type.at(map_key);
-                    if(mem_type == hipfftw_data_memory_type::pageable_host
-                       || mem_type == hipfftw_data_memory_type::pinned_host)
-                    {
-                        host_io_buffer[map_key].alloc(
-                            data_size, mem_type == hipfftw_data_memory_type::pinned_host);
-                    }
-                    else
-                    {
-                        auto original_device_id = hipInvalidDeviceId;
-                        auto hip_status         = hipGetDevice(&original_device_id);
-                        if(hip_status != hipSuccess)
-                        {
-                            ++n_hip_failures;
-                            gtest_info << "hipGetDevice failure with error " << hip_status;
-                            if(skip_runtime_fails)
-                                GTEST_SKIP() << gtest_info.str();
-                            else
-                                GTEST_FAIL() << gtest_info.str();
-                        }
-                        auto other_device_id = hipInvalidDeviceId;
-                        if(is_attached_to_other_device(mem_type))
-                        {
-                            int num_devices = 0;
-                            hip_status      = hipGetDeviceCount(&num_devices);
-                            if(hip_status != hipSuccess)
-                            {
-                                ++n_hip_failures;
-                                gtest_info << "hipGetDeviceCount failure with error " << hip_status;
-                                if(skip_runtime_fails)
-                                    GTEST_SKIP() << gtest_info.str();
-                                else
-                                    GTEST_FAIL() << gtest_info.str();
-                            }
-                            if(num_devices <= 1)
-                                throw std::runtime_error("Cannot attach memory to another "
-                                                         "device than the current one "
-                                                         "(only one available)");
-                            while((other_device_id = get_random_integer(0, num_devices - 1))
-                                  == original_device_id)
-                            {
-                                // do it again
-                            }
-                            hip_status = hipSetDevice(other_device_id);
-                            if(hip_status != hipSuccess)
-                            {
-                                ++n_hip_failures;
-                                gtest_info << "hipSetDevice failure with error " << hip_status
-                                           << ": couldn't change device id from "
-                                           << original_device_id << " to " << other_device_id;
-                                if(skip_runtime_fails)
-                                    GTEST_SKIP() << gtest_info.str();
-                                else
-                                    GTEST_FAIL() << gtest_info.str();
-                            }
-                        }
-#ifndef WIN32
-                        hip_status = gpu_io_buffer[map_key].alloc(
-                            data_size, mem_type == hipfftw_data_memory_type::managed);
-#else
-                        hip_status = gpu_io_buffer[map_key].alloc(data_size);
-#endif
-                        if(hip_status != hipSuccess)
-                        {
-                            gtest_info << "failed to allocate a buffer of type "
-                                       << hipfftw_data_mem_type_to_string(mem_type)
-                                       << " and byte size " << std::to_string(data_size)
-                                       << ". Original device ID is " << original_device_id;
-                            if(is_attached_to_other_device(mem_type))
-                                gtest_info << ", other device ID is" << other_device_id;
-                            ++n_hip_failures;
-                            if(skip_runtime_fails)
-                                GTEST_SKIP() << gtest_info.str();
-                            else
-                                GTEST_FAIL() << gtest_info.str();
-                        }
+                    const size_t data_size = params.plan_helper.get_data_byte_size(io);
+                    auto&        io_verification_vec
+                        = io == fft_io::fft_io_in ? verification_input : verification_output;
+                    io_verification_vec.resize(1);
+                    io_verification_vec[0].alloc(data_size);
 
-                        if(is_attached_to_other_device(mem_type))
+                    for(auto step : step_range)
+                    {
+                        const std::pair<hipfftw_step, fft_io> map_key = {step, io};
+                        const auto mem_type                           = params.mem_type.at(map_key);
+                        if(mem_type == hipfftw_data_memory_type::pageable_host
+                           || mem_type == hipfftw_data_memory_type::pinned_host)
                         {
-                            hip_status = hipSetDevice(original_device_id);
+                            host_io_buffer[map_key].alloc(
+                                data_size, mem_type == hipfftw_data_memory_type::pinned_host);
+                        }
+                        else
+                        {
+#ifndef WIN32
+                            const auto hip_status = gpu_io_buffer[map_key].alloc(
+                                data_size, mem_type == hipfftw_data_memory_type::managed);
+#else
+                            const auto hip_status = gpu_io_buffer[map_key].alloc(data_size);
+#endif
                             if(hip_status != hipSuccess)
                             {
-                                ++n_hip_failures;
-                                gtest_info << "hipSetDevice failure with error " << hip_status
-                                           << ": couldn't reset device id from " << other_device_id
-                                           << " to " << original_device_id;
-                                if(skip_runtime_fails)
-                                    GTEST_SKIP() << gtest_info.str();
-                                else
-                                    GTEST_FAIL() << gtest_info.str();
+                                std::ostringstream gtest_info;
+                                gtest_info << "failed to allocate a buffer of type "
+                                           << hipfftw_data_mem_type_to_string(mem_type)
+                                           << " and byte size " << std::to_string(data_size)
+                                           << ". Current device ID is " << get_current_device_id();
+                                throw hip_runtime_error(gtest_info.str(), hip_status);
                             }
                         }
                     }
                 }
-            }
-            if(verification_input.size() != 1
-               || (params.get_placement() != fft_placement_inplace
-                   && verification_output.size() != 1))
-                GTEST_FAIL() << "Verification IO buffer incorrectly initialized";
-            // generate input data
-            const std::vector<size_t> field_lower(params.get_rank(), 0);
-            const auto                ilength = params.get_ilengths();
-            std::vector<size_t>       contiguous_istride(params.get_rank());
-            size_t                    val = 1;
-            for(int dim = params.get_rank() - 1; dim >= 0; dim--)
-            {
-                contiguous_istride[dim] = val;
-                val *= ilength[dim];
-            }
-            const auto contiguous_idist = val;
-            set_input<hostbuf, hipfftw_real_t<prec>>(verification_input,
-                                                     fft_input_generator_host,
-                                                     params.get_array_type(fft_io::fft_io_in),
-                                                     params.get_lengths(),
-                                                     ilength,
-                                                     params.get_istride(),
-                                                     params.get_idist(),
-                                                     params.get_nbatch(),
-                                                     get_curr_device_prop(),
-                                                     field_lower,
-                                                     0 /* field_lower_batch */,
-                                                     contiguous_istride,
-                                                     contiguous_idist);
-            // create the reference plan (systematically using the most general guru64 creation)
-            reference_plan = params.plan_helper.get_reference_plan(
-                verification_input[0].data(),
-                params.get_placement() == fft_placement_inplace ? verification_input[0].data()
-                                                                : verification_output[0].data());
+                if(verification_input.size() != 1
+                   || (params.get_placement() != fft_placement_inplace
+                       && verification_output.size() != 1))
+                    GTEST_FAIL() << "Verification IO buffer incorrectly initialized";
+                // generate input data
+                const std::vector<size_t> field_lower(params.get_rank(), 0);
+                const auto                ilength = params.get_ilengths();
+                std::vector<size_t>       contiguous_istride(params.get_rank());
+                size_t                    val = 1;
+                for(int dim = params.get_rank() - 1; dim >= 0; dim--)
+                {
+                    contiguous_istride[dim] = val;
+                    val *= ilength[dim];
+                }
+                const auto contiguous_idist = val;
+                set_input<hostbuf, hipfftw_real_t<prec>>(verification_input,
+                                                         fft_input_generator_host,
+                                                         params.get_array_type(fft_io::fft_io_in),
+                                                         params.get_lengths(),
+                                                         ilength,
+                                                         params.get_istride(),
+                                                         params.get_idist(),
+                                                         params.get_nbatch(),
+                                                         get_curr_device_prop(),
+                                                         field_lower,
+                                                         0 /* field_lower_batch */,
+                                                         contiguous_istride,
+                                                         contiguous_idist);
+                // create the reference plan (systematically using the most general guru64 creation)
+                reference_plan = params.plan_helper.get_reference_plan(
+                    verification_input[0].data(),
+                    params.get_placement() == fft_placement_inplace
+                        ? verification_input[0].data()
+                        : verification_output[0].data());
 
-            if(!reference_plan)
+                if(!reference_plan)
+                {
+                    GTEST_FAIL() << "could not create a reference plan";
+                }
+            }
+            catch(const hip_runtime_error& e)
             {
-                GTEST_FAIL() << "could not create a reference plan";
+                ++n_hip_failures;
+                if(skip_runtime_fails)
+                    GTEST_SKIP() << e.what() << "\nError code: " << e.hip_error << ".";
+                else
+                    GTEST_FAIL() << e.what() << "\nError code: " << e.hip_error << ".";
             }
         }
         void TearDown() override
@@ -2030,75 +1875,16 @@ namespace
                 // copy input data to hipfftw's input
                 const std::pair<hipfftw_step, fft_io> exec_in_key
                     = {hipfftw_step::plan_execution, fft_io::fft_io_in};
-                if(test_io_type.at(exec_in_key) == hipfftw_data_memory_type::current_device
-                   || test_io_type.at(exec_in_key) == hipfftw_data_memory_type::other_device)
+                if(test_io_type.at(exec_in_key) == hipfftw_data_memory_type::device)
                 {
-                    int  test_device_id = hipInvalidDeviceId;
-                    auto hip_status     = hipGetDevice(&test_device_id);
+                    // an explicit host-to-device copy is needed
+                    const auto hip_status
+                        = hipMemcpyAsync(test_io_ptr.at(exec_in_key),
+                                         verification_input[0].data(),
+                                         params.plan_helper.get_data_byte_size(fft_io::fft_io_in),
+                                         hipMemcpyHostToDevice);
                     if(hip_status != hipSuccess)
-                    {
-                        ++n_hip_failures;
-                        gtest_info << "hipGetDevice failure with error " << hip_status;
-                        if(skip_runtime_fails)
-                            GTEST_SKIP() << gtest_info.str();
-                        else
-                            GTEST_FAIL() << gtest_info.str();
-                    }
-                    if(test_io_type.at(exec_in_key) == hipfftw_data_memory_type::other_device)
-                    {
-                        hipPointerAttribute_t ptr_attributes;
-                        hip_status
-                            = hipPointerGetAttributes(&ptr_attributes, test_io_ptr.at(exec_in_key));
-                        if(hip_status != hipSuccess)
-                        {
-                            ++n_hip_failures;
-                            gtest_info << "hipPointerGetAttributes failure with error "
-                                       << hip_status;
-                            if(skip_runtime_fails)
-                                GTEST_SKIP() << gtest_info.str();
-                            else
-                                GTEST_FAIL() << gtest_info.str();
-                        }
-                        EXPECT_NE(ptr_attributes.device, test_device_id);
-
-                        hip_status = hipSetDevice(ptr_attributes.device);
-                        if(hip_status != hipSuccess)
-                        {
-                            ++n_hip_failures;
-                            gtest_info << "hipSetDevice failure with error " << hip_status;
-                            if(skip_runtime_fails)
-                                GTEST_SKIP() << gtest_info.str();
-                            else
-                                GTEST_FAIL() << gtest_info.str();
-                        }
-                    }
-                    hip_status = hipMemcpy(test_io_ptr.at(exec_in_key),
-                                           verification_input[0].data(),
-                                           params.plan_helper.get_data_byte_size(fft_io::fft_io_in),
-                                           hipMemcpyHostToDevice);
-                    if(hip_status != hipSuccess)
-                    {
-                        ++n_hip_failures;
-                        gtest_info << "hipMemcpy failure with error " << hip_status;
-                        if(skip_runtime_fails)
-                            GTEST_SKIP() << gtest_info.str();
-                        else
-                            GTEST_FAIL() << gtest_info.str();
-                    }
-                    if(test_io_type.at(exec_in_key) == hipfftw_data_memory_type::other_device)
-                    {
-                        // reset device id
-                        hip_status = hipSetDevice(test_device_id);
-                        if(hip_status != hipSuccess)
-                        {
-                            ++n_hip_failures;
-                            gtest_info << "hipSetDevice failure with error " << hip_status;
-                            if(skip_runtime_fails)
-                                GTEST_SKIP() << gtest_info.str();
-                            else
-                                GTEST_FAIL() << gtest_info.str();
-                        }
-                    }
+                        throw hip_runtime_error("hipMemcpyAsync failed.", hip_status);
                 }
                 else
                 {
@@ -2113,7 +1899,6 @@ namespace
                     else
                         fftw_execute(reference_plan);
                 });
-
                 auto exception_logger = std::make_unique<hipfftw_exception_logger>();
                 params.plan_helper.create_plan(
                     test_io_ptr.at({hipfftw_step::plan_creation, fft_io::fft_io_in}),
@@ -2135,77 +1920,17 @@ namespace
                 // for verification purposes
                 const std::pair<hipfftw_step, fft_io> exec_out_key
                     = {hipfftw_step::plan_execution, fft_io::fft_io_out};
-                if(test_io_type.at(exec_out_key) == hipfftw_data_memory_type::current_device
-                   || test_io_type.at(exec_out_key) == hipfftw_data_memory_type::other_device)
+                if(test_io_type.at(exec_out_key) == hipfftw_data_memory_type::device)
                 {
-                    int  test_device_id = hipInvalidDeviceId;
-                    auto hip_status     = hipGetDevice(&test_device_id);
+                    // making this copy synchronous as the next step is verifying the results
+                    const auto hip_status
+                        = hipMemcpy(execution_results_on_host[0].data(),
+                                    test_io_ptr.at(exec_out_key),
+                                    params.plan_helper.get_data_byte_size(fft_io::fft_io_out),
+                                    hipMemcpyDeviceToHost);
                     if(hip_status != hipSuccess)
-                    {
-                        ++n_hip_failures;
-                        gtest_info << "hipGetDevice failure with error " << hip_status;
-                        if(skip_runtime_fails)
-                            GTEST_SKIP() << gtest_info.str();
-                        else
-                            GTEST_FAIL() << gtest_info.str();
-                    }
-                    if(test_io_type.at(exec_out_key) == hipfftw_data_memory_type::other_device)
-                    {
-                        hipPointerAttribute_t ptr_attributes;
-                        hip_status = hipPointerGetAttributes(&ptr_attributes,
-                                                             test_io_ptr.at(exec_out_key));
-                        if(hip_status != hipSuccess)
-                        {
-                            ++n_hip_failures;
-                            gtest_info << "hipPointerGetAttributes failure with error "
-                                       << hip_status;
-                            if(skip_runtime_fails)
-                                GTEST_SKIP() << gtest_info.str();
-                            else
-                                GTEST_FAIL() << gtest_info.str();
-                        }
-                        EXPECT_NE(ptr_attributes.device, test_device_id);
-
-                        hip_status = hipSetDevice(ptr_attributes.device);
-                        if(hip_status != hipSuccess)
-                        {
-                            ++n_hip_failures;
-                            gtest_info << "hipSetDevice failure with error " << hip_status;
-                            if(skip_runtime_fails)
-                                GTEST_SKIP() << gtest_info.str();
-                            else
-                                GTEST_FAIL() << gtest_info.str();
-                        }
-                    }
-                    const size_t out_data_size
-                        = params.plan_helper.get_data_byte_size(fft_io::fft_io_out);
-                    hip_status = hipMemcpy(execution_results_on_host[0].data(),
-                                           test_io_ptr.at(exec_out_key),
-                                           out_data_size,
-                                           hipMemcpyDeviceToHost);
-                    if(hip_status != hipSuccess)
-                    {
-                        ++n_hip_failures;
-                        gtest_info << "hipMemcpy failure with error " << hip_status;
-                        if(skip_runtime_fails)
-                            GTEST_SKIP() << gtest_info.str();
-                        else
-                            GTEST_FAIL() << gtest_info.str();
-                    }
-                    if(test_io_type.at(exec_out_key) == hipfftw_data_memory_type::other_device)
-                    {
-                        // reset device id
-                        hip_status = hipSetDevice(test_device_id);
-                        if(hip_status != hipSuccess)
-                        {
-                            ++n_hip_failures;
-                            gtest_info << "hipSetDevice failure with error " << hip_status;
-                            if(skip_runtime_fails)
-                                GTEST_SKIP() << gtest_info.str();
-                            else
-                                GTEST_FAIL() << gtest_info.str();
-                        }
-                    }
+                        throw hip_runtime_error("hipMemcpy failed (copying output results).",
+                                                hip_status);
                 }
                 else
                 {
@@ -2273,6 +1998,14 @@ namespace
             {
                 GTEST_FAIL() << "undefined function pointers detected. Error info: " << e.what();
             }
+            catch(const hip_runtime_error e)
+            {
+                ++n_hip_failures;
+                if(skip_runtime_fails)
+                    GTEST_SKIP() << e.what() << "\nError code: " << e.hip_error << ".";
+                else
+                    GTEST_FAIL() << e.what() << "\nError code: " << e.hip_error << ".";
+            }
             catch(const std::runtime_error e)
             {
                 GTEST_FAIL() << e.what();
@@ -2297,9 +2030,9 @@ namespace
     {
         std::vector<hipfftw_functional_validation_params<prec>> full_list;
         hipfftw_functional_validation_params<prec>              to_add;
-        constexpr bool                                          valid_value
-            = true; // for readability of template specialization values below
-        const auto& possible_mem_types = get_possible_data_mem_types();
+        // for readability of template specialization values below
+        constexpr bool valid_value        = true;
+        const auto&    possible_mem_types = get_possible_data_mem_types();
         while(full_list.size() < desired_full_suite_size)
         {
             // TODO: randomly alternate between hipfftw_execution_io_args::use_creation_io and
@@ -2347,13 +2080,6 @@ namespace
                     {
                         to_add.mem_type[key]
                             = possible_mem_types[get_random_idx(possible_mem_types.size())];
-                        while(step == hipfftw_step::plan_creation
-                              && is_attached_to_other_device(to_add.mem_type[key]))
-                        {
-                            // pick another one
-                            to_add.mem_type[key]
-                                = possible_mem_types[get_random_idx(possible_mem_types.size())];
-                        }
                     }
                 }
             }

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -435,7 +435,7 @@ namespace
             {
 #ifdef WIN32
                 pinned_host_alloc_was_disabled
-                    = SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", "0") != 0;
+                    = SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", "0");
 #else
                 pinned_host_alloc_was_disabled
                     = setenv("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", "0", 1) == EXIT_SUCCESS;
@@ -449,8 +449,8 @@ namespace
             if(params.avoid_alloc_kind & alloc_kind_disabler::pageable_host)
             {
 #ifdef WIN32
-                pageable_host_alloc_was_disabled                          = SetEnvironmentVariable(
-                    "HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", "0") ! = 0;
+                pageable_host_alloc_was_disabled
+                    = SetEnvironmentVariable("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", "0");
 #else
                 pageable_host_alloc_was_disabled
                     = setenv("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", "0", 1) == EXIT_SUCCESS;
@@ -1418,8 +1418,8 @@ namespace
                 if(num_devices > 1)
                     ret.push_back(hipfftw_data_memory_type::managed_other_device);
             }
-            return ret;
 #endif
+            return ret;
         };
         const static std::vector<hipfftw_data_memory_type> possible_cases = create_possible_cases();
         return possible_cases;
@@ -1713,8 +1713,7 @@ namespace
                                 GTEST_FAIL() << gtest_info.str();
                         }
                         auto other_device_id = hipInvalidDeviceId;
-                        if(mem_type == hipfftw_data_memory_type::managed_other_device
-                           || mem_type == hipfftw_data_memory_type::other_device)
+                        if(is_attached_to_other_device(mem_type))
                         {
                             int num_devices = 0;
                             hip_status      = hipGetDeviceCount(&num_devices);
@@ -1770,8 +1769,7 @@ namespace
                                 GTEST_FAIL() << gtest_info.str();
                         }
 
-                        if(mem_type == hipfftw_data_memory_type::managed_other_device
-                           || mem_type == hipfftw_data_memory_type::other_device)
+                        if(is_attached_to_other_device(mem_type))
                         {
                             hip_status = hipSetDevice(original_device_id);
                             if(hip_status != hipSuccess)

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -812,9 +812,9 @@ namespace
     enum hipfftw_execution_io_args : unsigned
     {
         use_creation_io       = 0x0,
-        non_null_new_in       = 0x1 << 1,
-        non_null_new_out      = 0x1 << 2,
-        new_io_same_placement = 0x1 << 3,
+        non_null_new_in       = 0x1 << 0,
+        non_null_new_out      = 0x1 << 1,
+        new_io_same_placement = 0x1 << 2,
         // all flags must be up to be generally clean with new I/O
         clean_new_io = non_null_new_in | non_null_new_out | new_io_same_placement
     };

--- a/projects/hipfft/library/CMakeLists.txt
+++ b/projects/hipfft/library/CMakeLists.txt
@@ -87,6 +87,8 @@ else()
   add_library( hip::hipfftw ALIAS hipfftw )
   list( APPEND HIPFFT_LIBRARY_TARGETS hipfftw )
   list( APPEND HIPFFT_EXPORT_TARGETS hip::hipfftw )
+  # hipfftw.h header uses the same hipfft-export.h as hipfft.h
+  target_compile_definitions( hipfftw PRIVATE hipfft_EXPORTS )
 endif()
 
 set(static_depends)

--- a/projects/hipfft/library/CMakeLists.txt
+++ b/projects/hipfft/library/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #############################################################################
-# Copyright (C) 2020 - 2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2020 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -52,28 +52,41 @@ source_group( "Header Files\\Public" FILES ${hipfft_headers_public} )
 # Include sources
 include( src/CMakeLists.txt )
 
-# Create hipFFT library
+# Create hipFFT library (and hipfftw on ROCm)
 add_library( hipfft ${hipfft_source} ${hipfft_headers_public} )
 add_library( hip::hipfft ALIAS hipfft )
+set( HIPFFT_LIBRARY_TARGETS hipfft )
+set( HIPFFT_EXPORT_TARGETS hip::hipfft )
 if( BUILD_WITH_LIB STREQUAL "CUDA" )
   # static hipfft build should link against static cufft
   if( BUILD_SHARED_LIBS )
     if( NVHPC_FOUND )
+      find_library( CUFFTW_LIB cufftw REQUIRED PATHS ${NVHPC_ROOT_DIR}/math_libs/lib64 )
       if( HIPFFT_MPI_ENABLE )
         target_link_libraries( hipfft PRIVATE NVHPC::CUFFTMP )
       else()
         target_link_libraries( hipfft PRIVATE NVHPC::CUFFT )
       endif()
     else()
+      set( CUFFTW_LIB CUDA::cufftw )
       target_link_libraries( hipfft PRIVATE CUDA::cufft )
     endif()
   else()
     if( NVHPC_FOUND )
+      find_library( CUFFTW_LIB cufftw_static REQUIRED PATHS ${NVHPC_ROOT_DIR}/math_libs/lib64 )
       target_link_libraries( hipfft PRIVATE NVHPC::CUFFT_static )
     else()
+      set( CUFFTW_LIB CUDA::cufftw_static )
       target_link_libraries( hipfft PRIVATE CUDA::cufft_static )
     endif()
   endif()
+  add_library( hipfftw ALIAS ${CUFFTW_LIB} )
+  add_library( hip::hipfftw ALIAS ${CUFFTW_LIB} )
+else()
+  add_library( hipfftw ${hipfftw_source} ${hipfftw_headers_public} )
+  add_library( hip::hipfftw ALIAS hipfftw )
+  list( APPEND HIPFFT_LIBRARY_TARGETS hipfftw )
+  list( APPEND HIPFFT_EXPORT_TARGETS hip::hipfftw )
 endif()
 
 set(static_depends)
@@ -94,36 +107,44 @@ endif()
 # Target include directories
 # Hip header files installed in cmake install includedir
 # HIP_INCLUDE_DIRS is not required
-target_include_directories( hipfft
-  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include>
-  PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/library/include>
-  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/hipfft>
-  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-  $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  )
+foreach( lib ${HIPFFT_LIBRARY_TARGETS} )
+  target_include_directories( ${lib}
+    PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include>
+    PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/library/include>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/hipfft>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+
+  # Target link libraries - on ROCm we just use rocFFT for
+  # everything.  CUDA has to be handled separately for normal and
+  # "Mp" libs
+  if( BUILD_WITH_LIB STREQUAL "ROCM" )
+    list(APPEND static_depends PACKAGE rocfft)
+    target_link_libraries( ${lib} PRIVATE roc::rocfft )
+    if( WIN32 )
+      target_link_libraries( ${lib} PRIVATE hip::device )
+    endif()
+    target_link_libraries( ${lib} PUBLIC hip::host )
+  endif()
+
+  target_compile_options( ${lib} PRIVATE ${WARNING_FLAGS} )
+
+  # Target properties
+  set_target_properties( ${lib} PROPERTIES CXX_EXTENSIONS NO )
+  set_target_properties( ${lib} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
+
+  if (BUILD_CODE_COVERAGE)
+    target_compile_options( ${lib} PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
+    target_link_options( ${lib} PUBLIC -fprofile-instr-generate )
+  endif()
+
+endforeach()
 
 if( BUILD_WITH_LIB STREQUAL "CUDA" )
   target_include_directories( hipfft PUBLIC $<BUILD_INTERFACE:${CUDAToolkit_INCLUDE_DIRS}> )
 endif()
-
-# Target link libraries - on ROCm we just use rocFFT for
-# everything.  CUDA has to be handled separately for normal and
-# "Mp" libs
-if( BUILD_WITH_LIB STREQUAL "ROCM" )
-  list(APPEND static_depends PACKAGE rocfft)
-  target_link_libraries( hipfft PRIVATE roc::rocfft )
-  if( WIN32 )
-    target_link_libraries( hipfft PRIVATE hip::device )
-  endif()
-  target_link_libraries( hipfft PUBLIC hip::host )
-endif()
-
-target_compile_options( hipfft PRIVATE ${WARNING_FLAGS} )
-
-# Target properties
-set_target_properties( hipfft PROPERTIES CXX_EXTENSIONS NO )
-set_target_properties( hipfft PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
 
 if (BUILD_WITH_COMPILER STREQUAL "HIP-NVCC" )
   set_property(TARGET hipfft PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -151,7 +172,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}
 
 if( ROCmCMakeBuildTools_FOUND )
 
-  rocm_install_targets( TARGETS hipfft
+  rocm_install_targets( TARGETS ${HIPFFT_LIBRARY_TARGETS}
     INCLUDE
     ${CMAKE_BINARY_DIR}/include
   )
@@ -161,9 +182,4 @@ if( ROCmCMakeBuildTools_FOUND )
     STATIC_DEPENDS
       ${static_depends}
     NAMESPACE hip:: )
-endif()
-
-if (BUILD_CODE_COVERAGE)
-  target_compile_options( hipfft PRIVATE -g -O0 -fprofile-instr-generate -fcoverage-mapping )
-  target_link_options( hipfft PUBLIC -fprofile-instr-generate )
 endif()

--- a/projects/hipfft/library/include/hipfft/hipfftw.h
+++ b/projects/hipfft/library/include/hipfft/hipfftw.h
@@ -63,8 +63,9 @@ HIPFFT_EXPORT void fftw_free(void* p);
 HIPFFT_EXPORT void fftwf_free(void* p);
 
 // Plan usage
-typedef void*      fftw_plan;
-typedef void*      fftwf_plan;
+typedef struct fftw_plan_s*  fftw_plan;
+typedef struct fftwf_plan_s* fftwf_plan;
+
 HIPFFT_EXPORT void fftw_destroy_plan(fftw_plan plan);
 HIPFFT_EXPORT void fftwf_destroy_plan(fftwf_plan plan);
 HIPFFT_EXPORT void fftw_cleanup();

--- a/projects/hipfft/library/include/hipfft/hipfftw.h
+++ b/projects/hipfft/library/include/hipfft/hipfftw.h
@@ -1,0 +1,141 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef HIPFFTW_H_
+#define HIPFFTW_H_
+
+#include "hipfft-export.h"
+#include <cstddef>
+#include <cstdlib>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// FFTW can use standard complex type
+#if defined(_Complex_I) && defined(complex) && defined(I)
+typedef double complex fftw_complex;
+typedef float complex  fftwf_complex;
+#else
+typedef double fftw_complex[2];
+typedef float  fftwf_complex[2];
+#endif
+
+// Planning flags and constants
+#define FFTW_MEASURE (0U)
+#define FFTW_DESTROY_INPUT (1U << 0)
+#define FFTW_UNALIGNED (1U << 1)
+#define FFTW_CONSERVE_MEMORY (1U << 2)
+#define FFTW_EXHAUSTIVE (1U << 3)
+#define FFTW_PRESERVE_INPUT (1U << 4)
+#define FFTW_PATIENT (1U << 5)
+#define FFTW_ESTIMATE (1U << 6)
+#define FFTW_WISDOM_ONLY (1U << 21)
+#define FFTW_FORWARD (-1)
+#define FFTW_BACKWARD (1)
+
+// Buffer management
+HIPFFT_EXPORT void*   fftw_malloc(size_t n);
+HIPFFT_EXPORT void*   fftwf_malloc(size_t n);
+HIPFFT_EXPORT double* fftw_alloc_real(size_t n);
+HIPFFT_EXPORT float*  fftwf_alloc_real(size_t n);
+HIPFFT_EXPORT fftw_complex* fftw_alloc_complex(size_t n);
+HIPFFT_EXPORT fftwf_complex* fftwf_alloc_complex(size_t n);
+
+HIPFFT_EXPORT void fftw_free(void* p);
+HIPFFT_EXPORT void fftwf_free(void* p);
+
+// Plan usage
+typedef void*      fftw_plan;
+typedef void*      fftwf_plan;
+HIPFFT_EXPORT void fftw_destroy_plan(fftw_plan plan);
+HIPFFT_EXPORT void fftwf_destroy_plan(fftwf_plan plan);
+HIPFFT_EXPORT void fftw_cleanup();
+HIPFFT_EXPORT void fftwf_cleanup();
+HIPFFT_EXPORT void fftw_execute(const fftw_plan plan);
+HIPFFT_EXPORT void fftwf_execute(const fftwf_plan plan);
+
+// Basic plans
+HIPFFT_EXPORT fftw_plan
+    fftw_plan_dft_1d(int n, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+HIPFFT_EXPORT fftwf_plan
+    fftwf_plan_dft_1d(int n, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags);
+HIPFFT_EXPORT fftw_plan
+    fftw_plan_dft_2d(int n0, int n1, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+HIPFFT_EXPORT fftwf_plan fftwf_plan_dft_2d(
+    int n0, int n1, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags);
+HIPFFT_EXPORT fftw_plan fftw_plan_dft_3d(
+    int n0, int n1, int n2, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+HIPFFT_EXPORT fftwf_plan fftwf_plan_dft_3d(
+    int n0, int n1, int n2, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags);
+HIPFFT_EXPORT fftw_plan fftw_plan_dft(
+    int rank, const int* n, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+HIPFFT_EXPORT fftwf_plan fftwf_plan_dft(
+    int rank, const int* n, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags);
+HIPFFT_EXPORT fftw_plan  fftw_plan_dft_r2c_1d(int n, double* in, fftw_complex* out, unsigned flags);
+HIPFFT_EXPORT fftwf_plan fftwf_plan_dft_r2c_1d(int            n,
+                                               float*         in,
+                                               fftwf_complex* out,
+                                               unsigned       flags);
+HIPFFT_EXPORT fftw_plan
+    fftw_plan_dft_r2c_2d(int n0, int n1, double* in, fftw_complex* out, unsigned flags);
+HIPFFT_EXPORT fftwf_plan
+    fftwf_plan_dft_r2c_2d(int n0, int n1, float* in, fftwf_complex* out, unsigned flags);
+HIPFFT_EXPORT fftw_plan
+    fftw_plan_dft_r2c_3d(int n0, int n1, int n2, double* in, fftw_complex* out, unsigned flags);
+HIPFFT_EXPORT fftwf_plan
+    fftwf_plan_dft_r2c_3d(int n0, int n1, int n2, float* in, fftwf_complex* out, unsigned flags);
+HIPFFT_EXPORT fftw_plan
+    fftw_plan_dft_r2c(int rank, const int* n, double* in, fftw_complex* out, unsigned flags);
+HIPFFT_EXPORT fftwf_plan
+    fftwf_plan_dft_r2c(int rank, const int* n, float* in, fftwf_complex* out, unsigned flags);
+HIPFFT_EXPORT fftw_plan  fftw_plan_dft_c2r_1d(int n, fftw_complex* in, double* out, unsigned flags);
+HIPFFT_EXPORT fftwf_plan fftwf_plan_dft_c2r_1d(int            n,
+                                               fftwf_complex* in,
+                                               float*         out,
+                                               unsigned       flags);
+HIPFFT_EXPORT fftw_plan
+    fftw_plan_dft_c2r_2d(int n0, int n1, fftw_complex* in, double* out, unsigned flags);
+HIPFFT_EXPORT fftwf_plan
+    fftwf_plan_dft_c2r_2d(int n0, int n1, fftwf_complex* in, float* out, unsigned flags);
+HIPFFT_EXPORT fftw_plan
+    fftw_plan_dft_c2r_3d(int n0, int n1, int n2, fftw_complex* in, double* out, unsigned flags);
+HIPFFT_EXPORT fftwf_plan
+    fftwf_plan_dft_c2r_3d(int n0, int n1, int n2, fftwf_complex* in, float* out, unsigned flags);
+HIPFFT_EXPORT fftw_plan
+    fftw_plan_dft_c2r(int rank, const int* n, fftw_complex* in, double* out, unsigned flags);
+HIPFFT_EXPORT fftwf_plan
+    fftwf_plan_dft_c2r(int rank, const int* n, fftwf_complex* in, float* out, unsigned flags);
+
+// Non-functional utility APIs
+HIPFFT_EXPORT void   fftw_print_plan(const fftw_plan);
+HIPFFT_EXPORT void   fftwf_print_plan(const fftwf_plan);
+HIPFFT_EXPORT void   fftw_set_timelimit(double);
+HIPFFT_EXPORT void   fftwf_set_timelimit(double);
+HIPFFT_EXPORT double fftw_cost(const fftw_plan);
+HIPFFT_EXPORT double fftwf_cost(const fftw_plan);
+HIPFFT_EXPORT void   fftw_flops(const fftw_plan, double*, double*, double*);
+HIPFFT_EXPORT void   fftwf_flops(const fftw_plan, double*, double*, double*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/projects/hipfft/library/src/CMakeLists.txt
+++ b/projects/hipfft/library/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # #############################################################################
-# Copyright (C) 2020 - 2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2020 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,10 @@
 if(NOT BUILD_WITH_LIB STREQUAL "CUDA")
   # hipFFT source
   set(hipfft_source src/amd_detail/hipfft.cpp)
+  set(hipfftw_source src/amd_detail/hipfftw.cpp)
 else()
   # hipFFT CUDA source
   set(hipfft_source src/nvidia_detail/hipfft.cpp)
+  # hipFFTW has no source code on nvidia, as we just link in cufftw
+  set(hipfftw_source "")
 endif()

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 #include "hipfft/hipfftw.h"
+#include "../../../shared/environment.h"
 #include "rocfft/rocfft.h"
 #include <algorithm>
 #include <array>
@@ -31,9 +32,6 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
-#ifdef WIN32
-#include <windows.h> // GetEnvironmentVariableA
-#endif
 
 // anonymous namespace for implementation details
 namespace
@@ -75,7 +73,7 @@ namespace
     struct hipfftw_runtime_error : public std::runtime_error
     {
         const hipError_t hip_error;
-        hipfftw_runtime_error(const std::string& info, hipError_t hip_status = hipSuccess)
+        hipfftw_runtime_error(const std::string& info, hipError_t hip_status)
             : std::runtime_error::runtime_error(info)
             , hip_error(hip_status)
 
@@ -188,7 +186,6 @@ namespace
     {
         H2D = static_cast<std::underlying_type_t<hipMemcpyKind>>(hipMemcpyHostToDevice),
         D2H = static_cast<std::underlying_type_t<hipMemcpyKind>>(hipMemcpyDeviceToHost),
-        D2D = static_cast<std::underlying_type_t<hipMemcpyKind>>(hipMemcpyDeviceToDevice),
         NONE
     };
     enum class hipfftw_memcpy_direction
@@ -270,17 +267,23 @@ namespace
         }
 
         template <hipfftw_memcpy_direction dir>
-        hipfftw_memcpy_kind get_copy_kind(int deviceId) const
+        hipfftw_memcpy_kind get_copy_kind(int plan_device_id) const
         {
+            if(attributes.type != hipMemoryType::hipMemoryTypeUnregistered
+               && attributes.device != plan_device_id)
+            {
+                throw hipfftw_invalid_arg(
+                    "if using registered data allocation for I/O, hipfftw requires them to be "
+                    "visible to the device used at plan creation.");
+            }
             static_assert(dir == hipfftw_memcpy_direction::TO
                           || dir == hipfftw_memcpy_direction::FROM);
             switch(attributes.type)
             {
-            case hipMemoryType::hipMemoryTypeManaged:
-                return hipfftw_memcpy_kind::NONE; // the runtime is supposed to manage it
+            case hipMemoryType::hipMemoryTypeManaged: // the runtime is supposed to manage it
+                [[fallthrough]];
             case hipMemoryType::hipMemoryTypeDevice:
-                return attributes.device != deviceId ? hipfftw_memcpy_kind::D2D
-                                                     : hipfftw_memcpy_kind::NONE;
+                return hipfftw_memcpy_kind::NONE;
             case hipMemoryType::hipMemoryTypeUnregistered:
             case hipMemoryType::hipMemoryTypeHost:
                 // TODO: check if device is APU and return false (systematically?) in that case
@@ -342,45 +345,21 @@ namespace
     }
 
     // helper routine for assigning a device allocation to an owning data_ptr_bundle
+    // (the current device is used)
     void hipfftw_set_device_allocation(hipfftw_data_ptr_bundle<hipfftw_owns_it>& bundle,
                                        size_t                                    alloc_size,
-                                       const std::string&                        buffer_qualifier,
-                                       int                                       desired_device_id)
+                                       const std::string&                        buffer_qualifier)
     {
         void* temp = nullptr;
         if(alloc_size > 0)
         {
-            std::ostringstream info;
-            const auto         original_device_id = hipfftw_get_current_device_id();
-            hipError_t         hip_status         = hipSuccess;
-            // set device id to the desired one
-            if(original_device_id != desired_device_id)
-            {
-                hip_status = hipSetDevice(desired_device_id);
-                if(hip_status != hipSuccess)
-                {
-                    info << "the device ID could not be set temporarily to " << desired_device_id
-                         << " when creating the " << buffer_qualifier << " buffer.";
-                    throw hipfftw_runtime_error(info.str(), hip_status);
-                }
-            }
-            hip_status = hipMalloc(&temp, alloc_size);
+            const auto hip_status = hipMalloc(&temp, alloc_size);
             if(hip_status != hipSuccess || !temp)
             {
+                std::ostringstream info;
                 info << "device memory could not be allocated for the " << buffer_qualifier
                      << " buffer.";
                 throw hipfftw_bad_gpu_alloc(info.str(), alloc_size, hip_status);
-            }
-            // reset device id to what it was
-            if(original_device_id != desired_device_id)
-            {
-                hip_status = hipSetDevice(original_device_id);
-                if(hip_status != hipSuccess)
-                {
-                    info << "the device ID could not be reset to to " << original_device_id
-                         << " upon creation of the " << buffer_qualifier << " buffer.";
-                    throw hipfftw_runtime_error(info.str(), hip_status);
-                }
             }
         }
         bundle.set(temp);
@@ -683,7 +662,7 @@ namespace
             // create and set device work buffer
             if(work_buffer_size > 0)
             {
-                hipfftw_set_device_allocation(work_buffer, work_buffer_size, "work", device_id);
+                hipfftw_set_device_allocation(work_buffer, work_buffer_size, "work");
                 if(rocfft_execution_info_set_work_buffer(
                        internal_rocfft_info, work_buffer.get_data_ptr(), work_buffer_size)
                    != rocfft_status_success)
@@ -714,14 +693,14 @@ namespace
                && intended_execute_in.get_copy_kind<hipfftw_memcpy_direction::TO>(device_id)
                       != hipfftw_memcpy_kind::NONE)
             {
-                hipfftw_set_device_allocation(in_device, in_bytes, "input", device_id);
+                hipfftw_set_device_allocation(in_device, in_bytes, "input");
             }
 
             if(plan_placement != rocfft_placement_inplace && !out_device
                && intended_execute_out.get_copy_kind<hipfftw_memcpy_direction::FROM>(device_id)
                       != hipfftw_memcpy_kind::NONE)
             {
-                hipfftw_set_device_allocation(out_device, out_bytes, "output", device_id);
+                hipfftw_set_device_allocation(out_device, out_bytes, "output");
             }
             return;
         }
@@ -778,8 +757,8 @@ namespace
             if(exec_out.is_host_accessible())
             {
                 // results must be accessible from the host upon completion
-                hipfftw_raii_event sync_ev;
-                sync_ev.record().sync();
+                hipfftw_raii_event synchronizing_event;
+                synchronizing_event.record().sync();
             }
             return;
         }
@@ -865,18 +844,9 @@ namespace
     {
         try
         {
-#ifdef WIN32
-            // no more than 8*sizeof(size_t) + 3 characters for valid values
-            // (if variable defined in binary representation "0b[...]")
-            char       tmp[8 * sizeof(size_t) + 3];
-            const auto sz = GetEnvironmentVariableA(env_var, tmp, sizeof(tmp));
-            if(sz == 0 || sz > sizeof(tmp))
+            const std::string tmp = rocfft_getenv(env_var);
+            if(tmp.empty())
                 return default_val;
-#else
-            const char* tmp = std::getenv(env_var);
-            if(!tmp)
-                return default_val;
-#endif
             const auto ret = std::stoull(tmp);
             return ret > std::numeric_limits<size_t>::max() ? std::numeric_limits<size_t>::max()
                                                             : static_cast<size_t>(ret);
@@ -947,7 +917,7 @@ namespace
     {
         if(hipfftw_handler_is_verbose())
         {
-            std::cerr << "A hipfftw-specific runtime error was detected and reported by "
+            std::cerr << "A hip-specific runtime error was detected and reported by "
                       << user_facing_function << ". Details: " << e.what();
             if(e.hip_error != hipSuccess)
                 std::cerr << "\nThe hip error code was " << e.hip_error << ".";

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -136,53 +136,6 @@ namespace
             return rocfft_array_type_real;
     }
 
-    struct hipfftw_raii_event
-    {
-    private:
-        hipEvent_t ev;
-
-    public:
-        hipfftw_raii_event()
-        {
-            auto hip_status = hipEventCreate(&ev);
-            if(hip_status != hipSuccess)
-            {
-                throw hipfftw_runtime_error("an event could not be created.", hip_status);
-            }
-        }
-
-        hipfftw_raii_event& record()
-        {
-            auto hip_status = hipEventRecord(ev);
-            if(hip_status != hipSuccess)
-            {
-                throw hipfftw_runtime_error("an event could not be recorded.", hip_status);
-            }
-            return *this;
-        }
-
-        hipfftw_raii_event& sync()
-        {
-            auto hip_status = hipEventSynchronize(ev);
-            if(hip_status != hipSuccess)
-            {
-                throw hipfftw_runtime_error("an event synchronization failed.", hip_status);
-            }
-            return *this;
-        }
-
-        ~hipfftw_raii_event()
-        {
-            (void)hipEventDestroy(ev);
-        }
-
-        // disable copies and moves
-        hipfftw_raii_event(hipfftw_raii_event&& other) = delete;
-        hipfftw_raii_event& operator=(hipfftw_raii_event&& other) = delete;
-        hipfftw_raii_event(const hipfftw_raii_event& other)       = delete;
-        hipfftw_raii_event& operator=(const hipfftw_raii_event& other) = delete;
-    };
-
     enum class hipfftw_memcpy_kind : std::underlying_type_t<hipMemcpyKind>
     {
         H2D = static_cast<std::underlying_type_t<hipMemcpyKind>>(hipMemcpyHostToDevice),
@@ -758,8 +711,19 @@ namespace
             if(exec_out.is_host_accessible())
             {
                 // results must be accessible from the host upon completion
-                hipfftw_raii_event synchronizing_event;
-                synchronizing_event.record().sync();
+                hipEvent_t synchronizing_event = nullptr;
+                auto       hip_status          = hipEventCreate(&synchronizing_event);
+                if(hip_status != hipSuccess)
+                    throw hipfftw_runtime_error("an event could not be created.", hip_status);
+                hip_status = hipEventRecord(synchronizing_event);
+                if(hip_status != hipSuccess)
+                    throw hipfftw_runtime_error("an event could not be recorded.", hip_status);
+                hip_status = hipEventSynchronize(synchronizing_event);
+                if(hip_status != hipSuccess)
+                    throw hipfftw_runtime_error("an event synchronization failed.", hip_status);
+                hip_status = hipEventDestroy(synchronizing_event);
+                if(hip_status != hipSuccess)
+                    throw hipfftw_runtime_error("an event could not be destroyed.", hip_status);
             }
             return;
         }

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -31,6 +31,9 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#ifdef WIN32
+#include <windows.h> // GetEnvironmentVariableA
+#endif
 
 // anonymous namespace for implementation details
 namespace
@@ -82,8 +85,8 @@ namespace
 
     enum class hipfftw_io_label
     {
-        IN,
-        OUT
+        INPUT_DATA,
+        OUTPUT_DATA
     };
 
     constexpr bool is_real(rocfft_transform_type dft_type)
@@ -116,7 +119,7 @@ namespace
     using hipfftw_user_data_t
         = std::conditional_t<!is_real(dft_type)
                                  || (dft_type == rocfft_transform_type_real_forward
-                                     ^ io == hipfftw_io_label::IN),
+                                     ^ io == hipfftw_io_label::INPUT_DATA),
                              // user data is complex
                              hipfftw_complex_data_t<prec>,
                              // user data is real
@@ -128,7 +131,7 @@ namespace
         if constexpr(!is_real(dft_type))
             return rocfft_array_type_complex_interleaved;
         else if constexpr(dft_type == rocfft_transform_type_real_forward
-                          ^ io == hipfftw_io_label::IN)
+                          ^ io == hipfftw_io_label::INPUT_DATA)
             return rocfft_array_type_hermitian_interleaved;
         else
             return rocfft_array_type_real;
@@ -555,15 +558,15 @@ namespace
                   size_t                rank,
                   typename T,
                   size_t batch_rank>
-        void init(const std::array<T, rank>&                                  lengths_rm,
-                  const std::array<T, rank>&                                  istrides_rm,
-                  const std::array<T, rank>&                                  ostrides_rm,
-                  hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>*  user_in,
-                  hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>* user_out,
-                  const std::array<T, batch_rank>&                            batch,
-                  const std::array<T, batch_rank>&                            idist,
-                  const std::array<T, batch_rank>&                            odist,
-                  unsigned                                                    flags)
+        void init(const std::array<T, rank>&                                          lengths_rm,
+                  const std::array<T, rank>&                                          istrides_rm,
+                  const std::array<T, rank>&                                          ostrides_rm,
+                  hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  user_in,
+                  hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* user_out,
+                  const std::array<T, batch_rank>&                                    batch,
+                  const std::array<T, batch_rank>&                                    idist,
+                  const std::array<T, batch_rank>&                                    odist,
+                  unsigned                                                            flags)
         {
             // compile-time validations of template specialization values
             static_assert(1 <= rank && rank <= 3);
@@ -625,11 +628,11 @@ namespace
                 // {k[0], k[1], ..., k[rank - 2], 0} ":= k" and every
                 // {m[0], m[1], .., m[batch_dim-1]} ":= m" (in applicable ranges), the byte offset
                 // on input, i.e.,
-                // sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>)*
+                // sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>)*
                 //      std::inner_product(m.begin(), m.end(), idist.begin(),
                 //                         std::inner_product(k.begin(), k.end(), istrides_rm.begin(), 0))
                 // must be equal to the byte offset on output, i.e.,
-                // sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>)*
+                // sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>)*
                 //      std::inner_product(m.begin(), m.end(), odist.begin(),
                 //                         std::inner_product(k.begin(), k.end(), ostrides_rm.begin(), 0)).
                 // This requirement translates into the followng element-wise conditions on
@@ -641,9 +644,12 @@ namespace
                     if(batch[batch_dim] == 1)
                         continue;
                     if(idist[batch_dim]
-                           * sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>)
+                           * sizeof(
+                               hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>)
                        != odist[batch_dim]
-                              * sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>))
+                              * sizeof(hipfftw_user_data_t<dft_type,
+                                                           prec,
+                                                           hipfftw_io_label::OUTPUT_DATA>))
                         throw hipfftw_invalid_arg("distances rejected for in-place configuration.");
                 }
                 for(auto dim = 0; dim < rank - 1 /* exclude leading dimension */; dim++)
@@ -651,9 +657,12 @@ namespace
                     if(lengths_rm[dim] == 1)
                         continue;
                     if(istrides_rm[dim]
-                           * sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>)
+                           * sizeof(
+                               hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>)
                        != ostrides_rm[dim]
-                              * sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>))
+                              * sizeof(hipfftw_user_data_t<dft_type,
+                                                           prec,
+                                                           hipfftw_io_label::OUTPUT_DATA>))
                     {
                         throw hipfftw_invalid_arg("strides rejected for in-place configuration..");
                     }
@@ -695,9 +704,9 @@ namespace
                     "representable in the chosen integral type are not supported (consider using "
                     "guru64 plan creation functions).");
             }
-            in_bytes = sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>)
+            in_bytes = sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>)
                        * (last_input_element_idx + 1);
-            out_bytes = sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>)
+            out_bytes = sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>)
                         * (last_output_element_idx + 1);
             if(plan_placement == rocfft_placement_inplace)
             {
@@ -722,8 +731,8 @@ namespace
             }
             if(rocfft_plan_description_set_data_layout(
                    internal_rocfft_desc,
-                   hipfftw_get_array_type<dft_type, hipfftw_io_label::IN>(),
-                   hipfftw_get_array_type<dft_type, hipfftw_io_label::OUT>(),
+                   hipfftw_get_array_type<dft_type, hipfftw_io_label::INPUT_DATA>(),
+                   hipfftw_get_array_type<dft_type, hipfftw_io_label::OUTPUT_DATA>(),
                    nullptr /* in_offsets */,
                    nullptr /* out_offsets */,
                    rank /* in_strides_sizes */,
@@ -786,16 +795,16 @@ namespace
               size_t                rank,
               typename T,
               size_t batch_rank = 1>
-    hipfftw_plan_internal*
-        hipfftw_create_plan(const std::array<T, rank>&                                  lengths_rm,
-                            const std::array<T, rank>&                                  istrides_rm,
-                            const std::array<T, rank>&                                  ostrides_rm,
-                            hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>*  user_in,
-                            hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>* user_out,
-                            const std::array<T, batch_rank>&                            batch,
-                            const std::array<T, batch_rank>&                            idist,
-                            const std::array<T, batch_rank>&                            odist,
-                            unsigned                                                    flags)
+    hipfftw_plan_internal* hipfftw_create_plan(
+        const std::array<T, rank>&                                          lengths_rm,
+        const std::array<T, rank>&                                          istrides_rm,
+        const std::array<T, rank>&                                          ostrides_rm,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  user_in,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* user_out,
+        const std::array<T, batch_rank>&                                    batch,
+        const std::array<T, batch_rank>&                                    idist,
+        const std::array<T, batch_rank>&                                    odist,
+        unsigned                                                            flags)
     {
         auto ret = std::make_unique<hipfftw_plan_internal>();
         ret->init<dft_type, prec, rank, T, batch_rank>(
@@ -872,10 +881,10 @@ namespace
 
     template <rocfft_transform_type dft_type, rocfft_precision prec, size_t rank>
     hipfftw_plan_internal* hipfftw_create_default_unbatched_plan(
-        const std::array<int, rank>&                                n,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>*  in,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>* out,
-        unsigned                                                    flags)
+        const std::array<int, rank>&                                        n,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  in,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* out,
+        unsigned                                                            flags)
     {
         auto layout_data = hipfftw_get_default_data_layout_info_rm<rank, dft_type>(
             static_cast<void*>(in) == static_cast<void*>(out), n);
@@ -892,11 +901,11 @@ namespace
 
     template <rocfft_transform_type dft_type, rocfft_precision prec>
     hipfftw_plan_internal* hipfftw_create_default_unbatched_plan(
-        int                                                         rank,
-        const int*                                                  n,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>*  in,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>* out,
-        unsigned                                                    flags)
+        int                                                                 rank,
+        const int*                                                          n,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  in,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* out,
+        unsigned                                                            flags)
     {
         if(rank <= 0)
             throw hipfftw_invalid_arg("ranks must be strictly positive.");
@@ -963,15 +972,38 @@ namespace
                                                          prec>(rank, n, in, out, flags);
     }
 
-    bool hipfftw_handler_is_verbose() noexcept
-    try
+    // read the environment variable env_var and convert it to a size_t value.
+    // If the environment variable is not set or if the conversion fails, the default value
+    // is returned.
+    size_t hipfftw_fetch_env_var(const char* env_var, size_t default_val) noexcept
     {
-        const char* env = std::getenv("HIPFFTW_LOG_EXCEPTIONS");
-        return env && std::stoi(env) > 0;
+        try
+        {
+#ifdef WIN32
+            // no more than 8*sizeof(size_t) + 3 characters for valid values
+            // (if variable defined in binary representation "0b[...]")
+            char       tmp[8 * sizeof(size_t) + 3];
+            const auto sz = GetEnvironmentVariableA(env_var, tmp, sizeof(tmp));
+            if(sz == 0 || sz > sizeof(tmp))
+                return default_val;
+#else
+            const char* tmp = std::getenv(env_var);
+            if(!tmp)
+                return default_val;
+#endif
+            const auto ret = std::stoull(tmp);
+            return ret > std::numeric_limits<size_t>::max() ? std::numeric_limits<size_t>::max()
+                                                            : static_cast<size_t>(ret);
+        }
+        catch(...)
+        {
+            return default_val;
+        }
     }
-    catch(...)
+
+    bool hipfftw_handler_is_verbose() noexcept
     {
-        return false;
+        return hipfftw_fetch_env_var("HIPFFTW_LOG_EXCEPTIONS", 0) > 0;
     }
 
     inline void hipfftw_exception_handler(const char* user_facing_function) noexcept
@@ -1049,27 +1081,16 @@ namespace
                       << user_facing_function << "." << std::endl;
     }
 
-    constexpr size_t no_limit = std::numeric_limits<size_t>::max();
     template <hipMemoryType type>
     size_t hipfftw_alloc_host_limit() noexcept
-    try
     {
         static_assert(type == hipMemoryType::hipMemoryTypeHost
                       || type == hipMemoryType::hipMemoryTypeUnregistered);
-        const char* env = nullptr;
+        constexpr size_t no_limit = std::numeric_limits<size_t>::max();
         if constexpr(type == hipMemoryType::hipMemoryTypeHost)
-            env = std::getenv("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC");
+            return hipfftw_fetch_env_var("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC", no_limit);
         else
-            env = std::getenv("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC");
-        if(!env)
-            throw int(); // no limit set
-        const unsigned long long desired_limit = std::stoull(env);
-        return desired_limit > no_limit ? no_limit : static_cast<size_t>(desired_limit);
-    }
-    catch(...)
-    {
-        // no actual limit set, or failed to read it
-        return no_limit;
+            return hipfftw_fetch_env_var("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC", no_limit);
     }
 
     // possible TODO for hipfftw_alloc_host_accessible: consider using hipMallocManaged,

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -866,35 +866,35 @@ namespace
     inline void hipfftw_exception_handler(const char* user_facing_function) noexcept
     try
     {
-        throw;
-    }
-    catch(const hipfftw_invalid_arg& e)
-    {
-        if(hipfftw_handler_is_verbose())
+        if(!hipfftw_handler_is_verbose())
+            return;
+
+        // log failure-specific information
+        try
+        {
+            throw;
+        }
+        catch(const hipfftw_invalid_arg& e)
+        {
             std::cerr << "Invalid argument reported by " << user_facing_function
                       << ". Details: " << e.what() << std::endl;
-    }
-    catch(const hipfftw_unsupported& e)
-    {
-        if(hipfftw_handler_is_verbose())
+        }
+        catch(const hipfftw_unsupported& e)
+        {
             std::cerr << "Unsupported usage reported by " << user_facing_function
                       << ". Details: " << e.what() << std::endl;
-    }
-    catch(const hipfftw_internal_logic_error& e)
-    {
-        if(hipfftw_handler_is_verbose())
+        }
+        catch(const hipfftw_internal_logic_error& e)
+        {
             std::cerr << "A logic error internal to hipfftw was detected and reported by "
                       << user_facing_function << ". Details: " << e.what() << std::endl;
-    }
-    catch(const rocfft_failure& e)
-    {
-        if(hipfftw_handler_is_verbose())
+        }
+        catch(const rocfft_failure& e)
+        {
             std::cerr << "A rocfft failure was detected and reported by " << user_facing_function
                       << ". Details: " << e.what() << std::endl;
-    }
-    catch(const hipfftw_bad_gpu_alloc& e)
-    {
-        if(hipfftw_handler_is_verbose())
+        }
+        catch(const hipfftw_bad_gpu_alloc& e)
         {
             std::cerr << "A GPU allocation failure was detected and reported by "
                       << user_facing_function << ". Details: " << e.what();
@@ -902,10 +902,7 @@ namespace
                 std::cerr << "\nThe hip error code was " << e.hip_error << ".";
             std::cerr << "\nThe attempted size was " << e.attempted_size << " bytes" << std::endl;
         }
-    }
-    catch(const hipfftw_bad_alloc& e)
-    {
-        if(hipfftw_handler_is_verbose())
+        catch(const hipfftw_bad_alloc& e)
         {
             std::cerr << "An allocation failure was detected and reported by "
                       << user_facing_function << ". Details: " << e.what();
@@ -913,10 +910,7 @@ namespace
                 std::cerr << "\nThe hip error code was " << e.hip_error << ".";
             std::cerr << "\nThe attempted size was " << e.attempted_size << " bytes" << std::endl;
         }
-    }
-    catch(const hipfftw_runtime_error& e)
-    {
-        if(hipfftw_handler_is_verbose())
+        catch(const hipfftw_runtime_error& e)
         {
             std::cerr << "A hip-specific runtime error was detected and reported by "
                       << user_facing_function << ". Details: " << e.what();
@@ -924,18 +918,21 @@ namespace
                 std::cerr << "\nThe hip error code was " << e.hip_error << ".";
             std::cerr << std::endl;
         }
-    }
-    catch(const std::runtime_error& e)
-    {
-        if(hipfftw_handler_is_verbose())
+        catch(const std::runtime_error& e)
+        {
             std::cerr << "A runtime error was detected and reported by " << user_facing_function
                       << ". Details: " << e.what() << std::endl;
+        }
+        catch(...)
+        {
+            std::cerr << "An unidentified exception was detected and reported by "
+                      << user_facing_function << "." << std::endl;
+        }
     }
     catch(...)
     {
-        if(hipfftw_handler_is_verbose())
-            std::cerr << "An unidentified exception was detected and reported by "
-                      << user_facing_function << "." << std::endl;
+        // one of the above catch blocks threw as it attempted to log failure-related information...
+        // ignore (std::terminate invoked otherwise...)
     }
 
     template <hipMemoryType type>

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -23,6 +23,7 @@
 #include "rocfft/rocfft.h"
 #include <algorithm>
 #include <array>
+#include <cstdint> // std::int64_t
 #include <cstdlib>
 #include <hip/hip_runtime_api.h>
 #include <iostream>
@@ -804,7 +805,7 @@ namespace
         hipfftw_general_layout_data<rank, 1, int> ret;
         ret.lengths = user_lengths_rm;
         int ival = 1, oval = 1;
-        for(int dim_idx = static_cast<int>(rank) - 1; dim_idx >= 0; dim_idx--)
+        for(auto dim_idx = rank; dim_idx-- > 0;)
         {
             ret.istrides[dim_idx] = ival;
             ret.ostrides[dim_idx] = oval;

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -386,6 +386,27 @@ namespace
         bundle.set(temp);
     }
 
+    void init_rocfft()
+    {
+        struct rocfft_initializer
+        {
+            rocfft_initializer()
+            {
+                rocfft_setup();
+            }
+            ~rocfft_initializer()
+            {
+                rocfft_cleanup();
+            }
+        };
+        // magic static to handle rocfft setup/cleanup
+        static rocfft_initializer init;
+    }
+
+    template <rocfft_precision prec,
+              // single or double precision only
+              std::enable_if_t<prec == rocfft_precision_single || prec == rocfft_precision_double,
+                               bool> = true>
     struct hipfftw_plan_internal
     {
         hipfftw_plan_internal() = default;
@@ -418,6 +439,7 @@ namespace
         rocfft_plan_description internal_rocfft_desc = nullptr;
         rocfft_execution_info   internal_rocfft_info = nullptr;
         rocfft_result_placement plan_placement;
+        rocfft_transform_type   plan_dft_type;
         // Sizes of the buffers so we know how much to copy
         size_t in_bytes         = 0;
         size_t out_bytes        = 0;
@@ -426,9 +448,9 @@ namespace
         int device_id = hipInvalidDeviceId;
         // bundles for owned data pointers
         hipfftw_data_ptr_bundle<hipfftw_owns_it> work_buffer;
-        // mutables below because possibly modified in new-array execute paths
-        mutable hipfftw_data_ptr_bundle<hipfftw_owns_it> in_device;
-        mutable hipfftw_data_ptr_bundle<hipfftw_owns_it> out_device;
+        // possibly allocated in new-array execute paths if not allocated at plan creation
+        hipfftw_data_ptr_bundle<hipfftw_owns_it> in_device;
+        hipfftw_data_ptr_bundle<hipfftw_owns_it> out_device;
         // bundles for non-owned (user's) data pointers used at plan creation
         hipfftw_data_ptr_bundle<!hipfftw_owns_it> plan_creation_input;
         hipfftw_data_ptr_bundle<!hipfftw_owns_it> plan_creation_output;
@@ -440,11 +462,7 @@ namespace
         // TODO:
         // void execute(new_in, new_out) const {...}
 
-        template <rocfft_transform_type dft_type,
-                  rocfft_precision      prec,
-                  size_t                rank,
-                  typename T,
-                  size_t batch_rank>
+        template <rocfft_transform_type dft_type, size_t rank, typename T, size_t batch_rank>
         void init(const std::array<T, rank>&                                          lengths_rm,
                   const std::array<T, rank>&                                          istrides_rm,
                   const std::array<T, rank>&                                          ostrides_rm,
@@ -458,8 +476,6 @@ namespace
             // compile-time validations of template specialization values
             static_assert(1 <= rank && rank <= 3);
             static_assert(1 == batch_rank); // only supported case at the moment
-            // single of double precision only
-            static_assert(prec == rocfft_precision_single || prec == rocfft_precision_double);
             // assuming no overflow when converting values from T into size_t below
             static_assert(std::numeric_limits<T>::max() <= std::numeric_limits<size_t>::max());
             // Validation of input arguments:
@@ -509,6 +525,7 @@ namespace
             plan_placement = plan_creation_input == plan_creation_output
                                  ? rocfft_placement_inplace
                                  : rocfft_placement_notinplace;
+            plan_dft_type  = dft_type;
             if(plan_placement == rocfft_placement_inplace)
             {
                 // Check that the memory location is identical on input an output for the first
@@ -679,29 +696,11 @@ namespace
         }
 
     private:
-        void init_rocfft() const
-        {
-            // magic static to handle rocfft setup/cleanup
-            struct rocfft_initializer
-            {
-                rocfft_initializer()
-                {
-                    rocfft_setup();
-                }
-                ~rocfft_initializer()
-                {
-                    rocfft_cleanup();
-                }
-            };
-            static rocfft_initializer init;
-        }
-
-        // NOTE: const-qualified routine possibly modifying mutable members
-        // Motivation: new-array execute paths require const qualifier yet they may need
-        // to create the I/O device buffers
+        // NOTE: new-array execute paths may need to allocate the I/O device buffers if the new
+        // I/O require them (and if the I/O from plan creation did not).
         void set_io_device_buffers_for_execution(
             const hipfftw_data_ptr_bundle<!hipfftw_owns_it>& intended_execute_in,
-            const hipfftw_data_ptr_bundle<!hipfftw_owns_it>& intended_execute_out) const
+            const hipfftw_data_ptr_bundle<!hipfftw_owns_it>& intended_execute_out)
         {
             // TODO: check if the current device is an APU and simply never use
             // I/O device buffers in that case
@@ -710,7 +709,7 @@ namespace
                 // buffers are ready to go, nothing to do
                 return;
             }
-            // set device I/O buffer, if they're needed (possibly modifying mutable members)
+            // set device I/O buffer, if they're needed
             if(!in_device
                && intended_execute_in.get_copy_kind<hipfftw_memcpy_direction::TO>(device_id)
                       != hipfftw_memcpy_kind::NONE)
@@ -732,7 +731,7 @@ namespace
         {
             if(!internal_rocfft_plan)
                 throw hipfftw_internal_logic_error("the rocfft plan (internal detail to hipfftw) "
-                                                   "was unexpectedly uninitialized for execution.");
+                                                   "was uninitialized for execution (unexpected).");
             if(!exec_in || !exec_out)
                 throw hipfftw_invalid_arg("nullptr(s) cannot be used for execution data pointers.");
             // in/out may or may not need to be copied to the device
@@ -744,10 +743,10 @@ namespace
             void* exec_in_ptr = exec_in.get_data_ptr();
             if(input_copy_kind != hipfftw_memcpy_kind::NONE)
             {
-                auto hip_status = hipMemcpyAsync(in_device.get_data_ptr(),
-                                                 exec_in_ptr,
-                                                 in_bytes,
-                                                 static_cast<hipMemcpyKind>(input_copy_kind));
+                const auto hip_status = hipMemcpyAsync(in_device.get_data_ptr(),
+                                                       exec_in_ptr,
+                                                       in_bytes,
+                                                       static_cast<hipMemcpyKind>(input_copy_kind));
                 if(hip_status != hipSuccess)
                 {
                     throw hipfftw_runtime_error(
@@ -764,10 +763,11 @@ namespace
             rocfft_execute(internal_rocfft_plan, &exec_in_ptr, &exec_out_ptr, internal_rocfft_info);
             if(output_copy_kind != hipfftw_memcpy_kind::NONE)
             {
-                auto hip_status = hipMemcpyAsync(exec_out.get_data_ptr(),
-                                                 exec_out_ptr,
-                                                 out_bytes,
-                                                 static_cast<hipMemcpyKind>(output_copy_kind));
+                const auto hip_status
+                    = hipMemcpyAsync(exec_out.get_data_ptr(),
+                                     exec_out_ptr,
+                                     out_bytes,
+                                     static_cast<hipMemcpyKind>(output_copy_kind));
                 if(hip_status != hipSuccess)
                 {
                     throw hipfftw_runtime_error(
@@ -784,28 +784,6 @@ namespace
             return;
         }
     };
-
-    template <rocfft_transform_type dft_type,
-              rocfft_precision      prec,
-              size_t                rank,
-              typename T,
-              size_t batch_rank = 1>
-    hipfftw_plan_internal* hipfftw_create_plan(
-        const std::array<T, rank>&                                          lengths_rm,
-        const std::array<T, rank>&                                          istrides_rm,
-        const std::array<T, rank>&                                          ostrides_rm,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  user_in,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* user_out,
-        const std::array<T, batch_rank>&                                    batch,
-        const std::array<T, batch_rank>&                                    idist,
-        const std::array<T, batch_rank>&                                    odist,
-        unsigned                                                            flags)
-    {
-        auto ret = std::make_unique<hipfftw_plan_internal>();
-        ret->init<dft_type, prec, rank, T, batch_rank>(
-            lengths_rm, istrides_rm, ostrides_rm, user_in, user_out, batch, idist, odist, flags);
-        return ret.release();
-    }
 
     template <size_t rank,
               size_t batch_rank,
@@ -874,97 +852,10 @@ namespace
         return ret;
     }
 
-    template <rocfft_transform_type dft_type, rocfft_precision prec, size_t rank>
-    hipfftw_plan_internal* hipfftw_create_default_unbatched_plan(
-        const std::array<int, rank>&                                        n,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  in,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* out,
-        unsigned                                                            flags)
-    {
-        auto layout_data = hipfftw_get_default_data_layout_info_rm<rank, dft_type>(
-            static_cast<void*>(in) == static_cast<void*>(out), n);
-        return hipfftw_create_plan<dft_type, prec, rank, int>(layout_data.lengths,
-                                                              layout_data.istrides,
-                                                              layout_data.ostrides,
-                                                              in,
-                                                              out,
-                                                              layout_data.batches,
-                                                              layout_data.idist,
-                                                              layout_data.odist,
-                                                              flags);
-    }
-
-    template <rocfft_transform_type dft_type, rocfft_precision prec>
-    hipfftw_plan_internal* hipfftw_create_default_unbatched_plan(
-        int                                                                 rank,
-        const int*                                                          n,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  in,
-        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* out,
-        unsigned                                                            flags)
-    {
-        if(rank <= 0)
-            throw hipfftw_invalid_arg("ranks must be strictly positive.");
-        if(!n)
-            throw hipfftw_invalid_arg("lengths argument must not be nullptr.");
-        // rank == 1, 2, 3, or unsupported
-        switch(rank)
-        {
-        case 1:
-            return hipfftw_create_default_unbatched_plan<dft_type, prec, 1>(
-                std::array<int, 1>({n[0]}), in, out, flags);
-        case 2:
-            return hipfftw_create_default_unbatched_plan<dft_type, prec, 2>(
-                std::array<int, 2>({n[0], n[1]}), in, out, flags);
-        case 3:
-            return hipfftw_create_default_unbatched_plan<dft_type, prec, 3>(
-                std::array<int, 3>({n[0], n[1], n[2]}), in, out, flags);
-        default:
-            throw hipfftw_unsupported("rank values larger than 3 are not supported.");
-        }
-        // unreachable
-    }
-
     inline void hipfftw_validate_sign(int sign)
     {
         if(sign != FFTW_FORWARD && sign != FFTW_BACKWARD)
             throw hipfftw_invalid_arg("sign values must be FFTW_FORWARD or FFTW_BACKWARD.");
-    }
-
-    template <rocfft_precision prec, size_t rank>
-    hipfftw_plan_internal*
-        hipfftw_create_default_unbatched_complex_plan(const std::array<int, rank>&  n,
-                                                      int                           sign,
-                                                      hipfftw_complex_data_t<prec>* in,
-                                                      hipfftw_complex_data_t<prec>* out,
-                                                      unsigned                      flags)
-    {
-        hipfftw_validate_sign(sign);
-        if(sign == FFTW_FORWARD)
-            return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_forward,
-                                                         prec,
-                                                         rank>(n, in, out, flags);
-        else
-            return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_inverse,
-                                                         prec,
-                                                         rank>(n, in, out, flags);
-    }
-
-    template <rocfft_precision prec>
-    hipfftw_plan_internal*
-        hipfftw_create_default_unbatched_complex_plan(int                           rank,
-                                                      const int*                    n,
-                                                      int                           sign,
-                                                      hipfftw_complex_data_t<prec>* in,
-                                                      hipfftw_complex_data_t<prec>* out,
-                                                      unsigned                      flags)
-    {
-        hipfftw_validate_sign(sign);
-        if(sign == FFTW_FORWARD)
-            return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_forward,
-                                                         prec>(rank, n, in, out, flags);
-        else
-            return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_inverse,
-                                                         prec>(rank, n, in, out, flags);
     }
 
     // read the environment variable env_var and convert it to a size_t value.
@@ -1178,6 +1069,138 @@ namespace
     }
 } // end of implementation details
 
+// definition of the header's precision-specific structures
+struct fftwf_plan_s : public hipfftw_plan_internal<rocfft_precision_single>
+{
+};
+struct fftw_plan_s : public hipfftw_plan_internal<rocfft_precision_double>
+{
+};
+
+template <rocfft_precision prec>
+struct hipfftw_plan;
+template <>
+struct hipfftw_plan<rocfft_precision_single>
+{
+    using type = fftwf_plan_s;
+};
+template <>
+struct hipfftw_plan<rocfft_precision_double>
+{
+    using type = fftw_plan_s;
+};
+template <rocfft_precision prec>
+using hipfftw_plan_t = typename hipfftw_plan<prec>::type;
+
+template <rocfft_transform_type dft_type,
+          rocfft_precision      prec,
+          size_t                rank,
+          typename T,
+          size_t batch_rank = 1>
+static hipfftw_plan_t<prec>* hipfftw_create_plan(
+    const std::array<T, rank>&                                          lengths_rm,
+    const std::array<T, rank>&                                          istrides_rm,
+    const std::array<T, rank>&                                          ostrides_rm,
+    hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  user_in,
+    hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* user_out,
+    const std::array<T, batch_rank>&                                    batch,
+    const std::array<T, batch_rank>&                                    idist,
+    const std::array<T, batch_rank>&                                    odist,
+    unsigned                                                            flags)
+{
+    auto ret = std::make_unique<hipfftw_plan_t<prec>>();
+    ret->template init<dft_type, rank, T, batch_rank>(
+        lengths_rm, istrides_rm, ostrides_rm, user_in, user_out, batch, idist, odist, flags);
+    return ret.release();
+}
+
+template <rocfft_transform_type dft_type, rocfft_precision prec, size_t rank>
+static hipfftw_plan_t<prec>* hipfftw_create_default_unbatched_plan(
+    const std::array<int, rank>&                                        n,
+    hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  in,
+    hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* out,
+    unsigned                                                            flags)
+{
+    auto layout_data = hipfftw_get_default_data_layout_info_rm<rank, dft_type>(
+        static_cast<void*>(in) == static_cast<void*>(out), n);
+    return hipfftw_create_plan<dft_type, prec, rank, int>(layout_data.lengths,
+                                                          layout_data.istrides,
+                                                          layout_data.ostrides,
+                                                          in,
+                                                          out,
+                                                          layout_data.batches,
+                                                          layout_data.idist,
+                                                          layout_data.odist,
+                                                          flags);
+}
+
+template <rocfft_transform_type dft_type, rocfft_precision prec>
+static hipfftw_plan_t<prec>* hipfftw_create_default_unbatched_plan(
+    int                                                                 rank,
+    const int*                                                          n,
+    hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  in,
+    hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* out,
+    unsigned                                                            flags)
+{
+    if(rank <= 0)
+        throw hipfftw_invalid_arg("ranks must be strictly positive.");
+    if(!n)
+        throw hipfftw_invalid_arg("lengths argument must not be nullptr.");
+    // rank == 1, 2, 3, or unsupported
+    switch(rank)
+    {
+    case 1:
+        return hipfftw_create_default_unbatched_plan<dft_type, prec, 1>(
+            std::array<int, 1>({n[0]}), in, out, flags);
+    case 2:
+        return hipfftw_create_default_unbatched_plan<dft_type, prec, 2>(
+            std::array<int, 2>({n[0], n[1]}), in, out, flags);
+    case 3:
+        return hipfftw_create_default_unbatched_plan<dft_type, prec, 3>(
+            std::array<int, 3>({n[0], n[1], n[2]}), in, out, flags);
+    default:
+        throw hipfftw_unsupported("rank values larger than 3 are not supported.");
+    }
+    // unreachable
+}
+
+template <rocfft_precision prec, size_t rank>
+static hipfftw_plan_t<prec>*
+    hipfftw_create_default_unbatched_complex_plan(const std::array<int, rank>&  n,
+                                                  int                           sign,
+                                                  hipfftw_complex_data_t<prec>* in,
+                                                  hipfftw_complex_data_t<prec>* out,
+                                                  unsigned                      flags)
+{
+    hipfftw_validate_sign(sign);
+    if(sign == FFTW_FORWARD)
+        return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_forward,
+                                                     prec,
+                                                     rank>(n, in, out, flags);
+    else
+        return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_inverse,
+                                                     prec,
+                                                     rank>(n, in, out, flags);
+}
+
+template <rocfft_precision prec>
+static hipfftw_plan_t<prec>*
+    hipfftw_create_default_unbatched_complex_plan(int                           rank,
+                                                  const int*                    n,
+                                                  int                           sign,
+                                                  hipfftw_complex_data_t<prec>* in,
+                                                  hipfftw_complex_data_t<prec>* out,
+                                                  unsigned                      flags)
+{
+    hipfftw_validate_sign(sign);
+    if(sign == FFTW_FORWARD)
+        return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_forward, prec>(
+            rank, n, in, out, flags);
+    else
+        return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_inverse, prec>(
+            rank, n, in, out, flags);
+}
+
 void* fftw_malloc(size_t n)
 try
 {
@@ -1268,27 +1291,24 @@ catch(...)
 
 void fftw_destroy_plan(fftw_plan plan)
 {
-    auto internal_plan = static_cast<hipfftw_plan_internal*>(plan);
-    delete internal_plan;
+    delete plan;
 }
 
 void fftwf_destroy_plan(fftwf_plan plan)
 {
-    auto internal_plan = static_cast<hipfftw_plan_internal*>(plan);
-    delete internal_plan;
+    delete plan;
 }
 
 void fftw_cleanup() {}
 
 void fftwf_cleanup() {}
 
-void fftw_execute(const fftwf_plan plan)
+void fftw_execute(const fftw_plan plan)
 try
 {
-    auto internal_plan = static_cast<const hipfftw_plan_internal*>(plan);
-    if(!internal_plan)
+    if(!plan)
         throw hipfftw_invalid_arg("plan argument cannot be nullptr.");
-    internal_plan->execute();
+    plan->execute();
 }
 catch(...)
 {
@@ -1299,10 +1319,9 @@ catch(...)
 void fftwf_execute(const fftwf_plan plan)
 try
 {
-    auto internal_plan = static_cast<const hipfftw_plan_internal*>(plan);
-    if(!internal_plan)
+    if(!plan)
         throw hipfftw_invalid_arg("plan argument cannot be nullptr.");
-    internal_plan->execute();
+    plan->execute();
 }
 catch(...)
 {

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -1,0 +1,1660 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "hipfft/hipfftw.h"
+#include "rocfft/rocfft.h"
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <hip/hip_runtime_api.h>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+// anonymous namespace for implementation details
+namespace
+{
+    struct hipfftw_invalid_arg : public std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+    struct hipfftw_unsupported : public std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+    struct hipfftw_internal_logic_error : public std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+    struct rocfft_failure : public std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+    struct hipfftw_bad_alloc : public std::runtime_error
+    {
+        const size_t     attempted_size;
+        const hipError_t hip_error;
+        hipfftw_bad_alloc(const std::string& info,
+                          size_t             alloc_size,
+                          hipError_t         hip_status = hipSuccess)
+            : std::runtime_error::runtime_error(info)
+            , attempted_size(alloc_size)
+            , hip_error(hip_status)
+
+        {
+        }
+    };
+    struct hipfftw_bad_gpu_alloc : public hipfftw_bad_alloc
+    {
+        using hipfftw_bad_alloc::hipfftw_bad_alloc;
+    };
+    struct hipfftw_runtime_error : public std::runtime_error
+    {
+        const hipError_t hip_error;
+        hipfftw_runtime_error(const std::string& info, hipError_t hip_status = hipSuccess)
+            : std::runtime_error::runtime_error(info)
+            , hip_error(hip_status)
+
+        {
+        }
+    };
+
+    enum class hipfftw_io_label
+    {
+        IN,
+        OUT
+    };
+
+    constexpr bool is_real(rocfft_transform_type dft_type)
+    {
+        return dft_type == rocfft_transform_type_real_forward
+               || dft_type == rocfft_transform_type_real_inverse;
+    }
+
+    template <rocfft_precision prec>
+    struct hipfftw_scalar_trait;
+    template <>
+    struct hipfftw_scalar_trait<rocfft_precision_single>
+    {
+        using complex_t = fftwf_complex;
+        using real_t    = float;
+    };
+    template <>
+    struct hipfftw_scalar_trait<rocfft_precision_double>
+    {
+        using complex_t = fftw_complex;
+        using real_t    = double;
+    };
+
+    template <rocfft_precision prec>
+    using hipfftw_complex_data_t = typename hipfftw_scalar_trait<prec>::complex_t;
+    template <rocfft_precision prec>
+    using hipfftw_real_data_t = typename hipfftw_scalar_trait<prec>::real_t;
+    // template helper struct for data type consistency (compile-time checks)
+    template <rocfft_transform_type dft_type, rocfft_precision prec, hipfftw_io_label io>
+    using hipfftw_user_data_t
+        = std::conditional_t<!is_real(dft_type)
+                                 || (dft_type == rocfft_transform_type_real_forward
+                                     ^ io == hipfftw_io_label::IN),
+                             // user data is complex
+                             hipfftw_complex_data_t<prec>,
+                             // user data is real
+                             hipfftw_real_data_t<prec>>;
+
+    template <rocfft_transform_type dft_type, hipfftw_io_label io>
+    constexpr rocfft_array_type hipfftw_get_array_type()
+    {
+        if constexpr(!is_real(dft_type))
+            return rocfft_array_type_complex_interleaved;
+        else if constexpr(dft_type == rocfft_transform_type_real_forward
+                          ^ io == hipfftw_io_label::IN)
+            return rocfft_array_type_hermitian_interleaved;
+        else
+            return rocfft_array_type_real;
+    }
+
+    struct hipfftw_raii_event
+    {
+    private:
+        hipEvent_t ev;
+
+    public:
+        hipfftw_raii_event()
+        {
+            auto hip_status = hipEventCreate(&ev);
+            if(hip_status != hipSuccess)
+            {
+                throw hipfftw_runtime_error("an event could not be created.", hip_status);
+            }
+        }
+
+        hipfftw_raii_event& record()
+        {
+            auto hip_status = hipEventRecord(ev);
+            if(hip_status != hipSuccess)
+            {
+                throw hipfftw_runtime_error("an event could not be recorded.", hip_status);
+            }
+            return *this;
+        }
+
+        hipfftw_raii_event& sync()
+        {
+            auto hip_status = hipEventSynchronize(ev);
+            if(hip_status != hipSuccess)
+            {
+                throw hipfftw_runtime_error("an event synchronization failed.", hip_status);
+            }
+            return *this;
+        }
+
+        ~hipfftw_raii_event()
+        {
+            (void)hipEventDestroy(ev);
+        }
+
+        // disable copies and moves
+        hipfftw_raii_event(hipfftw_raii_event&& other) = delete;
+        hipfftw_raii_event& operator=(hipfftw_raii_event&& other) = delete;
+        hipfftw_raii_event(const hipfftw_raii_event& other)       = delete;
+        hipfftw_raii_event& operator=(const hipfftw_raii_event& other) = delete;
+    };
+
+    enum class hipfftw_memcpy_kind : std::underlying_type_t<hipMemcpyKind>
+    {
+        H2D = static_cast<std::underlying_type_t<hipMemcpyKind>>(hipMemcpyHostToDevice),
+        D2H = static_cast<std::underlying_type_t<hipMemcpyKind>>(hipMemcpyDeviceToHost),
+        D2D = static_cast<std::underlying_type_t<hipMemcpyKind>>(hipMemcpyDeviceToDevice),
+        NONE
+    };
+    enum class hipfftw_memcpy_direction
+    {
+        TO,
+        FROM
+    };
+
+    // constexpr used for readability
+    constexpr bool hipfftw_owns_it = true;
+
+    template <bool owning>
+    struct hipfftw_data_ptr_bundle
+    {
+    private:
+        void*                 ptr;
+        hipPointerAttribute_t attributes;
+
+        void free_owned_resources()
+        {
+            if constexpr(!owning)
+                return;
+            if(!ptr)
+                return;
+            switch(attributes.type)
+            {
+            case hipMemoryType::hipMemoryTypeManaged:
+            case hipMemoryType::hipMemoryTypeDevice:
+                (void)hipFree(ptr);
+                break;
+            case hipMemoryType::hipMemoryTypeHost:
+                (void)hipHostFree(ptr);
+                break;
+            case hipMemoryType::hipMemoryTypeUnregistered:
+#ifdef WIN32
+                _aligned_free(ptr);
+#else
+                std::free(ptr);
+#endif
+                break;
+            // hipMemoryTypeUnified & hipMemoryTypeArray not set by hipPointerGetAttributes on AMD platforms
+            case hipMemoryType::hipMemoryTypeArray:
+            case hipMemoryType::hipMemoryTypeUnified:
+            default:
+                throw hipfftw_internal_logic_error("unexpected type of allocation (supposedly "
+                                                   "owned or created by hipfftw) to be freed.");
+                break;
+            }
+            ptr = nullptr;
+        }
+
+    public:
+        hipfftw_data_ptr_bundle(void* init_ptr = nullptr)
+            : ptr(nullptr)
+        {
+            set(init_ptr);
+        }
+        void set(void* new_ptr)
+        {
+            if(ptr == new_ptr)
+                return;
+            free_owned_resources();
+            ptr = new_ptr;
+            // hipPointerGetAttributes sets default attributes
+            // (with attributes.type == hipMemoryTypeUnregistered) if
+            // new_ptr = nullptr or if new_ptr is not to be found in the map
+            // that the run-time manages (error possibly reported to a log in
+            // the latter case in case of debug runtime version)
+            auto hip_status = hipPointerGetAttributes(&attributes, new_ptr);
+            if(hip_status != hipSuccess)
+            {
+                throw hipfftw_runtime_error("pointer attributes could not be determined.",
+                                            hip_status);
+            }
+        }
+        ~hipfftw_data_ptr_bundle()
+        {
+            free_owned_resources();
+        }
+
+        template <hipfftw_memcpy_direction dir>
+        hipfftw_memcpy_kind get_copy_kind(int deviceId) const
+        {
+            static_assert(dir == hipfftw_memcpy_direction::TO
+                          || dir == hipfftw_memcpy_direction::FROM);
+            switch(attributes.type)
+            {
+            case hipMemoryType::hipMemoryTypeManaged:
+                return hipfftw_memcpy_kind::NONE; // the runtime is supposed to manage it
+            case hipMemoryType::hipMemoryTypeDevice:
+                return attributes.device != deviceId ? hipfftw_memcpy_kind::D2D
+                                                     : hipfftw_memcpy_kind::NONE;
+            case hipMemoryType::hipMemoryTypeUnregistered:
+            case hipMemoryType::hipMemoryTypeHost:
+                // TODO: check if device is APU and return false (systematically?) in that case
+                if constexpr(dir == hipfftw_memcpy_direction::TO)
+                    return hipfftw_memcpy_kind::H2D;
+                else
+                    return hipfftw_memcpy_kind::D2H;
+            // hipMemoryTypeUnified & hipMemoryTypeArray not set by hipPointerGetAttributes on AMD platforms
+            case hipMemoryType::hipMemoryTypeArray:
+            case hipMemoryType::hipMemoryTypeUnified:
+            default:
+                throw hipfftw_internal_logic_error(
+                    "unexpected type of memory to deduce (possibly-required) copy kind(s) from.");
+            }
+            // unreachable
+        }
+
+        bool is_host_accessible() const
+        {
+            return attributes.type == hipMemoryType::hipMemoryTypeUnregistered
+                   || attributes.type == hipMemoryType::hipMemoryTypeHost
+                   || attributes.type == hipMemoryType::hipMemoryTypeManaged
+                   || attributes.type == hipMemoryType::hipMemoryTypeUnified;
+        }
+
+        void* get_data_ptr() const
+        {
+            return ptr;
+        }
+
+        bool operator==(const hipfftw_data_ptr_bundle& other) const
+        {
+            return ptr == other.ptr;
+        }
+        bool operator!=(const hipfftw_data_ptr_bundle& other) const
+        {
+            return !(*this == other);
+        }
+        operator bool() const
+        {
+            return ptr;
+        }
+
+        // disable copies and move
+        hipfftw_data_ptr_bundle(const hipfftw_data_ptr_bundle&) = delete;
+        hipfftw_data_ptr_bundle& operator=(const hipfftw_data_ptr_bundle&) = delete;
+        hipfftw_data_ptr_bundle(hipfftw_data_ptr_bundle&&)                 = delete;
+        hipfftw_data_ptr_bundle& operator=(hipfftw_data_ptr_bundle&&) = delete;
+    };
+
+    int hipfftw_get_current_device_id()
+    {
+        auto ret        = hipInvalidDeviceId;
+        auto hip_status = hipGetDevice(&ret);
+        if(hip_status != hipSuccess)
+            throw hipfftw_runtime_error("the current device ID could not be determined.",
+                                        hip_status);
+        return ret;
+    }
+
+    // helper routine for assigning a device allocation to an owning data_ptr_bundle
+    void hipfftw_set_device_allocation(hipfftw_data_ptr_bundle<hipfftw_owns_it>& bundle,
+                                       size_t                                    alloc_size,
+                                       const std::string&                        buffer_qualifier,
+                                       int                                       desired_device_id)
+    {
+        void* temp = nullptr;
+        if(alloc_size > 0)
+        {
+            std::ostringstream info;
+            const auto         original_device_id = hipfftw_get_current_device_id();
+            hipError_t         hip_status         = hipSuccess;
+            // set device id to the desired one
+            if(original_device_id != desired_device_id)
+            {
+                hip_status = hipSetDevice(desired_device_id);
+                if(hip_status != hipSuccess)
+                {
+                    info << "the device ID could not be set temporarily to " << desired_device_id
+                         << " when creating the " << buffer_qualifier << " buffer.";
+                    throw hipfftw_runtime_error(info.str(), hip_status);
+                }
+            }
+            hip_status = hipMalloc(&temp, alloc_size);
+            if(hip_status != hipSuccess || !temp)
+            {
+                info << "device memory could not be allocated for the " << buffer_qualifier
+                     << " buffer.";
+                throw hipfftw_bad_gpu_alloc(info.str(), alloc_size, hip_status);
+            }
+            // reset device id to what it was
+            if(original_device_id != desired_device_id)
+            {
+                hip_status = hipSetDevice(original_device_id);
+                if(hip_status != hipSuccess)
+                {
+                    info << "the device ID could not be reset to to " << original_device_id
+                         << " upon creation of the " << buffer_qualifier << " buffer.";
+                    throw hipfftw_runtime_error(info.str(), hip_status);
+                }
+            }
+        }
+        bundle.set(temp);
+    }
+
+    struct hipfftw_plan_internal
+    {
+        hipfftw_plan_internal() = default;
+        ~hipfftw_plan_internal()
+        {
+            if(internal_rocfft_info)
+            {
+                rocfft_execution_info_destroy(internal_rocfft_info);
+                internal_rocfft_info = nullptr;
+            }
+            if(internal_rocfft_desc)
+            {
+                rocfft_plan_description_destroy(internal_rocfft_desc);
+                internal_rocfft_desc = nullptr;
+            }
+            if(internal_rocfft_plan)
+            {
+                rocfft_plan_destroy(internal_rocfft_plan);
+                internal_rocfft_plan = nullptr;
+            }
+        }
+
+        // disallow copies and moves
+        hipfftw_plan_internal(const hipfftw_plan_internal&) = delete;
+        hipfftw_plan_internal& operator=(const hipfftw_plan_internal&) = delete;
+        hipfftw_plan_internal(hipfftw_plan_internal&&)                 = delete;
+        hipfftw_plan_internal& operator=(hipfftw_plan_internal&&) = delete;
+
+        rocfft_plan             internal_rocfft_plan = nullptr;
+        rocfft_plan_description internal_rocfft_desc = nullptr;
+        rocfft_execution_info   internal_rocfft_info = nullptr;
+        rocfft_result_placement plan_placement;
+        // Sizes of the buffers so we know how much to copy
+        size_t in_bytes         = 0;
+        size_t out_bytes        = 0;
+        size_t work_buffer_size = 0;
+        // Once initialized, the plan is configured for the device id set when initializing it
+        int device_id = hipInvalidDeviceId;
+        // bundles for owned data pointers
+        hipfftw_data_ptr_bundle<hipfftw_owns_it> work_buffer;
+        // mutables below because possibly modified in new-array execute paths
+        mutable hipfftw_data_ptr_bundle<hipfftw_owns_it> in_device;
+        mutable hipfftw_data_ptr_bundle<hipfftw_owns_it> out_device;
+        // bundles for non-owned (user's) data pointers, possibly modified in new-array execute paths
+        mutable hipfftw_data_ptr_bundle<!hipfftw_owns_it> input;
+        mutable hipfftw_data_ptr_bundle<!hipfftw_owns_it> output;
+
+        void execute() const
+        {
+            if(!internal_rocfft_plan)
+                throw hipfftw_internal_logic_error(
+                    "the rocfft plan (internal detail to hipfftw) was "
+                    "unexpectedly uninitialized for execution.");
+            if(!input || !output)
+                throw hipfftw_invalid_arg("nullptr(s) cannot be used for execution data pointers.");
+            // in/out may or may not need to be copied to the device
+            const auto input_copy_kind
+                = input.get_copy_kind<hipfftw_memcpy_direction::TO>(device_id);
+            const auto output_copy_kind
+                = output.get_copy_kind<hipfftw_memcpy_direction::FROM>(device_id);
+
+            void* in_exec = input.get_data_ptr();
+            if(input_copy_kind != hipfftw_memcpy_kind::NONE)
+            {
+                auto hip_status = hipMemcpyAsync(in_device.get_data_ptr(),
+                                                 in_exec,
+                                                 in_bytes,
+                                                 static_cast<hipMemcpyKind>(input_copy_kind));
+                if(hip_status != hipSuccess)
+                {
+                    throw hipfftw_runtime_error(
+                        "the input data could not be copied into the GPU input buffer.",
+                        hip_status);
+                }
+                in_exec = in_device.get_data_ptr();
+            }
+            void* out_exec
+                = plan_placement == rocfft_placement_inplace
+                      ? in_exec
+                      : (output_copy_kind != hipfftw_memcpy_kind::NONE ? out_device.get_data_ptr()
+                                                                       : output.get_data_ptr());
+            rocfft_execute(internal_rocfft_plan, &in_exec, &out_exec, internal_rocfft_info);
+            if(output_copy_kind != hipfftw_memcpy_kind::NONE)
+            {
+                auto hip_status = hipMemcpyAsync(output.get_data_ptr(),
+                                                 out_exec,
+                                                 out_bytes,
+                                                 static_cast<hipMemcpyKind>(output_copy_kind));
+                if(hip_status != hipSuccess)
+                {
+                    throw hipfftw_runtime_error(
+                        "the output data could not be copied from the GPU output buffer.",
+                        hip_status);
+                }
+            }
+            if(output.is_host_accessible())
+            {
+                // results must be accessible from the host upon completion
+                hipfftw_raii_event sync_ev;
+                sync_ev.record().sync();
+            }
+            return;
+        }
+
+        void init_rocfft() const
+        {
+            // magic static to handle rocfft setup/cleanup
+            struct rocfft_initializer
+            {
+                rocfft_initializer()
+                {
+                    rocfft_setup();
+                }
+                ~rocfft_initializer()
+                {
+                    rocfft_cleanup();
+                }
+            };
+            static rocfft_initializer init;
+        }
+
+        // NOTE: const-qualified routine modifying mutable members
+        // Motivation: new-array execute path requires const qualifier yet it may need the
+        // input/output bundles to be updated and may need to create the I/O device buffers
+        void update_io_ptr_and_buffers(void* user_in, void* user_out) const
+        {
+            // cannot be called before internal structures were created
+            if(!internal_rocfft_info || !internal_rocfft_desc || !internal_rocfft_plan)
+                throw hipfftw_internal_logic_error(
+                    "rocfft details internal to hipfftw were unexpectedly uninitialized when "
+                    "updating input/output data pointers.");
+            // check that placement requirement is honored by the new user I/O
+            // if internal_rocfft_plan already exists
+            const auto new_io_placement
+                = user_in == user_out ? rocfft_placement_inplace : rocfft_placement_notinplace;
+            if(new_io_placement != plan_placement)
+                throw hipfftw_invalid_arg("the new execution arrays cannot imply a different "
+                                          "placement than what was set at plan's creation.");
+            // possibly modifying mutable members here:
+            input.set(user_in);
+            output.set(user_out);
+
+            // set device I/O buffer, if they're needed
+            // TODO: check if the current device is an APU and simply never use
+            // I/O device buffers in that case
+            if(input.get_copy_kind<hipfftw_memcpy_direction::TO>(device_id)
+               != hipfftw_memcpy_kind::NONE)
+            {
+                if(!in_device)
+                    hipfftw_set_device_allocation(in_device, in_bytes, "input", device_id);
+            }
+            else // in_device is not needed, free resources to minimize device memory footprint
+                in_device.set(nullptr);
+
+            if(input != output
+               && output.get_copy_kind<hipfftw_memcpy_direction::FROM>(device_id)
+                      != hipfftw_memcpy_kind::NONE)
+            {
+                if(!out_device)
+                    hipfftw_set_device_allocation(out_device, out_bytes, "output", device_id);
+            }
+            else // out_device is not needed, free resources to minimize device memory footprint
+                out_device.set(nullptr);
+
+            return;
+        }
+
+        template <rocfft_transform_type dft_type,
+                  rocfft_precision      prec,
+                  size_t                rank,
+                  typename T,
+                  size_t batch_rank>
+        void init(const std::array<T, rank>&                                  lengths_rm,
+                  const std::array<T, rank>&                                  istrides_rm,
+                  const std::array<T, rank>&                                  ostrides_rm,
+                  hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>*  user_in,
+                  hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>* user_out,
+                  const std::array<T, batch_rank>&                            batch,
+                  const std::array<T, batch_rank>&                            idist,
+                  const std::array<T, batch_rank>&                            odist,
+                  unsigned                                                    flags)
+        {
+            // compile-time validations of template specialization values
+            static_assert(1 <= rank && rank <= 3);
+            static_assert(1 == batch_rank); // only supported case at the moment
+            // single of double precision only
+            static_assert(prec == rocfft_precision_single || prec == rocfft_precision_double);
+            // assuming no overflow when converting values from T into size_t below
+            static_assert(std::numeric_limits<T>::max() <= std::numeric_limits<size_t>::max());
+            // Validation of input arguments:
+            auto is_strictly_negative = [](const T& val) { return val < static_cast<T>(0); };
+            auto is_strictly_positive = [](const T& val) { return val > static_cast<T>(0); };
+            if(!std::all_of(lengths_rm.begin(), lengths_rm.end(), is_strictly_positive))
+                throw hipfftw_invalid_arg("length(s) must be strictly positive.");
+            // Negative strides are not supported
+            for(const auto& strides : {istrides_rm, ostrides_rm})
+                if(std::any_of(strides.begin(), strides.end(), is_strictly_negative))
+                    throw hipfftw_unsupported("strides must be positive.");
+            if(!std::all_of(batch.begin(), batch.end(), is_strictly_positive))
+                throw hipfftw_invalid_arg("batch(es) must be strictly positive.");
+            // Negative distances are not supported
+            for(const auto& dist : {idist, odist})
+                if(std::any_of(dist.begin(), dist.end(), is_strictly_negative))
+                    throw hipfftw_unsupported("distance(s) must be positive.");
+            // Valid flag values are defined as bitwise OR of zero or more (unsigned) power-of-2
+            // compile-time constants, (enabling well-defined identification via bitwise manipulations).
+            if(flags
+               != (flags
+                   & (FFTW_WISDOM_ONLY | FFTW_MEASURE | FFTW_DESTROY_INPUT | FFTW_UNALIGNED
+                      | FFTW_CONSERVE_MEMORY | FFTW_EXHAUSTIVE | FFTW_PRESERVE_INPUT | FFTW_PATIENT
+                      | FFTW_ESTIMATE)))
+            {
+                throw hipfftw_invalid_arg("flags are ill-defined.");
+            }
+            if((!user_in || !user_out) && !(flags & FFTW_ESTIMATE) && !(flags & FFTW_WISDOM_ONLY))
+            {
+                throw hipfftw_invalid_arg(
+                    "input/output data pointer(s) cannot be nullptr(s) with the given flags.");
+            }
+            if(flags & FFTW_WISDOM_ONLY)
+            {
+                throw hipfftw_unsupported("FFTW_WISDOM_ONLY is not supported.");
+            }
+            if constexpr(dft_type == rocfft_transform_type_real_inverse && rank > 1)
+            {
+                if(flags & FFTW_PRESERVE_INPUT)
+                {
+                    throw hipfftw_unsupported(
+                        "FFTW_PRESERVE_INPUT is not supported for multi-dimensional C2R DFTs.");
+                }
+            }
+            plan_placement = static_cast<void*>(user_in) == static_cast<void*>(user_out)
+                                 ? rocfft_placement_inplace
+                                 : rocfft_placement_notinplace;
+            if(plan_placement == rocfft_placement_inplace)
+            {
+                // Check that the memory location is identical on input an output for the first
+                // element of every leading dimension's sub-array. In order words, using row-major
+                // convention, check that for every integer arrays
+                // {k[0], k[1], ..., k[rank - 2], 0} ":= k" and every
+                // {m[0], m[1], .., m[batch_dim-1]} ":= m" (in applicable ranges), the byte offset
+                // on input, i.e.,
+                // sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>)*
+                //      std::inner_product(m.begin(), m.end(), idist.begin(),
+                //                         std::inner_product(k.begin(), k.end(), istrides_rm.begin(), 0))
+                // must be equal to the byte offset on output, i.e.,
+                // sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>)*
+                //      std::inner_product(m.begin(), m.end(), odist.begin(),
+                //                         std::inner_product(k.begin(), k.end(), ostrides_rm.begin(), 0)).
+                // This requirement translates into the followng element-wise conditions on
+                // idist, odist, istides_rm, and ostides_rm.
+                for(auto batch_dim = 0; batch_dim < batch_rank; batch_dim++)
+                {
+                    // 0 <= m[batch_dim] < batch[batch_dim], so the corresponding distance is
+                    // irrelevant if batch[batch_dim] == 1.
+                    if(batch[batch_dim] == 1)
+                        continue;
+                    if(idist[batch_dim]
+                           * sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>)
+                       != odist[batch_dim]
+                              * sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>))
+                        throw hipfftw_invalid_arg("distances rejected for in-place configuration.");
+                }
+                for(auto dim = 0; dim < rank - 1 /* exclude leading dimension */; dim++)
+                {
+                    if(lengths_rm[dim] == 1)
+                        continue;
+                    if(istrides_rm[dim]
+                           * sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>)
+                       != ostrides_rm[dim]
+                              * sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>))
+                    {
+                        throw hipfftw_invalid_arg("strides rejected for in-place configuration..");
+                    }
+                }
+            }
+            // TODO (required when user-defined strides/distances may be used): add validity check
+            // on strides and distances for non-aliasing data
+
+            // Generalized input are validated... Let's initialize the plan!
+            init_rocfft(); // "magic" common to all template specializations
+            // compute min i/o data sizes via the index of the last relevant i/o element
+            // Note: strides and distances (resp. lengths and batch) are non-negative
+            // (resp. strictly positive), as verified above
+            size_t last_input_element_idx  = 0;
+            size_t last_output_element_idx = 0;
+            for(auto dim = 0; dim < rank; dim++)
+            {
+                const auto last_input_entry_for_dim
+                    = dft_type == rocfft_transform_type_real_inverse && dim == rank - 1
+                          ? lengths_rm[dim] / 2
+                          : lengths_rm[dim] - 1;
+                const auto last_output_entry_for_dim
+                    = dft_type == rocfft_transform_type_real_forward && dim == rank - 1
+                          ? lengths_rm[dim] / 2
+                          : lengths_rm[dim] - 1;
+                last_input_element_idx += last_input_entry_for_dim * istrides_rm[dim];
+                last_output_element_idx += last_output_entry_for_dim * ostrides_rm[dim];
+            }
+            for(auto batch_dim = 0; batch_dim < batch_rank; batch_dim++)
+            {
+                last_input_element_idx += (batch[batch_dim] - 1) * idist[batch_dim];
+                last_output_element_idx += (batch[batch_dim] - 1) * odist[batch_dim];
+            }
+            if(last_input_element_idx > std::numeric_limits<T>::max()
+               || last_output_element_idx > std::numeric_limits<T>::max())
+            {
+                throw hipfftw_unsupported(
+                    "data layouts involving element indices that exceed the maximum value "
+                    "representable in the chosen integral type are not supported (consider using "
+                    "guru64 plan creation functions).");
+            }
+            in_bytes = sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>)
+                       * (last_input_element_idx + 1);
+            out_bytes = sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>)
+                        * (last_output_element_idx + 1);
+            if(plan_placement == rocfft_placement_inplace)
+            {
+                in_bytes = out_bytes = std::max(in_bytes, out_bytes);
+            }
+
+            // Change row-major to col-major for all relevant inputs, converting from T to size_t
+            auto reverse = [](const std::array<T, rank>& in_array) {
+                auto ret = std::array<size_t, rank>();
+                std::reverse_copy(in_array.begin(), in_array.end(), ret.begin());
+                return ret;
+            };
+            const auto lengths_cm  = reverse(lengths_rm);
+            const auto istrides_cm = reverse(istrides_rm);
+            const auto ostrides_cm = reverse(ostrides_rm);
+
+            // Create plan description
+            if(rocfft_plan_description_create(&internal_rocfft_desc) != rocfft_status_success)
+            {
+                throw rocfft_failure(
+                    "an error was received from rocfft when creating the plan description.");
+            }
+            if(rocfft_plan_description_set_data_layout(
+                   internal_rocfft_desc,
+                   hipfftw_get_array_type<dft_type, hipfftw_io_label::IN>(),
+                   hipfftw_get_array_type<dft_type, hipfftw_io_label::OUT>(),
+                   nullptr /* in_offsets */,
+                   nullptr /* out_offsets */,
+                   rank /* in_strides_sizes */,
+                   istrides_cm.data(),
+                   idist[0],
+                   rank /* out_strides_size */,
+                   ostrides_cm.data(),
+                   odist[0])
+               != rocfft_status_success)
+            {
+                throw rocfft_failure(
+                    "an error was received from rocfft when setting the data layout.");
+            }
+
+            if(rocfft_plan_create(&internal_rocfft_plan,
+                                  plan_placement,
+                                  dft_type,
+                                  prec,
+                                  rank,
+                                  lengths_cm.data(),
+                                  batch[0],
+                                  internal_rocfft_desc)
+               != rocfft_status_success)
+            {
+                throw rocfft_failure(
+                    "an error was received from rocfft when creating the internal rocfft plan.");
+            }
+
+            if(rocfft_execution_info_create(&internal_rocfft_info) != rocfft_status_success)
+            {
+                throw rocfft_failure("an error was received from rocfft when creating the "
+                                     "execution info structure.");
+            }
+            if(rocfft_plan_get_work_buffer_size(internal_rocfft_plan, &work_buffer_size)
+               != rocfft_status_success)
+            {
+                throw rocfft_failure("an error was received from rocfft when fetching the size of "
+                                     "the internal plan's work area.");
+            }
+            // set device id
+            device_id = hipfftw_get_current_device_id();
+            // create and set device work buffer
+            if(work_buffer_size > 0)
+            {
+                hipfftw_set_device_allocation(work_buffer, work_buffer_size, "work", device_id);
+                if(rocfft_execution_info_set_work_buffer(
+                       internal_rocfft_info, work_buffer.get_data_ptr(), work_buffer_size)
+                   != rocfft_status_success)
+                    throw rocfft_failure(
+                        "an error was received from rocfft when setting the plan's work buffer.");
+            }
+            // set input and outut pointers and possible device buffers
+            update_io_ptr_and_buffers(user_in, user_out);
+            return;
+        }
+    };
+
+    template <rocfft_transform_type dft_type,
+              rocfft_precision      prec,
+              size_t                rank,
+              typename T,
+              size_t batch_rank = 1>
+    hipfftw_plan_internal*
+        hipfftw_create_plan(const std::array<T, rank>&                                  lengths_rm,
+                            const std::array<T, rank>&                                  istrides_rm,
+                            const std::array<T, rank>&                                  ostrides_rm,
+                            hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>*  user_in,
+                            hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>* user_out,
+                            const std::array<T, batch_rank>&                            batch,
+                            const std::array<T, batch_rank>&                            idist,
+                            const std::array<T, batch_rank>&                            odist,
+                            unsigned                                                    flags)
+    {
+        auto ret = std::make_unique<hipfftw_plan_internal>();
+        ret->init<dft_type, prec, rank, T, batch_rank>(
+            lengths_rm, istrides_rm, ostrides_rm, user_in, user_out, batch, idist, odist, flags);
+        return ret.release();
+    }
+
+    template <size_t rank,
+              size_t batch_rank,
+              typename T,
+              std::enable_if_t<std::is_integral_v<T> && (rank > 0 && batch_rank > 0), bool> = true>
+    struct hipfftw_general_layout_data
+    {
+        std::array<T, rank>       lengths;
+        std::array<T, rank>       istrides;
+        std::array<T, rank>       ostrides;
+        std::array<T, batch_rank> batches;
+        std::array<T, batch_rank> idist;
+        std::array<T, batch_rank> odist;
+        // constexpr getters
+        constexpr inline size_t get_rank() const
+        {
+            return rank;
+        }
+        constexpr inline size_t get_batch_rank() const
+        {
+            return batch_rank;
+        }
+    };
+
+    template <size_t rank, rocfft_transform_type dft_type>
+    hipfftw_general_layout_data<rank, 1, int> hipfftw_get_default_data_layout_info_rm(
+        bool is_in_place, const std::array<int, rank>& user_lengths_rm, size_t batch_sz = 1)
+    {
+        auto overflow_guarded_mult = [](int& a, const int& b) {
+            auto tmp = static_cast<std::int64_t>(a) * static_cast<std::int64_t>(b);
+            if(tmp > std::numeric_limits<int>::max() || tmp < std::numeric_limits<int>::min())
+                throw hipfftw_unsupported(
+                    "length(s) that trigger integer overflow(s) for default stride(s) and/or "
+                    "distance(s) are not supported via the default plan creation functions "
+                    "(consider guru64 plan creation functions).");
+            a = static_cast<int>(tmp);
+        };
+
+        hipfftw_general_layout_data<rank, 1, int> ret;
+        ret.lengths = user_lengths_rm;
+        int ival = 1, oval = 1;
+        for(int dim_idx = static_cast<int>(rank) - 1; dim_idx >= 0; dim_idx--)
+        {
+            ret.istrides[dim_idx] = ival;
+            ret.ostrides[dim_idx] = oval;
+            if(is_real(dft_type) && dim_idx == rank - 1)
+            {
+                int& cmplx_stride_val
+                    = dft_type == rocfft_transform_type_real_forward ? oval : ival;
+                int& real_stride_val = dft_type == rocfft_transform_type_real_forward ? ival : oval;
+                overflow_guarded_mult(cmplx_stride_val, ret.lengths[dim_idx] / 2 + 1);
+                if(is_in_place)
+                    overflow_guarded_mult(real_stride_val, 2 * (ret.lengths[dim_idx] / 2 + 1));
+                else
+                    overflow_guarded_mult(real_stride_val, ret.lengths[dim_idx]);
+            }
+            else
+            {
+                overflow_guarded_mult(ival, ret.lengths[dim_idx]);
+                overflow_guarded_mult(oval, ret.lengths[dim_idx]);
+            }
+        }
+        ret.batches[0] = batch_sz;
+        ret.idist[0]   = ival;
+        ret.odist[0]   = oval;
+        return ret;
+    }
+
+    template <rocfft_transform_type dft_type, rocfft_precision prec, size_t rank>
+    hipfftw_plan_internal* hipfftw_create_default_unbatched_plan(
+        const std::array<int, rank>&                                n,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>*  in,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>* out,
+        unsigned                                                    flags)
+    {
+        auto layout_data = hipfftw_get_default_data_layout_info_rm<rank, dft_type>(
+            static_cast<void*>(in) == static_cast<void*>(out), n);
+        return hipfftw_create_plan<dft_type, prec, rank, int>(layout_data.lengths,
+                                                              layout_data.istrides,
+                                                              layout_data.ostrides,
+                                                              in,
+                                                              out,
+                                                              layout_data.batches,
+                                                              layout_data.idist,
+                                                              layout_data.odist,
+                                                              flags);
+    }
+
+    template <rocfft_transform_type dft_type, rocfft_precision prec>
+    hipfftw_plan_internal* hipfftw_create_default_unbatched_plan(
+        int                                                         rank,
+        const int*                                                  n,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::IN>*  in,
+        hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUT>* out,
+        unsigned                                                    flags)
+    {
+        if(rank <= 0)
+            throw hipfftw_invalid_arg("ranks must be strictly positive.");
+        if(!n)
+            throw hipfftw_invalid_arg("lengths argument must not be nullptr.");
+        // rank == 1, 2, 3, or unsupported
+        switch(rank)
+        {
+        case 1:
+            return hipfftw_create_default_unbatched_plan<dft_type, prec, 1>(
+                std::array<int, 1>({n[0]}), in, out, flags);
+        case 2:
+            return hipfftw_create_default_unbatched_plan<dft_type, prec, 2>(
+                std::array<int, 2>({n[0], n[1]}), in, out, flags);
+        case 3:
+            return hipfftw_create_default_unbatched_plan<dft_type, prec, 3>(
+                std::array<int, 3>({n[0], n[1], n[2]}), in, out, flags);
+        default:
+            throw hipfftw_unsupported("rank values larger than 3 are not supported.");
+        }
+        // unreachable
+    }
+
+    inline void hipfftw_validate_sign(int sign)
+    {
+        if(sign != FFTW_FORWARD && sign != FFTW_BACKWARD)
+            throw hipfftw_invalid_arg("sign values must be FFTW_FORWARD or FFTW_BACKWARD.");
+    }
+
+    template <rocfft_precision prec, size_t rank>
+    hipfftw_plan_internal*
+        hipfftw_create_default_unbatched_complex_plan(const std::array<int, rank>&  n,
+                                                      int                           sign,
+                                                      hipfftw_complex_data_t<prec>* in,
+                                                      hipfftw_complex_data_t<prec>* out,
+                                                      unsigned                      flags)
+    {
+        hipfftw_validate_sign(sign);
+        if(sign == FFTW_FORWARD)
+            return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_forward,
+                                                         prec,
+                                                         rank>(n, in, out, flags);
+        else
+            return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_inverse,
+                                                         prec,
+                                                         rank>(n, in, out, flags);
+    }
+
+    template <rocfft_precision prec>
+    hipfftw_plan_internal*
+        hipfftw_create_default_unbatched_complex_plan(int                           rank,
+                                                      const int*                    n,
+                                                      int                           sign,
+                                                      hipfftw_complex_data_t<prec>* in,
+                                                      hipfftw_complex_data_t<prec>* out,
+                                                      unsigned                      flags)
+    {
+        hipfftw_validate_sign(sign);
+        if(sign == FFTW_FORWARD)
+            return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_forward,
+                                                         prec>(rank, n, in, out, flags);
+        else
+            return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_inverse,
+                                                         prec>(rank, n, in, out, flags);
+    }
+
+    bool hipfftw_handler_is_verbose() noexcept
+    try
+    {
+        const char* env = std::getenv("HIPFFTW_LOG_EXCEPTIONS");
+        return env && std::stoi(env) > 0;
+    }
+    catch(...)
+    {
+        return false;
+    }
+
+    inline void hipfftw_exception_handler(const char* user_facing_function) noexcept
+    try
+    {
+        throw;
+    }
+    catch(const hipfftw_invalid_arg& e)
+    {
+        if(hipfftw_handler_is_verbose())
+            std::cerr << "Invalid argument reported by " << user_facing_function
+                      << ". Details: " << e.what() << std::endl;
+    }
+    catch(const hipfftw_unsupported& e)
+    {
+        if(hipfftw_handler_is_verbose())
+            std::cerr << "Unsupported usage reported by " << user_facing_function
+                      << ". Details: " << e.what() << std::endl;
+    }
+    catch(const hipfftw_internal_logic_error& e)
+    {
+        if(hipfftw_handler_is_verbose())
+            std::cerr << "A logic error internal to hipfftw was detected and reported by "
+                      << user_facing_function << ". Details: " << e.what() << std::endl;
+    }
+    catch(const rocfft_failure& e)
+    {
+        if(hipfftw_handler_is_verbose())
+            std::cerr << "A rocfft failure was detected and reported by " << user_facing_function
+                      << ". Details: " << e.what() << std::endl;
+    }
+    catch(const hipfftw_bad_gpu_alloc& e)
+    {
+        if(hipfftw_handler_is_verbose())
+        {
+            std::cerr << "A GPU allocation failure was detected and reported by "
+                      << user_facing_function << ". Details: " << e.what();
+            if(e.hip_error != hipSuccess)
+                std::cerr << "\nThe hip error code was " << e.hip_error << ".";
+            std::cerr << "\nThe attempted size was " << e.attempted_size << " bytes" << std::endl;
+        }
+    }
+    catch(const hipfftw_bad_alloc& e)
+    {
+        if(hipfftw_handler_is_verbose())
+        {
+            std::cerr << "An allocation failure was detected and reported by "
+                      << user_facing_function << ". Details: " << e.what();
+            if(e.hip_error != hipSuccess)
+                std::cerr << "\nThe hip error code was " << e.hip_error << ".";
+            std::cerr << "\nThe attempted size was " << e.attempted_size << " bytes" << std::endl;
+        }
+    }
+    catch(const hipfftw_runtime_error& e)
+    {
+        if(hipfftw_handler_is_verbose())
+        {
+            std::cerr << "A hipfftw-specific runtime error was detected and reported by "
+                      << user_facing_function << ". Details: " << e.what();
+            if(e.hip_error != hipSuccess)
+                std::cerr << "\nThe hip error code was " << e.hip_error << ".";
+            std::cerr << std::endl;
+        }
+    }
+    catch(const std::runtime_error& e)
+    {
+        if(hipfftw_handler_is_verbose())
+            std::cerr << "A runtime error was detected and reported by " << user_facing_function
+                      << ". Details: " << e.what() << std::endl;
+    }
+    catch(...)
+    {
+        if(hipfftw_handler_is_verbose())
+            std::cerr << "An unidentified exception was detected and reported by "
+                      << user_facing_function << "." << std::endl;
+    }
+
+    constexpr size_t no_limit = std::numeric_limits<size_t>::max();
+    template <hipMemoryType type>
+    size_t hipfftw_alloc_host_limit() noexcept
+    try
+    {
+        static_assert(type == hipMemoryType::hipMemoryTypeHost
+                      || type == hipMemoryType::hipMemoryTypeUnregistered);
+        const char* env = nullptr;
+        if constexpr(type == hipMemoryType::hipMemoryTypeHost)
+            env = std::getenv("HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC");
+        else
+            env = std::getenv("HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC");
+        if(!env)
+            throw int(); // no limit set
+        const unsigned long long desired_limit = std::stoull(env);
+        return desired_limit > no_limit ? no_limit : static_cast<size_t>(desired_limit);
+    }
+    catch(...)
+    {
+        // no actual limit set, or failed to read it
+        return no_limit;
+    }
+
+    // possible TODO for hipfftw_alloc_host_accessible: consider using hipMallocManaged,
+    // first, if the device supports it [LINUX ONLY].
+    // NOTE: a limit may be set for any attempted kind of allocation via a dedicated
+    // environment variable. If the requested byte size exceeds that limit, a lesser-ranked
+    // kind of allocation is attempted instead.
+    // Current ranking:
+    // 1. pinned host allocation
+    // 2. pageable host allocation
+    template <typename element_type = void, hipMemoryType type = hipMemoryType::hipMemoryTypeHost>
+    element_type* hipfftw_alloc_host_accessible(size_t num_elements)
+    {
+        static_assert(type == hipMemoryType::hipMemoryTypeHost
+                      || type == hipMemoryType::hipMemoryTypeUnregistered);
+        // exception specific to this internal routine:
+        struct hipfftw_flow_redirection : public std::runtime_error
+        {
+            using std::runtime_error::runtime_error;
+        };
+
+        void* ret = nullptr;
+        try
+        {
+            const size_t byte_size
+                = num_elements
+                  * sizeof(
+                      std::conditional_t<std::is_same_v<void, element_type>, char, element_type>);
+            if(byte_size > 0)
+            {
+                if(byte_size > hipfftw_alloc_host_limit<type>())
+                {
+                    throw hipfftw_flow_redirection(
+                        "the requested size exceeds the limit set via a dedicated environment "
+                        "variable: a lesser-ranked allocation type may be attempted.");
+                }
+                if constexpr(type == hipMemoryType::hipMemoryTypeHost)
+                {
+                    auto hip_status = hipHostMalloc(&ret, byte_size);
+                    if(hip_status != hipSuccess || !ret)
+                    {
+                        throw hipfftw_bad_alloc(
+                            "allocation for pinned host memory failed.", byte_size, hip_status);
+                    }
+                }
+                else
+                {
+                    constexpr size_t alignment = 64;
+#ifdef WIN32
+                    ret = _aligned_malloc(byte_size, alignment);
+#else
+                    ret = std::aligned_alloc(alignment, byte_size);
+#endif
+                    if(!ret)
+                        throw hipfftw_bad_alloc("allocation for pageable host memory failed.",
+                                                byte_size);
+                }
+            }
+        }
+        catch(const hipfftw_flow_redirection& e)
+        {
+            if(hipfftw_handler_is_verbose())
+                std::cerr << "Redirecting execution flow: " << e.what() << std::endl;
+            if constexpr(type == hipMemoryType::hipMemoryTypeHost)
+            {
+                // pinned host allocation was ruled out
+                // --> attempt pageable allocation
+                return hipfftw_alloc_host_accessible<element_type,
+                                                     hipMemoryType::hipMemoryTypeUnregistered>(
+                    num_elements);
+            }
+            else
+            {
+                // no other fallback
+                ret = nullptr;
+            }
+        }
+        catch(...)
+        {
+            throw;
+        }
+        return static_cast<element_type*>(ret);
+    }
+
+    void hipfftw_free(void* ptr)
+    {
+        // create an owning data pointer bundle on given pointed to leverage
+        // the structure destructor's logic as it goes out of scope
+        hipfftw_data_ptr_bundle<hipfftw_owns_it> bundle(ptr);
+    }
+} // end of implementation details
+
+void* fftw_malloc(size_t n)
+try
+{
+    return hipfftw_alloc_host_accessible(n);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+void* fftwf_malloc(size_t n)
+try
+{
+    return hipfftw_alloc_host_accessible(n);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+double* fftw_alloc_real(size_t n)
+try
+{
+    return hipfftw_alloc_host_accessible<double>(n);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_complex* fftw_alloc_complex(size_t n)
+try
+{
+    return hipfftw_alloc_host_accessible<fftw_complex>(n);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+float* fftwf_alloc_real(size_t n)
+try
+{
+    return hipfftw_alloc_host_accessible<float>(n);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_complex* fftwf_alloc_complex(size_t n)
+try
+{
+    return hipfftw_alloc_host_accessible<fftwf_complex>(n);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+void fftw_free(void* p)
+try
+{
+    hipfftw_free(p);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return;
+}
+
+void fftwf_free(void* p)
+try
+{
+    hipfftw_free(p);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return;
+}
+
+void fftw_destroy_plan(fftw_plan plan)
+{
+    auto internal_plan = static_cast<hipfftw_plan_internal*>(plan);
+    delete internal_plan;
+}
+
+void fftwf_destroy_plan(fftwf_plan plan)
+{
+    auto internal_plan = static_cast<hipfftw_plan_internal*>(plan);
+    delete internal_plan;
+}
+
+void fftw_cleanup() {}
+
+void fftwf_cleanup() {}
+
+void fftw_execute(const fftwf_plan plan)
+try
+{
+    auto internal_plan = static_cast<const hipfftw_plan_internal*>(plan);
+    if(!internal_plan)
+        throw hipfftw_invalid_arg("plan argument cannot be nullptr.");
+    internal_plan->execute();
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return;
+}
+
+void fftwf_execute(const fftwf_plan plan)
+try
+{
+    auto internal_plan = static_cast<const hipfftw_plan_internal*>(plan);
+    if(!internal_plan)
+        throw hipfftw_invalid_arg("plan argument cannot be nullptr.");
+    internal_plan->execute();
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return;
+}
+
+fftw_plan fftw_plan_dft_1d(int n, fftw_complex* in, fftw_complex* out, int sign, unsigned flags)
+try
+{
+    constexpr int  rank = 1;
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
+        std::array<int, rank>({n}), sign, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft_1d(int n, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags)
+try
+{
+    constexpr int  rank = 1;
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
+        std::array<int, rank>({n}), sign, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan
+    fftw_plan_dft_2d(int n0, int n1, fftw_complex* in, fftw_complex* out, int sign, unsigned flags)
+try
+{
+    constexpr int  rank = 2;
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
+        std::array<int, rank>({n0, n1}), sign, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft_2d(
+    int n0, int n1, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags)
+try
+{
+    constexpr int  rank = 2;
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
+        std::array<int, rank>({n0, n1}), sign, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_dft_3d(
+    int n0, int n1, int n2, fftw_complex* in, fftw_complex* out, int sign, unsigned flags)
+try
+{
+    constexpr int  rank = 3;
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
+        std::array<int, rank>({n0, n1, n2}), sign, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft_3d(
+    int n0, int n1, int n2, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags)
+try
+{
+    constexpr int  rank = 3;
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
+        std::array<int, rank>({n0, n1, n2}), sign, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_dft(
+    int rank, const int* n, fftw_complex* in, fftw_complex* out, int sign, unsigned flags)
+try
+{
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_complex_plan<prec>(rank, n, sign, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft(
+    int rank, const int* n, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags)
+try
+{
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_complex_plan<prec>(rank, n, sign, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_dft_r2c_1d(int n, double* in, fftw_complex* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 1;
+    constexpr auto dft_type = rocfft_transform_type_real_forward;
+    constexpr auto prec     = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft_r2c_1d(int n, float* in, fftwf_complex* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 1;
+    constexpr auto dft_type = rocfft_transform_type_real_forward;
+    constexpr auto prec     = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_dft_r2c_2d(int n0, int n1, double* in, fftw_complex* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 2;
+    constexpr auto dft_type = rocfft_transform_type_real_forward;
+    constexpr auto prec     = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n0, n1}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft_r2c_2d(int n0, int n1, float* in, fftwf_complex* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 2;
+    constexpr auto dft_type = rocfft_transform_type_real_forward;
+    constexpr auto prec     = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n0, n1}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan
+    fftw_plan_dft_r2c_3d(int n0, int n1, int n2, double* in, fftw_complex* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 3;
+    constexpr auto dft_type = rocfft_transform_type_real_forward;
+    constexpr auto prec     = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n0, n1, n2}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan
+    fftwf_plan_dft_r2c_3d(int n0, int n1, int n2, float* in, fftwf_complex* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 3;
+    constexpr auto dft_type = rocfft_transform_type_real_forward;
+    constexpr auto prec     = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n0, n1, n2}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_dft_r2c(int rank, const int* n, double* in, fftw_complex* out, unsigned flags)
+try
+{
+    constexpr auto dft_type = rocfft_transform_type_real_forward;
+    constexpr auto prec     = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec>(rank, n, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft_r2c(int rank, const int* n, float* in, fftwf_complex* out, unsigned flags)
+try
+{
+    constexpr auto dft_type = rocfft_transform_type_real_forward;
+    constexpr auto prec     = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec>(rank, n, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_dft_c2r_1d(int n, fftw_complex* in, double* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 1;
+    constexpr auto dft_type = rocfft_transform_type_real_inverse;
+    constexpr auto prec     = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft_c2r_1d(int n, fftwf_complex* in, float* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 1;
+    constexpr auto dft_type = rocfft_transform_type_real_inverse;
+    constexpr auto prec     = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_dft_c2r_2d(int n0, int n1, fftw_complex* in, double* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 2;
+    constexpr auto dft_type = rocfft_transform_type_real_inverse;
+    constexpr auto prec     = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n0, n1}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft_c2r_2d(int n0, int n1, fftwf_complex* in, float* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 2;
+    constexpr auto dft_type = rocfft_transform_type_real_inverse;
+    constexpr auto prec     = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n0, n1}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan
+    fftw_plan_dft_c2r_3d(int n0, int n1, int n2, fftw_complex* in, double* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 3;
+    constexpr auto dft_type = rocfft_transform_type_real_inverse;
+    constexpr auto prec     = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n0, n1, n2}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan
+    fftwf_plan_dft_c2r_3d(int n0, int n1, int n2, fftwf_complex* in, float* out, unsigned flags)
+try
+{
+    constexpr int  rank     = 3;
+    constexpr auto dft_type = rocfft_transform_type_real_inverse;
+    constexpr auto prec     = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
+        std::array<int, rank>({n0, n1, n2}), in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_dft_c2r(int rank, const int* n, fftw_complex* in, double* out, unsigned flags)
+try
+{
+    constexpr auto dft_type = rocfft_transform_type_real_inverse;
+    constexpr auto prec     = rocfft_precision_double;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec>(rank, n, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_dft_c2r(int rank, const int* n, fftwf_complex* in, float* out, unsigned flags)
+try
+{
+    constexpr auto dft_type = rocfft_transform_type_real_inverse;
+    constexpr auto prec     = rocfft_precision_single;
+    return hipfftw_create_default_unbatched_plan<dft_type, prec>(rank, n, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+void   fftw_print_plan(const fftw_plan) {}
+void   fftwf_print_plan(const fftwf_plan) {}
+void   fftw_set_timelimit(double) {}
+void   fftwf_set_timelimit(double) {}
+double fftw_cost(const fftw_plan)
+{
+    return 0.0;
+}
+double fftwf_cost(const fftw_plan)
+{
+    return 0.0;
+}
+void fftw_flops(const fftw_plan, double*, double*, double*) {}
+void fftwf_flops(const fftw_plan, double*, double*, double*) {}

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -429,129 +429,16 @@ namespace
         // mutables below because possibly modified in new-array execute paths
         mutable hipfftw_data_ptr_bundle<hipfftw_owns_it> in_device;
         mutable hipfftw_data_ptr_bundle<hipfftw_owns_it> out_device;
-        // bundles for non-owned (user's) data pointers, possibly modified in new-array execute paths
-        mutable hipfftw_data_ptr_bundle<!hipfftw_owns_it> input;
-        mutable hipfftw_data_ptr_bundle<!hipfftw_owns_it> output;
+        // bundles for non-owned (user's) data pointers used at plan creation
+        hipfftw_data_ptr_bundle<!hipfftw_owns_it> plan_creation_input;
+        hipfftw_data_ptr_bundle<!hipfftw_owns_it> plan_creation_output;
 
         void execute() const
         {
-            if(!internal_rocfft_plan)
-                throw hipfftw_internal_logic_error(
-                    "the rocfft plan (internal detail to hipfftw) was "
-                    "unexpectedly uninitialized for execution.");
-            if(!input || !output)
-                throw hipfftw_invalid_arg("nullptr(s) cannot be used for execution data pointers.");
-            // in/out may or may not need to be copied to the device
-            const auto input_copy_kind
-                = input.get_copy_kind<hipfftw_memcpy_direction::TO>(device_id);
-            const auto output_copy_kind
-                = output.get_copy_kind<hipfftw_memcpy_direction::FROM>(device_id);
-
-            void* in_exec = input.get_data_ptr();
-            if(input_copy_kind != hipfftw_memcpy_kind::NONE)
-            {
-                auto hip_status = hipMemcpyAsync(in_device.get_data_ptr(),
-                                                 in_exec,
-                                                 in_bytes,
-                                                 static_cast<hipMemcpyKind>(input_copy_kind));
-                if(hip_status != hipSuccess)
-                {
-                    throw hipfftw_runtime_error(
-                        "the input data could not be copied into the GPU input buffer.",
-                        hip_status);
-                }
-                in_exec = in_device.get_data_ptr();
-            }
-            void* out_exec
-                = plan_placement == rocfft_placement_inplace
-                      ? in_exec
-                      : (output_copy_kind != hipfftw_memcpy_kind::NONE ? out_device.get_data_ptr()
-                                                                       : output.get_data_ptr());
-            rocfft_execute(internal_rocfft_plan, &in_exec, &out_exec, internal_rocfft_info);
-            if(output_copy_kind != hipfftw_memcpy_kind::NONE)
-            {
-                auto hip_status = hipMemcpyAsync(output.get_data_ptr(),
-                                                 out_exec,
-                                                 out_bytes,
-                                                 static_cast<hipMemcpyKind>(output_copy_kind));
-                if(hip_status != hipSuccess)
-                {
-                    throw hipfftw_runtime_error(
-                        "the output data could not be copied from the GPU output buffer.",
-                        hip_status);
-                }
-            }
-            if(output.is_host_accessible())
-            {
-                // results must be accessible from the host upon completion
-                hipfftw_raii_event sync_ev;
-                sync_ev.record().sync();
-            }
-            return;
+            internal_execute(plan_creation_input, plan_creation_output);
         }
-
-        void init_rocfft() const
-        {
-            // magic static to handle rocfft setup/cleanup
-            struct rocfft_initializer
-            {
-                rocfft_initializer()
-                {
-                    rocfft_setup();
-                }
-                ~rocfft_initializer()
-                {
-                    rocfft_cleanup();
-                }
-            };
-            static rocfft_initializer init;
-        }
-
-        // NOTE: const-qualified routine modifying mutable members
-        // Motivation: new-array execute path requires const qualifier yet it may need the
-        // input/output bundles to be updated and may need to create the I/O device buffers
-        void update_io_ptr_and_buffers(void* user_in, void* user_out) const
-        {
-            // cannot be called before internal structures were created
-            if(!internal_rocfft_info || !internal_rocfft_desc || !internal_rocfft_plan)
-                throw hipfftw_internal_logic_error(
-                    "rocfft details internal to hipfftw were unexpectedly uninitialized when "
-                    "updating input/output data pointers.");
-            // check that placement requirement is honored by the new user I/O
-            // if internal_rocfft_plan already exists
-            const auto new_io_placement
-                = user_in == user_out ? rocfft_placement_inplace : rocfft_placement_notinplace;
-            if(new_io_placement != plan_placement)
-                throw hipfftw_invalid_arg("the new execution arrays cannot imply a different "
-                                          "placement than what was set at plan's creation.");
-            // possibly modifying mutable members here:
-            input.set(user_in);
-            output.set(user_out);
-
-            // set device I/O buffer, if they're needed
-            // TODO: check if the current device is an APU and simply never use
-            // I/O device buffers in that case
-            if(input.get_copy_kind<hipfftw_memcpy_direction::TO>(device_id)
-               != hipfftw_memcpy_kind::NONE)
-            {
-                if(!in_device)
-                    hipfftw_set_device_allocation(in_device, in_bytes, "input", device_id);
-            }
-            else // in_device is not needed, free resources to minimize device memory footprint
-                in_device.set(nullptr);
-
-            if(input != output
-               && output.get_copy_kind<hipfftw_memcpy_direction::FROM>(device_id)
-                      != hipfftw_memcpy_kind::NONE)
-            {
-                if(!out_device)
-                    hipfftw_set_device_allocation(out_device, out_bytes, "output", device_id);
-            }
-            else // out_device is not needed, free resources to minimize device memory footprint
-                out_device.set(nullptr);
-
-            return;
-        }
+        // TODO:
+        // void execute(new_in, new_out) const {...}
 
         template <rocfft_transform_type dft_type,
                   rocfft_precision      prec,
@@ -617,7 +504,9 @@ namespace
                         "FFTW_PRESERVE_INPUT is not supported for multi-dimensional C2R DFTs.");
                 }
             }
-            plan_placement = static_cast<void*>(user_in) == static_cast<void*>(user_out)
+            plan_creation_input.set(user_in);
+            plan_creation_output.set(user_out);
+            plan_placement = plan_creation_input == plan_creation_output
                                  ? rocfft_placement_inplace
                                  : rocfft_placement_notinplace;
             if(plan_placement == rocfft_placement_inplace)
@@ -784,8 +673,114 @@ namespace
                     throw rocfft_failure(
                         "an error was received from rocfft when setting the plan's work buffer.");
             }
-            // set input and outut pointers and possible device buffers
-            update_io_ptr_and_buffers(user_in, user_out);
+            // default execution uses the I/O data pointer used at creation
+            set_io_device_buffers_for_execution(plan_creation_input, plan_creation_output);
+            return;
+        }
+
+    private:
+        void init_rocfft() const
+        {
+            // magic static to handle rocfft setup/cleanup
+            struct rocfft_initializer
+            {
+                rocfft_initializer()
+                {
+                    rocfft_setup();
+                }
+                ~rocfft_initializer()
+                {
+                    rocfft_cleanup();
+                }
+            };
+            static rocfft_initializer init;
+        }
+
+        // NOTE: const-qualified routine possibly modifying mutable members
+        // Motivation: new-array execute paths require const qualifier yet they may need
+        // to create the I/O device buffers
+        void set_io_device_buffers_for_execution(
+            const hipfftw_data_ptr_bundle<!hipfftw_owns_it>& intended_execute_in,
+            const hipfftw_data_ptr_bundle<!hipfftw_owns_it>& intended_execute_out) const
+        {
+            // TODO: check if the current device is an APU and simply never use
+            // I/O device buffers in that case
+            if(in_device && (plan_placement == rocfft_placement_inplace || out_device))
+            {
+                // buffers are ready to go, nothing to do
+                return;
+            }
+            // set device I/O buffer, if they're needed (possibly modifying mutable members)
+            if(!in_device
+               && intended_execute_in.get_copy_kind<hipfftw_memcpy_direction::TO>(device_id)
+                      != hipfftw_memcpy_kind::NONE)
+            {
+                hipfftw_set_device_allocation(in_device, in_bytes, "input", device_id);
+            }
+
+            if(plan_placement != rocfft_placement_inplace && !out_device
+               && intended_execute_out.get_copy_kind<hipfftw_memcpy_direction::FROM>(device_id)
+                      != hipfftw_memcpy_kind::NONE)
+            {
+                hipfftw_set_device_allocation(out_device, out_bytes, "output", device_id);
+            }
+            return;
+        }
+
+        void internal_execute(const hipfftw_data_ptr_bundle<!hipfftw_owns_it>& exec_in,
+                              const hipfftw_data_ptr_bundle<!hipfftw_owns_it>& exec_out) const
+        {
+            if(!internal_rocfft_plan)
+                throw hipfftw_internal_logic_error("the rocfft plan (internal detail to hipfftw) "
+                                                   "was unexpectedly uninitialized for execution.");
+            if(!exec_in || !exec_out)
+                throw hipfftw_invalid_arg("nullptr(s) cannot be used for execution data pointers.");
+            // in/out may or may not need to be copied to the device
+            const auto input_copy_kind
+                = exec_in.get_copy_kind<hipfftw_memcpy_direction::TO>(device_id);
+            const auto output_copy_kind
+                = exec_out.get_copy_kind<hipfftw_memcpy_direction::FROM>(device_id);
+
+            void* exec_in_ptr = exec_in.get_data_ptr();
+            if(input_copy_kind != hipfftw_memcpy_kind::NONE)
+            {
+                auto hip_status = hipMemcpyAsync(in_device.get_data_ptr(),
+                                                 exec_in_ptr,
+                                                 in_bytes,
+                                                 static_cast<hipMemcpyKind>(input_copy_kind));
+                if(hip_status != hipSuccess)
+                {
+                    throw hipfftw_runtime_error(
+                        "the input data could not be copied into the GPU input buffer.",
+                        hip_status);
+                }
+                exec_in_ptr = in_device.get_data_ptr();
+            }
+            void* exec_out_ptr
+                = plan_placement == rocfft_placement_inplace
+                      ? exec_in_ptr
+                      : (output_copy_kind != hipfftw_memcpy_kind::NONE ? out_device.get_data_ptr()
+                                                                       : exec_out.get_data_ptr());
+            rocfft_execute(internal_rocfft_plan, &exec_in_ptr, &exec_out_ptr, internal_rocfft_info);
+            if(output_copy_kind != hipfftw_memcpy_kind::NONE)
+            {
+                auto hip_status = hipMemcpyAsync(exec_out.get_data_ptr(),
+                                                 exec_out_ptr,
+                                                 out_bytes,
+                                                 static_cast<hipMemcpyKind>(output_copy_kind));
+                if(hip_status != hipSuccess)
+                {
+                    throw hipfftw_runtime_error(
+                        "the output data could not be copied from the GPU output buffer.",
+                        hip_status);
+                }
+            }
+            if(exec_out.is_host_accessible())
+            {
+                // results must be accessible from the host upon completion
+                hipfftw_raii_event sync_ev;
+                sync_ev.record().sync();
+            }
             return;
         }
     };

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -724,7 +724,7 @@ inline void compare_round_trip_inverse(Tparams&              params,
         << params.str();
 
     EXPECT_TRUE(diff.l_2 / cpu_input_norm.l_2
-                < sqrt(log2(total_length)) * type_epsilon(params.precision))
+                <= sqrt(log2(total_length)) * type_epsilon(params.precision))
         << "L2 test failed. L2: " << diff.l_2
         << "\tnormalized L2: " << diff.l_2 / cpu_input_norm.l_2
         << "\tepsilon: " << sqrt(log2(total_length)) * type_epsilon(params.precision)

--- a/projects/hipfft/shared/environment.h
+++ b/projects/hipfft/shared/environment.h
@@ -92,6 +92,6 @@ struct EnvironmentSetTemp
         else
             rocfft_setenv(var.c_str(), oldvalue.c_str());
     }
-    std::string var;
-    std::string oldvalue;
+    const std::string var;
+    std::string       oldvalue;
 };

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -74,6 +74,31 @@ enum fft_precision
     fft_precision_double,
 };
 
+enum fft_io
+{
+    fft_io_in,
+    fft_io_out
+};
+
+static constexpr bool is_real(const fft_transform_type& dft_type)
+{
+    return dft_type == fft_transform_type_real_forward
+           || dft_type == fft_transform_type_real_inverse;
+}
+static constexpr bool is_complex(const fft_transform_type& dft_type)
+{
+    return !is_real(dft_type);
+}
+static constexpr bool is_fwd(const fft_transform_type& dft_type)
+{
+    return dft_type == fft_transform_type_real_forward
+           || dft_type == fft_transform_type_complex_forward;
+}
+static constexpr bool is_bwd(const fft_transform_type& dft_type)
+{
+    return !is_fwd(dft_type);
+}
+
 // Used for CLI11 parsing of precision enum
 static bool lexical_cast(const std::string& word, fft_precision& precision)
 {
@@ -804,13 +829,12 @@ public:
 
     bool is_inverse() const
     {
-        return transform_type == fft_transform_type_complex_inverse
-               || transform_type == fft_transform_type_real_inverse;
+        return is_bwd(transform_type);
     }
 
     bool is_forward() const
     {
-        return !is_inverse();
+        return is_fwd(transform_type);
     }
 
     // Convert to string for output.

--- a/projects/hipfft/shared/gpubuf.h
+++ b/projects/hipfft/shared/gpubuf.h
@@ -38,6 +38,7 @@ public:
         std::swap(owned, other.owned);
         std::swap(bsize, other.bsize);
         std::swap(device, other.device);
+        std::swap(is_managed_memory, other.is_managed_memory);
     }
     gpubuf_t& operator=(gpubuf_t&& other)
     {
@@ -45,6 +46,7 @@ public:
         std::swap(owned, other.owned);
         std::swap(bsize, other.bsize);
         std::swap(device, other.device);
+        std::swap(is_managed_memory, other.is_managed_memory);
         return *this;
     }
     gpubuf_t(const gpubuf_t&) = delete;
@@ -53,9 +55,10 @@ public:
     static gpubuf_t make_nonowned(T* p, size_t size_bytes = 0)
     {
         gpubuf_t ret;
-        ret.owned = false;
-        ret.buf   = p;
-        ret.bsize = size_bytes;
+        ret.owned             = false;
+        ret.buf               = p;
+        ret.bsize             = size_bytes;
+        ret.is_managed_memory = false; // irrelevant if not owned
         return ret;
     }
 
@@ -69,7 +72,7 @@ public:
         return std::getenv("ROCFFT_MALLOC_MANAGED");
     }
 
-    hipError_t alloc(const size_t size)
+    hipError_t alloc(const size_t size, bool make_it_shared = false)
     {
         // remember the device that was current as of alloc, so we can
         // free on the correct device
@@ -77,10 +80,10 @@ public:
         if(ret != hipSuccess)
             return ret;
 
-        bsize                     = size;
-        static bool alloc_managed = use_alloc_managed();
+        bsize             = size;
+        is_managed_memory = use_alloc_managed() || make_it_shared;
         free();
-        ret = alloc_managed ? hipMallocManaged(&buf, bsize) : hipMalloc(&buf, bsize);
+        ret = is_managed_memory ? hipMallocManaged(&buf, bsize) : hipMalloc(&buf, bsize);
         if(ret != hipSuccess)
         {
             buf   = nullptr;
@@ -142,9 +145,10 @@ private:
     void* buf = nullptr;
     // whether this object owns the 'buf' pointer (and hence needs to
     // free it)
-    bool   owned  = true;
-    size_t bsize  = 0;
-    int    device = 0;
+    bool   owned             = true;
+    bool   is_managed_memory = false;
+    size_t bsize             = 0;
+    int    device            = 0;
 };
 
 // default gpubuf that gives out void* pointers

--- a/projects/hipfft/shared/hostbuf.h
+++ b/projects/hipfft/shared/hostbuf.h
@@ -53,6 +53,7 @@ public:
         std::swap(owned, other.owned);
         std::swap(bsize, other.bsize);
         std::swap(bsize_track, other.bsize_track);
+        std::swap(is_pinned_memory, other.is_pinned_memory);
     }
     hostbuf_t& operator=(hostbuf_t&& other)
     {
@@ -60,6 +61,7 @@ public:
         std::swap(owned, other.owned);
         std::swap(bsize, other.bsize);
         std::swap(bsize_track, other.bsize_track);
+        std::swap(is_pinned_memory, other.is_pinned_memory);
         return *this;
     }
     hostbuf_t(const hostbuf_t&) = delete;
@@ -68,10 +70,11 @@ public:
     static hostbuf_t make_nonowned(T* p, size_t size_bytes = 0)
     {
         hostbuf_t ret;
-        ret.owned       = false;
-        ret.buf         = p;
-        ret.bsize       = size_bytes;
-        ret.bsize_track = 0;
+        ret.owned            = false;
+        ret.buf              = p;
+        ret.bsize            = size_bytes;
+        ret.bsize_track      = 0;
+        ret.is_pinned_memory = false; // irrelevant anyways if not owned
         return ret;
     }
 
@@ -80,7 +83,7 @@ public:
         free();
     }
 
-    void alloc(size_t size)
+    void alloc(size_t size, bool make_it_pinned = false)
     {
         free();
 
@@ -96,43 +99,60 @@ public:
             throw HOSTBUF_MEM_USAGE{msg.str()};
         }
 
-        // we're aligning to multiples of 64 bytes, so round the
-        // allocation size up to the nearest 64 to keep ASAN happy
-        if(size % 64)
+        if(make_it_pinned)
         {
-            size += 64 - size % 64;
-        }
-
-        // FFTW requires aligned allocations to use faster SIMD instructions.
-        // If enabling hugepages, align to 2 MiB. Otherwise, aligning to
-        // 64 bytes is enough for AVX instructions up to AVX512.
-#ifdef WIN32
-        buf = _aligned_malloc(size, 64);
-#else
-        // On Linux, ask for hugepages to reduce TLB pressure and
-        // improve performance.  Allocations need to be aligned to
-        // the hugepage size, and rounded up to the next whole
-        // hugepage.
-        static const size_t TWO_MiB = 2 * 1024 * 1024;
-        if(size >= TWO_MiB)
-        {
-            size_t rounded_size = DivRoundingUp(size, TWO_MiB) * TWO_MiB;
-            buf                 = aligned_alloc(TWO_MiB, rounded_size);
-            madvise(buf, rounded_size, MADV_HUGEPAGE);
+            if(hipHostMalloc(&buf, size) != hipSuccess)
+            {
+                buf   = nullptr;
+                bsize = 0;
+            }
         }
         else
-            buf = aligned_alloc(64, size);
+        {
+            // we're aligning to multiples of 64 bytes, so round the
+            // allocation size up to the nearest 64 to keep ASAN happy
+            if(size % 64)
+            {
+                size += 64 - size % 64;
+            }
+
+            // FFTW requires aligned allocations to use faster SIMD instructions.
+            // If enabling hugepages, align to 2 MiB. Otherwise, aligning to
+            // 64 bytes is enough for AVX instructions up to AVX512.
+#ifdef WIN32
+            buf = _aligned_malloc(size, 64);
+#else
+            // On Linux, ask for hugepages to reduce TLB pressure and
+            // improve performance.  Allocations need to be aligned to
+            // the hugepage size, and rounded up to the next whole
+            // hugepage.
+            static const size_t TWO_MiB = 2 * 1024 * 1024;
+            if(size >= TWO_MiB)
+            {
+                size_t rounded_size = DivRoundingUp(size, TWO_MiB) * TWO_MiB;
+                buf                 = aligned_alloc(TWO_MiB, rounded_size);
+                madvise(buf, rounded_size, MADV_HUGEPAGE);
+            }
+            else
+                buf = aligned_alloc(64, size);
 #endif
+        }
         if(!buf)
             throw std::bad_alloc();
 
-        bsize_track = size;
+        is_pinned_memory = make_it_pinned;
+        bsize_track      = size;
         total_used_mem += bsize_track;
     }
 
     size_t size() const
     {
         return bsize;
+    }
+
+    bool is_pinned() const
+    {
+        return is_pinned_memory;
     }
 
     void free()
@@ -142,12 +162,18 @@ public:
             if(owned)
             {
                 total_used_mem -= bsize_track;
-
+                if(is_pinned_memory)
+                {
+                    (void)hipHostFree(buf);
+                }
+                else
+                {
 #ifdef WIN32
-                _aligned_free(buf);
+                    _aligned_free(buf);
 #else
-                std::free(buf);
+                    std::free(buf);
 #endif
+                }
             }
             buf   = nullptr;
             bsize = bsize_track = 0;
@@ -169,10 +195,10 @@ public:
     }
 
     // Copy method
-    hostbuf_t copy() const
+    hostbuf_t copy(bool make_copy_pinned = false) const
     {
         hostbuf_t copy;
-        copy.alloc(bsize);
+        copy.alloc(bsize, make_copy_pinned);
         memcpy(copy.buf, buf, bsize);
         return copy;
     }
@@ -205,8 +231,9 @@ private:
     void* buf = nullptr;
     // whether this object owns the 'buf' pointer (and hence needs to
     // free it)
-    bool   owned = true;
-    size_t bsize = 0;
+    bool   owned            = true;
+    bool   is_pinned_memory = false;
+    size_t bsize            = 0;
 
     // Buffer size for tracking total memory usage.
     // When buffer is shrunk in place, bsize_track is not changed.

--- a/projects/hipfft/shared/params_gen.h
+++ b/projects/hipfft/shared/params_gen.h
@@ -36,6 +36,11 @@ const static std::vector<fft_precision> precision_range_sp_dp
 
 const static std::vector<fft_result_placement> place_range
     = {fft_placement_inplace, fft_placement_notinplace};
+const static std::vector<fft_transform_type> trans_type_range_full
+    = {fft_transform_type_complex_forward,
+       fft_transform_type_real_forward,
+       fft_transform_type_complex_inverse,
+       fft_transform_type_real_inverse};
 const static std::vector<fft_transform_type> trans_type_range
     = {fft_transform_type_complex_forward, fft_transform_type_real_forward};
 const static std::vector<fft_transform_type> trans_type_range_complex

--- a/projects/hipfft/shared/sys_mem.h
+++ b/projects/hipfft/shared/sys_mem.h
@@ -35,6 +35,8 @@
 #endif
 
 static constexpr size_t ONE_GiB = 1 << 30;
+static constexpr size_t ONE_MiB = 1 << 20;
+static constexpr size_t ONE_KiB = 1 << 10;
 
 inline size_t bytes_to_GiB(const size_t bytes)
 {

--- a/projects/hipfft/shared/test_params.h
+++ b/projects/hipfft/shared/test_params.h
@@ -37,6 +37,8 @@ extern double complex_interleaved_prob_factor;
 extern double real_prob_factor;
 extern double complex_planar_prob_factor;
 extern double callback_prob_factor;
+extern size_t max_length_for_hipfftw_test;
+extern size_t max_io_gb_for_hipfftw_test;
 
 extern double half_epsilon;
 extern double single_epsilon;

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -718,7 +718,7 @@ inline void compare_round_trip_inverse(Tparams&              params,
         << params.str();
 
     EXPECT_TRUE(diff.l_2 / cpu_input_norm.l_2
-                < sqrt(log2(total_length)) * type_epsilon(params.precision))
+                <= sqrt(log2(total_length)) * type_epsilon(params.precision))
         << "L2 test failed. L2: " << diff.l_2
         << "\tnormalized L2: " << diff.l_2 / cpu_input_norm.l_2
         << "\tepsilon: " << sqrt(log2(total_length)) * type_epsilon(params.precision)

--- a/projects/rocfft/shared/environment.h
+++ b/projects/rocfft/shared/environment.h
@@ -92,6 +92,6 @@ struct EnvironmentSetTemp
         else
             rocfft_setenv(var.c_str(), oldvalue.c_str());
     }
-    std::string var;
-    std::string oldvalue;
+    const std::string var;
+    std::string       oldvalue;
 };

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -74,6 +74,31 @@ enum fft_precision
     fft_precision_double,
 };
 
+enum fft_io
+{
+    fft_io_in,
+    fft_io_out
+};
+
+static constexpr bool is_real(const fft_transform_type& dft_type)
+{
+    return dft_type == fft_transform_type_real_forward
+           || dft_type == fft_transform_type_real_inverse;
+}
+static constexpr bool is_complex(const fft_transform_type& dft_type)
+{
+    return !is_real(dft_type);
+}
+static constexpr bool is_fwd(const fft_transform_type& dft_type)
+{
+    return dft_type == fft_transform_type_real_forward
+           || dft_type == fft_transform_type_complex_forward;
+}
+static constexpr bool is_bwd(const fft_transform_type& dft_type)
+{
+    return !is_fwd(dft_type);
+}
+
 // Used for CLI11 parsing of precision enum
 static bool lexical_cast(const std::string& word, fft_precision& precision)
 {
@@ -818,13 +843,12 @@ public:
 
     bool is_inverse() const
     {
-        return transform_type == fft_transform_type_complex_inverse
-               || transform_type == fft_transform_type_real_inverse;
+        return is_bwd(transform_type);
     }
 
     bool is_forward() const
     {
-        return !is_inverse();
+        return is_fwd(transform_type);
     }
 
     // Convert to string for output.

--- a/projects/rocfft/shared/gpubuf.h
+++ b/projects/rocfft/shared/gpubuf.h
@@ -38,6 +38,7 @@ public:
         std::swap(owned, other.owned);
         std::swap(bsize, other.bsize);
         std::swap(device, other.device);
+        std::swap(is_managed_memory, other.is_managed_memory);
     }
     gpubuf_t& operator=(gpubuf_t&& other)
     {
@@ -45,6 +46,7 @@ public:
         std::swap(owned, other.owned);
         std::swap(bsize, other.bsize);
         std::swap(device, other.device);
+        std::swap(is_managed_memory, other.is_managed_memory);
         return *this;
     }
     gpubuf_t(const gpubuf_t&) = delete;
@@ -53,9 +55,10 @@ public:
     static gpubuf_t make_nonowned(T* p, size_t size_bytes = 0)
     {
         gpubuf_t ret;
-        ret.owned = false;
-        ret.buf   = p;
-        ret.bsize = size_bytes;
+        ret.owned             = false;
+        ret.buf               = p;
+        ret.bsize             = size_bytes;
+        ret.is_managed_memory = false;
         return ret;
     }
 
@@ -69,7 +72,7 @@ public:
         return std::getenv("ROCFFT_MALLOC_MANAGED");
     }
 
-    hipError_t alloc(const size_t size)
+    hipError_t alloc(const size_t size, bool make_it_shared = false)
     {
         // remember the device that was current as of alloc, so we can
         // free on the correct device
@@ -77,10 +80,10 @@ public:
         if(ret != hipSuccess)
             return ret;
 
-        bsize                     = size;
-        static bool alloc_managed = use_alloc_managed();
+        bsize             = size;
+        is_managed_memory = use_alloc_managed() || make_it_shared;
         free();
-        ret = alloc_managed ? hipMallocManaged(&buf, bsize) : hipMalloc(&buf, bsize);
+        ret = is_managed_memory ? hipMallocManaged(&buf, bsize) : hipMalloc(&buf, bsize);
         if(ret != hipSuccess)
         {
             buf   = nullptr;
@@ -142,9 +145,10 @@ private:
     void* buf = nullptr;
     // whether this object owns the 'buf' pointer (and hence needs to
     // free it)
-    bool   owned  = true;
-    size_t bsize  = 0;
-    int    device = 0;
+    bool   owned             = true;
+    bool   is_managed_memory = false;
+    size_t bsize             = 0;
+    int    device            = 0;
 };
 
 // default gpubuf that gives out void* pointers

--- a/projects/rocfft/shared/hostbuf.h
+++ b/projects/rocfft/shared/hostbuf.h
@@ -53,6 +53,7 @@ public:
         std::swap(owned, other.owned);
         std::swap(bsize, other.bsize);
         std::swap(bsize_track, other.bsize_track);
+        std::swap(is_pinned_memory, other.is_pinned_memory);
     }
     hostbuf_t& operator=(hostbuf_t&& other)
     {
@@ -60,6 +61,7 @@ public:
         std::swap(owned, other.owned);
         std::swap(bsize, other.bsize);
         std::swap(bsize_track, other.bsize_track);
+        std::swap(is_pinned_memory, other.is_pinned_memory);
         return *this;
     }
     hostbuf_t(const hostbuf_t&) = delete;
@@ -68,10 +70,11 @@ public:
     static hostbuf_t make_nonowned(T* p, size_t size_bytes = 0)
     {
         hostbuf_t ret;
-        ret.owned       = false;
-        ret.buf         = p;
-        ret.bsize       = size_bytes;
-        ret.bsize_track = 0;
+        ret.owned            = false;
+        ret.buf              = p;
+        ret.bsize            = size_bytes;
+        ret.bsize_track      = 0;
+        ret.is_pinned_memory = false; // irrelevant anyways if not owned
         return ret;
     }
 
@@ -80,7 +83,7 @@ public:
         free();
     }
 
-    void alloc(size_t size)
+    void alloc(size_t size, bool make_it_pinned = false)
     {
         free();
 
@@ -96,43 +99,60 @@ public:
             throw HOSTBUF_MEM_USAGE{msg.str()};
         }
 
-        // we're aligning to multiples of 64 bytes, so round the
-        // allocation size up to the nearest 64 to keep ASAN happy
-        if(size % 64)
+        if(make_it_pinned)
         {
-            size += 64 - size % 64;
-        }
-
-        // FFTW requires aligned allocations to use faster SIMD instructions.
-        // If enabling hugepages, align to 2 MiB. Otherwise, aligning to
-        // 64 bytes is enough for AVX instructions up to AVX512.
-#ifdef WIN32
-        buf = _aligned_malloc(size, 64);
-#else
-        // On Linux, ask for hugepages to reduce TLB pressure and
-        // improve performance.  Allocations need to be aligned to
-        // the hugepage size, and rounded up to the next whole
-        // hugepage.
-        static const size_t TWO_MiB = 2 * 1024 * 1024;
-        if(size >= TWO_MiB)
-        {
-            size_t rounded_size = DivRoundingUp(size, TWO_MiB) * TWO_MiB;
-            buf                 = aligned_alloc(TWO_MiB, rounded_size);
-            madvise(buf, rounded_size, MADV_HUGEPAGE);
+            if(hipHostMalloc(&buf, size) != hipSuccess)
+            {
+                buf   = nullptr;
+                bsize = 0;
+            }
         }
         else
-            buf = aligned_alloc(64, size);
+        {
+            // we're aligning to multiples of 64 bytes, so round the
+            // allocation size up to the nearest 64 to keep ASAN happy
+            if(size % 64)
+            {
+                size += 64 - size % 64;
+            }
+
+            // FFTW requires aligned allocations to use faster SIMD instructions.
+            // If enabling hugepages, align to 2 MiB. Otherwise, aligning to
+            // 64 bytes is enough for AVX instructions up to AVX512.
+#ifdef WIN32
+            buf = _aligned_malloc(size, 64);
+#else
+            // On Linux, ask for hugepages to reduce TLB pressure and
+            // improve performance.  Allocations need to be aligned to
+            // the hugepage size, and rounded up to the next whole
+            // hugepage.
+            static const size_t TWO_MiB = 2 * 1024 * 1024;
+            if(size >= TWO_MiB)
+            {
+                size_t rounded_size = DivRoundingUp(size, TWO_MiB) * TWO_MiB;
+                buf                 = aligned_alloc(TWO_MiB, rounded_size);
+                madvise(buf, rounded_size, MADV_HUGEPAGE);
+            }
+            else
+                buf = aligned_alloc(64, size);
 #endif
+        }
         if(!buf)
             throw std::bad_alloc();
 
-        bsize_track = size;
+        is_pinned_memory = make_it_pinned;
+        bsize_track      = size;
         total_used_mem += bsize_track;
     }
 
     size_t size() const
     {
         return bsize;
+    }
+
+    bool is_pinned() const
+    {
+        return is_pinned_memory;
     }
 
     void free()
@@ -142,12 +162,18 @@ public:
             if(owned)
             {
                 total_used_mem -= bsize_track;
-
+                if(is_pinned_memory)
+                {
+                    (void)hipHostFree(buf);
+                }
+                else
+                {
 #ifdef WIN32
-                _aligned_free(buf);
+                    _aligned_free(buf);
 #else
-                std::free(buf);
+                    std::free(buf);
 #endif
+                }
             }
             buf   = nullptr;
             bsize = bsize_track = 0;
@@ -169,10 +195,10 @@ public:
     }
 
     // Copy method
-    hostbuf_t copy() const
+    hostbuf_t copy(bool make_copy_pinned = false) const
     {
         hostbuf_t copy;
-        copy.alloc(bsize);
+        copy.alloc(bsize, make_copy_pinned);
         memcpy(copy.buf, buf, bsize);
         return copy;
     }
@@ -205,8 +231,9 @@ private:
     void* buf = nullptr;
     // whether this object owns the 'buf' pointer (and hence needs to
     // free it)
-    bool   owned = true;
-    size_t bsize = 0;
+    bool   owned            = true;
+    bool   is_pinned_memory = false;
+    size_t bsize            = 0;
 
     // Buffer size for tracking total memory usage.
     // When buffer is shrunk in place, bsize_track is not changed.

--- a/projects/rocfft/shared/params_gen.h
+++ b/projects/rocfft/shared/params_gen.h
@@ -38,6 +38,11 @@ const static std::vector<fft_result_placement> place_range
     = {fft_placement_inplace, fft_placement_notinplace};
 const static std::vector<fft_transform_type> trans_type_range
     = {fft_transform_type_complex_forward, fft_transform_type_real_forward};
+const static std::vector<fft_transform_type> trans_type_range_full
+    = {fft_transform_type_complex_forward,
+       fft_transform_type_real_forward,
+       fft_transform_type_complex_inverse,
+       fft_transform_type_real_inverse};
 const static std::vector<fft_transform_type> trans_type_range_complex
     = {fft_transform_type_complex_forward};
 const static std::vector<fft_transform_type> trans_type_range_real

--- a/projects/rocfft/shared/sys_mem.h
+++ b/projects/rocfft/shared/sys_mem.h
@@ -35,6 +35,8 @@
 #endif
 
 static constexpr size_t ONE_GiB = 1 << 30;
+static constexpr size_t ONE_MiB = 1 << 20;
+static constexpr size_t ONE_KiB = 1 << 10;
 
 inline size_t bytes_to_GiB(const size_t bytes)
 {


### PR DESCRIPTION
# Motivation

This PR initiates the development of `hipfftw`, a GPU-aware interface for DFT computation defining the most commonly-used symbols from the `FFTW3` library and enabling DFT computations on AMD GPU devices. This PR only enables allocation-related functions, default plan execution, and default plan creations, _i.e._, plans for unbatched 1D, 2D and 3D DFTs with default strides are enabled and execution paths reusing the plan creation's input/output data pointer arguments are enabled as well. Subsequent developments will augment the supported cases.

# Technical Details

## Allocation/free functions
`hipfftw` defines the `{fftw, fftwf}_{malloc, alloc_real, alloc_complex}` and `{fftw, fftwf}_free` functions. Given the intended usage, the allocating functions must create allocations that are directly accessible by the host : pinned host allocations are used by default as that results in faster data transfers to/from the device(s) than pageable allocations if used at executions. However, users may disable (resp. limit) pinned host allocations entirely by setting the dedicated environment variable `HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC` to `0` (resp. the desired limit value). In such a case, pageable host allocations are used instead.
NOTE 1: any allocation created via `{fftw, fftwf}_{malloc, alloc_real, alloc_complex}` **_must_** be freed by `{fftw, fftwf}_free`, similarly to what `FFTW3` requires.
NOTE 2: pageable allocations may also be disabled/limited via the environment variable `HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC` 
NOTE 3: managed allocations may be considered as the default, first-ranked option on Linux systems in the future.

## Some plan details
The implementation intends to enable any kind of input/output data for DFT execution. The tests added herein randomly choose between pageable host memory allocations, pinned host memory allocations, run-time managed memory allocations, and device memory allocations. Unless the requested DFT is configured in-place, there is no expected correlation between the kind of input and the kind of output data. Synchronization is enforced upon completion of execution only if the output data may be directly accessed by the host (without requiring an explicit copy operation).
If the kind of input/output data is not directly accessible by the device used at plan creation, the input/output data is copied to/from the plan's device at execution. In such a case, the plan creates and owns device memory buffers dedicated to those copy operations. These buffers may be modified/created/freed at execution too, once "new-array execution" functions are enabled.

## Informative error reporting
As defined by `FFTW3`, the functions to be implemented are not the most informative to users when it comes to error-handling: failures at plan creation result in returning a `nullptr` for the desired plan (no additional detail as to "why" it failed) and, failures at execution simply cannot be detected _naturally_ (no returned error code, and no exceptions may leak through boundaries of a C++ code base).
This PR suggests to make the exception handler used internally to `hipfftw` implementation details possibly verbose by setting the environment variable `HIPFFTW_LOG_EXCEPTIONS` to any positive value. This feature is actually used in testing (unless the test user already enabled it).

# Testing

This PR defines dedicated parameterized tests in `hipfftw_test.cpp`, the most significant ones being divided in 3 categories:
- testing allocation/free functions;
- testing input argument validation for plan creation and plan execution;
- testing correctness for the supported cases (by direct comparison of the results from `hipfftw` with the results from `FFTW3`).

`hipfftw_helper.h` defines a `hipfftw_helper` template class for testing `hipfftw` for a particular precision (template parameter). Given that our tests already link to `FFTW3`, `hipfftw` must be loaded dynamically at test execution (since `hipfftw` and `FFTW3` exports the same symbols). If that library loading operation fails, all `hipfftw` tests will fail and report a (hopefully) informative message about the encountered error.

In their extensive forms, the suggested tests cover all implementation regions of `hipfftw.cpp` that may be targeted "organically". Test sets are also designed to enforce minimal coverage for input argument validation regardless of the chosen test probabilities (to generate representative code coverage metrics even when using the `smoketest` option).