### PR TITLE
[rocThrust] unique_ptr implementation (single-object version) 

### DIFF
--- a/projects/rocthrust/CHANGELOG.md
+++ b/projects/rocthrust/CHANGELOG.md
@@ -3,6 +3,12 @@
 Documentation for rocThrust available at
 [https://rocm.docs.amd.com/projects/rocThrust/en/latest/](https://rocm.docs.amd.com/projects/rocThrust/en/latest/).
 
+## rocThrust 4.2.0 for ROCm 7.2
+
+### Added
+
+* Added `thrust::unique_ptr` - a smart pointer for managing device memory with automatic cleanup.
+
 ## rocThrust 4.1.0 for ROCm 7.1
 
 ### Added

--- a/projects/rocthrust/test/CMakeLists.txt
+++ b/projects/rocthrust/test/CMakeLists.txt
@@ -299,6 +299,8 @@ if(BUILD_TEST)
     add_rocthrust_test("type_traits")
     add_rocthrust_test("uninitialized_copy")
     add_rocthrust_test("uninitialized_fill")
+    add_rocthrust_test("unique_ptr_general")
+    add_rocthrust_test("unique_ptr_allocate_deallocate")
     add_rocthrust_test("unique")
     # temporarily disable unique_by_key due to Azure CI build failure
     #add_rocthrust_test("unique_by_key")

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -1,5 +1,5 @@
 
-// #include <thrust/unique_ptr.h>
+#include <thrust/unique_ptr.h>
 #include "hip/hip_runtime.h"
 #include "test_param_fixtures.hpp"
 #include "test_utils.hpp"

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -1,16 +1,24 @@
 
 #include <thrust/unique_ptr.h>
+#include <thrust/device_delete.h>
 #include "hip/hip_runtime.h"
 #include "test_param_fixtures.hpp"
 #include "test_utils.hpp"
 
 class A {
 public:    
-    __host__ __device__ A() {}
-    __host__ __device__ A(int num): val_a(num) {}
+    __host__ __device__ A() : finished(nullptr), val_a(0) {}
+    __host__ __device__ A(int num): finished(nullptr), val_a(num) {}
+    __host__ __device__ A(thrust::device_ptr<bool> dev_p, int num): finished(dev_p), val_a(num) {}
 
-    __host__ __device__ ~A() {}
+    __host__ __device__ ~A() {
+    #if defined(__HIP_DEVICE_COMPILE__)
+        if(finished)
+            *finished = true; 
+    #endif
+    }
  
+    thrust::device_ptr<bool> finished;
     int val_a;
 }; 
 
@@ -48,22 +56,14 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrDltr)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    void *raw_addr = nullptr;
-    size_t sz = 0;
+    thrust::device_ptr<bool> finished = thrust::device_new<bool>(1);
+    *finished = false;
     {
-        thrust::unique_ptr<A> p = thrust::make_unique<A>();
+        thrust::unique_ptr<A> p = thrust::make_unique<A>(finished, 18);
         ASSERT_NE(p, nullptr);
-
-        hipError_t st = hipMemPtrGetInfo(static_cast<void*>(p.get_raw()), &sz);
-        ASSERT_EQ(st, hipSuccess);
-        ASSERT_GE(sz, sizeof(A));
-
-        raw_addr = static_cast<void*>(p.get_raw());
     }
-    
-    size_t dummy = 0;
-    hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
-    ASSERT_EQ(st, hipErrorInvalidValue);
+    ASSERT_EQ(*finished, true);
+    thrust::device_delete(finished);
 }
 
 TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmp)

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -1,0 +1,5 @@
+
+// #include <thrust/unique_ptr.h>
+#include "hip/hip_runtime.h"
+#include "test_param_fixtures.hpp"
+#include "test_utils.hpp"

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -24,6 +24,7 @@ public:
 
 TESTS_DEFINE(UniquePtrAllocDeallocTests, NumericalTestsParams);
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.single.pass.cpp
 TYPED_TEST(UniquePtrAllocDeallocTests, TestMakeUnique)
 {
     using T = typename TestFixture::input_type;
@@ -42,6 +43,7 @@ TYPED_TEST(UniquePtrAllocDeallocTests, TestMakeUnique)
     ASSERT_EQ(*p1, T {});
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.single.pass.cpp
 TEST(UniquePtrAllocDeallocTests, TestMakeUniqueUserType)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -52,6 +54,7 @@ TEST(UniquePtrAllocDeallocTests, TestMakeUniqueUserType)
     ASSERT_EQ(host_p.val_a, 7);
 }
 
+// Thrust-specific test for deleter behavior.
 TEST(UniquePtrAllocDeallocTests, TestUniquePtrDltr)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -66,6 +69,7 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrDltr)
     thrust::device_delete(finished);
 }
 
+// Based on llvm-project/libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/cmp.pass.cpp
 TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmp)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -119,6 +123,7 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmp)
     }
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
 TEST(UniquePtrAllocDeallocTests, TestUniquePtrNullptr)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -126,7 +131,7 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrNullptr)
     // Test with a non-null unqiue_ptr
     {
         const thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
-
+ 
         ASSERT_NE(p, nullptr);
         ASSERT_LT(nullptr, p);
         ASSERT_LE(nullptr, p);

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -3,3 +3,43 @@
 #include "hip/hip_runtime.h"
 #include "test_param_fixtures.hpp"
 #include "test_utils.hpp"
+
+class A {
+public:    
+    __host__ __device__ A() {}
+    __host__ __device__ A(int num): val_a(num) {}
+
+    __host__ __device__ ~A() {}
+ 
+    int val_a;
+}; 
+
+TESTS_DEFINE(UniquePtrAllocDeallocTests, NumericalTestsParams);
+
+TYPED_TEST(UniquePtrAllocDeallocTests, TestMakeUnique)
+{
+    using T = typename TestFixture::input_type;
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    T initial_value = T(1);
+    if(std::is_floating_point<T>::value)
+    {
+        initial_value = T(7.71);
+    }
+
+    thrust::unique_ptr<T> p1 = thrust::make_unique<T>(initial_value);
+    ASSERT_EQ(*p1, initial_value);
+
+    p1 = thrust::make_unique<T>();
+    ASSERT_EQ(*p1, T {});
+}
+
+TEST(UniquePtrAllocDeallocTests, TestMakeUniqueUserType)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    thrust::unique_ptr<A> p = thrust::make_unique<A>(7);
+    A host_p = *p;
+
+    ASSERT_EQ(host_p.val_a, 7);
+}

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -65,3 +65,83 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrDltr)
     hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
     ASSERT_EQ(st, hipErrorInvalidValue);
 }
+
+TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmp)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Pointers of same type
+    {
+        thrust::unique_ptr<int> p1 = thrust::make_unique<int>(1);
+        thrust::unique_ptr<int> p2 = thrust::make_unique<int>(2);
+
+        int* ptr1 = p1.get_raw();
+        int* ptr2 = p2.get_raw();
+
+        ASSERT_EQ((p1 == p2), (ptr1 == ptr2));
+        ASSERT_EQ((p1 != p2), (ptr1 != ptr2));
+        ASSERT_EQ((p1 < p2), (ptr1 < ptr2));
+        ASSERT_EQ((p1 <= p2), (ptr1 <= ptr2));
+        ASSERT_EQ((p1 > p2), (ptr1 > ptr2));
+        ASSERT_EQ((p1 >= p2), (ptr1 >= ptr2));
+    }
+
+    // Pointers of different type
+    {
+        thrust::unique_ptr<int>   p1 = thrust::make_unique<int>(1);
+        thrust::unique_ptr<float> p2 = thrust::make_unique<float>(2.2);
+
+        int*   ptr1 = p1.get_raw();
+        float* ptr2 = p2.get_raw();
+
+        ASSERT_EQ((p1 == p2), (static_cast<void*>(ptr1) == static_cast<void*>(ptr2)));
+        ASSERT_EQ((p1 != p2), (static_cast<void*>(ptr1) != static_cast<void*>(ptr2)));
+        ASSERT_EQ((p1 < p2), (static_cast<void*>(ptr1) < static_cast<void*>(ptr2)));
+        ASSERT_EQ((p1 <= p2), (static_cast<void*>(ptr1) <= static_cast<void*>(ptr2)));
+        ASSERT_EQ((p1 > p2), (static_cast<void*>(ptr1) > static_cast<void*>(ptr2)));
+        ASSERT_EQ((p1 >= p2), (static_cast<void*>(ptr1) >= static_cast<void*>(ptr2)));
+    }
+
+    // Default-constructed pointers of same type
+    {
+        const thrust::unique_ptr<int> p1;
+        const thrust::unique_ptr<int> p2;
+
+        ASSERT_EQ(p1, p2);
+    }
+
+    // Default-constructed pointers of different type
+    {
+        const thrust::unique_ptr<int>   p1;
+        const thrust::unique_ptr<float> p2;
+
+        ASSERT_EQ(p1, p2);
+    }
+}
+
+TEST(UniquePtrAllocDeallocTests, TestUniquePtrNullptr)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Test with a non-null unqiue_ptr
+    {
+        const thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+
+        ASSERT_NE(p, nullptr);
+        ASSERT_LT(nullptr, p);
+        ASSERT_LE(nullptr, p);
+        ASSERT_GT(p, nullptr);
+        ASSERT_GE(p, nullptr);
+    }
+
+    // Test with null unique_ptr
+    {
+        const thrust::unique_ptr<int> p;
+
+        ASSERT_EQ(p, nullptr);
+        ASSERT_LE(p, nullptr);
+        ASSERT_LE(nullptr, p);
+        ASSERT_GE(p, nullptr);
+        ASSERT_GE(nullptr, p);
+    }
+}

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -89,8 +89,8 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmp)
         A* ptr1 = p1.get_raw();
         A* ptr2 = p2.get_raw();
 
-        ASSERT_EQ((p1 == p2), (ptr1 == ptr2));
-        ASSERT_EQ((p1 != p2), (ptr1 != ptr2));
+        ASSERT_FALSE(p1 == p2);
+        ASSERT_TRUE(p1 != p2);
         ASSERT_EQ((p1 < p2), (ptr1 < ptr2));
         ASSERT_EQ((p1 <= p2), (ptr1 <= ptr2));
         ASSERT_EQ((p1 > p2), (ptr1 > ptr2));
@@ -105,8 +105,8 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmp)
         A* ptr1 = p1.get_raw();
         B* ptr2 = p2.get_raw();
 
-        ASSERT_EQ((p1 == p2), ((ptr1) == (ptr2)));
-        ASSERT_EQ((p1 != p2), ((ptr1) != (ptr2)));
+        ASSERT_FALSE(p1 == p2);
+        ASSERT_TRUE(p1 != p2);
         ASSERT_EQ((p1 < p2), ((ptr1) < (ptr2)));
         ASSERT_EQ((p1 <= p2), ((ptr1) <= (ptr2)));
         ASSERT_EQ((p1 > p2), ((ptr1) > (ptr2)));

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -22,6 +22,13 @@ public:
     int val_a;
 }; 
 
+class B : public A
+{
+public:
+    __host__ __device__ B() : A() {}
+    __host__ __device__ B(int num) : A(num) {}
+};
+
 TESTS_DEFINE(UniquePtrAllocDeallocTests, NumericalTestsParams);
 
 // Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.single.pass.cpp
@@ -76,11 +83,11 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmp)
 
     // Pointers of same type
     {
-        thrust::unique_ptr<int> p1 = thrust::make_unique<int>(1);
-        thrust::unique_ptr<int> p2 = thrust::make_unique<int>(2);
+        thrust::unique_ptr<A> p1 = thrust::make_unique<A>(1);
+        thrust::unique_ptr<A> p2 = thrust::make_unique<A>(2);
 
-        int* ptr1 = p1.get_raw();
-        int* ptr2 = p2.get_raw();
+        A* ptr1 = p1.get_raw();
+        A* ptr2 = p2.get_raw();
 
         ASSERT_EQ((p1 == p2), (ptr1 == ptr2));
         ASSERT_EQ((p1 != p2), (ptr1 != ptr2));
@@ -92,32 +99,32 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmp)
 
     // Pointers of different type
     {
-        thrust::unique_ptr<int>   p1 = thrust::make_unique<int>(1);
-        thrust::unique_ptr<float> p2 = thrust::make_unique<float>(2.2);
+        thrust::unique_ptr<A> p1(thrust::device_new<A>(1));
+        thrust::unique_ptr<B> p2(thrust::device_new<B>(2));
 
-        int*   ptr1 = p1.get_raw();
-        float* ptr2 = p2.get_raw();
+        A* ptr1 = p1.get_raw();
+        B* ptr2 = p2.get_raw();
 
-        ASSERT_EQ((p1 == p2), (static_cast<void*>(ptr1) == static_cast<void*>(ptr2)));
-        ASSERT_EQ((p1 != p2), (static_cast<void*>(ptr1) != static_cast<void*>(ptr2)));
-        ASSERT_EQ((p1 < p2), (static_cast<void*>(ptr1) < static_cast<void*>(ptr2)));
-        ASSERT_EQ((p1 <= p2), (static_cast<void*>(ptr1) <= static_cast<void*>(ptr2)));
-        ASSERT_EQ((p1 > p2), (static_cast<void*>(ptr1) > static_cast<void*>(ptr2)));
-        ASSERT_EQ((p1 >= p2), (static_cast<void*>(ptr1) >= static_cast<void*>(ptr2)));
+        ASSERT_EQ((p1 == p2), ((ptr1) == (ptr2)));
+        ASSERT_EQ((p1 != p2), ((ptr1) != (ptr2)));
+        ASSERT_EQ((p1 < p2), ((ptr1) < (ptr2)));
+        ASSERT_EQ((p1 <= p2), ((ptr1) <= (ptr2)));
+        ASSERT_EQ((p1 > p2), ((ptr1) > (ptr2)));
+        ASSERT_EQ((p1 >= p2), ((ptr1) >= (ptr2)));
     }
 
     // Default-constructed pointers of same type
     {
-        const thrust::unique_ptr<int> p1;
-        const thrust::unique_ptr<int> p2;
+        const thrust::unique_ptr<A> p1;
+        const thrust::unique_ptr<A> p2;
 
         ASSERT_EQ(p1, p2);
     }
 
     // Default-constructed pointers of different type
     {
-        const thrust::unique_ptr<int>   p1;
-        const thrust::unique_ptr<float> p2;
+        const thrust::unique_ptr<A> p1;
+        const thrust::unique_ptr<B> p2;
 
         ASSERT_EQ(p1, p2);
     }

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -43,3 +43,25 @@ TEST(UniquePtrAllocDeallocTests, TestMakeUniqueUserType)
 
     ASSERT_EQ(host_p.val_a, 7);
 }
+
+TEST(UniquePtrAllocDeallocTests, TestUniquePtrDltr)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    void *raw_addr = nullptr;
+    size_t sz = 0;
+    {
+        thrust::unique_ptr<A> p = thrust::make_unique<A>();
+        ASSERT_NE(p, nullptr);
+
+        hipError_t st = hipMemPtrGetInfo(static_cast<void*>(p.get_raw()), &sz);
+        ASSERT_EQ(st, hipSuccess);
+        ASSERT_GE(sz, sizeof(A));
+
+        raw_addr = static_cast<void*>(p.get_raw());
+    }
+    
+    size_t dummy = 0;
+    hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
+    ASSERT_EQ(st, hipErrorInvalidValue);
+}

--- a/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_allocate_deallocate.cpp
@@ -32,7 +32,7 @@ public:
 TESTS_DEFINE(UniquePtrAllocDeallocTests, NumericalTestsParams);
 
 // Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.single.pass.cpp
-TYPED_TEST(UniquePtrAllocDeallocTests, TestMakeUnique)
+TYPED_TEST(UniquePtrAllocDeallocTests, TestUniquePtrMakeUnique)
 {
     using T = typename TestFixture::input_type;
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -51,7 +51,7 @@ TYPED_TEST(UniquePtrAllocDeallocTests, TestMakeUnique)
 }
 
 // Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique.single.pass.cpp
-TEST(UniquePtrAllocDeallocTests, TestMakeUniqueUserType)
+TEST(UniquePtrAllocDeallocTests, TestUniquePtrMakeUniqueUserType)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
@@ -131,7 +131,7 @@ TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmp)
 }
 
 // Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/cmp_nullptr.pass.cpp
-TEST(UniquePtrAllocDeallocTests, TestUniquePtrNullptr)
+TEST(UniquePtrAllocDeallocTests, TestUniquePtrCmpNullptr)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -1,5 +1,5 @@
 
-// #include <thrust/unique_ptr.h>
+#include <thrust/unique_ptr.h>
 #include "hip/hip_runtime.h"
 #include "test_param_fixtures.hpp"
 #include "test_utils.hpp"

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -78,7 +78,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrSwap)
 }
 
 // Thrust-specific test for assignment operator.
-TEST(UniquePtrGeneralTests, TestUniquePtrMoveAsgn)
+TEST(UniquePtrGeneralTests, TestUniquePtrAsgnMove)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
@@ -105,7 +105,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrMoveAsgn)
 }
 
 // Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
