### PR TITLE
Autolabeler: Add glob for no project match

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,6 +42,11 @@
 - changed-files:
   - any-glob-to-any-file: 'projects/miopen/**/*'
 
+"project: none":
+- changed-files:
+  - all-globs-to-all-files: '!projects/**/*'
+  - all-globs-to-all-files: '!shared/**/*'
+
 "project: rocblas":
 - changed-files:
   - any-glob-to-any-file: 'projects/rocblas/**/*'


### PR DESCRIPTION
## Motivation

Add label for a PR that does not touch any `shared` or `project`. math-ci will use this to issue a skip status for PRs

## Test Plan

Needs to be merged to be tested
