### PR TITLE
[TheRock CI] Adding docker image for TheRock tests

### DIFF
--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -38,6 +38,14 @@ jobs:
   test_components:
     name: 'Test ${{ matrix.components.job_name }}'
     runs-on: ${{ inputs.test_runs_on }}
+    container:
+      image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26' || null }}
+      options: --ipc host
+        --group-add video
+        --device /dev/kfd
+        --device /dev/dri
+        --group-add 992
+        --env-file /etc/podinfo/gha-gpu-isolation-settings
     needs: configure_test_matrix
     # skip tests if no test matrix to run
     if: ${{ needs.configure_test_matrix.outputs.components != '[]' }}


### PR DESCRIPTION
Previously, these tests were running on machines with an already installed ROCm. 

Now, this docker image on Linux ensure that ROCm is not installed and we are getting ROCm from TheRock

Working here: https://github.com/ROCm/rocm-libraries/actions/runs/17135064877

(this will be testable in PR after #1306 goes through. Also, I plan to add documentation to TheRock on how to replicate errors with this docker image)