### PR TITLE
fix lintian warnings 

### DIFF
--- a/projects/hiprand/CMakeLists.txt
+++ b/projects/hiprand/CMakeLists.txt
@@ -222,7 +222,7 @@ endif()
 
 rocm_create_package(
         NAME ${package_name}
-        DESCRIPTION "A GPU-based random number generation library, written in HIP"
+        DESCRIPTION "GPU-based random number generation library, written in HIP"
         MAINTAINER "hipRAND Maintainer <hiprand-maintainer@amd.com>"
         LDCONFIG
         LDCONFIG_DIR ${HIPRAND_CONFIG_DIR}

--- a/projects/rocblas/CMakeLists.txt
+++ b/projects/rocblas/CMakeLists.txt
@@ -363,7 +363,7 @@ set( ROCBLAS_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBD
 
 rocm_create_package(
     NAME ${package_name}
-    DESCRIPTION "rocBLAS is the AMD library for BLAS in ROCm. Implemented using the HIP language and optimized for AMD GPUs"
+    DESCRIPTION "AMD library for BLAS in ROCm. Implemented in HIP and optimized for AMD GPUs"
     MAINTAINER "rocBLAS Maintainer <rocblas-maintainer@amd.com>"
     LDCONFIG
     LDCONFIG_DIR ${ROCBLAS_CONFIG_DIR}


### PR DESCRIPTION
fix lintian warnings description-synopsis-starts-with-article and description-too-long

## Motivation

fix lintian warnings description-synopsis-starts-with-article and description-too-long

## Technical Details

https://lintian.debian.org/tags/description-synopsis-starts-with-article.html
Remove "A" in projects/hiprand/CMakeLists.txt to resolve description-synopsis-starts-with-article

https://lintian.debian.org/tags/description-too-long.html
 "Description:" must be less than 80 characters long.

## Test Plan

compile and check for warnings

## Test Result

no warnings 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
