### PR TITLE
[rocPRIM] Fix hip version version check for hipStreamLegacy usage

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -395,7 +395,7 @@ inline hipError_t get_device_from_stream(const hipStream_t stream, int& device_i
     static constexpr hipStream_t default_stream = 0;
 
     // hipStreamLegacy is supported in HIP >= 6.2.0
-#if (HIP_VERSION_MAJOR >= 6 && HIP_VERSION_MINOR >= 2)
+#if (HIP_VERSION_MAJOR > 6 || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 2))
     const bool is_legacy_stream = (stream == hipStreamLegacy);
 #else
     const bool is_legacy_stream = false;


### PR DESCRIPTION
## Motivation

hipStreamLegacy was added with HIP 6.2. Our version check was failing in HIP 7.0 because it was comparing the minor version number components incorrectly.

## Technical Details

This change updates the check so that the major version number takes precedence over the minor version number.  

## Test Plan

Built and ran a simple reproducer program that calls `rocprim::detail::get_device_from_stream(hipStreamLegacy, device_id)`.

## Test Result

No segmentation fault occurs.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
