### PR TITLE
[hipblaslt] restore tensile tuning from interruption with log

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/BenchmarkProblems.py
+++ b/projects/hipblaslt/tensilelite/Tensile/BenchmarkProblems.py
@@ -201,7 +201,8 @@ def writeBenchmarkFiles(
         debugConfig: DebugConfig,
         deviceId: int,
         gfxName: str,
-        isaInfoMap: Dict[IsaVersion, IsaInfo]
+        isaInfoMap: Dict[IsaVersion, IsaInfo],
+        probSolMap: dict
     ):
     """Write all the files needed for a given benchmarking step"""
 
@@ -297,11 +298,11 @@ def writeBenchmarkFiles(
         idealProblemSizes = ProblemSizes(problemType, idealSizes)
         writeClientConfig(True, solutions, idealProblemSizes, biasTypeArgs, \
                           factorDimArgs, activationArgs, icacheFlushArgs, stepName, stepBaseDir, \
-                          newLibrary, codeObjectFiles, True, deviceId, gfxName)
+                          newLibrary, codeObjectFiles, True, deviceId, gfxName, probSolMap=probSolMap)
     else:
         writeClientConfig(True, solutions, problemSizes, biasTypeArgs, \
                           factorDimArgs, activationArgs, icacheFlushArgs, stepName, stepBaseDir, \
-                          newLibrary, codeObjectFiles, False, deviceId, gfxName)
+                          newLibrary, codeObjectFiles, False, deviceId, gfxName, probSolMap=probSolMap)
 
     if len(solutions) == 0:
         printExit("write solutions and kernels results 0 valid soultion.")
@@ -313,7 +314,7 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
                          asmToolchain: AssemblyToolchain, srcToolchain: SourceToolchain, cCompiler: str,
                          buildTmpPath: Path, benchmarkProblemsPath: Path,
                          debugConfig: DebugConfig, deviceId: int,
-                         gfxName: str, isaInfoMap: Dict[str, IsaInfo]
+                         gfxName: str, isaInfoMap: Dict[str, IsaInfo], probSolMap: dict
     ):
     """Run the benchmarking for a single entry in the BenchmarkProblems of a Tensile config"""
     benchmarkTestFails = 0
@@ -428,7 +429,7 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
                     benchmarkStep.problemSizes, benchmarkStep.biasTypeArgs, \
                     benchmarkStep.factorDimArgs, benchmarkStep.activationArgs, \
                     benchmarkStep.icacheFlushArgs, shortName, [], asmToolchain, srcToolchain, \
-                    sourcePath, debugConfig, deviceId, gfxName, isaInfoMap)
+                    sourcePath, debugConfig, deviceId, gfxName, isaInfoMap, probSolMap)
             # ^ this mutates solutions
 
             # write cache data
@@ -463,7 +464,7 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
                                  benchmarkStep.factorDimArgs, benchmarkStep.activationArgs,
                                  benchmarkStep.icacheFlushArgs, conProblemType,
                                  stepBaseDir, codeObjectFiles, resultsFileName,
-                                 outFile, deviceId)
+                                 outFile, deviceId, probSolMap=probSolMap)
 
         # I think the size portion of this yaml could be removed,
         # but for now it's needed, so we update it even in the cache case
@@ -503,7 +504,8 @@ def main(
     debugConfig: DebugConfig,
     deviceId: int,
     gfxName: str,
-    isaInfoMap: Dict[str, IsaInfo]
+    isaInfoMap: Dict[str, IsaInfo],
+    probSolMap: dict
 ):
     """Entry point for the "BenchmarkProblems" section of a Tensile config yaml"""
     getClientExecutablePath()
@@ -556,7 +558,8 @@ def main(
                             debugConfig,
                             deviceId,
                             gfxName,
-                            isaInfoMap
+                            isaInfoMap,
+                            probSolMap
                         )
                 totalTestFails += benchmarkErrors
 

--- a/projects/hipblaslt/tensilelite/Tensile/ClientWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/ClientWriter.py
@@ -514,7 +514,7 @@ def pruneModeName(mode):
     if mode == 5: return 'Prune0X0X'
     if mode == 6: return 'Prune00XX'
 
-def writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs, activationArgs, icacheFlushArgs, problemType, sourceDir, codeObjectFiles, resultsFileName, parametersFilePath, deviceId: int, gfxName: str, libraryFile=None):
+def writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs, activationArgs, icacheFlushArgs, problemType, sourceDir, codeObjectFiles, resultsFileName, parametersFilePath, deviceId: int, gfxName: str, libraryFile=None, probSolMap={}):
 
     assert os.path.exists(sourceDir), f"sourceDir={sourceDir} does not exist"
 
@@ -574,9 +574,14 @@ def writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs
         param('strided-batched', problemType.stridedBatched)
         param('grouped-gemm', problemType.groupedGemm)
 
+        probIdx = 0
         for problem in problemSizes.problems:
             for key,value in problemSizeParams(problemType, problem, factorDimArgs.factorDims):
                 param(key,value)
