### PR TITLE
[rocRAND] Optimize performance gains from PR #446 

### DIFF
--- a/projects/rocrand/library/include/rocrand/rocrand_common.h
+++ b/projects/rocrand/library/include/rocrand/rocrand_common.h
@@ -189,6 +189,44 @@ __forceinline__ __device__ __host__ void
     hi = 0;
 }
 
+template<typename T, typename = void>
+struct has_data : std::false_type
+{};
+
+template<typename T>
+struct has_data<T, decltype(std::declval<T>().data, void())> : std::true_type
+{};
+
+template<typename T>
+static constexpr bool has_data_v = has_data<T>::value;
+
+/// This is an accessor utility for HIP vector types (eg. int2, float4, etc.).
+/// Prior to HIP 7.0, individual elements could be accessed through the
+/// data member:
+///   int2 vec;
+///   vec.data[0] = 1;
+///
+/// Beginning with HIP 7.0, the data member is hidden, and individual
+/// elements can instead be accessed through the underlaying native vector.
+template<typename V, typename Index>
+__forceinline__ __device__ __host__
+auto get_element_at(V vector, Index i)
+{
+#if defined(__HIP_PLATFORM_AMD__)
+    if constexpr(has_data_v<V>)
+    {
+        return vector.data[i];
+    }
+    else
+    {
+        return get_native_vector(vector)[i];
+    }
+#else
+    return (&vector.x)[i];
+#endif
+}
+
+
 } // end namespace detail
 } // end namespace rocrand_device
 

--- a/projects/rocrand/library/include/rocrand/rocrand_philox4x32_10.h
+++ b/projects/rocrand/library/include/rocrand/rocrand_philox4x32_10.h
@@ -171,11 +171,7 @@ public:
 
     __forceinline__ __device__ __host__ unsigned int next()
     {
-    #if defined(__HIP_PLATFORM_AMD__)
-        unsigned int ret = ROCRAND_HIPVEC_ACCESS(m_state.result)[m_state.substate];
-    #else
-        unsigned int ret = (&m_state.result.x)[m_state.substate];
-    #endif
+        unsigned int ret = detail::get_element_at(m_state.result, m_state.substate);
 
         m_state.substate++;
         if(m_state.substate == 4)

--- a/projects/rocrand/library/include/rocrand/rocrand_threefry4_impl.h
+++ b/projects/rocrand/library/include/rocrand/rocrand_threefry4_impl.h
@@ -152,11 +152,8 @@ public:
 
     __forceinline__ __device__ __host__ value next()
     {
-#if defined(__HIP_PLATFORM_AMD__)
-        value ret = ROCRAND_HIPVEC_ACCESS(m_state.result)[m_state.substate];
-#else
-        value ret = (&m_state.result.x)[m_state.substate];
-#endif
+        value ret = detail::get_element_at(m_state.result, m_state.substate);
+
         m_state.substate++;
         if(m_state.substate == 4)
         {


### PR DESCRIPTION
## Motivation

PR #446 was intended to optimize performance for threefry2, threefry4, and phillox4. However, it inadvertently caused a performance regression in threefry2. PR #793 addressed this issue by reverting #446, which restored threefry2's performance but also removed the improvements made to threefry4 and phillox4.

This PR reintroduces the performance enhancements for threefry4 and phillox4 while preserving the optimized performance of threefry2.

## Technical Details

Applied the changes from PR #446 to threefry4 and phillox4 only, leaving threefry2 untouched. This should bring over the benefit of pr #446 while leaving behind the regressions.

## Test Plan

Run benchmarks comparing to build 16500 and 16392 in mutiple architectures. As well as standard CI. 

## Test Result

Pending results