-TEST(UniquePtrGeneralTests, TestUnqiuePtrSelfMoveAsgn)
+TEST(UniquePtrGeneralTests, TestUniquePtrAsgnSelfMove)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
@@ -119,7 +119,7 @@ TEST(UniquePtrGeneralTests, TestUnqiuePtrSelfMoveAsgn)
 }
 
 // Thrust-specific test for assigning nullptr to unique_ptr.
-TEST(UniquePtrGeneralTests, TestUniquePtrNullAsgn)
+TEST(UniquePtrGeneralTests, TestUniquePtrAsgnNull)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
@@ -140,7 +140,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrNullAsgn)
 }
 
 // Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp
-TEST(UniquePtrGeneralTests, TestUniquePtrDefaultCtor)
+TEST(UniquePtrGeneralTests, TestUniquePtrCtorDefault)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
@@ -152,7 +152,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrDefaultCtor)
 }
 
 // Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move.pass.cpp
-TEST(UniquePtrGeneralTests, TestUniquePtrMoveCtor)
+TEST(UniquePtrGeneralTests, TestUniquePtrCtorMove)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
@@ -167,7 +167,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrMoveCtor)
 }
 
 // Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp
-TEST(UniquePtrGeneralTests, TestUniquePtrNullptrCtor)
+TEST(UniquePtrGeneralTests, TestUniquePtrCtorNullptr)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
@@ -179,7 +179,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrNullptrCtor)
 }
 
 // Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp
-TEST(UniquePtrGeneralTests, TestUniquePtrPointerCtor)
+TEST(UniquePtrGeneralTests, TestUniquePtrCtorPointer)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -142,3 +142,22 @@ TEST(UniquePtrGeneralTests, TestUniquePtrPointerCtor)
         ASSERT_EQ(s.get(), dev_p);
     }
 }
+
+TEST(UniquePtrGeneralTests, TestUniquePtrDtorNullptr)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+    
+    // Single object
+    {
+        void* raw_addr = nullptr;
+        {
+            thrust::unique_ptr<int> p(nullptr);
+            ASSERT_EQ(p, nullptr);
+
+            raw_addr = static_cast<void*>(p.get_raw());
+        }
+        size_t dummy = 0;
+        hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
+        ASSERT_EQ(st, hipErrorInvalidValue);
+    }
+}

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -192,3 +192,50 @@ TEST(UniquePtrGeneralTests, TestUniquePtrModifierRelease)
         ASSERT_EQ(st, hipErrorInvalidValue);
     }
 }
+
+TEST(UniquePtrGeneralTests, TestUniquePtrModifierReset)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // reset(new pointer) for single object
+    void *raw_addr = nullptr;
+    {
+        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+
+        thrust::device_ptr<int> new_p = thrust::device_malloc<int>(1);
+
+        p.reset(new_p);
+        ASSERT_EQ(p.get(), new_p);
+
+        raw_addr = static_cast<void*>(p.get_raw());
+    }
+    size_t dummy = 0;
+    hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
+    ASSERT_EQ(st, hipErrorInvalidValue);
+
+    // reset(nullptr) for single object
+    raw_addr = nullptr;
+    {
+        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+        raw_addr = static_cast<void*>(p.get_raw());
+
+        p.reset(nullptr);
+        ASSERT_EQ(p, nullptr);
+            
+        st = hipMemPtrGetInfo(raw_addr, &dummy);
+        ASSERT_EQ(st, hipErrorInvalidValue);
+    }
+
+    // reset() for single object
+    raw_addr = nullptr;
+    {
+        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+        raw_addr = static_cast<void*>(p.get_raw());
+
+        p.reset();
+        ASSERT_EQ(p, nullptr);
+            
+        st = hipMemPtrGetInfo(raw_addr, &dummy);
+        ASSERT_EQ(st, hipErrorInvalidValue);    
+    }
+}

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -239,3 +239,60 @@ TEST(UniquePtrGeneralTests, TestUniquePtrModifierReset)
         ASSERT_EQ(st, hipErrorInvalidValue);    
     }
 }
+
+TEST(UniquePtrGeneralTests, TestUniquePtrObserversDereference)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    thrust::unique_ptr<int> p = thrust::make_unique<int>(3);
+    ASSERT_EQ(*p, 3);
+}
+
+TEST(UniquePtrGeneralTests, TestUniquePtrObserversExplicitBool)
+{
+    // Single non-null object
+    {
+        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+        const thrust::unique_ptr<int>& const_p = p;
+        if (p) 
+        {
+            SUCCEED();
+        } 
+        else
+        {
+            FAIL() << "Non-NULL unique_ptr evaluated to false";
+        }
+
+        if (const_p)
+        {
+            SUCCEED();
+        }
+        else
+        {
+            FAIL() << "Const non-NULL unique_ptr evaluated to false";
+        }
+    }
+
+    // Single null object
+    {
+        thrust::unique_ptr<int> p;
+        const thrust::unique_ptr<int>& const_p = p;
+        if (!p)
+        {
+            SUCCEED();
+        } 
+        else
+        {
+            FAIL() << "NULL unique_ptr evaluated to true";
+        }
+
+        if (!const_p)
+        {
+            SUCCEED();
+        }
+        else
+        {
+            FAIL() << "Const NULL unique_ptr evaluated to true";
+        }
+    }
+}

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -5,6 +5,7 @@
 #include "test_utils.hpp"
 #include <thrust/device_ptr.h>
 #include <thrust/device_malloc.h>
+#include <thrust/device_delete.h>
 
 
 TESTS_DEFINE(UniquePtrGeneralTests, NumericalTestsParams);
@@ -158,6 +159,36 @@ TEST(UniquePtrGeneralTests, TestUniquePtrDtorNullptr)
         }
         size_t dummy = 0;
         hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
+        ASSERT_EQ(st, hipErrorInvalidValue);
+    }
+}
+
+TEST(UniquePtrGeneralTests, TestUniquePtrModifierRelease)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Single object
+    void* raw_addr = nullptr;
+    size_t sz = 0;
+    {
+        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+        int* raw_p = p.get_raw();
+        ASSERT_NE(raw_p, nullptr);
+        
+        hipError_t st = hipMemPtrGetInfo(static_cast<void*>(raw_p), &sz);
+        ASSERT_EQ(st, hipSuccess);
+        ASSERT_GE(sz, sizeof(int));
+
+        thrust::device_ptr<int> released_p = p.release();
+
+        ASSERT_EQ(p, nullptr);
+        ASSERT_EQ(thrust::raw_pointer_cast(released_p), raw_p);
+
+        raw_addr = static_cast<void*>(thrust::raw_pointer_cast(released_p));
+
+        thrust::device_delete(released_p);
+        
+        st = hipMemPtrGetInfo(raw_addr, &sz);
         ASSERT_EQ(st, hipErrorInvalidValue);
     }
 }

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -8,6 +8,35 @@
 #include <thrust/device_delete.h>
 
 
+class A {
+public:    
+    __host__ __device__ A() : arr(nullptr), n(0) {}
+    __host__ __device__ A(int num): n(num) {
+        arr = thrust::device_new<int>(10);
+    }
+
+    __host__ __device__ int number() { return n; }
+
+    __host__ __device__ ~A() {}
+
+    thrust::device_ptr<int> arr; 
+    int n;
+}; 
+
+template <class T>
+struct A_deleter {
+
+    __host__ void operator()(thrust::device_ptr<T> p) const {
+        A host_copy = *p; 
+        if (host_copy.arr != nullptr) {
+            thrust::device_delete(host_copy.arr, 10);
+        }
+
+        thrust::for_each_n(p, 1, [] __device__(T& x) { x.~T(); });
+        thrust::device_free(p);
+    }
+};
+
 TESTS_DEFINE(UniquePtrGeneralTests, NumericalTestsParams);
 
 TEST(UniquePtrGeneralTests, TestUniquePtrSwap)
@@ -320,4 +349,48 @@ TEST(UniquePtrGeneralTests, TestUniquePtrObserversGet)
     //     ASSERT_EQ(p.get(), dev_p);
     //     ASSERT_EQ(const_p.get(), dev_p);
     // }
+}
+
+TEST(UniquePtrGeneralTests, TestUniquePtrUserTypeDefaultDeleter)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    void* raw_addr = nullptr;
+    {
+        thrust::device_ptr<A> dev_ptr = thrust::device_malloc<A>(1);
+        thrust::device_new<A>(dev_ptr, A(), 1);
+
+        thrust::unique_ptr<A> p(dev_ptr);
+        A host_p = *p;
+
+        ASSERT_EQ(host_p.n, 0);
+        ASSERT_EQ(host_p.arr, nullptr);
+
+        raw_addr = static_cast<void*>(p.get_raw());
+    }
+    size_t dummy = 0;
+    hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
+    ASSERT_EQ(st, hipErrorInvalidValue);
+}
+
+TEST(UniquePtrGeneralTests, TestUniquePtrUserTypeCustomDeleter)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    void* raw_addr = nullptr;
+    {
+        thrust::device_ptr<A> dev_ptr = thrust::device_malloc<A>(1);
+        thrust::device_new<A>(dev_ptr, A(3), 1);
+
+        thrust::unique_ptr<A, A_deleter<A>> p(dev_ptr);
+        A host_p = *p;
+
+        ASSERT_EQ(host_p.n, 3);
+        ASSERT_NE(host_p.arr, nullptr);
+
+        raw_addr = static_cast<void*>(thrust::raw_pointer_cast(p.get()));
+    }
+    size_t dummy = 0;
+    hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
+    ASSERT_EQ(st, hipErrorInvalidValue);
 }

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -10,15 +10,25 @@
 
 class A {
 public:    
-    __host__ __device__ A() : arr(nullptr), n(0) {}
-    __host__ __device__ A(int num): n(num) {
+    __host__ __device__ A() : finished(nullptr), arr(nullptr), n(0) {}
+    __host__ __device__ A(int num): finished(nullptr), n(num) {
         arr = thrust::device_new<int>(10);
     }
+    __host__ __device__ A(thrust::device_ptr<bool> dev_p): finished(dev_p), n(0) {
+        arr = thrust::device_new<int>(10);
+    }
+    __host__ __device__ A(thrust::device_ptr<bool> dev_p, int num): finished(dev_p), arr(nullptr), n(num) {}
 
     __host__ __device__ int number() { return n; }
 
-    __host__ __device__ ~A() {}
-
+    __host__ __device__ ~A() {
+    #if defined(__HIP_DEVICE_COMPILE__)
+        if(finished)
+            *finished = true; 
+    #endif
+    }
+ 
+    thrust::device_ptr<bool> finished;
     thrust::device_ptr<int> arr; 
     int n;
 }; 
@@ -72,12 +82,13 @@ TEST(UniquePtrGeneralTests, TestUniquePtrMoveAsgn)
 
     // Move assignment for single objects
     {
-        void* raw_addr = nullptr;
+        thrust::device_ptr<bool> finished = thrust::device_new<bool>(1);
+        *finished = false;
 
-        thrust::unique_ptr<int> p1 = thrust::make_unique<int>(1);
-        int* raw_p1 = p1.get_raw();
+        thrust::unique_ptr<A> p1 = thrust::make_unique<A>(finished, 1);
+        A* raw_p1 = p1.get_raw();
         {
-            thrust::unique_ptr<int> p2 = thrust::make_unique<int>(2);
+            thrust::unique_ptr<A> p2 = thrust::make_unique<A>(nullptr, 2);
             ASSERT_NE(p1.get_raw(), nullptr);
             ASSERT_NE(p2.get_raw(), nullptr);
 
@@ -85,12 +96,9 @@ TEST(UniquePtrGeneralTests, TestUniquePtrMoveAsgn)
 
             ASSERT_EQ(p2.get_raw(), raw_p1);
             ASSERT_EQ(p1.get_raw(), nullptr);
-
-            raw_addr = static_cast<void*>(p2.get_raw());
         }
-        size_t dummy = 0;
-        hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
-        ASSERT_EQ(st, hipErrorInvalidValue);
+        ASSERT_EQ(*finished, true);
+        thrust::device_delete(finished);
     }  
 }
 
@@ -112,24 +120,18 @@ TEST(UniquePtrGeneralTests, TestUniquePtrNullAsgn)
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     // NULL assignment for single object
-    void* raw_addr = nullptr;
-    size_t sz = 0;
+    thrust::device_ptr<bool> finished = thrust::device_new<bool>(1);
+    *finished = false;
     {
-        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+        thrust::unique_ptr<A> p = thrust::make_unique<A>(finished, 1);
         ASSERT_NE(p, nullptr);
-
-        hipError_t st = hipMemPtrGetInfo(static_cast<void*>(p.get_raw()), &sz);
-        ASSERT_EQ(st, hipSuccess);
-        ASSERT_GE(sz, sizeof(int));
-        raw_addr = static_cast<void*>(p.get_raw());
 
         p = nullptr;
 
         ASSERT_EQ(p, nullptr);
 
-        size_t dummy = 0;
-        st = hipMemPtrGetInfo(raw_addr, &dummy);
-        ASSERT_EQ(st, hipErrorInvalidValue);
+        ASSERT_EQ(*finished, true);
+        thrust::device_delete(finished);
     }
 }
 
@@ -188,16 +190,14 @@ TEST(UniquePtrGeneralTests, TestUniquePtrDtorNullptr)
     
     // Single object
     {
-        void* raw_addr = nullptr;
+        thrust::device_ptr<bool> finished = thrust::device_new<bool>(1);
+        *finished = false;
         {
-            thrust::unique_ptr<int> p(nullptr);
+            thrust::unique_ptr<A> p(nullptr);
             ASSERT_EQ(p, nullptr);
-
-            raw_addr = static_cast<void*>(p.get_raw());
         }
-        size_t dummy = 0;
-        hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
-        ASSERT_EQ(st, hipErrorInvalidValue);
+        ASSERT_EQ(*finished, false);
+        thrust::device_delete(finished);
     }
 }
 
@@ -206,28 +206,17 @@ TEST(UniquePtrGeneralTests, TestUniquePtrModifierRelease)
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     // Single object
-    void* raw_addr = nullptr;
-    size_t sz = 0;
     {
         thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
         int* raw_p = p.get_raw();
         ASSERT_NE(raw_p, nullptr);
-        
-        hipError_t st = hipMemPtrGetInfo(static_cast<void*>(raw_p), &sz);
-        ASSERT_EQ(st, hipSuccess);
-        ASSERT_GE(sz, sizeof(int));
 
         thrust::device_ptr<int> released_p = p.release();
 
         ASSERT_EQ(p, nullptr);
         ASSERT_EQ(thrust::raw_pointer_cast(released_p), raw_p);
 
-        raw_addr = static_cast<void*>(thrust::raw_pointer_cast(released_p));
-
         thrust::device_delete(released_p);
-        
-        st = hipMemPtrGetInfo(raw_addr, &sz);
-        ASSERT_EQ(st, hipErrorInvalidValue);
     }
 }
 
@@ -236,46 +225,45 @@ TEST(UniquePtrGeneralTests, TestUniquePtrModifierReset)
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     // reset(new pointer) for single object
-    void *raw_addr = nullptr;
+    thrust::device_ptr<bool> finished = thrust::device_new<bool>(1);
+    *finished = false;
     {
-        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+        thrust::unique_ptr<A> p = thrust::make_unique<A>(finished, 1);
 
-        thrust::device_ptr<int> new_p = thrust::device_malloc<int>(1);
+        thrust::device_ptr<A> new_p = thrust::device_malloc<A>(1);
+        thrust::device_new<A>(new_p, A(finished, 2), 1);
 
         p.reset(new_p);
         ASSERT_EQ(p.get(), new_p);
+        ASSERT_EQ(*finished, true);
 
-        raw_addr = static_cast<void*>(p.get_raw());
+        *finished = false;
     }
-    size_t dummy = 0;
-    hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
-    ASSERT_EQ(st, hipErrorInvalidValue);
-
+    ASSERT_EQ(*finished, true);
+    
     // reset(nullptr) for single object
-    raw_addr = nullptr;
+    *finished = false;
     {
-        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
-        raw_addr = static_cast<void*>(p.get_raw());
-
+        thrust::unique_ptr<A> p = thrust::make_unique<A>(finished, 1);
+        
         p.reset(nullptr);
         ASSERT_EQ(p, nullptr);
             
-        st = hipMemPtrGetInfo(raw_addr, &dummy);
-        ASSERT_EQ(st, hipErrorInvalidValue);
+        ASSERT_EQ(*finished, true);
     }
 
     // reset() for single object
-    raw_addr = nullptr;
+    *finished = false;
     {
-        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
-        raw_addr = static_cast<void*>(p.get_raw());
+        thrust::unique_ptr<A> p = thrust::make_unique<A>(finished, 1);
 
         p.reset();
         ASSERT_EQ(p, nullptr);
             
-        st = hipMemPtrGetInfo(raw_addr, &dummy);
-        ASSERT_EQ(st, hipErrorInvalidValue);    
+        ASSERT_EQ(*finished, true);    
     }
+
+    thrust::device_delete(finished);
 }
 
 TEST(UniquePtrGeneralTests, TestUniquePtrObserversDereference)