+            if probIdx in probSolMap:
+                solutionIdx = probSolMap[probIdx]
+                param('prob-sol-map', str(f'{probIdx},{solutionIdx}'),)
+            probIdx += 1
 
         if activationArgs:
           for setting in activationArgs.settingList:
@@ -674,7 +679,8 @@ def writeClientConfig(
       deviceId: int,
       gfxName: str,
       configBase = "ClientParameters",
-      libraryFile = None
+      libraryFile = None,
+      probSolMap = {}
     ):
 
     sourceDir = os.path.join(stepBaseDir, "source")
@@ -694,7 +700,7 @@ def writeClientConfig(
       resultsFileName = os.path.join(stepBaseDir, "../Data", stepName+".csv")
 
     newSolution = next(iter(newLibrary.solutions.values()))
-    writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs, activationArgs, icacheFlushArgs, newSolution.problemType, sourceDir, codeObjectFiles, resultsFileName, filename, deviceId, gfxName, libraryFile)
+    writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs, activationArgs, icacheFlushArgs, newSolution.problemType, sourceDir, codeObjectFiles, resultsFileName, filename, deviceId, gfxName, libraryFile, probSolMap)
 
     return filename
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -349,12 +349,16 @@ def restore_prob_sol_map(logfile):
     print(f"#  Restore Previous Tuning From Log File: {str(logfile)}")
 
     startHint = "run,problem-progress,"
-    finHint = "clientExit"
+    finTuningHint = "clientExit"
+    finProblemHint = "####"
     keyword = "Contraction"
     runningTuning = False
 
     prob_best_us_record = {}
     prob_sol_map = {}
+    cur_prob_idx = -1
+    cur_sol_idx = -1
+    last_fin_prob = -1
     allProblems = 0
     allSolutions = 0
 
@@ -363,50 +367,72 @@ def restore_prob_sol_map(logfile):
             # Iterate over each line in the file
             for line in sh_file:
                 line = line.strip()
-                # run untile we see "run,problem-progress,"
+                # run until we see a line: "run,problem-progress,...."
                 if not runningTuning:
                     runningTuning = line.startswith(startHint)
                     continue
 
-                # following lines should be bench result
+                # following lines should be the bench results
                 if runningTuning:
-                    # not a tuning result line (contains "Contraction")
-                    if keyword not in line:
-                        continue
-                    # we see a line with clientExit, then break
-                    if line.startswith(finHint):
+                    # we see a line with clientExit, then finish parsing log.
+                    if line.startswith(finTuningHint):
+                        print1(f'#  Parsed log finished the tuning with line: {line}')
                         break
+
+                    # a line starts and ends with "####" is printed in postProblem() which means the cur_prob completed tuning.
+                    elif line.startswith(finProblemHint) and line.endswith(finProblemHint):
+                        # print1(f'#  Parsed Prob-Idx: {cur_prob_idx} completed tuning.')
+                        last_fin_prob = cur_prob_idx
+
+                    # not a valid tuning result line (a valid tuning result line contains "Contraction")
+                    elif keyword not in line:
+                        continue
+
+                    # a valid tuning result line
                     else:
                         tokens = line.split('"')
-                        ## split with "(problem-size)" : there should be be 3 tokens: { "starting-numbers," , "problem-size-desc" , ",rest-of-numbers"}
-                        assert len(tokens) == 3, f'bench result line: {line} is not fitting expected format'
-                        tokens[1] = "problem-sizes"
-                        newline = tokens[0] + tokens[1] + tokens[2] # a new line " starting-number, 'problem-sizes' , rest-of-numbers "
+                        # split by '"' to extract "(problem-size-desc)"
+                        # there should be 3 tokens: { "some-info," , "(problem-size-desc)" , ",rest-of-other-info"}
+                        assert len(tokens) == 3, f'bench result line: {line} is not fitting the expected format'
+                        # original tokens[1] looks like "(M,N,B,K)", replace it with a string without comma
+                        tokens[1] = 'problem-sizes'
+                        newline = tokens[0] + tokens[1] + tokens[2]
+                        # now the new line = "some-info, 'problem-sizes' , rest-of-other-info"
+                        # 0,29/31,8/247,Contraction....,'problem-sizes',None,,None,[SOLUTION-NAME],[VALIDATION],[53.6248(us)],[63354.7(gflops)],.........
                         tokens = newline.split(',')
-                        probInfo = tokens[1].split('/') # tokens[1] should be "probId/AllProb"
-                        solInfo = tokens[2].split('/') # tokens[2] should be "solId/AllSol"
+                        probInfo = tokens[1].split('/')
+                        solInfo = tokens[2].split('/')
                         assert len(probInfo) == 2, f'tokens[1]: {tokens[1]} should be a token as probId/AllProb'
                         assert len(solInfo) == 2, f'tokens[2]: {tokens[2]} should be a token as solId/AllSol'
-                        # solName = tokens[7]
-                        usTimeInfo = float(tokens[10]) # tokens[10] should be tuning mju-second
+                        # solName = tokens[8] # Might be another choice to put in map...
+                        usTimeInfo = float(tokens[10]) # tokens[10] should be the mju-sec
+                        cur_prob_idx = int(probInfo[0])
+                        cur_sol_idx = int(solInfo[0])
 
