### PR TITLE
[hipBLASLt] Add `getDstParams` and `getSrcParams`

### DIFF
--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/branch.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/branch.hpp
@@ -49,6 +49,16 @@ namespace rocisa
             return {labelName};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {labelName};
+        }
+
         std::string toString() const
         {
             return formatWithComment(instStr + " " + labelName);

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/common.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/common.hpp
@@ -1236,6 +1236,16 @@ namespace rocisa
             return {prior};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {prior};
+        }
+
         std::string toString() const override
         {
             return formatWithComment(instStr + " " + std::to_string(prior));
@@ -1275,6 +1285,16 @@ namespace rocisa
             return {};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {};
+        }
+
         std::string toString() const override
         {
             return formatWithComment(instStr);
@@ -1300,6 +1320,16 @@ namespace rocisa
         }
 
         std::vector<InstructionInput> getParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
         {
             return {};
         }
@@ -1331,6 +1361,16 @@ namespace rocisa
         }
 
         std::vector<InstructionInput> getParams() const override
+        {
+            return {waitState};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
         {
             return {waitState};
         }
@@ -1367,6 +1407,16 @@ namespace rocisa
             return {};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {};
+        }
+
         std::string toString() const override
         {
             return formatWithComment(instStr);
@@ -1394,6 +1444,16 @@ namespace rocisa
         }
 
         std::vector<InstructionInput> getParams() const override
+        {
+            return {simm16};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
         {
             return {simm16};
         }
@@ -1499,6 +1559,16 @@ namespace rocisa
             return {lgkmcnt, vmcnt};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {lgkmcnt, vmcnt};
+        }
+
         std::string toString() const override
         {
             std::string waitStr;
@@ -1552,10 +1622,21 @@ namespace rocisa
             return {vscnt};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {vscnt};
+        }
+
         std::string toString() const override
         {
             int maxVscnt = getAsmCaps()["MaxVscnt"];
-            return formatWithComment("s_waitcnt_vscnt null " + std::to_string(std::min(vscnt, maxVscnt)));
+            return formatWithComment("s_waitcnt_vscnt null "
+                                     + std::to_string(std::min(vscnt, maxVscnt)));
         }
 
     private:
@@ -1586,10 +1667,21 @@ namespace rocisa
             return {storecnt};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {storecnt};
+        }
+
         std::string toString() const override
         {
             int maxStorecnt = getAsmCaps()["MaxStorecnt"];
-            return formatWithComment("s_wait_storecnt " + std::to_string(std::min(storecnt, maxStorecnt)));
+            return formatWithComment("s_wait_storecnt "
+                                     + std::to_string(std::min(storecnt, maxStorecnt)));
         }
 
     private:
@@ -1620,10 +1712,21 @@ namespace rocisa
             return {loadcnt};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {loadcnt};
+        }
+
         std::string toString() const override
         {
             int maxLoadcnt = getAsmCaps()["MaxLoadcnt"];
-            return formatWithComment("s_wait_loadcnt " + std::to_string(std::min(loadcnt, maxLoadcnt)));
+            return formatWithComment("s_wait_loadcnt "
+                                     + std::to_string(std::min(loadcnt, maxLoadcnt)));
         }
 
     private:
@@ -1650,6 +1753,16 @@ namespace rocisa
         }
 
         std::vector<InstructionInput> getParams() const override
