### PR TITLE
[rocroller] Bump mxdatagenerator

### DIFF
--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -84,7 +84,7 @@ def runTestCommand (platform, project)
 
                 pushd build
                 echo Using `nproc` threads for testing.
-                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j `nproc` --output-on-failure ${testExclude}
+                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j 8 --output-on-failure ${testExclude}
                 export ROCROLLER_BUILD_DIR="\$(pwd)"
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -85,7 +85,7 @@ def runTestCommand (platform, project)
                 cd ${project.paths.project_build_prefix}
 
                 pushd build
-                echo Using ${numThreads} (out of `nproc`) threads for testing.
+                echo Using ${numThreads} out of `nproc` threads for testing.
                 OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j ${numThreads} --output-on-failure ${testExclude}
                 export ROCROLLER_BUILD_DIR="\$(pwd)"
                 popd

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -78,15 +78,13 @@ def runTestCommand (platform, project)
 {
     String testExclude = platform.jenkinsLabel.contains('compile') ? '-LE GPU' : ''
 
-    def numThreads = 8
-
     def command = """#!/usr/bin/env bash
                 set -ex
                 cd ${project.paths.project_build_prefix}
 
                 pushd build
                 echo Using `nproc` threads for testing.
-                OMP_NUM_THREADS=1 ctest -j ${numThreads} --output-on-failure ${testExclude}
+                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j `nproc` --output-on-failure ${testExclude}
                 export ROCROLLER_BUILD_DIR="\$(pwd)"
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -78,13 +78,15 @@ def runTestCommand (platform, project)
 {
     String testExclude = platform.jenkinsLabel.contains('compile') ? '-LE GPU' : ''
 
+    def numThreads = 8
+
     def command = """#!/usr/bin/env bash
                 set -ex
                 cd ${project.paths.project_build_prefix}
 
                 pushd build
-                echo Using `nproc` threads for testing.
-                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j 8 --output-on-failure ${testExclude}
+                echo Using ${numThreads} (out of `nproc`) threads for testing.
+                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j ${numThreads} --output-on-failure ${testExclude}
                 export ROCROLLER_BUILD_DIR="\$(pwd)"
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -86,7 +86,7 @@ def runTestCommand (platform, project)
 
                 pushd build
                 echo Using ${numThreads} out of `nproc` threads for testing.
-                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j ${numThreads} --output-on-failure ${testExclude}
+                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=8 ctest -j ${numThreads} --output-on-failure ${testExclude}
                 export ROCROLLER_BUILD_DIR="\$(pwd)"
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -86,7 +86,7 @@ def runTestCommand (platform, project)
 
                 pushd build
                 echo Using ${numThreads} out of `nproc` threads for testing.
-                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=8 ctest -j ${numThreads} --output-on-failure ${testExclude}
+                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=2 ctest -j ${numThreads} --output-on-failure ${testExclude}
                 export ROCROLLER_BUILD_DIR="\$(pwd)"
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -43,7 +43,7 @@ option(ROCROLLER_ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(ROCROLLER_ENABLE_ASAN "Enable addresss sanitizers." OFF)
 option(ROCROLLER_ENABLE_PREGENERATED_ARCH_DEF "Use the pregenerates GPU architecture definition YAML file(s) in the repository." ON)
 set(ROCROLLER_MRISAS_DIR "${CMAKE_CURRENT_BINARY_DIR}/GPUArchitectureGenerator/amd-mrisa" CACHE STRING "Path to directory containing MRISA XML files.")
-set(MXDATAGENERATOR_GIT_TAG "3ac153eec4c1a1e0da7546abc9c0c4f54e180f43" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
+set(MXDATAGENERATOR_GIT_TAG "31407efa7938fd70ea9b28e08a4d53e398415f8b" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
 set(MXDATAGENERATOR_GIT_URL "https://github.com/ROCm/mxDataGenerator.git" CACHE STRING "Base Git URL to fetch mxDataGenerator from.")
 
 if(ROCROLLER_ENABLE_TEST_DISCOVERY)

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -43,7 +43,7 @@ option(ROCROLLER_ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(ROCROLLER_ENABLE_ASAN "Enable addresss sanitizers." OFF)
 option(ROCROLLER_ENABLE_PREGENERATED_ARCH_DEF "Use the pregenerates GPU architecture definition YAML file(s) in the repository." ON)
 set(ROCROLLER_MRISAS_DIR "${CMAKE_CURRENT_BINARY_DIR}/GPUArchitectureGenerator/amd-mrisa" CACHE STRING "Path to directory containing MRISA XML files.")
-set(MXDATAGENERATOR_GIT_TAG "3ac153eec4c1a1e0da7546abc9c0c4f54e180f43" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
+set(MXDATAGENERATOR_GIT_TAG "49d4b831a49bc599682a5e7b40c0d83aecf0c287" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
 set(MXDATAGENERATOR_GIT_URL "https://github.com/ROCm/mxDataGenerator.git" CACHE STRING "Base Git URL to fetch mxDataGenerator from.")
 
 if(ROCROLLER_ENABLE_TEST_DISCOVERY)

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -43,7 +43,7 @@ option(ROCROLLER_ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(ROCROLLER_ENABLE_ASAN "Enable addresss sanitizers." OFF)
 option(ROCROLLER_ENABLE_PREGENERATED_ARCH_DEF "Use the pregenerates GPU architecture definition YAML file(s) in the repository." ON)
 set(ROCROLLER_MRISAS_DIR "${CMAKE_CURRENT_BINARY_DIR}/GPUArchitectureGenerator/amd-mrisa" CACHE STRING "Path to directory containing MRISA XML files.")
-set(MXDATAGENERATOR_GIT_TAG "31407efa7938fd70ea9b28e08a4d53e398415f8b" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
+set(MXDATAGENERATOR_GIT_TAG "3ac153eec4c1a1e0da7546abc9c0c4f54e180f43" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
 set(MXDATAGENERATOR_GIT_URL "https://github.com/ROCm/mxDataGenerator.git" CACHE STRING "Base Git URL to fetch mxDataGenerator from.")
 
 if(ROCROLLER_ENABLE_TEST_DISCOVERY)

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -43,7 +43,7 @@ option(ROCROLLER_ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(ROCROLLER_ENABLE_ASAN "Enable addresss sanitizers." OFF)
 option(ROCROLLER_ENABLE_PREGENERATED_ARCH_DEF "Use the pregenerates GPU architecture definition YAML file(s) in the repository." ON)
 set(ROCROLLER_MRISAS_DIR "${CMAKE_CURRENT_BINARY_DIR}/GPUArchitectureGenerator/amd-mrisa" CACHE STRING "Path to directory containing MRISA XML files.")
-set(MXDATAGENERATOR_GIT_TAG "49d4b831a49bc599682a5e7b40c0d83aecf0c287" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
+set(MXDATAGENERATOR_GIT_TAG "31407efa7938fd70ea9b28e08a4d53e398415f8b" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
 set(MXDATAGENERATOR_GIT_URL "https://github.com/ROCm/mxDataGenerator.git" CACHE STRING "Base Git URL to fetch mxDataGenerator from.")
 
 if(ROCROLLER_ENABLE_TEST_DISCOVERY)

--- a/shared/rocroller/test/common/include/common/Utilities.hpp
+++ b/shared/rocroller/test/common/include/common/Utilities.hpp
@@ -283,7 +283,7 @@ AcceptableError
         {
             if constexpr(std::is_same_v<TA, rocRoller::BF8> || std::is_same_v<TB, rocRoller::BF8>)
             {
-                fudge *= 5;
+                fudge *= 7.58;
                 ss << " Increase fudge for mixed BF8: " << fudge;
             }
             else if constexpr(std::is_same_v<TA,

--- a/shared/rocroller/test/common/include/common/Utilities.hpp
+++ b/shared/rocroller/test/common/include/common/Utilities.hpp
@@ -264,7 +264,7 @@ AcceptableError
         {
             if constexpr(std::is_same_v<TA, rocRoller::BF6>)
             {
-                fudge *= 3;
+                fudge *= 3.29;
                 ss << " Increase fudge for BF6: " << fudge;
             }
             if constexpr(std::is_same_v<TA, rocRoller::BF8>)
@@ -289,7 +289,17 @@ AcceptableError
             else if constexpr(std::is_same_v<TA,
                                              rocRoller::FP8> || std::is_same_v<TB, rocRoller::FP8>)
             {
-                fudge *= 4.95;
+                if constexpr((std::is_same_v<TA, rocRoller::BF6>)
+                             || (std::is_same_v<TA, rocRoller::FP6>)
+                             || (std::is_same_v<TB, rocRoller::BF6>)
+                             || (std::is_same_v<TB, rocRoller::FP6>))
+                {
+                    fudge *= 6.63;
+                }
+                else
+                {
+                    fudge *= 4.95;
+                }
                 ss << " Increase fudge for mixed FP8: " << fudge;
             }
             else if constexpr(std::is_same_v<TA,

--- a/shared/rocroller/test/common/include/common/Utilities.hpp
+++ b/shared/rocroller/test/common/include/common/Utilities.hpp
@@ -264,7 +264,7 @@ AcceptableError
         {
             if constexpr(std::is_same_v<TA, rocRoller::BF6>)
             {
-                fudge *= 3.29;
+                fudge *= 3;
                 ss << " Increase fudge for BF6: " << fudge;
             }
             if constexpr(std::is_same_v<TA, rocRoller::BF8>)
@@ -283,23 +283,13 @@ AcceptableError
         {
             if constexpr(std::is_same_v<TA, rocRoller::BF8> || std::is_same_v<TB, rocRoller::BF8>)
             {
-                fudge *= 7.58;
+                fudge *= arch.gfx == rocRoller::GPUArchitectureGFX::GFX950 ? 7.58 : 6.0;
                 ss << " Increase fudge for mixed BF8: " << fudge;
             }
             else if constexpr(std::is_same_v<TA,
                                              rocRoller::FP8> || std::is_same_v<TB, rocRoller::FP8>)
             {
-                if constexpr((std::is_same_v<TA, rocRoller::BF6>)
-                             || (std::is_same_v<TA, rocRoller::FP6>)
-                             || (std::is_same_v<TB, rocRoller::BF6>)
-                             || (std::is_same_v<TB, rocRoller::FP6>))
-                {
-                    fudge *= 6.63;
-                }
-                else
-                {
-                    fudge *= 4.95;
-                }
+                fudge *= 4.95;
                 ss << " Increase fudge for mixed FP8: " << fudge;
             }
             else if constexpr(std::is_same_v<TA,


### PR DESCRIPTION
## Motivation

Mitigate CI problems w.r.t. parallelism.

## Technical Details
- Bump mxdatagenerator commit hash
- Specify OPENBLAS_NUM_THREADS for ctest
- Increase acceptable GEMM error fudge factor for 8-bit types

## Testing
- GEMM tests in CI


## Commit Message
[rocroller] Bump mxdatagenerator

- Bump mxdatagenerator commit hash
- Specify OPENBLAS_NUM_THREADS for ctest
- Increase acceptable GEMM error fudge factor for 8-bit types

Co-authored-by: Kerry Wang <kerrwang@amd.com>