-                        # This can handle both the log w/ or /wo PrintWinnerOnly
-                        current_best_us_for_prob = prob_best_us_record.get(int(probInfo[0]))
+                        # This can handle logs with or without PrintWinnerOnly
+                        current_best_us_for_prob = prob_best_us_record.get(cur_prob_idx)
                         if current_best_us_for_prob is None:
                             # print(f"None, added for probID: {probInfo[0]}, time: {usTimeInfo}")
-                            prob_best_us_record.update( {int(probInfo[0]) : float(usTimeInfo)} )
-                            prob_sol_map.update( {int(probInfo[0]) : int(solInfo[0])} )
+                            prob_best_us_record.update( {cur_prob_idx : usTimeInfo} )
+                            prob_sol_map.update( {cur_prob_idx : cur_sol_idx} )
                         else:
-                            # update the winner
+                            # update the winner if better
                             if usTimeInfo < current_best_us_for_prob:
                                 # print(f"Better, updated for probID: {probInfo[0]}, new time: {usTimeInfo}, old time: {current_best_us_for_prob}")
-                                prob_best_us_record.update( {int(probInfo[0]) : float(usTimeInfo)} )
-                                prob_sol_map.update( {int(probInfo[0]) : int(solInfo[0])} )
+                                prob_best_us_record.update( {cur_prob_idx : usTimeInfo} )
+                                prob_sol_map.update( {cur_prob_idx : cur_sol_idx} )
 
+                        # for printing information
                         if allProblems == 0:
                             allProblems = int(probInfo[1]) + 1
                         if allSolutions == 0:
                             allSolutions = int(solInfo[1]) + 1
+
+        # The final updated "cur_prob_idx" is not finished since we don't see its postProblem() "####" line
+        # -> The problem did not complete tuning, so we need to remove it from map
+        if cur_prob_idx != last_fin_prob:
+            prob_sol_map.pop(cur_prob_idx)
+            print1(f'#  Parsed Prob-Idx {cur_prob_idx} did not complete tuning. Remove it from map.')
 
     except FileNotFoundError:
         print(f'Error: The file {logfile} was not found.')
@@ -414,7 +440,7 @@ def restore_prob_sol_map(logfile):
     except Exception as e:
         print(f'An error occurred: {e}')
 
