### PR TITLE
[rocsparse] Deprecate trace, debug, and bench logging

### DIFF
--- a/projects/rocsparse/docs/how-to/using-rocsparse.rst
+++ b/projects/rocsparse/docs/how-to/using-rocsparse.rst
@@ -834,8 +834,8 @@ Similar to the vector and matrix results, the scalar result is only available wh
 
 .. _rocsparse_logging:
 
-Activity logging
-================
+Activity logging [Deprecated]
+=============================
 
 Four different environment variables can be set to enable logging in rocSPARSE:
 ``ROCSPARSE_LAYER``, ``ROCSPARSE_LOG_TRACE_PATH``, ``ROCSPARSE_LOG_BENCH_PATH``, and ``ROCSPARSE_LOG_DEBUG_PATH``.
@@ -871,6 +871,9 @@ To capture activity logging in a file, set the following environment variables a
 .. note::
 
    If the file cannot be opened, the logging output is streamed to ``stderr``.
+
+.. warning::
+  Trace, debug, and bench logging is deprecated and will be removed in a future release
 
 ROC-TX support in rocSPARSE
 ============================

--- a/projects/rocsparse/library/src/include/rocsparse_logging.hpp
+++ b/projects/rocsparse/library/src/include/rocsparse_logging.hpp
@@ -187,7 +187,9 @@ namespace rocsparse
     template <typename H, typename... Ts>
     void log_arguments(std::ostream& os, std::string& separator, H head, Ts&&... xs)
     {
-        os << "\n" << head;
+        os << " [Note: trace, debug, and bench logging is deprecated and will be removed in a "
+              "future release] \n"
+           << head;
         rocsparse::each_args(log_arg{os, separator}, std::forward<Ts>(xs)...);
     }
 
@@ -213,7 +215,9 @@ namespace rocsparse
     template <typename H>
     void log_argument(std::ostream& os, std::string& separator, H head)
     {
-        os << "\n" << head;
+        os << " [Note: trace, debug, and bench logging is deprecated and will be removed in a "
+              "future release] \n"
+           << head;
     }
 
     /**
@@ -234,7 +238,9 @@ namespace rocsparse
     template <typename H>
     void log_argument(std::ostream& os, H head)
     {
-        os << "\n" << head;
+        os << " [Note: trace, debug, and bench logging is deprecated and will be removed in a "
+              "future release] \n"
+           << head;
     }
 
     // if trace logging is turned on with


### PR DESCRIPTION
## Motivation

Deprecate trace, debug, and bench logging in rocSPARSE as no longer needed now that roctx instrumentation support has been added.