@@ -364,44 +352,40 @@ TEST(UniquePtrGeneralTests, TestUniquePtrUserTypeDefaultDeleter)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    void* raw_addr = nullptr;
+    thrust::device_ptr<bool> finished = thrust::device_new<bool>(1);
+    *finished = false;
     {
         thrust::device_ptr<A> dev_ptr = thrust::device_malloc<A>(1);
-        thrust::device_new<A>(dev_ptr, A(), 1);
+        thrust::device_new<A>(dev_ptr, A(finished, 1), 1);
 
         thrust::unique_ptr<A> p(dev_ptr);
         A host_p = *p;
 
-        ASSERT_EQ(host_p.n, 0);
+        ASSERT_EQ(host_p.n, 1);
         ASSERT_EQ(host_p.arr, nullptr);
-
-        raw_addr = static_cast<void*>(p.get_raw());
     }
-    size_t dummy = 0;
-    hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
-    ASSERT_EQ(st, hipErrorInvalidValue);
+    ASSERT_EQ(*finished, true);
+    thrust::device_delete(finished);
 }
 
 TEST(UniquePtrGeneralTests, TestUniquePtrUserTypeCustomDeleter)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    void* raw_addr = nullptr;
+    thrust::device_ptr<bool> finished = thrust::device_new<bool>(1);
+    *finished = false;
     {
         thrust::device_ptr<A> dev_ptr = thrust::device_malloc<A>(1);
-        thrust::device_new<A>(dev_ptr, A(3), 1);
+        thrust::device_new<A>(dev_ptr, A(finished), 1);
 
         thrust::unique_ptr<A, A_deleter<A>> p(dev_ptr);
         A host_p = *p;
 
-        ASSERT_EQ(host_p.n, 3);
+        ASSERT_EQ(host_p.n, 0);
         ASSERT_NE(host_p.arr, nullptr);
-
-        raw_addr = static_cast<void*>(thrust::raw_pointer_cast(p.get()));
     }
-    size_t dummy = 0;
-    hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
-    ASSERT_EQ(st, hipErrorInvalidValue);
+    ASSERT_EQ(*finished, true);
+    thrust::device_delete(finished);
 }
 
 TEST(UniquePtrGeneralTests, TestUniquePtrGetDeleter)

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -37,6 +37,15 @@ struct A_deleter {
     }
 };
 
+struct GetDeleterTestDeleter
+{
+    void operator()(thrust::device_ptr<int>) const {}
+    void operator()(thrust::device_ptr<int[]>) const {}
+
+    int test() { return 5; }
+    int test() const { return 6; }
+};
+
 TESTS_DEFINE(UniquePtrGeneralTests, NumericalTestsParams);
 
 TEST(UniquePtrGeneralTests, TestUniquePtrSwap)
@@ -393,4 +402,39 @@ TEST(UniquePtrGeneralTests, TestUniquePtrUserTypeCustomDeleter)
     size_t dummy = 0;
     hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
     ASSERT_EQ(st, hipErrorInvalidValue);
+}
+
+TEST(UniquePtrGeneralTests, TestUniquePtrGetDeleter)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Deleter stored by value
+    {
+        thrust::unique_ptr<int, GetDeleterTestDeleter> p;
+        ASSERT_EQ(p.get_deleter().test(), 5);
+
+        const thrust::unique_ptr<int, GetDeleterTestDeleter> const_p;
+        ASSERT_EQ(const_p.get_deleter().test(), 6);
+    }
+
+    // Deleter stored by const reference
+    {
+        const GetDeleterTestDeleter d;
+        thrust::unique_ptr<int, const GetDeleterTestDeleter&> p(nullptr, d);
+        const thrust::unique_ptr<int, const GetDeleterTestDeleter&>& const_p = p;
+
+        ASSERT_EQ(p.get_deleter().test(), 6);
+        ASSERT_EQ(const_p.get_deleter().test(), 6);
+    }
+
+    // Deleter stored by non-const reference
+    {
+        GetDeleterTestDeleter d;
+        thrust::device_ptr<int> dev_p;
+        thrust::unique_ptr<int, GetDeleterTestDeleter&> p(nullptr, d);
+        const thrust::unique_ptr<int, GetDeleterTestDeleter&>& const_p = p;
+
+        ASSERT_EQ(p.get_deleter().test(), 5);
+        ASSERT_EQ(const_p.get_deleter().test(), 5);
+    }
 }

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -296,3 +296,28 @@ TEST(UniquePtrGeneralTests, TestUniquePtrObserversExplicitBool)
         }
     }
 }
+
+TEST(UniquePtrGeneralTests, TestUniquePtrObserversGet)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // get() for single object
+    {
+        thrust::device_ptr<int> dev_p = thrust::device_malloc<int>(1);
+        thrust::unique_ptr<int> p(dev_p);
+        const thrust::unique_ptr<int>& const_p = p;
+
+        ASSERT_EQ(p.get(), dev_p);
+        ASSERT_EQ(const_p.get(), dev_p);
+    }
+
+    // // get() for single const object
+    // {
+    //     thrust::device_ptr<const int> dev_p = thrust::device_malloc<const int>(1);
+    //     thrust::unique_ptr<const int> p(dev_p);
+    //     const thrust::unique_ptr<const int>& const_p = p;
+
+    //     ASSERT_EQ(p.get(), dev_p);
+    //     ASSERT_EQ(const_p.get(), dev_p);
+    // }
+}

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -1,0 +1,26 @@
+
+// #include <thrust/unique_ptr.h>
+#include "hip/hip_runtime.h"
+#include "test_param_fixtures.hpp"
+#include "test_utils.hpp"
+
+
+TESTS_DEFINE(UniquePtrGeneralTests, NumericalTestsParams);
+
+TEST(UniquePtrGeneralTests, TestUniquePtrSwap)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Test swap for single objects
+    {
+        thrust::unique_ptr<int> p1 = thrust::make_unique<int>(11);
+        thrust::unique_ptr<int> p2 = thrust::make_unique<int>(22);
+
+        int* raw_p1 = p1.get_raw();
+        int* raw_p2 = p2.get_raw();
+
+        p1.swap(p2);
+        ASSERT_EQ(p1.get_raw(), raw_p2);
+        ASSERT_EQ(p2.get_raw(), raw_p1);
+    }
+}

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -65,3 +65,29 @@ TEST(UniquePtrGeneralTests, TestUnqiuePtrSelfMoveAsgn)
         ASSERT_EQ(p.get_raw(), raw_p);
     }
 }
+
+TEST(UniquePtrGeneralTests, TestUniquePtrNullAsgn)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // NULL assignment for single object
+    void* raw_addr = nullptr;
+    size_t sz = 0;
+    {
+        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+        ASSERT_NE(p, nullptr);
+
+        hipError_t st = hipMemPtrGetInfo(static_cast<void*>(p.get_raw()), &sz);
+        ASSERT_EQ(st, hipSuccess);
+        ASSERT_GE(sz, sizeof(int));
+        raw_addr = static_cast<void*>(p.get_raw());
+
+        p = nullptr;
+
+        ASSERT_EQ(p, nullptr);
+
+        size_t dummy = 0;
+        st = hipMemPtrGetInfo(raw_addr, &dummy);
+        ASSERT_EQ(st, hipErrorInvalidValue);
+    }
+}

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -3,6 +3,8 @@
 #include "hip/hip_runtime.h"
 #include "test_param_fixtures.hpp"
 #include "test_utils.hpp"
+#include <thrust/device_ptr.h>
+#include <thrust/device_malloc.h>
 
 
 TESTS_DEFINE(UniquePtrGeneralTests, NumericalTestsParams);
@@ -58,7 +60,7 @@ TEST(UniquePtrGeneralTests, TestUnqiuePtrSelfMoveAsgn)
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     // Self-move for single object
-    {   
+    {
         thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
         int* raw_p = p.get_raw();
         p = std::move(p);
@@ -89,5 +91,54 @@ TEST(UniquePtrGeneralTests, TestUniquePtrNullAsgn)
         size_t dummy = 0;
         st = hipMemPtrGetInfo(raw_addr, &dummy);
         ASSERT_EQ(st, hipErrorInvalidValue);
+    }
+}
+
+TEST(UniquePtrGeneralTests, TestUniquePtrDefaultCtor)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Default constructed unique_ptr
+    {
+        thrust::unique_ptr<int> p;
+        ASSERT_EQ(p, nullptr);
+    }
+}
+
+TEST(UniquePtrGeneralTests, TestUniquePtrMoveCtor)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Move constructor for single object
+    {
+        thrust::unique_ptr<int> p1 = thrust::make_unique<int>(42);
+        int* raw_p1 = p1.get_raw();
+        thrust::unique_ptr<int> p2(std::move(p1));
+        ASSERT_EQ(p2.get_raw(), raw_p1);
+        ASSERT_EQ(p1, nullptr);
+    }   
+}
+
+TEST(UniquePtrGeneralTests, TestUniquePtrNullptrCtor)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Single object
+    {
+        thrust::unique_ptr<int> p(nullptr);
+        ASSERT_EQ(p, nullptr);
+    }
+}
+
+TEST(UniquePtrGeneralTests, TestUniquePtrPointerCtor)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Single object, default deleter
+    {
+        thrust::device_ptr<int> dev_p = thrust::device_malloc<int>(1);
+
+        thrust::unique_ptr<int> s(dev_p);
+        ASSERT_EQ(s.get(), dev_p);
     }
 }

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -113,6 +113,8 @@ TEST(UniquePtrGeneralTests, TestUniquePtrAsgnSelfMove)
     {
         thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
         int* raw_p = p.get_raw();
+        THRUST_DIAG_PUSH
+        THRUST_DIAG_SUPPRESS_CLANG("-Wself-move")
         p = std::move(p);
         ASSERT_EQ(p.get_raw(), raw_p);
     }

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -351,6 +351,12 @@ TEST(UniquePtrGeneralTests, TestUniquePtrObserversGet)
         ASSERT_EQ(const_p.get(), dev_p);
     }
 
+    // TODO: Uncomment this part of the test when the underlying issue with thrust::device_free is resolved.
+    // This test is currently commented out because it fails to compile. The
+    // thrust::unique_ptr<const int> destructor calls thrust::device_free, which
+    // expects a thrust::device_ptr<void>. The implicit conversion from
+    // thrust::device_ptr<const int> to thrust::device_ptr<void> is not allowed,
+    // causing a compilation error.
     // // get() for single const object
     // {
     //     thrust::device_ptr<const int> dev_p = thrust::device_malloc<const int>(1);

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -58,6 +58,7 @@ struct GetDeleterTestDeleter
 
 TESTS_DEFINE(UniquePtrGeneralTests, NumericalTestsParams);
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.special/swap.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrSwap)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -76,6 +77,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrSwap)
     }
 }
 
+// Thrust-specific test for assignment operator.
 TEST(UniquePtrGeneralTests, TestUniquePtrMoveAsgn)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -102,6 +104,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrMoveAsgn)
     }  
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
 TEST(UniquePtrGeneralTests, TestUnqiuePtrSelfMoveAsgn)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -115,6 +118,7 @@ TEST(UniquePtrGeneralTests, TestUnqiuePtrSelfMoveAsgn)
     }
 }
 
+// Thrust-specific test for assigning nullptr to unique_ptr.
 TEST(UniquePtrGeneralTests, TestUniquePtrNullAsgn)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -135,6 +139,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrNullAsgn)
     }
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/default.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrDefaultCtor)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -146,6 +151,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrDefaultCtor)
     }
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/move.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrMoveCtor)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -160,6 +166,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrMoveCtor)
     }   
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/nullptr.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrNullptrCtor)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -171,6 +178,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrNullptrCtor)
     }
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/pointer.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrPointerCtor)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -184,6 +192,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrPointerCtor)
     }
 }
 
+// Thrust-specific test for checking if the object destruction is correct.
 TEST(UniquePtrGeneralTests, TestUniquePtrDtorNullptr)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -201,6 +210,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrDtorNullptr)
     }
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/release.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrModifierRelease)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -220,6 +230,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrModifierRelease)
     }
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.modifiers/reset.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrModifierReset)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -266,6 +277,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrModifierReset)
     thrust::device_delete(finished);
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/dereference.single.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrObserversDereference)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -274,6 +286,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrObserversDereference)
     ASSERT_EQ(*p, 3);
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/explicit_bool.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrObserversExplicitBool)
 {
     // Single non-null object
@@ -323,6 +336,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrObserversExplicitBool)
     }
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrObserversGet)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -348,6 +362,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrObserversGet)
     // }
 }
 
+// Thrust-specific test for testing if thrust::default_delete is correct.
 TEST(UniquePtrGeneralTests, TestUniquePtrUserTypeDefaultDeleter)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -368,6 +383,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrUserTypeDefaultDeleter)
     thrust::device_delete(finished);
 }
 
+// Thrust-specific test for testing if thrust::unique_ptr is correct with custom, user provided deleters.
 TEST(UniquePtrGeneralTests, TestUniquePtrUserTypeCustomDeleter)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
@@ -388,6 +404,7 @@ TEST(UniquePtrGeneralTests, TestUniquePtrUserTypeCustomDeleter)
     thrust::device_delete(finished);
 }
 
+// Based on libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.observers/get_deleter.pass.cpp
 TEST(UniquePtrGeneralTests, TestUniquePtrGetDeleter)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());

--- a/projects/rocthrust/test/test_unique_ptr_general.cpp
+++ b/projects/rocthrust/test/test_unique_ptr_general.cpp
@@ -24,3 +24,44 @@ TEST(UniquePtrGeneralTests, TestUniquePtrSwap)
         ASSERT_EQ(p2.get_raw(), raw_p1);
     }
 }
+
+TEST(UniquePtrGeneralTests, TestUniquePtrMoveAsgn)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Move assignment for single objects
+    {
+        void* raw_addr = nullptr;
+
+        thrust::unique_ptr<int> p1 = thrust::make_unique<int>(1);
+        int* raw_p1 = p1.get_raw();
+        {
+            thrust::unique_ptr<int> p2 = thrust::make_unique<int>(2);
+            ASSERT_NE(p1.get_raw(), nullptr);
+            ASSERT_NE(p2.get_raw(), nullptr);
+
+            p2 = std::move(p1);
+
+            ASSERT_EQ(p2.get_raw(), raw_p1);
+            ASSERT_EQ(p1.get_raw(), nullptr);
+
+            raw_addr = static_cast<void*>(p2.get_raw());
+        }
+        size_t dummy = 0;
+        hipError_t st = hipMemPtrGetInfo(raw_addr, &dummy);
+        ASSERT_EQ(st, hipErrorInvalidValue);
+    }  
+}
+
+TEST(UniquePtrGeneralTests, TestUnqiuePtrSelfMoveAsgn)
+{
+    SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+    // Self-move for single object
+    {   
+        thrust::unique_ptr<int> p = thrust::make_unique<int>(1);
+        int* raw_p = p.get_raw();
+        p = std::move(p);
+        ASSERT_EQ(p.get_raw(), raw_p);
+    }
+}

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -291,7 +291,8 @@ public:
         return m_deleter;
     }
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 const deleter_type& get_deleter() const noexcept
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 const deleter_type&
+    get_deleter() const noexcept
     {
         return m_deleter;
     }
@@ -312,15 +313,15 @@ public:
     THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer release() noexcept
     {
         pointer temp = m_ptr;
-        m_ptr = pointer();
+        m_ptr        = pointer();
         return temp;
     }
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void reset(pointer p = pointer()) noexcept 
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void reset(pointer p = pointer()) noexcept
     {
         pointer temp = m_ptr;
-        m_ptr = p;
-        if (temp)
+        m_ptr        = p;
+        if(temp)
             m_deleter(temp);
     }
 
@@ -330,7 +331,6 @@ public:
         swap(m_ptr, u.m_ptr);
         swap(m_deleter, u.m_deleter);
     }
-
 };
 
 template <class T, class D>
@@ -338,6 +338,12 @@ class unique_ptr<T[], D>
 {
 };
 
-
+template <class T,
+          class D,
+          typename thrust::detail::enable_if<std::is_swappable<D>::value, void>::type>
+inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept
+{
+    x.swap(y);
+}
 
 THRUST_NAMESPACE_END

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -6,6 +6,7 @@
 #include <thrust/device_new.h>
 #include <thrust/device_ptr.h>
 #include <thrust/for_each.h>
+#include <thrust/device_reference.h>
 
 #include <type_traits>
 #include <utility>
@@ -164,15 +165,15 @@ private:
         std::is_constructible<deleter_type, ArgType>::value>::type;
 
   template <class U, class E>
-  using EnableIfMoveConvertible = typename thrust::detail::enable_if<
-    thrust::detail::and_<thrust::detail::is_convertible<typename U::pointer, pointer>,
-                         thrust::detail::not_<std::is_array<E>>>::value>::type;
+  using EnableIfMoveConvertible =
+    typename thrust::detail::enable_if<thrust::detail::and_<thrust::detail::is_convertible<typename U::pointer, pointer>,
+                                                            thrust::detail::not_<std::is_array<E>>>::value>::type;
 
   template <class E>
   using EnableIfDeleterConvertible = typename thrust::detail::enable_if<
     thrust::detail::or_<thrust::detail::and_<thrust::detail::is_reference<D>, thrust::detail::is_same<D, E>>,
