### PR TITLE
[hipblaslt] Support both dot2 and non-dot2 in TF32 emu

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -289,7 +289,7 @@ class LocalReadMFMA(LocalRead):
                                 if valuiIdx % 4 == 0:
                                     tmpvgprIDx = (valuiIdx % 8) // 4
                                     tmpvgprHI.append(writer.vgprPool.checkOutAligned(2, 2))
-                                    numTmpForCVTSubTF32 = 4
+                                    numTmpForCVTSubTF32 = 1
                                     tmpvgpr =[]
                                     for i in range(numTmpForCVTSubTF32):
                                         tmpvgpr.append(writer.vgprPool.checkOut(1))
@@ -301,16 +301,30 @@ class LocalReadMFMA(LocalRead):
 
                                     packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]), src0=v0, src1=v1))
 
-                                    packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[0]), src=vgpr(tmpvgprHI[tmpvgprIDx])))
-                                    packCode.add(VSubF32(dst=v0, src0=v0, src1=vgpr(tmpvgpr[0])))
-                                    packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[1]), src=vgpr(tmpvgprHI[tmpvgprIDx]), vgprMask=None, vi=1))
-                                    packCode.add(VSubF32(dst=v1, src0=v1, src1=vgpr(tmpvgpr[1])))
+                                    if kernel["UseDot2F32XEmulation"]:
+                                        packCode.add(VDot2CF32BF16(dst=v0, src0=hex(0x8000bf80), src1=vgpr(tmpvgprHI[tmpvgprIDx])))
+                                        packCode.add(VDot2CF32BF16(dst=v1, src0=hex(0xbf800000), src1=vgpr(tmpvgprHI[tmpvgprIDx])))
+                                    else:
+                                        packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[0]), src=vgpr(tmpvgprHI[tmpvgprIDx])))
+                                        packCode.add(VSubF32(dst=v0, src0=v0, src1=vgpr(tmpvgpr[0])))
+                                        packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[0]), src=vgpr(tmpvgprHI[tmpvgprIDx]), vgprMask=None, vi=1))
+                                        packCode.add(VSubF32(dst=v1, src0=v1, src1=vgpr(tmpvgpr[0])))
 
                                     packCode.add(VCvtPkF32toBF16(dst=vgpr(tmpvgprHI[tmpvgprIDx]+1), src0=v2, src1=v3))
-                                    packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1)))
-                                    packCode.add(VSubF32(dst=v2, src0=v2, src1=vgpr(tmpvgpr[2])))
-                                    packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[2]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1), vgprMask=None, vi=1))
-                                    packCode.add(VSubF32(dst=v3, src0=v3, src1=vgpr(tmpvgpr[2])))
+
+                                    if kernel["UseDot2F32XEmulation"]:
+                                        packCode.add(VDot2CF32BF16(dst=v2, src0=hex(0x8000bf80), src1=vgpr(tmpvgprHI[tmpvgprIDx]+1)))
+                                    else:
+                                        packCode.add(PVCvtBF16toFP32(dst=vgpr(tmpvgpr[0]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1)))
+                                        packCode.add(VSubF32(dst=v2, src0=v2, src1=vgpr(tmpvgpr[0])))
+
+                                    # We use cvt+sub pair since dot2 requires adding 4 wait states.
+                                    packCode.add(VCvtBF16toFP32(dst=vgpr(tmpvgpr[0]), src=vgpr(tmpvgprHI[tmpvgprIDx]+1), vgprMask=None, vi=1))
+                                    packCode.add(VSubF32(dst=v3, src0=v3, src1=vgpr(tmpvgpr[0])))
+
+                                    if kernel["UseDot2F32XEmulation"]:
+                                        packCode.add(VMovB32(dst=vgpr(tmpvgpr[0]), src=0))
+                                        packCode.add(VMovB32(dst=vgpr(tmpvgpr[0]), src=0))
 
                                     for i in range(numTmpForCVTSubTF32):
                                         writer.vgprPool.checkIn(tmpvgpr[i])

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -949,8 +949,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
         scheduleTF32Emu = kernel["UseF32XEmulation"]
         if scheduleTF32Emu:
           # 26 is the instruction count for the TF32 emulation sequence in LocalRead.py
-          instPerPackA = 26#len(packAItems)
-          instPerPackB = 26#len(packBItems)
+          instPerPackA = 24 if kernel["UseDot2F32XEmulation"] else 26 #len(packAItems)
+          instPerPackB = 24 if kernel["UseDot2F32XEmulation"] else 26 #len(packBItems)
           while packAItems or packBItems:
             for n in range(instPerPackA):
               if packAItems:

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -891,6 +891,7 @@ class Solution(collections.abc.Mapping):
     # the keys "EnableF32XdlMathOp" and "F32XdlMathOp".
     state["EnableF32XdlMathOp"] = False
     state["UseF32XEmulation"] = False #enable emulation for missing hardware support
+    state["UseDot2F32XEmulation"] = True
     #ignore the F32 xDL MathOp by default.
     #enable F32 xDL MathOp only when the input type is f32.
     if "F32XdlMathOp" in state["ProblemType"] \


### PR DESCRIPTION
## Motivation

Add support for both dot2 and non-dot2 in TF32 emulation sequence. For some macro tiles, even though dot2 cannot be co-executed with mfma, it may still be beneficial since the overall cvt overhead is reduced.

## Technical Details

Add internal parameter to allow switching between the two. Default is to use dot2.

## Test Plan


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
