### PR TITLE
Add build and install rpath for hipfft-test and rocfft-test for finding libomp.so

### DIFF
--- a/projects/hipfft/.jenkins/staticanalysis.groovy
+++ b/projects/hipfft/.jenkins/staticanalysis.groovy
@@ -9,7 +9,7 @@ def runCI =
 {
     nodeDetails, jobName ->
 
-    def prj = new rocProject('hipFFT-internal', 'PreCheckin')
+    def prj = new rocProject('hipFFT', 'PreCheckin')
     // customize for project
     prj.libraryDependencies = ['rocRAND','rocFFT']
 

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -117,6 +117,12 @@ if( BUILD_CLIENTS_TESTS_OPENMP AND NOT BUILD_WITH_LIB STREQUAL "CUDA" )
   if( NOT OPENMP_FOUND OR NOT DEFINED ${openmp_LIB_DIR} )
      # Fall-back to module mode.
      find_package( OpenMP REQUIRED )
+     set( BUILD_RPATH "${HIP_CLANG_ROOT}/lib" )
+     set( INSTALL_RPATH "$ORIGIN/../llvm/lib" )
+  else()
+     set( BUILD_RPATH "${HIP_CLANG_ROOT}/${openmp_LIB_DIR}" )
+     set( INSTALL_RPATH "$ORIGIN/../llvm/${openmp_LIB_DIR}" )
+
   endif()
 endif()
 
@@ -125,6 +131,15 @@ foreach( target ${TEST_TARGETS} )
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
     )
+
+    if( BUILD_CLIENTS_TESTS_OPENMP )
+      set_target_properties( ${TEST_TARGETS} PROPERTIES
+         BUILD_RPATH "${BUILD_RPATH}"
+      )
+      set_target_properties( ${TEST_TARGETS} PROPERTIES
+        INSTALL_RPATH "${INSTALL_RPATH}"
+      )
+    endif()
 
   if( BUILD_WITH_LIB STREQUAL "ROCM" )
     target_compile_options( ${target} PRIVATE ${WARNING_FLAGS} )

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -32,6 +32,13 @@ else( )
     "Install path prefix, prepended onto install directories" )
 endif( )
 
+# Dependencies
+
+find_package( ROCmCMakeBuildTools REQUIRED CONFIG PATHS /opt/rocm )
+include(ROCMInstallTargets)
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../cmake )
+
+
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user
 # specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
@@ -42,12 +49,18 @@ endif()
 
 project( hipfft-clients-tests LANGUAGES CXX )
 
+if( NOT HIPFFT_BUILD_SCOPE )
+  find_package( hipfft REQUIRED CONFIG PATHS )
+endif()
 
 find_package( Boost REQUIRED)
 
 set( Boost_USE_STATIC_LIBS OFF )
 
+
 find_package( FFTW 3.0 REQUIRED MODULE COMPONENTS FLOAT DOUBLE )
+
+set( BUILD_WITH_LIB "ROCM" CACHE STRING "Build ${PROJECT_NAME} with ROCM or CUDA libraries" )
 
 set( THREADS_PREFER_PTHREAD_FLAG ON )
 find_package( Threads REQUIRED )
@@ -84,7 +97,7 @@ if( NOT BUILD_WITH_LIB STREQUAL "CUDA" )
   if( WIN32 )
     find_package( HIP CONFIG REQUIRED )
   else()
-    find_package( HIP MODULE REQUIRED )
+    find_package( hip REQUIRED CONFIG PATHS /opt/rocm/lib/cmake/hip/ )
   endif()
 endif()
 
@@ -98,6 +111,14 @@ endif()
 string( CONCAT TESTS_OUT_DIR "${PROJECT_BINARY_DIR}" ${TESTS_OUT_DIR} )
 
 option( BUILD_CLIENTS_TESTS_OPENMP "Build tests with OpenMP" ON )