-                         thrust::detail::and_<thrust::detail::not_<thrust::detail::is_reference<D>>,
-                                              thrust::detail::is_convertible<E, D>>>::value>::type;
+                        thrust::detail::and_<thrust::detail::not_<thrust::detail::is_reference<D>>,
+                                             thrust::detail::is_convertible<E, D>>>::value>::type;
 
     template <class E>
     using EnableIfDeleterAssignable =
@@ -300,7 +301,15 @@ public:
         return m_ptr != nullptr;
     }
 
-    // dont need memcpy or thrust::copy because device_ptr can be dereferenced in host?
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 auto operator*() const noexcept
+    {
+      return *m_ptr;
+    }
+
+    //==========================================================================
+    // Modifiers
+    //==========================================================================
+
 };
 
 template <class T, class D>

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -39,8 +39,17 @@ struct default_delete<T, typename std::enable_if<!std::is_array<T>::value>::type
       return;
     }
 
-    // We use for_each_n to launch a kernel that executes the destructor on the device,
-    // avoiding known issues with thrust::device_delete for user-defined types.
+    // The ideal implementation would be a simple call to `thrust::device_delete`:
+    //
+    //   thrust::device_delete(ptr);
+    //
+    // However, for non-trivially destructible types, `thrust::device_delete`
+    // calls `thrust::destroy_range`, which requires an allocator with a
+    // `value_type` typedef. The internal `thrust::detail::device_delete_allocator`
+    // is an empty struct that lacks this typedef, causing a compilation error.
+    //
+    // As a workaround, we manually invoke the destructor on the device using
+    // `thrust::for_each_n` and then separately free the memory.
     if constexpr (!std::is_trivially_destructible<T>::value)
     {
       thrust::for_each_n(ptr, 1, [] __device__(T & x) {
@@ -73,8 +82,18 @@ struct default_delete<T[], typename std::enable_if<!std::is_trivially_destructib
       return;
     }
 
-    // We use for_each_n to launch a kernel that executes the destructor on the device,
-    // avoiding known issues with thrust::device_delete for user-defined types.
+    // The ideal implementation would be a call to `thrust::device_delete`
+    // with the number of elements:
+    //
+    //   thrust::device_delete(ptr, m_size);
+    //
+    // However, for non-trivially destructible types, `thrust::device_delete`
+    // calls `thrust::destroy_range`, which requires an allocator with a
+    // `value_type` typedef. The internal `thrust::detail::device_delete_allocator`
+    // is an empty struct that lacks this typedef, causing a compilation error.
+    //
+    // As a workaround, we manually invoke the destructor on each element
+    // using `thrust::for_each_n` and then separately free the memory.
     if (m_size)
     {
       thrust::for_each_n(ptr, m_size, [] __device__(T & x) {

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -350,16 +350,17 @@ public:
     return *m_ptr;
   }
 
-  // Calling `->` on a `unique_ptr` from host code (e.g., `my_unique_ptr->member`)
-  // will attempt to dereference a device pointer on the host, leading to a
-  // segmentation fault.
-  //
-  // To access the object's members, you must first explicitly copy the data
-  // from the device to a host-side object (e.g., `host_copy = *my_unique_ptr;`).
-  // THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer operator->() const noexcept
-  // {
-  //     return m_ptr;
-  // }
+  // In host code, attempting to use this will produce a clear diagnostic
+  // instead of silently allowing an invalid dereference of device memory.
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer operator->() const noexcept
+  {
+
+    static_assert(false,
+                  "thrust::unique_ptr<T>::operator->(): cannot dereference device memory from host. "
+                  "Copy the object to host first (T host = *ptr) or access members inside device code.");
+
+    return m_ptr;
+  }
 
   //==========================================================================
   // Modifiers

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -18,15 +18,15 @@ struct default_delete;
 template <class T>
 struct default_delete<T, typename thrust::detail::enable_if<thrust::detail::not_<std::is_array<T>>::value>::type>
 {
-    using pointer = thrust::device_ptr<T>;
+  using pointer = thrust::device_ptr<T>;
 
-    THRUST_HOST
-    constexpr default_delete() noexcept = default;
+  THRUST_HOST
+  constexpr default_delete() noexcept = default;
 
-    template <class U>
-    THRUST_HOST
-    default_delete(const default_delete<U>&,
-                typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type * = nullptr) noexcept {}
+  template <class U>
+  THRUST_HOST
+  default_delete(const default_delete<U>&,
+              typename thrust::detail::enable_if<thrust::detail::is_convertible<thrust::device_ptr<U>, pointer>::value>::type * = nullptr) noexcept {}
 
   THRUST_HOST
   void operator()(pointer ptr) const noexcept
@@ -44,33 +44,31 @@ struct default_delete<
   T[],
   typename thrust::detail::enable_if<thrust::detail::not_<std::is_trivially_destructible<T>>::value>::type>
 {
-    using pointer = thrust::device_ptr<T>;
+  using pointer = thrust::device_ptr<T>;
 
-    THRUST_HOST
-    constexpr default_delete(size_t n = 0) noexcept : m_size(n) {};
+  THRUST_HOST
+  constexpr default_delete(size_t n = 0) noexcept : m_size(n) {};
 
-    template <class U>
-    THRUST_HOST
-    default_delete(const default_delete<U[]>& other,
-                typename std::enable_if<std::is_convertible<U(*)[], T(*)[]>::value>::type * = nullptr) noexcept 
-        : m_size(other.size())
-    {}
+  template <class U>
+  THRUST_HOST
+  default_delete(const default_delete<U[]>& other,
+              typename thrust::detail::enable_if<thrust::detail::is_convertible<U(*)[], T(*)[]>::value>::type * = nullptr) noexcept 
 
-    THRUST_HOST
-    void operator()(pointer ptr) const noexcept
-    {
-      // We use for_each_n to launch a kernel that executes the destructor on the device,
-      // avoiding known issues with thrust::device_delete for user-defined types.
-      if (m_size)
-        thrust::for_each_n(ptr, m_size, [] __device__(T& x) { x.~T(); });
-      thrust::device_free(ptr);
-    }
+  THRUST_HOST
+  void operator()(pointer ptr) const noexcept
+  {
+    // We use for_each_n to launch a kernel that executes the destructor on the device,
+    // avoiding known issues with thrust::device_delete for user-defined types.
+    if (m_size)
+      thrust::for_each_n(ptr, m_size, [] __device__(T& x) { x.~T(); });
+    thrust::device_free(ptr);
+  }
 
-    THRUST_HOST
-    size_t size() const
-    {
-        return m_size;
-    }
+  THRUST_HOST
+  size_t size() const
+  {
+      return m_size;
+  }
 
 private:
   size_t m_size;
@@ -95,6 +93,35 @@ struct default_delete<T[], typename thrust::detail::enable_if<std::is_trivially_
     thrust::device_free(ptr);
   }
 };
+
+template <class Deleter>
+struct unique_ptr_deleter_sfinae
+{
+  static_assert(thrust::detail::not_<thrust::detail::is_reference<Deleter>>, "incorrect specialization");
+  using lval_ref_type        = const Deleter&;
+  using good_rval_ref_type   = Deleter&&;
+  using bad_rval_ref_type    = void;
+  using enable_rval_overload = thrust::detail::true_type;
+};
+
+template <class Deleter>
+struct unique_ptr_deleter_sfinae<const Deleter&>
+{
+    using lval_ref_type        = const Deleter&;
+    using good_rval_ref_type   = void;
+    using bad_rval_ref_type    = const Deleter&&;
+    using enable_rval_overload = thrust::detail::false_type;
+};
+
+template <class Deleter>
+struct unique_ptr_deleter_sfinae<Deleter&>
+{
+    using lval_ref_type        = Deleter&;
+    using good_rval_ref_type   = void;
+    using bad_rval_ref_type    = Deleter&&;
+    using enable_rval_overload = thrust::detail::false_type;
+};
+
 template <class T, class D = default_delete<T>>
 class unique_ptr
 {
@@ -107,41 +134,75 @@ private:
     pointer                            m_ptr;
     [[no_unique_address]] deleter_type m_deleter;
 
+    using DeleterSFINAE = unique_ptr_deleter_sfinae<D>;
+
+  template <bool Dummy>
+  using LValRefType = typename thrust::detail::dependent_type<DeleterSFINAE, Dummy>::type::lval_ref_type;
+
+  template <bool Dummy>
+  using GoodRValRefType = typename thrust::detail::dependent_type<DeleterSFINAE, Dummy>::type::good_rval_ref_type;
+
+  template <bool Dummy>
+  using BadRValRefType = typename thrust::detail::dependent_type<DeleterSFINAE, Dummy>::type::bad_rval_ref_type;
+
+  template <bool Dummy,
+            class Deleter = typename thrust::detail::dependent_type<typename thrust::detail::identity_<deleter_type>::type, Dummy>::type>
+  using EnableIfDeleterDefaultConstructible = typename thrust::detail::enable_if<
+    thrust::detail::and_<std::is_default_constructible<Deleter>,
+                         thrust::detail::not_<thrust::detail::is_pointer<Deleter>>>::value>::type;
+
+    template <class ArgType>
+    using EnableIfDeleterConstructible = 
+        typename thrust::detail::enable_if<
+            std::is_constructible<deleter_type, ArgType>::value
+        >::type;
+
+  template <class U, class E>
+  using EnableIfMoveConvertible = typename thrust::detail::enable_if<
+    thrust::detail::and_<thrust::detail::is_convertible<typename U::pointer, pointer>,
+                         thrust::detail::not_<std::is_array<E>>>::value>::type;
+
+  template <class E>
+  using EnableIfDeleterConvertible = typename thrust::detail::enable_if<
+    thrust::detail::or_<thrust::detail::and_<thrust::detail::is_reference<D>, thrust::detail::is_same<D, E>>,
+                         thrust::detail::and_<thrust::detail::not_<thrust::detail::is_reference<D>>,
+                                              thrust::detail::is_convertible<E, D>>>::value>::type;
+
 public:
     //==========================================================================
     // Constructors
     //==========================================================================
 
-    THRUST_HOST
-    THRUST_CONSTEXPR_SINCE_CXX17 unique_ptr() noexcept : m_ptr(nullptr), m_deleter() {}
+    template<bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
+    THRUST_HOST constexpr unique_ptr() noexcept : m_ptr(), m_deleter() {}
+    
+    template<bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
+    THRUST_HOST constexpr unique_ptr(std::nullptr_t) noexcept : unique_ptr() {}
 
-    THRUST_HOST
-    THRUST_CONSTEXPR_SINCE_CXX17 unique_ptr(std::nullptr_t) noexcept : unique_ptr() {}
+    template<bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(pointer p) noexcept : m_ptr(p), m_deleter() {}
 
-    THRUST_HOST
-    explicit unique_ptr(pointer p) noexcept : m_ptr(p), m_deleter() {}
+    template<bool Dummy = true, class = EnableIfDeleterConstructible<LValRefType<Dummy>>>
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer p, LValRefType<Dummy> d) noexcept : m_ptr(p), m_deleter(d) {}
 
-    THRUST_HOST
-    unique_ptr(pointer p, const deleter_type& d) noexcept : m_ptr(p), m_deleter(d) {}
+    template<bool Dummy = true, class = EnableIfDeleterConstructible<GoodRValRefType<Dummy>>>
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer p, GoodRValRefType<Dummy> d) noexcept : m_ptr(p), m_deleter(std::move(d)) 
+    {
+      static_assert(thrust::detail::not_<thrust::detail::is_reference<deleter_type>>::value,
+                  "rvalue deleter bound to reference");
+    }
 
-    THRUST_HOST
-    unique_ptr(pointer p, deleter_type&& d) noexcept : m_ptr(p), m_deleter(std::move(d)) {}
+    template<bool Dummy = true, class = EnableIfDeleterConstructible<BadRValRefType<Dummy>>>
+    unique_ptr(pointer p, BadRValRefType<Dummy> d) = delete;
 
-    THRUST_HOST
-    unique_ptr(unique_ptr&& u) noexcept : m_ptr(u.release()), m_deleter(std::forward<deleter_type>(u.get_deleter())) {}
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& u) noexcept : m_ptr(u.release()), m_deleter(std::forward<deleter_type>(u.get_deleter())) {}
     
     template <
         class U, class E,
-        class = typename std::enable_if<
-                std::is_convertible<typename unique_ptr<U, E>::pointer, pointer>::value &&
-                !std::is_array<U>::value
-            >::type,
-        class = typename std::enable_if<
-            (std::is_reference<deleter_type>::value && std::is_same<deleter_type, E>::value) ||
-            (!std::is_reference<deleter_type>::value && std::is_convertible<E, deleter_type>::value)
-        >::type
+        class = EnableIfMoveConvertible<unique_ptr<U, E>, U>,
+        class = EnableIfDeleterConvertible<E>
     >
-    THRUST_HOST
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23
     unique_ptr(unique_ptr<U, E>&& u) noexcept
         : m_ptr(u.release()), m_deleter(std::forward<E>(u.get_deleter())) {}
 

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -97,7 +97,7 @@ struct default_delete<T[], typename thrust::detail::enable_if<std::is_trivially_
 template <class Deleter>
 struct unique_ptr_deleter_sfinae
 {
-  static_assert(thrust::detail::not_<thrust::detail::is_reference<Deleter>>, "incorrect specialization");
+  static_assert(thrust::detail::not_<thrust::detail::is_reference<Deleter>>::value, "incorrect specialization");
   using lval_ref_type        = const Deleter&;
   using good_rval_ref_type   = Deleter&&;
   using bad_rval_ref_type    = void;
@@ -206,6 +206,18 @@ public:
     unique_ptr(unique_ptr<U, E>&& u) noexcept
         : m_ptr(u.release()), m_deleter(std::forward<E>(u.get_deleter())) {}
 
+
+    //==========================================================================
+    // Assignment
+    //==========================================================================
+    
+    //==========================================================================
+    // Destructor
+    //==========================================================================
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 ~unique_ptr()
+    {
+        reset();
+    }
 
 };
 

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -183,12 +183,15 @@ struct unique_ptr_deleter_sfinae<Deleter&>
 } // namespace detail
 
 template <class T, class D = default_delete<T>>
-class unique_ptr
+class __attribute__((trivial_abi)) unique_ptr
 {
 public:
   using pointer      = typename thrust::detail::pointer_detector<T, D>::type;
   using element_type = T;
   using deleter_type = D;
+
+  // TODO: When a standard “trivially relocatable” facility lands, add an
+  // annotation/macro here to advertise that unique_ptr can be bitwise relocated
 
 private:
   pointer m_ptr;
@@ -354,7 +357,6 @@ public:
   // instead of silently allowing an invalid dereference of device memory.
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer operator->() const noexcept
   {
-
     static_assert(false,
                   "thrust::unique_ptr<T>::operator->(): cannot dereference device memory from host. "
                   "Copy the object to host first (T host = *ptr) or access members inside device code.");

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -195,6 +195,12 @@ private:
   using EnableIfDeleterAssignable =
     typename std::enable_if<std::is_assignable<D&, E&&>::value>::type;
 
+  template <
+    bool Dummy,
+    class Deleter =
+      typename thrust::detail::dependent_type<typename thrust::detail::identity_<deleter_type>::type, Dummy>::type>
+  using EnableIfDeleterDefaultDelete = typename std::enable_if<std::is_same<Deleter, default_delete<T>>::value>::type;
+
 public:
   //==========================================================================
   // Constructors
@@ -287,6 +293,8 @@ public:
     return m_ptr;
   }
 
+  template <bool Dummy = true,
+            class      = EnableIfDeleterDefaultDelete<Dummy>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 T* get_raw() const noexcept
   {
     return thrust::raw_pointer_cast(m_ptr);

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -362,4 +362,14 @@ inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T,
     x.swap(y);
 }
 
+template <class T,
+          class... Args,
+          class = typename thrust::detail::enable_if<
+              thrust::detail::not_<std::is_array<T>>::value>::type>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique(Args&&... args)
+{
+  thrust::device_ptr<T> p = thrust::device_malloc<T>(1);
+  return unique_ptr<T>(thrust::device_new<T>(p, T(std::forward<Args>(args)...), 1));
+}
+
 THRUST_NAMESPACE_END

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -8,6 +8,7 @@
 #include <thrust/for_each.h>
 #include <thrust/device_reference.h>
 
+#include <compare>
 #include <functional>
 #include <type_traits>
 #include <utility>
@@ -430,6 +431,15 @@ operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
   return !(x < y);
 }
 
+#if THRUST_STD_VER >= 20
+template <class T1, class D1, class T2, class D2>
+THRUST_HOST inline auto operator<=> (const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
+{
+  // TODO: once thrust::device_ptr supports three_way_comparison, we should be using that
+  return std::compare_three_way()(x.get_raw(), y.get_raw()); 
+}
+#endif
+
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
 operator==(const unique_ptr<T, D>& x, std::nullptr_t) noexcept
@@ -507,6 +517,15 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(std::nullptr_t, 
 {
   return !(y < nullptr);
 }
+
+#if THRUST_STD_VER >= 20
+template <class T, class D>
+THRUST_HOST inline auto operator<=> (const unique_ptr<T, D>& x, std::nullptr_t)
+{
+  // TODO: once thrust::device_ptr supports three_way_comparison, we should be using that
+  return std::compare_three_way()(x.get_raw(), static_cast<T*>(nullptr));
+}
+#endif
 
 //==============================================================================
 // Make unique

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -309,6 +309,27 @@ public:
     //==========================================================================
     // Modifiers
     //==========================================================================
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer release() noexcept
+    {
+        pointer temp = m_ptr;
+        m_ptr = pointer();
+        return temp;
+    }
+
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void reset(pointer p = pointer()) noexcept 
+    {
+        pointer temp = m_ptr;
+        m_ptr = p;
+        if (temp)
+            m_deleter(temp);
+    }
+
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr& u) noexcept
+    {
+        using std::swap;
+        swap(m_ptr, u.m_ptr);
+        swap(m_deleter, u.m_deleter);
+    }
 
 };
 

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -20,7 +20,7 @@ template <class T, class = void>
 struct default_delete;
 
 template <class T>
-struct default_delete<T, typename std::enable_if<!std::is_array<T>::value>::type>
+struct default_delete<T, std::enable_if_t<!std::is_array_v<T>>>
 {
   using pointer = thrust::device_ptr<T>;
 
@@ -29,7 +29,7 @@ struct default_delete<T, typename std::enable_if<!std::is_array<T>::value>::type
   template <class U>
   THRUST_HOST default_delete(
     const default_delete<U>&,
-    typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* = nullptr) noexcept
+    std::enable_if_t<std::is_convertible_v<thrust::device_ptr<U>, pointer>>* = nullptr) noexcept
   {}
 
   THRUST_HOST void operator()(pointer ptr) const noexcept
@@ -50,7 +50,7 @@ struct default_delete<T, typename std::enable_if<!std::is_array<T>::value>::type
     //
     // As a workaround, we manually invoke the destructor on the device using
     // `thrust::for_each_n` and then separately free the memory.
-    if constexpr (!std::is_trivially_destructible<T>::value)
+    if constexpr (!std::is_trivially_destructible_v<T>)
     {
       thrust::for_each_n(ptr, 1, [] __device__(T & x) {
         x.~T();
@@ -61,7 +61,7 @@ struct default_delete<T, typename std::enable_if<!std::is_array<T>::value>::type
 };
 
 template <class T>
-struct default_delete<T[], typename std::enable_if<!std::is_trivially_destructible<T>::value>::type>
+struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>>>
 {
   using pointer = thrust::device_ptr<T>;
 
@@ -71,7 +71,7 @@ struct default_delete<T[], typename std::enable_if<!std::is_trivially_destructib
   template <class U>
   THRUST_HOST
   default_delete(const default_delete<U[]>& other,
-                 typename std::enable_if<std::is_convertible<U (*)[], T (*)[]>::value>::type* = nullptr) noexcept
+                 std::enable_if_t<std::is_convertible_v<U (*)[], T (*)[]>>* = nullptr) noexcept
       : m_size(other.size())
   {}
 
@@ -119,7 +119,7 @@ private:
 // instantiations that use it to remain a zero-cost abstraction (the deleter
 // need not increase the overall object size).
 template <class T>
-struct default_delete<T[], typename std::enable_if<std::is_trivially_destructible<T>::value>::type>
+struct default_delete<T[], std::enable_if_t<std::is_trivially_destructible_v<T>>>
 {
   using pointer = thrust::device_ptr<T>;
 
@@ -128,7 +128,7 @@ struct default_delete<T[], typename std::enable_if<std::is_trivially_destructibl
   template <class U>
   THRUST_HOST default_delete(
     const default_delete<U>&,
-    typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* = nullptr) noexcept
+    std::enable_if_t<std::is_convertible_v<thrust::device_ptr<U>, pointer>>* = nullptr) noexcept
   {}
 
   THRUST_HOST void operator()(pointer ptr) const noexcept
@@ -155,7 +155,7 @@ struct pointer_detector<T, D, std::void_t<typename D::pointer>>
 template <class Deleter>
 struct unique_ptr_deleter_sfinae
 {
-  static_assert(!std::is_reference<Deleter>::value, "incorrect specialization");
+  static_assert(!std::is_reference_v<Deleter>, "incorrect specialization");
   using lval_ref_type        = const Deleter&;
   using good_rval_ref_type   = Deleter&&;
   using bad_rval_ref_type    = void;
@@ -213,29 +213,29 @@ private:
     class Deleter =
       typename thrust::detail::dependent_type<typename thrust::detail::identity_<deleter_type>::type, Dummy>::type>
   using EnableIfDeleterDefaultConstructible =
-    typename std::enable_if<std::is_default_constructible<Deleter>::value && !std::is_pointer<Deleter>::value>::type;
+    std::enable_if_t<std::is_default_constructible_v<Deleter> && !std::is_pointer_v<Deleter>>;
 
   template <class ArgType>
   using EnableIfDeleterConstructible =
-    typename std::enable_if<std::is_constructible<deleter_type, ArgType>::value>::type;
+    std::enable_if_t<std::is_constructible_v<deleter_type, ArgType>>;
 
   template <class U, class E>
   using EnableIfMoveConvertible =
-    typename std::enable_if<std::is_convertible<typename U::pointer, pointer>::value && !std::is_array<E>::value>::type;
+    std::enable_if_t<std::is_convertible_v<typename U::pointer, pointer> && !std::is_array_v<E>>;
 
   template <class E>
   using EnableIfDeleterConvertible =
-    typename std::enable_if<(std::is_reference<D>::value && std::is_same<D, E>::value)
-                            || (!std::is_reference<D>::value && std::is_convertible<E, D>::value)>::type;
+    std::enable_if_t<(std::is_reference_v<D> && std::is_same_v<D, E>)
+                            || (!std::is_reference_v<D> && std::is_convertible_v<E, D>)>;
 
   template <class E>
-  using EnableIfDeleterAssignable = typename std::enable_if<std::is_assignable<D&, E&&>::value>::type;
+  using EnableIfDeleterAssignable = std::enable_if_t<std::is_assignable_v<D&, E&&>>;
 
   template <
     bool Dummy,
     class Deleter =
       typename thrust::detail::dependent_type<typename thrust::detail::identity_<deleter_type>::type, Dummy>::type>
-  using EnableIfDeleterDefaultDelete = typename std::enable_if<std::is_same<Deleter, default_delete<T>>::value>::type;
+  using EnableIfDeleterDefaultDelete = std::enable_if_t<std::is_same_v<Deleter, default_delete<T>>>;
 
 public:
   //==========================================================================
@@ -270,7 +270,7 @@ public:
       : m_ptr(p)
       , m_deleter(std::move(d))
   {
-    static_assert(!std::is_reference<deleter_type>::value, "rvalue deleter bound to reference");
+    static_assert(!std::is_reference_v<deleter_type>, "rvalue deleter bound to reference");
   }
 
   template <bool Dummy = true, class = EnableIfDeleterConstructible<BadRValRefType<Dummy>>>
@@ -396,7 +396,7 @@ template <class T, class D>
 class unique_ptr<T[], D>
 {};
 
-template <class T, class D, typename std::enable_if<std::is_swappable<D>::value, void>::type>
+template <class T, class D, std::enable_if_t<std::is_swappable_v<D>, void>>
 inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept
 {
   x.swap(y);
@@ -541,7 +541,7 @@ template <class T, class D>
 //==============================================================================
 // Make unique
 //==============================================================================
-template <class T, class... Args, class = typename std::enable_if<!std::is_array<T>::value>::type>
+template <class T, class... Args, class = std::enable_if_t<!std::is_array_v<T>>>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique(Args&&... args)
 {
   thrust::device_ptr<T> p = thrust::device_malloc<T>(1);

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -412,18 +412,107 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(const unique_ptr<
 
 template <class T1, class D1, class T2, class D2>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(const unique_ptr<T1, D1>& x,
-                                                                 const unique_ptr<T2, D2>& y)
+                                                                        const unique_ptr<T2, D2>& y)
 {
     return !(y < x);
 }
 
 template <class T1, class D1, class T2, class D2>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(const unique_ptr<T1, D1>& x,
-                                                                 const unique_ptr<T2, D2>& y)
+                                                                        const unique_ptr<T2, D2>& y)
 {
     return !(x < y);
 }
 
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr<T, D>& x,
+                                                                        std::nullptr_t) noexcept
+{
+    return !x;
+}
+
+#if THRUST_STD_VER <= 17
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator==(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
+{
+    return !y;
+}
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(const unique_ptr<T, D>& x,
+                                                                        std::nullptr_t) noexcept
+{
+    return static_cast<bool>(x);
+}
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator!=(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
+{
+    return static_cast<bool>(y);
+}
+#endif
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<T, D>& x,
+                                                                       std::nullptr_t)
+{
+    return std::less<typename unique_ptr<T, D>::pointer>()(x.get(), nullptr); // x.get() < nullptr;
+}
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(std::nullptr_t,
+                                                                       const unique_ptr<T, D>& y)
+{
+    return std::less<typename unique_ptr<T, D>::pointer>()(nullptr, y.get()); // nullptr < y.get();
+}
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(const unique_ptr<T, D>& x,
+                                                                       std::nullptr_t)
+{
+    return nullptr < x;
+}
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(std::nullptr_t,
+                                                                       const unique_ptr<T, D>& y)
+{
+    return y < nullptr;
+}
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(const unique_ptr<T, D>& x,
+                                                                        std::nullptr_t)
+{
+    return !(nullptr < x);
+}
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(std::nullptr_t,
+                                                                        const unique_ptr<T, D>& y)
+{
+    return !(y < nullptr);
+}
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(const unique_ptr<T, D>& x,
+                                                                        std::nullptr_t)
+{
+    return !(x < nullptr);
+}
+
+template <class T, class D>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(std::nullptr_t,
+                                                                        const unique_ptr<T, D>& y)
+{
+    return !(y < nullptr);
+}
+
+//==============================================================================
+// Make unique
+//==============================================================================
 template <class T,
           class... Args,
           class = typename thrust::detail::enable_if<

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -199,6 +199,20 @@ private:
 
   using DeleterSFINAE = thrust::detail::unique_ptr_deleter_sfinae<D>;
 
+  // Next section implements SFINAE constraints for the unique_ptr constructors
+  // using a pattern that mirrors the implementation in libc++.
+  //
+  // The `dependent_type` helper makes the type aliases below (e.g., LValRefType)
+  // dependent on a dummy template parameter from the constructor itself. This
+  // forces the compiler to defer constraint checking until function overload
+  // resolution, rather than at class instantiation time.
+  //
+  // NOTE: A simpler SFINAE pattern using a `static constexpr bool` evaluated at
+  // class-instantiation time also works correctly. However, we intentionally
+  // follow the more complex libc++ pattern for consistency with a proven
+  // implementation, aiming to inherit its robustness against
+  // potential compiler-specific edge cases.
+
   template <bool Dummy>
   using LValRefType = typename thrust::detail::dependent_type<DeleterSFINAE, Dummy>::type::lval_ref_type;
 

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -406,17 +406,7 @@ inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T,
 template <class T1, class D1, class T2, class D2>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
-  // The initial `std::common_type` approach was considered to support comparisons
-  // between related types (e.g., a base and derived class pointer). However,
-  // a bug in `thrust::device_delete` prevented testing with class hierarchies.
-  //
-  // Testing was pivoted to use unrelated types (e.g., `int*` and `float*`),
-  // which revealed that `std::common_type` is ill-formed for such cases.
-  //
-  // The standard-compliant and robust solution for comparing any two object
-  // pointers is to cast them to `const void*`. This correctly handles all
-  // cases: related, unrelated, and incomplete types.
-  return std::equal_to<const void*>()(x.get_raw(), y.get_raw()); // const void*
+  return x.get() == y.get();
 }
 
 #if THRUST_STD_VER <= 17
@@ -430,11 +420,10 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(const unique_ptr
 template <class T1, class D1, class T2, class D2>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
-  // Similar to `operator==`, the `const void*` cast provides a robust,
-  // standard-compliant way to establish a strict total ordering for any two
-  // object pointers, which was necessary after testing with unrelated types
-  // proved the `std::common_type` approach to be insufficient.
-  return std::less<const void*>()(x.get_raw(), y.get_raw()); // const void*
+  using P1 = typename unique_ptr<T1, D1>::element_type*;
+  using P2 = typename unique_ptr<T2, D2>::element_type*;
+  using CTP = typename std::common_type<P1, P2>::type;
+  return std::less<CTP>()(thrust::raw_pointer_cast(x.get()), thrust::raw_pointer_cast(y.get()));
 }
 
 template <class T1, class D1, class T2, class D2>

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -112,6 +112,12 @@ private:
   size_t m_size;
 };
 
+// For arrays of trivially destructible element types we intentionally do NOT
+// store the element count. Their destruction is a no-op, so only the raw
+// deallocation is required. Omitting the size keeps this deleter
+// specialization an empty (zero-size) type, allowing unique_ptr<T[]>
+// instantiations that use it to remain a zero-cost abstraction (the deleter
+// need not increase the overall object size).
 template <class T>
 struct default_delete<T[], typename std::enable_if<std::is_trivially_destructible<T>::value>::type>
 {

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -286,6 +286,11 @@ public:
         return m_ptr;
     }
 
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 T* get_raw() const noexcept
+    {
+        return thrust::raw_pointer_cast(m_ptr);
+    }
+
     THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 deleter_type& get_deleter() noexcept
     {
         return m_deleter;

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -34,6 +34,9 @@ struct default_delete<T, typename std::enable_if<!std::is_array<T>::value>::type
   THRUST_HOST
   void operator()(pointer ptr) const noexcept
   {
+    if (ptr.get() == nullptr)
+      return;
+    
     // We use for_each_n to launch a kernel that executes the destructor on the device,
     // avoiding known issues with thrust::device_delete for user-defined types.
     if constexpr (!std::is_trivially_destructible<T>::value)
@@ -63,6 +66,9 @@ struct default_delete<
   THRUST_HOST
   void operator()(pointer ptr) const noexcept
   {
+    if (ptr.get() == nullptr)
+      return;
+      
     // We use for_each_n to launch a kernel that executes the destructor on the device,
     // avoiding known issues with thrust::device_delete for user-defined types.
     if (m_size)

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <thrust/detail/config.h>
+
+THRUST_NAMESPACE_BEGIN
+
+
+
+
+THRUST_NAMESPACE_END

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -307,6 +307,17 @@ public:
       return *m_ptr;
     }
 
+    // Calling `->` on a `unique_ptr` from host code (e.g., `my_unique_ptr->member`)
+    // will attempt to dereference a device pointer on the host, leading to a
+    // segmentation fault.
+    //
+    // To access the object's members, you must first explicitly copy the data
+    // from the device to a host-side object (e.g., `host_copy = *my_unique_ptr;`).
+    // THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer operator->() const noexcept
+    // {
+    //     return m_ptr;
+    // }
+
     //==========================================================================
     // Modifiers
     //==========================================================================

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -280,6 +280,25 @@ public:
     //==========================================================================
     // Observers
     //==========================================================================
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer get() const noexcept
+    {
+        return m_ptr;
+    }
+
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 deleter_type& get_deleter() noexcept
+    {
+        return m_deleter;
+    }
+
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 const deleter_type& get_deleter() const noexcept
+    {
+        return m_deleter;
+    }
+
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit operator bool() const noexcept
+    {
+        return m_ptr != nullptr;
+    }
 
     // dont need memcpy or thrust::copy because device_ptr can be dereferenced in host?
 };

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -22,17 +22,14 @@ struct default_delete<T, typename thrust::detail::enable_if<thrust::detail::not_
 {
   using pointer = thrust::device_ptr<T>;
 
-  THRUST_HOST
-  constexpr default_delete() noexcept = default;
+  THRUST_HOST constexpr default_delete() noexcept = default;
 
   template <class U>
-  THRUST_HOST
-  default_delete(const default_delete<U>&,
-              typename thrust::detail::enable_if<
-                  thrust::detail::is_convertible<thrust::device_ptr<U>,
-                                                  pointer>::value>::type* = nullptr) noexcept
-  {
-  }
+  THRUST_HOST default_delete(
+    const default_delete<U>&,
+    typename thrust::detail::enable_if<thrust::detail::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* =
+      nullptr) noexcept
+  {}
 
   THRUST_HOST
   void operator()(pointer ptr) const noexcept
@@ -56,13 +53,12 @@ struct default_delete<
   constexpr default_delete(size_t n = 0) noexcept : m_size(n) {};
 
   template <class U>
-  THRUST_HOST default_delete(
-      const default_delete<U[]>& other,
-      typename thrust::detail::enable_if<
-          thrust::detail::is_convertible<U (*)[], T (*)[]>::value>::type* = nullptr) noexcept
+  THRUST_HOST
+  default_delete(const default_delete<U[]>& other,
+              typename thrust::detail::enable_if<thrust::detail::is_convertible<U (*)[], T (*)[]>::value>::type* =
+                nullptr) noexcept
       : m_size(other.size())
-  {
-  }
+  {}
 
   THRUST_HOST
   void operator()(pointer ptr) const noexcept
@@ -74,10 +70,9 @@ struct default_delete<
     thrust::device_free(ptr);
   }
 
-  THRUST_HOST
-  size_t size() const
+  THRUST_HOST size_t size() const
   {
-      return m_size;
+    return m_size;
   }
 
 private:
@@ -117,34 +112,34 @@ struct unique_ptr_deleter_sfinae
 template <class Deleter>
 struct unique_ptr_deleter_sfinae<const Deleter&>
 {
-    using lval_ref_type        = const Deleter&;
-    using good_rval_ref_type   = void;
-    using bad_rval_ref_type    = const Deleter&&;
-    using enable_rval_overload = thrust::detail::false_type;
+  using lval_ref_type        = const Deleter&;
+  using good_rval_ref_type   = void;
+  using bad_rval_ref_type    = const Deleter&&;
+  using enable_rval_overload = thrust::detail::false_type;
 };
 
 template <class Deleter>
 struct unique_ptr_deleter_sfinae<Deleter&>
 {
-    using lval_ref_type        = Deleter&;
-    using good_rval_ref_type   = void;
-    using bad_rval_ref_type    = Deleter&&;
-    using enable_rval_overload = thrust::detail::false_type;
+  using lval_ref_type        = Deleter&;
+  using good_rval_ref_type   = void;
+  using bad_rval_ref_type    = Deleter&&;
+  using enable_rval_overload = thrust::detail::false_type;
 };
 
 template <class T, class D = default_delete<T>>
 class unique_ptr
 {
 public:
-    using pointer      = typename D::pointer;
-    using element_type = T;
-    using deleter_type = D;
+  using pointer      = typename D::pointer;
+  using element_type = T;
+  using deleter_type = D;
 
 private:
-    pointer                            m_ptr;
-    [[no_unique_address]] deleter_type m_deleter;
+  pointer                            m_ptr;
+  [[no_unique_address]] deleter_type m_deleter;
 
-    using DeleterSFINAE = unique_ptr_deleter_sfinae<D>;
+  using DeleterSFINAE = unique_ptr_deleter_sfinae<D>;
 
   template <bool Dummy>
   using LValRefType = typename thrust::detail::dependent_type<DeleterSFINAE, Dummy>::type::lval_ref_type;
@@ -161,9 +156,9 @@ private:
     thrust::detail::and_<std::is_default_constructible<Deleter>,
                          thrust::detail::not_<thrust::detail::is_pointer<Deleter>>>::value>::type;
 
-    template <class ArgType>
-    using EnableIfDeleterConstructible = typename thrust::detail::enable_if<
-        std::is_constructible<deleter_type, ArgType>::value>::type;
+  template <class ArgType>
+  using EnableIfDeleterConstructible =
+    typename thrust::detail::enable_if<std::is_constructible<deleter_type, ArgType>::value>::type;
 
   template <class U, class E>
   using EnableIfMoveConvertible =
@@ -176,42 +171,37 @@ private:
                         thrust::detail::and_<thrust::detail::not_<thrust::detail::is_reference<D>>,
                                              thrust::detail::is_convertible<E, D>>>::value>::type;
 
-    template <class E>
-    using EnableIfDeleterAssignable =
-        typename thrust::detail::enable_if<thrust::detail::is_assignable<D&, E&&>::value>::type;
+  template <class E>
+  using EnableIfDeleterAssignable =
+    typename thrust::detail::enable_if<thrust::detail::is_assignable<D&, E&&>::value>::type;
 
 public:
-    //==========================================================================
-    // Constructors
-    //==========================================================================
+  //==========================================================================
+  // Constructors
+  //==========================================================================
 
-    template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
-    THRUST_HOST constexpr unique_ptr() noexcept
-        : m_ptr()
-        , m_deleter()
-    {
-    }
+  template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
+  THRUST_HOST constexpr unique_ptr() noexcept
+      : m_ptr()
+      , m_deleter()
+  {}
 
-    template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
-    THRUST_HOST constexpr unique_ptr(std::nullptr_t) noexcept
-        : unique_ptr()
-    {
-    }
+  template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
+  THRUST_HOST constexpr unique_ptr(std::nullptr_t) noexcept
+      : unique_ptr()
+  {}
 
-    template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(pointer p) noexcept
-        : m_ptr(p)
-        , m_deleter()
-    {
-    }
+  template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(pointer p) noexcept
+      : m_ptr(p)
+      , m_deleter()
+  {}
 
-    template <bool Dummy = true, class = EnableIfDeleterConstructible<LValRefType<Dummy>>>
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer            p,
-                                                                LValRefType<Dummy> d) noexcept
-        : m_ptr(p)
-        , m_deleter(d)
-    {
-    }
+  template <bool Dummy = true, class = EnableIfDeleterConstructible<LValRefType<Dummy>>>
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer p, LValRefType<Dummy> d) noexcept
+      : m_ptr(p)
+      , m_deleter(d)
+  {}
 
     template <bool Dummy = true, class = EnableIfDeleterConstructible<GoodRValRefType<Dummy>>>
     THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer                p,
@@ -223,25 +213,19 @@ public:
                   "rvalue deleter bound to reference");
     }
 
-    template <bool Dummy = true, class = EnableIfDeleterConstructible<BadRValRefType<Dummy>>>
-    unique_ptr(pointer p, BadRValRefType<Dummy> d) = delete;
+  template <bool Dummy = true, class = EnableIfDeleterConstructible<BadRValRefType<Dummy>>>
+  unique_ptr(pointer p, BadRValRefType<Dummy> d) = delete;
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& u) noexcept
-        : m_ptr(u.release())
-        , m_deleter(std::forward<deleter_type>(u.get_deleter()))
-    {
-    }
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& u) noexcept
+      : m_ptr(u.release())
+      , m_deleter(std::forward<deleter_type>(u.get_deleter()))
+  {}
 
