### PR TITLE
Fix unroll amount in hipblaslt-rocroller integration

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
@@ -688,7 +688,7 @@ std::vector<SolutionIndexParameters> chooseSolutionIndexParameters(
             params.push_back({wgt, 1, true});
             while (unrollAmount > 1 && (prob.k % (wgt.k * unrollAmount) != 0))
             {
-                unrollAmount--;
+                unrollAmount = unrollAmount / 2;
             }
 
             params.back().prefetchInFlight = unrollAmount;


### PR DESCRIPTION
## Motivation

Should never pick a non-power of 2 for the unroll amount that rocRoller is using.

## Technical Details

Change search space from anywhere from 4 ->1 to 4, 2 and 1.

## Test Plan

Run existing tests.

## Test Result

Rely on CI tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
