### PR TITLE
[hipCUB][CCCL 2.8 Parity] deprecate APIs in rocprim and hipcub

### DIFF
--- a/projects/hipcub/CHANGELOG.md
+++ b/projects/hipcub/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Full documentation for hipCUB is available at [https://rocm.docs.amd.com/projects/hipCUB/en/latest/](https://rocm.docs.amd.com/projects/hipCUB/en/latest/).
 
+## hipCUB-4.1.0 for ROCm 7.1
+
+### Added
+
+### Removed
+* Deprecated `hipcub::ConstantInputIterator`, use `rocprim::constant_iterator` or `rocthrust::constant_iterator` instead.
+* Deprecated `hipcub::CountingInputIterator`, use `rocprim::counting_iterator` or `rocthrust::counting_iterator` instead.
+* Deprecated `hipcub::DiscardOutputIterator`, use `rocprim::discard_iterator` or `rocthrust::discard_iterator` instead.
+* Deprecated `hipcub::TransformInputIterator`, use `rocprim::transform_iterator` or `rocthrust::transform_iterator` instead.
+* Deprecated `hipcub::AliasTemporaries`, which is considered to be internal API. Moved it to detail namespace.
+* Deprecated almost all functions in `projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_ptx.hpp`.
+* Deprecated hipCUB macros: `HIPCUB_MAX`, `HIPCUB_MIN`, `HIPCUB_QUOTIENT_FLOOR`, `HIPCUB_QUOTIENT_CEILING`, `HIPCUB_ROUND_UP_NEAREST` and `HIPCUB_ROUND_DOWN_NEAREST`.
+
+### Changed
+
 ## hipCUB-4.0.0 for ROCm 7.0
 
 ### Added

--- a/projects/hipcub/benchmark/benchmark_device_spmv.cpp
+++ b/projects/hipcub/benchmark/benchmark_device_spmv.cpp
@@ -126,6 +126,7 @@ void run_benchmark(benchmark::State& state,
     size_t temp_storage_size_bytes;
 
     // Get size of d_temp_storage
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
     HIP_CHECK(hipcub::DeviceSpmv::CsrMV(nullptr,
                                         temp_storage_size_bytes,
                                         d_values,
@@ -137,6 +138,7 @@ void run_benchmark(benchmark::State& state,
                                         size,
                                         num_nonzeroes,
                                         stream));
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
     HIP_CHECK(hipDeviceSynchronize());
 
     // allocate temporary storage
@@ -147,6 +149,7 @@ void run_benchmark(benchmark::State& state,
     // Warm-up
     for(size_t i = 0; i < warmup_size; i++)
     {
+        HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
         HIP_CHECK(hipcub::DeviceSpmv::CsrMV(d_temp_storage,
                                             temp_storage_size_bytes,
                                             d_values,
@@ -158,6 +161,7 @@ void run_benchmark(benchmark::State& state,
                                             size,
                                             num_nonzeroes,
                                             stream));
+        HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
     }
     HIP_CHECK(hipDeviceSynchronize());
 
@@ -166,6 +170,7 @@ void run_benchmark(benchmark::State& state,
         auto start = std::chrono::high_resolution_clock::now();
         for(size_t i = 0; i < batch_size; i++)
         {
+            HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
             HIP_CHECK(hipcub::DeviceSpmv::CsrMV(d_temp_storage,
                                                 temp_storage_size_bytes,
                                                 d_values,
@@ -177,6 +182,7 @@ void run_benchmark(benchmark::State& state,
                                                 size,
                                                 num_nonzeroes,
                                                 stream));
+            HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
         }
         HIP_CHECK(hipDeviceSynchronize());
 

--- a/projects/hipcub/examples/example_utils.hpp
+++ b/projects/hipcub/examples/example_utils.hpp
@@ -406,7 +406,7 @@ int CompareResults(double* computed, double* reference, OffsetT len, bool verbos
 // template <typename S, typename OffsetT>
 // int CompareDeviceResults(
 //     S *h_reference,
-//     hipcub::DiscardOutputIterator<OffsetT> d_data,
+//     rocprim::discard_iterator d_data,
 //     std::size_t num_items,
 //     bool verbose = true,
 //     bool display_data = false)

--- a/projects/hipcub/hipcub/include/hipcub/backend/cub/agent/single_pass_scan_operators.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/cub/agent/single_pass_scan_operators.hpp
@@ -53,10 +53,11 @@ using TilePrefixCallbackOp
 
 template<typename ValueT,
          typename KeyT,
-         bool SINGLE_WORD = (Traits<ValueT>::PRIMITIVE) && (sizeof(ValueT) + sizeof(KeyT) < 16)>
+         bool SINGLE_WORD
+         = (cub::detail::is_primitive<ValueT>::value) && (sizeof(ValueT) + sizeof(KeyT) < 16)>
 using ReduceByKeyScanTileState = cub::ReduceByKeyScanTileState<ValueT, KeyT, SINGLE_WORD>;
 
-template<typename T, bool SINGLE_WORD = Traits<T>::PRIMITIVE>
+template<typename T, bool SINGLE_WORD = cub::detail::is_primitive<T>::value>
 struct ScanTileState : cub::ScanTileState<T, SINGLE_WORD>
 {
     HIPCUB_HOST_DEVICE

--- a/projects/hipcub/hipcub/include/hipcub/backend/cub/device/device_spmv.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/cub/device/device_spmv.hpp
@@ -38,89 +38,101 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-class DeviceSpmv
+class HIPCUB_DEPRECATED_BECAUSE("Use the cuSPARSE library instead") DeviceSpmv
 {
 
 public:
+    template<typename ValueT, ///< Matrix and vector value type
+             typename OffsetT> ///< Signed integer type for sequence offsets
+    struct HIPCUB_DEPRECATED_BECAUSE("Use the cuSPARSE library instead") SpmvParams
+    {
+        ValueT*
+            d_values; ///< Pointer to the array of \p num_nonzeros values of the corresponding nonzero elements of matrix <b>A</b>.
+        OffsetT*
+            d_row_end_offsets; ///< Pointer to the array of \p m offsets demarcating the end of every row in \p d_column_indices and \p d_values
+        OffsetT*
+            d_column_indices; ///< Pointer to the array of \p num_nonzeros column-indices of the corresponding nonzero elements of matrix <b>A</b>.  (Indices are zero-valued.)
+        ValueT*
+            d_vector_x; ///< Pointer to the array of \p num_cols values corresponding to the dense input vector <em>x</em>
+        ValueT*
+            d_vector_y; ///< Pointer to the array of \p num_rows values corresponding to the dense output vector <em>y</em>
+        int    num_rows; ///< Number of rows of matrix <b>A</b>.
+        int    num_cols; ///< Number of columns of matrix <b>A</b>.
+        int    num_nonzeros; ///< Number of nonzero elements of matrix <b>A</b>.
+        ValueT alpha; ///< Alpha multiplicand
+        ValueT beta; ///< Beta addend-multiplicand
 
-template <
-    typename        ValueT,              ///< Matrix and vector value type
-    typename        OffsetT>             ///< Signed integer type for sequence offsets
-struct SpmvParams
-{
-    ValueT*         d_values;            ///< Pointer to the array of \p num_nonzeros values of the corresponding nonzero elements of matrix <b>A</b>.
-    OffsetT*        d_row_end_offsets;   ///< Pointer to the array of \p m offsets demarcating the end of every row in \p d_column_indices and \p d_values
-    OffsetT*        d_column_indices;    ///< Pointer to the array of \p num_nonzeros column-indices of the corresponding nonzero elements of matrix <b>A</b>.  (Indices are zero-valued.)
-    ValueT*         d_vector_x;          ///< Pointer to the array of \p num_cols values corresponding to the dense input vector <em>x</em>
-    ValueT*         d_vector_y;          ///< Pointer to the array of \p num_rows values corresponding to the dense output vector <em>y</em>
-    int             num_rows;            ///< Number of rows of matrix <b>A</b>.
-    int             num_cols;            ///< Number of columns of matrix <b>A</b>.
-    int             num_nonzeros;        ///< Number of nonzero elements of matrix <b>A</b>.
-    ValueT          alpha;               ///< Alpha multiplicand
-    ValueT          beta;                ///< Beta addend-multiplicand
+        ::cub::TexRefInputIterator<ValueT, 66778899, OffsetT> t_vector_x;
+    };
 
-    ::cub::TexRefInputIterator<ValueT, 66778899, OffsetT>  t_vector_x;
-};
+    template<typename ValueT>
+    HIPCUB_DEPRECATED_BECAUSE("Use the cuSPARSE library instead")
+    HIPCUB_RUNTIME_FUNCTION static hipError_t CsrMV(void*       d_temp_storage,
+                                                    size_t&     temp_storage_bytes,
+                                                    ValueT*     d_values,
+                                                    int*        d_row_offsets,
+                                                    int*        d_column_indices,
+                                                    ValueT*     d_vector_x,
+                                                    ValueT*     d_vector_y,
+                                                    int         num_rows,
+                                                    int         num_cols,
+                                                    int         num_nonzeros,
+                                                    hipStream_t stream = 0)
+    {
+        _CCCL_SUPPRESS_DEPRECATED_PUSH
+        ::cub::SpmvParams<ValueT, int> spmv_params;
+        _CCCL_SUPPRESS_DEPRECATED_POP
+        spmv_params.d_values          = d_values;
+        spmv_params.d_row_end_offsets = d_row_offsets + 1;
+        spmv_params.d_column_indices  = d_column_indices;
+        spmv_params.d_vector_x        = d_vector_x;
+        spmv_params.d_vector_y        = d_vector_y;
+        spmv_params.num_rows          = num_rows;
+        spmv_params.num_cols          = num_cols;
+        spmv_params.num_nonzeros      = num_nonzeros;
+        spmv_params.alpha             = 1.0;
+        spmv_params.beta              = 0.0;
 
-template<typename ValueT>
-HIPCUB_RUNTIME_FUNCTION static hipError_t CsrMV(void*       d_temp_storage,
-                                                size_t&     temp_storage_bytes,
-                                                ValueT*     d_values,
-                                                int*        d_row_offsets,
-                                                int*        d_column_indices,
-                                                ValueT*     d_vector_x,
-                                                ValueT*     d_vector_y,
-                                                int         num_rows,
-                                                int         num_cols,
-                                                int         num_nonzeros,
-                                                hipStream_t stream = 0)
-{
-    ::cub::SpmvParams<ValueT, int> spmv_params;
-    spmv_params.d_values          = d_values;
-    spmv_params.d_row_end_offsets = d_row_offsets + 1;
-    spmv_params.d_column_indices  = d_column_indices;
-    spmv_params.d_vector_x        = d_vector_x;
-    spmv_params.d_vector_y        = d_vector_y;
-    spmv_params.num_rows          = num_rows;
-    spmv_params.num_cols          = num_cols;
-    spmv_params.num_nonzeros      = num_nonzeros;
-    spmv_params.alpha             = 1.0;
-    spmv_params.beta              = 0.0;
+        _CCCL_SUPPRESS_DEPRECATED_PUSH
+        return static_cast<hipError_t>(
+            ::cub::DispatchSpmv<ValueT, int>::Dispatch(d_temp_storage,
+                                                       temp_storage_bytes,
+                                                       spmv_params,
+                                                       stream));
+        _CCCL_SUPPRESS_DEPRECATED_POP
+    }
 
-    return static_cast<hipError_t>(::cub::DispatchSpmv<ValueT, int>::Dispatch(d_temp_storage,
-                                                                              temp_storage_bytes,
-                                                                              spmv_params,
-                                                                              stream));
-}
-
-template<typename ValueT>
-HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION static hipError_t
-    CsrMV(void*       d_temp_storage,
-          size_t&     temp_storage_bytes,
-          ValueT*     d_values,
-          int*        d_row_offsets,
-          int*        d_column_indices,
-          ValueT*     d_vector_x,
-          ValueT*     d_vector_y,
-          int         num_rows,
-          int         num_cols,
-          int         num_nonzeros,
-          hipStream_t stream,
-          bool        debug_synchronous)
-{
-    HIPCUB_DETAIL_RUNTIME_LOG_DEBUG_SYNCHRONOUS();
-    return CsrMV(d_temp_storage,
-                 temp_storage_bytes,
-                 d_values,
-                 d_row_offsets,
-                 d_column_indices,
-                 d_vector_x,
-                 d_vector_y,
-                 num_rows,
-                 num_cols,
-                 num_nonzeros,
-                 stream);
-}
+    template<typename ValueT>
+    HIPCUB_DEPRECATED_BECAUSE("Use the cuSPARSE library instead")
+    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION static hipError_t
+        CsrMV(void*       d_temp_storage,
+              size_t&     temp_storage_bytes,
+              ValueT*     d_values,
+              int*        d_row_offsets,
+              int*        d_column_indices,
+              ValueT*     d_vector_x,
+              ValueT*     d_vector_y,
+              int         num_rows,
+              int         num_cols,
+              int         num_nonzeros,
+              hipStream_t stream,
+              bool        debug_synchronous)
+    {
+        HIPCUB_DETAIL_RUNTIME_LOG_DEBUG_SYNCHRONOUS();
+        _CCCL_SUPPRESS_DEPRECATED_PUSH
+        return CsrMV(d_temp_storage,
+                     temp_storage_bytes,
+                     d_values,
+                     d_row_offsets,
+                     d_column_indices,
+                     d_vector_x,
+                     d_vector_y,
+                     num_rows,
+                     num_cols,
+                     num_nonzeros,
+                     stream);
+        _CCCL_SUPPRESS_DEPRECATED_POP
+    }
 };
 
 END_HIPCUB_NAMESPACE

--- a/projects/hipcub/hipcub/include/hipcub/backend/cub/grid/grid_barrier.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/cub/grid/grid_barrier.hpp
@@ -35,8 +35,10 @@
 #include <cub/grid/grid_barrier.cuh> // IWYU pragma: export
 
 BEGIN_HIPCUB_NAMESPACE
-
-class GridBarrierLifetime : public ::cub::GridBarrierLifetime
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+// This API will be deprecated, suggest to use hip cooperative groups apis.
+class HIPCUB_DEPRECATED_BECAUSE("Use the APIs from cooperative groups instead") GridBarrierLifetime
+    : public ::cub::GridBarrierLifetime
 {
 public:
     hipError_t HostReset()
@@ -46,9 +48,6 @@ public:
         );
     }
 
-
-
-
     hipError_t Setup(int sweep_grid_size)
     {
         return hipCUDAErrorTohipError(
@@ -56,7 +55,7 @@ public:
         );
     }
 };
-
+_CCCL_SUPPRESS_DEPRECATED_POP
 END_HIPCUB_NAMESPACE
 
 #endif // HIPCUB_CUB_GRID_GRID_BARRIER_HPP_

--- a/projects/hipcub/hipcub/include/hipcub/backend/cub/util_macro.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/cub/util_macro.hpp
@@ -36,34 +36,40 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_MAX
     /// Select maximum(a, b)
-    #define HIPCUB_MAX(a, b) CUB_MAX(a, b)
+    #define HIPCUB_MAX(a, b) (((b) > (a)) ? (b) : (a))
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_MIN
     /// Select minimum(a, b)
-    #define HIPCUB_MIN(a, b) CUB_MIN(a, b)
+    #define HIPCUB_MIN(a, b) (((b) < (a)) ? (b) : (a))
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_QUOTIENT_FLOOR
     /// Quotient of x/y rounded down to nearest integer
-    #define HIPCUB_QUOTIENT_FLOOR(x, y) CUB_QUOTIENT_FLOOR(x, y)
+    #define HIPCUB_QUOTIENT_FLOOR(x, y) ((x) / (y))
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_QUOTIENT_CEILING
     /// Quotient of x/y rounded up to nearest integer
-    #define HIPCUB_QUOTIENT_CEILING(x, y) CUB_QUOTIENT_CEILING(x, y)
+    #define HIPCUB_QUOTIENT_CEILING(x, y) (((x) + (y)-1) / (y))
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_ROUND_UP_NEAREST
     /// x rounded up to the nearest multiple of y
-    #define HIPCUB_ROUND_UP_NEAREST(x, y) CUB_ROUND_UP_NEAREST(x, y)
+    #define HIPCUB_ROUND_UP_NEAREST(x, y) (HIPCUB_QUOTIENT_CEILING(x, y) * y)
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_ROUND_DOWN_NEAREST
     /// x rounded down to the nearest multiple of y
-    #define HIPCUB_ROUND_DOWN_NEAREST(x, y) CUB_ROUND_DOWN_NEAREST(x, y)
+    #define HIPCUB_ROUND_DOWN_NEAREST(x, y) (((x) / (y)) * y)
 #endif
 
 END_HIPCUB_NAMESPACE

--- a/projects/hipcub/hipcub/include/hipcub/backend/cub/util_temporary_storage.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/cub/util_temporary_storage.hpp
@@ -43,16 +43,17 @@ BEGIN_HIPCUB_NAMESPACE
 /// \param allocations [out] Pointers to device allocations needed.
 /// \param allocation_sizes [in] Sizes in bytes of device allocations needed.
 template<int ALLOCATIONS>
-HIPCUB_HOST_DEVICE
-HIPCUB_FORCEINLINE hipError_t AliasTemporaries(void*   d_temp_storage,
-                                               size_t& temp_storage_bytes,
-                                               void* (&allocations)[ALLOCATIONS],
-                                               const size_t (&allocation_sizes)[ALLOCATIONS])
+HIPCUB_DEPRECATED_BECAUSE("Internal-only implementation detail")
+HIPCUB_HOST_DEVICE HIPCUB_FORCEINLINE hipError_t
+    AliasTemporaries(void*   d_temp_storage,
+                     size_t& temp_storage_bytes,
+                     void* (&allocations)[ALLOCATIONS],
+                     const size_t (&allocation_sizes)[ALLOCATIONS])
 {
-    cudaError_t error = ::cub::AliasTemporaries(d_temp_storage,
-                                                temp_storage_bytes,
-                                                allocations,
-                                                allocation_sizes);
+    cudaError_t error = ::cub::detail::AliasTemporaries(d_temp_storage,
+                                                        temp_storage_bytes,
+                                                        allocations,
+                                                        allocation_sizes);
 
     if(cudaSuccess == error)
     {

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/agent/single_pass_scan_operators.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/agent/single_pass_scan_operators.hpp
@@ -74,8 +74,9 @@ struct BlockScanRunningPrefixOp
 };
 
 // Forward declare for use in detail namespace.
-// CUB uses cub::Trait<T>::PRIMITIVE for deducing SINGLE_WORD, but this isn't needed by the rocPRIM backend.
-template<typename T, bool SINGLE_WORD = (sizeof(T) <= 7) /* hipcub::Traits<T>::PRIMITIVE */>
+// CUB uses cub::detail::is_primitive<T>::value for deducing SINGLE_WORD, but this isn't needed by the rocPRIM backend.
+template<typename T,
+         bool SINGLE_WORD = (sizeof(T) <= 7) /* hipcub::detail::is_primitive<T>::value */>
 class ScanTileState;
 
 namespace detail
@@ -465,7 +466,7 @@ public:
     }
 };
 
-// CUB uses cub::Trait<T>::PRIMITIVE for deducing SINGLE_WORD, but this isn't needed by the rocPRIM backend.
+// CUB uses cub::detail::is_primitive<T>::value for deducing SINGLE_WORD, but this isn't needed by the rocPRIM backend.
 template<typename ValueT, typename KeyT, bool SINGLE_WORD = (sizeof(ValueT) + sizeof(KeyT) <= 7)>
 struct ReduceByKeyScanTileState : hipcub::ScanTileState<KeyValuePair<KeyT, ValueT>>
 {

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/block/block_histogram.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/block/block_histogram.hpp
@@ -133,7 +133,7 @@ public:
                    CounterT histogram[BINS])
     {
         base_type::init_histogram(histogram);
-        CTA_SYNC();
+        __syncthreads();
         base_type::composite(items, histogram, temp_storage_);
     }
 

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/block/block_merge_sort.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/block/block_merge_sort.hpp
@@ -799,7 +799,7 @@ public:
 private:
   HIPCUB_DEVICE __forceinline__ void SyncImplementation() const
   {
-    CTA_SYNC();
+      __syncthreads();
   }
 
   friend BlockMergeSortStrategyT;

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/block/block_run_length_decode.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/block/block_run_length_decode.hpp
@@ -281,7 +281,7 @@ private:
         }
 
         // Ensure run offsets and run values have been writen to shared memory
-        CTA_SYNC();
+        __syncthreads();
     }
 
     template <typename RunLengthT, typename TotalDecodedSizeT>
@@ -301,7 +301,7 @@ private:
         total_decoded_size = static_cast<TotalDecodedSizeT>(decoded_size_aggregate);
 
         // Ensure the prefix scan's temporary storage can be reused (may be superfluous, but depends on scan implementation)
-        CTA_SYNC();
+        __syncthreads();
 
         InitWithRunOffsets(run_values, run_offsets);
     }

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/block/radix_rank_sort_operations.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/block/radix_rank_sort_operations.hpp
@@ -92,7 +92,8 @@ struct RadixSortTwiddle
 
         enum
         {
-            FLOAT_KEY = TraitsT::CATEGORY == FLOATING_POINT,
+            HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH FLOAT_KEY = TraitsT::CATEGORY == FLOATING_POINT,
+            HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
         };
 
         static __device__ __forceinline__ UnsignedBits ProcessFloatMinusZero(UnsignedBits key)

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_for.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_for.hpp
@@ -77,8 +77,7 @@ struct DeviceFor
                             hipError_t>
     {
         using T              = typename std::iterator_traits<RandomAccessIteratorT>::value_type;
-        using OutputIterator = typename hipcub::DiscardOutputIterator<OffsetT>;
-
+        using OutputIterator = typename rocprim::discard_iterator;
         detail::bulk::OpWrapper<T, OpT> wrapper_op = {op};
 
         OutputIterator output;
@@ -220,10 +219,8 @@ HIPCUB_RUNTIME_FUNCTION
     static hipError_t Bulk(ShapeT shape, OpT op, hipStream_t stream = 0)
     {
         static_assert(std::is_integral<ShapeT>::value, "ShapeT must be an integral type");
-
-        using InputIterator  = typename hipcub::CountingInputIterator<ShapeT>;
-        using OutputIterator = typename hipcub::DiscardOutputIterator<ShapeT>;
-
+        using InputIterator  = typename rocprim::counting_iterator<ShapeT>;
+        using OutputIterator = typename rocprim::discard_iterator;
         detail::bulk::OpWrapper<ShapeT, OpT> wrapper_op = {op};
 
         InputIterator  input(ShapeT(0));

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
@@ -40,29 +40,32 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-class DeviceSpmv
+class HIPCUB_DEPRECATED_BECAUSE("Use the hipSPARSE library instead") DeviceSpmv
 {
 
 public:
+    template<typename ValueT, ///< Matrix and vector value type
+             typename OffsetT> ///< Signed integer type for sequence offsets
+    struct HIPCUB_DEPRECATED_BECAUSE("Use the rocSPARSE library instead") SpmvParams
+    {
+        ValueT*
+            d_values; ///< Pointer to the array of \p num_nonzeros values of the corresponding nonzero elements of matrix <b>A</b>.
+        OffsetT*
+            d_row_end_offsets; ///< Pointer to the array of \p m offsets demarcating the end of every row in \p d_column_indices and \p d_values
+        OffsetT*
+            d_column_indices; ///< Pointer to the array of \p num_nonzeros column-indices of the corresponding nonzero elements of matrix <b>A</b>.  (Indices are zero-valued.)
+        ValueT*
+            d_vector_x; ///< Pointer to the array of \p num_cols values corresponding to the dense input vector <em>x</em>
+        ValueT*
+            d_vector_y; ///< Pointer to the array of \p num_rows values corresponding to the dense output vector <em>y</em>
+        int    num_rows; ///< Number of rows of matrix <b>A</b>.
+        int    num_cols; ///< Number of columns of matrix <b>A</b>.
+        int    num_nonzeros; ///< Number of nonzero elements of matrix <b>A</b>.
+        ValueT alpha; ///< Alpha multiplicand
+        ValueT beta; ///< Beta addend-multiplicand
 
-template <
-    typename        ValueT,              ///< Matrix and vector value type
-    typename        OffsetT>             ///< Signed integer type for sequence offsets
-struct SpmvParams
-{
-    ValueT*         d_values;            ///< Pointer to the array of \p num_nonzeros values of the corresponding nonzero elements of matrix <b>A</b>.
-    OffsetT*        d_row_end_offsets;   ///< Pointer to the array of \p m offsets demarcating the end of every row in \p d_column_indices and \p d_values
-    OffsetT*        d_column_indices;    ///< Pointer to the array of \p num_nonzeros column-indices of the corresponding nonzero elements of matrix <b>A</b>.  (Indices are zero-valued.)
-    ValueT*         d_vector_x;          ///< Pointer to the array of \p num_cols values corresponding to the dense input vector <em>x</em>
-    ValueT*         d_vector_y;          ///< Pointer to the array of \p num_rows values corresponding to the dense output vector <em>y</em>
-    int             num_rows;            ///< Number of rows of matrix <b>A</b>.
-    int             num_cols;            ///< Number of columns of matrix <b>A</b>.
-    int             num_nonzeros;        ///< Number of nonzero elements of matrix <b>A</b>.
-    ValueT          alpha;               ///< Alpha multiplicand
-    ValueT          beta;                ///< Beta addend-multiplicand
-
-    ::hipcub::TexRefInputIterator<ValueT, 66778899, OffsetT>  t_vector_x;
-};
+        ::hipcub::TexRefInputIterator<ValueT, 66778899, OffsetT> t_vector_x;
+    };
 
 static constexpr uint32_t CsrMVKernel_MaxThreads = 256;
 
@@ -106,6 +109,7 @@ CsrMVKernel(SpmvParams<ValueT, int> spmv_params)
 }
 
 template<typename ValueT>
+HIPCUB_DEPRECATED_BECAUSE("Use the rocSPARSE library instead")
 HIPCUB_RUNTIME_FUNCTION static hipError_t CsrMV(void*       d_temp_storage,
                                                 size_t&     temp_storage_bytes,
                                                 ValueT*     d_values,
@@ -118,7 +122,9 @@ HIPCUB_RUNTIME_FUNCTION static hipError_t CsrMV(void*       d_temp_storage,
                                                 int         num_nonzeros,
                                                 hipStream_t stream = 0)
 {
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
     SpmvParams<ValueT, int> spmv_params;
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
     spmv_params.d_values          = d_values;
     spmv_params.d_row_end_offsets = d_row_offsets + 1;
     spmv_params.d_column_indices  = d_column_indices;
@@ -146,28 +152,29 @@ HIPCUB_RUNTIME_FUNCTION static hipError_t CsrMV(void*       d_temp_storage,
         {
             start = std::chrono::high_resolution_clock::now();
         }
+        HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
         CsrMVKernel<<<grid_size, block_size, 0, stream>>>(spmv_params);
+        HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
         HIPCUB_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("CsrMV", block_size * grid_size, start);
     }
     return hipSuccess;
 }
 
 template<typename ValueT>
-HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION static hipError_t
-    CsrMV(void*       d_temp_storage,
-          size_t&     temp_storage_bytes,
-          ValueT*     d_values,
-          int*        d_row_offsets,
-          int*        d_column_indices,
-          ValueT*     d_vector_x,
-          ValueT*     d_vector_y,
-          int         num_rows,
-          int         num_cols,
-          int         num_nonzeros,
-          hipStream_t stream,
-          bool        debug_synchronous)
+HIPCUB_DEPRECATED_BECAUSE("Use the rocSPARSE library instead")
+HIPCUB_RUNTIME_FUNCTION static hipError_t CsrMV(void*       d_temp_storage,
+                                                size_t&     temp_storage_bytes,
+                                                ValueT*     d_values,
+                                                int*        d_row_offsets,
+                                                int*        d_column_indices,
+                                                ValueT*     d_vector_x,
+                                                ValueT*     d_vector_y,
+                                                int         num_rows,
+                                                int         num_cols,
+                                                int         num_nonzeros,
+                                                hipStream_t stream,
+                                                bool /*debug_synchronous*/)
 {
-    HIPCUB_DETAIL_RUNTIME_LOG_DEBUG_SYNCHRONOUS();
     return CsrMV(d_temp_storage,
                  temp_storage_bytes,
                  d_values,

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/grid/grid_barrier.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/grid/grid_barrier.hpp
@@ -31,6 +31,7 @@
 #define HIPCUB_ROCPRIM_GRID_GRID_BARRIER_HPP_
 
 #include "../../../config.hpp"
+#include "../../../util_deprecated.hpp"
 
 #include "../../../thread/thread_load.hpp"
 
@@ -43,11 +44,13 @@ BEGIN_HIPCUB_NAMESPACE
  * @{
  */
 
-
 /**
  * \brief GridBarrier implements a software global barrier among thread blocks within a hip grid
+ * 
+ * deprecated [Since rocm 7.1.0]
+ * 
  */
-class GridBarrier
+class HIPCUB_DEPRECATED_BECAUSE("Use the APIs from cooperative groups instead") GridBarrier
 {
 protected :
     using SyncFlag = unsigned int;
@@ -122,14 +125,18 @@ public:
     }
 };
 
-
 /**
  * \brief GridBarrierLifetime extends GridBarrier to provide lifetime management of the temporary device storage needed for cooperation.
  *
  * Uses RAII for lifetime, i.e., device resources are reclaimed when
  * the destructor is called.
+ * 
+ * deprecated [Since rocm 7.1.0]
+ * 
  */
-class GridBarrierLifetime : public GridBarrier
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+class HIPCUB_DEPRECATED_BECAUSE("Use the APIs from cooperative groups instead") GridBarrierLifetime
+    : public GridBarrier
 {
 protected:
 
@@ -196,7 +203,7 @@ public:
         return retval;
     }
 };
-
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 END_HIPCUB_NAMESPACE
 
 #endif // HIPCUB_ROCPRIM_GRID_GRID_BARRIER_HPP_

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/grid/grid_even_share.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/grid/grid_even_share.hpp
@@ -136,10 +136,10 @@ public:
      * for a "raking" access pattern in which each thread block is assigned a
      * consecutive sequence of input tiles.
      */
-    template <int TILE_ITEMS>
-    __device__ __forceinline__ void BlockInit(
-        int block_id,
-        Int2Type<GRID_MAPPING_RAKE> /*strategy_tag*/)
+    template<int TILE_ITEMS>
+    HIPCUB_DEVICE
+    HIPCUB_FORCEINLINE void BlockInit(int block_id,
+                                      detail::int_constant_t<GRID_MAPPING_RAKE> /*strategy_tag*/)
     {
         block_stride = TILE_ITEMS;
         if (block_id < big_shares)
@@ -163,10 +163,10 @@ public:
      * pattern in which each thread block is assigned a consecutive sequence
      * of input tiles.
      */
-    template <int TILE_ITEMS>
-    __device__ __forceinline__ void BlockInit(
-        int block_id,
-        Int2Type<GRID_MAPPING_STRIP_MINE> /*strategy_tag*/)
+    template<int TILE_ITEMS>
+    HIPCUB_DEVICE
+    HIPCUB_FORCEINLINE void
+        BlockInit(int block_id, detail::int_constant_t<GRID_MAPPING_STRIP_MINE> /*strategy_tag*/)
     {
         block_stride = grid_size * TILE_ITEMS;
         block_offset = (block_id * TILE_ITEMS);
@@ -179,12 +179,11 @@ public:
      * pattern in which the input tiles assigned to each thread block are
      * separated by a stride equal to the the extent of the grid.
      */
-    template <
-        int TILE_ITEMS,
-        GridMappingStrategy STRATEGY>
-    __device__ __forceinline__ void BlockInit()
+    template<int TILE_ITEMS, GridMappingStrategy STRATEGY>
+    HIPCUB_DEVICE
+    HIPCUB_FORCEINLINE void BlockInit()
     {
-        BlockInit<TILE_ITEMS>(blockIdx.x, Int2Type<STRATEGY>());
+        BlockInit<TILE_ITEMS>(blockIdx.x, detail::int_constant_t<STRATEGY>());
     }
 
 
@@ -193,10 +192,11 @@ public:
      * pattern in which each thread block is assigned a consecutive sequence
      * of input tiles.
      */
-    template <int TILE_ITEMS>
-    __device__ __forceinline__ void BlockInit(
-        OffsetT block_offset,                       ///< [in] Threadblock begin offset (inclusive)
-        OffsetT block_end)                          ///< [in] Threadblock end offset (exclusive)
+    template<int TILE_ITEMS, typename OffsetT1 = OffsetT>
+    HIPCUB_DEVICE
+    HIPCUB_FORCEINLINE void
+        BlockInit(OffsetT1 block_offset, ///< [in] Threadblock begin offset (inclusive)
+                  OffsetT1 block_end) ///< [in] Threadblock end offset (exclusive)
     {
         this->block_offset = block_offset;
         this->block_end = block_end;

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/iterator/constant_input_iterator.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/iterator/constant_input_iterator.hpp
@@ -31,6 +31,7 @@
 #define HIPCUB_ROCPRIM_ITERATOR_CONSTANT_INPUT_ITERATOR_HPP_
 
 #include "../../../config.hpp"
+#include "../../../util_deprecated.hpp"
 
 #include "iterator_category.hpp"
 #include "iterator_wrapper.hpp"
@@ -44,7 +45,8 @@ BEGIN_HIPCUB_NAMESPACE
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 
 template<class ValueType, class Difference = std::ptrdiff_t>
-class ConstantInputIterator
+class HIPCUB_DEPRECATED_BECAUSE(
+    "Use rocprim::constant_iterator or rocthrust::constant_iterator instead") ConstantInputIterator
     : public detail::IteratorWrapper<rocprim::constant_iterator<ValueType, Difference>,
                                      ConstantInputIterator<ValueType, Difference>>
 {

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/iterator/counting_input_iterator.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/iterator/counting_input_iterator.hpp
@@ -31,6 +31,7 @@
 #define HIPCUB_ROCPRIM_ITERATOR_COUNTING_INPUT_ITERATOR_HPP_
 
 #include "../../../config.hpp"
+#include "../../../util_deprecated.hpp"
 
 #include "iterator_category.hpp"
 #include "iterator_wrapper.hpp"
@@ -44,7 +45,8 @@ BEGIN_HIPCUB_NAMESPACE
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 
 template<class Incrementable, class Difference = std::ptrdiff_t>
-class CountingInputIterator
+class HIPCUB_DEPRECATED_BECAUSE(
+    "Use rocprim::counting_iterator or rocthrust::counting_iterator instead") CountingInputIterator
     : public detail::IteratorWrapper<rocprim::counting_iterator<Incrementable, Difference>,
                                      CountingInputIterator<Incrementable, Difference>>
 {

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/iterator/discard_output_iterator.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/iterator/discard_output_iterator.hpp
@@ -31,8 +31,11 @@
 #define HIPCUB_ROCPRIM_ITERATOR_DISCARD_OUTPUT_ITERATOR_HPP_
 
 #include "../../../config.hpp"
+#include "../../../util_deprecated.hpp"
 
 #include "iterator_category.hpp"
+
+#include <rocprim/iterator/discard_iterator.hpp> // IWYU pragma: export
 
 #include <iterator>
 #include <iostream>
@@ -48,8 +51,9 @@ BEGIN_HIPCUB_NAMESPACE
 /**
  * \brief A discard iterator
  */
-template <typename OffsetT = ptrdiff_t>
-class DiscardOutputIterator
+template<typename OffsetT = ptrdiff_t>
+class HIPCUB_DEPRECATED_BECAUSE(
+    "Use rocprim::discard_iterator or rocthrust::discard_iterator instead") DiscardOutputIterator
 {
 public:
     // Required iterator traits
@@ -209,11 +213,13 @@ public:
     * @typedef self_type
     * @brief ostream operator
     */
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
     friend std::ostream& operator<<(std::ostream& os, const self_type& itr)
     {
         os << "[" << itr.offset << "]";
         return os;
     }
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 };
 
 END_HIPCUB_NAMESPACE

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/iterator/transform_input_iterator.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/iterator/transform_input_iterator.hpp
@@ -51,7 +51,9 @@ template<class ValueType,
          class InputIteratorT,
          class OffsetT = std::ptrdiff_t // ignored
          >
-class TransformInputIterator
+class HIPCUB_DEPRECATED_BECAUSE(
+    "Use rocprim::transform_iterator or rocthrust::transform_iterator instead")
+    TransformInputIterator
     : public detail::IteratorWrapper<
           rocprim::transform_iterator<InputIteratorT, ConversionOp, ValueType>,
           TransformInputIterator<ValueType, ConversionOp, InputIteratorT, OffsetT>>

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_load.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_load.hpp
@@ -78,15 +78,18 @@ HIPCUB_FORCEINLINE T ThreadLoadVolatilePointer(T* ptr, Fundamental /* is_fundame
 template<int MODIFIER, typename InputIteratorT>
 HIPCUB_DEVICE
 HIPCUB_FORCEINLINE typename std::iterator_traits<InputIteratorT>::value_type
-    ThreadLoad(InputIteratorT itr, Int2Type<MODIFIER> /*modifier*/, Int2Type<false> /*is_pointer*/)
+    ThreadLoad(InputIteratorT itr,
+               detail::int_constant_t<MODIFIER> /*modifier*/,
+               ::std::false_type /*is_pointer*/)
 {
     return rocprim::thread_load<rocprim::cache_load_modifier(MODIFIER)>(itr);
 }
 
 template<int MODIFIER, typename T>
 HIPCUB_DEVICE
-HIPCUB_FORCEINLINE
-    T ThreadLoad(T* ptr, Int2Type<MODIFIER> /*modifier*/, Int2Type<true> /*is_pointer*/)
+HIPCUB_FORCEINLINE T ThreadLoad(T* ptr,
+                                detail::int_constant_t<MODIFIER> /*modifier*/,
+                                ::std::true_type /*is_pointer*/)
 {
     return rocprim::thread_load<rocprim::cache_load_modifier(MODIFIER)>(ptr);
 }
@@ -97,8 +100,8 @@ HIPCUB_FORCEINLINE
     typename std::iterator_traits<InputIteratorT>::value_type ThreadLoad(InputIteratorT itr)
 {
     return ThreadLoad(itr,
-                      Int2Type<MODIFIER>(),
-                      Int2Type<std::is_pointer<InputIteratorT>::value>());
+                      detail::int_constant_t<MODIFIER>(),
+                      ::std::bool_constant<::std::is_pointer<InputIteratorT>::value>());
 }
 
 END_HIPCUB_NAMESPACE

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
@@ -106,7 +106,8 @@ struct Max
     HIPCUB_HOST_DEVICE inline constexpr typename std::common_type<T, U>::type
         operator()(T&& t, U&& u) const
     {
-        return HIPCUB_MAX(t, u);
+        // TODO: change to use hip::std::max after libhipcxx is ready
+        return (((u) > (t)) ? (u) : (t));
     }
 };
 
@@ -116,7 +117,8 @@ struct Min
     HIPCUB_HOST_DEVICE inline constexpr typename std::common_type<T, U>::type
         operator()(T&& t, U&& u) const
     {
-        return HIPCUB_MIN(t, u);
+        // TODO: change to use hip::std::min after libhipcxx is ready
+        return (((u) < (t)) ? (u) : (t));
     }
 };
 

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_scan.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_scan.hpp
@@ -49,28 +49,28 @@ namespace internal {
   * @{
   */
 
- template <
-     int         LENGTH,
-     typename    T,
-     typename    ScanOp>
- __device__ __forceinline__ T ThreadScanExclusive(
-     T                   inclusive,              ///< [in] Initial value for inclusive aggregate
-     T                   exclusive,              ///< [in] Initial value for exclusive aggregate
-     T                   *input,                 ///< [in] Input array
-     T                   *output,                ///< [out] Output array (may be aliased to \p input)
-     ScanOp              scan_op,                ///< [in] Binary scan operator
-     Int2Type<LENGTH>    /*length*/)
- {
-     #pragma unroll
-     for (int i = 0; i < LENGTH; ++i)
-     {
-         inclusive = scan_op(exclusive, input[i]);
-         output[i] = exclusive;
-         exclusive = inclusive;
-     }
+template<int LENGTH,
+         typename T,
+         typename ScanOp>
+ HIPCUB_DEVICE
+HIPCUB_FORCEINLINE
+    T ThreadScanExclusive(T      inclusive, ///< [in] Initial value for inclusive aggregate
+                          T      exclusive, ///< [in] Initial value for exclusive aggregate
+                          T*     input, ///< [in] Input array
+                          T*     output, ///< [out] Output array (may be aliased to \p input)
+                          ScanOp scan_op, ///< [in] Binary scan operator
+                          detail::int_constant_t<LENGTH> /*length*/)
+{
+#pragma unroll
+    for(int i = 0; i < LENGTH; ++i)
+    {
+        inclusive = scan_op(exclusive, input[i]);
+        output[i] = exclusive;
+        exclusive = inclusive;
+    }
 
-     return inclusive;
- }
+    return inclusive;
+}
 
  #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
@@ -81,27 +81,33 @@ namespace internal {
   * \tparam T          <b>[inferred]</b> The data type to be scanned.
   * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
   */
- template <
-     int         LENGTH,
-     typename    T,
-     typename    ScanOp>
- __device__ __forceinline__ T ThreadScanExclusive(
-     T           *input,                 ///< [in] Input array
-     T           *output,                ///< [out] Output array (may be aliased to \p input)
-     ScanOp      scan_op,                ///< [in] Binary scan operator
-     T           prefix,                 ///< [in] Prefix to seed scan with
-     bool        apply_prefix = true)    ///< [in] Whether or not the calling thread should apply its prefix.  If not, the first output element is undefined.  (Handy for preventing thread-0 from applying a prefix.)
- {
-     T inclusive = input[0];
-     if (apply_prefix)
-     {
-         inclusive = scan_op(prefix, inclusive);
-     }
-     output[0] = prefix;
-     T exclusive = inclusive;
+template<int LENGTH,
+         typename T,
+         typename ScanOp>
+ HIPCUB_DEVICE
+HIPCUB_FORCEINLINE T ThreadScanExclusive(
+    T*     input, ///< [in] Input array
+    T*     output, ///< [out] Output array (may be aliased to \p input)
+    ScanOp scan_op, ///< [in] Binary scan operator
+    T      prefix, ///< [in] Prefix to seed scan with
+    bool   apply_prefix
+    = true) ///< [in] Whether or not the calling thread should apply its prefix.  If not, the first output element is undefined.  (Handy for preventing thread-0 from applying a prefix.)
+{
+    T inclusive = input[0];
+    if(apply_prefix)
+    {
+        inclusive = scan_op(prefix, inclusive);
+    }
+    output[0]   = prefix;
+    T exclusive = inclusive;
 
-     return ThreadScanExclusive(inclusive, exclusive, input + 1, output + 1, scan_op, Int2Type<LENGTH - 1>());
- }
+    return ThreadScanExclusive(inclusive,
+                               exclusive,
+                               input + 1,
+                               output + 1,
+                               scan_op,
+                               detail::int_constant_t<LENGTH - 1>());
+}
 
  /**
   * \brief Perform a sequential exclusive prefix scan over the statically-sized \p input array, seeded with the specified \p prefix.  The aggregate is returned.
@@ -110,42 +116,43 @@ namespace internal {
   * \tparam T          <b>[inferred]</b> The data type to be scanned.
   * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
   */
- template <
-     int         LENGTH,
-     typename    T,
-     typename    ScanOp>
- __device__ __forceinline__ T ThreadScanExclusive(
-     T           (&input)[LENGTH],       ///< [in] Input array
-     T           (&output)[LENGTH],      ///< [out] Output array (may be aliased to \p input)
-     ScanOp      scan_op,                ///< [in] Binary scan operator
-     T           prefix,                 ///< [in] Prefix to seed scan with
-     bool        apply_prefix = true)    ///< [in] Whether or not the calling thread should apply its prefix.  (Handy for preventing thread-0 from applying a prefix.)
- {
-     return ThreadScanExclusive<LENGTH>((T*) input, (T*) output, scan_op, prefix, apply_prefix);
- }
+template<int LENGTH,
+         typename T,
+         typename ScanOp>
+ HIPCUB_DEVICE
+HIPCUB_FORCEINLINE T ThreadScanExclusive(
+    T (&input)[LENGTH], ///< [in] Input array
+    T (&output)[LENGTH], ///< [out] Output array (may be aliased to \p input)
+    ScanOp scan_op, ///< [in] Binary scan operator
+    T      prefix, ///< [in] Prefix to seed scan with
+    bool   apply_prefix
+    = true) ///< [in] Whether or not the calling thread should apply its prefix.  (Handy for preventing thread-0 from applying a prefix.)
+{
+    return ThreadScanExclusive<LENGTH>((T*)input, (T*)output, scan_op, prefix, apply_prefix);
+}
 
  #endif
 
- template <
-     int         LENGTH,
-     typename    T,
-     typename    ScanOp>
- __device__ __forceinline__ T ThreadScanInclusive(
-     T                   inclusive,              ///< [in] Initial value for inclusive aggregate
-     T                   *input,                 ///< [in] Input array
-     T                   *output,                ///< [out] Output array (may be aliased to \p input)
-     ScanOp              scan_op,                ///< [in] Binary scan operator
-     Int2Type<LENGTH>    /*length*/)
- {
-     #pragma unroll
-     for (int i = 0; i < LENGTH; ++i)
-     {
-         inclusive = scan_op(inclusive, input[i]);
-         output[i] = inclusive;
-     }
+template<int LENGTH,
+         typename T,
+         typename ScanOp>
+ HIPCUB_DEVICE
+HIPCUB_FORCEINLINE
+    T ThreadScanInclusive(T      inclusive, ///< [in] Initial value for inclusive aggregate
+                          T*     input, ///< [in] Input array
+                          T*     output, ///< [out] Output array (may be aliased to \p input)
+                          ScanOp scan_op, ///< [in] Binary scan operator
+                          detail::int_constant_t<LENGTH> /*length*/)
+{
+#pragma unroll
+    for(int i = 0; i < LENGTH; ++i)
+    {
+        inclusive = scan_op(inclusive, input[i]);
+        output[i] = inclusive;
+    }
 
-     return inclusive;
- }
+    return inclusive;
+}
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
@@ -156,21 +163,25 @@ namespace internal {
   * \tparam T          <b>[inferred]</b> The data type to be scanned.
   * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
   */
- template <
-     int         LENGTH,
-     typename    T,
-     typename    ScanOp>
- __device__ __forceinline__ T ThreadScanInclusive(
-     T           *input,                 ///< [in] Input array
-     T           *output,                ///< [out] Output array (may be aliased to \p input)
-     ScanOp      scan_op)                ///< [in] Binary scan operator
- {
-     T inclusive = input[0];
-     output[0] = inclusive;
+template<int LENGTH,
+         typename T,
+         typename ScanOp>
+ HIPCUB_DEVICE
+HIPCUB_FORCEINLINE
+    T ThreadScanInclusive(T*     input, ///< [in] Input array
+                          T*     output, ///< [out] Output array (may be aliased to \p input)
+                          ScanOp scan_op) ///< [in] Binary scan operator
+{
+    T inclusive = input[0];
+    output[0]   = inclusive;
 
-     // Continue scan
-     return ThreadScanInclusive(inclusive, input + 1, output + 1, scan_op, Int2Type<LENGTH - 1>());
- }
+    // Continue scan
+    return ThreadScanInclusive(inclusive,
+                               input + 1,
+                               output + 1,
+                               scan_op,
+                               detail::int_constant_t<LENGTH - 1>());
+}
 
  /**
   * \brief Perform a sequential inclusive prefix scan over the statically-sized \p input array.  The aggregate is returned.
@@ -179,17 +190,17 @@ namespace internal {
   * \tparam T          <b>[inferred]</b> The data type to be scanned.
   * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
   */
- template <
-     int         LENGTH,
-     typename    T,
-     typename    ScanOp>
- __device__ __forceinline__ T ThreadScanInclusive(
-     T           (&input)[LENGTH],       ///< [in] Input array
-     T           (&output)[LENGTH],      ///< [out] Output array (may be aliased to \p input)
-     ScanOp      scan_op)                ///< [in] Binary scan operator
- {
-     return ThreadScanInclusive<LENGTH>((T*) input, (T*) output, scan_op);
- }
+template<int LENGTH,
+         typename T,
+         typename ScanOp>
+ HIPCUB_DEVICE
+HIPCUB_FORCEINLINE
+    T ThreadScanInclusive(T (&input)[LENGTH], ///< [in] Input array
+                          T (&output)[LENGTH], ///< [out] Output array (may be aliased to \p input)
+                          ScanOp scan_op) ///< [in] Binary scan operator
+{
+    return ThreadScanInclusive<LENGTH>((T*)input, (T*)output, scan_op);
+}
 
  /**
   * \brief Perform a sequential inclusive prefix scan over \p LENGTH elements of the \p input array, seeded with the specified \p prefix.  The aggregate is returned.
@@ -198,27 +209,32 @@ namespace internal {
   * \tparam T          <b>[inferred]</b> The data type to be scanned.
   * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
   */
- template <
-     int         LENGTH,
-     typename    T,
-     typename    ScanOp>
- __device__ __forceinline__ T ThreadScanInclusive(
-     T           *input,                 ///< [in] Input array
-     T           *output,                ///< [out] Output array (may be aliased to \p input)
-     ScanOp      scan_op,                ///< [in] Binary scan operator
-     T           prefix,                 ///< [in] Prefix to seed scan with
-     bool        apply_prefix = true)    ///< [in] Whether or not the calling thread should apply its prefix.  (Handy for preventing thread-0 from applying a prefix.)
- {
-     T inclusive = input[0];
-     if (apply_prefix)
-     {
-         inclusive = scan_op(prefix, inclusive);
-     }
-     output[0] = inclusive;
+template<int LENGTH,
+         typename T,
+         typename ScanOp>
+ HIPCUB_DEVICE
+HIPCUB_FORCEINLINE T ThreadScanInclusive(
+    T*     input, ///< [in] Input array
+    T*     output, ///< [out] Output array (may be aliased to \p input)
+    ScanOp scan_op, ///< [in] Binary scan operator
+    T      prefix, ///< [in] Prefix to seed scan with
+    bool   apply_prefix
+    = true) ///< [in] Whether or not the calling thread should apply its prefix.  (Handy for preventing thread-0 from applying a prefix.)
+{
+    T inclusive = input[0];
+    if(apply_prefix)
+    {
+        inclusive = scan_op(prefix, inclusive);
+    }
+    output[0] = inclusive;
 
-     // Continue scan
-     return ThreadScanInclusive(inclusive, input + 1, output + 1, scan_op, Int2Type<LENGTH - 1>());
- }
+    // Continue scan
+    return ThreadScanInclusive(inclusive,
+                               input + 1,
+                               output + 1,
+                               scan_op,
+                               detail::int_constant_t<LENGTH - 1>());
+}
 
  /**
   * \brief Perform a sequential inclusive prefix scan over the statically-sized \p input array, seeded with the specified \p prefix.  The aggregate is returned.
@@ -227,19 +243,20 @@ namespace internal {
   * \tparam T          <b>[inferred]</b> The data type to be scanned.
   * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
   */
- template <
-     int         LENGTH,
-     typename    T,
-     typename    ScanOp>
- __device__ __forceinline__ T ThreadScanInclusive(
-     T           (&input)[LENGTH],       ///< [in] Input array
-     T           (&output)[LENGTH],      ///< [out] Output array (may be aliased to \p input)
-     ScanOp      scan_op,                ///< [in] Binary scan operator
-     T           prefix,                 ///< [in] Prefix to seed scan with
-     bool        apply_prefix = true)    ///< [in] Whether or not the calling thread should apply its prefix.  (Handy for preventing thread-0 from applying a prefix.)
- {
-     return ThreadScanInclusive<LENGTH>((T*) input, (T*) output, scan_op, prefix, apply_prefix);
- }
+template<int LENGTH,
+         typename T,
+         typename ScanOp>
+ HIPCUB_DEVICE
+HIPCUB_FORCEINLINE T ThreadScanInclusive(
+    T (&input)[LENGTH], ///< [in] Input array
+    T (&output)[LENGTH], ///< [out] Output array (may be aliased to \p input)
+    ScanOp scan_op, ///< [in] Binary scan operator
+    T      prefix, ///< [in] Prefix to seed scan with
+    bool   apply_prefix
+    = true) ///< [in] Whether or not the calling thread should apply its prefix.  (Handy for preventing thread-0 from applying a prefix.)
+{
+    return ThreadScanInclusive<LENGTH>((T*)input, (T*)output, scan_op, prefix, apply_prefix);
+}
 
  #endif
 

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_sort.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_sort.hpp
@@ -38,9 +38,10 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-
-template <typename T>
-HIPCUB_DEVICE __forceinline__ void Swap(T &lhs, T &rhs)
+// Should be deprecated once hip::std::swap is available in this scope.
+template<typename T>
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE void Swap(T& lhs, T& rhs)
 {
   T temp = lhs;
   lhs    = rhs;

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_store.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_store.hpp
@@ -52,16 +52,17 @@ enum CacheStoreModifier
 
 template<typename T, typename Fundamental>
 HIPCUB_DEVICE
-HIPCUB_FORCEINLINE void
-    ThreadStoreVolatilePtr(T* ptr, T val, Fundamental /*Int2Type<Bool> is_fundamental*/)
+HIPCUB_FORCEINLINE void ThreadStoreVolatilePtr(T* ptr, T val, Fundamental /*is_fundamental*/)
 {
     rocprim::thread_store<rocprim::store_volatile, T>(ptr, val);
 }
 
 template<int MODIFIER, typename T>
 HIPCUB_DEVICE
-HIPCUB_FORCEINLINE void
-    ThreadStore(T* ptr, T val, Int2Type<MODIFIER> /*modifier*/, Int2Type<true> /*is_pointer*/)
+HIPCUB_FORCEINLINE void ThreadStore(T* ptr,
+                                    T  val,
+                                    detail::int_constant_t<MODIFIER> /*modifier*/,
+                                    ::std::true_type /*is_pointer*/)
 {
     rocprim::thread_store<rocprim::cache_store_modifier(MODIFIER), T>(ptr, val);
 }
@@ -70,10 +71,10 @@ template<int MODIFIER, typename OutputIteratorT, typename T>
 HIPCUB_DEVICE
 HIPCUB_FORCEINLINE void ThreadStore(OutputIteratorT itr,
                                     T               val,
-                                    Int2Type<MODIFIER> /*modifier*/,
-                                    Int2Type<false> /*is_pointer*/)
+                                    detail::int_constant_t<MODIFIER> /*modifier*/,
+                                    ::std::false_type /*is_pointer*/)
 {
-    ThreadStore<MODIFIER>(&(*itr), val, Int2Type<MODIFIER>(), Int2Type<true>());
+    ThreadStore<MODIFIER>(&(*itr), val, detail::int_constant_t<MODIFIER>{}, ::std::true_type{});
 }
 
 template<CacheStoreModifier MODIFIER = STORE_DEFAULT, typename OutputIteratorT, typename T>
@@ -82,20 +83,23 @@ HIPCUB_FORCEINLINE void ThreadStore(OutputIteratorT itr, T val)
 {
     ThreadStore(itr,
                 val,
-                Int2Type<MODIFIER>(),
-                Int2Type<std::is_pointer<OutputIteratorT>::value>());
+                detail::int_constant_t<MODIFIER>{},
+                ::std::bool_constant<::std::is_pointer<OutputIteratorT>::value>());
 }
+
+namespace detail
+{
 
 /// Helper structure for templated store iteration (inductive case)
 template<int COUNT, int MAX>
-struct IterateThreadStore
+struct iterate_thread_store
 {
     template<CacheStoreModifier MODIFIER, typename T>
     static HIPCUB_DEVICE
     HIPCUB_FORCEINLINE void Store(T* ptr, T* vals)
     {
         ThreadStore<MODIFIER>(ptr + COUNT, vals[COUNT]);
-        IterateThreadStore<COUNT + 1, MAX>::template Store<MODIFIER>(ptr, vals);
+        iterate_thread_store<COUNT + 1, MAX>::template Store<MODIFIER>(ptr, vals);
     }
 
     template<typename OutputIteratorT, typename T>
@@ -103,13 +107,13 @@ struct IterateThreadStore
     HIPCUB_FORCEINLINE void Dereference(OutputIteratorT ptr, T* vals)
     {
         ptr[COUNT] = vals[COUNT];
-        IterateThreadStore<COUNT + 1, MAX>::Dereference(ptr, vals);
+        iterate_thread_store<COUNT + 1, MAX>::Dereference(ptr, vals);
     }
 };
 
 /// Helper structure for templated store iteration (termination case)
 template<int MAX>
-struct IterateThreadStore<MAX, MAX>
+struct iterate_thread_store<MAX, MAX>
 {
     template<CacheStoreModifier MODIFIER, typename T>
     static HIPCUB_DEVICE
@@ -121,6 +125,11 @@ struct IterateThreadStore<MAX, MAX>
     HIPCUB_FORCEINLINE void Dereference(OutputIteratorT /*ptr*/, T* /*vals*/)
     {}
 };
+
+} // namespace detail
+
+template<int COUNT, int MAX>
+using IterateThreadStore HIPCUB_DEPRECATED = detail::iterate_thread_store<COUNT, MAX>;
 
 END_HIPCUB_NAMESPACE
 #endif

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_macro.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_macro.hpp
@@ -61,31 +61,37 @@ auto max HIPCUB_PREVENT_MACRO_SUBSTITUTION(T&& t, U&& u)
     #undef HIPCUB_PREVENT_MACRO_SUBSTITUTION
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_MAX
     /// Select maximum(a, b)
     #define HIPCUB_MAX(a, b) (((b) > (a)) ? (b) : (a))
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_MIN
     /// Select minimum(a, b)
     #define HIPCUB_MIN(a, b) (((b) < (a)) ? (b) : (a))
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_QUOTIENT_FLOOR
     /// Quotient of x/y rounded down to nearest integer
     #define HIPCUB_QUOTIENT_FLOOR(x, y) ((x) / (y))
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_QUOTIENT_CEILING
     /// Quotient of x/y rounded up to nearest integer
     #define HIPCUB_QUOTIENT_CEILING(x, y) (((x) + (y)-1) / (y))
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_ROUND_UP_NEAREST
     /// x rounded up to the nearest multiple of y
     #define HIPCUB_ROUND_UP_NEAREST(x, y) (HIPCUB_QUOTIENT_CEILING(x, y) * y)
 #endif
 
+/// Deprecated since rocm [7.1]
 #ifndef HIPCUB_ROUND_DOWN_NEAREST
     /// x rounded down to the nearest multiple of y
     #define HIPCUB_ROUND_DOWN_NEAREST(x, y) (((x) / (y)) * y)

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_ptx.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_ptx.hpp
@@ -42,10 +42,14 @@ BEGIN_HIPCUB_NAMESPACE
 
 // Missing compared to CUB:
 // * ThreadExit - not supported
-// * ThreadTrap - not supported
-// * FFMA_RZ, FMUL_RZ - not in CUB public API
-// * WARP_SYNC - not supported, not CUB public API
-// * CTA_SYNC_AND - not supported, not CUB public API
+// * LogicShiftLeft
+// * LogicShiftRight
+// * ThreadTrap - not supported, deprecated in CUB
+// * FFMA_RZ, FMUL_RZ - not supported, deprecated in CUB
+// * SHFL_IDX_SYNC - not supported, deprecated in CUB
+// * WARP_SYNC - deprecated, deprecated in CUB
+// * CTA_SYNC_AND - not supported, deprecated in CUB
+// * CTA_SYNC_OR - not supported, deprecated in CUB
 // * MatchAny - not in CUB public API
 //
 // Differences:
@@ -57,29 +61,30 @@ BEGIN_HIPCUB_NAMESPACE
 
 // ID functions etc.
 
-HIPCUB_DEVICE inline
-int RowMajorTid(int block_dim_x, int block_dim_y, int block_dim_z)
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE int RowMajorTid(int block_dim_x, int block_dim_y, int block_dim_z)
 {
     return ((block_dim_z == 1) ? 0 : (hipThreadIdx_z * block_dim_x * block_dim_y))
         + ((block_dim_y == 1) ? 0 : (hipThreadIdx_y * block_dim_x))
         + hipThreadIdx_x;
 }
 
-HIPCUB_DEVICE inline
-unsigned int LaneId()
+HIPCUB_DEPRECATED_BECAUSE("use ::rocprim::lane_id() instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE unsigned int LaneId()
 {
     return ::rocprim::lane_id();
 }
 
-HIPCUB_DEVICE inline
-unsigned int WarpId()
+HIPCUB_DEPRECATED_BECAUSE("use ::rocprim::warp_id instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE unsigned int WarpId()
 {
     return ::rocprim::warp_id();
 }
 
-template <int LOGICAL_WARP_THREADS, int /* ARCH */ = 0>
-HIPCUB_DEVICE inline 
-uint64_t WarpMask(unsigned int warp_id) {
+template<int LOGICAL_WARP_THREADS, int /* ARCH */ = 0>
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE uint64_t WarpMask(unsigned int warp_id)
+{
     constexpr bool is_pow_of_two = ::rocprim::detail::is_power_of_two(LOGICAL_WARP_THREADS);
     const bool     is_arch_warp  = LOGICAL_WARP_THREADS == ::rocprim::arch::wavefront::size();
 
@@ -93,44 +98,38 @@ uint64_t WarpMask(unsigned int warp_id) {
 }
 
 // Returns the warp lane mask of all lanes less than the calling thread
-HIPCUB_DEVICE inline
-uint64_t LaneMaskLt()
+HIPCUB_DEPRECATED_BECAUSE("use ::rocprim::get_sreg_lanemask_lt instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE uint64_t LaneMaskLt()
 {
-    return (uint64_t(1) << LaneId()) - 1;
+    return (uint64_t(1) << ::rocprim::lane_id()) - 1;
 }
 
 // Returns the warp lane mask of all lanes less than or equal to the calling thread
-HIPCUB_DEVICE inline
-uint64_t LaneMaskLe()
+HIPCUB_DEPRECATED_BECAUSE("use ::rocprim::get_sreg_lanemask_le instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE uint64_t LaneMaskLe()
 {
-    return ((uint64_t(1) << LaneId()) << 1) - 1;
+    return ((uint64_t(1) << ::rocprim::lane_id()) << 1) - 1;
 }
 
 // Returns the warp lane mask of all lanes greater than the calling thread
-HIPCUB_DEVICE inline
-uint64_t LaneMaskGt()
+HIPCUB_DEPRECATED_BECAUSE("use ::rocprim::get_sreg_lanemask_gt instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE uint64_t LaneMaskGt()
 {
     return uint64_t(-1)^LaneMaskLe();
 }
 
 // Returns the warp lane mask of all lanes greater than or equal to the calling thread
-HIPCUB_DEVICE inline
-uint64_t LaneMaskGe()
+HIPCUB_DEPRECATED_BECAUSE("use ::rocprim::get_sreg_lanemask_ge instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE uint64_t LaneMaskGe()
 {
     return uint64_t(-1)^LaneMaskLt();
 }
 
 // Shuffle funcs
 
-template <
-    int LOGICAL_WARP_THREADS,
-    typename T
->
-HIPCUB_DEVICE inline
-T ShuffleUp(T input,
-            int src_offset,
-            int first_thread,
-            unsigned int member_mask)
+template<int LOGICAL_WARP_THREADS, typename T>
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE T ShuffleUp(T input, int src_offset, int first_thread, unsigned int member_mask)
 {
     // Not supported in rocPRIM.
     (void) first_thread;
@@ -142,15 +141,9 @@ T ShuffleUp(T input,
     );
 }
 
-template <
-    int LOGICAL_WARP_THREADS,
-    typename T
->
-HIPCUB_DEVICE inline
-T ShuffleDown(T input,
-              int src_offset,
-              int last_thread,
-              unsigned int member_mask)
+template<int LOGICAL_WARP_THREADS, typename T>
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE T ShuffleDown(T input, int src_offset, int last_thread, unsigned int member_mask)
 {
     // Not supported in rocPRIM.
     (void) last_thread;
@@ -162,14 +155,9 @@ T ShuffleDown(T input,
     );
 }
 
-template <
-    int LOGICAL_WARP_THREADS,
-    typename T
->
-HIPCUB_DEVICE inline
-T ShuffleIndex(T input,
-               int src_lane,
-               unsigned int member_mask)
+template<int LOGICAL_WARP_THREADS, typename T>
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE T ShuffleIndex(T input, int src_lane, unsigned int member_mask)
 {
     // Member mask is not supported in rocPRIM, because it's
     // not supported in ROCm.
@@ -181,30 +169,27 @@ T ShuffleIndex(T input,
 
 // Other
 
-HIPCUB_DEVICE inline
-unsigned int SHR_ADD(unsigned int x,
-                     unsigned int shift,
-                     unsigned int addend)
+HIPCUB_DEPRECATED_BECAUSE("will be removed in the next major release")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE
+    unsigned int SHR_ADD(unsigned int x, unsigned int shift, unsigned int addend)
 {
     return (x >> shift) + addend;
 }
 
-HIPCUB_DEVICE inline
-unsigned int SHL_ADD(unsigned int x,
-                     unsigned int shift,
-                     unsigned int addend)
+HIPCUB_DEPRECATED_BECAUSE("will be removed in the next major release")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE
+    unsigned int SHL_ADD(unsigned int x, unsigned int shift, unsigned int addend)
 {
     return (x << shift) + addend;
 }
 
 namespace detail {
 
-template <typename UnsignedBits>
-HIPCUB_DEVICE inline
-auto unsigned_bit_extract(UnsignedBits source,
-                          unsigned int bit_start,
-                          unsigned int num_bits)
-    -> typename std::enable_if<sizeof(UnsignedBits) == 8, unsigned int>::type
+template<typename UnsignedBits>
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE auto
+    unsigned_bit_extract(UnsignedBits source, unsigned int bit_start, unsigned int num_bits) ->
+    typename std::enable_if<sizeof(UnsignedBits) == 8, unsigned int>::type
 {
     #ifdef __HIP_PLATFORM_AMD__
         return __bitextract_u64(source, bit_start, num_bits);
@@ -213,12 +198,11 @@ auto unsigned_bit_extract(UnsignedBits source,
     #endif // __HIP_PLATFORM_AMD__
 }
 
-template <typename UnsignedBits>
-HIPCUB_DEVICE inline
-auto unsigned_bit_extract(UnsignedBits source,
-                          unsigned int bit_start,
-                          unsigned int num_bits)
-    -> typename std::enable_if<sizeof(UnsignedBits) < 8, unsigned int>::type
+template<typename UnsignedBits>
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE auto
+    unsigned_bit_extract(UnsignedBits source, unsigned int bit_start, unsigned int num_bits) ->
+    typename std::enable_if<sizeof(UnsignedBits) < 8, unsigned int>::type
 {
     #ifdef __HIP_PLATFORM_AMD__
         return __bitextract_u32(source, bit_start, num_bits);
@@ -232,11 +216,10 @@ auto unsigned_bit_extract(UnsignedBits source,
 // Bitfield-extract.
 // Extracts \p num_bits from \p source starting at bit-offset \p bit_start.
 // The input \p source may be an 8b, 16b, 32b, or 64b unsigned integer type.
-template <typename UnsignedBits>
-HIPCUB_DEVICE inline
-unsigned int BFE(UnsignedBits source,
-                 unsigned int bit_start,
-                 unsigned int num_bits)
+template<typename UnsignedBits>
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE unsigned int
+    BFE(UnsignedBits source, unsigned int bit_start, unsigned int num_bits)
 {
     static_assert(std::is_unsigned<UnsignedBits>::value, "UnsignedBits must be unsigned");
     return detail::unsigned_bit_extract(source, bit_start, num_bits);
@@ -247,10 +230,11 @@ unsigned int BFE(UnsignedBits source,
  * Bitfield-extract for 128-bit types.
  */
 template<typename UnsignedBits>
-__device__ __forceinline__ unsigned int BFE(UnsignedBits source,
-                                            unsigned int bit_start,
-                                            unsigned int num_bits,
-                                            Int2Type<16> /*byte_len*/)
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE unsigned int BFE(UnsignedBits source,
+                                    unsigned int bit_start,
+                                    unsigned int num_bits,
+                                    detail::int_constant_t<16> /*byte_len*/)
 {
     const __uint128_t MASK = (__uint128_t{1} << num_bits) - 1;
     return (source >> bit_start) & MASK;
@@ -259,12 +243,12 @@ __device__ __forceinline__ unsigned int BFE(UnsignedBits source,
 
 // Bitfield insert.
 // Inserts the \p num_bits least significant bits of \p y into \p x at bit-offset \p bit_start.
-HIPCUB_DEVICE inline
-void BFI(unsigned int &ret,
-         unsigned int x,
-         unsigned int y,
-         unsigned int bit_start,
-         unsigned int num_bits)
+HIPCUB_DEPRECATED_BECAUSE("will be removed in the next major release")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE void BFI(unsigned int& ret,
+                                          unsigned int  x,
+                                          unsigned int  y,
+                                          unsigned int  bit_start,
+                                          unsigned int  num_bits)
 {
     #ifdef __HIP_PLATFORM_AMD__
         ret = __bitinsert_u32(x, y, bit_start, num_bits);
@@ -276,58 +260,83 @@ void BFI(unsigned int &ret,
     #endif // __HIP_PLATFORM_AMD__
 }
 
-HIPCUB_DEVICE inline
-unsigned int IADD3(unsigned int x, unsigned int y, unsigned int z)
+HIPCUB_DEPRECATED_BECAUSE("will be removed in the next major release")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE unsigned int IADD3(unsigned int x, unsigned int y, unsigned int z)
 {
     return x + y + z;
 }
 
-HIPCUB_DEVICE inline
-int PRMT(unsigned int a, unsigned int b, unsigned int index)
+HIPCUB_DEPRECATED_BECAUSE("will be removed in the next major release")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE int PRMT(unsigned int a, unsigned int b, unsigned int index)
 {
     return ::__byte_perm(a, b, index);
 }
 
-HIPCUB_DEVICE inline
-void BAR(int count)
+HIPCUB_DEPRECATED_BECAUSE("will be removed in the next major release")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE void BAR(int count)
 {
     (void) count;
     __syncthreads();
 }
 
-HIPCUB_DEVICE inline
-void CTA_SYNC()
+HIPCUB_DEPRECATED_BECAUSE("use __syncthreads() instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE void CTA_SYNC()
 {
     __syncthreads();
 }
 
-HIPCUB_DEVICE inline
-void WARP_SYNC(unsigned int member_mask)
+HIPCUB_DEPRECATED_BECAUSE("use ::rocprim::wave_barrier() instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE void WARP_SYNC(unsigned int member_mask)
 {
     (void) member_mask;
     ::rocprim::wave_barrier();
 }
 
-HIPCUB_DEVICE inline
-int WARP_ANY(int predicate, uint64_t member_mask)
+HIPCUB_DEPRECATED_BECAUSE("use ::__any(predicate) instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE int WARP_ANY(int predicate, uint64_t member_mask)
 {
     (void) member_mask;
     return ::__any(predicate);
 }
 
-HIPCUB_DEVICE inline
-int WARP_ALL(int predicate, uint64_t member_mask)
+HIPCUB_DEPRECATED_BECAUSE("use ::__all(predicate) instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE int WARP_ALL(int predicate, uint64_t member_mask)
 {
     (void) member_mask;
     return ::__all(predicate);
 }
 
-HIPCUB_DEVICE inline
-int64_t WARP_BALLOT(int predicate, uint64_t member_mask)
+HIPCUB_DEPRECATED_BECAUSE("use ::__ballot(predicate) instead")
+HIPCUB_DEVICE HIPCUB_FORCEINLINE int64_t WARP_BALLOT(int predicate, uint64_t member_mask)
 {
     (void) member_mask;
     return __ballot(predicate);
 }
+
+namespace detail
+{
+
+/**
+ * @brief Shifts @p val left by the amount specified by unsigned 32-bit value in @p num_bits. If @p
+ * num_bits is larger than 32 bits, @p num_bits is clamped to 32.
+ */
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE uint32_t LogicShiftLeft(uint32_t val, uint32_t num_bits)
+{
+    return num_bits >= sizeof(val) * 8 ? 0 : val << num_bits;
+}
+
+/**
+ * @brief Shifts @p val right by the amount specified by unsigned 32-bit value in @p num_bits. If @p
+ * num_bits is larger than 32 bits, @p num_bits is clamped to 32.
+ */
+HIPCUB_DEVICE
+HIPCUB_FORCEINLINE uint32_t LogicShiftRight(uint32_t val, uint32_t num_bits)
+{
+    return num_bits >= sizeof(val) * 8 ? 0 : val >> num_bits;
+}
+
+} // namespace detail
 
 END_HIPCUB_NAMESPACE
 

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_temporary_storage.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_temporary_storage.hpp
@@ -31,6 +31,7 @@
 #define HIPCUB_ROCPRIM_UTIL_TEMPORARY_STORAGE_HPP_
 
 #include "../../config.hpp"
+#include "../../util_deprecated.hpp"
 
 #include <rocprim/detail/temp_storage.hpp> // IWYU pragma: export
 
@@ -62,14 +63,7 @@ typename std::enable_if<(N > 0), hipError_t>::type
 {
     return generate_partition<N - 1>(d_temp_storage, temp_storage_bytes, gen, gen(N - 1), args...);
 }
-} // namespace detail
 
-/// \brief Alias temporaries to externally-allocated device storage (or simply return the amount of storage needed).
-/// \tparam ALLOCATIONS The number of allocations that are needed.
-/// \param d_temp_storage [in] Device-accessible allocation of temporary storage.  When nullptr, the required allocation size is written to \p temp_storage_bytes and no work is done.
-/// \param temp_storage_bytes [in,out] Size in bytes of \t d_temp_storage allocation.
-/// \param allocations [out] Pointers to device allocations needed.
-/// \param allocation_sizes [in] Sizes in bytes of device allocations needed.
 template<int ALLOCATIONS>
 HIPCUB_HOST_DEVICE
 HIPCUB_FORCEINLINE hipError_t AliasTemporaries(void*   d_temp_storage,
@@ -81,6 +75,28 @@ HIPCUB_FORCEINLINE hipError_t AliasTemporaries(void*   d_temp_storage,
     { return rocprim::detail::temp_storage::make_partition(&allocations[i], allocation_sizes[i]); };
 
     return detail::generate_partition<ALLOCATIONS>(d_temp_storage, temp_storage_bytes, generator);
+}
+
+} // namespace detail
+
+/// \brief Alias temporaries to externally-allocated device storage (or simply return the amount of storage needed).
+/// \tparam ALLOCATIONS The number of allocations that are needed.
+/// \param d_temp_storage [in] Device-accessible allocation of temporary storage.  When nullptr, the required allocation size is written to \p temp_storage_bytes and no work is done.
+/// \param temp_storage_bytes [in,out] Size in bytes of \t d_temp_storage allocation.
+/// \param allocations [out] Pointers to device allocations needed.
+/// \param allocation_sizes [in] Sizes in bytes of device allocations needed.
+template<int ALLOCATIONS>
+HIPCUB_DEPRECATED_BECAUSE("Internal-only implementation detail")
+HIPCUB_HOST_DEVICE HIPCUB_FORCEINLINE hipError_t
+    AliasTemporaries(void*   d_temp_storage,
+                     size_t& temp_storage_bytes,
+                     void* (&allocations)[ALLOCATIONS],
+                     const size_t (&allocation_sizes)[ALLOCATIONS])
+{
+    return detail::AliasTemporaries(d_temp_storage,
+                                    temp_storage_bytes,
+                                    allocations,
+                                    allocation_sizes);
 }
 
 END_HIPCUB_NAMESPACE

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_type.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_type.hpp
@@ -31,9 +31,9 @@
 #define HIPCUB_ROCPRIM_UTIL_TYPE_HPP_
 
 #include "../../config.hpp"
+#include "../../util_deprecated.hpp"
 
 #include <rocprim/detail/various.hpp> // IWYU pragma: export
-#include <rocprim/thread/radix_key_codec.hpp> // IWYU pragma: export
 #include <rocprim/type_traits.hpp> // IWYU pragma: export
 #include <rocprim/types/future_value.hpp> // IWYU pragma: export
 
@@ -147,8 +147,8 @@ struct DoubleBuffer
     }
 };
 
-template <int A>
-struct Int2Type
+template<int A>
+struct HIPCUB_DEPRECATED_BECAUSE("Use ::std::integral_constant instead") Int2Type
 {
     enum {VALUE = A};
 };
@@ -480,21 +480,16 @@ struct Uninitialized
 
 /******************************************************************************
  * Simple type traits utilities.
- *
- * For example:
- *     Traits<int>::CATEGORY             // SIGNED_INTEGER
- *     Traits<NullType>::nullptr_TYPE       // true
- *     Traits<uint4>::CATEGORY           // NOT_A_NUMBER
- *     Traits<uint4>::PRIMITIVE;         // false
- *
  ******************************************************************************/
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 
 /**
- * \brief Basic type traits categories
+ * \brief Basic type traits categories.
+ * This enum is deprecated, please use <rocprim/type_traits> instead. Or if you have
+ * libhipcxx, please use the type_traits system in libhipcxx.
  */
-enum Category
+enum HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.") Category
 {
     NOT_A_NUMBER,
     SIGNED_INTEGER,
@@ -502,10 +497,10 @@ enum Category
     FLOATING_POINT
 };
 
-
 /**
  * \brief Basic type traits
  */
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
 template<Category _CATEGORY,
          bool     _PRIMITIVE,
          bool     _nullptr_TYPE,
@@ -514,31 +509,34 @@ template<Category _CATEGORY,
 struct BaseTraits
 {
     /// Category
-    static const Category CATEGORY      = _CATEGORY;
+    HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.")
+    static constexpr Category CATEGORY = _CATEGORY;
     enum
     {
-        PRIMITIVE    = _PRIMITIVE,
-        nullptr_TYPE = _nullptr_TYPE,
+        PRIMITIVE HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.") = _PRIMITIVE,
+        nullptr_TYPE                                                              = _nullptr_TYPE,
     };
 };
-
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 
 /**
  * Basic type traits (unsigned primitive specialization)
  */
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
 template <typename _UnsignedBits, typename T>
 struct BaseTraits<UNSIGNED_INTEGER, true, false, _UnsignedBits, T>
 {
     using UnsignedBits = _UnsignedBits;
 
-    static const Category       CATEGORY    = UNSIGNED_INTEGER;
-    static const UnsignedBits   LOWEST_KEY  = UnsignedBits(0);
-    static const UnsignedBits   MAX_KEY     = UnsignedBits(-1);
+    HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.")
+    static constexpr Category     CATEGORY   = UNSIGNED_INTEGER;
+    static constexpr UnsignedBits LOWEST_KEY = UnsignedBits(0);
+    static constexpr UnsignedBits MAX_KEY    = UnsignedBits(-1);
 
     enum
     {
-        PRIMITIVE    = true,
-        nullptr_TYPE = false,
+        PRIMITIVE HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.") = true,
+        nullptr_TYPE                                                              = false,
     };
 
     using key_codec = decltype(::rocprim::traits::get<T>().template radix_key_codec<false>());
@@ -569,25 +567,27 @@ struct BaseTraits<UNSIGNED_INTEGER, true, false, _UnsignedBits, T>
         return retval;
     }
 };
-
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 
 /**
  * Basic type traits (signed primitive specialization)
  */
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
 template <typename _UnsignedBits, typename T>
 struct BaseTraits<SIGNED_INTEGER, true, false, _UnsignedBits, T>
 {
     using UnsignedBits = _UnsignedBits;
 
-    static const Category       CATEGORY    = SIGNED_INTEGER;
-    static const UnsignedBits   HIGH_BIT    = UnsignedBits(1) << ((sizeof(UnsignedBits) * 8) - 1);
-    static const UnsignedBits   LOWEST_KEY  = HIGH_BIT;
-    static const UnsignedBits   MAX_KEY     = UnsignedBits(-1) ^ HIGH_BIT;
+    HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.")
+    static constexpr Category     CATEGORY   = SIGNED_INTEGER;
+    static constexpr UnsignedBits HIGH_BIT   = UnsignedBits(1) << ((sizeof(UnsignedBits) * 8) - 1);
+    static constexpr UnsignedBits LOWEST_KEY = HIGH_BIT;
+    static constexpr UnsignedBits MAX_KEY    = UnsignedBits(-1) ^ HIGH_BIT;
 
     enum
     {
-        PRIMITIVE    = true,
-        nullptr_TYPE = false,
+        PRIMITIVE HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.") = true,
+        nullptr_TYPE                                                              = false,
     };
 
     using key_codec = decltype(::rocprim::traits::get<T>().template radix_key_codec<false>());
@@ -614,10 +614,13 @@ struct BaseTraits<SIGNED_INTEGER, true, false, _UnsignedBits, T>
         return reinterpret_cast<T&>(retval);
     }
 };
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 
+// This API needs to be deprecated once libhipcxx is available.
 template <typename _T>
 struct FpLimits;
 
+// This API needs to be deprecated once libhipcxx is available.
 template <>
 struct FpLimits<float>
 {
@@ -630,6 +633,7 @@ struct FpLimits<float>
     }
 };
 
+// This API needs to be deprecated once libhipcxx is available.
 template <>
 struct FpLimits<double>
 {
@@ -642,6 +646,7 @@ struct FpLimits<double>
     }
 };
 
+// This API needs to be deprecated once libhipcxx is available.
 template <>
 struct FpLimits<__half>
 {
@@ -656,6 +661,7 @@ struct FpLimits<__half>
     }
 };
 
+// This API needs to be deprecated once libhipcxx is available.
 template <>
 struct FpLimits<hip_bfloat16>
 {
@@ -673,22 +679,24 @@ struct FpLimits<hip_bfloat16>
 /**
  * Basic type traits (fp primitive specialization)
  */
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
 template <typename _UnsignedBits, typename T>
 struct BaseTraits<FLOATING_POINT, true, false, _UnsignedBits, T>
 {
     using UnsignedBits = _UnsignedBits;
 
-    static const Category       CATEGORY    = FLOATING_POINT;
-    static const UnsignedBits   HIGH_BIT    = UnsignedBits(1) << ((sizeof(UnsignedBits) * 8) - 1);
-    static const UnsignedBits   LOWEST_KEY  = UnsignedBits(-1);
-    static const UnsignedBits   MAX_KEY     = UnsignedBits(-1) ^ HIGH_BIT;
+    HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.")
+    static constexpr Category     CATEGORY   = FLOATING_POINT;
+    static constexpr UnsignedBits HIGH_BIT   = UnsignedBits(1) << ((sizeof(UnsignedBits) * 8) - 1);
+    static constexpr UnsignedBits LOWEST_KEY = UnsignedBits(-1);
+    static constexpr UnsignedBits MAX_KEY    = UnsignedBits(-1) ^ HIGH_BIT;
 
     using key_codec = decltype(::rocprim::traits::get<T>().template radix_key_codec<false>());
 
     enum
     {
-        PRIMITIVE    = true,
-        nullptr_TYPE = false,
+        PRIMITIVE HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.") = true,
+        nullptr_TYPE                                                              = false,
     };
 
     static HIPCUB_HOST_DEVICE __forceinline__ UnsignedBits TwiddleIn(UnsignedBits key)
@@ -711,11 +719,12 @@ struct BaseTraits<FLOATING_POINT, true, false, _UnsignedBits, T>
         return FpLimits<T>::Lowest();
     }
 };
-
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 
 /**
  * \brief Numeric type traits
  */
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
 template <typename T> struct NumericTraits :            BaseTraits<NOT_A_NUMBER, false, false, T, T> {};
 
 template <> struct NumericTraits<NullType> :            BaseTraits<NOT_A_NUMBER, false, true, NullType, NullType> {};
@@ -744,7 +753,8 @@ struct NumericTraits<__uint128_t>
     static constexpr UnsignedBits LOWEST_KEY = UnsignedBits(0);
     static constexpr UnsignedBits MAX_KEY    = UnsignedBits(-1);
 
-    static constexpr bool PRIMITIVE = false;
+    HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.")
+    static constexpr bool PRIMITIVE    = false;
     static constexpr bool nullptr_TYPE = false;
 
     using key_codec = decltype(::rocprim::traits::get<T>().template radix_key_codec<false>());
@@ -781,6 +791,7 @@ struct NumericTraits<__int128_t>
     static constexpr UnsignedBits LOWEST_KEY = HIGH_BIT;
     static constexpr UnsignedBits MAX_KEY    = UnsignedBits(-1) ^ HIGH_BIT;
 
+    HIPCUB_DEPRECATED_BECAUSE("Use <rocprim/type_traits> instead.")
     static constexpr bool PRIMITIVE = false;
     static constexpr bool nullptr_TYPE = false;
 
@@ -816,12 +827,30 @@ template <> struct NumericTraits<__half> :              BaseTraits<FLOATING_POIN
 template <> struct NumericTraits<hip_bfloat16 > :       BaseTraits<FLOATING_POINT, true, false, unsigned short, hip_bfloat16 > {};
 
 template <> struct NumericTraits<bool> :                BaseTraits<UNSIGNED_INTEGER, true, false, typename UnitWord<bool>::VolatileWord, bool> {};
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 
 /**
  * \brief Type traits
  */
-template <typename T>
-struct Traits : NumericTraits<typename std::remove_cv<T>::type> {};
+template<typename T>
+struct Traits : NumericTraits<typename std::remove_cv<T>::type>
+{};
+
+namespace detail
+{
+// __uint128_t and __int128_t are not primitive
+
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+template<typename T>
+struct is_primitive : ::std::bool_constant<Traits<T>::PRIMITIVE>
+{};
+
+template<typename T>
+inline constexpr bool is_primitive_v = is_primitive<T>::value;
+
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
+
+} // namespace detail
 
 /**
  * \brief Common type of zero types.
@@ -909,6 +938,9 @@ struct common_type_extended_fp<
 
 template<class...>
 using void_t = void;
+
+template<int Value>
+using int_constant_t = ::std::integral_constant<int, Value>;
 
 // Common type of more than two types.
 

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/warp/warp_merge_sort.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/warp/warp_merge_sort.hpp
@@ -150,13 +150,12 @@ private:
 public:
   WarpMergeSort() = delete;
 
-  HIPCUB_DEVICE __forceinline__
-  WarpMergeSort(typename BlockMergeSortStrategyT::TempStorage &temp_storage)
+  HIPCUB_DEVICE __forceinline__ WarpMergeSort(
+      typename BlockMergeSortStrategyT::TempStorage& temp_storage)
       : BlockMergeSortStrategyT(temp_storage,
-                                IS_ARCH_WARP
-                                  ? LaneId()
-                                  : (LaneId() % LOGICAL_WARP_THREADS))
-      , warp_id(IS_ARCH_WARP ? 0 : (LaneId() / LOGICAL_WARP_THREADS))
+                                IS_ARCH_WARP ? ::rocprim::lane_id()
+                                             : (::rocprim::lane_id() % LOGICAL_WARP_THREADS))
+      , warp_id(IS_ARCH_WARP ? 0 : (::rocprim::lane_id() / LOGICAL_WARP_THREADS))
       , member_mask(WarpMask<LOGICAL_WARP_THREADS>(warp_id))
   {
   }
@@ -169,7 +168,7 @@ public:
 private:
   HIPCUB_DEVICE __forceinline__ void SyncImplementation() const
   {
-    WARP_SYNC(member_mask);
+      ::rocprim::wave_barrier();
   }
 
   friend BlockMergeSortStrategyT;

--- a/projects/hipcub/test/hipcub/bfloat16.hpp
+++ b/projects/hipcub/test/hipcub/bfloat16.hpp
@@ -32,8 +32,9 @@
  * Utilities for interacting with the opaque CUDA __nv_bfloat16 type
  */
 
-#include <stdint.h>
+#include <hipcub/config.hpp>
 #include <hipcub/util_type.hpp>
+#include <stdint.h>
 
 #include <ostream>
 
@@ -285,7 +286,17 @@ struct hipcub::FpLimits<bfloat16_t>
     static __host__ __device__ __forceinline__ bfloat16_t Lowest() { return bfloat16_t::lowest(); }
 };
 
+#if defined(__HIP_PLATFORM_NVIDIA__)
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+#else
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+#endif
 template <> struct hipcub::NumericTraits<bfloat16_t> : hipcub::BaseTraits<FLOATING_POINT, true, false, unsigned short, bfloat16_t> {};
+#if defined(__HIP_PLATFORM_NVIDIA__)
+_CCCL_SUPPRESS_DEPRECATED_POP
+#else
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
+#endif
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/projects/hipcub/test/hipcub/half.hpp
+++ b/projects/hipcub/test/hipcub/half.hpp
@@ -33,12 +33,13 @@
  * Utilities for interacting with the opaque CUDA __half type
  */
 
- #include <stdint.h>
- #include <hipcub/util_type.hpp>
+#include <hipcub/config.hpp>
+#include <hipcub/util_type.hpp>
+#include <stdint.h>
 
- #if defined(__HIP_PLATFORM_NVIDIA__)
-     #include <cuda_fp16.h>
- #endif
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    #include <cuda_fp16.h>
+#endif
 
 #include <cstring>
 #include <ostream>
@@ -338,8 +339,17 @@ struct hipcub::FpLimits<half_t>
     static __host__ __device__ __forceinline__ half_t Lowest() { return half_t::lowest(); }
 };
 
+#if defined(__HIP_PLATFORM_NVIDIA__)
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+#else
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+#endif
 template <> struct hipcub::NumericTraits<half_t> : hipcub::BaseTraits<FLOATING_POINT, true, false, unsigned short, half_t> {};
-
+#if defined(__HIP_PLATFORM_NVIDIA__)
+_CCCL_SUPPRESS_DEPRECATED_POP
+#else
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
+#endif
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/projects/hipcub/test/hipcub/test_hipcub_block_exchange.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_exchange.cpp
@@ -1103,7 +1103,7 @@ TYPED_TEST(HipcubBlockExchangeTests, StripedToBlockedOneParam)
     HIP_CHECK(hipSetDevice(device_id));
 
     using type        = typename TestFixture::params::type;
-    using output_type = typename TestFixture::params::output_type;
+    using output_type [[maybe_unused]] = typename TestFixture::params::output_type;
 
     constexpr size_t block_size       = TestFixture::params::block_size;
     constexpr size_t items_per_thread = TestFixture::params::items_per_thread;
@@ -1196,7 +1196,7 @@ TYPED_TEST(HipcubBlockExchangeTests, BlockedToStripedOneParam)
     HIP_CHECK(hipSetDevice(device_id));
 
     using type        = typename TestFixture::params::type;
-    using output_type = typename TestFixture::params::output_type;
+    using output_type [[maybe_unused]] = typename TestFixture::params::output_type;
 
     constexpr size_t block_size       = TestFixture::params::block_size;
     constexpr size_t items_per_thread = TestFixture::params::items_per_thread;
@@ -1843,7 +1843,7 @@ TYPED_TEST(HipcubBlockExchangeTests, ScatterToStripedGuardedNoOutputParam)
         device_input,
         device_ranks);
 
-    type* host_output = new type[size];
+    [[maybe_unused]] type* host_output = new type[size];
     HIP_CHECK(hipMemcpy(host_input, device_input, sizeof(type) * size, hipMemcpyDeviceToHost));
 
     for(size_t i = 0; i < size; i++)

--- a/projects/hipcub/test/hipcub/test_hipcub_block_load_store.hpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_load_store.hpp
@@ -373,6 +373,8 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreDiscardIterator)
 
         // Test with discard output iterator
         // using OffsetT = typename std::iterator_traits<Type>::difference_type;
+        HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+        // TODO: Here in block load an store, it's not possible to use rocprim::discard_iterator
         hipcub::DiscardOutputIterator<size_t> discard_itr;
 
         // Running kernel
@@ -386,7 +388,7 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreDiscardIterator)
                                                     discard_itr,
                                                     discard_itr,
                                                     guarded_elements);
-
+        HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
         // Running kernel
         load_store_guarded_kernel<Type *,
                                   Type *,

--- a/projects/hipcub/test/hipcub/test_hipcub_block_merge_sort.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_merge_sort.cpp
@@ -895,8 +895,8 @@ TYPED_TEST(HipcubBlockMergeSort, StableSortKeysValuesWithValidItems)
     T*           host_keys_input   = new T[size];
     T*           host_values_input = new T[size];
 
-    T* host_keys_expected   = new T[size];
-    T* host_values_expected = new T[size];
+    [[maybe_unused]] T* host_keys_expected   = new T[size];
+    [[maybe_unused]] T* host_values_expected = new T[size];
 
     T* device_keys_input;
     T* device_values_input;

--- a/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -596,7 +596,7 @@ void rank_with_prefix_sum_kernel(const KeyType* keys_input,
 
     const size_t pfs_size       = (1 << RadixBits);
     const size_t pfs_offset     = (blockIdx.x * pfs_size) + (threadIdx.x * bins_tracked_per_thread);
-    const size_t pfs_total_size = pfs_size * blockDim.x;
+    [[maybe_unused]] const size_t pfs_total_size = pfs_size * blockDim.x;
 
     for(size_t i = 0; i < bins_tracked_per_thread; i++)
     {

--- a/projects/hipcub/test/hipcub/test_hipcub_device_adjacent_difference.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_adjacent_difference.cpp
@@ -481,11 +481,8 @@ TYPED_TEST(HipcubDeviceAdjacentDifferenceLargeTests, LargeIndicesAndOpOnce)
             HIP_CHECK(hipMemset(d_counter, 0, sizeof(*d_counter)));
 
             OutputIterator output(d_incorrect_flag, d_counter);
-
-            const auto input = hipcub::CountingInputIterator<T>(T{0});
-
+            const auto            input    = rocprim::counting_iterator<T>(T{0});
             static constexpr auto left_tag = std::integral_constant<bool, left>{};
-
             static constexpr auto copy_tag = std::integral_constant<bool, copy>{};
 
             FocusIndex<left> op;

--- a/projects/hipcub/test/hipcub/test_hipcub_device_for.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_for.cpp
@@ -687,8 +687,7 @@ TEST(HipcubDeviceForTests, ForCountingIterator)
 
             // Device pointers
             unsigned int* d_count;
-            const auto    it = hipcub::CountingInputIterator<T>{0};
-
+            const auto    it = rocprim::counting_iterator<T>{0};
             // Allocate memory
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_count, sizeof(unsigned int)));
 
@@ -739,7 +738,7 @@ TEST(HipcubDeviceForTests, ForCopyCountingIterator)
 
             // Device pointers
             unsigned int* d_count;
-            const auto    it = hipcub::CountingInputIterator<T>{0};
+            const auto    it = rocprim::counting_iterator<T>{0};
 
             // Allocate memory
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_count, sizeof(unsigned int)));

--- a/projects/hipcub/test/hipcub/test_hipcub_device_histogram.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_histogram.cpp
@@ -387,7 +387,7 @@ TYPED_TEST(HipcubDeviceHistogramEvenOverflow, EvenOverflow)
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
         // Generate data
-        auto          d_input = hipcub::CountingInputIterator<sample_type>{0UL};
+        auto          d_input = rocprim::counting_iterator<sample_type>{0UL};
         counter_type* d_histogram;
         HIP_CHECK(test_common_utils::hipMallocHelper(&d_histogram, bins * sizeof(counter_type)));
 
@@ -880,12 +880,8 @@ TYPED_TEST(HipcubDeviceHistogramMultiEven, MultiEven)
                     }
                 }
             }
-
-            hipcub::TransformInputIterator<sample_type, transform_op<sample_type>, sample_type *> d_input2(
-                d_input,
-                transform_op<sample_type>()
-            );
-
+            rocprim::transform_iterator<sample_type*, transform_op<sample_type>, sample_type>
+                   d_input2(d_input, transform_op<sample_type>());
             size_t temporary_storage_bytes = 0;
             if(rows == 1)
             {
@@ -1214,12 +1210,8 @@ TYPED_TEST(HipcubDeviceHistogramMultiRange, MultiRange)
                     }
                 }
             }
-
-            hipcub::TransformInputIterator<sample_type, transform_op<sample_type>, sample_type *> d_input2(
-                d_input,
-                transform_op<sample_type>()
-            );
-
+            rocprim::transform_iterator<sample_type*, transform_op<sample_type>, sample_type>
+                   d_input2(d_input, transform_op<sample_type>());
             size_t temporary_storage_bytes = 0;
             if(rows == 1)
             {

--- a/projects/hipcub/test/hipcub/test_hipcub_device_merge.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_merge.cpp
@@ -496,10 +496,9 @@ TEST(HipcubDeviceMerge, MergeLargeSizeIterators)
         compare_function compare_op;
 
         // Generate data
-        const auto input1 = hipcub::CountingInputIterator<key_type>(key_type{0});
+        const auto input1 = rocprim::counting_iterator<key_type>(key_type{0});
         const auto input2
-            = hipcub::CountingInputIterator<key_type>(key_type{static_cast<key_type>(size1)});
-
+            = rocprim::counting_iterator<key_type>(key_type{static_cast<key_type>(size1)});
         std::vector<key_type> vec_input1(size1);
         std::vector<key_type> vec_input2(size2);
         std::iota(vec_input1.begin(), vec_input1.end(), 0);

--- a/projects/hipcub/test/hipcub/test_hipcub_device_radix_sort.hpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_radix_sort.hpp
@@ -82,9 +82,9 @@ public:
 TYPED_TEST_SUITE_P(HipcubDeviceRadixSort);
 
 template<class T>
-auto generate_key_input(size_t size, unsigned int seed_value)
-    -> std::enable_if_t<hipcub::NumericTraits<T>::CATEGORY == hipcub::FLOATING_POINT,
-                        std::vector<T>>
+auto generate_key_input(size_t size, unsigned int seed_value) HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+    ->std::enable_if_t<hipcub::NumericTraits<T>::CATEGORY == hipcub::FLOATING_POINT,
+                       std::vector<T>> HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 {
     auto result = test_utils::get_random_data<T>(size,
                                                  test_utils::numeric_limits<T>::min(),
@@ -95,9 +95,9 @@ auto generate_key_input(size_t size, unsigned int seed_value)
 }
 
 template<class T>
-auto generate_key_input(size_t size, unsigned int seed_value)
-    -> std::enable_if_t<hipcub::NumericTraits<T>::CATEGORY != hipcub::FLOATING_POINT,
-                        std::vector<T>>
+auto generate_key_input(size_t size, unsigned int seed_value) HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+    ->std::enable_if_t<hipcub::NumericTraits<T>::CATEGORY != hipcub::FLOATING_POINT,
+                       std::vector<T>> HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 {
     using inner_t = typename test_utils::inner_type<T>::type;
     return test_utils::get_random_data<T>(size,

--- a/projects/hipcub/test/hipcub/test_hipcub_device_reduce.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_reduce.cpp
@@ -884,8 +884,7 @@ TYPED_TEST(HipcubDeviceReduceLargeIndicesTests, LargeIndices)
 
     using T            = typename TestFixture::input_type;
     using U            = typename TestFixture::output_type;
-    using IteratorType = hipcub::ConstantInputIterator<T>;
-
+    using IteratorType                  = rocprim::constant_iterator<T>;
     const std::vector<size_t> exponents = {30, 31, 32, 33, 34};
     for(auto exponent : exponents)
     {

--- a/projects/hipcub/test/hipcub/test_hipcub_device_scan.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_scan.cpp
@@ -139,8 +139,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
     // use float as device-side accumulator and double as host-side accumulator
     using is_add_op    = test_utils::is_add_operator<scan_op_type>;
     using acc_type     = typename accum_type<T, scan_op_type>::type;
-    using IteratorType = hipcub::TransformInputIterator<acc_type, hipcub::CastOp<acc_type>, T*>;
-
+    using IteratorType     = rocprim::transform_iterator<T*, hipcub::CastOp<acc_type>, acc_type>;
     constexpr bool inplace = std::is_same<T, U>::value && std::is_same<acc_type, T>::value;
 
     // for non-associative operations in inclusive scan
@@ -332,8 +331,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScanInit)
     // use float as device-side accumulator and double as host-side accumulator
     using is_add_op    = test_utils::is_add_operator<scan_op_type>;
     using acc_type     = typename accum_type<T, scan_op_type>::type;
-    using IteratorType = hipcub::TransformInputIterator<acc_type, hipcub::CastOp<acc_type>, T*>;
-
+    using IteratorType     = rocprim::transform_iterator<T*, hipcub::CastOp<acc_type>, acc_type>;
     constexpr bool inplace = std::is_same<T, U>::value && std::is_same<acc_type, T>::value;
 
     // for non-associative operations in inclusive scan
@@ -517,8 +515,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScanByKey)
     // use float as device-side accumulator and double as host-side accumulator
     using is_add_op    = test_utils::is_add_operator<scan_op_type>;
     using acc_type     = typename accum_type<T, scan_op_type>::type;
-    using IteratorType = hipcub::TransformInputIterator<acc_type, hipcub::CastOp<acc_type>, T*>;
-
+    using IteratorType = rocprim::transform_iterator<T*, hipcub::CastOp<acc_type>, acc_type>;
     // for non-associative operations in inclusive scan
     // intermediate results use the type of input iterator, then
     // as all conversions in the tests are to more precise types,
@@ -703,8 +700,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
     // use float as device-side accumulator and double as host-side accumulator
     using is_add_op    = test_utils::is_add_operator<scan_op_type>;
     using acc_type     = typename accum_type<T, scan_op_type>::type;
-    using IteratorType = hipcub::TransformInputIterator<acc_type, hipcub::CastOp<acc_type>, T*>;
-
+    using IteratorType     = rocprim::transform_iterator<T*, hipcub::CastOp<acc_type>, acc_type>;
     constexpr bool inplace = std::is_same<T, U>::value && std::is_same<acc_type, T>::value;
 
     // for non-associative operations in inclusive scan
@@ -909,8 +905,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanByKey)
     // use float as device-side accumulator and double as host-side accumulator
     using is_add_op    = test_utils::is_add_operator<scan_op_type>;
     using acc_type     = typename accum_type<T, scan_op_type>::type;
-    using IteratorType = hipcub::TransformInputIterator<acc_type, hipcub::CastOp<acc_type>, T*>;
-
+    using IteratorType = rocprim::transform_iterator<T*, hipcub::CastOp<acc_type>, acc_type>;
     // for non-associative operations in inclusive scan
     // intermediate results use the type of input iterator, then
     // as all conversions in the tests are to more precise types,
@@ -1098,7 +1093,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanByKey)
 TEST(HipcubDeviceScanTests, LargeIndicesInclusiveScan)
 {
     using T              = unsigned int;
-    using InputIterator  = typename hipcub::CountingInputIterator<T>;
+    using InputIterator  = rocprim::counting_iterator<T>;
     using OutputIterator = test_utils::single_index_iterator<T>;
 
     const size_t size = (1ul << 31) + 1ul;
@@ -1108,7 +1103,7 @@ TEST(HipcubDeviceScanTests, LargeIndicesInclusiveScan)
     unsigned int seed_value = rand();
     SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
-    // Create CountingInputIterator<U> with random starting point
+    // Create rocprim::counting_iterator<U> with random starting point
     InputIterator input_begin(test_utils::get_random_value<T>(0, 200, seed_value));
 
     T* d_output;
@@ -1168,7 +1163,7 @@ TEST(HipcubDeviceScanTests, LargeIndicesInclusiveScan)
 TEST(HipcubDeviceScanTests, LargeIndicesExclusiveScan)
 {
     using T              = unsigned int;
-    using InputIterator  = typename hipcub::CountingInputIterator<T>;
+    using InputIterator  = rocprim::counting_iterator<T>;
     using OutputIterator = test_utils::single_index_iterator<T>;
 
     const size_t size = (1ul << 31) + 1ul;
@@ -1178,7 +1173,7 @@ TEST(HipcubDeviceScanTests, LargeIndicesExclusiveScan)
     unsigned int seed_value = rand();
     SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
-    // Create CountingInputIterator<U> with random starting point
+    // Create rocprim::counting_iterator<U> with random starting point
     InputIterator input_begin(test_utils::get_random_value<T>(0, 200, seed_value));
     T             initial_value = test_utils::get_random_value<T>(1, 10, seed_value);
 
@@ -1263,8 +1258,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanFuture)
     // use float as device-side accumulator and double as host-side accumulator
     using is_add_op    = test_utils::is_add_operator<scan_op_type>;
     using acc_type     = typename accum_type<T, scan_op_type>::type;
-    using IteratorType = hipcub::TransformInputIterator<acc_type, hipcub::CastOp<acc_type>, T*>;
-
+    using IteratorType = rocprim::transform_iterator<T*, hipcub::CastOp<acc_type>, acc_type>;
     // for non-associative operations in inclusive scan
     // intermediate results use the type of input iterator, then
     // as all conversions in the tests are to more precise types,

--- a/projects/hipcub/test/hipcub/test_hipcub_device_segmented_reduce.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_segmented_reduce.cpp
@@ -1144,7 +1144,7 @@ TEST(HipcubDeviceSegmentedReduceLargeIndicesTests, LargeIndices)
     using T              = size_t;
     using input_type     = T;
     using output_type    = T;
-    using IteratorType   = hipcub::CountingInputIterator<input_type>;
+    using IteratorType   = rocprim::counting_iterator<input_type>;
     using reduce_op_type = typename hipcub::Sum;
     using offset_type    = T;
 

--- a/projects/hipcub/test/hipcub/test_hipcub_device_select.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_select.cpp
@@ -244,9 +244,8 @@ TEST(HipcubDeviceSelectTests, FlagNormalization)
     for(size_t size : test_utils::get_sizes(seed_value))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
-
-        hipcub::CountingInputIterator<T> d_input(0);
-        hipcub::CountingInputIterator<F> d_flags(1);
+        rocprim::counting_iterator<T>    d_input(0);
+        rocprim::counting_iterator<F>    d_flags(1);
         U*                               d_output;
         unsigned int*                    d_selected_count_output;
 
@@ -808,9 +807,8 @@ TEST(HipcubDeviceSelectTests, UniqueDiscardOutputIterator)
     for(size_t size : test_utils::get_sizes(seed_value))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
-
-        hipcub::CountingInputIterator<unsigned int> d_input(0);
-        hipcub::DiscardOutputIterator<>             d_output;
+        rocprim::counting_iterator<unsigned int>    d_input(0);
+        rocprim::discard_iterator                   d_output;
         size_t*                                     d_selected_count_output;
 
         HIP_CHECK(test_common_utils::hipMallocHelper((&d_selected_count_output), sizeof(size_t)));
@@ -903,7 +901,7 @@ TEST_P(HipcubDeviceSelectLargeIndicesTests, LargeIndicesSelectOp)
 #endif
 
         // Generate data
-        hipcub::CountingInputIterator<T> d_input(0);
+        rocprim::counting_iterator<T>    d_input(0);
         U*                               d_output;
         selected_count_type*             d_selected_count_output;
         selected_count_type              expected_output_size = selected_size;
@@ -1243,10 +1241,8 @@ TEST(HipcubDeviceUniqueByKeyTests, LargeIndicesUniqueByKey)
                 = (size + TestUniqueEqualityOp::segment - 1) / TestUniqueEqualityOp::segment;
             const size_t output_index = selected_count - 1;
             const size_t input_index  = output_index * TestUniqueEqualityOp::segment;
-
-            hipcub::CountingInputIterator<key_type>   d_keys_input(0);
-            hipcub::CountingInputIterator<value_type> d_values_input(123);
-
+            rocprim::counting_iterator<key_type>   d_keys_input(0);
+            rocprim::counting_iterator<value_type> d_values_input(123);
             key_type*   d_keys_output;
             value_type* d_values_output;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, sizeof(*d_keys_output)));

--- a/projects/hipcub/test/hipcub/test_hipcub_device_spmv.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_spmv.cpp
@@ -173,8 +173,10 @@ TYPED_TEST(HipcubDeviceSpmvTests, Spmv)
     // Compute reference answer
     SpmvGold(csr_matrix, vector_x, vector_y_in, vector_y_out, alpha_const, beta_const);
 
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
     // Allocate and initialize GPU problem
-    hipcub::DeviceSpmv::SpmvParams<T, OffsetType> params;
+    hipcub::DeviceSpmv::SpmvParams<T, OffsetType> params{};
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 
     HIP_CHECK(g_allocator.DeviceAllocate((void **) &params.d_values,          sizeof(T) * csr_matrix.num_nonzeros));
     HIP_CHECK(g_allocator.DeviceAllocate((void **) &params.d_row_end_offsets, sizeof(OffsetType) * (csr_matrix.num_rows + 1)));
@@ -199,6 +201,7 @@ TYPED_TEST(HipcubDeviceSpmvTests, Spmv)
     void*  d_temp_storage     = nullptr;
 
     // Get amount of temporary storage needed
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
     HIP_CHECK(hipcub::DeviceSpmv::CsrMV(d_temp_storage,
                                         temp_storage_bytes,
                                         params.d_values,
@@ -210,6 +213,7 @@ TYPED_TEST(HipcubDeviceSpmvTests, Spmv)
                                         params.num_cols,
                                         params.num_nonzeros,
                                         stream));
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 
     // Allocate
     //HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_bytes);
@@ -220,6 +224,7 @@ TYPED_TEST(HipcubDeviceSpmvTests, Spmv)
     if (TestFixture::use_graphs)
         gHelper.startStreamCapture(stream);
 
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
     HIP_CHECK(hipcub::DeviceSpmv::CsrMV(d_temp_storage,
                                         temp_storage_bytes,
                                         params.d_values,
@@ -231,6 +236,7 @@ TYPED_TEST(HipcubDeviceSpmvTests, Spmv)
                                         params.num_cols,
                                         params.num_nonzeros,
                                         stream));
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
 
     if (TestFixture::use_graphs)
         gHelper.createAndLaunchGraph(stream);

--- a/projects/hipcub/test/hipcub/test_hipcub_grid.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_grid.cpp
@@ -36,9 +36,18 @@
 #include "hipcub/grid/grid_even_share.hpp"
 #include "hipcub/grid/grid_queue.hpp"
 
-__global__ void KernelGridBarrier(
-    hipcub::GridBarrier global_barrier,
-    int iterations)
+#if defined(__HIP_PLATFORM_NVIDIA__)
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+#else
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+#endif
+__global__
+void KernelGridBarrier(hipcub::GridBarrier global_barrier, int iterations)
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    _CCCL_SUPPRESS_DEPRECATED_POP
+#else
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
+#endif
 {
     for (int i = 0; i < iterations; i++)
     {
@@ -80,8 +89,17 @@ TEST(HipcubGridTests, GridBarrier)
     {
         occupancy = grid_size / sm_count;
     }
-
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    _CCCL_SUPPRESS_DEPRECATED_PUSH
+#else
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+#endif
     hipcub::GridBarrierLifetime global_barrier;
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    _CCCL_SUPPRESS_DEPRECATED_POP
+#else
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
+#endif
     HIP_CHECK(global_barrier.Setup(grid_size));
 
     KernelGridBarrier<<<grid_size, block_size>>>(global_barrier, iterations);

--- a/projects/hipcub/test/hipcub/test_hipcub_iterators.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_iterators.cpp
@@ -231,8 +231,7 @@ TYPED_TEST(HipcubIteratorTests, TestConstant)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::input_type;
-    using IteratorType = hipcub::ConstantInputIterator<T>;
-
+    using IteratorType            = rocprim::constant_iterator<T>;
     constexpr uint32_t array_size = 8;
 
     std::vector<T> h_reference(array_size);
@@ -259,8 +258,7 @@ TYPED_TEST(HipcubIteratorTests, TestCounting)
     HIP_CHECK(hipSetDevice(device_id));
 
     using T = typename TestFixture::input_type;
-    using IteratorType = hipcub::CountingInputIterator<T>;
-
+    using IteratorType            = rocprim::counting_iterator<T>;
     constexpr uint32_t array_size = 8;
 
     std::vector<T> h_reference(array_size);
@@ -292,8 +290,7 @@ TYPED_TEST(HipcubIteratorTests, TestTransform)
 
     using T = typename TestFixture::input_type;
     using CastT = typename TestFixture::input_type;
-    using IteratorType = hipcub::TransformInputIterator<T, TransformOp<T>, CastT*>;
-
+    using IteratorType        = rocprim::transform_iterator<CastT*, TransformOp<T>, T>;
     constexpr int TEST_VALUES = 11000;
 
     std::vector<T> h_data(TEST_VALUES);
@@ -535,13 +532,11 @@ TYPED_TEST(HipcubIteratorTests, TestTexTransform)
         HIP_CHECK(d_tex_itr.BindTexture(d_data, sizeof(T) * TEST_VALUES));
 
         // Create transform iterator
-        hipcub::TransformInputIterator<T, TransformOp<T>, TextureIteratorType> xform_itr(d_tex_itr,
-                                                                                         op);
+        rocprim::transform_iterator<TextureIteratorType, TransformOp<T>, T> xform_itr(d_tex_itr,
+                                                                                      op);
 
-        iterator_test_function<
-            hipcub::TransformInputIterator<T, TransformOp<T>, TextureIteratorType>,
-            T>(xform_itr, h_reference);
-
+        iterator_test_function<rocprim::transform_iterator<TextureIteratorType, TransformOp<T>, T>,
+                               T>(xform_itr, h_reference);
         HIP_CHECK(g_allocator.DeviceFree(d_data));
     }
 }

--- a/projects/hipcub/test/hipcub/test_hipcub_thread.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_thread.cpp
@@ -108,7 +108,7 @@ void thread_load_kernel(Type* volatile const device_input, Type* device_output)
     {
         device_output[index] = hipcub::ThreadLoadVolatilePointer(
             device_input + index,
-            hipcub::Int2Type<std::is_fundamental<Type>::value>());
+            std::bool_constant<std::is_fundamental<Type>::value>());
     }
 }
 
@@ -298,7 +298,7 @@ void thread_store_kernel(Type* const device_input, Type* device_output)
     {
         hipcub::ThreadStoreVolatilePtr(device_output + index,
                                        device_input[index],
-                                       hipcub::Int2Type<std::is_fundamental<Type>::value>());
+                                       std::bool_constant<std::is_fundamental<Type>::value>());
     }
 }
 
@@ -380,14 +380,13 @@ void iterate_thread_kernel(Type* const device_input, Type* device_output)
 
     if(id % 2 == 0)
     {
-        hipcub::IterateThreadStore<0, ItemsPerThread>::Dereference(device_output + index,
-                                                                   device_input + index);
+        hipcub::detail::iterate_thread_store<0, ItemsPerThread>::Dereference(device_output + index,
+                                                                             device_input + index);
     }
     else
     {
-        hipcub::IterateThreadStore<0, ItemsPerThread>::template Store<hipcub::STORE_DEFAULT>(
-            device_output + index,
-            device_input + index);
+        hipcub::detail::iterate_thread_store<0, ItemsPerThread>::template Store<
+            hipcub::STORE_DEFAULT>(device_output + index, device_input + index);
     }
 }
 

--- a/projects/hipcub/test/hipcub/test_hipcub_thread_operators.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_thread_operators.cpp
@@ -740,8 +740,7 @@ TYPED_TEST(HipcubNCThreadOperatorsTests, CastOp)
     using input_type  = typename TestFixture::input_type;
     using output_type = typename TestFixture::output_type;
     using IteratorType
-        = hipcub::TransformInputIterator<output_type, hipcub::CastOp<output_type>, input_type*>;
-
+        = rocprim::transform_iterator<input_type*, hipcub::CastOp<output_type>, output_type>;
     const std::vector<size_t> sizes = get_sizes();
     for(auto input_size : sizes)
     {

--- a/projects/hipcub/test/hipcub/test_hipcub_util_device.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_util_device.cpp
@@ -31,7 +31,8 @@ void alias_temporaries_kernel(T* data, size_t* temp_storage_bytes)
 {
     T*     allocations[10];
     size_t allocation_sizes[10] = {1, 2, 3, 5, 8, 13, 21, 34, 55, 89};
-    (void)hipcub::AliasTemporaries(data, *temp_storage_bytes, allocations, allocation_sizes);
+    (void)
+        hipcub::detail::AliasTemporaries(data, *temp_storage_bytes, allocations, allocation_sizes);
 }
 
 TEST(HipcubUtilDevice, AliasTemporariesDevice)
@@ -88,7 +89,8 @@ TEST(HipcubUtilDevice, AliasTemporariesHost)
     }
 
     // Determine storage size
-    HIP_CHECK(hipcub::AliasTemporaries(data, temp_storage_bytes, allocations, allocation_sizes));
+    HIP_CHECK(
+        hipcub::detail::AliasTemporaries(data, temp_storage_bytes, allocations, allocation_sizes));
 
     // Should be larger or equal to the sum of all sizes.
     ASSERT_GT(temp_storage_bytes, min_size - 1);
@@ -98,10 +100,12 @@ TEST(HipcubUtilDevice, AliasTemporariesHost)
 
     size_t zero_size = 0;
     // Check for error if it does not fit
-    hipError_t error = hipcub::AliasTemporaries(data, zero_size, allocations, allocation_sizes);
+    hipError_t error
+        = hipcub::detail::AliasTemporaries(data, zero_size, allocations, allocation_sizes);
     test_utils::assert_eq(error, hipErrorInvalidValue);
 
-    HIP_CHECK(hipcub::AliasTemporaries(data, temp_storage_bytes, allocations, allocation_sizes));
+    HIP_CHECK(
+        hipcub::detail::AliasTemporaries(data, temp_storage_bytes, allocations, allocation_sizes));
 
     test_utils::assert_eq(data, allocations[0]);
 

--- a/projects/hipcub/test/hipcub/test_hipcub_util_ptx.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_util_ptx.cpp
@@ -697,7 +697,7 @@ __global__
 void warp_id_kernel(unsigned int* output)
 {
     const unsigned int index = (hipBlockIdx_x * hipBlockDim_x) + hipThreadIdx_x;
-    output[index] = hipcub::WarpId();
+    output[index]            = ::rocprim::warp_id();
 }
 
 TEST(HipcubUtilPtxTests, WarpId)
@@ -778,7 +778,7 @@ template <unsigned int LogicalWarpSize>
 HIPCUB_DEVICE
 std::enable_if_t<(HIPCUB_DEVICE_WARP_THREADS >= LogicalWarpSize), TestStatus>
 test_warp_mask_pow_two() {
-    const unsigned int logical_warp_id = hipcub::LaneId() / LogicalWarpSize;
+    const unsigned int logical_warp_id = ::rocprim::lane_id() / LogicalWarpSize;
     const uint64_t mask = hipcub::WarpMask<LogicalWarpSize>(logical_warp_id);
 
     const unsigned int warp_start = logical_warp_id * LogicalWarpSize;
@@ -812,7 +812,7 @@ template <unsigned int LogicalWarpSize>
 HIPCUB_DEVICE
 std::enable_if_t<(HIPCUB_DEVICE_WARP_THREADS >= LogicalWarpSize), TestStatus>
 test_warp_mask_non_pow_two() {
-    const unsigned int logical_warp_id = hipcub::LaneId() / LogicalWarpSize;
+    const unsigned int logical_warp_id = ::rocprim::lane_id() / LogicalWarpSize;
     const uint64_t mask = hipcub::WarpMask<LogicalWarpSize>(logical_warp_id);
 
     for (unsigned int lane = 0; lane < LogicalWarpSize; ++lane) {

--- a/projects/hipcub/test/hipcub/test_utils_sort_comparator.hpp
+++ b/projects/hipcub/test/hipcub/test_utils_sort_comparator.hpp
@@ -45,9 +45,10 @@ namespace detail
 template<unsigned int StartBit,
          unsigned int EndBit,
          class Key,
-         std::enable_if_t<hipcub::NumericTraits<Key>::CATEGORY == hipcub::SIGNED_INTEGER
-                              || hipcub::NumericTraits<Key>::CATEGORY == hipcub::UNSIGNED_INTEGER,
-                          int>
+         HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH std::enable_if_t<
+             hipcub::NumericTraits<Key>::CATEGORY == hipcub::SIGNED_INTEGER
+                 || hipcub::NumericTraits<Key>::CATEGORY == hipcub::UNSIGNED_INTEGER,
+             int> HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
          = 0>
 Key to_bits(const Key key)
 {
@@ -62,8 +63,10 @@ Key to_bits(const Key key)
 template<unsigned int StartBit,
          unsigned int EndBit,
          class Key,
-         std::enable_if_t<hipcub::NumericTraits<Key>::CATEGORY == hipcub::FLOATING_POINT, int> = 0>
-auto to_bits(const Key key)
+         HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
+             std::enable_if_t<hipcub::NumericTraits<Key>::CATEGORY == hipcub::FLOATING_POINT, int>
+         = 0>
+HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP auto to_bits(const Key key)
 {
     using unsigned_bits_type = typename hipcub::NumericTraits<Key>::UnsignedBits;
 
@@ -109,12 +112,15 @@ auto to_bits(const Key& key)
     auto bit_key_lower = static_cast<unsigned_bits_type>(to_bits<0, sizeof(key.y) * 8>(key.y));
 
     // Flip sign bit to properly order signed types
+    HIPCUB_CLANG_SUPPRESS_DEPRECATED_PUSH
     if(::hipcub::NumericTraits<inner_t>::CATEGORY == hipcub::SIGNED_INTEGER)
-    {
-        constexpr auto sign_bit = static_cast<unsigned_bits_type>(1) << (sizeof(inner_t) * 8 - 1);
-        bit_key_upper ^= sign_bit;
-        bit_key_lower ^= sign_bit;
-    }
+        HIPCUB_CLANG_SUPPRESS_DEPRECATED_POP
+        {
+            constexpr auto sign_bit = static_cast<unsigned_bits_type>(1)
+                                      << (sizeof(inner_t) * 8 - 1);
+            bit_key_upper ^= sign_bit;
+            bit_key_lower ^= sign_bit;
+        }
 
     // Create the result containing both parts
     const auto bit_key

--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projects/rocPRIM/en/latest/](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/).
 
+## rocPRIM 4.1.0 for ROCm 7.1
+
+### Added
+* Added `get_sreg_lanemask_lt`, `get_sreg_lanemask_le`, `get_sreg_lanemask_gt` and `get_sreg_lanemask_ge`.
+
+
 ## rocPRIM 4.0.0 for ROCm 7.0
 
 ### Added

--- a/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -674,7 +674,7 @@ hipError_t
     }
     unsigned int single_sort_items_per_block
         = block_sort_config::block_size * block_sort_config::items_per_thread;
-    if(size <= single_sort_items_per_block)
+    if(size <= static_cast<decltype(size)>(single_sort_items_per_block))
     {
         if(temporary_storage == nullptr)
         {

--- a/projects/rocprim/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -164,6 +164,34 @@ auto flat_block_id()
     return blockIdx.x + (blockIdx.y * gridDim.x) +
            (blockIdx.z * gridDim.y * gridDim.x);
 }
+// Returns the warp lane mask of all lanes less than the calling thread
+ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+uint64_t get_sreg_lanemask_lt()
+{
+    return (uint64_t(1) << ::rocprim::lane_id()) - 1;
+}
+
+// Returns the warp lane mask of all lanes less than or equal to the calling thread
+ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+uint64_t get_sreg_lanemask_le()
+{
+    return ((uint64_t(1) << ::rocprim::lane_id()) << 1) - 1;
+}
+
+// Returns the warp lane mask of all lanes greater than the calling thread
+ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+uint64_t get_sreg_lanemask_gt()
+{
+    return uint64_t(-1) ^ get_sreg_lanemask_le();
+}
+
+// Returns the warp lane mask of all lanes greater than or equal to the calling thread
+ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+uint64_t get_sreg_lanemask_ge()
+{
+    return uint64_t(-1) ^ get_sreg_lanemask_lt();
+}
+
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 // Sync


### PR DESCRIPTION
## hipCUB-4.1.0 for ROCm 7.1 Deprecation
### Removed
* Deprecated `hipcub::ConstantInputIterator`, use `rocprim::constant_iterator` or `rocthrust::constant_iterator` instead.
* Deprecated `hipcub::CountingInputIterator`, use `rocprim::counting_iterator` or `rocthrust::counting_iterator` instead.
* Deprecated `hipcub::DiscardOutputIterator`, use `rocprim::discard_iterator` or `rocthrust::discard_iterator` instead.
* Deprecated `hipcub::TransformInputIterator`, use `rocprim::transform_iterator` or `rocthrust::transform_iterator` instead.
* Deprecated `hipcub::AliasTemporaries`, which is considered to be internal API. Moved it to detail namespace.
* Deprecated almost all functions in `projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_ptx.hpp`.
* Deprecated hipCUB macros: `HIPCUB_MAX`, `HIPCUB_MIN`, `HIPCUB_QUOTIENT_FLOOR`, `HIPCUB_QUOTIENT_CEILING`, `HIPCUB_ROUND_UP_NEAREST` and `HIPCUB_ROUND_DOWN_NEAREST`.

## rocPRIM 4.1.0 for ROCm 7.1 Deprecation

### Added
* Added `get_sreg_lanemask_lt`, `get_sreg_lanemask_le`, `get_sreg_lanemask_gt` and `get_sreg_lanemask_ge`.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
