### PR TITLE
[hipblaslt] Reduce build warnings

### DIFF
--- a/projects/hipblaslt/clients/bench/src/client_extop_matrixtransform.cpp
+++ b/projects/hipblaslt/clients/bench/src/client_extop_matrixtransform.cpp
@@ -52,18 +52,18 @@ struct TypedMatrixTransformIO : public MatrixTransformIO
 {
     TypedMatrixTransformIO(int64_t m, int64_t n, int64_t b, hipblaslt_initialization initMethod)
     {
-        hipMalloc(&this->a, m * n * b * sizeof(DType));
-        hipMalloc(&this->b, m * n * b * sizeof(DType));
-        hipMalloc(&this->c, m * n * b * sizeof(DType));
+        auto        hipErr = hipMalloc(&this->a, m * n * b * sizeof(DType));
+        hipErr = hipMalloc(&this->b, m * n * b * sizeof(DType));
+        hipErr = hipMalloc(&this->c, m * n * b * sizeof(DType));
         init(this->a, m * n * b, initMethod);
         init(this->b, m * n * b, initMethod);
     }
 
     ~TypedMatrixTransformIO() override
     {
-        hipFree(a);
-        hipFree(b);
-        hipFree(c);
+        auto        hipErr = hipFree(a);
+        hipErr = hipFree(b);
+        hipErr = hipFree(c);
     }
 
     void* getBuf(size_t i) override
@@ -103,7 +103,7 @@ private:
             break;
         }
 
-        hipMemcpy(buf, ref.data(), len * sizeof(DType), hipMemcpyHostToDevice);
+        auto err = hipMemcpy(buf, ref.data(), len * sizeof(DType), hipMemcpyHostToDevice);
     }
 
 private:
