### PR TITLE
fix(rocprim): arrow operator iterators

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -106,7 +106,7 @@ when the input or inital type was smaller than the output type.
 * Fixed constness of equality operators (`==` and `!=`) in `rocprim::key_value_pair`.
 * Fixed an issue for the comparison operators in `arg_index_iterator` and `texture_cache_iterator`, where `<` and `>` comparators were swapped.
 * Fixed an issue for the `rocprim::thread_reduce` not working correctly with a prefix value.
-* Fixed the `->` operator for the `transform_iterator`, the `texture_cache_iterrator` and the `arg_index_iterator`, by now returning a proxy pointer.
+* Fixed the `->` operator for the `transform_iterator`, the `texture_cache_iterator` and the `arg_index_iterator`, by now returning a proxy pointer.
   * The `arg_index_iterator` also now only returns the internal iterator for the `->`.
 
 ### Known issues

--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -4,9 +4,15 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 ## rocPRIM 4.1.0 for ROCm 7.1
 
+### Upcoming changes
+
+* Deprecated the `->` operator for the `zip_iterator`.
+
 ### Resolved issues
 
 * Fixed `device_select`, `device_merge`, and `device_merge_sort` not allocating the correct amount of virtual shared memory on the host.
+* Fixed the `->` operator for the `transform_iterator`, the `texture_cache_iterator` and the `arg_index_iterator`, by now returning a proxy pointer.
+  * The `arg_index_iterator` also now only returns the internal iterator for the `->`.
 
 ## rocPRIM 4.0.0 for ROCm 7.0
 
@@ -66,7 +72,6 @@ when the input or inital type was smaller than the output type.
 ### Upcoming changes
 
 * `rocprim::invoke_result_binary_op` and `rocprim::invoke_result_binary_op_t` are deprecated. Use `rocprim::accumulator_t` now.
-* Deprecated the `->` operator for the `zip_iterator`.
 
 ### Removed
 
@@ -106,8 +111,6 @@ when the input or inital type was smaller than the output type.
 * Fixed constness of equality operators (`==` and `!=`) in `rocprim::key_value_pair`.
 * Fixed an issue for the comparison operators in `arg_index_iterator` and `texture_cache_iterator`, where `<` and `>` comparators were swapped.
 * Fixed an issue for the `rocprim::thread_reduce` not working correctly with a prefix value.
-* Fixed the `->` operator for the `transform_iterator`, the `texture_cache_iterator` and the `arg_index_iterator`, by now returning a proxy pointer.
-  * The `arg_index_iterator` also now only returns the internal iterator for the `->`.
 
 ### Known issues
 * When using `rocprim::deterministic_inclusive_scan_by_key` and `rocprim::deterministic_exclusive_scan_by_key` the intermediate values can change order on Navi3x

--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -66,6 +66,7 @@ when the input or inital type was smaller than the output type.
 ### Upcoming changes
 
 * `rocprim::invoke_result_binary_op` and `rocprim::invoke_result_binary_op_t` are deprecated. Use `rocprim::accumulator_t` now.
+* Deprecated the `->` operator for the `zip_iterator`.
 
 ### Removed
 
@@ -105,6 +106,8 @@ when the input or inital type was smaller than the output type.
 * Fixed constness of equality operators (`==` and `!=`) in `rocprim::key_value_pair`.
 * Fixed an issue for the comparison operators in `arg_index_iterator` and `texture_cache_iterator`, where `<` and `>` comparators were swapped.
 * Fixed an issue for the `rocprim::thread_reduce` not working correctly with a prefix value.
+* Fixed the `->` operator for the `transform_iterator`, the `texture_cache_iterrator` and the `arg_index_iterator`, by now returning a proxy pointer.
+  * The `arg_index_iterator` also now only returns the internal iterator for the `->`.
 
 ### Known issues
 * When using `rocprim::deterministic_inclusive_scan_by_key` and `rocprim::deterministic_exclusive_scan_by_key` the intermediate values can change order on Navi3x

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -98,23 +98,30 @@ namespace detail
             auto not_equal
                 = [compare](const auto& a, const auto& b) mutable { return !compare(a, b); };
 