-    print(f"#  Parsed Log File is for a {allProblems} problems vs {allSolutions} solutions tuning.")
+    print(f"#  Parsed log is for a '{allProblems}-problems-vs-{allSolutions}-solutions' tuning.")
 
     return prob_sol_map
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -73,7 +73,8 @@ def executeStepsInConfig(
         isaInfoMap: Dict[str, IsaInfo],
         cCompiler: str,
         debugConfig: DebugConfig,
-        deviceId: int
+        deviceId: int,
+        probSolDict: dict
    ):
     """Conducts the steps in the provided ``config`` according to the Tensile workflow.
 
@@ -111,6 +112,7 @@ def executeStepsInConfig(
             deviceId,
             gfxName,
             isaInfoMap,
+            probSolDict,
         )
         print1("")
 
@@ -342,6 +344,59 @@ def store_max_frequency(max_frequency):
         print(f"Error setting MAX_FREQ environment variable: {e}")
         return False
 
+def restore_prob_sol_map(logfile):
+
+    print(f"#  Restore Previous Tuning From Log File: {str(logfile)}")
+
+    startHint = "run,problem-progress,"
+    finHint = "clientExit"
+    keyword = "Contraction"
+    runningTuning = False
+
+    prob_sol_map = {}
+    allProblems = 0
+    allSolutions = 0
+
+    try:
+        with open(logfile, 'r') as sh_file:
+            # Iterate over each line in the file
+            for line in sh_file:
+                line = line.strip()
+                # run untile we see "run,problem-progress,"
+                if not runningTuning:
+                    runningTuning = line.startswith(startHint)
+                    continue
+
+                # following lines should be bench result
+                if runningTuning:
+                    # not a tuning result line (contains "Contraction")
+                    if keyword not in line:
+                        continue
+                    # we see a line with clientExit, then break
+                    if line.startswith(finHint):
+                        break
+                    else:
+                        tokens = line.split(',')
+                        probInfo = tokens[1].split('/') # tokens[1] should be "probId/AllProb"
+                        solInfo = tokens[2].split('/') # tokens[2] should be "solId/AllSol"
+                        assert len(probInfo) == 2, f'tokens[1]: {tokens[1]} should be a token as probId/AllProb'
+                        assert len(solInfo) == 2, f'tokens[2]: {tokens[2]} should be a token as solId/AllSol'
+                        prob_sol_map.update({ int(probInfo[0]) : int(solInfo[0])})
+                        if allProblems == 0:
+                            allProblems = int(probInfo[1]) + 1
+                        if allSolutions == 0:
+                            allSolutions = int(solInfo[1]) + 1
+
+    except FileNotFoundError:
+        print(f'Error: The file {logfile} was not found.')
+
+    except Exception as e:
+        print(f'An error occurred: {e}')
+
+    print(f"#  Parsed Log File is for a {allProblems} problems vs {allSolutions} solutions tuning.")
+
+    return prob_sol_map
+
 
 ################################################################################
 # Tensile
@@ -367,6 +422,8 @@ def Tensile(userArgs):
             "and optional second file is size list")
     argParser.add_argument("--use-cache", dest="useCache", action="store_true",
             help="Ignore cache; redo parameter forking and solution generation")
+    argParser.add_argument("--restore-from-log", type=str, dest="RestoreLog",
+            help="A log file captured in previous tuning. ONLY RELIABLE when configs yaml not changes")
 
     addCommonArguments(argParser)
     args = argParser.parse_args(userArgs)
@@ -384,6 +441,15 @@ def Tensile(userArgs):
     elif not altFormat and len(configPaths) != 1:
         printExit("Only 1 config_file is accepted for the default config format. "
                   "Did you mean to add '--alternate-formate'?")
+
+    prob_sol_map = {}
+    if args.RestoreLog:
+        restoreLogPath = Path(os.path.abspath(args.RestoreLog))
+        if not os.path.exists(restoreLogPath):
+            printExit(f'restore log file: {restoreLogPath} is not existing, abort. Please check')
+        prob_sol_map = restore_prob_sol_map(restoreLogPath)
+        for key,value in prob_sol_map.items():
+            print1(f'#  Restored Prob-Solution From Log: [Prob:{key},Sol:{value}]')
 
     # 2nd half of splash
     if len(configPaths) == 1:
@@ -494,7 +560,7 @@ def Tensile(userArgs):
     if "MaxFileName" in globalParameters or "MaxFileName" in config:
         printWarning("MaxFileName is no longer configurable, it will be automatically set to 64")
 
-    executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, device_id)
+    executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, device_id, prob_sol_map)
 
 def TensileConfigPath(*args):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "Configs", *args)

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -353,6 +353,7 @@ def restore_prob_sol_map(logfile):
     keyword = "Contraction"
     runningTuning = False
 
+    prob_best_us_record = {}
     prob_sol_map = {}
     allProblems = 0
     allSolutions = 0
@@ -376,12 +377,32 @@ def restore_prob_sol_map(logfile):
                     if line.startswith(finHint):
                         break
                     else:
-                        tokens = line.split(',')
+                        tokens = line.split('"')
+                        ## split with "(problem-size)" : there should be be 3 tokens: { "starting-numbers," , "problem-size-desc" , ",rest-of-numbers"}
+                        assert len(tokens) == 3, f'bench result line: {line} is not fitting expected format'
+                        tokens[1] = "problem-sizes"
+                        newline = tokens[0] + tokens[1] + tokens[2] # a new line " starting-number, 'problem-sizes' , rest-of-numbers "
+                        tokens = newline.split(',')
                         probInfo = tokens[1].split('/') # tokens[1] should be "probId/AllProb"
                         solInfo = tokens[2].split('/') # tokens[2] should be "solId/AllSol"
                         assert len(probInfo) == 2, f'tokens[1]: {tokens[1]} should be a token as probId/AllProb'
                         assert len(solInfo) == 2, f'tokens[2]: {tokens[2]} should be a token as solId/AllSol'
-                        prob_sol_map.update({ int(probInfo[0]) : int(solInfo[0])})
+                        # solName = tokens[7]
+                        usTimeInfo = float(tokens[10]) # tokens[10] should be tuning mju-second
+
+                        # This can handle both the log w/ or /wo PrintWinnerOnly
+                        current_best_us_for_prob = prob_best_us_record.get(int(probInfo[0]))
+                        if current_best_us_for_prob is None:
+                            # print(f"None, added for probID: {probInfo[0]}, time: {usTimeInfo}")
+                            prob_best_us_record.update( {int(probInfo[0]) : float(usTimeInfo)} )
+                            prob_sol_map.update( {int(probInfo[0]) : int(solInfo[0])} )
+                        else:
+                            # update the winner
+                            if usTimeInfo < current_best_us_for_prob:
+                                # print(f"Better, updated for probID: {probInfo[0]}, new time: {usTimeInfo}, old time: {current_best_us_for_prob}")
+                                prob_best_us_record.update( {int(probInfo[0]) : float(usTimeInfo)} )
+                                prob_sol_map.update( {int(probInfo[0]) : int(solInfo[0])} )
+
                         if allProblems == 0:
                             allProblems = int(probInfo[1]) + 1
                         if allSolutions == 0:

--- a/projects/hipblaslt/tensilelite/client/include/BenchmarkTimer.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/BenchmarkTimer.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/projects/hipblaslt/tensilelite/client/include/BenchmarkTimer.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/BenchmarkTimer.hpp
@@ -127,6 +127,7 @@ namespace TensileLite
             using double_millis = std::chrono::duration<double, std::milli>;
             using double_micros = std::chrono::duration<double, std::micro>;
             using double_nanos  = std::chrono::duration<double, std::nano>;
+            using prob_sol_map  = std::map<int, int>;
 
             double_millis m_timeInSolution;
             double_millis m_totalGPUTime;
@@ -135,6 +136,11 @@ namespace TensileLite
             float         m_skip_slow_solution_ratio;
             bool          m_skip_slow_solution;
             size_t        m_numSolutionSkip;
+            prob_sol_map  m_prob_sol_map;
+            bool          m_skiprun_from_map;
+            int           m_currProblemIdx;
+            int           m_currSolutionIdx;
+            int           m_probOnlyRunSolIdx;
         };
     } // namespace Client
 } // namespace TensileLite

--- a/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
@@ -367,8 +367,8 @@ namespace TensileLite
                         std::cout << curRow[ResultKey::BenchmarkRunNumber] << ","
                                   << curRow[ResultKey::ProblemProgress] << ","
                                   << curRow[ResultKey::SolutionProgress]
-                                  << ",Solution Skipped (slow or doing restoration): " << curRow[ResultKey::SolutionName]
-                                  << std::endl;
+                                  << ",Solution Skipped (slow or doing restoration): "
+                                  << curRow[ResultKey::SolutionName] << std::endl;
                     else
                         m_csvOutput.writeCurrentRow();
                     if(validation && !std::isnan(currentTimeUS))

--- a/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
@@ -367,7 +367,7 @@ namespace TensileLite
                         std::cout << curRow[ResultKey::BenchmarkRunNumber] << ","
                                   << curRow[ResultKey::ProblemProgress] << ","
                                   << curRow[ResultKey::SolutionProgress]
-                                  << ", Skip Slow Solution: " << curRow[ResultKey::SolutionName]
+                                  << ",Solution Skipped (slow or doing restoration): " << curRow[ResultKey::SolutionName]
                                   << std::endl;
                     else
                         m_csvOutput.writeCurrentRow();

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -659,7 +659,6 @@ int main(int argc, const char* argv[])
     bool        exitOnError      = args["exit-on-error"].as<bool>();
     bool        groupedGemm      = args["grouped-gemm"].as<bool>();
     const auto& icacheFlushArgs  = args["icache-flush-args"].as<std::vector<bool>>();
-    const auto& probSolMap       = args["prob-sol-map"].as<std::map<int,int>>();
 
     float skip_slow_solution_ratio = args["skip-slow-solution-ratio"].as<float>();
     if(skip_slow_solution_ratio > 1.0 || skip_slow_solution_ratio < 0.0)
@@ -749,9 +748,6 @@ int main(int argc, const char* argv[])
             {
                 auto problem = problems[problemIdx].get();
 
-                int runOnlySolIdx = -1;
-                if(probSolMap.count(problemIdx) != 0)
-                    runOnlySolIdx = probSolMap.at(problemIdx);
 
                 reporters->report(ResultKey::ProblemIndex, problemIdx);
                 reporters->report(ResultKey::ProblemProgress,
@@ -779,10 +775,7 @@ int main(int argc, const char* argv[])
 
                     listeners.preSolution(*solution);
 
-                    // skip if this problem has a specified solution to run
-                    bool skipRun = (runOnlySolIdx != -1 && cur_sol_idx != runOnlySolIdx);
-
-                    if(solutionIterator->runCurrentSolution() && runKernels && !skipRun)
+                    if(solutionIterator->runCurrentSolution() && runKernels)
                     {
                         try
                         {

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -748,7 +748,6 @@ int main(int argc, const char* argv[])
             {
                 auto problem = problems[problemIdx].get();
 
-
                 reporters->report(ResultKey::ProblemIndex, problemIdx);
                 reporters->report(ResultKey::ProblemProgress,
                                   concatenate(problemIdx, "/", lastProblemIdx));
@@ -765,8 +764,6 @@ int main(int argc, const char* argv[])
                     maxRotatingBufferNum, problem, inputs, stream);
                 static_cast<void>(hipDeviceSynchronize());
                 bool resetInput = false;
-
-                int cur_sol_idx = 0;
                 while(solutionIterator->moreSolutionsInProblem())
                 {
                     auto solution = solutionIterator->getSolution();
@@ -774,7 +771,6 @@ int main(int argc, const char* argv[])
                         throw std::runtime_error("Could not find a solution");
 
                     listeners.preSolution(*solution);
-
                     if(solutionIterator->runCurrentSolution() && runKernels)
                     {
                         try
@@ -876,8 +872,6 @@ int main(int argc, const char* argv[])
                     }
 
                     listeners.postSolution();
-
-                    cur_sol_idx++;
 
                     if(exitOnError && listeners.error() > 0)
                     {

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -521,7 +521,7 @@ namespace TensileLite
             std::map<int, int> outValue;
             for(auto const& str : inValue)
             {
-                auto vec = split_nums<T>(str);
+                auto vec         = split_nums<T>(str);
                 outValue[vec[0]] = vec[1];
                 // std::cout << "map: [" << vec[0] << "," << vec[1] << "]" << std::endl;
             }

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -286,6 +286,8 @@ namespace TensileLite
                 ("problem-size,p",           vector_default_empty<std::string>(), "Specify a problem size.  Comma-separated list of "
                                                                                   "sizes, in the order of the Einstein notation.")
 
+                ("prob-sol-map",             vector_default_empty<std::string>(), "[probIdx, solIdx]")
+
                 ("a-strides",                vector_default_empty<std::string>(), "Unspecified means default stride "
                                                                                   "(prev_dim_stride*prev_dim_size)"
                                                                                   "specifying once applies to all problem sizes, "
@@ -511,6 +513,29 @@ namespace TensileLite
             args.at(name).value() = boost::any(type);
         }
 
+        template <typename T>
+        void parse_arg_nums_map(po::variables_map& args, std::string const& name)
+        {
+            auto inValue = args[name].as<std::vector<std::string>>();
+
+            std::map<int, int> outValue;
+            for(auto const& str : inValue)
+            {
+                auto vec = split_nums<T>(str);
+                outValue[vec[0]] = vec[1];
+                // std::cout << "map: [" << vec[0] << "," << vec[1] << "]" << std::endl;
+            }
+
+            boost::any v(outValue);
+
+            args.at(name).value() = v;
+        }
+
+        void parse_arg_ints_map(po::variables_map& args, std::string const& name)
+        {
+            parse_arg_nums_map<int>(args, name);
+        }
+
         void fix_data_types(po::variables_map& args)
         {
             auto type = args["type"].as<rocisa::DataType>();
@@ -571,6 +596,8 @@ namespace TensileLite
             parse_activation_enum_args(args, "activation-enum-args");
             parse_arg_double(args, "activation-additional-args");
             parse_arg_bools(args, "icache-flush-args");
+            // std::cout << "Pasring parse_arg_ints_map()" << std::endl;
+            parse_arg_ints_map(args, "prob-sol-map");
             return args;
         }
 
@@ -632,6 +659,7 @@ int main(int argc, const char* argv[])
     bool        exitOnError      = args["exit-on-error"].as<bool>();
     bool        groupedGemm      = args["grouped-gemm"].as<bool>();
     const auto& icacheFlushArgs  = args["icache-flush-args"].as<std::vector<bool>>();
+    const auto& probSolMap       = args["prob-sol-map"].as<std::map<int,int>>();
 
     float skip_slow_solution_ratio = args["skip-slow-solution-ratio"].as<float>();
     if(skip_slow_solution_ratio > 1.0 || skip_slow_solution_ratio < 0.0)
@@ -721,6 +749,10 @@ int main(int argc, const char* argv[])
             {
                 auto problem = problems[problemIdx].get();
 
+                int runOnlySolIdx = -1;
+                if(probSolMap.count(problemIdx) != 0)
+                    runOnlySolIdx = probSolMap.at(problemIdx);
+
                 reporters->report(ResultKey::ProblemIndex, problemIdx);
                 reporters->report(ResultKey::ProblemProgress,
                                   concatenate(problemIdx, "/", lastProblemIdx));
@@ -737,6 +769,8 @@ int main(int argc, const char* argv[])
                     maxRotatingBufferNum, problem, inputs, stream);
                 static_cast<void>(hipDeviceSynchronize());
                 bool resetInput = false;
+
+                int cur_sol_idx = 0;
                 while(solutionIterator->moreSolutionsInProblem())
                 {
                     auto solution = solutionIterator->getSolution();
@@ -744,7 +778,11 @@ int main(int argc, const char* argv[])
                         throw std::runtime_error("Could not find a solution");
 
                     listeners.preSolution(*solution);
-                    if(solutionIterator->runCurrentSolution() && runKernels)
+
+                    // skip if this problem has a specified solution to run
+                    bool skipRun = (runOnlySolIdx != -1 && cur_sol_idx != runOnlySolIdx);
+
+                    if(solutionIterator->runCurrentSolution() && runKernels && !skipRun)
                     {
                         try
                         {
@@ -845,6 +883,8 @@ int main(int argc, const char* argv[])
                     }
 
                     listeners.postSolution();
+
+                    cur_sol_idx++;
 
                     if(exitOnError && listeners.error() > 0)
                     {

--- a/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
@@ -63,6 +63,7 @@ namespace TensileLite
             , m_skip_slow_solution_ratio(args["skip-slow-solution-ratio"].as<float>())
             , m_skip_slow_solution(0)
             , m_numSolutionSkip(0)
+            , m_prob_sol_map(args["prob-sol-map"].as<prob_sol_map>())
         {
         }
 
@@ -71,27 +72,48 @@ namespace TensileLite
             return m_numBenchmarksRun < m_numBenchmarks;
         }
 
-        void BenchmarkTimer::preBenchmarkRun() {}
+        void BenchmarkTimer::preBenchmarkRun()
+        {
+            m_currProblemIdx = -1; // init
+        }
 
         void BenchmarkTimer::postBenchmarkRun()
         {
             m_numBenchmarksRun++;
+            m_currProblemIdx = -1; // reset
         }
 
         void BenchmarkTimer::preProblem(ContractionProblem* const problem)
         {
+            ++m_currProblemIdx; // update current prob-idx
+
+            // test if we only have a specific solution to run (When restore-from-log)
+            m_probOnlyRunSolIdx = -1;
+            if(m_prob_sol_map.count(m_currProblemIdx) != 0)
+                m_probOnlyRunSolIdx = m_prob_sol_map.at(m_currProblemIdx);
+
             m_problem               = problem;
             m_currentBestWarmUpTime = double_millis(std::numeric_limits<double>::max());
             m_numSolutionSkip       = 0;
+            m_currSolutionIdx       = -1; // init
         }
 
         void BenchmarkTimer::postProblem()
         {
+            m_currSolutionIdx = -1; // reset
             if(m_numSolutionSkip)
+            {
                 std::cout << "########################## " << m_numSolutionSkip
                           << " solutions were skipped in total. (Skip Ratio: "
                           << m_skip_slow_solution_ratio << ")##########################"
                           << std::endl;
+            }
+            else
+            {
+                // startwith "###" as an indication of end-of-problem
+                std::cout << "########################## "
+                          << std::endl;
+            }
         }
 
         void BenchmarkTimer::preSolution(ContractionSolution const& solution)
@@ -99,6 +121,12 @@ namespace TensileLite
             m_numEnqueuesInSolution = 0;
             m_timeInSolution        = double_millis::zero();
             m_skip_slow_solution    = false;
+
+            ++m_currSolutionIdx; // update current sol-idx
+            // When restore-from-log: check if this solution is skipped if it's not the specified one, init this flag as false
+            m_skiprun_from_map = false;
+            if((m_probOnlyRunSolIdx != -1) && (m_probOnlyRunSolIdx != m_currSolutionIdx))
+                m_skiprun_from_map = true;
 
             ContractionSolution::ProjectedPerformance pp;
 
@@ -132,8 +160,9 @@ namespace TensileLite
 
         void BenchmarkTimer::postSolution()
         {
+            bool sol_is_skipped = (m_skiprun_from_map || m_skip_slow_solution);
             double timePerEnqueue_us
-                = !m_skip_slow_solution
+                = !sol_is_skipped
                       ? double_micros(m_timeInSolution).count() / m_numEnqueuesInSolution
                             - m_flushTimeUs
                       : std::numeric_limits<double>::quiet_NaN();
@@ -156,7 +185,7 @@ namespace TensileLite
                     "[BenchmarkTimer] Failed to cast problem to any ContractionProblem.");
             }
 
-            double gflops  = !m_skip_slow_solution ? flopCount / (timePerEnqueue_us) / 1000.0 : 0;
+            double gflops  = !sol_is_skipped ? flopCount / (timePerEnqueue_us) / 1000.0 : 0;
             int    tiles   = pp.granularities.tilesPerCu * perf.CUs;
             int    usedCus = std::min(tiles, perf.CUs);
             double gflopsPerCu = gflops / usedCus;
@@ -171,7 +200,8 @@ namespace TensileLite
 
         bool BenchmarkTimer::needMoreRunsInSolution() const
         {
-            return m_numEnqueuesInSolution < m_numEnqueuesPerSolution && !m_skip_slow_solution;
+            bool sol_is_skipped = (m_skiprun_from_map || m_skip_slow_solution);
+            return m_numEnqueuesInSolution < m_numEnqueuesPerSolution && !sol_is_skipped;
         }
 
         size_t BenchmarkTimer::numWarmupRuns()
@@ -186,13 +216,21 @@ namespace TensileLite
                     "Expected at least", m_numWarmups, " warmup runs, got ", count, "."));
         }
 
-        void BenchmarkTimer::preWarmup() {}
+        void BenchmarkTimer::preWarmup()
+        {
+            // When restore-from-log, we only run on the specified solution
+            if(m_skiprun_from_map)
+                return;
+        }
 
         void BenchmarkTimer::postWarmup(TimingEvents const& startEvents,
                                         TimingEvents const& stopEvents,
                                         hipStream_t const&  stream)
         {
-            if(!m_skip_slow_solution_ratio)
+            // no need to do the warmup test when:
+            // 1. skip_from_map (When restore-from-log) or
+            // 2. skip_slow_solution_ratio is not set
+            if(m_skiprun_from_map || !m_skip_slow_solution_ratio)
                 return;
 
             double_millis totalTime(0.0);
@@ -241,7 +279,10 @@ namespace TensileLite
 
         size_t BenchmarkTimer::numEnqueuesPerSync()
         {
-            if(m_skip_slow_solution)
+            // No need to run when
+            // 1. this solution is skip_from_map (restore-from-log) or
+            // 2. m_skip_slow_solution
+            if(m_skiprun_from_map || m_skip_slow_solution)
                 return 0;
             size_t enqueuesByFlops = 0;
             if(m_minFlopsPerSync > 0)

--- a/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -110,9 +110,8 @@ namespace TensileLite
             }
             else
             {
-                // startwith "###" as an indication of end-of-problem
-                std::cout << "########################## "
-                          << std::endl;
+                // print this as an indication of end-of-problem
+                std::cout << "########################## " << std::endl;
             }
         }
 
@@ -160,12 +159,11 @@ namespace TensileLite
 
         void BenchmarkTimer::postSolution()
         {
-            bool sol_is_skipped = (m_skiprun_from_map || m_skip_slow_solution);
-            double timePerEnqueue_us
-                = !sol_is_skipped
-                      ? double_micros(m_timeInSolution).count() / m_numEnqueuesInSolution
-                            - m_flushTimeUs
-                      : std::numeric_limits<double>::quiet_NaN();
+            bool   sol_is_skipped    = (m_skiprun_from_map || m_skip_slow_solution);
+            double timePerEnqueue_us = !sol_is_skipped ? double_micros(m_timeInSolution).count()
+                                                                 / m_numEnqueuesInSolution
+                                                             - m_flushTimeUs
+                                                       : std::numeric_limits<double>::quiet_NaN();
 
             ContractionSolution::ProjectedPerformance pp;
             double                                    flopCount = 0;
@@ -185,9 +183,9 @@ namespace TensileLite
                     "[BenchmarkTimer] Failed to cast problem to any ContractionProblem.");
             }
 
-            double gflops  = !sol_is_skipped ? flopCount / (timePerEnqueue_us) / 1000.0 : 0;
-            int    tiles   = pp.granularities.tilesPerCu * perf.CUs;
-            int    usedCus = std::min(tiles, perf.CUs);
+            double gflops      = !sol_is_skipped ? flopCount / (timePerEnqueue_us) / 1000.0 : 0;
+            int    tiles       = pp.granularities.tilesPerCu * perf.CUs;
+            int    usedCus     = std::min(tiles, perf.CUs);
             double gflopsPerCu = gflops / usedCus;
 
             m_reporter->report(ResultKey::TimeUS, timePerEnqueue_us);

--- a/projects/hipblaslt/tensilelite/client/src/ResultFileReporter.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/ResultFileReporter.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/projects/hipblaslt/tensilelite/client/src/ResultFileReporter.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/ResultFileReporter.cpp
@@ -81,8 +81,9 @@ namespace TensileLite
                 ++m_currSolutionIdx;
                 if(!m_invalidSolution)
                 {
-                    double timeUS = std::stod(valueStr);
-                    if(m_fasterTimeUS < 0 || m_fasterTimeUS > timeUS)
+                    double timeUS    = std::stod(valueStr);
+                    bool   timeIsNan = std::isnan(timeUS);
+                    if((!timeIsNan) && (m_fasterTimeUS < 0 || m_fasterTimeUS > timeUS))
                     {
                         m_fasterTimeUS = timeUS;
                         if(m_extraCol)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Tensilelite tuning usually takes long time. And there are also many unexpected interruptions during a long tuning task. (for example, server down, reboot, GPU hang, crashing...etc). When tuning is unexpected interrupted, all the tuned work is in vain since there is no any output in folder **/2_BenchmarkData** and this means we need to rerun the tuning. 

This PR provides a restore-from-log feature when this happens and we have the log of the previous interrupted tuning. When  you re-run the tuning with the log, it can directly run the best solution and continue tuning the rest of problem-sizes.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Added an optional argument **`--restore-from-log [log-file]`** for `Tensile.sh` when an unexpected interruption of tuning happens.
To use `--restore-from-log`, there are some preconditions.
1. You have the log file of the previous tuning. ( e.g. **2>&1 | tee** my_tuning.log ) So this is recommended when you are going to do a long tuning every time.
2. When an unexpected interruption happens, re-run the tuning with `--restore-from-log my_tuning.log` 
3. **DO NOT** change the tuning configs that lead any changes of solutions (no matter the total numbers or the order of solutions)
4. **DO NOT** change the **order of TUNED problem-sizes** (you can remove and change the "un-tuned" problems)
5. The reason of point 3, 4 is because this `--restore-from-log` is reading a log and generating a simple **[probID, bestSolID]** map, and then send  it to client via the ini file. 

Though point 3, 4 seem a bit limited, but since this feature is playing a role as a remedy to quickly restore one single tuning task. So currently it should be sufficient to use. (a safer way might be to store [ "proble-size" , "solution-name" ], but it will write a long str in the ini file which is also not good)

### Some details to be noted: (Please be aware of these details)
- [ ] --restore-from-log only retrieves the tuned [problem, solution] info. It doesn't save the tuned us, GFLOPS, GlobalParameter settings (i.e, iterations, warmup,...etc)
- [ ] It only supports a tuning yaml with one single problem-type. Since it only saves one map.
- [ ] Please understand this is a remedy feature to restore the turning results from interruption. Do not use it to generate a logic yaml with an out-of-date log, or even on a different GPU arch...etc.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
This is a helper script and will be used manually when needed. So it won't impact any functionality and correctness of gemm. 
No need to test in CI. I tested this feature directly with a tensilelite tuning log, and see if the restoration is correct.

## Test Result

<!-- Briefly summarize test outcomes. -->
The **`--restore-from-log`** works as expected. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Supported log from "PrintWinnerOnly: True" -> easier to parse, only take the latest one
- [x] Supported log from "PrintWinnerOnly: False" -> need to parse the log and take the best one. 
- [x] Can detect if a problem in the log finished tuning or was interrupted (can't save to map). 