+if( BUILD_CLIENTS_TESTS_OPENMP AND NOT BUILD_WITH_LIB STREQUAL "CUDA" )
+  # Attempt to find a config version, which provides openmp_LIB_DIR.
+  find_package( OpenMP CONFIG PATHS "${HIP_CLANG_ROOT}/lib/cmake" )
+  if( NOT OPENMP_FOUND OR NOT DEFINED ${openmp_LIB_DIR} )
+     # Fall-back to module mode.
+     find_package( OpenMP REQUIRED )
+  endif()
+endif()
 
 foreach( target ${TEST_TARGETS} )
   set_target_properties( ${target} PROPERTIES
@@ -140,30 +161,14 @@ foreach( target ${TEST_TARGETS} )
     target_compile_definitions( ${target} PUBLIC _CUFFT_BACKEND )
   endif()
 
-  if( BUILD_CLIENTS_TESTS_OPENMP )
-    if( BUILD_WITH_LIB STREQUAL "CUDA" )
-      message( STATUS "OpenMP is not supported on CUDA, building tests without it" )
-    else()
-      target_compile_options( ${target} PRIVATE -DBUILD_CLIENTS_TESTS_OPENMP )
-      if(NOT (CMAKE_CXX_COMPILER MATCHES ".*hipcc$" OR CMAKE_CXX_COMPILER MATCHES ".*clang\\+\\+"))
-        target_compile_options( ${target} PRIVATE -fopenmp )
-        target_link_libraries( ${target} PRIVATE -fopenmp -L${HIP_CLANG_ROOT}/lib -Wl,-rpath=${HIP_CLANG_ROOT}/lib )
-        target_include_directories( ${target} PRIVATE ${HIP_CLANG_ROOT}/include )
-      else()
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-          target_compile_options( ${target} PRIVATE -fopenmp=libomp )
-          target_link_options( ${target} PRIVATE -fopenmp=libomp )
-        endif()
-      endif()
-    endif()
-  endif()
-
   target_include_directories( ${target}
     PRIVATE
     $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${FFTW_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${hip_INCLUDE_DIRS}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
+    if( HIPFFT_BUILD_SCOPE )
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
+    endif()
   )
 
   target_link_libraries( ${target}
@@ -171,6 +176,18 @@ foreach( target ${TEST_TARGETS} )
     hip::hipfft
     ${FFTW_LIBRARIES}
   )
+  
+  if( BUILD_CLIENTS_TESTS_OPENMP )
+    if( BUILD_WITH_LIB STREQUAL "CUDA" )
+      message( STATUS "OpenMP is not supported on CUDA, building tests without it" )
+    else()
+      if( DEFINED ${openmp_LIB_DIR} )
+        set_target_properties( ${target} PROPERTIES BUILD_RPATH "${HIP_CLANG_ROOT}/${openmp_LIB_DIR}" )
+        set_target_properties( ${target} PROPERTIES INSTALL_RPATH "${HIP_CLANG_ROOT}/${openmp_LIB_DIR}" )
+      endif()
+      target_link_libraries( ${target} PRIVATE OpenMP::OpenMP_CXX )
+    endif()
+  endif()
 
   if( HIPFFT_MPI_ENABLE )
     target_link_libraries( ${target}
@@ -186,6 +203,8 @@ foreach( target ${TEST_TARGETS} )
 
   rocm_install(TARGETS ${target} COMPONENT tests)
 endforeach()
+
+find_package( GTest 1.11.0 )
 
 if( GTEST_FOUND )
   target_include_directories( hipfft-test PRIVATE $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}> )

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -181,9 +181,6 @@ foreach( target ${TEST_TARGETS} )
     $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${FFTW_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${hip_INCLUDE_DIRS}>
-    if( HIPFFT_BUILD_SCOPE )
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
-    endif()
   )
 
   target_link_libraries( ${target}

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -599,7 +599,10 @@ public:
             }
         }
 
-        assert(selected_grid[0] * selected_grid[1] * selected_grid[2] == mp_ranks);
+        if(selected_grid[0] * selected_grid[1] * selected_grid[2] != mp_ranks)
+        {
+            throw std::runtime_error("Grid dimensions do not multiply to mp_ranks.");
+        }
 
         fft_grid = {selected_grid[0], selected_grid[1], selected_grid[2]};
     }
@@ -638,7 +641,10 @@ public:
             }
         }
 
-        assert(selected_grid[0] * selected_grid[1] == mp_ranks);
+        if(selected_grid[0] * selected_grid[1] == mp_ranks)
+        {
+            throw std::runtime_error("Grid dimensions do not multiply to mp_ranks.");
+        }
 
         fft_grid = {selected_grid[0], selected_grid[1]};
     }

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -186,8 +186,19 @@ set( rocfft-test_include_dirs
   )
 
 set( rocfft-test_link_libs
-  ${FFTW_LIBRARIES} OpenMP::OpenMP_CXX
+  ${FFTW_LIBRARIES}
   )
+
+option( BUILD_CLIENTS_TESTS_OPENMP "Build tests with OpenMP" ON )
+if( BUILD_CLIENTS_TESTS_OPENMP )
+  # Attempt to find a config version, which provides openmp_LIB_DIR.
+  #find_package( OpenMP CONFIG PATHS "${HIP_CLANG_ROOT}/lib/cmake" )
+  if( NOT OPENMP_FOUND OR NOT DEFINED ${openmp_LIB_DIR} )
+     # Fall-back to module mode.
+     find_package( OpenMP REQUIRED )
+  endif()
+    list( APPEND rocfft-test_link_libs OpenMP::OpenMP_CXX )	
+endif()
 
 include( ../cmake/build-gtest.cmake )
 
@@ -262,27 +273,15 @@ if( USE_CUDA )
     )
   target_compile_definitions( rocfft-test PRIVATE __HIP_PLATFORM_NVCC__ )
 endif( )
-target_link_libraries( rocfft-test PRIVATE ${ROCFFT_CLIENTS_HOST_LINK_LIBS} ${ROCFFT_CLIENTS_DEVICE_LINK_LIBS} )
+target_link_libraries( rocfft-test PRIVATE
+   ${ROCFFT_CLIENTS_HOST_LINK_LIBS}
+   ${ROCFFT_CLIENTS_DEVICE_LINK_LIBS} )
 
 include( ../../cmake/sqlite.cmake )
 target_link_libraries( rocfft-test PUBLIC ${ROCFFT_SQLITE_LIB} )
 target_include_directories( rocfft-test PRIVATE ${sqlite_local_SOURCE_DIR} )
 
 set_property( TARGET rocfft-test APPEND PROPERTY LINK_LIBRARIES ${ROCFFT_SQLITE_LIB} )
