### PR TITLE
[hipblaslt] Use correct MT for B for `mx_block_size`

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/analytical/AnalyticalGemm.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Source/lib/source/analytical/AnalyticalGemm.cpp
@@ -307,7 +307,7 @@ namespace TensileLite
             if(element_size_B < 8 && mx_block_size != 0)
             {
                 //Number of scales per tile
-                size_t num_scales_B = safe_ceil_div(MT_M * MT_K, mx_block_size);
+                size_t num_scales_B = safe_ceil_div(MT_N * MT_K, mx_block_size);
                 Ld_CU_bytes += num_scales_B; //One Byte per scale
             }
             // 3) occupancy
@@ -418,7 +418,6 @@ namespace TensileLite
 
                 hardware.log_debug("H_mem1 (mem1 hit ratio)", H_mem1);
                 hardware.log_debug("H_mem2 (mem2 hit ratio)", H_mem2);
-                hardware.log_debug("Ld_mem1 (bytes)", Ld_mem2);
                 hardware.log_debug("Active CUs", active_cu);
                 hardware.log_debug("Total Load (bytes)", total_Ld);
                 hardware.log_debug("L_mem_mem1 (cycles)", L_mem_mem1);


### PR DESCRIPTION
A simple bug-fix that should only impact when `mx_block_size != 0`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
