### PR TITLE
Default to rocm-libraries shared Tensile instead of deprecated repo

### DIFF
--- a/projects/rocblas/rmake.py
+++ b/projects/rocblas/rmake.py
@@ -463,6 +463,9 @@ def config_cmd():
         cmake_options.append(f"-DTensile_CODE_OBJECT_VERSION=default")
         if args.tensile_logic:
             cmake_options.append(f"-DTensile_LOGIC={args.tensile_logic}")
+        # Default to rocm-libraries shared Tensile if not otherwise specified
+        if not (args.tensile_fork or args.tensile_tag or args.tensile_test_local_path or args.tensile_version):
+            cmake_options.append(f"-DTensile_TEST_LOCAL_PATH='../../../../shared/tensile'")
         if args.tensile_fork:
             cmake_options.append(f"-Dtensile_fork={args.tensile_fork}")
         if args.tensile_tag:

--- a/projects/rocblas/rmake.py
+++ b/projects/rocblas/rmake.py
@@ -464,7 +464,8 @@ def config_cmd():
         if args.tensile_logic:
             cmake_options.append(f"-DTensile_LOGIC={args.tensile_logic}")
         # Default to rocm-libraries shared Tensile if not otherwise specified
-        if not (args.tensile_fork or args.tensile_tag or args.tensile_test_local_path or args.tensile_version):
+        if (not (args.tensile_fork or args.tensile_tag or args.tensile_test_local_path or args.tensile_version)
+            and os.path.isdir('../../../../shared/tensile')):
             cmake_options.append(f"-DTensile_TEST_LOCAL_PATH='../../../../shared/tensile'")
         if args.tensile_fork:
             cmake_options.append(f"-Dtensile_fork={args.tensile_fork}")


### PR DESCRIPTION
In rocblas installation, set the local Tensile path to the rocm-libraries shared Tensile if Tensile origin is not otherwise specified.

## Motivation

rocblas installation currently pulls Tensile from the deprecated repo (ROCm/Tensile) by default. We're already providing Tensile in rocm-libraries so there should be no need to pull during installation, or at least we should not pull from the deprecated repo.

## Technical Details

If no options are passed to rocblas install.sh to specify a Tensile path, the same code for specifying a local Tensile directory is used with the relative path of the rocm-libraries Tensile directory.

## Test Plan

In rocblas folder, run install.sh -idc and observe output before and after change. Afterward there should be no mention of git wrt Tensile.

## Test Result

Before: output contains `/home/rocm/rocm-libraries-2/projects/rocblas/build/release/virtualenv/bin/python3 -m pip install git+https://github.com/ROCm/Tensile.git@9c23c3d6dc88c7bc374da2abd4529d7d9674a4ec`

After: output contains `/home/rocm/rocm-libraries/projects/rocblas/build/release/virtualenv/bin/python3 -m pip install /home/rocm/rocm-libraries/shared/tensile`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