-    template <class U,
-              class E,
-              class = EnableIfMoveConvertible<unique_ptr<U, E>, U>,
-              class = EnableIfDeleterConvertible<E>>
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr<U, E>&& u) noexcept
-        : m_ptr(u.release())
-        , m_deleter(std::forward<E>(u.get_deleter()))
-    {
-    }
-
+  template <class U, class E, class = EnableIfMoveConvertible<unique_ptr<U, E>, U>, class = EnableIfDeleterConvertible<E>>
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr<U, E>&& u) noexcept
+      : m_ptr(u.release())
+      , m_deleter(std::forward<E>(u.get_deleter()))
+  {}
 
   //==========================================================================
   // Assignment
@@ -253,17 +237,13 @@ public:
     return *this;
   }
 
-    template <class U,
-              class E,
-              class = EnableIfMoveConvertible<unique_ptr<U, E>, U>,
-              class = EnableIfDeleterAssignable<E>>
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr&
-    operator=(unique_ptr<U, E>&& u) noexcept
-    {
-        reset(u.release());
-        m_deleter = std::forward<E>(u.get_deleter());
-        return *this;
-    }
+  template <class U, class E, class = EnableIfMoveConvertible<unique_ptr<U, E>, U>, class = EnableIfDeleterAssignable<E>>
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept
+  {
+    reset(u.release());
+    m_deleter = std::forward<E>(u.get_deleter());
+    return *this;
+  }
 
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(std::nullptr_t) noexcept
   {
@@ -279,96 +259,94 @@ public:
         reset();
     }
 