+        {
+            return {kmcnt};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
         {
             return {kmcnt};
         }
@@ -1688,6 +1801,16 @@ namespace rocisa
             return {dscnt};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {dscnt};
+        }
+
         std::string toString() const override
         {
             int maxDscnt = getAsmCaps()["MaxDscnt"];
@@ -1706,7 +1829,7 @@ namespace rocisa
         dscnt: Number of LDS instructions issued but not yet completed.
         kmcnt: Number of constant-fetch (scalar memory read), and message instructions issued but not yet completed.
 
-        In some ISA, VMEM load/store share the same counter(vmcnt). LDS, scalar memory read and message share 
+        In some ISA, VMEM load/store share the same counter(vmcnt). LDS, scalar memory read and message share
         the same counter(lgkmcnt). These counters are combined from the 4 counters above as:
             vmcnt   = vlcnt + vscnt
             lgkmcnt = dscnt + kmcnt
@@ -1715,7 +1838,7 @@ namespace rocisa
 
             If the target ISA has separate counters for load and store, use SWaitCnt(vlcnt=1),
             which means vl_2 is not completed yet.
-            
+
             If the target ISA has a single counter for load and store, use SWaitCnt(vlcnt=1, vscnt=1),
             which means vs_0, vl_2 are not completed yet.
         */
@@ -1759,6 +1882,16 @@ namespace rocisa
             return {};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {};
+        }
+
         std::vector<std::shared_ptr<Instruction>> setupInstructions() const override
         {
             int         vlcnt   = this->vlcnt;
@@ -1782,8 +1915,10 @@ namespace rocisa
             std::vector<std::shared_ptr<Instruction>> instructions;
 
             if(getAsmCaps()["SeparateVscnt"])
-            {  
-                int lgkmcnt = (dscnt != -1 || kmcnt != -1)? (dscnt != -1 ? dscnt : 0) + (kmcnt != -1 ? kmcnt : 0) : -1;
+            {
+                int lgkmcnt = (dscnt != -1 || kmcnt != -1)
+                                  ? (dscnt != -1 ? dscnt : 0) + (kmcnt != -1 ? kmcnt : 0)
+                                  : -1;
                 int vmcnt   = vlcnt; // With SeparateVscnt, vmcnt only counts load instructions
                 if(vlcnt != -1 || lgkmcnt != -1)
                 {
@@ -1815,8 +1950,12 @@ namespace rocisa
             }
             else
             {
-                int lgkmcnt = (dscnt != -1 || kmcnt != -1)? (dscnt != -1 ? dscnt : 0) + (kmcnt != -1 ? kmcnt : 0) : -1;
-                int vmcnt   = (vscnt != -1 || vlcnt != -1)? (vscnt != -1 ? vscnt : 0) + (vlcnt != -1 ? vlcnt : 0) : -1;
+                int lgkmcnt = (dscnt != -1 || kmcnt != -1)
+                                  ? (dscnt != -1 ? dscnt : 0) + (kmcnt != -1 ? kmcnt : 0)
+                                  : -1;
+                int vmcnt   = (vscnt != -1 || vlcnt != -1)
+                                  ? (vscnt != -1 ? vscnt : 0) + (vlcnt != -1 ? vlcnt : 0)
+                                  : -1;
                 if(vmcnt != -1 || lgkmcnt != -1)
                 {
                     instructions.push_back(std::make_shared<_SWaitCnt>(lgkmcnt, vmcnt, comment));
@@ -1884,6 +2023,16 @@ namespace rocisa
         }
 
         std::vector<InstructionInput> getParams() const override
+        {
+            return {va_vdst, va_sdst, va_ssrc, hold_cnt, vm_vsrc, va_vcc, sa_sdst};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
         {
             return {va_vdst, va_sdst, va_ssrc, hold_cnt, vm_vsrc, va_vcc, sa_sdst};
         }
@@ -1980,6 +2129,16 @@ namespace rocisa
         }
 
         std::vector<InstructionInput> getParams() const override
+        {
+            return getSrcParams();
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
         {
             if(hasInstID1())
             {
@@ -4580,9 +4739,9 @@ namespace rocisa
     struct VSwapB32 : public CommonInstruction
     {
         VSwapB32(const std::shared_ptr<Container>&   dst,
-                const InstructionInput&             src,
-                const std::optional<SDWAModifiers>& sdwa    = std::nullopt,
-                const std::string&                  comment = "")
+                 const InstructionInput&             src,
+                 const std::optional<SDWAModifiers>& sdwa    = std::nullopt,
+                 const std::string&                  comment = "")
             : CommonInstruction(
                 InstType::INST_B32, dst, {src}, std::nullopt, sdwa, std::nullopt, comment)
         {

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/instruction.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/instruction.hpp
@@ -187,6 +187,9 @@ namespace rocisa
 
         virtual std::vector<InstructionInput> getParams() const = 0;
 
+        virtual std::vector<InstructionInput> getDstParams() const = 0;
+        virtual std::vector<InstructionInput> getSrcParams() const = 0;
+
         virtual int getIssueLatency() const
         {
             return 1; // Default issue latency is 1, should be overridden in derived classes
@@ -259,6 +262,21 @@ namespace rocisa
                 plist.insert(plist.end(), srcs.begin(), srcs.end());
             }
             return plist;
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            std::vector<InstructionInput> dsts;
+            if(dst)
+            {
+                dsts.push_back(dst);
+            }
+            return dsts;
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return srcs;
         }
 
         std::string toString() const override
@@ -382,6 +400,25 @@ namespace rocisa
             return l;
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            std::vector<InstructionInput> dsts;
+            if(dst)
+            {
+                dsts.push_back(dst);
+            }
+            if(dst1)
+            {
+                dsts.push_back(dst1);
+            }
+            return dsts;
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return srcs;
+        }
+
         std::string toString() const override
         {
             auto        newInstStr = preStr();
@@ -448,6 +485,18 @@ namespace rocisa
         std::vector<InstructionInput> getParams() const override
         {
             return args;
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            throw std::runtime_error("MacroInstruction does not have destination parameters");
+            return {}; // Macro instructions do not have destination parameters
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            throw std::runtime_error("MacroInstruction does not have source parameters");
+            return args; // All arguments are treated as source parameters
         }
 
         std::string getArgStr() const

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/mem.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/mem.hpp
@@ -176,6 +176,16 @@ namespace rocisa
             return {dst, vaddr};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {dst};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {vaddr};
+        }
+
         virtual std::string getArgStr() const
         {
             return dst->toString() + ", " + vaddr->toString();
@@ -228,6 +238,16 @@ namespace rocisa
         std::vector<InstructionInput> getParams() const override
         {
             return {dst, vaddr, saddr, soffset};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {dst};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {vaddr, saddr, soffset};
         }
 
         std::string getArgStr() const
@@ -316,6 +336,16 @@ namespace rocisa
             return {dst, base};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {dst};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {base};
+        }
+
         std::string getArgStr() const
         {
             return dst->toString() + ", " + base->toString();
@@ -364,6 +394,16 @@ namespace rocisa
         std::vector<InstructionInput> getParams() const override
         {
             return {dst, base, soffset};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {dst};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {base, soffset};
         }
 
         std::string getArgStr() const
@@ -436,6 +476,16 @@ namespace rocisa
             return {srcData, base, soffset};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {srcData, base, soffset};
+        }
+
         std::string getArgStr() const
         {
             return srcData->toString() + ", " + base->toString() + ", "
@@ -479,6 +529,16 @@ namespace rocisa
         }
 
         std::vector<InstructionInput> getParams() const override
+        {
+            return {vaddr, srcData};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
         {
             return {vaddr, srcData};
         }
@@ -533,6 +593,16 @@ namespace rocisa
         }
 
         std::vector<InstructionInput> getParams() const override
+        {
+            return {srcData, vaddr, saddr, soffset};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
         {
             return {srcData, vaddr, saddr, soffset};
         }
@@ -620,6 +690,16 @@ namespace rocisa
             return {dst, srcs};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {dst};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {srcs};
+        }
+
         std::string preStr() const override
         {
             if(kernel().isaVersion[0] < 11)
@@ -702,6 +782,16 @@ namespace rocisa
 
         // TODO: Not returning ds
         std::vector<InstructionInput> getParams() const override
+        {
+            return {dstAddr, src0, src1};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
         {
             return {dstAddr, src0, src1};
         }

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/mfma.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/mfma.hpp
@@ -162,6 +162,16 @@ namespace rocisa
             return {acc, a, b, acc2, negStr};
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {acc};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {a, b, acc2};
+        }
+
         std::string preStr() const override
         {
             std::string variantStr = std::to_string(variant[0]) + "x" + std::to_string(variant[1])
@@ -305,6 +315,16 @@ namespace rocisa
         std::vector<InstructionInput> getParams() const override
         {
             return {acc, a, b, metadata};
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            return {acc};
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            return {a, b, metadata};
         }
 
         std::string preStr() const override

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/instruction/instruction.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/instruction/instruction.cpp
@@ -43,6 +43,16 @@ namespace rocisa
         {
             NB_OVERRIDE_PURE(getParams);
         }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            NB_OVERRIDE_PURE(getDstParams);
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            NB_OVERRIDE_PURE(getSrcParams);
+        }
     };
 
     struct PyCompositeInstruction : public CompositeInstruction

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/instruction/mem.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/instruction/mem.cpp
@@ -41,6 +41,16 @@ namespace rocisa
             NB_OVERRIDE_PURE(getParams);
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            NB_OVERRIDE_PURE(getDstParams);
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            NB_OVERRIDE_PURE(getSrcParams);
+        }
+
         std::string toString() const override
         {
             NB_OVERRIDE_PURE(toString);
@@ -53,6 +63,16 @@ namespace rocisa
         std::vector<InstructionInput> getParams() const override
         {
             NB_OVERRIDE_PURE(getParams);
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            NB_OVERRIDE_PURE(getDstParams);
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            NB_OVERRIDE_PURE(getSrcParams);
         }
 
         std::string toString() const override
@@ -69,6 +89,16 @@ namespace rocisa
             NB_OVERRIDE_PURE(getParams);
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            NB_OVERRIDE_PURE(getDstParams);
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            NB_OVERRIDE_PURE(getSrcParams);
+        }
+
         std::string toString() const override
         {
             NB_OVERRIDE_PURE(toString);
@@ -81,6 +111,16 @@ namespace rocisa
         std::vector<InstructionInput> getParams() const override
         {
             NB_OVERRIDE_PURE(getParams);
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            NB_OVERRIDE_PURE(getDstParams);
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            NB_OVERRIDE_PURE(getSrcParams);
         }
 
         std::string toString() const override
@@ -97,6 +137,16 @@ namespace rocisa
             NB_OVERRIDE_PURE(getParams);
         }
 
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            NB_OVERRIDE_PURE(getDstParams);
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            NB_OVERRIDE_PURE(getSrcParams);
+        }
+
         std::string toString() const override
         {
             NB_OVERRIDE_PURE(toString);
@@ -109,6 +159,16 @@ namespace rocisa
         std::vector<InstructionInput> getParams() const override
         {
             NB_OVERRIDE_PURE(getParams);
+        }
+
+        std::vector<InstructionInput> getDstParams() const override
+        {
+            NB_OVERRIDE_PURE(getDstParams);
+        }
+
+        std::vector<InstructionInput> getSrcParams() const override
+        {
+            NB_OVERRIDE_PURE(getSrcParams);
         }
 
         std::string toString() const override


### PR DESCRIPTION
## Motivation

Separate `getParams` into `getDstParams` and `getSrcParams` in case some instructions have `dst`, `dst1`, so the user doesn't have to do dynamic cast to check if the instruction has two `dst` or no `dst` at all.

## Technical Details

NA

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
