### PR TITLE
Set mx data generator num threads

### DIFF
--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -84,7 +84,7 @@ def runTestCommand (platform, project)
 
                 pushd build
                 echo Using `nproc` threads for testing.
-                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j `nproc` --output-on-failure ${testExclude}
+                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j 8 --output-on-failure ${testExclude}
                 export ROCROLLER_BUILD_DIR="\$(pwd)"
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -78,15 +78,13 @@ def runTestCommand (platform, project)
 {
     String testExclude = platform.jenkinsLabel.contains('compile') ? '-LE GPU' : ''
 
-    def numThreads = 8
-
     def command = """#!/usr/bin/env bash
                 set -ex
                 cd ${project.paths.project_build_prefix}
 
                 pushd build
                 echo Using `nproc` threads for testing.
-                OMP_NUM_THREADS=1 ctest -j ${numThreads} --output-on-failure ${testExclude}
+                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j `nproc` --output-on-failure ${testExclude}
                 export ROCROLLER_BUILD_DIR="\$(pwd)"
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -43,7 +43,7 @@ option(ROCROLLER_ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(ROCROLLER_ENABLE_ASAN "Enable addresss sanitizers." OFF)
 option(ROCROLLER_ENABLE_PREGENERATED_ARCH_DEF "Use the pregenerates GPU architecture definition YAML file(s) in the repository." ON)
 set(ROCROLLER_MRISAS_DIR "${CMAKE_CURRENT_BINARY_DIR}/GPUArchitectureGenerator/amd-mrisa" CACHE STRING "Path to directory containing MRISA XML files.")
-set(MXDATAGENERATOR_GIT_TAG "3ac153eec4c1a1e0da7546abc9c0c4f54e180f43" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
+set(MXDATAGENERATOR_GIT_TAG "49d4b831a49bc599682a5e7b40c0d83aecf0c287" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
 set(MXDATAGENERATOR_GIT_URL "https://github.com/ROCm/mxDataGenerator.git" CACHE STRING "Base Git URL to fetch mxDataGenerator from.")
 
 if(ROCROLLER_ENABLE_TEST_DISCOVERY)

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -43,7 +43,7 @@ option(ROCROLLER_ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(ROCROLLER_ENABLE_ASAN "Enable addresss sanitizers." OFF)
 option(ROCROLLER_ENABLE_PREGENERATED_ARCH_DEF "Use the pregenerates GPU architecture definition YAML file(s) in the repository." ON)
 set(ROCROLLER_MRISAS_DIR "${CMAKE_CURRENT_BINARY_DIR}/GPUArchitectureGenerator/amd-mrisa" CACHE STRING "Path to directory containing MRISA XML files.")
-set(MXDATAGENERATOR_GIT_TAG "31407efa7938fd70ea9b28e08a4d53e398415f8b" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
+set(MXDATAGENERATOR_GIT_TAG "836544a61aa5a9d4ced23e7e316a1f930468d83f" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
 set(MXDATAGENERATOR_GIT_URL "https://github.com/ROCm/mxDataGenerator.git" CACHE STRING "Base Git URL to fetch mxDataGenerator from.")
 
 if(ROCROLLER_ENABLE_TEST_DISCOVERY)

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -43,7 +43,7 @@ option(ROCROLLER_ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(ROCROLLER_ENABLE_ASAN "Enable addresss sanitizers." OFF)
 option(ROCROLLER_ENABLE_PREGENERATED_ARCH_DEF "Use the pregenerates GPU architecture definition YAML file(s) in the repository." ON)
 set(ROCROLLER_MRISAS_DIR "${CMAKE_CURRENT_BINARY_DIR}/GPUArchitectureGenerator/amd-mrisa" CACHE STRING "Path to directory containing MRISA XML files.")
-set(MXDATAGENERATOR_GIT_TAG "49d4b831a49bc599682a5e7b40c0d83aecf0c287" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
+set(MXDATAGENERATOR_GIT_TAG "31407efa7938fd70ea9b28e08a4d53e398415f8b" CACHE STRING "mxDataGenerator tag/commit hash to checkout")
 set(MXDATAGENERATOR_GIT_URL "https://github.com/ROCm/mxDataGenerator.git" CACHE STRING "Base Git URL to fetch mxDataGenerator from.")
 
 if(ROCROLLER_ENABLE_TEST_DISCOVERY)


### PR DESCRIPTION
Locally, values < 32 appear to cause failures on gfx950:
```
OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ctest -j16 -R ".*MatrixMultiplyTest/ScaledMatrixMultiplyMixedTestGPU.GPU_ScaledMatrixMultiplyMacroTileMixed.*" --output-on-failure
```
plus a few more.
Uses https://github.com/ROCm/mxDataGenerator/commit/836544a61aa5a9d4ced23e7e316a1f930468d83f