-    //==========================================================================
-    // Observers
-    //==========================================================================
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer get() const noexcept
-    {
-        return m_ptr;
-    }
+  //==========================================================================
+  // Observers
+  //==========================================================================
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer get() const noexcept
+  {
+    return m_ptr;
+  }
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 T* get_raw() const noexcept
-    {
-        return thrust::raw_pointer_cast(m_ptr);
-    }
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 T* get_raw() const noexcept
+  {
+    return thrust::raw_pointer_cast(m_ptr);
+  }
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 deleter_type& get_deleter() noexcept
-    {
-        return m_deleter;
-    }
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 deleter_type& get_deleter() noexcept
+  {
+    return m_deleter;
+  }
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 const deleter_type&
-    get_deleter() const noexcept
-    {
-        return m_deleter;
-    }
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 const deleter_type& get_deleter() const noexcept
+  {
+    return m_deleter;
+  }
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit operator bool() const noexcept
-    {
-        return m_ptr != nullptr;
-    }
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit operator bool() const noexcept
+  {
+    return m_ptr != nullptr;
+  }
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 auto operator*() const noexcept
-    {
-      return *m_ptr;
-    }
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 auto operator*() const noexcept
+  {
+    return *m_ptr;
+  }
 
-    // Calling `->` on a `unique_ptr` from host code (e.g., `my_unique_ptr->member`)
-    // will attempt to dereference a device pointer on the host, leading to a
-    // segmentation fault.
-    //
-    // To access the object's members, you must first explicitly copy the data
-    // from the device to a host-side object (e.g., `host_copy = *my_unique_ptr;`).
-    // THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer operator->() const noexcept
-    // {
-    //     return m_ptr;
-    // }
+  // Calling `->` on a `unique_ptr` from host code (e.g., `my_unique_ptr->member`)
+  // will attempt to dereference a device pointer on the host, leading to a
+  // segmentation fault.
+  //
+  // To access the object's members, you must first explicitly copy the data
+  // from the device to a host-side object (e.g., `host_copy = *my_unique_ptr;`).
+  // THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer operator->() const noexcept
+  // {
+  //     return m_ptr;
+  // }
 
-    //==========================================================================
-    // Modifiers
-    //==========================================================================
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer release() noexcept
-    {
-        pointer temp = m_ptr;
-        m_ptr        = pointer();
-        return temp;
-    }
+  //==========================================================================
+  // Modifiers
+  //==========================================================================
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer release() noexcept
+  {
+    pointer temp = m_ptr;
+    m_ptr        = pointer();
+    return temp;
+  }
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void reset(pointer p = pointer()) noexcept
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void reset(pointer p = pointer()) noexcept
+  {
+    pointer temp = m_ptr;
+    m_ptr        = p;
+    if (temp)
     {
-        pointer temp = m_ptr;
-        m_ptr        = p;
-        if(temp)
-            m_deleter(temp);
+      m_deleter(temp);
     }
+  }
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr& u) noexcept
-    {
-        using std::swap;
-        swap(m_ptr, u.m_ptr);
-        swap(m_deleter, u.m_deleter);
-    }
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr& u) noexcept
+  {
+    using std::swap;
+    swap(m_ptr, u.m_ptr);
+    swap(m_deleter, u.m_deleter);
+  }
 };
 
 template <class T, class D>
 class unique_ptr<T[], D>
-{
-};
+{};
 
-template <class T,
-          class D,
-          typename thrust::detail::enable_if<std::is_swappable<D>::value, void>::type>
+template <class T, class D, typename thrust::detail::enable_if<std::is_swappable<D>::value, void>::type>
 inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept
 {
-    x.swap(y);
+  x.swap(y);
 }
 
 //==============================================================================
 // Comparison Operators
 //==============================================================================
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr<T1, D1>& x,
-                                                                        const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   // The initial `std::common_type` approach was considered to support comparisons
   // between related types (e.g., a base and derived class pointer). However,
@@ -385,16 +363,16 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr
 
 #if THRUST_STD_VER <= 17
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(const unique_ptr<T1, D1>& x,
-                                                                        const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator!=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
-    return !(x == y);
+  return !(x == y);
 }
 #endif
 
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<T1, D1>& x,
-                                                                       const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   // Similar to `operator==`, the `const void*` cast provides a robust,
   // standard-compliant way to establish a strict total ordering for any two
@@ -404,31 +382,31 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<
 }
 
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(const unique_ptr<T1, D1>& x,
-                                                                       const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
-    return y < x;
+  return y < x;
 }
 
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(const unique_ptr<T1, D1>& x,
-                                                                        const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
-    return !(y < x);
+  return !(y < x);
 }
 
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(const unique_ptr<T1, D1>& x,
-                                                                        const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
-    return !(x < y);
+  return !(x < y);
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr<T, D>& x,
-                                                                        std::nullptr_t) noexcept
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator==(const unique_ptr<T, D>& x, std::nullptr_t) noexcept
 {
-    return !x;
+  return !x;
 }
 
 #if THRUST_STD_VER <= 17