-            const auto flag_segment_boundaries = [&]() {
+            const auto flag_segment_boundaries = [&]()
+            {
                 if(Exclusive)
                 {
                     const key_type tile_successor
                         = starting_block + flat_block_id < number_of_blocks - 1
-                              ? block_keys[items_per_block]
-                              : *block_keys;
-                    block_discontinuity {}.flag_tails(
-                        flags, tile_successor, keys, not_equal, storage.keys.flag);
+                              ? static_cast<key_type>(block_keys[items_per_block])
+                              : static_cast<key_type>(*block_keys);
+                    block_discontinuity{}.flag_tails(flags,
+                                                     tile_successor,
+                                                     keys,
+                                                     not_equal,
+                                                     storage.keys.flag);
                 }
                 else
                 {
                     const key_type tile_predecessor = starting_block + flat_block_id > 0
-                                                          ? block_keys[-1]
-                                                          : *block_keys;
-                    block_discontinuity {}.flag_heads(
-                        flags, tile_predecessor, keys, not_equal, storage.keys.flag);
+                                                          ? static_cast<key_type>(block_keys[-1])
+                                                          : static_cast<key_type>(*block_keys);
+                    block_discontinuity{}.flag_heads(flags,
+                                                     tile_predecessor,
+                                                     keys,
+                                                     not_equal,
+                                                     storage.keys.flag);
                 }
             };
 

--- a/projects/rocprim/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
@@ -28,6 +28,7 @@
 
 #include "../config.hpp"
 #include "../types/key_value_pair.hpp"
+#include "detail/common.hpp"
 
 /// \addtogroup iteratormodule
 /// @{
@@ -58,29 +59,6 @@ class arg_index_iterator
 private:
     using input_category = typename std::iterator_traits<InputIterator>::iterator_category;
 
-    template<typename T>
-    class proxy_pointer
-    {
-        T value_;
-
-    public:
-        ROCPRIM_HOST_DEVICE inline proxy_pointer(const T& value) : value_(value) {}
-
-        ROCPRIM_HOST_DEVICE
-        const T*
-            operator->() const
-        {
-            return &value_;
-        }
-
-        ROCPRIM_HOST_DEVICE
-        const T&
-            operator*() const
-        {
-            return value_;
-        }
-    };
-
 public:
     /// The type of the value that can be obtained by dereferencing the iterator.
     using value_type = ::rocprim::key_value_pair<Difference, InputValueType>;
@@ -89,7 +67,7 @@ public:
     using reference = const value_type&;
     /// \brief A pointer type of the type iterated over (\p value_type).
     /// It's `const` since arg_index_iterator is a read-only iterator.
-    using pointer = const proxy_pointer<InputValueType>;
+    using pointer = const detail::proxy_pointer<InputValueType>;
     /// A type used for identify distance between iterators.
     using difference_type = Difference;
     /// The category of the iterator.

--- a/projects/rocprim/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
@@ -64,18 +64,18 @@ private:
         T value_;
 
     public:
-        ROCPRIM_HOST_DEVICE
-        inline proxy_pointer(const T& value)
-            : value_(value)
-        {}
+        ROCPRIM_HOST_DEVICE inline proxy_pointer(const T& value) : value_(value) {}
 
         ROCPRIM_HOST_DEVICE
-        const T* operator->() const
+        const T*
+            operator->() const
         {
             return &value_;
         }
 
-        ROCPRIM_HOST_DEVICE const T& operator*() const
+        ROCPRIM_HOST_DEVICE
+        const T&
+            operator*() const
         {
             return value_;
         }

--- a/projects/rocprim/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/arg_index_iterator.hpp
@@ -58,6 +58,29 @@ class arg_index_iterator
 private:
     using input_category = typename std::iterator_traits<InputIterator>::iterator_category;
 
+    template<typename T>
+    class proxy_pointer
+    {
+        T value_;
+
+    public:
+        ROCPRIM_HOST_DEVICE
+        inline proxy_pointer(const T& value)
+            : value_(value)
+        {}
+
+        ROCPRIM_HOST_DEVICE
+        const T* operator->() const
+        {
+            return &value_;
+        }
+
+        ROCPRIM_HOST_DEVICE const T& operator*() const
+        {
+            return value_;
+        }
+    };
+
 public:
     /// The type of the value that can be obtained by dereferencing the iterator.
     using value_type = ::rocprim::key_value_pair<Difference, InputValueType>;
@@ -66,7 +89,7 @@ public:
     using reference = const value_type&;
     /// \brief A pointer type of the type iterated over (\p value_type).
     /// It's `const` since arg_index_iterator is a read-only iterator.
-    using pointer = const value_type*;
+    using pointer = const proxy_pointer<InputValueType>;
     /// A type used for identify distance between iterators.
     using difference_type = Difference;
     /// The category of the iterator.
@@ -122,7 +145,7 @@ public:
     ROCPRIM_HOST_DEVICE inline
     pointer operator->() const
     {
-        return &(*(*this));
+        return pointer(*iterator_);
     }
 
     ROCPRIM_HOST_DEVICE inline

--- a/projects/rocprim/rocprim/include/rocprim/iterator/detail/common.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/detail/common.hpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ROCPRIM_ITERATOR_DETAIL_COMMON_HPP_
+#define ROCPRIM_ITERATOR_DETAIL_COMMON_HPP_
+
+#include "../../config.hpp"
+
+BEGIN_ROCPRIM_NAMESPACE
+
+namespace detail
+{
+
+template<typename T>
+class proxy_pointer
+{
+    T value_;
+
+public:
+    ROCPRIM_HOST_DEVICE explicit inline proxy_pointer(const T& value) : value_(value) {}
+
+    ROCPRIM_HOST_DEVICE
+    const T*
+        operator->() const
+    {
+        return &value_;
+    }
+
+    ROCPRIM_HOST_DEVICE
+    const T&
+        operator*() const
+    {
+        return value_;
+    }
+};
+
+} // namespace detail
+
+END_ROCPRIM_NAMESPACE
+
+#endif // ROCPRIM_DEVICE_DETAIL_COMMON_HPP_

--- a/projects/rocprim/rocprim/include/rocprim/iterator/predicate_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/predicate_iterator.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -287,9 +287,7 @@ ROCPRIM_HOST_DEVICE inline predicate_iterator<DataIterator, DataIterator, UnaryP
 template<class DataIterator, class FlagIterator>
 auto make_mask_iterator(DataIterator data_iterator, FlagIterator flag_iterator)
 {
-    return make_predicate_iterator(data_iterator,
-                                   flag_iterator,
-                                   [] ROCPRIM_HOST_DEVICE(bool value) { return value; });
+    return make_predicate_iterator(data_iterator, flag_iterator, [](bool value) { return value; });
 }
 
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/iterator/predicate_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/predicate_iterator.hpp
@@ -93,7 +93,7 @@ public:
         /// \return The referenced value or the default-constructed value.
         ROCPRIM_HOST_DEVICE ROCPRIM_INLINE operator value_type() const
         {
-            return keep_ ? underlying_ : value_type{};
+            return keep_ ? static_cast<value_type>(underlying_) : value_type{};
         }
 
     private:

--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -26,8 +26,9 @@
 #include <type_traits>
 
 #include "../config.hpp"
-#include "../functional.hpp"
 #include "../detail/various.hpp"
+#include "../functional.hpp"
+#include "detail/common.hpp"
 
 /// \addtogroup iteratormodule
 /// @{
@@ -132,37 +133,13 @@ template<
 >
 class texture_cache_iterator
 {
-private:
-    template<typename V>
-    class proxy_pointer
-    {
-        V value_;
-
-    public:
-        ROCPRIM_HOST_DEVICE inline proxy_pointer(const V& value) : value_(value) {}
-
-        ROCPRIM_HOST_DEVICE
-        const V*
-            operator->() const
-        {
-            return &value_;
-        }
-
-        ROCPRIM_HOST_DEVICE
-        const V&
-            operator*() const
-        {
-            return value_;
-        }
-    };
-
 public:
     /// The type of the value that can be obtained by dereferencing the iterator.
     using value_type = typename std::remove_const<T>::type;
     /// \brief A reference type of the type iterated over (\p value_type).
     using reference = const value_type&;
     /// \brief A pointer type of the type iterated over (\p value_type).
-    using pointer = proxy_pointer<value_type>;
+    using pointer = detail::proxy_pointer<value_type>;
     /// A type used for identify distance between iterators.
     using difference_type = Difference;
     /// The category of the iterator.

--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -132,13 +132,37 @@ template<
 >
 class texture_cache_iterator
 {
+private:
+    template<typename V>
+    class proxy_pointer
+    {
+        V value_;
+
+    public:
+        ROCPRIM_HOST_DEVICE
+        inline proxy_pointer(const V& value)
+            : value_(value)
+        {}
+
+        ROCPRIM_HOST_DEVICE
+        const V* operator->() const
+        {
+            return &value_;
+        }
+
+        ROCPRIM_HOST_DEVICE const V& operator*() const
+        {
+            return value_;
+        }
+    };
+
 public:
     /// The type of the value that can be obtained by dereferencing the iterator.
     using value_type = typename std::remove_const<T>::type;
     /// \brief A reference type of the type iterated over (\p value_type).
     using reference = const value_type&;
     /// \brief A pointer type of the type iterated over (\p value_type).
-    using pointer = const value_type*;
+    using pointer = proxy_pointer<value_type>;
     /// A type used for identify distance between iterators.
     using difference_type = Difference;
     /// The category of the iterator.
@@ -236,10 +260,10 @@ public:
         #endif
     }
 
-    ROCPRIM_HOST_DEVICE inline
-    pointer operator->() const
+    ROCPRIM_HOST_DEVICE
+    inline pointer operator->() const
     {
-        return &(*(*this));
+        return pointer(*(*this));
     }
 
     ROCPRIM_HOST_DEVICE inline

--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -139,18 +139,18 @@ private:
         V value_;
 
     public:
-        ROCPRIM_HOST_DEVICE
-        inline proxy_pointer(const V& value)
-            : value_(value)
-        {}
+        ROCPRIM_HOST_DEVICE inline proxy_pointer(const V& value) : value_(value) {}
 
         ROCPRIM_HOST_DEVICE
-        const V* operator->() const
+        const V*
+            operator->() const
         {
             return &value_;
         }
 
-        ROCPRIM_HOST_DEVICE const V& operator*() const
+        ROCPRIM_HOST_DEVICE
+        const V&
+            operator*() const
         {
             return value_;
         }
@@ -261,7 +261,8 @@ public:
     }
 
     ROCPRIM_HOST_DEVICE
-    inline pointer operator->() const
+    inline pointer
+        operator->() const
     {
         return pointer(*(*this));
     }

--- a/projects/rocprim/rocprim/include/rocprim/iterator/transform_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/transform_iterator.hpp
@@ -27,6 +27,7 @@
 
 #include "../config.hpp"
 #include "../type_traits.hpp"
+#include "detail/common.hpp"
 
 /// \addtogroup iteratormodule
 /// @{
@@ -54,30 +55,6 @@ template<class InputIterator,
              typename std::iterator_traits<InputIterator>::value_type>::type>
 class transform_iterator
 {
-private:
-    template<typename T>
-    class proxy_pointer
-    {
-        T value_;
-
-    public:
-        ROCPRIM_HOST_DEVICE inline proxy_pointer(const T& value) : value_(value) {}
-
-        ROCPRIM_HOST_DEVICE
-        const T*
-            operator->() const
-        {
-            return &value_;
-        }
-
-        ROCPRIM_HOST_DEVICE
-        const T&
-            operator*() const
-        {
-            return value_;
-        }
-    };
-
 public:
     /// The type of the value that can be obtained by dereferencing the iterator.
     using value_type = ValueType;
@@ -86,7 +63,7 @@ public:
     using reference = const std::remove_reference_t<value_type>&;
     /// \brief A pointer type of the type iterated over (\p value_type).
     /// It's `const` since transform_iterator is a read-only iterator.
-    using pointer = const proxy_pointer<std::remove_reference_t<value_type>>;
+    using pointer = const detail::proxy_pointer<std::remove_reference_t<value_type>>;
     /// A type used for identify distance between iterators.
     using difference_type = typename std::iterator_traits<InputIterator>::difference_type;
     /// The category of the iterator.

--- a/projects/rocprim/rocprim/include/rocprim/iterator/transform_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/transform_iterator.hpp
@@ -61,18 +61,18 @@ private:
         T value_;
 
     public:
-        ROCPRIM_HOST_DEVICE
-        inline proxy_pointer(const T& value)
-            : value_(value)
-        {}
+        ROCPRIM_HOST_DEVICE inline proxy_pointer(const T& value) : value_(value) {}
 
         ROCPRIM_HOST_DEVICE
-        const T* operator->() const
+        const T*
+            operator->() const
         {
             return &value_;
         }
 
-        ROCPRIM_HOST_DEVICE const T& operator*() const
+        ROCPRIM_HOST_DEVICE
+        const T&
+            operator*() const
         {
             return value_;
         }
@@ -150,12 +150,16 @@ public:
         return transform_(*iterator_);
     }
 
-    ROCPRIM_HOST_DEVICE inline pointer operator->() const
+    ROCPRIM_HOST_DEVICE
+    inline pointer
+        operator->() const
     {
         return pointer(transform_(*iterator_));
     }
 
-    ROCPRIM_HOST_DEVICE inline value_type operator[](difference_type distance) const
+    ROCPRIM_HOST_DEVICE
+    inline value_type
+        operator[](difference_type distance) const
     {
         transform_iterator i = (*this) + distance;
         return *i;

--- a/projects/rocprim/rocprim/include/rocprim/iterator/transform_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/transform_iterator.hpp
@@ -56,23 +56,6 @@ class transform_iterator
 {
 private:
     template<typename T>
-    class proxy_ref
-    {
-        T value_;
-
-    public:
-        ROCPRIM_HOST_DEVICE
-        inline proxy_ref(const T& value)
-            : value_(value)
-        {}
-
-        ROCPRIM_HOST_DEVICE operator const T&() const
-        {
-            return value_;
-        }
-    };
-
-    template<typename T>
     class proxy_pointer
     {
         T value_;
@@ -100,7 +83,7 @@ public:
     using value_type = ValueType;
     /// \brief A reference type of the type iterated over (\p value_type).
     /// It's `const` since transform_iterator is a read-only iterator.
-    using reference = const proxy_ref<std::remove_reference_t<value_type>>;
+    using reference = const std::remove_reference_t<value_type>&;
     /// \brief A pointer type of the type iterated over (\p value_type).
     /// It's `const` since transform_iterator is a read-only iterator.
     using pointer = const proxy_pointer<std::remove_reference_t<value_type>>;
@@ -162,9 +145,9 @@ public:
     }
 
     ROCPRIM_HOST_DEVICE inline
-    reference operator*() const
+    value_type operator*() const
     {
-        return reference(transform_(*iterator_));
+        return transform_(*iterator_);
     }
 
     ROCPRIM_HOST_DEVICE inline pointer operator->() const

--- a/projects/rocprim/rocprim/include/rocprim/iterator/transform_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/transform_iterator.hpp
@@ -54,15 +54,56 @@ template<class InputIterator,
              typename std::iterator_traits<InputIterator>::value_type>::type>
 class transform_iterator
 {
+private:
+    template<typename T>
+    class proxy_ref
+    {
+        T value_;
+
+    public:
+        ROCPRIM_HOST_DEVICE
+        inline proxy_ref(const T& value)
+            : value_(value)
+        {}
+
+        ROCPRIM_HOST_DEVICE operator const T&() const
+        {
+            return value_;
+        }
+    };
+
+    template<typename T>
+    class proxy_pointer
+    {
+        T value_;
+
+    public:
+        ROCPRIM_HOST_DEVICE
+        inline proxy_pointer(const T& value)
+            : value_(value)
+        {}
+
+        ROCPRIM_HOST_DEVICE
+        const T* operator->() const
+        {
+            return &value_;
+        }
+
+        ROCPRIM_HOST_DEVICE const T& operator*() const
+        {
+            return value_;
+        }
+    };
+
 public:
     /// The type of the value that can be obtained by dereferencing the iterator.
     using value_type = ValueType;
     /// \brief A reference type of the type iterated over (\p value_type).
     /// It's `const` since transform_iterator is a read-only iterator.
-    using reference = const value_type&;
+    using reference = const proxy_ref<std::remove_reference_t<value_type>>;
     /// \brief A pointer type of the type iterated over (\p value_type).
     /// It's `const` since transform_iterator is a read-only iterator.
-    using pointer = const value_type*;
+    using pointer = const proxy_pointer<std::remove_reference_t<value_type>>;
     /// A type used for identify distance between iterators.
     using difference_type = typename std::iterator_traits<InputIterator>::difference_type;
     /// The category of the iterator.
@@ -70,6 +111,7 @@ public:
     /// The type of unary function used to transform input range.
     using unary_function = UnaryFunction;
 
+public:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     using self_type = transform_iterator;
 #endif
@@ -120,19 +162,17 @@ public:
     }
 
     ROCPRIM_HOST_DEVICE inline
-    value_type operator*() const
+    reference operator*() const
     {
-        return transform_(*iterator_);
+        return reference(transform_(*iterator_));
     }
 
-    ROCPRIM_HOST_DEVICE inline
-    pointer operator->() const
+    ROCPRIM_HOST_DEVICE inline pointer operator->() const
     {
-        return &(*(*this));
+        return pointer(transform_(*iterator_));
     }
 
-    ROCPRIM_HOST_DEVICE inline
-    value_type operator[](difference_type distance) const
+    ROCPRIM_HOST_DEVICE inline value_type operator[](difference_type distance) const
     {
         transform_iterator i = (*this) + distance;
         return *i;

--- a/projects/rocprim/rocprim/include/rocprim/iterator/zip_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/zip_iterator.hpp
@@ -195,14 +195,16 @@ public:
         return detail::dereference_iterator_tuple<reference>(iterator_tuple_);
     }
 
-    ROCPRIM_HOST_DEVICE inline
-    pointer operator->() const
+    [[deprecated("This operator is no longer supported and will be removed in the next major "
+                 "release.")]]
+    ROCPRIM_HOST_DEVICE
+    inline pointer operator->() const
     {
         return &(*(*this));
     }
 
-    ROCPRIM_HOST_DEVICE inline
-    reference operator[](difference_type distance) const
+    ROCPRIM_HOST_DEVICE
+    inline reference operator[](difference_type distance) const
     {
         zip_iterator i = (*this) + distance;
         return *i;

--- a/projects/rocprim/rocprim/include/rocprim/iterator/zip_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/zip_iterator.hpp
@@ -198,13 +198,15 @@ public:
     [[deprecated("This operator is no longer supported and will be removed in the next major "
                  "release.")]]
     ROCPRIM_HOST_DEVICE
-    inline pointer operator->() const
+    inline pointer
+        operator->() const
     {
         return &(*(*this));
     }
 
     ROCPRIM_HOST_DEVICE
-    inline reference operator[](difference_type distance) const
+    inline reference
+        operator[](difference_type distance) const
     {
         zip_iterator i = (*this) + distance;
         return *i;

--- a/projects/rocprim/test/rocprim/test_arg_index_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_arg_index_iterator.cpp
@@ -150,6 +150,22 @@ TYPED_TEST(RocprimArgIndexIteratorTests, Basic)
         Iterator normalized = mid;
         normalized.normalize();
         ASSERT_EQ((*normalized).key, 0);
+
+        struct Wrapper
+        {
+            T value;
+        };
+
+        std::vector<Wrapper> input_wrapped(input.size());
+        for(size_t i = 0; i < input.size(); i++)
+        {
+            input_wrapped[i].value = input[i];
+        }
+
+        auto test_wrap = rocprim::make_arg_index_iterator(input_wrapped.data());
+
+        ASSERT_EQ(test_wrap->value, input[0]);
+        ASSERT_EQ((++test_wrap)->value, input[1]);
     }
 }
 

--- a/projects/rocprim/test/rocprim/test_texture_cache_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_texture_cache_iterator.cpp
@@ -246,7 +246,7 @@ TYPED_TEST(RocprimTextureCacheIteratorTests, DeviceIteratorOps)
         std::vector<T> input = test_utils::get_random_data_wrapped<T>(10, 1, 200, seed_value);
 
         std::vector<Wrapper<T>> input_wrapped(input.size());
-        for (size_t i = 0; i < input.size(); i++)
+        for(size_t i = 0; i < input.size(); i++)
         {
             input_wrapped[i].value = input[i];
         }

--- a/projects/rocprim/test/rocprim/test_texture_cache_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_texture_cache_iterator.cpp
@@ -245,7 +245,6 @@ TYPED_TEST(RocprimTextureCacheIteratorTests, DeviceIteratorOps)
 
         std::vector<T> input = test_utils::get_random_data_wrapped<T>(10, 1, 200, seed_value);
 
-
         std::vector<Wrapper<T>> input_wrapped(input.size());
         for (size_t i = 0; i < input.size(); i++)
         {

--- a/projects/rocprim/test/rocprim/test_texture_cache_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_texture_cache_iterator.cpp
@@ -145,9 +145,18 @@ TYPED_TEST(RocprimTextureCacheIteratorTests, Transform)
     }
 }
 
+template<typename T>
+struct Wrapper
+{
+    T value;
+};
+
 template<typename T, int NumOps>
 __global__
-void texture_iterator_kernel(rocprim::texture_cache_iterator<T> it, T* input, int* output)
+void texture_iterator_kernel(rocprim::texture_cache_iterator<T>          it,
+                             rocprim::texture_cache_iterator<Wrapper<T>> it_wrap,
+                             T*                                          input,
+                             int*                                        output)
 {
     const int i = threadIdx.x * NumOps;
 
@@ -183,21 +192,24 @@ void texture_iterator_kernel(rocprim::texture_cache_iterator<T> it, T* input, in
     auto it_minus = it_plus - 2;
     output[i + 9] = (*it_minus == input[2]);
 
+    // Test ->
+    output[i + 10] = (((it_wrap + 2)->value) == input[2]);
+
     auto begin = it - 2;
     auto end   = it + 2;
 
     // Comparisons
-    output[i + 10] = (begin == begin) ? true : false;
-    output[i + 11] = (begin != end) ? true : false;
-    output[i + 12] = (begin < end) ? true : false;
-    output[i + 13] = (end > begin) ? true : false;
-    output[i + 14] = (begin <= begin) ? true : false;
-    output[i + 15] = (begin <= end) ? true : false;
-    output[i + 16] = (end >= begin) ? true : false;
-    output[i + 17] = (end >= end) ? true : false;
+    output[i + 11] = (begin == begin) ? true : false;
+    output[i + 12] = (begin != end) ? true : false;
+    output[i + 13] = (begin < end) ? true : false;
+    output[i + 14] = (end > begin) ? true : false;
+    output[i + 15] = (begin <= begin) ? true : false;
+    output[i + 16] = (begin <= end) ? true : false;
+    output[i + 17] = (end >= begin) ? true : false;
+    output[i + 18] = (end >= end) ? true : false;
 
     // Substracting iterators
-    output[i + 18] = ((end - begin) == 4);
+    output[i + 19] = ((end - begin) == 4);
 }
 
 TYPED_TEST(RocprimTextureCacheIteratorTests, DeviceIteratorOps)
@@ -219,9 +231,10 @@ TYPED_TEST(RocprimTextureCacheIteratorTests, DeviceIteratorOps)
 
     using T        = typename TestFixture::input_type;
     using Iterator = rocprim::texture_cache_iterator<T>;
+    using WrappedIterator = rocprim::texture_cache_iterator<Wrapper<T>>;
 
     constexpr int num_threads  = 10;
-    constexpr int num_ops      = 19;
+    constexpr int num_ops      = 20;
     constexpr int result_count = num_threads * num_ops;
 
     for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
@@ -232,14 +245,25 @@ TYPED_TEST(RocprimTextureCacheIteratorTests, DeviceIteratorOps)
 
         std::vector<T> input = test_utils::get_random_data_wrapped<T>(10, 1, 200, seed_value);
 
-        common::device_ptr<T>   d_input(input);
-        common::device_ptr<int> d_output(result_count);
+
+        std::vector<Wrapper<T>> input_wrapped(input.size());
+        for (size_t i = 0; i < input.size(); i++)
+        {
+            input_wrapped[i].value = input[i];
+        }
+
+        common::device_ptr<T>          d_input(input);
+        common::device_ptr<Wrapper<T>> d_input_wrapped(input_wrapped);
+        common::device_ptr<int>        d_output(result_count);
 
         Iterator it;
         HIP_CHECK(it.bind_texture(d_input.get(), sizeof(T) * input.size()));
 
+        WrappedIterator it_wrap;
+        HIP_CHECK(it_wrap.bind_texture(d_input_wrapped.get(), sizeof(Wrapper<T>) * input.size()));
+
         texture_iterator_kernel<T, num_ops>
-            <<<dim3(1), dim3(num_threads), 0, 0>>>(it, d_input.get(), d_output.get());
+            <<<dim3(1), dim3(num_threads), 0, 0>>>(it, it_wrap, d_input.get(), d_output.get());
 
         HIP_CHECK(hipDeviceSynchronize());
         HIP_CHECK(hipGetLastError());

--- a/projects/rocprim/test/rocprim/test_transform_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_transform_iterator.cpp
@@ -183,6 +183,48 @@ TYPED_TEST(RocprimTransformIteratorTests, Basic)
         ASSERT_TRUE(begin <= end);
         ASSERT_TRUE(end >= begin);
         ASSERT_TRUE(end >= end);
+
+        struct Wrapper
+        {
+            value_type value;
+        };
+
+        auto transform_wrap = [&](const value_type& value) -> Wrapper
+        { return Wrapper{static_cast<value_type>(transform(value))}; };
+        auto test_transform_wrap = rocprim::make_transform_iterator(input.data(), transform_wrap);
+
+        ASSERT_EQ(test_transform_wrap->value, transform(input[0]));
+        ASSERT_EQ((++test_transform_wrap)->value, transform(input[1]));
+
+        struct WrapperPointer
+        {
+            value_type* a;
+        };
+
+        std::vector<WrapperPointer> input_test;
+        input_test.reserve(input.size());
+
+        for(const auto& val : input)
+        {
+            value_type* copy = new value_type(val);
+            input_test.push_back(WrapperPointer{copy});
+        }
+
+        auto func = [&](const WrapperPointer& wrapper) -> const WrapperPointer&
+        {
+            *(wrapper.a) = transform(static_cast<value_type>(*(wrapper.a)));
+            return wrapper;
+        };
+
+        auto test_transform_wrap_ref = rocprim::make_transform_iterator(input_test.data(), func);
+
+        ASSERT_EQ(*(test_transform_wrap_ref->a), transform(input[0]));
+        ASSERT_EQ(*((++test_transform_wrap_ref)->a), transform(input[1]));
+
+        for(auto& wp : input_test)
+        {
+            delete wp.a;
+        }
     }
 }
 

--- a/projects/rocprim/test/rocprim/test_transform_iterator.cpp
+++ b/projects/rocprim/test/rocprim/test_transform_iterator.cpp
@@ -194,6 +194,7 @@ TYPED_TEST(RocprimTransformIteratorTests, Basic)
         auto test_transform_wrap = rocprim::make_transform_iterator(input.data(), transform_wrap);
 
         ASSERT_EQ(test_transform_wrap->value, transform(input[0]));
+        ASSERT_EQ((*test_transform_wrap).value, transform(input[0]));
         ASSERT_EQ((++test_transform_wrap)->value, transform(input[1]));
 
         struct WrapperPointer
@@ -218,7 +219,8 @@ TYPED_TEST(RocprimTransformIteratorTests, Basic)
 
         auto test_transform_wrap_ref = rocprim::make_transform_iterator(input_test.data(), func);
 
-        ASSERT_EQ(*(test_transform_wrap_ref->a), transform(input[0]));
+        ASSERT_EQ(*((*test_transform_wrap_ref).a), transform(input[0]));
+        ASSERT_EQ(*(test_transform_wrap_ref->a), transform(transform(input[0])));
         ASSERT_EQ(*((++test_transform_wrap_ref)->a), transform(input[1]));
 
         for(auto& wp : input_test)


### PR DESCRIPTION
## Motivation

The '->' operator currently does not compile when used for `transform_iterator`, the `texture_cache_iterator`, the `zip_iterator` and the `arg_index_iterator`.

## Technical Details

Fixed the `->` operator for the `transform_iterator`, the `texture_cache_iterator` and the `arg_index_iterator`, by now returning a proxy pointer. It did not compile before when used.

Deprecated the  `->` operator for the `zip_iterator`. It did not work and there is no useful implementation for this operator, CUB also does not have this operator.

## Test Plan

Extra tests have been added for  the `transform_iterator`, the `texture_cache_iterator` and the `arg_index_iterator` with this operator.

## Test Result

They all pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