@@ -366,9 +366,9 @@ void validation(void*    c,
     std::vector<DType> dA(m * n * batchSize);
     std::vector<DType> dB(m * n * batchSize);
     std::vector<DType> dC(m * n * batchSize);
-    hipMemcpyDtoH(dA.data(), a, m * n * batchSize * sizeof(DType));
-    hipMemcpyDtoH(dB.data(), b, m * n * batchSize * sizeof(DType));
-    hipMemcpyDtoH(dC.data(), c, m * n * batchSize * sizeof(DType));
+    auto        hipErr = hipMemcpyDtoH(dA.data(), a, m * n * batchSize * sizeof(DType));
+    hipErr = hipMemcpyDtoH(dB.data(), b, m * n * batchSize * sizeof(DType));
+    hipErr = hipMemcpyDtoH(dC.data(), c, m * n * batchSize * sizeof(DType));
 
     std::transform(begin(dC), end(dC), begin(hC), [](auto i) { return float(i); });
 

--- a/projects/hipblaslt/clients/bench/src/client_extop_softmax.cpp
+++ b/projects/hipblaslt/clients/bench/src/client_extop_softmax.cpp
@@ -149,9 +149,9 @@ int main(int argc, char** argv)
     if(hipblasltErr)
     {
         std::cerr << "Invalid shape (" << m << ", " << n << "), currently support n <= 256\n";
-        hipFree(input);
-        hipFree(output);
-        hipStreamDestroy(stream);
+        hipErr = hipFree(input);
+        hipErr = hipFree(output);
+        hipErr = hipStreamDestroy(stream);
         return EXIT_FAILURE;
     }
 

--- a/projects/hipblaslt/clients/bench/src/client_sequence.cpp
+++ b/projects/hipblaslt/clients/bench/src/client_sequence.cpp
@@ -579,7 +579,7 @@ int main(int argc, char** argv)
         CHECK_HIP_ERROR(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
         CHECK_HIP_ERROR(hipEventSynchronize(event_gpu_time_start));
         CHECK_HIP_ERROR(hipEventRecord(event_gpu_time_start, stream));
-        hipGraphLaunch(graph_exec, stream);
+        CHECK_HIP_ERROR(hipGraphLaunch(graph_exec, stream));
         CHECK_HIP_ERROR(hipEventRecord(event_gpu_time_end, stream));
         CHECK_HIP_ERROR(hipEventSynchronize(event_gpu_time_end));
         CHECK_HIP_ERROR(hipGraphExecDestroy(graph_exec));

--- a/projects/hipblaslt/clients/common/include/near.hpp
+++ b/projects/hipblaslt/clients/common/include/near.hpp
@@ -45,20 +45,20 @@ template <class Tc, class Ti, class To>
 static constexpr double sum_error_tolerance_for_gfx11 = std::numeric_limits<Tc>::epsilon();
 
 template <>
-static constexpr double sum_error_tolerance_for_gfx11<float, hip_bfloat16, float> = 1 / 10.0;
+constexpr double sum_error_tolerance_for_gfx11<float, hip_bfloat16, float> = 1 / 10.0;
 
 template <>
-static constexpr double sum_error_tolerance_for_gfx11<float, hip_bfloat16, hip_bfloat16> = 1 / 10.0;
+constexpr double sum_error_tolerance_for_gfx11<float, hip_bfloat16, hip_bfloat16> = 1 / 10.0;
 
 template <>
-static constexpr double sum_error_tolerance_for_gfx11<float, hipblasLtHalf, float> = 1 / 100.0;
+constexpr double sum_error_tolerance_for_gfx11<float, hipblasLtHalf, float> = 1 / 100.0;
 
 template <>
-static constexpr double
+constexpr double
     sum_error_tolerance_for_gfx11<float, hipblasLtHalf, hipblasLtHalf> = 1 / 100.0;
 
 template <>
-static constexpr double
+constexpr double
     sum_error_tolerance_for_gfx11<hipblasLtHalf, hipblasLtHalf, hipblasLtHalf> = 1 / 100.0;
 
 double sum_error_tolerance_for_gfx11_type(hipDataType Tc, hipDataType Ti, hipDataType To)

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -43,7 +43,9 @@
 #include "norm.hpp"
 #include "unit.hpp"
 #include "utility.hpp"
+#include <algorithm>
 #include <cstddef>
+#include <cstdlib>
 #include <functional>
 #include <hipblaslt/hipblaslt-ext-op.h>
 #include <hipblaslt/hipblaslt-ext.hpp>
@@ -169,7 +171,7 @@ void swizzle_tensor(T*               dst,
         auto orgTensor = Tensor::create<T>({b, k, m});
         for(size_t i = 0; i < b * k; i++)
         {
-            memcpy(orgTensor.template as<T>() + (i * m), src + (i * ld), m * sizeof(T));
+            std::copy(src + (i * ld), src + (i * ld) + m, orgTensor.template as<T>() + (i * m));
         }
         tmpTensor = permute(orgTensor, {0, 2, 1});
     }
@@ -177,7 +179,7 @@ void swizzle_tensor(T*               dst,
     {
         for(size_t i = 0; i < b * m; i++)
         {
-            memcpy(tmpTensor.template as<T>() + (i * k), src + (i * ld), k * sizeof(T));
+            std::copy(src + (i * ld), src + (i * ld) + k, tmpTensor.template as<T>() + (i * k));
         }
     }
 
@@ -190,7 +192,7 @@ void swizzle_tensor(T*               dst,
     paddedTensor.reshape(
         {b, paddedM / MiM, MiM, paddedK / (MiK * PackK), MiK / MiKv, MiKv * PackK});
     Tensor permuted = permute(paddedTensor, {0, 1, 3, 4, 2, 5});
-    memcpy(dst, permuted.template as<void>(), b * paddedM * paddedK * sizeof(T));
+    std::copy(permuted.template as<T>(), permuted.template as<T>() + (b * paddedM * paddedK), dst);
 }
 
 void swizzle_tensor_type(HipHostBuffer&       dst,
@@ -430,9 +432,9 @@ void epilogue_func(int64_t     m,
             for(int j = 0; j < n; j++)
             {
                 CALCULATE_EPILOGUE_ACT;
-                *amaxD = *amaxD > fabs(static_cast<Tc>(in_Tact_act))
+                *amaxD = *amaxD > std::abs(static_cast<Tc>(in_Tact_act))
                              ? *amaxD
-                             : fabs(static_cast<Tc>(in_Tact_act));
+                             : std::abs(static_cast<Tc>(in_Tact_act));
                 saturate_cast_to_type(out, in_Tact_act * scaleD, To, pos);
                 *(out_raw + pos) = static_cast<Tc>(in_Tact_act * scaleD);
             }
@@ -580,7 +582,7 @@ void epilogue_func(int64_t     m,
             {
                 CALCULATE_EPILOGUE_BASIC;
                 *amaxD
-                    = *amaxD > fabs(static_cast<Tc>(temp)) ? *amaxD : fabs(static_cast<Tc>(temp));
+                    = *amaxD > std::abs(static_cast<Tc>(temp)) ? *amaxD : std::abs(static_cast<Tc>(temp));
                 temp *= scaleD;
                 saturate_cast_to_type(out, temp, To, pos);
                 *(out_raw + pos) = static_cast<Tc>(temp);

--- a/projects/hipblaslt/clients/samples/15_hipblaslt_gemm_with_scale_a_b_vector/sample_hipblaslt_gemm_swizzleA_with_scale_a_b_vector.cpp
+++ b/projects/hipblaslt/clients/samples/15_hipblaslt_gemm_with_scale_a_b_vector/sample_hipblaslt_gemm_swizzleA_with_scale_a_b_vector.cpp
@@ -144,16 +144,16 @@ int main()
 
     swizzleRunner.run([&swizzleRunner, &runner, m, n, k, scale_a_vec, scale_b_vec] {
         // copy inputs from first runner for comparison and validation
-        hipMemcpy(swizzleRunner.d_a,
+        CHECK_HIP_ERROR(hipMemcpy(swizzleRunner.d_a,
                   runner.d_a,
                   m * k * sizeof(hipblaslt_f8_fnuz),
-                  hipMemcpyDeviceToDevice);
-        hipMemcpy(swizzleRunner.d_b,
+                  hipMemcpyDeviceToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(swizzleRunner.d_b,
                   runner.d_b,
                   n * k * sizeof(hipblaslt_f8_fnuz),
-                  hipMemcpyDeviceToDevice);
-        hipMemcpy(
-            swizzleRunner.d_c, runner.d_c, m * n * sizeof(hip_bfloat16), hipMemcpyDeviceToDevice);
+                  hipMemcpyDeviceToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(
+            swizzleRunner.d_c, runner.d_c, m * n * sizeof(hip_bfloat16), hipMemcpyDeviceToDevice));
 
         simpleGemm(swizzleRunner.handle,
                    HIPBLAS_OP_T,
@@ -244,9 +244,9 @@ void simpleGemm(hipblasLtHandle_t  handle,
         std::vector<hipblaslt_f8_fnuz> dst(m * k, 0);
 
         // pre-shuffle input data in host memory
-        hipMemcpy(src.data(), d_a, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyDeviceToHost);
+        CHECK_HIP_ERROR(hipMemcpy(src.data(), d_a, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyDeviceToHost));
         swizzleTensor(dst.data(), src.data(), m, k, false);
-        hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyHostToDevice);
+        CHECK_HIP_ERROR(hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyHostToDevice));
     }
 
     hipblasLtMatmulDesc_t matmul;

--- a/projects/hipblaslt/clients/samples/15_hipblaslt_gemm_with_scale_a_b_vector/sample_hipblaslt_gemm_swizzleA_with_scale_a_b_vector.cpp
+++ b/projects/hipblaslt/clients/samples/15_hipblaslt_gemm_with_scale_a_b_vector/sample_hipblaslt_gemm_swizzleA_with_scale_a_b_vector.cpp
@@ -24,6 +24,7 @@
  *
  *******************************************************************************/
 
+#include <algorithm>
 #include <hip/hip_runtime.h>
 #include <hipblaslt/hipblaslt.h>
 #include <iostream>
@@ -65,18 +66,18 @@ void swizzleTensor(T* dst, const T* src, size_t m, size_t k, bool colMaj)
     size_t MiK = 0, MiKv = 0, PackK = 0;
     calculateKforSwizzling(hipblaslt_type2datatype<T>(), MiK, MiKv, PackK);
     auto tmpTensor = Tensor::create<T>({m, k});
-    memcpy(tmpTensor.template as<void>(), src, m * k * sizeof(T));
+    std::copy(src, src + (m * k), tmpTensor.template as<T>());
 
     if(colMaj)
     {
         auto orgTensor = Tensor::create<T>({k, m});
-        memcpy(orgTensor.template as<void>(), src, m * k * sizeof(T));
+        std::copy(src, src + (m * k), orgTensor.template as<T>());
         tmpTensor = permute(orgTensor, {1, 0});
     }
 
     tmpTensor.reshape({m / MiM, MiM, k / (MiK * PackK), MiK / MiKv, MiKv * PackK});
     Tensor permuted = permute(tmpTensor, {0, 2, 3, 1, 4});
-    memcpy(dst, permuted.template as<void>(), m * k * sizeof(T));
+    std::copy(permuted.template as<T>(), permuted.template as<T>() + (m * k), dst);
 }
 
 void simpleGemm(hipblasLtHandle_t  handle,

--- a/projects/hipblaslt/clients/samples/19_hipblaslt_gemm_mix_precision_ext/sample_hipblaslt_gemm_mix_precision_ext.cpp
+++ b/projects/hipblaslt/clients/samples/19_hipblaslt_gemm_mix_precision_ext/sample_hipblaslt_gemm_mix_precision_ext.cpp
@@ -81,8 +81,8 @@ int validate(const Runner<TypeA, TypeB, TypeCD, AlphaType, BetaType>& runner)
     }
 
     std::vector<TypeCD> gpuResult(runner.m * runner.n * runner.batch_count);
-    hipMemcpyDtoH(
-        gpuResult.data(), runner.d_d, runner.batch_count * runner.m * runner.n * sizeof(TypeCD));
+    CHECK_HIP_ERROR(hipMemcpyDtoH(
+        gpuResult.data(), runner.d_d, runner.batch_count * runner.m * runner.n * sizeof(TypeCD)));
 
     for(int64_t b = 0; b < runner.batch_count; ++b)
     {

--- a/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_bias_swizzle_a_ext/sample_hipblaslt_gemm_bias_swizzle_a_ext.cpp
+++ b/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_bias_swizzle_a_ext/sample_hipblaslt_gemm_bias_swizzle_a_ext.cpp
@@ -170,9 +170,9 @@ void swizzleGemmEpilogueBiasVecExt(hipblasLtHandle_t  handle,
                 matA, HIPBLASLT_MATRIX_LAYOUT_ORDER, &orderA, sizeof(orderA)));
             std::vector<hipblasLtHalf> src(m * k, 0);
             std::vector<hipblasLtHalf> dst(m * k, 0);
-            hipMemcpy(src.data(), d_a, m * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToHost);
+            CHECK_HIP_ERROR(hipMemcpy(src.data(), d_a, m * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToHost));
             swizzleTensor(dst.data(), src.data(), m, k, true);
-            hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblasLtHalf), hipMemcpyHostToDevice);
+            CHECK_HIP_ERROR(hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblasLtHalf), hipMemcpyHostToDevice));
         }
     }
     else

--- a/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a.cpp
+++ b/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a.cpp
@@ -27,6 +27,7 @@
 #include <hip/hip_runtime.h>
 #include <hipblaslt/hipblaslt.h>
 #include <iostream>
+#include <algorithm>
 
 #include "TensorDataManipulation.hpp"
 #include "datatype_interface.hpp"
@@ -65,18 +66,18 @@ void swizzleTensor(T* dst, const T* src, size_t m, size_t k, bool colMaj)
     size_t MiK = 0, MiKv = 0, PackK = 0;
     calculateKforSwizzling(hipblaslt_type2datatype<T>(), MiK, MiKv, PackK);
     auto tmpTensor = Tensor::create<T>({m, k});
-    memcpy(tmpTensor.template as<void>(), src, m * k * sizeof(T));
+    std::copy(src, src + m * k, static_cast<T*>(tmpTensor.template as<void>()));
 
     if(colMaj)
     {
         auto orgTensor = Tensor::create<T>({k, m});
-        memcpy(orgTensor.template as<void>(), src, m * k * sizeof(T));
+        std::copy(src, src + m * k, static_cast<T*>(orgTensor.template as<void>()));
         tmpTensor = permute(orgTensor, {1, 0});
     }
 
     tmpTensor.reshape({m / MiM, MiM, k / (MiK * PackK), MiK / MiKv, MiKv * PackK});
     Tensor permuted = permute(tmpTensor, {0, 2, 3, 1, 4});
-    memcpy(dst, permuted.template as<void>(), m * k * sizeof(T));
+    std::copy(static_cast<const T*>(permuted.template as<void>()), static_cast<const T*>(permuted.template as<void>()) + m * k, dst);
 }
 
 void simpleGemm(hipblasLtHandle_t  handle,

--- a/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a.cpp
+++ b/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a.cpp
@@ -132,12 +132,12 @@ int main()
 
     swizzleRunner.run([&swizzleRunner, &runner, m, n, k] {
         // copy inputs from first runner for comparison and validation
-        hipMemcpy(
-            swizzleRunner.d_a, runner.d_a, m * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToDevice);
-        hipMemcpy(
-            swizzleRunner.d_b, runner.d_b, n * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToDevice);
-        hipMemcpy(
-            swizzleRunner.d_c, runner.d_c, m * n * sizeof(hipblasLtHalf), hipMemcpyDeviceToDevice);
+        CHECK_HIP_ERROR(hipMemcpy(
+            swizzleRunner.d_a, runner.d_a, m * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(
+            swizzleRunner.d_b, runner.d_b, n * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(
+            swizzleRunner.d_c, runner.d_c, m * n * sizeof(hipblasLtHalf), hipMemcpyDeviceToDevice));
         /** This is an example with swizzle-A
          *  a = (k, m). lda = k
          *  b = (k, n). ldb = k
@@ -174,14 +174,14 @@ int main()
         std::vector<hipblaslt_f8_fnuz> cpuAF8(m * k, hipblaslt_f8_fnuz(0.f));
         std::vector<hipblaslt_f8_fnuz> cpuBF8(k * n, hipblaslt_f8_fnuz(0.f));
 
-        hipMemcpy(cpuAF16.data(),
+        CHECK_HIP_ERROR(hipMemcpy(cpuAF16.data(),
                   runner.d_a,
                   cpuAF16.size() * sizeof(hipblasLtHalf),
-                  hipMemcpyDeviceToHost);
-        hipMemcpy(cpuBF16.data(),
+                  hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(cpuBF16.data(),
                   runner.d_b,
                   cpuBF16.size() * sizeof(hipblasLtHalf),
-                  hipMemcpyDeviceToHost);
+                  hipMemcpyDeviceToHost));
 
         for(size_t i = 0; i < cpuAF16.size(); ++i)
         {
@@ -194,18 +194,18 @@ int main()
         }
 
         // copy inputs from first runner for comparison and validation
-        hipMemcpy(swizzleRunner_F8.d_a,
+        CHECK_HIP_ERROR(hipMemcpy(swizzleRunner_F8.d_a,
                   cpuAF8.data(),
                   m * k * sizeof(hipblaslt_f8_fnuz),
-                  hipMemcpyHostToDevice);
-        hipMemcpy(swizzleRunner_F8.d_b,
+                  hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(swizzleRunner_F8.d_b,
                   cpuBF8.data(),
                   n * k * sizeof(hipblaslt_f8_fnuz),
-                  hipMemcpyHostToDevice);
-        hipMemcpy(swizzleRunner_F8.d_c,
+                  hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(swizzleRunner_F8.d_c,
                   runner.d_c,
                   m * n * sizeof(hipblasLtHalf),
-                  hipMemcpyDeviceToDevice);
+                  hipMemcpyDeviceToDevice));
         /** This is an example with swizzle-A
          *  a = (k, m). lda = k
          *  b = (k, n). ldb = k
@@ -296,9 +296,9 @@ void simpleGemm(hipblasLtHandle_t  handle,
                 matA, HIPBLASLT_MATRIX_LAYOUT_ORDER, &orderA, sizeof(orderA)));
             std::vector<hipblasLtHalf> src(m * k, 0);
             std::vector<hipblasLtHalf> dst(m * k, 0);
-            hipMemcpy(src.data(), d_a, m * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToHost);
+            CHECK_HIP_ERROR(hipMemcpy(src.data(), d_a, m * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToHost));
             swizzleTensor(dst.data(), src.data(), m, k, true);
-            hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblasLtHalf), hipMemcpyHostToDevice);
+            CHECK_HIP_ERROR(hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblasLtHalf), hipMemcpyHostToDevice));
         }
         else if(swizzleA && TiAB == HIP_R_8F_E4M3_FNUZ)
         {
@@ -311,9 +311,9 @@ void simpleGemm(hipblasLtHandle_t  handle,
                 hipMalloc(&src, m * k * sizeof(hipblaslt_f8_fnuz))); // Allocate memory on device
             CHECK_HIP_ERROR(
                 hipMalloc(&dst, m * k * sizeof(hipblaslt_f8_fnuz))); // Allocate memory on device
-            hipMemcpy(src, d_a, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyDeviceToHost);
+            CHECK_HIP_ERROR(hipMemcpy(src, d_a, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyDeviceToHost));
             swizzleTensor(dst, src, m, k, true);
-            hipMemcpy(d_a, dst, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyHostToDevice);
+            CHECK_HIP_ERROR(hipMemcpy(d_a, dst, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyHostToDevice));
         }
     }
     else
@@ -424,9 +424,9 @@ void simpleGemm(hipblasLtHandle_t  handle,
         }
 
         hipEvent_t start, stop;
-        hipEventCreate(&start);
-        hipEventCreate(&stop);
-        hipEventRecord(start, stream);
+        CHECK_HIP_ERROR(hipEventCreate(&start));
+        CHECK_HIP_ERROR(hipEventCreate(&stop));
+        CHECK_HIP_ERROR(hipEventRecord(start, stream));
 
         for(int i = 0; i < numRuns; ++i)
         {


### PR DESCRIPTION
## Motivation

There are approx 1760 lines being added by client side warnings in the build log. This PR will eliminate those by using safer code

## Technical Details

### 1. Replace `memcpy` with `std::copy` for Non-Trivially Copyable Types

**Warning Fixed:** `warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'hipblaslt_f8_fnuz'`

**Solution:** Replaced `memcpy` calls with type-safe `std::copy` calls. The issue occurred because `memcpy` performs byte-wise copying and should not be used with non-trivially copyable types like `hipblaslt_f8_fnuz`. The `std::copy` function respects the copy semantics of the type and works correctly for both trivially and non-trivially copyable types.

**Changes:**
- Added `#include <algorithm>` 
- Replaced `memcpy(dst, src, count * sizeof(T))` with `std::copy(src, src + count, dst)`
- Updated void pointer casts to use appropriate `static_cast<T*>` and `static_cast<const T*>`

### 2. Replace `fabs` with `std::abs` for Integer Compute Types

**Warning Fixed:** `warning: using floating point absolute value function fabs when argument is of integer type [-Wabsolute-value]`

**Solution:** Replaced `fabs` calls with `std::abs`. The issue occurred because `fabs` is specifically designed for floating-point types, but when the compute type `Tc` is an integer type (like `int32_t` for `HIP_R_32I`), `fabs` is inappropriate. The `std::abs` function is overloaded for different numeric types and correctly handles both floating-point and integer types.

**Changes:**
- Replaced `fabs(static_cast<Tc>(value))` with `std::abs(static_cast<Tc>(value))` 
- Ensured type-safe absolute value computation regardless of whether `Tc` is floating-point or integer

### 3. Remove static from Explicit Specialization to Comply with C++17

**Warning Fixed:**
`warning: explicit specialization cannot have a storage class [-Wexplicit-specialization-storage-class]
static constexpr double sum_error_tolerance_for_gfx11<float, hip_bfloat16, float> = 1 / 10.0;`

**Solution:** Removed static from the explicit specialization. In C++17, explicit specializations are not allowed to use storage-class specifiers like static. Keeping it triggers the compiler warning. It is not needed here because constexpr variables at namespace scope are const and, by default, have internal linkage unless declared extern or inline. Removing static therefore preserves the intended linkage while complying with the language rules.

### 4. Handle [[nodiscard]] HIP Return Values (Don’t Ignore Status Codes)

**Warning Fixed:**
`warning: ignoring return value of function declared with 'nodiscard' attribute`

**Solution:** Stopped discarding the return status of HIP API calls  that are annotated [[nodiscard]]. Each call now records or checks the returned hipError_t (or library-specific status) following the project’s existing patterns:

These fixes improve type safety and eliminate compiler warnings while maintaining identical functionality.

## Test Plan

Plan to use CI to test changes 

## Test Result


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