@@ -436,78 +414,70 @@ template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
 operator==(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
 {
-    return !y;
+  return !y;
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(const unique_ptr<T, D>& x,
-                                                                        std::nullptr_t) noexcept
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
+operator!=(const unique_ptr<T, D>& x, std::nullptr_t) noexcept
 {
-    return static_cast<bool>(x);
+  return static_cast<bool>(x);
 }
 
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
 operator!=(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
 {
-    return static_cast<bool>(y);
+  return static_cast<bool>(y);
 }
 #endif
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<T, D>& x,
-                                                                       std::nullptr_t)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<T, D>& x, std::nullptr_t)
 {
-    return std::less<typename unique_ptr<T, D>::pointer>()(x.get(), nullptr); // x.get() < nullptr;
+  return std::less<typename unique_ptr<T, D>::pointer>()(x.get(), nullptr); // x.get() < nullptr;
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(std::nullptr_t,
-                                                                       const unique_ptr<T, D>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(std::nullptr_t, const unique_ptr<T, D>& y)
 {
-    return std::less<typename unique_ptr<T, D>::pointer>()(nullptr, y.get()); // nullptr < y.get();
+  return std::less<typename unique_ptr<T, D>::pointer>()(nullptr, y.get()); // nullptr < y.get();
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(const unique_ptr<T, D>& x,
-                                                                       std::nullptr_t)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(const unique_ptr<T, D>& x, std::nullptr_t)
 {
-    return nullptr < x;
+  return nullptr < x;
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(std::nullptr_t,
-                                                                       const unique_ptr<T, D>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(std::nullptr_t, const unique_ptr<T, D>& y)
 {
-    return y < nullptr;
+  return y < nullptr;
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(const unique_ptr<T, D>& x,
-                                                                        std::nullptr_t)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(const unique_ptr<T, D>& x, std::nullptr_t)
 {
-    return !(nullptr < x);
+  return !(nullptr < x);
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(std::nullptr_t,
-                                                                        const unique_ptr<T, D>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(std::nullptr_t, const unique_ptr<T, D>& y)
 {
-    return !(y < nullptr);
+  return !(y < nullptr);
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(const unique_ptr<T, D>& x,
-                                                                        std::nullptr_t)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(const unique_ptr<T, D>& x, std::nullptr_t)
 {
-    return !(x < nullptr);
+  return !(x < nullptr);
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(std::nullptr_t,
-                                                                        const unique_ptr<T, D>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(std::nullptr_t, const unique_ptr<T, D>& y)
 {
-    return !(y < nullptr);
+  return !(y < nullptr);
 }
 
 //==============================================================================

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -26,7 +26,11 @@ struct default_delete<T, typename thrust::detail::enable_if<thrust::detail::not_
   template <class U>
   THRUST_HOST
   default_delete(const default_delete<U>&,
-              typename thrust::detail::enable_if<thrust::detail::is_convertible<thrust::device_ptr<U>, pointer>::value>::type * = nullptr) noexcept {}
+              typename thrust::detail::enable_if<
+                  thrust::detail::is_convertible<thrust::device_ptr<U>,
+                                                  pointer>::value>::type* = nullptr) noexcept
+  {
+  }
 
   THRUST_HOST
   void operator()(pointer ptr) const noexcept
@@ -50,9 +54,13 @@ struct default_delete<
   constexpr default_delete(size_t n = 0) noexcept : m_size(n) {};
 
   template <class U>
-  THRUST_HOST
-  default_delete(const default_delete<U[]>& other,
-              typename thrust::detail::enable_if<thrust::detail::is_convertible<U(*)[], T(*)[]>::value>::type * = nullptr) noexcept 
+  THRUST_HOST default_delete(
+      const default_delete<U[]>& other,
+      typename thrust::detail::enable_if<
+          thrust::detail::is_convertible<U (*)[], T (*)[]>::value>::type* = nullptr) noexcept
+      : m_size(other.size())
+  {
+  }
 
   THRUST_HOST
   void operator()(pointer ptr) const noexcept
@@ -126,7 +134,7 @@ template <class T, class D = default_delete<T>>
 class unique_ptr
 {
 public:
-    using pointer = typename D::pointer;
+    using pointer      = typename D::pointer;
     using element_type = T;
     using deleter_type = D;
 
@@ -152,10 +160,8 @@ private:
                          thrust::detail::not_<thrust::detail::is_pointer<Deleter>>>::value>::type;
 
     template <class ArgType>
-    using EnableIfDeleterConstructible = 
-        typename thrust::detail::enable_if<
-            std::is_constructible<deleter_type, ArgType>::value
-        >::type;
+    using EnableIfDeleterConstructible = typename thrust::detail::enable_if<
+        std::is_constructible<deleter_type, ArgType>::value>::type;
 
   template <class U, class E>
   using EnableIfMoveConvertible = typename thrust::detail::enable_if<
@@ -168,49 +174,101 @@ private:
                          thrust::detail::and_<thrust::detail::not_<thrust::detail::is_reference<D>>,
                                               thrust::detail::is_convertible<E, D>>>::value>::type;
 
+    template <class E>
+    using EnableIfDeleterAssignable =
+        typename thrust::detail::enable_if<thrust::detail::is_assignable<D&, E&&>::value>::type;
+
 public:
     //==========================================================================
     // Constructors
     //==========================================================================
 
-    template<bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
-    THRUST_HOST constexpr unique_ptr() noexcept : m_ptr(), m_deleter() {}
-    
-    template<bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
-    THRUST_HOST constexpr unique_ptr(std::nullptr_t) noexcept : unique_ptr() {}
+    template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
+    THRUST_HOST constexpr unique_ptr() noexcept
+        : m_ptr()
+        , m_deleter()
+    {
+    }
 
-    template<bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(pointer p) noexcept : m_ptr(p), m_deleter() {}
+    template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
+    THRUST_HOST constexpr unique_ptr(std::nullptr_t) noexcept
+        : unique_ptr()
+    {
+    }
 
-    template<bool Dummy = true, class = EnableIfDeleterConstructible<LValRefType<Dummy>>>
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer p, LValRefType<Dummy> d) noexcept : m_ptr(p), m_deleter(d) {}
+    template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(pointer p) noexcept
+        : m_ptr(p)
+        , m_deleter()
+    {
+    }
 
-    template<bool Dummy = true, class = EnableIfDeleterConstructible<GoodRValRefType<Dummy>>>
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer p, GoodRValRefType<Dummy> d) noexcept : m_ptr(p), m_deleter(std::move(d)) 
+    template <bool Dummy = true, class = EnableIfDeleterConstructible<LValRefType<Dummy>>>
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer            p,
+                                                                LValRefType<Dummy> d) noexcept
+        : m_ptr(p)
+        , m_deleter(d)
+    {
+    }
+
+    template <bool Dummy = true, class = EnableIfDeleterConstructible<GoodRValRefType<Dummy>>>
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer                p,
+                                                                GoodRValRefType<Dummy> d) noexcept
+        : m_ptr(p)
+        , m_deleter(std::move(d))
     {
       static_assert(thrust::detail::not_<thrust::detail::is_reference<deleter_type>>::value,
                   "rvalue deleter bound to reference");
     }
 
-    template<bool Dummy = true, class = EnableIfDeleterConstructible<BadRValRefType<Dummy>>>
+    template <bool Dummy = true, class = EnableIfDeleterConstructible<BadRValRefType<Dummy>>>
     unique_ptr(pointer p, BadRValRefType<Dummy> d) = delete;
 
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& u) noexcept : m_ptr(u.release()), m_deleter(std::forward<deleter_type>(u.get_deleter())) {}
-    
-    template <
-        class U, class E,
-        class = EnableIfMoveConvertible<unique_ptr<U, E>, U>,
-        class = EnableIfDeleterConvertible<E>
-    >
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23
-    unique_ptr(unique_ptr<U, E>&& u) noexcept
-        : m_ptr(u.release()), m_deleter(std::forward<E>(u.get_deleter())) {}
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& u) noexcept
+        : m_ptr(u.release())
+        , m_deleter(std::forward<deleter_type>(u.get_deleter()))
+    {
+    }
+
+    template <class U,
+              class E,
+              class = EnableIfMoveConvertible<unique_ptr<U, E>, U>,
+              class = EnableIfDeleterConvertible<E>>
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr<U, E>&& u) noexcept
+        : m_ptr(u.release())
+        , m_deleter(std::forward<E>(u.get_deleter()))
+    {
+    }
 
 
-    //==========================================================================
-    // Assignment
-    //==========================================================================
-    
+  //==========================================================================
+  // Assignment
+  //==========================================================================
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr&& u) noexcept
+  {
+    reset(u.release());
+    m_deleter = std::forward<deleter_type>(u.get_deleter());
+    return *this;
+  }
+
+    template <class U,
+              class E,
+              class = EnableIfMoveConvertible<unique_ptr<U, E>, U>,
+              class = EnableIfDeleterAssignable<E>>
+    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr&
+    operator=(unique_ptr<U, E>&& u) noexcept
+    {
+        reset(u.release());
+        m_deleter = std::forward<E>(u.get_deleter());
+        return *this;
+    }
+
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(std::nullptr_t) noexcept
+  {
+    reset();
+    return *this;
+  }
+
     //==========================================================================
     // Destructor
     //==========================================================================
@@ -219,14 +277,17 @@ public:
         reset();
     }
 
+    //==========================================================================
+    // Observers
+    //==========================================================================
+
+    // dont need memcpy or thrust::copy because device_ptr can be dereferenced in host?
 };
 
 template <class T, class D>
 class unique_ptr<T[], D>
 {
-
 };
-
 
 
 

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -8,6 +8,7 @@
 #include <thrust/for_each.h>
 #include <thrust/device_reference.h>
 
+#include <functional>
 #include <type_traits>
 #include <utility>
 
@@ -360,6 +361,67 @@ template <class T,
 inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept
 {
     x.swap(y);
+}
+
+//==============================================================================
+// Comparison Operators
+//==============================================================================
+template <class T1, class D1, class T2, class D2>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr<T1, D1>& x,
+                                                                        const unique_ptr<T2, D2>& y)
+{
+  // The initial `std::common_type` approach was considered to support comparisons
+  // between related types (e.g., a base and derived class pointer). However,
+  // a bug in `thrust::device_delete` prevented testing with class hierarchies.
+  //
+  // Testing was pivoted to use unrelated types (e.g., `int*` and `float*`),
+  // which revealed that `std::common_type` is ill-formed for such cases.
+  //
+  // The standard-compliant and robust solution for comparing any two object
+  // pointers is to cast them to `const void*`. This correctly handles all
+  // cases: related, unrelated, and incomplete types.
+  return std::equal_to<const void*>()(x.get_raw(), y.get_raw()); // const void*
+}
+
+#if THRUST_STD_VER <= 17
+template <class T1, class D1, class T2, class D2>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(const unique_ptr<T1, D1>& x,
+                                                                        const unique_ptr<T2, D2>& y)
+{
+    return !(x == y);
+}
+#endif
+
+template <class T1, class D1, class T2, class D2>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<T1, D1>& x,
+                                                                       const unique_ptr<T2, D2>& y)
+{
+  // Similar to `operator==`, the `const void*` cast provides a robust,
+  // standard-compliant way to establish a strict total ordering for any two
+  // object pointers, which was necessary after testing with unrelated types
+  // proved the `std::common_type` approach to be insufficient.
+  return std::less<const void*>()(x.get_raw(), y.get_raw()); // const void*
+}
+
+template <class T1, class D1, class T2, class D2>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(const unique_ptr<T1, D1>& x,
+                                                                       const unique_ptr<T2, D2>& y)
+{
+    return y < x;
+}
+
+template <class T1, class D1, class T2, class D2>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(const unique_ptr<T1, D1>& x,
+                                                                 const unique_ptr<T2, D2>& y)
+{
+    return !(y < x);
+}
+
+template <class T1, class D1, class T2, class D2>
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(const unique_ptr<T1, D1>& x,
+                                                                 const unique_ptr<T2, D2>& y)
+{
+    return !(x < y);
 }
 
 template <class T,

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <thrust/detail/config.h>
+
 #include <thrust/detail/type_traits.h>
 #include <thrust/device_free.h>
 #include <thrust/device_new.h>
 #include <thrust/device_ptr.h>
-#include <thrust/for_each.h>
 #include <thrust/device_reference.h>
+#include <thrust/for_each.h>
 
 #include <compare>
 #include <functional>
@@ -28,52 +29,58 @@ struct default_delete<T, typename std::enable_if<!std::is_array<T>::value>::type
   template <class U>
   THRUST_HOST default_delete(
     const default_delete<U>&,
-    typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* =
-      nullptr) noexcept
+    typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* = nullptr) noexcept
   {}
 
-  THRUST_HOST
-  void operator()(pointer ptr) const noexcept
+  THRUST_HOST void operator()(pointer ptr) const noexcept
   {
     if (ptr.get() == nullptr)
+    {
       return;
-    
+    }
+
     // We use for_each_n to launch a kernel that executes the destructor on the device,
     // avoiding known issues with thrust::device_delete for user-defined types.
     if constexpr (!std::is_trivially_destructible<T>::value)
-      thrust::for_each_n(ptr, 1, [] __device__(T& x) { x.~T(); });
+    {
+      thrust::for_each_n(ptr, 1, [] __device__(T & x) {
+        x.~T();
+      });
+    }
     thrust::device_free(ptr);
   }
 };
 
 template <class T>
-struct default_delete<
-  T[],
-  typename std::enable_if<!std::is_trivially_destructible<T>::value>::type>
+struct default_delete<T[], typename std::enable_if<!std::is_trivially_destructible<T>::value>::type>
 {
   using pointer = thrust::device_ptr<T>;
 
-  THRUST_HOST
-  constexpr default_delete(size_t n = 0) noexcept : m_size(n) {};
+  THRUST_HOST constexpr default_delete(size_t n = 0) noexcept
+      : m_size(n){};
 
   template <class U>
   THRUST_HOST
   default_delete(const default_delete<U[]>& other,
-              typename std::enable_if<std::is_convertible<U (*)[], T (*)[]>::value>::type* =
-                nullptr) noexcept
+                 typename std::enable_if<std::is_convertible<U (*)[], T (*)[]>::value>::type* = nullptr) noexcept
       : m_size(other.size())
   {}
 
-  THRUST_HOST
-  void operator()(pointer ptr) const noexcept
+  THRUST_HOST void operator()(pointer ptr) const noexcept
   {
     if (ptr.get() == nullptr)
+    {
       return;
-      
+    }
+
     // We use for_each_n to launch a kernel that executes the destructor on the device,
     // avoiding known issues with thrust::device_delete for user-defined types.
     if (m_size)
-      thrust::for_each_n(ptr, m_size, [] __device__(T& x) { x.~T(); });
+    {
+      thrust::for_each_n(ptr, m_size, [] __device__(T & x) {
+        x.~T();
+      });
+    }
     thrust::device_free(ptr);
   }
 
@@ -96,8 +103,7 @@ struct default_delete<T[], typename std::enable_if<std::is_trivially_destructibl
   template <class U>
   THRUST_HOST default_delete(
     const default_delete<U>&,
-    typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* =
-      nullptr) noexcept
+    typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* = nullptr) noexcept
   {}
 
   THRUST_HOST void operator()(pointer ptr) const noexcept
@@ -149,7 +155,7 @@ struct unique_ptr_deleter_sfinae<Deleter&>
   using enable_rval_overload = thrust::detail::false_type;
 };
 
-}
+} // namespace detail
 
 template <class T, class D = default_delete<T>>
 class unique_ptr
@@ -160,7 +166,7 @@ public:
   using deleter_type = D;
 
 private:
-  pointer                            m_ptr;
+  pointer m_ptr;
   [[no_unique_address]] deleter_type m_deleter;
 
   using DeleterSFINAE = thrust::detail::unique_ptr_deleter_sfinae<D>;
@@ -174,27 +180,28 @@ private:
   template <bool Dummy>
   using BadRValRefType = typename thrust::detail::dependent_type<DeleterSFINAE, Dummy>::type::bad_rval_ref_type;
 
-  template <bool Dummy,
-            class Deleter = typename thrust::detail::dependent_type<typename thrust::detail::identity_<deleter_type>::type, Dummy>::type>
-  using EnableIfDeleterDefaultConstructible = typename std::enable_if< 
-    std::is_default_constructible<Deleter>::value && !std::is_pointer<Deleter>::value>::type;
+  template <
+    bool Dummy,
+    class Deleter =
+      typename thrust::detail::dependent_type<typename thrust::detail::identity_<deleter_type>::type, Dummy>::type>
+  using EnableIfDeleterDefaultConstructible =
+    typename std::enable_if<std::is_default_constructible<Deleter>::value && !std::is_pointer<Deleter>::value>::type;
 
   template <class ArgType>
   using EnableIfDeleterConstructible =
     typename std::enable_if<std::is_constructible<deleter_type, ArgType>::value>::type;
 
   template <class U, class E>
-  using EnableIfMoveConvertible = typename std::enable_if<
-      std::is_convertible<typename U::pointer, pointer>::value && !std::is_array<E>::value>::type;
+  using EnableIfMoveConvertible =
+    typename std::enable_if<std::is_convertible<typename U::pointer, pointer>::value && !std::is_array<E>::value>::type;
 
   template <class E>
-  using EnableIfDeleterConvertible = 
-    typename std::enable_if<(std::is_reference<D>::value && std::is_same<D, E>::value) 
-                                      || (!std::is_reference<D>::value && std::is_convertible<E, D>::value)>::type;
+  using EnableIfDeleterConvertible =
+    typename std::enable_if<(std::is_reference<D>::value && std::is_same<D, E>::value)
+                            || (!std::is_reference<D>::value && std::is_convertible<E, D>::value)>::type;
 
   template <class E>
-  using EnableIfDeleterAssignable =
-    typename std::enable_if<std::is_assignable<D&, E&&>::value>::type;
+  using EnableIfDeleterAssignable = typename std::enable_if<std::is_assignable<D&, E&&>::value>::type;
 
   template <
     bool Dummy,
@@ -230,15 +237,13 @@ public:
       , m_deleter(d)
   {}
 
-    template <bool Dummy = true, class = EnableIfDeleterConstructible<GoodRValRefType<Dummy>>>
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer                p,
-                                                                GoodRValRefType<Dummy> d) noexcept
-        : m_ptr(p)
-        , m_deleter(std::move(d))
-    {
-      static_assert(!std::is_reference<deleter_type>::value,
-                  "rvalue deleter bound to reference");
-    }
+  template <bool Dummy = true, class = EnableIfDeleterConstructible<GoodRValRefType<Dummy>>>
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer p, GoodRValRefType<Dummy> d) noexcept
+      : m_ptr(p)
+      , m_deleter(std::move(d))
+  {
+    static_assert(!std::is_reference<deleter_type>::value, "rvalue deleter bound to reference");
+  }
 
   template <bool Dummy = true, class = EnableIfDeleterConstructible<BadRValRefType<Dummy>>>
   unique_ptr(pointer p, BadRValRefType<Dummy> d) = delete;
@@ -278,13 +283,13 @@ public:
     return *this;
   }
 
-    //==========================================================================
-    // Destructor
-    //==========================================================================
-    THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 ~unique_ptr()
-    {
-        reset();
-    }
+  //==========================================================================
+  // Destructor
+  //==========================================================================
+  THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 ~unique_ptr()
+  {
+    reset();
+  }
 
   //==========================================================================
   // Observers
@@ -294,8 +299,7 @@ public:
     return m_ptr;
   }
 
-  template <bool Dummy = true,
-            class      = EnableIfDeleterDefaultDelete<Dummy>>
+  template <bool Dummy = true, class = EnableIfDeleterDefaultDelete<Dummy>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 T* get_raw() const noexcept
   {
     return thrust::raw_pointer_cast(m_ptr);
@@ -374,8 +378,7 @@ inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T,
 // Comparison Operators
 //==============================================================================
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   // The initial `std::common_type` approach was considered to support comparisons
   // between related types (e.g., a base and derived class pointer). However,
@@ -392,16 +395,14 @@ operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 
 #if THRUST_STD_VER <= 17
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator!=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   return !(x == y);
 }
 #endif
 
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   // Similar to `operator==`, the `const void*` cast provides a robust,
   // standard-compliant way to establish a strict total ordering for any two
@@ -411,60 +412,53 @@ operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 }
 
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   return y < x;
 }
 
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   return !(y < x);
 }
 
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   return !(x < y);
 }
 
 #if THRUST_STD_VER >= 20
 template <class T1, class D1, class T2, class D2>
