### PR TITLE
[MIOpen] [rocBLAS] cmake block command support

### DIFF
--- a/projects/miopen/CMakeLists.txt
+++ b/projects/miopen/CMakeLists.txt
@@ -23,7 +23,7 @@
 # SOFTWARE.
 #
 ################################################################################
-cmake_minimum_required( VERSION 3.15 )
+cmake_minimum_required( VERSION 3.25 )
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/projects/rocblas/CMakeLists.txt
+++ b/projects/rocblas/CMakeLists.txt
@@ -20,7 +20,7 @@
 #
 # ########################################################################
 
-cmake_minimum_required( VERSION 3.24.4 )
+cmake_minimum_required( VERSION 3.25 )
 
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE


### PR DESCRIPTION
- Change minimum version of cmake required to 3.25 to support block command.
- block command is part of the hipblaslt build refactor.
- Changing minimum required for consumers of hipblaslt during build-time.
- https://cmake.org/cmake/help/latest/release/3.25.html
- Preference is to make this minimum requirement across rocm-libraries, but we'll increment to gather tech lead input and feedback,
- MIOpen build on Azure Pipelines fails when consuming the new hipblaslt build if CMake is too old (e.g., 3.22.1 default on Ubuntu 22.04 LTS).