-
-option( BUILD_CLIENTS_TESTS_OPENMP "Build tests with OpenMP" ON )
-
-if( BUILD_CLIENTS_TESTS_OPENMP )
-  find_package(OpenMP REQUIRED)
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-    target_link_libraries( rocfft-test PRIVATE OpenMP::OpenMP_CXX -L${HIP_CLANG_ROOT}/lib -Wl,-rpath=${HIP_CLANG_ROOT}/lib )
-    target_include_directories( rocfft-test PRIVATE ${HIP_CLANG_ROOT}/include )
-  else()
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      target_link_libraries( rocfft-test PRIVATE OpenMP::OpenMP_CXX )
-    endif()
-  endif()
-endif()
 
 if(FFTW_MULTITHREAD)
   target_compile_options( rocfft-test PRIVATE -DFFTW_MULTITHREAD )
@@ -390,7 +389,7 @@ if( ROCFFT_MPI_ENABLE )
 
 endif()
 
-set(COVERAGE_TEST_OPTIONS "--smoketest" CACHE STRING "Command line arguments for rocfft-test when generating a code coverage report")
+set(COVERAGE_TEST_OPTIONS "--smoketest;--gtest_filter=-*call*" CACHE STRING "Command line arguments for rocfft-test when generating a code coverage report")
 
 if(BUILD_CODE_COVERAGE)
   # Coverage won't work in a standalone build of the tests, as we can't

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -196,9 +196,23 @@ if( BUILD_CLIENTS_TESTS_OPENMP )
   if( NOT OPENMP_FOUND OR NOT DEFINED ${openmp_LIB_DIR} )
      # Fall-back to module mode.
      find_package( OpenMP REQUIRED )
+     set( BUILD_RPATH "${HIP_CLANG_ROOT}/lib" )
+     set( INSTALL_RPATH "$ORIGIN/../llvm/lib" )
+  else()
+     set( BUILD_RPATH "${HIP_CLANG_ROOT}/${openmp_LIB_DIR}" )
+     set( INSTALL_RPATH "$ORIGIN/../llvm/${openmp_LIB_DIR}" )
   endif()
-    list( APPEND rocfft-test_link_libs OpenMP::OpenMP_CXX )	
+  list( APPEND rocfft-test_link_libs OpenMP::OpenMP_CXX )	
+
+  set_target_properties( rocfft-test PROPERTIES
+     BUILD_RPATH "{$BUILD_RPATH}"
+  )
+  set_target_properties( rocfft-test PROPERTIES
+    INSTALL_RPATH "${INSTALL_RPATH}"
+  )
 endif()
+
+
 
 include( ../cmake/build-gtest.cmake )
 
@@ -334,7 +348,16 @@ if( ROCFFT_MPI_ENABLE )
   # normal and dynamic-loading MPI worker processes
   foreach(worker rocfft_mpi_worker dyna_rocfft_mpi_worker)
     add_executable( ${worker} rocfft_mpi_worker.cpp )
-    if( BUILD_FFTW )
+
+    if( BUILD_CLIENTS_TESTS_OPENMP )
+      set_target_properties( ${worker} PROPERTIES
+         BUILD_RPATH "${BUILD_RPATH}"
+      )
+      set_target_properties( ${worker} PROPERTIES
+        INSTALL_RPATH "${INSTALL_RPATH}"
+      )
+    endif()
+    if( BUILD_FFTW  OR NOT FFTW_FOUND )
       add_dependencies( ${worker} fftw_double fftw_single )
     endif()
     target_include_directories( ${worker}

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -614,7 +614,10 @@ public:
             }
         }
 
-        assert(selected_grid[0] * selected_grid[1] * selected_grid[2] == mp_ranks);
+        if(selected_grid[0] * selected_grid[1] * selected_grid[2] != mp_ranks)
+        {
+            throw std::runtime_error("Grid dimensions do not multiply to mp_ranks.");
+        }
 
         fft_grid = {selected_grid[0], selected_grid[1], selected_grid[2]};
     }
@@ -653,7 +656,10 @@ public:
             }
         }
 
-        assert(selected_grid[0] * selected_grid[1] == mp_ranks);
+        if(selected_grid[0] * selected_grid[1] != mp_ranks)
+        {
+            throw std::runtime_error("Grid dimensions do not multiply to mp_ranks.");
+        }
 
         fft_grid = {selected_grid[0], selected_grid[1]};
     }


### PR DESCRIPTION
## Motivation

Cherry-pick ~~#995~~ #1004 and #1164 to 7.0, to fix RHEL10/OL10.

## Technical Details

Test executables have absolute rpaths, which are not allowed in RHEL10 and OL10.

## Test Plan

Regular regression tests are now runnable via packages on these OSes.