-THRUST_HOST inline auto operator<=> (const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
+  THRUST_HOST inline auto operator<=> (const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   // TODO: once thrust::device_ptr supports three_way_comparison, we should be using that
-  return std::compare_three_way()(x.get_raw(), y.get_raw()); 
+  return std::compare_three_way()(x.get_raw(), y.get_raw());
 }
 #endif
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator==(const unique_ptr<T, D>& x, std::nullptr_t) noexcept
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr<T, D>& x, std::nullptr_t) noexcept
 {
   return !x;
 }
 
 #if THRUST_STD_VER <= 17
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator==(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
 {
   return !y;
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator!=(const unique_ptr<T, D>& x, std::nullptr_t) noexcept
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(const unique_ptr<T, D>& x, std::nullptr_t) noexcept
 {
   return static_cast<bool>(x);
 }
 
 template <class T, class D>
-THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool
-operator!=(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
+THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
 {
   return static_cast<bool>(y);
 }
@@ -520,7 +514,7 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(std::nullptr_t, 
 
 #if THRUST_STD_VER >= 20
 template <class T, class D>
-THRUST_HOST inline auto operator<=> (const unique_ptr<T, D>& x, std::nullptr_t)
+  THRUST_HOST inline auto operator<=> (const unique_ptr<T, D>& x, std::nullptr_t)
 {
   // TODO: once thrust::device_ptr supports three_way_comparison, we should be using that
   return std::compare_three_way()(x.get_raw(), static_cast<T*>(nullptr));
@@ -530,10 +524,7 @@ THRUST_HOST inline auto operator<=> (const unique_ptr<T, D>& x, std::nullptr_t)
 //==============================================================================
 // Make unique
 //==============================================================================
-template <class T,
-          class... Args,
-          class = typename std::enable_if<
-              !std::is_array<T>::value>::type>
+template <class T, class... Args, class = typename std::enable_if<!std::is_array<T>::value>::type>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique(Args&&... args)
 {
   thrust::device_ptr<T> p = thrust::device_malloc<T>(1);

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -99,6 +99,23 @@ struct default_delete<T[], typename thrust::detail::enable_if<std::is_trivially_
   }
 };
 
+namespace detail
+{
+
+template <class T, class D, class = void>
+struct pointer_detector
+{
+  using type = thrust::device_ptr<T>;
+};
+
+template <class T, class D>
+struct pointer_detector<T, D, std::void_t<typename D::pointer>>
+{
+  using type = typename D::pointer;
+};
+
+}
+
 template <class Deleter>
 struct unique_ptr_deleter_sfinae
 {
@@ -131,7 +148,7 @@ template <class T, class D = default_delete<T>>
 class unique_ptr
 {
 public:
-  using pointer      = typename D::pointer;
+  using pointer      = typename thrust::detail::pointer_detector<T, D>::type;
   using element_type = T;
   using deleter_type = D;
 

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -18,7 +18,7 @@ template <class T, class = void>
 struct default_delete;
 
 template <class T>
-struct default_delete<T, typename thrust::detail::enable_if<thrust::detail::not_<std::is_array<T>>::value>::type>
+struct default_delete<T, typename std::enable_if<!std::is_array<T>::value>::type>
 {
   using pointer = thrust::device_ptr<T>;
 
@@ -27,7 +27,7 @@ struct default_delete<T, typename thrust::detail::enable_if<thrust::detail::not_
   template <class U>
   THRUST_HOST default_delete(
     const default_delete<U>&,
-    typename thrust::detail::enable_if<thrust::detail::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* =
+    typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* =
       nullptr) noexcept
   {}
 
@@ -45,7 +45,7 @@ struct default_delete<T, typename thrust::detail::enable_if<thrust::detail::not_
 template <class T>
 struct default_delete<
   T[],
-  typename thrust::detail::enable_if<thrust::detail::not_<std::is_trivially_destructible<T>>::value>::type>
+  typename std::enable_if<!std::is_trivially_destructible<T>::value>::type>
 {
   using pointer = thrust::device_ptr<T>;
 
@@ -55,7 +55,7 @@ struct default_delete<
   template <class U>
   THRUST_HOST
   default_delete(const default_delete<U[]>& other,
-              typename thrust::detail::enable_if<thrust::detail::is_convertible<U (*)[], T (*)[]>::value>::type* =
+              typename std::enable_if<std::is_convertible<U (*)[], T (*)[]>::value>::type* =
                 nullptr) noexcept
       : m_size(other.size())
   {}
@@ -80,7 +80,7 @@ private:
 };
 
 template <class T>
-struct default_delete<T[], typename thrust::detail::enable_if<std::is_trivially_destructible<T>::value>::type>
+struct default_delete<T[], typename std::enable_if<std::is_trivially_destructible<T>::value>::type>
 {
   using pointer = thrust::device_ptr<T>;
 
@@ -89,7 +89,7 @@ struct default_delete<T[], typename thrust::detail::enable_if<std::is_trivially_
   template <class U>
   THRUST_HOST default_delete(
     const default_delete<U>&,
-    typename thrust::detail::enable_if<thrust::detail::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* =
+    typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* =
       nullptr) noexcept
   {}
 
@@ -119,7 +119,7 @@ struct pointer_detector<T, D, std::void_t<typename D::pointer>>
 template <class Deleter>
 struct unique_ptr_deleter_sfinae
 {
-  static_assert(thrust::detail::not_<thrust::detail::is_reference<Deleter>>::value, "incorrect specialization");
+  static_assert(!std::is_reference<Deleter>::value, "incorrect specialization");
   using lval_ref_type        = const Deleter&;
   using good_rval_ref_type   = Deleter&&;
   using bad_rval_ref_type    = void;
@@ -169,28 +169,25 @@ private:
 
   template <bool Dummy,
             class Deleter = typename thrust::detail::dependent_type<typename thrust::detail::identity_<deleter_type>::type, Dummy>::type>
-  using EnableIfDeleterDefaultConstructible = typename thrust::detail::enable_if<
-    thrust::detail::and_<std::is_default_constructible<Deleter>,
-                         thrust::detail::not_<thrust::detail::is_pointer<Deleter>>>::value>::type;
+  using EnableIfDeleterDefaultConstructible = typename std::enable_if< 
+    std::is_default_constructible<Deleter>::value && !std::is_pointer<Deleter>::value>::type;
 
   template <class ArgType>
   using EnableIfDeleterConstructible =
-    typename thrust::detail::enable_if<std::is_constructible<deleter_type, ArgType>::value>::type;
+    typename std::enable_if<std::is_constructible<deleter_type, ArgType>::value>::type;
 
   template <class U, class E>
-  using EnableIfMoveConvertible =
-    typename thrust::detail::enable_if<thrust::detail::and_<thrust::detail::is_convertible<typename U::pointer, pointer>,
-                                                            thrust::detail::not_<std::is_array<E>>>::value>::type;
+  using EnableIfMoveConvertible = typename std::enable_if<
+      std::is_convertible<typename U::pointer, pointer>::value && !std::is_array<E>::value>::type;
 
   template <class E>
-  using EnableIfDeleterConvertible = typename thrust::detail::enable_if<
-    thrust::detail::or_<thrust::detail::and_<thrust::detail::is_reference<D>, thrust::detail::is_same<D, E>>,
-                        thrust::detail::and_<thrust::detail::not_<thrust::detail::is_reference<D>>,
-                                             thrust::detail::is_convertible<E, D>>>::value>::type;
+  using EnableIfDeleterConvertible = 
+    typename std::enable_if<(std::is_reference<D>::value && std::is_same<D, E>::value) 
+                                      || (!std::is_reference<D>::value && std::is_convertible<E, D>::value)>::type;
 
   template <class E>
   using EnableIfDeleterAssignable =
-    typename thrust::detail::enable_if<thrust::detail::is_assignable<D&, E&&>::value>::type;
+    typename std::enable_if<std::is_assignable<D&, E&&>::value>::type;
 
 public:
   //==========================================================================
@@ -226,7 +223,7 @@ public:
         : m_ptr(p)
         , m_deleter(std::move(d))
     {
-      static_assert(thrust::detail::not_<thrust::detail::is_reference<deleter_type>>::value,
+      static_assert(!std::is_reference<deleter_type>::value,
                   "rvalue deleter bound to reference");
     }
 
@@ -352,7 +349,7 @@ template <class T, class D>
 class unique_ptr<T[], D>
 {};
 
-template <class T, class D, typename thrust::detail::enable_if<std::is_swappable<D>::value, void>::type>
+template <class T, class D, typename std::enable_if<std::is_swappable<D>::value, void>::type>
 inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept
 {
   x.swap(y);
@@ -502,8 +499,8 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(std::nullptr_t, 
 //==============================================================================
 template <class T,
           class... Args,
-          class = typename thrust::detail::enable_if<
-              thrust::detail::not_<std::is_array<T>>::value>::type>
+          class = typename std::enable_if<
+              !std::is_array<T>::value>::type>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique(Args&&... args)
 {
   thrust::device_ptr<T> p = thrust::device_malloc<T>(1);

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -1,8 +1,158 @@
 #pragma once
 
 #include <thrust/detail/config.h>
+#include <thrust/detail/type_traits.h>
+#include <thrust/device_free.h>
+#include <thrust/device_new.h>
+#include <thrust/device_ptr.h>
+#include <thrust/for_each.h>
+
+#include <type_traits>
+#include <utility>
 
 THRUST_NAMESPACE_BEGIN
+
+template <class T, class = void>
+struct default_delete;
+
+template <class T>
+struct default_delete<T, typename thrust::detail::enable_if<thrust::detail::not_<std::is_array<T>>::value>::type>
+{
+    using pointer = thrust::device_ptr<T>;
+
+    THRUST_HOST
+    constexpr default_delete() noexcept = default;
+
+    template <class U>
+    THRUST_HOST
+    default_delete(const default_delete<U>&,
+                typename std::enable_if<std::is_convertible<thrust::device_ptr<U>, pointer>::value>::type * = nullptr) noexcept {}
+
+  THRUST_HOST
+  void operator()(pointer ptr) const noexcept
+  {
+    // We use for_each_n to launch a kernel that executes the destructor on the device,
+    // avoiding known issues with thrust::device_delete for user-defined types.
+    if constexpr (!std::is_trivially_destructible<T>::value)
+      thrust::for_each_n(ptr, 1, [] __device__(T& x) { x.~T(); });
+    thrust::device_free(ptr);
+  }
+};
+
+template <class T>
+struct default_delete<
+  T[],
+  typename thrust::detail::enable_if<thrust::detail::not_<std::is_trivially_destructible<T>>::value>::type>
+{
+    using pointer = thrust::device_ptr<T>;
+
+    THRUST_HOST
+    constexpr default_delete(size_t n = 0) noexcept : m_size(n) {};
+
+    template <class U>
+    THRUST_HOST
+    default_delete(const default_delete<U[]>& other,
+                typename std::enable_if<std::is_convertible<U(*)[], T(*)[]>::value>::type * = nullptr) noexcept 
+        : m_size(other.size())
+    {}
+
+    THRUST_HOST
+    void operator()(pointer ptr) const noexcept
+    {
+      // We use for_each_n to launch a kernel that executes the destructor on the device,
+      // avoiding known issues with thrust::device_delete for user-defined types.
+      if (m_size)
+        thrust::for_each_n(ptr, m_size, [] __device__(T& x) { x.~T(); });
+      thrust::device_free(ptr);
+    }
+
+    THRUST_HOST
+    size_t size() const
+    {
+        return m_size;
+    }
+
+private:
+  size_t m_size;
+};
+
+template <class T>
+struct default_delete<T[], typename thrust::detail::enable_if<std::is_trivially_destructible<T>::value>::type>
+{
+  using pointer = thrust::device_ptr<T>;
+
+  THRUST_HOST constexpr default_delete(size_t = 0) noexcept {};
+
+  template <class U>
+  THRUST_HOST default_delete(
+    const default_delete<U>&,
+    typename thrust::detail::enable_if<thrust::detail::is_convertible<thrust::device_ptr<U>, pointer>::value>::type* =
+      nullptr) noexcept
+  {}
+
+  THRUST_HOST void operator()(pointer ptr) const noexcept
+  {
+    thrust::device_free(ptr);
+  }
+};
+template <class T, class D = default_delete<T>>
+class unique_ptr
+{
+public:
+    using pointer = typename D::pointer;
+    using element_type = T;
+    using deleter_type = D;
+
+private:
+    pointer                            m_ptr;
+    [[no_unique_address]] deleter_type m_deleter;
+
+public:
+    //==========================================================================
+    // Constructors
+    //==========================================================================
+
+    THRUST_HOST
+    THRUST_CONSTEXPR_SINCE_CXX17 unique_ptr() noexcept : m_ptr(nullptr), m_deleter() {}
+
+    THRUST_HOST
+    THRUST_CONSTEXPR_SINCE_CXX17 unique_ptr(std::nullptr_t) noexcept : unique_ptr() {}
+
+    THRUST_HOST
+    explicit unique_ptr(pointer p) noexcept : m_ptr(p), m_deleter() {}
+
+    THRUST_HOST
+    unique_ptr(pointer p, const deleter_type& d) noexcept : m_ptr(p), m_deleter(d) {}
+
+    THRUST_HOST
+    unique_ptr(pointer p, deleter_type&& d) noexcept : m_ptr(p), m_deleter(std::move(d)) {}
+
+    THRUST_HOST
+    unique_ptr(unique_ptr&& u) noexcept : m_ptr(u.release()), m_deleter(std::forward<deleter_type>(u.get_deleter())) {}
+    
+    template <
+        class U, class E,
+        class = typename std::enable_if<
+                std::is_convertible<typename unique_ptr<U, E>::pointer, pointer>::value &&
+                !std::is_array<U>::value
+            >::type,
+        class = typename std::enable_if<
+            (std::is_reference<deleter_type>::value && std::is_same<deleter_type, E>::value) ||
+            (!std::is_reference<deleter_type>::value && std::is_convertible<E, deleter_type>::value)
+        >::type
+    >
+    THRUST_HOST
+    unique_ptr(unique_ptr<U, E>&& u) noexcept
+        : m_ptr(u.release()), m_deleter(std::forward<E>(u.get_deleter())) {}
+
+
+};
+
+template <class T, class D>
+class unique_ptr<T[], D>
+{
+
+};
 
 
 

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -120,8 +120,6 @@ struct pointer_detector<T, D, std::void_t<typename D::pointer>>
   using type = typename D::pointer;
 };
 
-}
-
 template <class Deleter>
 struct unique_ptr_deleter_sfinae
 {
@@ -150,6 +148,8 @@ struct unique_ptr_deleter_sfinae<Deleter&>
   using enable_rval_overload = thrust::detail::false_type;
 };
 
+}
+
 template <class T, class D = default_delete<T>>
 class unique_ptr
 {
@@ -162,7 +162,7 @@ private:
   pointer                            m_ptr;
   [[no_unique_address]] deleter_type m_deleter;
 
-  using DeleterSFINAE = unique_ptr_deleter_sfinae<D>;
+  using DeleterSFINAE = thrust::detail::unique_ptr_deleter_sfinae<D>;
 
   template <bool Dummy>
   using LValRefType = typename thrust::detail::dependent_type<DeleterSFINAE, Dummy>::type::lval_ref_type;


### PR DESCRIPTION
## Motivation
This PR introduces `thrust::unique_ptr` for single objects, a key C++ standard library feature for smart resource management. This implementation is specifically designed to **allow host code to manage the lifecycle of device-side memory allocations** in a safe, RAII-compliant manner. The primary goal is to provide users with a safe, standard, and RAII-compliant mechanism for managing the lifetime of dynamically allocated objects in device memory.

By offering a familiar `unique_ptr` interface, this change aims to:

- Prevent common memory leaks by automating resource deallocation.
- Improve code clarity and safety when working with device pointers.
- Align rocThrust more closely with modern C++ practices.

This PR implements the single-object form (`unique_ptr<T>`). The array specialization (`unique_ptr<T[]>`) will be handled in a subsequent PR (https://github.com/ROCm/rocm-libraries/pull/1298).

## Technical Details
New header is introduced, `unique_ptr.h`, which contains a from-scratch implementation of `unique_ptr` modeled closely on the C++ standard library specification.

Key features include:

- `thrust::unique_ptr<T, D>` **Class template**: Implements the full interface for single objects, including all constructors, assignment operators, modifiers(`release`, `reset`, `swap`), and observers (`get`, `get_deleter`, `operator*`, etc.).
- `thrust::host_delete`: A custom default deleter that correctly handles the destruction of objects in device memory from host code. For non-trivially destructible types, it launches a kernel via `thrust::for_each_n` to execute the destructor on the device before freeing the memory, thus bypassing the issues with `thrust::device_delete`.
- **SFINAE Correctness**: Extensive use of SFINAE to enable and disable constructors and assignment operators, mirroring the behavior of `std::unique_ptr`.
- **Factory Functions**: `thrust::make_unique` is provided for convenient and safe object creation.
- **Comparison Operators**: A full suite of comparison operators to compare `unique_ptr` instances with each other and with `nullptr`.
- **Safety Guards**: The `operator->` is intentionally commented out to prevent users from dereferencing a device pointer on the host, which would lead to a segmentation fault. A detailed comment guides the user to copy the data to the host before accessing members.


## Test Plan
A comprehensive test suite has been added to validate the implementation. The tests are organized into new files (`test_unique_ptr_allocate_deallocate.cpp`, `test_unique_ptr_general.cpp`) and cover all aspects of the `unique_ptr`'s functionality:
- **Lifecycle**: Constructors, destructor and move semantics.
- **Modifiers**: `release`, `reset` and `swap` functionality.
- **Observers**: `get`, `get_raw`, `get_deleter` and `operator bool`.
- **Deleters**: Correct behavior with both the default `host_delete` and user-defined deleters.
- **Comparison**: All relational operators.
- **Memory Management**: Tests confirm that memory is correctly allocated and deallocated, preventing leaks.

## Test Result
All newly added tests pass successfully, as confirmed by the provided test logs: 
```
:~/rocThrust/projects/rocthrust/build/release$ ctest -R unique_ptr*
Test project /home/marsavic/rocThrust/projects/rocthrust/build/release
    Start 284: unique_ptr_general.hip
1/2 Test #284: unique_ptr_general.hip ...............   Passed    0.93 sec
    Start 285: unique_ptr_allocate_deallocate.hip
2/2 Test #285: unique_ptr_allocate_deallocate.hip ...   Passed    0.29 sec

100% tests passed, 0 tests failed out of 2

Label Time Summary:
hip    =   1.21 sec*proc (2 tests)

Total Test time (real) =   1.22 sec
```
