### PR TITLE
SPIR-V using tuned configs

### DIFF
--- a/projects/hipcub/.gitignore
+++ b/projects/hipcub/.gitignore
@@ -1,6 +1,6 @@
 
 ### Build dirs ###
-build/
+build*/
 
 # Created by https://www.gitignore.io/api/c++,cmake
 

--- a/projects/hipcub/CMakeLists.txt
+++ b/projects/hipcub/CMakeLists.txt
@@ -116,6 +116,13 @@ else()
   endif()
 endif()
 
+# Compressed offload binaries are currently not working with the SPIR-V target
+if("amdgcnspirv" IN_LIST GPU_TARGETS)
+  if(BUILD_OFFLOAD_COMPRESS)
+    message(FATAL_ERROR "Cannot combine SPIR-V and BUILD_OFFLOAD_COMPRESS")
+  endif()
+endif()
+
 # Find and verify HIP.
 include(VerifyCompiler)
 

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_for.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_for.hpp
@@ -348,10 +348,10 @@ HIPCUB_RUNTIME_FUNCTION
         using wrapped_op_type
             = detail::for_each_in_extents::OpWrapper<OpT, IndexType, ext_index_type, Extents...>;
 
-        // CountingInputIterator only holds the index, not the data.
-        using InputIterator = typename hipcub::CountingInputIterator<IndexType>;
-        // We don't actually need the output, so we use DiscardOutputIterator here as a placeholder.
-        using OutputIterator = typename hipcub::DiscardOutputIterator<IndexType>;
+        // rocprim::counting_iterator only holds the index, not the data.
+        using InputIterator = typename rocprim::counting_iterator<IndexType>;
+        // We don't actually need the output, so we use rocprim::discard_iterator here as a placeholder.
+        using OutputIterator = typename rocprim::discard_iterator;
 
         // How many times rocprim::transform will iterate.
         constexpr auto ext_size = ::hipcub::extents_size<ext_type>::value;
@@ -362,8 +362,8 @@ HIPCUB_RUNTIME_FUNCTION
         // `ForEachInExtents` only iterates over the extents on device and does not guarantee ordering.
         // We only need to invoke `$op` `$ext_size` times. Therefore, `rocprim::transform` is suitable.
         // In `ForEachInExtents`, the data isn’t necessarily needed, but even if it's needed, it may be embedded
-        // in `OpT`. We only need to iterate exactly `$ext_size` times. Therefore, we use a `CountingInputIterator`,
-        // which provides only the index, and a `DiscardOutputIterator` for output.
+        // in `OpT`. We only need to iterate exactly `$ext_size` times. Therefore, we use a `rocprim::counting_iterator`,
+        // which provides only the index, and a `rocprim::discard_iterator` for output.
         return rocprim::transform(input,
                                   output,
                                   ext_size,

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
@@ -103,7 +103,7 @@ inline hipError_t launch_segmented_arg_minmax(::rocprim::detail::target_arch arc
         }
     };
 
-    return ::rocprim::launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return ::rocprim::detail::launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 /// Dispatch function similar to \p rocprim::segmented_reduce but writes \p empty_value for empty
@@ -138,7 +138,7 @@ inline hipError_t segmented_arg_minmax(void*          temporary_storage,
         return result;
     }
     const ::rocprim::detail::reduce_config_params params
-        = ::rocprim::detail::dispatch_target_arch<config>(target_arch);
+        = ::rocprim::detail::dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int block_size = params.kernel_config.block_size;
 
@@ -159,18 +159,19 @@ inline hipError_t segmented_arg_minmax(void*          temporary_storage,
     {
         start = std::chrono::high_resolution_clock::now();
     }
-    ROCPRIM_RETURN_ON_ERROR(launch_segmented_arg_minmax(target_arch,
-                                                        input,
-                                                        output,
-                                                        begin_offsets,
-                                                        end_offsets,
-                                                        reduce_op,
-                                                        static_cast<result_type>(initial_value),
-                                                        static_cast<result_type>(empty_value),
-                                                        dim3(segments),
-                                                        dim3(block_size),
-                                                        0,
-                                                        stream));
+    ROCPRIM_RETURN_ON_ERROR(
+        launch_segmented_arg_minmax<config>(target_arch,
+                                            input,
+                                            output,
+                                            begin_offsets,
+                                            end_offsets,
+                                            reduce_op,
+                                            static_cast<result_type>(initial_value),
+                                            static_cast<result_type>(empty_value),
+                                            dim3(segments),
+                                            dim3(block_size),
+                                            0,
+                                            stream));
     HIPCUB_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_arg_minmax", segments, start);
 
     return hipSuccess;

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
@@ -103,7 +103,7 @@ inline hipError_t launch_segmented_arg_minmax(::rocprim::detail::target_arch arc
         }
     };
 
-    return ::rocprim::detail::launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return ::rocprim::detail::execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 /// Dispatch function similar to \p rocprim::segmented_reduce but writes \p empty_value for empty

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
@@ -56,46 +56,54 @@ template<class Config,
          class OffsetIterator,
          class ResultType,
          class BinaryFunction>
-ROCPRIM_KERNEL __launch_bounds__(::rocprim::detail::device_params<Config>()
-                                     .reduce_config.block_size)
-    void segmented_arg_minmax_kernel(InputIterator  input,
-                                     OutputIterator output,
-                                     OffsetIterator begin_offsets,
-                                     OffsetIterator end_offsets,
-                                     BinaryFunction reduce_op,
-                                     ResultType     initial_value,
-                                     ResultType     empty_value)
+inline hipError_t launch_segmented_arg_minmax(::rocprim::detail::target_arch arch,
+                                              InputIterator                  input,
+                                              OutputIterator                 output,
+                                              OffsetIterator                 begin_offsets,
+                                              OffsetIterator                 end_offsets,
+                                              BinaryFunction                 reduce_op,
+                                              ResultType                     initial_value,
+                                              ResultType                     empty_value,
+                                              dim3                           grid,
+                                              dim3                           block,
+                                              size_t                         shmem,
+                                              hipStream_t                    stream)
 {
-    // each block processes one segment
-    ::rocprim::detail::segmented_reduce<Config>(input,
-                                                output,
-                                                begin_offsets,
-                                                end_offsets,
-                                                reduce_op,
-                                                initial_value);
-    // no synchronization is needed since thread 0 writes to output
-
-    const unsigned int flat_id    = ::rocprim::detail::block_thread_id<0>();
-    const unsigned int segment_id = ::rocprim::detail::block_id<0>();
-
-    // Large indices need bigger offset type than unsigned int
-    using offset_type = typename std::iterator_traits<OffsetIterator>::value_type;
-
-    const offset_type begin_offset = begin_offsets[segment_id];
-    const offset_type end_offset   = end_offsets[segment_id];
-
-    // transform the segment output
-    if(flat_id == 0)
+    auto kernel = [=](auto arch_config)
     {
-        if(begin_offset == end_offset)
+        // each block processes one segment
+        ::rocprim::detail::segmented_reduce<decltype(arch_config)>(input,
+                                                                   output,
+                                                                   begin_offsets,
+                                                                   end_offsets,
+                                                                   reduce_op,
+                                                                   initial_value);
+        // no synchronization is needed since thread 0 writes to output
+
+        const unsigned int flat_id    = ::rocprim::detail::block_thread_id<0>();
+        const unsigned int segment_id = ::rocprim::detail::block_id<0>();
+
+        // Large indices need bigger offset type than unsigned int
+        using offset_type = typename std::iterator_traits<OffsetIterator>::value_type;
+
+        const offset_type begin_offset = begin_offsets[segment_id];
+        const offset_type end_offset   = end_offsets[segment_id];
+
+        // transform the segment output
+        if(flat_id == 0)
         {
-            output[segment_id] = empty_value;
+            if(begin_offset == end_offset)
+            {
+                output[segment_id] = empty_value;
+            }
+            else
+            {
+                output[segment_id].key -= begin_offset;
+            }
         }
-        else
-        {
-            output[segment_id].key -= begin_offset;
-        }
-    }
+    };
+
+    return ::rocprim::launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 /// Dispatch function similar to \p rocprim::segmented_reduce but writes \p empty_value for empty
@@ -118,7 +126,7 @@ inline hipError_t segmented_arg_minmax(void*          temporary_storage,
                                        InitValueType  empty_value,
                                        hipStream_t    stream)
 {
-    using input_type = typename std::iterator_traits<InputIterator>::value_type;
+    using input_type  = typename std::iterator_traits<InputIterator>::value_type;
     using result_type = ::rocprim::accumulator_t<BinaryFunction, input_type>;
 
     using config = ::rocprim::detail::wrapped_reduce_config<Config, result_type>;
@@ -132,7 +140,7 @@ inline hipError_t segmented_arg_minmax(void*          temporary_storage,
     const ::rocprim::detail::reduce_config_params params
         = ::rocprim::detail::dispatch_target_arch<config>(target_arch);
 
-    const unsigned int block_size = params.reduce_config.block_size;
+    const unsigned int block_size = params.kernel_config.block_size;
 
     if(temporary_storage == nullptr)
     {
@@ -151,18 +159,18 @@ inline hipError_t segmented_arg_minmax(void*          temporary_storage,
     {
         start = std::chrono::high_resolution_clock::now();
     }
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_arg_minmax_kernel<config>),
-                       dim3(segments),
-                       dim3(block_size),
-                       0,
-                       stream,
-                       input,
-                       output,
-                       begin_offsets,
-                       end_offsets,
-                       reduce_op,
-                       static_cast<result_type>(initial_value),
-                       static_cast<result_type>(empty_value));
+    ROCPRIM_RETURN_ON_ERROR(launch_segmented_arg_minmax(target_arch,
+                                                        input,
+                                                        output,
+                                                        begin_offsets,
+                                                        end_offsets,
+                                                        reduce_op,
+                                                        static_cast<result_type>(initial_value),
+                                                        static_cast<result_type>(empty_value),
+                                                        dim3(segments),
+                                                        dim3(block_size),
+                                                        0,
+                                                        stream));
     HIPCUB_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_arg_minmax", segments, start);
 
     return hipSuccess;
@@ -177,16 +185,17 @@ struct DeviceSegmentedReduce
              typename OffsetIteratorT,
              typename ReductionOp,
              typename T>
-    HIPCUB_RUNTIME_FUNCTION static hipError_t Reduce(void*           d_temp_storage,
-                                                     size_t&         temp_storage_bytes,
-                                                     InputIteratorT  d_in,
-                                                     OutputIteratorT d_out,
-                                                     int             num_segments,
-                                                     OffsetIteratorT d_begin_offsets,
-                                                     OffsetIteratorT d_end_offsets,
-                                                     ReductionOp     reduction_op,
-                                                     T               initial_value,
-                                                     hipStream_t     stream = 0)
+    HIPCUB_RUNTIME_FUNCTION
+    static hipError_t Reduce(void*           d_temp_storage,
+                             size_t&         temp_storage_bytes,
+                             InputIteratorT  d_in,
+                             OutputIteratorT d_out,
+                             int             num_segments,
+                             OffsetIteratorT d_begin_offsets,
+                             OffsetIteratorT d_end_offsets,
+                             ReductionOp     reduction_op,
+                             T               initial_value,
+                             hipStream_t     stream = 0)
     {
         return ::rocprim::segmented_reduce(
             d_temp_storage,
@@ -206,18 +215,18 @@ struct DeviceSegmentedReduce
              typename OffsetIteratorT,
              typename ReductionOp,
              typename T>
-    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION static hipError_t
-        Reduce(void*           d_temp_storage,
-               size_t&         temp_storage_bytes,
-               InputIteratorT  d_in,
-               OutputIteratorT d_out,
-               int             num_segments,
-               OffsetIteratorT d_begin_offsets,
-               OffsetIteratorT d_end_offsets,
-               ReductionOp     reduction_op,
-               T               initial_value,
-               hipStream_t     stream,
-               bool            debug_synchronous)
+    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION
+    static hipError_t Reduce(void*           d_temp_storage,
+                             size_t&         temp_storage_bytes,
+                             InputIteratorT  d_in,
+                             OutputIteratorT d_out,
+                             int             num_segments,
+                             OffsetIteratorT d_begin_offsets,
+                             OffsetIteratorT d_end_offsets,
+                             ReductionOp     reduction_op,
+                             T               initial_value,
+                             hipStream_t     stream,
+                             bool            debug_synchronous)
     {
         HIPCUB_DETAIL_RUNTIME_LOG_DEBUG_SYNCHRONOUS();
         return Reduce(d_temp_storage,
@@ -233,14 +242,15 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static hipError_t Sum(void*           d_temp_storage,
-                                                  size_t&         temp_storage_bytes,
-                                                  InputIteratorT  d_in,
-                                                  OutputIteratorT d_out,
-                                                  int             num_segments,
-                                                  OffsetIteratorT d_begin_offsets,
-                                                  OffsetIteratorT d_end_offsets,
-                                                  hipStream_t     stream = 0)
+    HIPCUB_RUNTIME_FUNCTION
+    static hipError_t Sum(void*           d_temp_storage,
+                          size_t&         temp_storage_bytes,
+                          InputIteratorT  d_in,
+                          OutputIteratorT d_out,
+                          int             num_segments,
+                          OffsetIteratorT d_begin_offsets,
+                          OffsetIteratorT d_end_offsets,
+                          hipStream_t     stream = 0)
     {
         using input_type = typename std::iterator_traits<InputIteratorT>::value_type;
 
@@ -257,16 +267,16 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION static hipError_t
-        Sum(void*           d_temp_storage,
-            size_t&         temp_storage_bytes,
-            InputIteratorT  d_in,
-            OutputIteratorT d_out,
-            int             num_segments,
-            OffsetIteratorT d_begin_offsets,
-            OffsetIteratorT d_end_offsets,
-            hipStream_t     stream,
-            bool            debug_synchronous)
+    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION
+    static hipError_t Sum(void*           d_temp_storage,
+                          size_t&         temp_storage_bytes,
+                          InputIteratorT  d_in,
+                          OutputIteratorT d_out,
+                          int             num_segments,
+                          OffsetIteratorT d_begin_offsets,
+                          OffsetIteratorT d_end_offsets,
+                          hipStream_t     stream,
+                          bool            debug_synchronous)
     {
         HIPCUB_DETAIL_RUNTIME_LOG_DEBUG_SYNCHRONOUS();
         return Sum(d_temp_storage,
@@ -280,14 +290,15 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static hipError_t Min(void*           d_temp_storage,
-                                                  size_t&         temp_storage_bytes,
-                                                  InputIteratorT  d_in,
-                                                  OutputIteratorT d_out,
-                                                  int             num_segments,
-                                                  OffsetIteratorT d_begin_offsets,
-                                                  OffsetIteratorT d_end_offsets,
-                                                  hipStream_t     stream = 0)
+    HIPCUB_RUNTIME_FUNCTION
+    static hipError_t Min(void*           d_temp_storage,
+                          size_t&         temp_storage_bytes,
+                          InputIteratorT  d_in,
+                          OutputIteratorT d_out,
+                          int             num_segments,
+                          OffsetIteratorT d_begin_offsets,
+                          OffsetIteratorT d_end_offsets,
+                          hipStream_t     stream = 0)
     {
         using input_type = typename std::iterator_traits<InputIteratorT>::value_type;
 
@@ -304,16 +315,16 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION static hipError_t
-        Min(void*           d_temp_storage,
-            size_t&         temp_storage_bytes,
-            InputIteratorT  d_in,
-            OutputIteratorT d_out,
-            int             num_segments,
-            OffsetIteratorT d_begin_offsets,
-            OffsetIteratorT d_end_offsets,
-            hipStream_t     stream,
-            bool            debug_synchronous)
+    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION
+    static hipError_t Min(void*           d_temp_storage,
+                          size_t&         temp_storage_bytes,
+                          InputIteratorT  d_in,
+                          OutputIteratorT d_out,
+                          int             num_segments,
+                          OffsetIteratorT d_begin_offsets,
+                          OffsetIteratorT d_end_offsets,
+                          hipStream_t     stream,
+                          bool            debug_synchronous)
     {
         HIPCUB_DETAIL_RUNTIME_LOG_DEBUG_SYNCHRONOUS();
         return Min(d_temp_storage,
@@ -327,26 +338,24 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMin(void*           d_temp_storage,
-                                                     size_t&         temp_storage_bytes,
-                                                     InputIteratorT  d_in,
-                                                     OutputIteratorT d_out,
-                                                     int             num_segments,
-                                                     OffsetIteratorT d_begin_offsets,
-                                                     OffsetIteratorT d_end_offsets,
-                                                     hipStream_t     stream = 0)
+    HIPCUB_RUNTIME_FUNCTION
+    static hipError_t ArgMin(void*           d_temp_storage,
+                             size_t&         temp_storage_bytes,
+                             InputIteratorT  d_in,
+                             OutputIteratorT d_out,
+                             int             num_segments,
+                             OffsetIteratorT d_begin_offsets,
+                             OffsetIteratorT d_end_offsets,
+                             hipStream_t     stream = 0)
     {
-        using OffsetT = int;
-        using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        using O = typename std::iterator_traits<OutputIteratorT>::value_type;
-        using OutputTupleT = typename std::conditional<
-                                 std::is_same<O, void>::value,
-                                 KeyValuePair<OffsetT, T>,
-                                 O
-                             >::type;
+        using OffsetT      = int;
+        using T            = typename std::iterator_traits<InputIteratorT>::value_type;
+        using O            = typename std::iterator_traits<OutputIteratorT>::value_type;
+        using OutputTupleT = typename std::
+            conditional<std::is_same<O, void>::value, KeyValuePair<OffsetT, T>, O>::type;
 
         using OutputValueT = typename OutputTupleT::Value;
-        using IteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+        using IteratorT    = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
         IteratorT d_indexed_in(d_in);
         // true maximum value of the full range
@@ -370,16 +379,16 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION static hipError_t
-        ArgMin(void*           d_temp_storage,
-               size_t&         temp_storage_bytes,
-               InputIteratorT  d_in,
-               OutputIteratorT d_out,
-               int             num_segments,
-               OffsetIteratorT d_begin_offsets,
-               OffsetIteratorT d_end_offsets,
-               hipStream_t     stream,
-               bool            debug_synchronous)
+    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION
+    static hipError_t ArgMin(void*           d_temp_storage,
+                             size_t&         temp_storage_bytes,
+                             InputIteratorT  d_in,
+                             OutputIteratorT d_out,
+                             int             num_segments,
+                             OffsetIteratorT d_begin_offsets,
+                             OffsetIteratorT d_end_offsets,
+                             hipStream_t     stream,
+                             bool            debug_synchronous)
     {
         HIPCUB_DETAIL_RUNTIME_LOG_DEBUG_SYNCHRONOUS();
         return ArgMin(d_temp_storage,
@@ -393,14 +402,15 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static hipError_t Max(void*           d_temp_storage,
-                                                  size_t&         temp_storage_bytes,
-                                                  InputIteratorT  d_in,
-                                                  OutputIteratorT d_out,
-                                                  int             num_segments,
-                                                  OffsetIteratorT d_begin_offsets,
-                                                  OffsetIteratorT d_end_offsets,
-                                                  hipStream_t     stream = 0)
+    HIPCUB_RUNTIME_FUNCTION
+    static hipError_t Max(void*           d_temp_storage,
+                          size_t&         temp_storage_bytes,
+                          InputIteratorT  d_in,
+                          OutputIteratorT d_out,
+                          int             num_segments,
+                          OffsetIteratorT d_begin_offsets,
+                          OffsetIteratorT d_end_offsets,
+                          hipStream_t     stream = 0)
     {
         using input_type = typename std::iterator_traits<InputIteratorT>::value_type;
 
@@ -417,16 +427,16 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION static hipError_t
-        Max(void*           d_temp_storage,
-            size_t&         temp_storage_bytes,
-            InputIteratorT  d_in,
-            OutputIteratorT d_out,
-            int             num_segments,
-            OffsetIteratorT d_begin_offsets,
-            OffsetIteratorT d_end_offsets,
-            hipStream_t     stream,
-            bool            debug_synchronous)
+    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION
+    static hipError_t Max(void*           d_temp_storage,
+                          size_t&         temp_storage_bytes,
+                          InputIteratorT  d_in,
+                          OutputIteratorT d_out,
+                          int             num_segments,
+                          OffsetIteratorT d_begin_offsets,
+                          OffsetIteratorT d_end_offsets,
+                          hipStream_t     stream,
+                          bool            debug_synchronous)
     {
         HIPCUB_DETAIL_RUNTIME_LOG_DEBUG_SYNCHRONOUS();
         return Max(d_temp_storage,
@@ -440,26 +450,24 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMax(void*           d_temp_storage,
-                                                     size_t&         temp_storage_bytes,
-                                                     InputIteratorT  d_in,
-                                                     OutputIteratorT d_out,
-                                                     int             num_segments,
-                                                     OffsetIteratorT d_begin_offsets,
-                                                     OffsetIteratorT d_end_offsets,
-                                                     hipStream_t     stream = 0)
+    HIPCUB_RUNTIME_FUNCTION
+    static hipError_t ArgMax(void*           d_temp_storage,
+                             size_t&         temp_storage_bytes,
+                             InputIteratorT  d_in,
+                             OutputIteratorT d_out,
+                             int             num_segments,
+                             OffsetIteratorT d_begin_offsets,
+                             OffsetIteratorT d_end_offsets,
+                             hipStream_t     stream = 0)
     {
-        using OffsetT = int;
-        using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        using O = typename std::iterator_traits<OutputIteratorT>::value_type;
-        using OutputTupleT = typename std::conditional<
-                                 std::is_same<O, void>::value,
-                                 KeyValuePair<OffsetT, T>,
-                                 O
-                             >::type;
+        using OffsetT      = int;
+        using T            = typename std::iterator_traits<InputIteratorT>::value_type;
+        using O            = typename std::iterator_traits<OutputIteratorT>::value_type;
+        using OutputTupleT = typename std::
+            conditional<std::is_same<O, void>::value, KeyValuePair<OffsetT, T>, O>::type;
 
         using OutputValueT = typename OutputTupleT::Value;
-        using IteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+        using IteratorT    = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
         IteratorT d_indexed_in(d_in);
         // true minimum value of the full range
@@ -483,16 +491,16 @@ struct DeviceSegmentedReduce
     }
 
     template<typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
-    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION static hipError_t
-        ArgMax(void*           d_temp_storage,
-               size_t&         temp_storage_bytes,
-               InputIteratorT  d_in,
-               OutputIteratorT d_out,
-               int             num_segments,
-               OffsetIteratorT d_begin_offsets,
-               OffsetIteratorT d_end_offsets,
-               hipStream_t     stream,
-               bool            debug_synchronous)
+    HIPCUB_DETAIL_DEPRECATED_DEBUG_SYNCHRONOUS HIPCUB_RUNTIME_FUNCTION
+    static hipError_t ArgMax(void*           d_temp_storage,
+                             size_t&         temp_storage_bytes,
+                             InputIteratorT  d_in,
+                             OutputIteratorT d_out,
+                             int             num_segments,
+                             OffsetIteratorT d_begin_offsets,
+                             OffsetIteratorT d_end_offsets,
+                             hipStream_t     stream,
+                             bool            debug_synchronous)
     {
         HIPCUB_DETAIL_RUNTIME_LOG_DEBUG_SYNCHRONOUS();
         return ArgMax(d_temp_storage,

--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -8,6 +8,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 * Added `get_sreg_lanemask_lt`, `get_sreg_lanemask_le`, `get_sreg_lanemask_gt` and `get_sreg_lanemask_ge`.
 * Added `rocprim::transform_output_iterator` and `rocprim::make_transform_output_iterator`.
+* Added experimental support for SPIR-V, to use the correct tuned config for part of the appliable algorithms.
 
 ### Changed
 

--- a/projects/rocprim/benchmark/benchmark_device_batch_memcpy.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_batch_memcpy.cpp
@@ -144,7 +144,7 @@ BatchMemcpyData<ValueType, BufferSizeType> prepare_data(hipStream_t         stre
     }
 
     const rocprim::detail::batch_memcpy_config_params params
-        = rocprim::detail::dispatch_target_arch<config>(target_arch);
+        = rocprim::detail::dispatch_target_arch<config, false>(target_arch);
 
     const int32_t wlev_min_size = params.wlev_size_threshold;
     const int32_t blev_min_size = params.blev_size_threshold;

--- a/projects/rocprim/benchmark/benchmark_device_merge_sort_block_sort.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_merge_sort_block_sort.parallel.hpp
@@ -67,8 +67,8 @@ template<typename Config>
 std::string config_name()
 {
     const rocprim::detail::merge_sort_block_sort_config_params config = Config();
-    return "{bs:" + std::to_string(config.block_sort_config.block_size)
-           + ",ipt:" + std::to_string(config.block_sort_config.items_per_thread) + "}";
+    return "{bs:" + std::to_string(config.kernel_config.block_size)
+           + ",ipt:" + std::to_string(config.kernel_config.items_per_thread) + "}";
 }
 
 template<>

--- a/projects/rocprim/benchmark/benchmark_device_reduce.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_reduce.parallel.hpp
@@ -62,8 +62,8 @@ template<typename Config>
 std::string config_name()
 {
     const rocprim::detail::reduce_config_params config = Config();
-    return "{bs:" + std::to_string(config.reduce_config.block_size)
-           + ",ipt:" + std::to_string(config.reduce_config.items_per_thread)
+    return "{bs:" + std::to_string(config.kernel_config.block_size)
+           + ",ipt:" + std::to_string(config.kernel_config.items_per_thread)
            + ",method:" + std::string(get_reduce_method_name(config.block_reduce_method)) + "}";
 }
 

--- a/projects/rocprim/benchmark/benchmark_device_segmented_reduce.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_segmented_reduce.parallel.hpp
@@ -63,8 +63,8 @@ template<typename Config>
 std::string config_name()
 {
     const rocprim::detail::reduce_config_params config = Config();
-    return "{bs:" + std::to_string(config.reduce_config.block_size)
-           + ",ipt:" + std::to_string(config.reduce_config.items_per_thread)
+    return "{bs:" + std::to_string(config.kernel_config.block_size)
+           + ",ipt:" + std::to_string(config.kernel_config.items_per_thread)
            + ",method:" + std::string(get_reduce_method_name(config.block_reduce_method)) + "}";
 }
 

--- a/projects/rocprim/docs/how-to/rocPRIM-spir-v.rst
+++ b/projects/rocprim/docs/how-to/rocPRIM-spir-v.rst
@@ -22,7 +22,7 @@ For example, with hipcc:
 
     hipcc -DROCPRIM_EXPERIMENTAL_SPIRV=1 --offload-arch=amdgcnspirv
 
-For example, with cmake:
+For example, with CMake:
 
 .. code:: shell
 
@@ -35,6 +35,8 @@ For example, with cmake:
     
     Setting ``ROCPRIM_EXPERIMENTAL_SPIRV`` will disable all config dispatching.
 
+
+When consuming rocPRIM via its CMake package, the ``ROCPRIM_EXPERIMENTAL_SPIRV`` macro is set automatically. In this case, you only need to specify the GPU targets ``-DGPU_TARGETS="amdgcnspirv"`` when compiling rocPRIM.
 
 When targeting SPIR-V, the hardware wavefront size (also known as warp size) is not known
 at compile time. 

--- a/projects/rocprim/docs/how-to/rocPRIM-spir-v.rst
+++ b/projects/rocprim/docs/how-to/rocPRIM-spir-v.rst
@@ -22,7 +22,7 @@ For example, with hipcc:
 
     hipcc -DROCPRIM_EXPERIMENTAL_SPIRV=1 --offload-arch=amdgcnspirv
 
-For example, with CMake:
+For example, with cmake:
 
 .. code:: shell
 
@@ -35,8 +35,6 @@ For example, with CMake:
     
     Setting ``ROCPRIM_EXPERIMENTAL_SPIRV`` will disable all config dispatching.
 
-
-When consuming rocPRIM via its CMake package, the ``ROCPRIM_EXPERIMENTAL_SPIRV`` macro is set automatically. In this case, you only need to specify the GPU targets ``-DGPU_TARGETS="amdgcnspirv"`` when compiling rocPRIM.
 
 When targeting SPIR-V, the hardware wavefront size (also known as warp size) is not known
 at compile time. 

--- a/projects/rocprim/rocprim/CMakeLists.txt
+++ b/projects/rocprim/rocprim/CMakeLists.txt
@@ -39,11 +39,6 @@ target_include_directories(rocprim
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-# Workaround to know if targeting SPIR-V on host
-if("amdgcnspirv" IN_LIST GPU_TARGETS)
-  target_compile_definitions(rocprim INTERFACE ROCPRIM_EXPERIMENTAL_SPIRV=1)
-endif()
-
 # This target links against HIP library
 add_library(rocprim_hip INTERFACE)
 target_link_libraries(rocprim_hip INTERFACE rocprim hip::device)

--- a/projects/rocprim/rocprim/CMakeLists.txt
+++ b/projects/rocprim/rocprim/CMakeLists.txt
@@ -39,6 +39,11 @@ target_include_directories(rocprim
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+# Workaround to know if targeting SPIR-V on host
+if("amdgcnspirv" IN_LIST GPU_TARGETS)
+  target_compile_definitions(rocprim INTERFACE ROCPRIM_EXPERIMENTAL_SPIRV=1)
+endif()
+
 # This target links against HIP library
 add_library(rocprim_hip INTERFACE)
 target_link_libraries(rocprim_hip INTERFACE rocprim hip::device)

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -140,7 +140,7 @@
 #endif
 
 // SPIR-V and unknown targets do not support 128-bit atomics.
-#if defined(ROCPRIM_TARGET_UKNOWN) || defined(ROCPRIM_TARGET_SPIRV)
+#if defined(ROCPRIM_TARGET_UNKNOWN) || defined(ROCPRIM_TARGET_SPIRV)
     #define ROCPRIM_MAX_ATOMIC_SIZE 8
 #else
     #define ROCPRIM_MAX_ATOMIC_SIZE 16

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -146,6 +146,10 @@
     #define ROCPRIM_MAX_ATOMIC_SIZE 16
 #endif
 
+#if !defined(ROCPRIM_EXPERIMENTAL_SPIRV) || !ROCPRIM_EXPERIMENTAL_SPIRV
+    #define ROCPRIM_EXPERIMENTAL_SPIRV 0
+#endif
+
 // DPP is supported only after Volcanic Islands (GFX8+)
 // Only defined when support is present, in contrast to ROCPRIM_DETAIL_USE_DPP, which should be
 // always defined
@@ -196,7 +200,7 @@
 /// Quad size (group of 4 threads)
 #define ROCPRIM_QUAD_SIZE 4u
 
-#if(defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
+#if (defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
     #define ROCPRIM_UNROLL
     #define ROCPRIM_NO_UNROLL
 #else

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -146,10 +146,6 @@
     #define ROCPRIM_MAX_ATOMIC_SIZE 16
 #endif
 
-#if !defined(ROCPRIM_EXPERIMENTAL_SPIRV) || !ROCPRIM_EXPERIMENTAL_SPIRV
-    #define ROCPRIM_EXPERIMENTAL_SPIRV 0
-#endif
-
 // DPP is supported only after Volcanic Islands (GFX8+)
 // Only defined when support is present, in contrast to ROCPRIM_DETAIL_USE_DPP, which should be
 // always defined

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -196,7 +196,7 @@
 /// Quad size (group of 4 threads)
 #define ROCPRIM_QUAD_SIZE 4u
 
-#if (defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
+#if(defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
     #define ROCPRIM_UNROLL
     #define ROCPRIM_NO_UNROLL
 #else

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -30,6 +30,7 @@
 
 #include "../config.hpp"
 #include "../detail/various.hpp"
+#include "../intrinsics/arch.hpp"
 
 /// \addtogroup primitivesmodule_deviceconfigs
 /// @{
@@ -256,6 +257,36 @@ constexpr void for_each_arch(F&& f)
                        std::make_index_sequence<std::size(target_architectures)>{});
 }
 
+constexpr arch::wavefront::target arch_wavefront_size(const target_arch target_arch)
+{
+    switch(target_arch)
+    {
+        case target_arch::unknown: return arch::wavefront::target::dynamic;
+        case target_arch::gfx803: return arch::wavefront::target::size64;
+        case target_arch::gfx900: return arch::wavefront::target::size64;
+        case target_arch::gfx906: return arch::wavefront::target::size64;
+        case target_arch::gfx908: return arch::wavefront::target::size64;
+        case target_arch::gfx90a: return arch::wavefront::target::size64;
+        case target_arch::gfx942: return arch::wavefront::target::size64;
+        case target_arch::gfx1030: return arch::wavefront::target::size32;
+        case target_arch::gfx1100: return arch::wavefront::target::size32;
+        case target_arch::gfx1102: return arch::wavefront::target::size32;
+        case target_arch::gfx1200: return arch::wavefront::target::size32;
+        case target_arch::gfx1201: return arch::wavefront::target::size32;
+
+        // Unreachable
+        case target_arch::invalid: return arch::wavefront::target::dynamic;
+    }
+}
+
+template<class Config, target_arch Arch>
+struct target_config
+{
+    constexpr static auto params    = Config::template architecture_config<Arch>::params;
+    constexpr static auto wavefront = arch_wavefront_size(Arch);
+    constexpr static auto arch      = Arch;
+};
+
 // Trampoline that is fully specialized at compile-time for a single GPU architecture.
 // By instantiating this template once per supported `target_arch`,the correct tuned config
 // will be derived from the template
@@ -264,7 +295,7 @@ __global__
 __launch_bounds__(Config::template architecture_config<Arch>::params.kernel_config.block_size)
 void trampoline(Kernel kernel)
 {
-    using ArchConfig = typename Config::template architecture_config<Arch>;
+    using ArchConfig = target_config<Config, Arch>;
 
 #ifndef ROCPRIM_EXPERIMENTAL_SPIRV
     if constexpr(Arch == device_target_arch())
@@ -304,8 +335,7 @@ auto configure_kernel(target_arch arch, Kernel kernel) -> tuned_kernel<Kernel>
             if(Arch != arch || tuned_kernel)
                 return;
 
-            using ArchConfig = typename Config::template architecture_config<Arch>;
-            tuned_kernel     = trampoline<Config, Arch, Kernel>;
+            tuned_kernel = trampoline<Config, Arch, Kernel>;
         });
 
     if(!tuned_kernel)

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -277,12 +277,8 @@ void trampoline(Kernel k)
 // Host-side helper running at run-time, picking the trampoline whose template
 // argument `Arch` matches the actual GPU we are executing on.
 template<class Config, class Kernel>
-hipError_t launch_kernel(target_arch arch,
-                         Kernel      k,
-                         dim3        grid_size,
-                         dim3        block_size,
-                         size_t      shmem,
-                         hipStream_t stream)
+hipError_t launch_kernel(
+    target_arch arch, Kernel k, dim3 grid_size, dim3 block_size, size_t shmem, hipStream_t stream)
 {
     bool launched = false;
 
@@ -295,7 +291,8 @@ hipError_t launch_kernel(target_arch arch,
 
             using ArchConfig = typename Config::template architecture_config<Arch>;
 
-            assert(block_size.x * block_size.y * block_size.z == ArchConfig::params.kernel_config.block_size);
+            assert(block_size.x * block_size.y * block_size.z
+                   == ArchConfig::params.kernel_config.block_size);
 
             trampoline<Config, Arch, Kernel><<<grid_size, block_size, shmem, stream>>>(k);
             launched = true;

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -262,7 +262,7 @@ constexpr void for_each_arch(F&& f)
 template<typename Config, target_arch Arch, class Kernel>
 __global__
 __launch_bounds__(Config::template architecture_config<Arch>::params.kernel_config.block_size)
-void trampoline(Kernel k)
+void trampoline(Kernel kernel)
 {
     using ArchConfig = typename Config::template architecture_config<Arch>;
 
@@ -270,41 +270,67 @@ void trampoline(Kernel k)
     if constexpr(Arch == device_target_arch())
 #endif
     {
-        k(ArchConfig{});
+        kernel(ArchConfig{});
     }
 }
 
-// Host-side helper running at run-time, picking the trampoline whose template
-// argument `Arch` matches the actual GPU we are executing on.
-template<class Config, class Kernel>
-hipError_t launch_kernel(
-    target_arch arch, Kernel k, dim3 grid_size, dim3 block_size, size_t shmem, hipStream_t stream)
+template<typename Kernel>
+struct tuned_kernel
 {
-    bool launched = false;
+    using kernel_type = void (*)(Kernel);
+    kernel_type kernel;
+    Kernel      device_callback;
+
+    void launch(dim3 grid_size, dim3 block_size, size_t shared_mem, hipStream_t stream) const
+    {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel),
+                           grid_size,
+                           block_size,
+                           shared_mem,
+                           stream,
+                           device_callback);
+    }
+};
+
+template<class Config, class Kernel>
+auto configure_kernel(target_arch arch, Kernel kernel) -> tuned_kernel<Kernel>
+{
+    std::optional<void (*)(Kernel)> tuned_kernel = std::nullopt;
 
     for_each_arch(
         [&](auto arch_tag)
         {
             constexpr target_arch Arch = decltype(arch_tag)::value;
-            if(Arch != arch || launched)
+            if(Arch != arch || tuned_kernel)
                 return;
 
             using ArchConfig = typename Config::template architecture_config<Arch>;
-
-            assert(block_size.x * block_size.y * block_size.z
-                   == ArchConfig::params.kernel_config.block_size);
-
-            trampoline<Config, Arch, Kernel><<<grid_size, block_size, shmem, stream>>>(k);
-            launched = true;
+            tuned_kernel     = trampoline<Config, Arch, Kernel>;
         });
 
-    if(!launched)
+    if(!tuned_kernel)
     {
-        trampoline<Config, target_arch::unknown, Kernel>
-            <<<grid_size, block_size, shmem, stream>>>(k);
+        tuned_kernel = trampoline<Config, target_arch::unknown, Kernel>;
+
+        printf("[transform][unknow]\n");
     }
 
-    return hipSuccess;
+    return {tuned_kernel.value(), kernel};
+}
+
+// Host-side helper running at run-time, picking the trampoline whose template
+// argument `Arch` matches the actual GPU we are executing on.
+template<class Config, class Kernel>
+hipError_t launch_kernel(target_arch arch,
+                         Kernel      kernel,
+                         dim3        grid_size,
+                         dim3        block_size,
+                         size_t      shmem,
+                         hipStream_t stream)
+{
+    const auto tuned_kernel = configure_kernel<Config>(arch, kernel);
+    tuned_kernel.launch(grid_size, block_size, shmem, stream);
+    return hipGetLastError();
 }
 
 /**
@@ -326,7 +352,7 @@ constexpr target_arch device_target_arch()
 #endif
 }
 
-template<class Config, bool IgnoreConfig = ROCPRIM_EXPERIMENTAL_SPIRV>
+template<class Config, bool IgnoreConfig>
 auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
 {
     if constexpr(!IgnoreConfig)

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -256,6 +256,60 @@ constexpr void for_each_arch(F&& f)
                        std::make_index_sequence<std::size(target_architectures)>{});
 }
 
+// Trampoline that is fully specialized at compile-time for a single GPU architecture.
+// By instantiating this template once per supported `target_arch`,the correct tuned config
+// will be derived from the template
+template<typename Config, target_arch Arch, class Kernel>
+__global__
+__launch_bounds__(Config::template architecture_config<Arch>::params.kernel_config.block_size)
+void trampoline(Kernel k)
+{
+    using ArchConfig = typename Config::template architecture_config<Arch>;
+
+#ifndef ROCPRIM_EXPERIMENTAL_SPIRV
+    if constexpr(Arch == device_target_arch())
+#endif
+    {
+        k(ArchConfig{});
+    }
+}
+
+// Host-side helper running at run-time, picking the trampoline whose template
+// argument `Arch` matches the actual GPU we are executing on.
+template<class Config, class Kernel>
+hipError_t launch_kernel(target_arch arch,
+                         Kernel      k,
+                         dim3        grid_size,
+                         dim3        block_size,
+                         size_t      shmem,
+                         hipStream_t stream)
+{
+    bool launched = false;
+
+    for_each_arch(
+        [&](auto arch_tag)
+        {
+            constexpr target_arch Arch = decltype(arch_tag)::value;
+            if(Arch != arch || launched)
+                return;
+
+            using ArchConfig = typename Config::template architecture_config<Arch>;
+
+            assert(block_size.x * block_size.y * block_size.z == ArchConfig::params.kernel_config.block_size);
+
+            trampoline<Config, Arch, Kernel><<<grid_size, block_size, shmem, stream>>>(k);
+            launched = true;
+        });
+
+    if(!launched)
+    {
+        trampoline<Config, target_arch::unknown, Kernel>
+            <<<grid_size, block_size, shmem, stream>>>(k);
+    }
+
+    return hipSuccess;
+}
+
 /**
  * \brief Get the current architecture in device compilation.
  *

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -300,6 +300,27 @@ struct blev_batch_memcpy_kernel_config_selector
                                                    .blev_batch_memcpy_kernel_config.block_size;
 };
 
+template<typename Config, target_arch Arch>
+struct merge_oddeven_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.merge_oddeven_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct merge_mergepath_partition_config_selector
+{
+    static constexpr unsigned int block_size = Config::template architecture_config<Arch>::params
+                                                   .merge_mergepath_partition_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct merge_mergepath_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.merge_mergepath_config.block_size;
+};
+
 template<class Config, target_arch Arch>
 struct target_config
 {

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -371,7 +371,7 @@ template<typename Config,
          class Kernel,
          template<typename, target_arch>
          class LaunchSelector>
-__global__ __launch_bounds__((LaunchSelector<Config, Arch>::block_size))
+ROCPRIM_KERNEL __launch_bounds__((LaunchSelector<Config, Arch>::block_size))
 void trampoline(Kernel kernel)
 {
     using ArchConfig = target_config<Config, Arch>;

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -300,21 +300,21 @@ constexpr target_arch device_target_arch()
 }
 
 template<typename Config, target_arch Arch>
-struct default_kernel_config_selector
+struct default_config_selector
 {
     static constexpr unsigned int block_size
         = Config::template architecture_config<Arch>::params.kernel_config.block_size;
 };
 
 template<typename Config, target_arch Arch>
-struct non_blev_batch_memcpy_kernel_config_selector
+struct non_blev_batch_memcpy_config_selector
 {
     static constexpr unsigned int block_size = Config::template architecture_config<Arch>::params
                                                    .non_blev_batch_memcpy_kernel_config.block_size;
 };
 
 template<typename Config, target_arch Arch>
-struct blev_batch_memcpy_kernel_config_selector
+struct blev_batch_memcpy_config_selector
 {
     static constexpr unsigned int block_size = Config::template architecture_config<Arch>::params
                                                    .blev_batch_memcpy_kernel_config.block_size;
@@ -341,14 +341,6 @@ struct merge_mergepath_config_selector
         = Config::template architecture_config<Arch>::params.merge_mergepath_config.block_size;
 };
 
-template<class Config, target_arch Arch>
-struct target_config
-{
-    constexpr static auto params    = Config::template architecture_config<Arch>::params;
-    constexpr static auto wavefront = arch_wavefront_size(Arch);
-    constexpr static auto arch      = Arch;
-};
-
 template<typename Config, target_arch Arch>
 struct segmented_radix_sort_warp_sort_small_config_selector
 {
@@ -363,7 +355,15 @@ struct segmented_radix_sort_warp_sort_meduim_config_selector
         = Config::template architecture_config<Arch>::params.warp_sort_config.block_size_medium;
 };
 
-// Trampoline that is fully specialized at compile-time for a single GPU architecture.
+template<class Config, target_arch Arch>
+struct target_config
+{
+    constexpr static auto params    = Config::template architecture_config<Arch>::params;
+    constexpr static auto wavefront = arch_wavefront_size(Arch);
+    constexpr static auto arch      = Arch;
+};
+
+// trampoline_kernel that is fully specialized at compile-time for a single GPU architecture.
 // By instantiating this template once per supported `target_arch`,the correct tuned config
 // will be derived from the template
 template<typename Config,
@@ -372,7 +372,7 @@ template<typename Config,
          template<typename, target_arch>
          class LaunchSelector>
 ROCPRIM_KERNEL __launch_bounds__((LaunchSelector<Config, Arch>::block_size))
-void trampoline(Kernel kernel)
+void trampoline_kernel(Kernel kernel)
 {
     using ArchConfig = target_config<Config, Arch>;
 
@@ -385,7 +385,7 @@ void trampoline(Kernel kernel)
 }
 
 template<typename Kernel>
-struct tuned_kernel
+struct launch_plan
 {
     using kernel_type = void (*)(Kernel);
     kernel_type kernel;
@@ -404,8 +404,8 @@ struct tuned_kernel
 
 template<class Config,
          class Kernel,
-         template<typename, target_arch> class LaunchSelector = default_kernel_config_selector>
-auto configure_kernel(target_arch arch, Kernel kernel) -> tuned_kernel<Kernel>
+         template<typename, target_arch> class LaunchSelector = default_config_selector>
+auto make_launch_plan(target_arch arch, Kernel kernel) -> launch_plan<Kernel>
 {
     std::optional<void (*)(Kernel)> tuned_kernel = std::nullopt;
 
@@ -416,31 +416,31 @@ auto configure_kernel(target_arch arch, Kernel kernel) -> tuned_kernel<Kernel>
             if(Arch != arch || tuned_kernel)
                 return;
 
-            tuned_kernel = trampoline<Config, Arch, Kernel, LaunchSelector>;
+            tuned_kernel = trampoline_kernel<Config, Arch, Kernel, LaunchSelector>;
         });
 
     if(!tuned_kernel)
     {
-        tuned_kernel = trampoline<Config, target_arch::unknown, Kernel, LaunchSelector>;
+        tuned_kernel = trampoline_kernel<Config, target_arch::unknown, Kernel, LaunchSelector>;
     }
 
     return {tuned_kernel.value(), kernel};
 }
 
-// Host-side helper running at run-time, picking the trampoline whose template
+// Host-side helper running at run-time, picking the trampoline_kernel whose template
 // argument `Arch` matches the actual GPU we are executing on.
 template<class Config,
          class Kernel,
-         template<typename, target_arch> class LaunchSelector = default_kernel_config_selector>
-hipError_t launch_kernel(target_arch arch,
-                         Kernel      kernel,
-                         dim3        grid_size,
-                         dim3        block_size,
-                         size_t      shmem,
-                         hipStream_t stream)
+         template<typename, target_arch> class LaunchSelector = default_config_selector>
+hipError_t execute_launch_plan(target_arch arch,
+                               Kernel      kernel,
+                               dim3        grid_size,
+                               dim3        block_size,
+                               size_t      shmem,
+                               hipStream_t stream)
 {
-    const auto tuned_kernel = configure_kernel<Config, Kernel, LaunchSelector>(arch, kernel);
-    tuned_kernel.launch(grid_size, block_size, shmem, stream);
+    const auto launch_plan = make_launch_plan<Config, Kernel, LaunchSelector>(arch, kernel);
+    launch_plan.launch(grid_size, block_size, shmem, stream);
     return hipGetLastError();
 }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -321,6 +321,20 @@ struct blev_batch_memcpy_config_selector
 };
 
 template<typename Config, target_arch Arch>
+struct histogram_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.histogram_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct histogram_global_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.histogram_global_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
 struct merge_oddeven_config_selector
 {
     static constexpr unsigned int block_size

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <atomic>
 #include <limits>
+#include <optional>
 #include <type_traits>
 
 #include <cassert>
@@ -178,7 +179,7 @@ enum class target_arch : unsigned int
 
 /**
  * \brief Checks if the first `n` characters of `rhs` are equal to `lhs`
- *
+ * 
  * \param lhs the string to compare against
  * \param rhs the string to compare with
  * \param n length of the substring of `rhs` to chceck
@@ -261,7 +262,7 @@ constexpr arch::wavefront::target arch_wavefront_size(const target_arch target_a
 {
     switch(target_arch)
     {
-        case target_arch::unknown: return arch::wavefront::target::dynamic;
+        case target_arch::unknown: return arch::wavefront::get_target();
         case target_arch::gfx803: return arch::wavefront::target::size64;
         case target_arch::gfx900: return arch::wavefront::target::size64;
         case target_arch::gfx906: return arch::wavefront::target::size64;
@@ -277,6 +278,25 @@ constexpr arch::wavefront::target arch_wavefront_size(const target_arch target_a
         // Unreachable
         case target_arch::invalid: return arch::wavefront::target::dynamic;
     }
+}
+
+/**
+ * \brief Get the current architecture in device compilation.
+ * 
+ * This function will always return `unknown` when called from the host, host could should instead
+ * call host_target_arch to query the current device from the HIP API.
+ * 
+ * \return target_arch the architecture currently being compiled for on the device.
+ */
+constexpr target_arch device_target_arch()
+{
+#if defined(__amdgcn_processor__) && !defined(ROCPRIM_EXPERIMENTAL_SPIRV)
+    // The terminating zero is not counted in the length of the string
+    return get_target_arch_from_name(__amdgcn_processor__,
+                                     sizeof(__amdgcn_processor__) - sizeof('\0'));
+#else
+    return target_arch::unknown;
+#endif
 }
 
 template<typename Config, target_arch Arch>
@@ -341,7 +361,7 @@ void trampoline(Kernel kernel)
 {
     using ArchConfig = target_config<Config, Arch>;
 
-#ifndef ROCPRIM_EXPERIMENTAL_SPIRV
+#if !defined(ROCPRIM_TARGET_SPIRV) || ROCPRIM_TARGET_SPIRV == 0
     if constexpr(Arch == device_target_arch())
 #endif
     {
@@ -409,29 +429,14 @@ hipError_t launch_kernel(target_arch arch,
     return hipGetLastError();
 }
 
-/**
- * \brief Get the current architecture in device compilation.
- *
- * This function will always return `unknown` when called from the host, host could should instead
- * call host_target_arch to query the current device from the HIP API.
- *
- * \return target_arch the architecture currently being compiled for on the device.
- */
-constexpr target_arch device_target_arch()
-{
-#if defined(__amdgcn_processor__) && !defined(ROCPRIM_EXPERIMENTAL_SPIRV)
-    // The terminating zero is not counted in the length of the string
-    return get_target_arch_from_name(__amdgcn_processor__,
-                                     sizeof(__amdgcn_processor__) - sizeof('\0'));
+#ifdef ROCPRIM_EXPERIMENTAL_SPIRV
+template<class Config, bool ForceUnknownArch = true>
 #else
-    return target_arch::unknown;
+template<class Config, bool ForceUnknownArch = false>
 #endif
-}
-
-template<class Config, bool IgnoreConfig>
 auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
 {
-    if constexpr(!IgnoreConfig)
+    if constexpr(!ForceUnknownArch)
     {
         switch(target_arch)
         {
@@ -465,46 +470,6 @@ auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
         }
     }
     return Config::template architecture_config<target_arch::unknown>::params;
-}
-
-// Wrapper that forces a Conf to use the params for ForcedArch.
-template<target_arch ForcedArch, class Conf, class PartitionConfigParams>
-struct force_arch_config
-{
-    template<target_arch Arch>
-    struct architecture_config
-    {
-        static constexpr PartitionConfigParams params
-            = Conf::template architecture_config<ForcedArch>::params;
-    };
-};
-
-template<typename F>
-inline hipError_t generic_dispatch_target_arch(detail::target_arch target_arch, F&& f)
-{
-    using ta = detail::target_arch;
-
-    switch(target_arch)
-    {
-        case ta::unknown: return f.template operator()<ta::unknown>();
-        case ta::gfx803: return f.template operator()<ta::gfx803>();
-        case ta::gfx900: return f.template operator()<ta::gfx900>();
-        case ta::gfx906: return f.template operator()<ta::gfx906>();
-        case ta::gfx908: return f.template operator()<ta::gfx908>();
-        case ta::gfx90a: return f.template operator()<ta::gfx90a>();
-        case ta::gfx942: return f.template operator()<ta::gfx942>();
-        case ta::gfx1030: return f.template operator()<ta::gfx1030>();
-        case ta::gfx1100: return f.template operator()<ta::gfx1100>();
-        case ta::gfx1102: return f.template operator()<ta::gfx1102>();
-        case ta::gfx1200: return f.template operator()<ta::gfx1200>();
-        case ta::gfx1201: return f.template operator()<ta::gfx1201>();
-        case ta::invalid:
-            assert(false && "Invalid target architecture");
-            return hipErrorInvalidValue;
-    }
-
-    assert(false && "Unhandled target_arch.");
-    return hipErrorInvalidValue;
 }
 
 template<typename Config>

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -355,7 +355,8 @@ struct target_config
 template<typename Config,
          target_arch Arch,
          class Kernel,
-         template<typename, target_arch> class LaunchSelector>
+         template<typename, target_arch>
+         class LaunchSelector>
 __global__ __launch_bounds__((LaunchSelector<Config, Arch>::block_size))
 void trampoline(Kernel kernel)
 {

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -349,6 +349,20 @@ struct target_config
     constexpr static auto arch      = Arch;
 };
 
+template<typename Config, target_arch Arch>
+struct segmented_radix_sort_warp_sort_small_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.warp_sort_config.block_size_small;
+};
+
+template<typename Config, target_arch Arch>
+struct segmented_radix_sort_warp_sort_meduim_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.warp_sort_config.block_size_medium;
+};
+
 // Trampoline that is fully specialized at compile-time for a single GPU architecture.
 // By instantiating this template once per supported `target_arch`,the correct tuned config
 // will be derived from the template

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -279,6 +279,27 @@ constexpr arch::wavefront::target arch_wavefront_size(const target_arch target_a
     }
 }
 
+template<typename Config, target_arch Arch>
+struct default_kernel_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.kernel_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct non_blev_batch_memcpy_kernel_config_selector
+{
+    static constexpr unsigned int block_size = Config::template architecture_config<Arch>::params
+                                                   .non_blev_batch_memcpy_kernel_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct blev_batch_memcpy_kernel_config_selector
+{
+    static constexpr unsigned int block_size = Config::template architecture_config<Arch>::params
+                                                   .blev_batch_memcpy_kernel_config.block_size;
+};
+
 template<class Config, target_arch Arch>
 struct target_config
 {
@@ -290,9 +311,11 @@ struct target_config
 // Trampoline that is fully specialized at compile-time for a single GPU architecture.
 // By instantiating this template once per supported `target_arch`,the correct tuned config
 // will be derived from the template
-template<typename Config, target_arch Arch, class Kernel>
-__global__
-__launch_bounds__(Config::template architecture_config<Arch>::params.kernel_config.block_size)
+template<typename Config,
+         target_arch Arch,
+         class Kernel,
+         template<typename, target_arch> class LaunchSelector>
+__global__ __launch_bounds__((LaunchSelector<Config, Arch>::block_size))
 void trampoline(Kernel kernel)
 {
     using ArchConfig = target_config<Config, Arch>;
@@ -323,7 +346,9 @@ struct tuned_kernel
     }
 };
 
-template<class Config, class Kernel>
+template<class Config,
+         class Kernel,
+         template<typename, target_arch> class LaunchSelector = default_kernel_config_selector>
 auto configure_kernel(target_arch arch, Kernel kernel) -> tuned_kernel<Kernel>
 {
     std::optional<void (*)(Kernel)> tuned_kernel = std::nullopt;
@@ -335,12 +360,12 @@ auto configure_kernel(target_arch arch, Kernel kernel) -> tuned_kernel<Kernel>
             if(Arch != arch || tuned_kernel)
                 return;
 
-            tuned_kernel = trampoline<Config, Arch, Kernel>;
+            tuned_kernel = trampoline<Config, Arch, Kernel, LaunchSelector>;
         });
 
     if(!tuned_kernel)
     {
-        tuned_kernel = trampoline<Config, target_arch::unknown, Kernel>;
+        tuned_kernel = trampoline<Config, target_arch::unknown, Kernel, LaunchSelector>;
     }
 
     return {tuned_kernel.value(), kernel};
@@ -348,7 +373,9 @@ auto configure_kernel(target_arch arch, Kernel kernel) -> tuned_kernel<Kernel>
 
 // Host-side helper running at run-time, picking the trampoline whose template
 // argument `Arch` matches the actual GPU we are executing on.
-template<class Config, class Kernel>
+template<class Config,
+         class Kernel,
+         template<typename, target_arch> class LaunchSelector = default_kernel_config_selector>
 hipError_t launch_kernel(target_arch arch,
                          Kernel      kernel,
                          dim3        grid_size,
@@ -356,7 +383,7 @@ hipError_t launch_kernel(target_arch arch,
                          size_t      shmem,
                          hipStream_t stream)
 {
-    const auto tuned_kernel = configure_kernel<Config>(arch, kernel);
+    const auto tuned_kernel = configure_kernel<Config, Kernel, LaunchSelector>(arch, kernel);
     tuned_kernel.launch(grid_size, block_size, shmem, stream);
     return hipGetLastError();
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -341,8 +341,6 @@ auto configure_kernel(target_arch arch, Kernel kernel) -> tuned_kernel<Kernel>
     if(!tuned_kernel)
     {
         tuned_kernel = trampoline<Config, target_arch::unknown, Kernel>;
-
-        printf("[transform][unknow]\n");
     }
 
     return {tuned_kernel.value(), kernel};

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -342,6 +342,27 @@ struct merge_mergepath_config_selector
 };
 
 template<typename Config, target_arch Arch>
+struct radix_sort_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct radix_sort_onesweep_histogram_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.histogram.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct radix_sort_onesweep_sort_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.sort.block_size;
+};
+
+template<typename Config, target_arch Arch>
 struct segmented_radix_sort_warp_sort_small_config_selector
 {
     static constexpr unsigned int block_size

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -153,11 +153,7 @@ struct fallback_block_size
 
 template<class Config, class Default>
 using default_or_custom_config =
-    typename std::conditional<
-        std::is_same<Config, default_config>::value,
-        Default,
-        Config
-    >::type;
+    typename std::conditional<std::is_same<Config, default_config>::value, Default, Config>::type;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 enum class target_arch : unsigned int
@@ -204,32 +200,34 @@ constexpr bool prefix_equals(const char* lhs, const char* rhs, std::size_t n)
     return i == n && *lhs == '\0';
 }
 
+constexpr const char* target_names[] = {"gfx803",
+                                        "gfx900",
+                                        "gfx906",
+                                        "gfx908",
+                                        "gfx90a",
+                                        "gfx942",
+                                        "gfx1030",
+                                        "gfx1100",
+                                        "gfx1102",
+                                        "gfx1200",
+                                        "gfx1201"};
+
+constexpr target_arch target_architectures[] = {
+    target_arch::gfx803,
+    target_arch::gfx900,
+    target_arch::gfx906,
+    target_arch::gfx908,
+    target_arch::gfx90a,
+    target_arch::gfx942,
+    target_arch::gfx1030,
+    target_arch::gfx1100,
+    target_arch::gfx1102,
+    target_arch::gfx1200,
+    target_arch::gfx1201,
+};
+
 constexpr target_arch get_target_arch_from_name(const char* const arch_name, const std::size_t n)
 {
-    constexpr const char* target_names[]         = {"gfx803",
-                                                    "gfx900",
-                                                    "gfx906",
-                                                    "gfx908",
-                                                    "gfx90a",
-                                                    "gfx942",
-                                                    "gfx1030",
-                                                    "gfx1100",
-                                                    "gfx1102",
-                                                    "gfx1200",
-                                                    "gfx1201"};
-    constexpr target_arch target_architectures[] = {
-        target_arch::gfx803,
-        target_arch::gfx900,
-        target_arch::gfx906,
-        target_arch::gfx908,
-        target_arch::gfx90a,
-        target_arch::gfx942,
-        target_arch::gfx1030,
-        target_arch::gfx1100,
-        target_arch::gfx1102,
-        target_arch::gfx1200,
-        target_arch::gfx1201,
-    };
     static_assert(sizeof(target_names) / sizeof(target_names[0])
                       == sizeof(target_architectures) / sizeof(target_architectures[0]),
                   "target_names and target_architectures should have the same number of elements");
@@ -243,6 +241,19 @@ constexpr target_arch get_target_arch_from_name(const char* const arch_name, con
         }
     }
     return target_arch::unknown;
+}
+
+template<class F, std::size_t... Is>
+constexpr void for_each_arch_impl(F&& f, std::index_sequence<Is...>)
+{
+    (f(std::integral_constant<target_arch, target_architectures[Is]>{}), ...);
+}
+
+template<class F>
+constexpr void for_each_arch(F&& f)
+{
+    for_each_arch_impl(std::forward<F>(f),
+                       std::make_index_sequence<std::size(target_architectures)>{});
 }
 
 /**
@@ -264,41 +275,42 @@ constexpr target_arch device_target_arch()
 #endif
 }
 
-template<class Config>
+template<class Config, bool IgnoreConfig = ROCPRIM_EXPERIMENTAL_SPIRV>
 auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
 {
-#if !defined(ROCPRIM_EXPERIMENTAL_SPIRV)
-    switch(target_arch)
+    if constexpr(!IgnoreConfig)
     {
+        switch(target_arch)
+        {
 
-        case target_arch::unknown:
-            return Config::template architecture_config<target_arch::unknown>::params;
-        case target_arch::gfx803:
-            return Config::template architecture_config<target_arch::gfx803>::params;
-        case target_arch::gfx900:
-            return Config::template architecture_config<target_arch::gfx900>::params;
-        case target_arch::gfx906:
-            return Config::template architecture_config<target_arch::gfx906>::params;
-        case target_arch::gfx908:
-            return Config::template architecture_config<target_arch::gfx908>::params;
-        case target_arch::gfx90a:
-            return Config::template architecture_config<target_arch::gfx90a>::params;
-        case target_arch::gfx942:
-            return Config::template architecture_config<target_arch::gfx942>::params;
-        case target_arch::gfx1030:
-            return Config::template architecture_config<target_arch::gfx1030>::params;
-        case target_arch::gfx1100:
-            return Config::template architecture_config<target_arch::gfx1100>::params;
-        case target_arch::gfx1102:
-            return Config::template architecture_config<target_arch::gfx1102>::params;
-        case target_arch::gfx1200:
-            return Config::template architecture_config<target_arch::gfx1200>::params;
-        case target_arch::gfx1201:
-            return Config::template architecture_config<target_arch::gfx1201>::params;
-        case target_arch::invalid:
-            assert(false && "Invalid target architecture selected at runtime.");
+            case target_arch::unknown:
+                return Config::template architecture_config<target_arch::unknown>::params;
+            case target_arch::gfx803:
+                return Config::template architecture_config<target_arch::gfx803>::params;
+            case target_arch::gfx900:
+                return Config::template architecture_config<target_arch::gfx900>::params;
+            case target_arch::gfx906:
+                return Config::template architecture_config<target_arch::gfx906>::params;
+            case target_arch::gfx908:
+                return Config::template architecture_config<target_arch::gfx908>::params;
+            case target_arch::gfx90a:
+                return Config::template architecture_config<target_arch::gfx90a>::params;
+            case target_arch::gfx942:
+                return Config::template architecture_config<target_arch::gfx942>::params;
+            case target_arch::gfx1030:
+                return Config::template architecture_config<target_arch::gfx1030>::params;
+            case target_arch::gfx1100:
+                return Config::template architecture_config<target_arch::gfx1100>::params;
+            case target_arch::gfx1102:
+                return Config::template architecture_config<target_arch::gfx1102>::params;
+            case target_arch::gfx1200:
+                return Config::template architecture_config<target_arch::gfx1200>::params;
+            case target_arch::gfx1201:
+                return Config::template architecture_config<target_arch::gfx1201>::params;
+            case target_arch::invalid:
+                assert(false && "Invalid target architecture selected at runtime.");
+        }
     }
-#endif
     return Config::template architecture_config<target_arch::unknown>::params;
 }
 
@@ -401,7 +413,7 @@ inline hipError_t get_device_from_stream(const hipStream_t stream, int& device_i
     const bool is_legacy_stream = false;
 #endif
 
-    if (stream == default_stream || stream == hipStreamPerThread || is_legacy_stream)
+    if(stream == default_stream || stream == hipStreamPerThread || is_legacy_stream)
     {
         const hipError_t result = hipGetDevice(&device_id);
         if(result != hipSuccess)
@@ -466,7 +478,8 @@ inline hipError_t host_warp_size(const int device_id, unsigned int& warp_size)
 /// \return hipError_t any error that might occur.
 ///
 /// It is constant for a device.
-ROCPRIM_HOST inline hipError_t host_warp_size(const hipStream_t stream, unsigned int& warp_size)
+ROCPRIM_HOST
+inline hipError_t host_warp_size(const hipStream_t stream, unsigned int& warp_size)
 {
     int        hip_device;
     hipError_t success = detail::get_device_from_stream(stream, hip_device);

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_difference.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_difference.hpp
@@ -165,7 +165,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE auto select_previous_values_iterator(T* /*previous
     return input;
 }
 
-template <typename Config,
+template <typename ArchConfig,
           bool InPlace,
           bool Right,
           typename InputIt,
@@ -182,11 +182,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void adjacent_difference_kernel_impl(
     using input_type  = typename std::iterator_traits<InputIt>::value_type;
     using output_type = ::rocprim::accumulator_t<BinaryFunction, input_type>;
 
-    static constexpr adjacent_difference_config_params params = device_params<Config>();
+    static constexpr adjacent_difference_config_params params = ArchConfig::params;
 
-    static constexpr unsigned int block_size = params.adjacent_difference_kernel_config.block_size;
+    static constexpr unsigned int block_size = params.kernel_config.block_size;
     static constexpr unsigned int items_per_thread
-        = params.adjacent_difference_kernel_config.items_per_thread;
+        = params.kernel_config.items_per_thread;
     static constexpr unsigned int items_per_block  = block_size * items_per_thread;
 
     using block_load_type

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_difference.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_difference.hpp
@@ -184,9 +184,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void adjacent_difference_kernel_impl(
 
     static constexpr adjacent_difference_config_params params = ArchConfig::params;
 
-    static constexpr unsigned int block_size = params.kernel_config.block_size;
-    static constexpr unsigned int items_per_thread
-        = params.kernel_config.items_per_thread;
+    static constexpr unsigned int block_size       = params.kernel_config.block_size;
+    static constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
     static constexpr unsigned int items_per_block  = block_size * items_per_thread;
 
     using block_load_type

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_find.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_find.hpp
@@ -33,8 +33,7 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<typename Config,
-         typename TransformedInputIterator,
+template<typename TransformedInputIterator,
          typename ReduceIndexIterator,
          typename BinaryPred,
          typename OrderedTileIdType>
@@ -52,25 +51,28 @@ struct adjacent_find_impl_kernels
         ordered_tile_id.reset();
     }
 
-    static ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>()
-                                                    .kernel_config.block_size) void
-        block_reduce_kernel(TransformedInputIterator transformed_input,
-                            ReduceIndexIterator      reduce_output,
-                            const std::size_t        size,
-                            BinaryPred               op,
-                            OrderedTileIdType        ordered_tile_id)
+    template<typename ArchConfig>
+    static ROCPRIM_DEVICE
+    void block_reduce_kernel(TransformedInputIterator transformed_input,
+                             ReduceIndexIterator      reduce_output,
+                             const std::size_t        size,
+                             BinaryPred               op,
+                             OrderedTileIdType        ordered_tile_id)
     {
-        static constexpr adjacent_find_config_params params     = device_params<Config>();
+        static constexpr adjacent_find_config_params params     = ArchConfig::params;
         static constexpr unsigned int                block_size = params.kernel_config.block_size;
         static constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
         static constexpr unsigned int items_per_tile   = block_size * items_per_thread;
 
         using transformed_input_type =
             typename std::iterator_traits<TransformedInputIterator>::value_type;
-        using block_reduce_type = ::rocprim::block_reduce<
-            transformed_input_type,
-            block_size,
-            block_reduce_algorithm::raking_reduce>; // TODO?: params.block_reduce_method>;
+        using block_reduce_type
+            = ::rocprim::block_reduce<transformed_input_type,
+                                      block_size,
+                                      block_reduce_algorithm::raking_reduce,
+                                      1,
+                                      1,
+                                      ArchConfig::wavefront>; // TODO?: params.block_reduce_method>;
 
         ROCPRIM_SHARED_MEMORY union
         {

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -82,17 +82,20 @@ private:
     BackingUnitType          data[num_items];
 
 public:
-    ROCPRIM_DEVICE ROCPRIM_INLINE uint32_t get(size_class index) const
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    uint32_t get(size_class index) const
     {
         return data[static_cast<uint32_t>(index)];
     }
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE void add(size_class index, uint32_t value)
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void add(size_class index, uint32_t value)
     {
         data[static_cast<uint32_t>(index)] += value;
     }
 
-    ROCPRIM_DEVICE counter operator+(const counter& other) const
+    ROCPRIM_DEVICE
+    counter operator+(const counter& other) const
     {
         counter result{};
 
@@ -198,8 +201,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE static void vectorized_copy_bytes(const void
     using vector_type                      = uint4;
     constexpr uint32_t ints_in_vector_type = sizeof(uint4) / sizeof(uint32_t);
 
-    const auto     warp_size = ::rocprim::arch::wavefront::size();
-    const auto     rank      = ::rocprim::detail::block_thread_id<0>() % warp_size;
+    const auto warp_size = ::rocprim::arch::wavefront::size();
+    const auto rank      = ::rocprim::detail::block_thread_id<0>() % warp_size;
 
     const uint8_t* src = reinterpret_cast<const uint8_t*>(input_buffer) + offset;
     uint8_t*       dst = reinterpret_cast<uint8_t*>(output_buffer) + offset;
@@ -327,13 +330,15 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE static void
 // Use template specialization on IsMemCpy is done in order to avoid using std::conditional.
 // Using std::conditional can result in build errors because the compiler evaluates both sides
 // of the conditional.
-template <bool IsMemCpy, typename InputBufferItType>
-struct AliasType { };
+template<bool IsMemCpy, typename InputBufferItType>
+struct AliasType
+{};
 
 template<typename InputBufferItType>
 struct AliasType<false, InputBufferItType>
 {
-    using type = typename std::iterator_traits<typename std::iterator_traits<InputBufferItType>::value_type>::value_type;
+    using type = typename std::iterator_traits<
+        typename std::iterator_traits<InputBufferItType>::value_type>::value_type;
 };
 
 template<typename InputBufferItType>
@@ -416,28 +421,40 @@ private:
                                                           blev_block_scan_state_type,
                                                           rocprim::plus<tile_offset_type>>;
 
-    template<class Config>
+    template<class ArchConfig>
     struct non_blev_memcpy
     {
-        ROCPRIM_DEVICE static constexpr batch_memcpy_config_params params = device_params<Config>();
+        ROCPRIM_DEVICE
+        static constexpr batch_memcpy_config_params params
+            = ArchConfig::params;
 
-        ROCPRIM_DEVICE static constexpr uint32_t block_size
+        ROCPRIM_DEVICE
+        static constexpr uint32_t block_size
             = params.non_blev_batch_memcpy_kernel_config.block_size;
-        ROCPRIM_DEVICE static constexpr uint32_t buffers_per_thread
+        ROCPRIM_DEVICE
+        static constexpr uint32_t buffers_per_thread
             = params.non_blev_batch_memcpy_kernel_config.items_per_thread;
-        ROCPRIM_DEVICE static constexpr uint32_t buffers_per_block
+        ROCPRIM_DEVICE
+        static constexpr uint32_t buffers_per_block
             = buffers_per_thread * block_size;
 
-        ROCPRIM_DEVICE static constexpr uint32_t blev_block_size
+        ROCPRIM_DEVICE
+        static constexpr uint32_t blev_block_size
             = params.blev_batch_memcpy_kernel_config.block_size;
-        ROCPRIM_DEVICE static constexpr uint32_t blev_bytes_per_thread
+        ROCPRIM_DEVICE
+        static constexpr uint32_t blev_bytes_per_thread
             = params.blev_batch_memcpy_kernel_config.items_per_thread;
 
-        ROCPRIM_DEVICE static constexpr uint32_t tlev_bytes_per_thread
+        ROCPRIM_DEVICE
+        static constexpr uint32_t tlev_bytes_per_thread
             = params.tlev_items_per_thread;
 
-        ROCPRIM_DEVICE static constexpr uint32_t blev_buffers_per_thread = buffers_per_thread;
-        ROCPRIM_DEVICE static constexpr uint32_t tlev_buffers_per_thread = buffers_per_thread;
+        ROCPRIM_DEVICE
+        static constexpr uint32_t blev_buffers_per_thread
+            = buffers_per_thread;
+        ROCPRIM_DEVICE
+        static constexpr uint32_t tlev_buffers_per_thread
+            = buffers_per_thread;
 
         using buffer_load_type
             = rocprim::block_load<buffer_size_type,
@@ -494,7 +511,8 @@ private:
 
         ROCPRIM_DEVICE ROCPRIM_INLINE non_blev_memcpy() {}
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE static size_class_counter get_buffer_size_class_histogram(
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        static size_class_counter get_buffer_size_class_histogram(
             const buffer_size_type (&buffer_sizes)[buffers_per_thread])
         {
             size_class_counter counters{};
@@ -502,16 +520,16 @@ private:
             ROCPRIM_UNROLL
             for(uint32_t i = 0; i < buffers_per_thread; ++i)
             {
-                auto size_class = get_size_class(buffer_sizes[i], device_params<Config>());
+                auto size_class = get_size_class(buffer_sizes[i], ArchConfig::params);
                 counters.add(size_class, buffer_sizes[i] > 0 ? 1 : 0);
             }
             return counters;
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void
-            partition_buffer_by_size(const buffer_size_type (&buffer_sizes)[buffers_per_thread],
-                                     size_class_counter counters,
-                                     buffer_tuple (&buffers_by_size_class)[buffers_per_block])
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void partition_buffer_by_size(const buffer_size_type (&buffer_sizes)[buffers_per_thread],
+                                      size_class_counter counters,
+                                      buffer_tuple (&buffers_by_size_class)[buffers_per_block])
         {
             const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
 
@@ -526,7 +544,7 @@ private:
                     continue;
                 }
 
-                const auto size_class = get_size_class(buffer_sizes[i], device_params<Config>());
+                const auto     size_class   = get_size_class(buffer_sizes[i], ArchConfig::params);
                 const uint32_t write_offset = counters.get(size_class);
                 buffers_by_size_class[write_offset]
                     = buffer_tuple{static_cast<tlev_byte_offset_type>(buffer_sizes[i]), buffer_id};
@@ -535,15 +553,15 @@ private:
             }
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void
-            prepare_blev_buffers(typename storage::shared_t::prepare_blev_t& blev_storage,
-                                 buffer_tuple*                               buffer_by_size_class,
-                                 copyable_buffers                            buffers,
-                                 buffer_offset_type                          num_blev_buffers,
-                                 copyable_blev_buffers                       blev_buffers,
-                                 buffer_offset_type                          tile_buffer_offset,
-                                 blev_block_scan_state_type                  blev_block_scan_state,
-                                 buffer_offset_type                          tile_id)
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void prepare_blev_buffers(typename storage::shared_t::prepare_blev_t& blev_storage,
+                                  buffer_tuple*                               buffer_by_size_class,
+                                  copyable_buffers                            buffers,
+                                  buffer_offset_type                          num_blev_buffers,
+                                  copyable_blev_buffers                       blev_buffers,
+                                  buffer_offset_type                          tile_buffer_offset,
+                                  blev_block_scan_state_type                  blev_block_scan_state,
+                                  buffer_offset_type                          tile_id)
         {
             const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
 
@@ -561,7 +579,8 @@ private:
                     / rocthrust::device_reference<T>. This is possible since rocthrust::device_reference<T>
                     / can be implicitly cast to type T.
                     */
-                    buffer_size_type size = static_cast<buffer_size_type>(buffers.sizes[tile_buffer_id]);
+                    buffer_size_type size
+                        = static_cast<buffer_size_type>(buffers.sizes[tile_buffer_id]);
                     tile_offsets[i]
                         = rocprim::detail::ceiling_div(size,
                                                        blev_block_size * blev_bytes_per_thread);
@@ -625,9 +644,10 @@ private:
             }
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void copy_wlev_buffers(buffer_tuple*    buffers_by_size_class,
-                                                             copyable_buffers tile_buffers,
-                                                             buffer_offset_type num_wlev_buffers)
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void copy_wlev_buffers(buffer_tuple*      buffers_by_size_class,
+                               copyable_buffers   tile_buffers,
+                               buffer_offset_type num_wlev_buffers)
         {
             const uint32_t warp_id = rocprim::warp_id();
             const uint32_t warps_per_block
@@ -642,18 +662,19 @@ private:
                 / rocthrust::device_reference<T>. This is possible since rocthrust::device_reference<T>
                 / can be implicitly cast to type T.
                 */
-                buffer_size_type size = static_cast<buffer_size_type>(tile_buffers.sizes[buffer_id]);
+                buffer_size_type size
+                    = static_cast<buffer_size_type>(tile_buffers.sizes[buffer_id]);
                 batch_memcpy::copy_items<IsMemCpy>(tile_buffers.srcs[buffer_id],
-                            tile_buffers.dsts[buffer_id],
-                            size);
+                                                   tile_buffers.dsts[buffer_id],
+                                                   size);
             }
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void
-            copy_tlev_buffers(typename storage::shared_t::copy_tlev_t& tlev_storage,
-                              buffer_tuple*                            buffers_by_size_class,
-                              copyable_buffers                         tile_buffers,
-                              buffer_offset_type                       num_tlev_buffers)
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void copy_tlev_buffers(typename storage::shared_t::copy_tlev_t& tlev_storage,
+                               buffer_tuple*                            buffers_by_size_class,
+                               copyable_buffers                         tile_buffers,
+                               buffer_offset_type                       num_tlev_buffers)
         {
             const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
 
@@ -782,13 +803,14 @@ private:
             }
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void copy(storage&                    temp_storage,
-                                                copyable_buffers            buffers,
-                                                uint32_t                    num_buffers,
-                                                copyable_blev_buffers       blev_buffers,
-                                                blev_buffer_scan_state_type blev_buffer_scan_state,
-                                                blev_block_scan_state_type  blev_block_scan_state,
-                                                const buffer_offset_type    tile_id)
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void copy(storage&                    temp_storage,
+                  copyable_buffers            buffers,
+                  uint32_t                    num_buffers,
+                  copyable_blev_buffers       blev_buffers,
+                  blev_buffer_scan_state_type blev_buffer_scan_state,
+                  blev_block_scan_state_type  blev_block_scan_state,
+                  const buffer_offset_type    tile_id)
         {
             const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
 
@@ -941,31 +963,32 @@ public:
         block_scan_state.initialize_prefix(flat_thread_id, num_tiles);
     }
 
-    template<class Config>
-    static ROCPRIM_KERNEL
-    void non_blev_memcpy_kernel(copyable_buffers            buffers,
-                                buffer_offset_type          num_buffers,
-                                copyable_blev_buffers       blev_buffers,
-                                blev_buffer_scan_state_type blev_buffer_scan_state,
-                                blev_block_scan_state_type  blev_block_scan_state)
+    template<class ArchConfig>
+    static ROCPRIM_DEVICE
+    void non_blev_memcpy_kernel_impl(copyable_buffers            buffers,
+                                     buffer_offset_type          num_buffers,
+                                     copyable_blev_buffers       blev_buffers,
+                                     blev_buffer_scan_state_type blev_buffer_scan_state,
+                                     blev_block_scan_state_type  blev_block_scan_state)
     {
-        ROCPRIM_SHARED_MEMORY typename non_blev_memcpy<Config>::storage_type temp_storage;
-        non_blev_memcpy<Config>{}.copy(temp_storage.get(),
-                                       buffers,
-                                       num_buffers,
-                                       blev_buffers,
-                                       blev_buffer_scan_state,
-                                       blev_block_scan_state,
-                                       rocprim::flat_block_id());
+        ROCPRIM_SHARED_MEMORY
+        typename non_blev_memcpy<ArchConfig>::storage_type temp_storage;
+        non_blev_memcpy<ArchConfig>{}.copy(temp_storage.get(),
+                                           buffers,
+                                           num_buffers,
+                                           blev_buffers,
+                                           blev_buffer_scan_state,
+                                           blev_block_scan_state,
+                                           rocprim::flat_block_id());
     }
 
-    template<typename Config>
-    static ROCPRIM_KERNEL
-    void blev_memcpy_kernel(copyable_blev_buffers       blev_buffers,
-                            blev_buffer_scan_state_type buffer_offset_tile,
-                            tile_offset_type            last_tile_offset)
+    template<typename ArchConfig>
+    static ROCPRIM_DEVICE
+    void blev_memcpy_kernel_impl(copyable_blev_buffers       blev_buffers,
+                                 blev_buffer_scan_state_type buffer_offset_tile,
+                                 tile_offset_type            last_tile_offset)
     {
-        static constexpr batch_memcpy_config_params params = device_params<Config>();
+        static constexpr batch_memcpy_config_params params = ArchConfig::params;
         static constexpr uint32_t                   blev_block_size
             = params.blev_batch_memcpy_kernel_config.block_size;
         static constexpr uint32_t blev_bytes_per_thread
@@ -988,7 +1011,8 @@ public:
         uint32_t tile_id = flat_block_id;
         while(true)
         {
-            __shared__ buffer_offset_type shared_buffer_id;
+            __shared__
+            buffer_offset_type shared_buffer_id;
 
             rocprim::syncthreads();
 
@@ -1048,22 +1072,23 @@ public:
     }
 };
 
-template<class Config_,
+template<class Config,
          class InputBufferItType,
          class OutputBufferItType,
          class BufferSizeItType,
          bool IsMemCpy>
-ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_storage,
-                                                   size_t&            storage_size,
-                                                   InputBufferItType  sources,
-                                                   OutputBufferItType destinations,
-                                                   BufferSizeItType   sizes,
-                                                   uint32_t           num_copies,
-                                                   hipStream_t        stream = hipStreamDefault,
-                                                   bool               debug_synchronous = false)
+ROCPRIM_INLINE
+static hipError_t batch_memcpy_func(void*              temporary_storage,
+                                    size_t&            storage_size,
+                                    InputBufferItType  sources,
+                                    OutputBufferItType destinations,
+                                    BufferSizeItType   sizes,
+                                    uint32_t           num_copies,
+                                    hipStream_t        stream            = hipStreamDefault,
+                                    bool               debug_synchronous = false)
 {
     using config
-        = wrapped_batch_memcpy_config<Config_,
+        = wrapped_batch_memcpy_config<Config,
                                       typename std::iterator_traits<InputBufferItType>::value_type,
                                       IsMemCpy>;
 
@@ -1075,7 +1100,7 @@ ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_
     }
 
     const detail::batch_memcpy_config_params params
-        = detail::dispatch_target_arch<config>(target_arch);
+        = detail::dispatch_target_arch<config, false>(target_arch);
 
     using BufferOffsetType = unsigned int;
     using BlockOffsetType  = unsigned int;
@@ -1152,37 +1177,9 @@ ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_
                                                   hipDeviceAttributeMultiprocessorCount,
                                                   device_id));
 
-    // `hipOccupancyMaxActiveBlocksPerMultiprocessor` uses the default device.
-    // We need to perserve the current default device id while we change it temporarily
-    // to get the max occupancy on this stream.
-    int previous_device;
-    ROCPRIM_RETURN_ON_ERROR(hipGetDevice(&previous_device));
-
-    ROCPRIM_RETURN_ON_ERROR(hipSetDevice(device_id));
-
-    int blev_occupancy{};
-    hipError_t error = hipOccupancyMaxActiveBlocksPerMultiprocessor(
-        &blev_occupancy,
-        batch_memcpy_impl_type::template blev_memcpy_kernel<config>,
-        blev_block_size,
-        0 /* dynSharedMemPerBlk */);
-    if(error != hipSuccess)
-    {
-        // Attempt to reset the device.
-        static_cast<void>(hipSetDevice(previous_device));
-
-        return error;
-    }
-
-    // Restore the default device id to initial state
-    ROCPRIM_RETURN_ON_ERROR(hipSetDevice(previous_device));
-
     constexpr BlockOffsetType init_kernel_threads = 128;
     const BlockOffsetType     init_kernel_grid_size
         = rocprim::detail::ceiling_div(num_blocks, init_kernel_threads);
-
-    auto batch_memcpy_blev_grid_size
-        = multiprocessor_count * blev_occupancy * 1 /* subscription factor */;
 
     BlockOffsetType batch_memcpy_grid_size = num_blocks;
 
@@ -1198,6 +1195,47 @@ ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_
                                                           blev_block_scan_state_data,
                                                           num_blocks,
                                                           stream));
+
+    // `hipOccupancyMaxActiveBlocksPerMultiprocessor` uses the default device.
+    // We need to perserve the current default device id while we change it temporarily
+    // to get the max occupancy on this stream.
+    int previous_device;
+    ROCPRIM_RETURN_ON_ERROR(hipGetDevice(&previous_device));
+
+    ROCPRIM_RETURN_ON_ERROR(hipSetDevice(device_id));
+
+    auto blev_memcpy_kernel = [=] __device__ (auto arch_config)
+    {
+        batch_memcpy_impl_type::template blev_memcpy_kernel_impl<decltype(arch_config)>(
+            blev_buffers,
+            scan_state_buffer,
+            batch_memcpy_grid_size - 1);
+    };
+
+    auto blev_memcpy_tuned_kernel
+        = configure_kernel<config,
+                           decltype(blev_memcpy_kernel),
+                           blev_batch_memcpy_kernel_config_selector>(target_arch,
+                                                                     blev_memcpy_kernel);
+
+    int        blev_occupancy{};
+    hipError_t error = hipOccupancyMaxActiveBlocksPerMultiprocessor(&blev_occupancy,
+                                                                    blev_memcpy_tuned_kernel.kernel,
+                                                                    blev_block_size,
+                                                                    0 /* dynSharedMemPerBlk */);
+    if(error != hipSuccess)
+    {
+        // Attempt to reset the device.
+        static_cast<void>(hipSetDevice(previous_device));
+
+        return error;
+
+        // Restore the default device id to initial state
+        ROCPRIM_RETURN_ON_ERROR(hipSetDevice(previous_device));
+    }
+
+    auto batch_memcpy_blev_grid_size
+        = multiprocessor_count * blev_occupancy * 1 /* subscription factor */;
 
     // Start point for time measurements
     std::chrono::steady_clock::time_point start;
@@ -1235,22 +1273,39 @@ ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_
             num_blocks);
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_tile_state_kernel", num_blocks, start);
 
+    auto non_blev_memcpy_kernel = [=] __device__ (auto arch_config)
+    {
+        batch_memcpy_impl_type::template non_blev_memcpy_kernel_impl<decltype(arch_config)>(
+            buffers,
+            num_copies,
+            blev_buffers,
+            scan_state_buffer,
+            scan_state_block);
+    };
+
     // Launch batch_memcpy_non_blev_kernel.
     start_timer();
-    batch_memcpy_impl_type::template non_blev_memcpy_kernel<config>
-        <<<batch_memcpy_grid_size, non_blev_block_size, 0, stream>>>(buffers,
-                                                                     num_copies,
-                                                                     blev_buffers,
-                                                                     scan_state_buffer,
-                                                                     scan_state_block);
+
+    hipError_t launch_err
+        = launch_kernel<config,
+                        decltype(non_blev_memcpy_kernel),
+                        non_blev_batch_memcpy_kernel_config_selector>(target_arch,
+                                                                      non_blev_memcpy_kernel,
+                                                                      batch_memcpy_grid_size,
+                                                                      non_blev_block_size,
+                                                                      0,
+                                                                      stream);
+
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("non_blev_memcpy_kernel", num_copies, start);
+
+    if(launch_err != hipSuccess)
+    {
+        return launch_err;
+    }
 
     // Launch batch_memcpy_blev_kernel.
     start_timer();
-    batch_memcpy_impl_type::template blev_memcpy_kernel<config>
-        <<<batch_memcpy_blev_grid_size, blev_block_size, 0, stream>>>(blev_buffers,
-                                                                      scan_state_buffer,
-                                                                      batch_memcpy_grid_size - 1);
+    blev_memcpy_tuned_kernel.launch(batch_memcpy_blev_grid_size, blev_block_size, 0, stream);
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("blev_memcpy_kernel",
                                                 batch_memcpy_grid_size - 1,
                                                 start);

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -1199,15 +1199,14 @@ static hipError_t batch_memcpy_func(void*              temporary_storage,
             batch_memcpy_grid_size - 1);
     };
 
-    auto blev_memcpy_tuned_kernel
-        = configure_kernel<config,
-                           decltype(blev_memcpy_kernel),
-                           blev_batch_memcpy_kernel_config_selector>(target_arch,
-                                                                     blev_memcpy_kernel);
+    auto blev_memcpy_launch_plan
+        = make_launch_plan<config, decltype(blev_memcpy_kernel), blev_batch_memcpy_config_selector>(
+            target_arch,
+            blev_memcpy_kernel);
 
     int        blev_occupancy{};
     hipError_t error = hipOccupancyMaxActiveBlocksPerMultiprocessor(&blev_occupancy,
-                                                                    blev_memcpy_tuned_kernel.kernel,
+                                                                    blev_memcpy_launch_plan.kernel,
                                                                     blev_block_size,
                                                                     0 /* dynSharedMemPerBlk */);
     if(error != hipSuccess)
@@ -1274,19 +1273,19 @@ static hipError_t batch_memcpy_func(void*              temporary_storage,
     start_timer();
 
     ROCPRIM_RETURN_ON_ERROR(
-        launch_kernel<config,
-                      decltype(non_blev_memcpy_kernel),
-                      non_blev_batch_memcpy_kernel_config_selector>(target_arch,
-                                                                    non_blev_memcpy_kernel,
-                                                                    batch_memcpy_grid_size,
-                                                                    non_blev_block_size,
-                                                                    0,
-                                                                    stream));
+        execute_launch_plan<config,
+                            decltype(non_blev_memcpy_kernel),
+                            non_blev_batch_memcpy_config_selector>(target_arch,
+                                                                   non_blev_memcpy_kernel,
+                                                                   batch_memcpy_grid_size,
+                                                                   non_blev_block_size,
+                                                                   0,
+                                                                   stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("non_blev_memcpy_kernel", num_copies, start);
 
     // Launch batch_memcpy_blev_kernel.
     start_timer();
-    blev_memcpy_tuned_kernel.launch(batch_memcpy_blev_grid_size, blev_block_size, 0, stream);
+    blev_memcpy_launch_plan.launch(batch_memcpy_blev_grid_size, blev_block_size, 0, stream);
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("blev_memcpy_kernel",
                                                 batch_memcpy_grid_size - 1,
                                                 start);

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -1273,22 +1273,16 @@ static hipError_t batch_memcpy_func(void*              temporary_storage,
     // Launch batch_memcpy_non_blev_kernel.
     start_timer();
 
-    hipError_t launch_err
-        = launch_kernel<config,
-                        decltype(non_blev_memcpy_kernel),
-                        non_blev_batch_memcpy_kernel_config_selector>(target_arch,
-                                                                      non_blev_memcpy_kernel,
-                                                                      batch_memcpy_grid_size,
-                                                                      non_blev_block_size,
-                                                                      0,
-                                                                      stream);
-
+    ROCPRIM_RETURN_ON_ERROR(
+        launch_kernel<config,
+                      decltype(non_blev_memcpy_kernel),
+                      non_blev_batch_memcpy_kernel_config_selector>(target_arch,
+                                                                    non_blev_memcpy_kernel,
+                                                                    batch_memcpy_grid_size,
+                                                                    non_blev_block_size,
+                                                                    0,
+                                                                    stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("non_blev_memcpy_kernel", num_copies, start);
-
-    if(launch_err != hipSuccess)
-    {
-        return launch_err;
-    }
 
     // Launch batch_memcpy_blev_kernel.
     start_timer();

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -95,7 +95,8 @@ public:
     }
 
     ROCPRIM_DEVICE
-    counter operator+(const counter& other) const
+    counter
+        operator+(const counter& other) const
     {
         counter result{};
 
@@ -424,37 +425,25 @@ private:
     template<class ArchConfig>
     struct non_blev_memcpy
     {
-        ROCPRIM_DEVICE
-        static constexpr batch_memcpy_config_params params
-            = ArchConfig::params;
+        ROCPRIM_DEVICE static constexpr batch_memcpy_config_params params = ArchConfig::params;
 
-        ROCPRIM_DEVICE
-        static constexpr uint32_t block_size
+        ROCPRIM_DEVICE static constexpr uint32_t block_size
             = params.non_blev_batch_memcpy_kernel_config.block_size;
-        ROCPRIM_DEVICE
-        static constexpr uint32_t buffers_per_thread
+        ROCPRIM_DEVICE static constexpr uint32_t buffers_per_thread
             = params.non_blev_batch_memcpy_kernel_config.items_per_thread;
-        ROCPRIM_DEVICE
-        static constexpr uint32_t buffers_per_block
+        ROCPRIM_DEVICE static constexpr uint32_t buffers_per_block
             = buffers_per_thread * block_size;
 
-        ROCPRIM_DEVICE
-        static constexpr uint32_t blev_block_size
+        ROCPRIM_DEVICE static constexpr uint32_t blev_block_size
             = params.blev_batch_memcpy_kernel_config.block_size;
-        ROCPRIM_DEVICE
-        static constexpr uint32_t blev_bytes_per_thread
+        ROCPRIM_DEVICE static constexpr uint32_t blev_bytes_per_thread
             = params.blev_batch_memcpy_kernel_config.items_per_thread;
 
-        ROCPRIM_DEVICE
-        static constexpr uint32_t tlev_bytes_per_thread
+        ROCPRIM_DEVICE static constexpr uint32_t tlev_bytes_per_thread
             = params.tlev_items_per_thread;
 
-        ROCPRIM_DEVICE
-        static constexpr uint32_t blev_buffers_per_thread
-            = buffers_per_thread;
-        ROCPRIM_DEVICE
-        static constexpr uint32_t tlev_buffers_per_thread
-            = buffers_per_thread;
+        ROCPRIM_DEVICE static constexpr uint32_t blev_buffers_per_thread = buffers_per_thread;
+        ROCPRIM_DEVICE static constexpr uint32_t tlev_buffers_per_thread = buffers_per_thread;
 
         using buffer_load_type
             = rocprim::block_load<buffer_size_type,
@@ -971,8 +960,7 @@ public:
                                      blev_buffer_scan_state_type blev_buffer_scan_state,
                                      blev_block_scan_state_type  blev_block_scan_state)
     {
-        ROCPRIM_SHARED_MEMORY
-        typename non_blev_memcpy<ArchConfig>::storage_type temp_storage;
+        ROCPRIM_SHARED_MEMORY typename non_blev_memcpy<ArchConfig>::storage_type temp_storage;
         non_blev_memcpy<ArchConfig>{}.copy(temp_storage.get(),
                                            buffers,
                                            num_buffers,
@@ -1011,8 +999,7 @@ public:
         uint32_t tile_id = flat_block_id;
         while(true)
         {
-            __shared__
-            buffer_offset_type shared_buffer_id;
+            __shared__ buffer_offset_type shared_buffer_id;
 
             rocprim::syncthreads();
 
@@ -1204,7 +1191,7 @@ static hipError_t batch_memcpy_func(void*              temporary_storage,
 
     ROCPRIM_RETURN_ON_ERROR(hipSetDevice(device_id));
 
-    auto blev_memcpy_kernel = [=] __device__ (auto arch_config)
+    auto blev_memcpy_kernel = [=](auto arch_config)
     {
         batch_memcpy_impl_type::template blev_memcpy_kernel_impl<decltype(arch_config)>(
             blev_buffers,
@@ -1273,7 +1260,7 @@ static hipError_t batch_memcpy_func(void*              temporary_storage,
             num_blocks);
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_tile_state_kernel", num_blocks, start);
 
-    auto non_blev_memcpy_kernel = [=] __device__ (auto arch_config)
+    auto non_blev_memcpy_kernel = [=](auto arch_config)
     {
         batch_memcpy_impl_type::template non_blev_memcpy_kernel_impl<decltype(arch_config)>(
             buffers,

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -866,7 +866,7 @@ struct adjacent_difference_config_tag
 
 struct adjacent_difference_config_params
 {
-    kernel_config_params          adjacent_difference_kernel_config;
+    kernel_config_params          kernel_config;
     ::rocprim::block_load_method  block_load_method;
     ::rocprim::block_store_method block_store_method;
 };

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -49,7 +49,7 @@ namespace detail
 /// \brief Default values are provided by \p merge_sort_block_sort_config_base.
 struct merge_sort_block_sort_config_params
 {
-    kernel_config_params block_sort_config = {0, 0};
+    kernel_config_params kernel_config = {0, 0};
 };
 
 // Necessary to construct a parameterized type of `merge_sort_block_sort_config_params`.
@@ -59,7 +59,7 @@ template<unsigned int                  BlockSize,
          rocprim::block_sort_algorithm Algo = block_sort_algorithm::stable_merge_sort>
 struct merge_sort_block_sort_config : rocprim::detail::merge_sort_block_sort_config_params
 {
-    using sort_config = kernel_config<BlockSize, ItemsPerThread>;
+    using sort_config = ::rocprim::kernel_config<BlockSize, ItemsPerThread>;
     constexpr merge_sort_block_sort_config()
         : rocprim::detail::merge_sort_block_sort_config_params{sort_config()} {};
 };

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_config_helper.hpp
@@ -242,7 +242,7 @@ struct radix_sort_onesweep_config_base
 
 struct reduce_config_params
 {
-    kernel_config_params   reduce_config;
+    kernel_config_params   kernel_config;
     block_reduce_algorithm block_reduce_method;
 };
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_merge.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_merge.hpp
@@ -235,10 +235,10 @@ typename std::enable_if<!WithValues>::type merge_values(unsigned int         fla
     (void)input2_size;
 }
 
-template<class Config, class Key, class Value>
+template<class ArchConfig, class Key, class Value>
 struct merge_kernel_impl_
 {
-    static constexpr merge_config_params params = device_params<Config>();
+    static constexpr merge_config_params params = ArchConfig::params;
 
     static constexpr unsigned int block_size       = params.kernel_config.block_size;
     static constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -261,28 +261,26 @@ struct merge_kernel_impl_
         typename keys_store_type::storage_type keys_store;
     };
 
-    template<
-    class IndexIterator,
-    class KeysInputIterator1,
-    class KeysInputIterator2,
-    class KeysOutputIterator,
-    class ValuesInputIterator1,
-    class ValuesInputIterator2,
-    class ValuesOutputIterator,
-    class BinaryFunction
->
+    template<class IndexIterator,
+             class KeysInputIterator1,
+             class KeysInputIterator2,
+             class KeysOutputIterator,
+             class ValuesInputIterator1,
+             class ValuesInputIterator2,
+             class ValuesOutputIterator,
+             class BinaryFunction>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
-void merge(IndexIterator indices,
-                       KeysInputIterator1 keys_input1,
-                       KeysInputIterator2 keys_input2,
-                       KeysOutputIterator keys_output,
-                       ValuesInputIterator1 values_input1,
-                       ValuesInputIterator2 values_input2,
-                       ValuesOutputIterator values_output,
-                       const size_t input1_size,
-                       const size_t input2_size,
-                       BinaryFunction compare_function, 
-                       storage_type&           storage)
+    void merge(IndexIterator indices,
+               KeysInputIterator1 keys_input1,
+               KeysInputIterator2 keys_input2,
+               KeysOutputIterator keys_output,
+               ValuesInputIterator1 values_input1,
+               ValuesInputIterator2 values_input2,
+               ValuesOutputIterator values_output,
+               const size_t input1_size,
+               const size_t input2_size,
+               BinaryFunction compare_function, 
+               storage_type&           storage)
     {
         using key_type1   = typename std::iterator_traits<KeysInputIterator1>::value_type;
         using key_type2   = typename std::iterator_traits<KeysInputIterator2>::value_type;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
@@ -69,12 +69,13 @@ struct nth_element_onesweep_lookback_state
 
     underlying_type state;
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE explicit nth_element_onesweep_lookback_state(underlying_type state)
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    explicit nth_element_onesweep_lookback_state(underlying_type state)
         : state(state)
     {}
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE nth_element_onesweep_lookback_state(prefix_flag     status,
-                                                                     underlying_type value)
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    nth_element_onesweep_lookback_state(prefix_flag status, underlying_type value)
         : state(static_cast<underlying_type>(status) | value)
     {}
 
@@ -120,11 +121,11 @@ struct n_th_element_iteration_data
     bool         equality_bucket;
 };
 
-template<class config, class KeysIterator, class BinaryFunction>
+template<class ArchConfig, class KeysIterator, class BinaryFunction>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_block_sort_impl(KeysIterator keys, const unsigned int size, BinaryFunction compare_function)
+    block_sort_kernel_impl(KeysIterator keys, const unsigned int size, BinaryFunction compare_function)
 {
-    constexpr nth_element_config_params params = device_params<config>();
+    constexpr nth_element_config_params params = ArchConfig::params;
 
     constexpr unsigned int stop_recursion_size = params.stop_recursion_size;
 
@@ -154,29 +155,41 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     block_store_key().store(keys, sample_buffer, size, storage.store);
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().stop_recursion_size) void
-    kernel_block_sort(KeysIterator keys, const unsigned int size, BinaryFunction compare_function)
+template<class Config, class KeysIterator, class BinaryFunction>
+inline hipError_t launch_block_sort(detail::target_arch arch,
+                                    KeysIterator        keys,
+                                    const unsigned int  size,
+                                    BinaryFunction      compare_function,
+                                    dim3                grid,
+                                    dim3                block,
+                                    size_t              shmem,
+                                    hipStream_t         stream)
 {
-    kernel_block_sort_impl<config>(keys, size, compare_function);
+    auto kernel = [=] __device__ (auto arch_config)
+    {
+        block_sort_kernel_impl<decltype(arch_config)>(keys, size, compare_function);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_find_splitters_impl(KeysIterator                                             keys,
+template<class ArchConfig, class KeysIterator, class BinaryFunction>
+ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void find_splitters_kernel_impl(
+                               KeysIterator                                             keys,
                                typename std::iterator_traits<KeysIterator>::value_type* tree,
                                bool*          equality_buckets,
                                const unsigned int   size,
                                BinaryFunction compare_function)
 {
-    constexpr nth_element_config_params params        = device_params<config>();
+    constexpr nth_element_config_params params        = ArchConfig::params;
     constexpr unsigned int              num_splitters = params.number_of_buckets - 1;
 
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
 
     using block_sort_key = block_sort<key_type, num_splitters>;
 
-    ROCPRIM_SHARED_MEMORY typename block_sort_key::storage_type storage;
+    ROCPRIM_SHARED_MEMORY
+    typename block_sort_key::storage_type storage;
 
     const unsigned int stride = size / num_splitters;
     const unsigned int idx    = threadIdx.x;
@@ -203,27 +216,41 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     equality_buckets[idx] = equality_bucket;
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().number_of_buckets - 1) void
-    kernel_find_splitters(KeysIterator                                             keys,
+template<class Config, class KeysIterator, class BinaryFunction>
+inline hipError_t
+    launch_find_splitters(detail::target_arch                                      arch,
+                          KeysIterator                                             keys,
                           typename std::iterator_traits<KeysIterator>::value_type* tree,
                           bool*                                                    equality_buckets,
                           const unsigned int                                       size,
-                          BinaryFunction                                           compare_function)
+                          BinaryFunction                                           compare_function,
+                          dim3                                                     grid,
+                          dim3                                                     block,
+                          size_t                                                   shmem,
+                          hipStream_t                                              stream)
 {
-    kernel_find_splitters_impl<config>(keys, tree, equality_buckets, size, compare_function);
+    auto kernel = [=] __device__ (auto arch_config)
+    {
+        find_splitters_kernel_impl<decltype(arch_config)>(keys,
+                                                        tree,
+                                                        equality_buckets,
+                                                        size,
+                                                        compare_function);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
+template<class ArchConfig, class KeysIterator, class BinaryFunction>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_count_bucket_sizes_impl(KeysIterator                                             keys,
+    count_bucket_sizes_kernel_impl(KeysIterator                                             keys,
                                    typename std::iterator_traits<KeysIterator>::value_type* tree,
                                    const unsigned int                                             size,
                                    unsigned int*                                                  buckets,
                                    bool*          equality_buckets,
                                    BinaryFunction compare_function)
 {
-    constexpr nth_element_config_params params = device_params<config>();
+    constexpr nth_element_config_params params = ArchConfig::params;
 
     constexpr unsigned int num_buckets           = params.number_of_buckets;
     constexpr unsigned int num_threads_per_block = params.kernel_config.block_size;
@@ -318,32 +345,42 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     }
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().kernel_config.block_size) void
-    kernel_count_bucket_sizes(KeysIterator                                             keys,
+template<class Config, class KeysIterator, class BinaryFunction>
+inline hipError_t
+    launch_count_bucket_sizes(detail::target_arch                                      arch,
+                              KeysIterator                                             keys,
                               typename std::iterator_traits<KeysIterator>::value_type* tree,
                               const unsigned int                                       size,
                               unsigned int*                                            buckets,
                               bool*          equality_buckets,
-                              BinaryFunction compare_function)
+                              BinaryFunction compare_function,
+                              dim3           grid,
+                              dim3           block,
+                              size_t         shmem,
+                              hipStream_t    stream)
 {
-    kernel_count_bucket_sizes_impl<config>(keys,
-                                           tree,
-                                           size,
-                                           buckets,
-                                           equality_buckets,
-                                           compare_function);
+    auto kernel = [=] __device__ (auto arch_config)
+    {
+        count_bucket_sizes_kernel_impl<decltype(arch_config)>(keys,
+                                                            tree,
+                                                            size,
+                                                            buckets,
+                                                            equality_buckets,
+                                                            compare_function);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config>
+template<class ArchConfig>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_find_nth_element_bucket_impl(unsigned int*                      buckets,
+    find_nth_element_bucket_kernel_impl(unsigned int*                      buckets,
                                         n_th_element_iteration_data* nth_element_data,
                                         bool*                        equality_buckets,
                                         const unsigned int           rank)
 
 {
-    constexpr nth_element_config_params params = device_params<config>();
+    constexpr nth_element_config_params params = ArchConfig::params;
 
     constexpr unsigned int num_buckets = params.number_of_buckets;
 
@@ -381,20 +418,32 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     }
 }
 
-template<class config>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().number_of_buckets) void
-    kernel_find_nth_element_bucket(unsigned int*                buckets,
-                                   n_th_element_iteration_data* nth_element_data,
-                                   bool*                        equality_buckets,
-                                   const unsigned int           rank)
+template<class Config>
+inline hipError_t launch_find_nth_element_bucket(detail::target_arch          arch,
+                                                 unsigned int*                buckets,
+                                                 n_th_element_iteration_data* nth_element_data,
+                                                 bool*                        equality_buckets,
+                                                 const unsigned int           rank,
+                                                 dim3                         grid,
+                                                 dim3                         block,
+                                                 size_t                       shmem,
+                                                 hipStream_t                  stream)
 
 {
-    kernel_find_nth_element_bucket_impl<config>(buckets, nth_element_data, equality_buckets, rank);
+    auto kernel = [=] __device__ (auto arch_config)
+    {
+        find_nth_element_bucket_kernel_impl<decltype(arch_config)>(buckets,
+                                                                    nth_element_data,
+                                                                    equality_buckets,
+                                                                    rank);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+template<class ArchConfig, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_copy_buckets_impl(KeysIterator                                             keys,
+    copy_buckets_kernel_impl(KeysIterator                                             keys,
                              typename std::iterator_traits<KeysIterator>::value_type* tree,
                              const unsigned int                                       size,
                              nth_element_onesweep_lookback_state* lookback_states,
@@ -406,7 +455,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
     using state    = nth_element_onesweep_lookback_state;
 
-    constexpr nth_element_config_params params = device_params<config>();
+    constexpr nth_element_config_params params = ArchConfig::params;
 
     constexpr unsigned int num_buckets           = params.number_of_buckets;
     constexpr unsigned int num_splitters         = num_buckets - 1;
@@ -415,9 +464,10 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     constexpr unsigned int num_items_per_block   = num_threads_per_block * num_items_per_thread;
     constexpr unsigned int num_partitions        = NumPartitions;
 
-    using block_rank         = rocprim::block_radix_rank<num_threads_per_block,
+    using block_rank = rocprim::block_radix_rank<num_threads_per_block,
                                                  Log2<static_cast<int>(num_partitions + 1)>::VALUE,
                                                  params.radix_rank_algorithm>;
+
     using block_load_element = block_load<key_type, num_threads_per_block, num_items_per_thread>;
 
     static_assert(block_rank::digits_per_thread == 1,
@@ -581,31 +631,42 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     }
 }
 
-template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().kernel_config.block_size) void
-    kernel_copy_buckets(KeysIterator                                             keys,
+template<class Config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+inline hipError_t
+    launch_copy_buckets(detail::target_arch                                      arch,
+                        KeysIterator                                             keys,
                         typename std::iterator_traits<KeysIterator>::value_type* tree,
                         const unsigned int                                       size,
                         nth_element_onesweep_lookback_state*                     lookback_states,
                         n_th_element_iteration_data*                             nth_element_data,
                         typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
                         bool*                                                    equality_buckets,
-                        BinaryFunction                                           compare_function)
+                        BinaryFunction                                           compare_function,
+                        dim3                                                     grid,
+                        dim3                                                     block,
+                        size_t                                                   shmem,
+                        hipStream_t                                              stream)
 {
-    kernel_copy_buckets_impl<config, NumPartitions>(keys,
-                                                    tree,
-                                                    size,
-                                                    lookback_states,
-                                                    nth_element_data,
-                                                    keys_buffer,
-                                                    equality_buckets,
-                                                    compare_function);
+    auto kernel = [=] __device__ (auto arch_config)
+    {
+        copy_buckets_kernel_impl<decltype(arch_config), NumPartitions>(keys,
+                                                                       tree,
+                                                                       size,
+                                                                       lookback_states,
+                                                                       nth_element_data,
+                                                                       keys_buffer,
+                                                                       equality_buckets,
+                                                                       compare_function);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+template<class Config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
 ROCPRIM_INLINE
 hipError_t
-    nth_element_keys_impl(KeysIterator                                             keys,
+    nth_element_keys_impl(detail::target_arch                                      arch,
+                          KeysIterator                                             keys,
                           typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
                           typename std::iterator_traits<KeysIterator>::value_type* tree,
                           unsigned int                                             rank,
@@ -664,36 +725,75 @@ hipError_t
                                                        stream));
 
         start_timer();
-        kernel_find_splitters<config>
-            <<<1, num_splitters, 0, stream>>>(keys, tree, equality_buckets, size, compare_function);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_find_splitters", size, start);
+        hipError_t launch_err = launch_find_splitters<Config>(arch,
+                                                              keys,
+                                                              tree,
+                                                              equality_buckets,
+                                                              size,
+                                                              compare_function,
+                                                              1,
+                                                              num_splitters,
+                                                              0,
+                                                              stream);
+        if(launch_err != hipSuccess)
+        {
+            return launch_err;
+        }
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("find_splitters_kernel", size, start);
 
         start_timer();
-        kernel_count_bucket_sizes<config>
-            <<<num_blocks, num_threads_per_block, 0, stream>>>(keys,
-                                                               tree,
-                                                               size,
-                                                               buckets,
-                                                               equality_buckets,
-                                                               compare_function);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_count_bucket_sizes", size, start);
+        launch_err = launch_count_bucket_sizes<Config>(arch,
+                                                       keys,
+                                                       tree,
+                                                       size,
+                                                       buckets,
+                                                       equality_buckets,
+                                                       compare_function,
+                                                       num_blocks,
+                                                       num_threads_per_block,
+                                                       0,
+                                                       stream);
+        if(launch_err != hipSuccess)
+        {
+            return launch_err;
+        }
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("count_bucket_sizes_kernel", size, start);
 
         start_timer();
-        kernel_find_nth_element_bucket<config>
-            <<<1, num_buckets, 0, stream>>>(buckets, nth_element_data, equality_buckets, rank);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_find_nth_element_bucket", size, start);
+        launch_err = launch_find_nth_element_bucket<Config>(arch,
+                                                            buckets,
+                                                            nth_element_data,
+                                                            equality_buckets,
+                                                            rank,
+                                                            1,
+                                                            num_buckets,
+                                                            0,
+                                                            stream);
+        if(launch_err != hipSuccess)
+        {
+            return launch_err;
+        }
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("find_nth_element_bucket_kernel", size, start);
 
         start_timer();
-        kernel_copy_buckets<config, num_partitions>
-            <<<num_blocks, num_threads_per_block, 0, stream>>>(keys,
-                                                               tree,
-                                                               size,
-                                                               lookback_states,
-                                                               nth_element_data,
-                                                               keys_buffer,
-                                                               equality_buckets,
-                                                               compare_function);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_copy_buckets", size, start);
+        launch_err = launch_copy_buckets<Config, num_partitions>(arch,
+                                                                 keys,
+                                                                 tree,
+                                                                 size,
+                                                                 lookback_states,
+                                                                 nth_element_data,
+                                                                 keys_buffer,
+                                                                 equality_buckets,
+                                                                 compare_function,
+                                                                 num_blocks,
+                                                                 num_threads_per_block,
+                                                                 0,
+                                                                 stream);
+        if(launch_err != hipSuccess)
+        {
+            return launch_err;
+        }
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("copy_buckets_kernel", size, start);
 
         // Copy the results in keys_buffer back to the keys
         ROCPRIM_RETURN_ON_ERROR(transform(keys_buffer,
@@ -729,7 +829,18 @@ hipError_t
     }
 
     start_timer();
-    kernel_block_sort<config><<<1, stop_recursion_size, 0, stream>>>(keys, size, compare_function);
+    hipError_t launch_err = launch_block_sort<Config>(arch,
+                                                      keys,
+                                                      size,
+                                                      compare_function,
+                                                      1,
+                                                      stop_recursion_size,
+                                                      0,
+                                                      stream);
+    if(launch_err != hipSuccess)
+    {
+        return launch_err;
+    }
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_block_sort", size, start);
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
@@ -69,13 +69,12 @@ struct nth_element_onesweep_lookback_state
 
     underlying_type state;
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE
-    explicit nth_element_onesweep_lookback_state(underlying_type state)
+    ROCPRIM_DEVICE ROCPRIM_INLINE explicit nth_element_onesweep_lookback_state(underlying_type state)
         : state(state)
     {}
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE
-    nth_element_onesweep_lookback_state(prefix_flag status, underlying_type value)
+    ROCPRIM_DEVICE ROCPRIM_INLINE nth_element_onesweep_lookback_state(prefix_flag     status,
+                                                                     underlying_type value)
         : state(static_cast<underlying_type>(status) | value)
     {}
 
@@ -165,10 +164,8 @@ inline hipError_t launch_block_sort(detail::target_arch arch,
                                     size_t              shmem,
                                     hipStream_t         stream)
 {
-    auto kernel = [=] __device__ (auto arch_config)
-    {
-        block_sort_kernel_impl<decltype(arch_config)>(keys, size, compare_function);
-    };
+    auto kernel = [=](auto arch_config)
+    { block_sort_kernel_impl<decltype(arch_config)>(keys, size, compare_function); };
 
     return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
@@ -188,8 +185,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void find_splitters_kernel_impl(
 
     using block_sort_key = block_sort<key_type, num_splitters>;
 
-    ROCPRIM_SHARED_MEMORY
-    typename block_sort_key::storage_type storage;
+    ROCPRIM_SHARED_MEMORY typename block_sort_key::storage_type storage;
 
     const unsigned int stride = size / num_splitters;
     const unsigned int idx    = threadIdx.x;
@@ -229,13 +225,13 @@ inline hipError_t
                           size_t                                                   shmem,
                           hipStream_t                                              stream)
 {
-    auto kernel = [=] __device__ (auto arch_config)
+    auto kernel = [=](auto arch_config)
     {
         find_splitters_kernel_impl<decltype(arch_config)>(keys,
-                                                        tree,
-                                                        equality_buckets,
-                                                        size,
-                                                        compare_function);
+                                                          tree,
+                                                          equality_buckets,
+                                                          size,
+                                                          compare_function);
     };
 
     return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
@@ -359,14 +355,14 @@ inline hipError_t
                               size_t         shmem,
                               hipStream_t    stream)
 {
-    auto kernel = [=] __device__ (auto arch_config)
+    auto kernel = [=](auto arch_config)
     {
         count_bucket_sizes_kernel_impl<decltype(arch_config)>(keys,
-                                                            tree,
-                                                            size,
-                                                            buckets,
-                                                            equality_buckets,
-                                                            compare_function);
+                                                              tree,
+                                                              size,
+                                                              buckets,
+                                                              equality_buckets,
+                                                              compare_function);
     };
 
     return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
@@ -430,12 +426,12 @@ inline hipError_t launch_find_nth_element_bucket(detail::target_arch          ar
                                                  hipStream_t                  stream)
 
 {
-    auto kernel = [=] __device__ (auto arch_config)
+    auto kernel = [=](auto arch_config)
     {
         find_nth_element_bucket_kernel_impl<decltype(arch_config)>(buckets,
-                                                                    nth_element_data,
-                                                                    equality_buckets,
-                                                                    rank);
+                                                                   nth_element_data,
+                                                                   equality_buckets,
+                                                                   rank);
     };
 
     return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
@@ -647,7 +643,7 @@ inline hipError_t
                         size_t                                                   shmem,
                         hipStream_t                                              stream)
 {
-    auto kernel = [=] __device__ (auto arch_config)
+    auto kernel = [=](auto arch_config)
     {
         copy_buckets_kernel_impl<decltype(arch_config), NumPartitions>(keys,
                                                                        tree,
@@ -725,7 +721,7 @@ hipError_t
                                                        stream));
 
         start_timer();
-        hipError_t launch_err = launch_find_splitters<Config>(arch,
+        ROCPRIM_RETURN_ON_ERROR(launch_find_splitters<Config>(arch,
                                                               keys,
                                                               tree,
                                                               equality_buckets,
@@ -734,65 +730,49 @@ hipError_t
                                                               1,
                                                               num_splitters,
                                                               0,
-                                                              stream);
-        if(launch_err != hipSuccess)
-        {
-            return launch_err;
-        }
+                                                              stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("find_splitters_kernel", size, start);
 
         start_timer();
-        launch_err = launch_count_bucket_sizes<Config>(arch,
-                                                       keys,
-                                                       tree,
-                                                       size,
-                                                       buckets,
-                                                       equality_buckets,
-                                                       compare_function,
-                                                       num_blocks,
-                                                       num_threads_per_block,
-                                                       0,
-                                                       stream);
-        if(launch_err != hipSuccess)
-        {
-            return launch_err;
-        }
+        ROCPRIM_RETURN_ON_ERROR(launch_count_bucket_sizes<Config>(arch,
+                                                                  keys,
+                                                                  tree,
+                                                                  size,
+                                                                  buckets,
+                                                                  equality_buckets,
+                                                                  compare_function,
+                                                                  num_blocks,
+                                                                  num_threads_per_block,
+                                                                  0,
+                                                                  stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("count_bucket_sizes_kernel", size, start);
 
         start_timer();
-        launch_err = launch_find_nth_element_bucket<Config>(arch,
-                                                            buckets,
-                                                            nth_element_data,
-                                                            equality_buckets,
-                                                            rank,
-                                                            1,
-                                                            num_buckets,
-                                                            0,
-                                                            stream);
-        if(launch_err != hipSuccess)
-        {
-            return launch_err;
-        }
+        ROCPRIM_RETURN_ON_ERROR(launch_find_nth_element_bucket<Config>(arch,
+                                                                       buckets,
+                                                                       nth_element_data,
+                                                                       equality_buckets,
+                                                                       rank,
+                                                                       1,
+                                                                       num_buckets,
+                                                                       0,
+                                                                       stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("find_nth_element_bucket_kernel", size, start);
 
         start_timer();
-        launch_err = launch_copy_buckets<Config, num_partitions>(arch,
-                                                                 keys,
-                                                                 tree,
-                                                                 size,
-                                                                 lookback_states,
-                                                                 nth_element_data,
-                                                                 keys_buffer,
-                                                                 equality_buckets,
-                                                                 compare_function,
-                                                                 num_blocks,
-                                                                 num_threads_per_block,
-                                                                 0,
-                                                                 stream);
-        if(launch_err != hipSuccess)
-        {
-            return launch_err;
-        }
+        ROCPRIM_RETURN_ON_ERROR(launch_copy_buckets<Config, num_partitions>(arch,
+                                                                            keys,
+                                                                            tree,
+                                                                            size,
+                                                                            lookback_states,
+                                                                            nth_element_data,
+                                                                            keys_buffer,
+                                                                            equality_buckets,
+                                                                            compare_function,
+                                                                            num_blocks,
+                                                                            num_threads_per_block,
+                                                                            0,
+                                                                            stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("copy_buckets_kernel", size, start);
 
         // Copy the results in keys_buffer back to the keys
@@ -829,18 +809,14 @@ hipError_t
     }
 
     start_timer();
-    hipError_t launch_err = launch_block_sort<Config>(arch,
+    ROCPRIM_RETURN_ON_ERROR(launch_block_sort<Config>(arch,
                                                       keys,
                                                       size,
                                                       compare_function,
                                                       1,
                                                       stop_recursion_size,
                                                       0,
-                                                      stream);
-    if(launch_err != hipSuccess)
-    {
-        return launch_err;
-    }
+                                                      stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_block_sort", size, start);
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
@@ -167,7 +167,7 @@ inline hipError_t launch_block_sort(detail::target_arch arch,
     auto kernel = [=](auto arch_config)
     { block_sort_kernel_impl<decltype(arch_config)>(keys, size, compare_function); };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class ArchConfig, class KeysIterator, class BinaryFunction>
@@ -234,7 +234,7 @@ inline hipError_t
                                                           compare_function);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class ArchConfig, class KeysIterator, class BinaryFunction>
@@ -365,7 +365,7 @@ inline hipError_t
                                                               compare_function);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class ArchConfig>
@@ -434,7 +434,7 @@ inline hipError_t launch_find_nth_element_bucket(detail::target_arch          ar
                                                                    rank);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class ArchConfig, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
@@ -655,7 +655,7 @@ inline hipError_t
                                                                        compare_function);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
@@ -21,18 +21,18 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_PARTITION_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_PARTITION_HPP_
 
-#include <type_traits>
 #include <iterator>
+#include <type_traits>
 
 #include "../../detail/various.hpp"
-#include "../../intrinsics.hpp"
 #include "../../functional.hpp"
+#include "../../intrinsics.hpp"
 #include "../../types.hpp"
 
-#include "../../block/block_load.hpp"
-#include "../../block/block_store.hpp"
-#include "../../block/block_scan.hpp"
 #include "../../block/block_discontinuity.hpp"
+#include "../../block/block_load.hpp"
+#include "../../block/block_scan.hpp"
+#include "../../block/block_store.hpp"
 #include "ordered_block_id.hpp"
 
 #include "../config_types.hpp"
@@ -84,18 +84,18 @@ template<select_method SelectMethod,
          class UnaryPredicate,
          class InequalityOp,
          class StorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_block_load_flags(InputIterator /* block_predecessor */,
-                               FlagIterator block_flags,
-                               ValueType (&/* values */)[ItemsPerThread],
-                               bool (&is_selected)[ItemsPerThread],
-                               UnaryPredicate /* predicate */,
-                               InequalityOp /* inequality_op */,
-                               StorageType& storage,
-                               const bool /* is_first_block */,
-                               const unsigned int /* block_thread_id */,
-                               const bool         is_global_last_block,
-                               const unsigned int valid_in_global_last_block) ->
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_block_load_flags(InputIterator /* block_predecessor */,
+                                FlagIterator block_flags,
+                                ValueType (& /* values */)[ItemsPerThread],
+                                bool (&is_selected)[ItemsPerThread],
+                                UnaryPredicate /* predicate */,
+                                InequalityOp /* inequality_op */,
+                                StorageType& storage,
+                                const bool /* is_first_block */,
+                                const unsigned int /* block_thread_id */,
+                                const bool         is_global_last_block,
+                                const unsigned int valid_in_global_last_block) ->
     typename std::enable_if<SelectMethod == select_method::flag>::type
 {
     if(is_global_last_block) // last block
@@ -108,12 +108,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE auto
     }
     else
     {
-        BlockLoadFlagsType()
-            .load(
-                block_flags,
-                is_selected,
-                storage.load_flags
-            );
+        BlockLoadFlagsType().load(block_flags, is_selected, storage.load_flags);
     }
     ::rocprim::syncthreads(); // sync threads to reuse shared memory
 }
@@ -183,18 +178,18 @@ template<select_method SelectMethod,
          class UnaryPredicate,
          class InequalityOp,
          class StorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_block_load_flags(InputIterator /* block_predecessor */,
-                               FlagIterator /* block_flags */,
-                               ValueType (&values)[ItemsPerThread],
-                               bool (&is_selected)[ItemsPerThread],
-                               UnaryPredicate predicate,
-                               InequalityOp /* inequality_op */,
-                               StorageType& /* storage */,
-                               const bool /* is_first_block */,
-                               const unsigned int block_thread_id,
-                               const bool         is_global_last_block,
-                               const unsigned int valid_in_global_last_block) ->
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_block_load_flags(InputIterator /* block_predecessor */,
+                                FlagIterator /* block_flags */,
+                                ValueType (&values)[ItemsPerThread],
+                                bool (&is_selected)[ItemsPerThread],
+                                UnaryPredicate predicate,
+                                InequalityOp /* inequality_op */,
+                                StorageType& /* storage */,
+                                const bool /* is_first_block */,
+                                const unsigned int block_thread_id,
+                                const bool         is_global_last_block,
+                                const unsigned int valid_in_global_last_block) ->
     typename std::enable_if<SelectMethod == select_method::predicate>::type
 {
     if(is_global_last_block) // last block
@@ -255,18 +250,18 @@ template<select_method SelectMethod,
          class UnaryPredicate,
          class InequalityOp,
          class StorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_block_load_flags(InputIterator block_predecessor,
-                               FlagIterator /* block_flags */,
-                               ValueType (&values)[ItemsPerThread],
-                               bool (&is_selected)[ItemsPerThread],
-                               UnaryPredicate /* predicate */,
-                               InequalityOp       inequality_op,
-                               StorageType&       storage,
-                               const bool         is_first_block,
-                               const unsigned int block_thread_id,
-                               const bool         is_global_last_block,
-                               const unsigned int valid_in_global_last_block) ->
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_block_load_flags(InputIterator block_predecessor,
+                                FlagIterator /* block_flags */,
+                                ValueType (&values)[ItemsPerThread],
+                                bool (&is_selected)[ItemsPerThread],
+                                UnaryPredicate /* predicate */,
+                                InequalityOp       inequality_op,
+                                StorageType&       storage,
+                                const bool         is_first_block,
+                                const unsigned int block_thread_id,
+                                const bool         is_global_last_block,
+                                const unsigned int valid_in_global_last_block) ->
     typename std::enable_if<SelectMethod == select_method::unique>::type
 {
     if(is_first_block)
@@ -309,7 +304,6 @@ ROCPRIM_DEVICE ROCPRIM_INLINE auto
         }
     }
 
-
     // Set is_selected for invalid items to false
     if(is_global_last_block)
     {
@@ -338,19 +332,19 @@ template<select_method SelectMethod,
          class SecondUnaryPredicate,
          class InequalityOp,
          class StorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE void
-    partition_block_load_flags(InputIterator /*block_predecessor*/,
-                               FlagIterator /* block_flags */,
-                               ValueType (&values)[ItemsPerThread],
-                               bool (&is_selected)[2][ItemsPerThread],
-                               FirstUnaryPredicate  select_first_part_op,
-                               SecondUnaryPredicate select_second_part_op,
-                               InequalityOp /*inequality_op*/,
-                               StorageType& /*storage*/,
-                               const unsigned int /*block_id*/,
-                               const unsigned int block_thread_id,
-                               const bool         is_global_last_block,
-                               const unsigned int valid_in_global_last_block)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void partition_block_load_flags(InputIterator /*block_predecessor*/,
+                                FlagIterator /* block_flags */,
+                                ValueType (&values)[ItemsPerThread],
+                                bool (&is_selected)[2][ItemsPerThread],
+                                FirstUnaryPredicate  select_first_part_op,
+                                SecondUnaryPredicate select_second_part_op,
+                                InequalityOp /*inequality_op*/,
+                                StorageType& /*storage*/,
+                                const unsigned int /*block_id*/,
+                                const unsigned int block_thread_id,
+                                const bool         is_global_last_block,
+                                const unsigned int valid_in_global_last_block)
 {
     if(is_global_last_block)
     {
@@ -389,21 +383,21 @@ template<bool         OnlySelected,
          class OffsetType,
          class SelectType,
          class ScatterStorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_scatter(ValueType (&values)[ItemsPerThread],
-                      bool (&is_selected)[ItemsPerThread],
-                      OffsetType (&output_indices)[ItemsPerThread],
-                      tuple<SelectType, ::rocprim::empty_type*> output,
-                      const size_t                              total_size,
-                      const OffsetType                          selected_prefix,
-                      const OffsetType                          selected_in_block,
-                      ScatterStorageType&                       storage,
-                      const unsigned int                        flat_block_id,
-                      const unsigned int                        flat_block_thread_id,
-                      const bool                                is_global_last_block,
-                      const unsigned int                        valid_in_global_last_block,
-                      size_t (&prev_selected_count_values)[1],
-                      size_t prev_processed) -> typename std::enable_if<!OnlySelected>::type
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_scatter(ValueType (&values)[ItemsPerThread],
+                       bool (&is_selected)[ItemsPerThread],
+                       OffsetType (&output_indices)[ItemsPerThread],
+                       tuple<SelectType, ::rocprim::empty_type*> output,
+                       const size_t                              total_size,
+                       const OffsetType                          selected_prefix,
+                       const OffsetType                          selected_in_block,
+                       ScatterStorageType&                       storage,
+                       const unsigned int                        flat_block_id,
+                       const unsigned int                        flat_block_thread_id,
+                       const bool                                is_global_last_block,
+                       const unsigned int                        valid_in_global_last_block,
+                       size_t (&prev_selected_count_values)[1],
+                       size_t prev_processed) -> typename std::enable_if<!OnlySelected>::type
 {
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
@@ -467,21 +461,21 @@ template<bool         OnlySelected,
          class SelectType,
          class RejectType,
          class ScatterStorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto partition_scatter(ValueType (&values)[ItemsPerThread],
-                                                     bool (&is_selected)[ItemsPerThread],
-                                                     OffsetType (&output_indices)[ItemsPerThread],
-                                                     tuple<SelectType, RejectType> output,
-                                                     const size_t /*total_size*/,
-                                                     const OffsetType    selected_prefix,
-                                                     const OffsetType    selected_in_block,
-                                                     ScatterStorageType& storage,
-                                                     const unsigned int  flat_block_id,
-                                                     const unsigned int  flat_block_thread_id,
-                                                     const bool          is_global_last_block,
-                                                     const unsigned int  valid_in_global_last_block,
-                                                     size_t (&prev_selected_count_values)[1],
-                                                     size_t prev_processed) ->
-    typename std::enable_if<!OnlySelected>::type
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_scatter(ValueType (&values)[ItemsPerThread],
+                       bool (&is_selected)[ItemsPerThread],
+                       OffsetType (&output_indices)[ItemsPerThread],
+                       tuple<SelectType, RejectType> output,
+                       const size_t /*total_size*/,
+                       const OffsetType    selected_prefix,
+                       const OffsetType    selected_in_block,
+                       ScatterStorageType& storage,
+                       const unsigned int  flat_block_id,
+                       const unsigned int  flat_block_thread_id,
+                       const bool          is_global_last_block,
+                       const unsigned int  valid_in_global_last_block,
+                       size_t (&prev_selected_count_values)[1],
+                       size_t prev_processed) -> typename std::enable_if<!OnlySelected>::type
 {
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
@@ -552,21 +546,21 @@ template<bool         OnlySelected,
          class SelectType,
          class RejectType,
          class ScatterStorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_scatter(ValueType (&values)[ItemsPerThread],
-                      bool (&is_selected)[ItemsPerThread],
-                      OffsetType (&output_indices)[ItemsPerThread],
-                      tuple<SelectType, RejectType> output,
-                      const size_t /*total_size*/,
-                      const OffsetType    selected_prefix,
-                      const OffsetType    selected_in_block,
-                      ScatterStorageType& storage,
-                      const unsigned int /*flat_block_id*/,
-                      const unsigned int flat_block_thread_id,
-                      const bool         is_global_last_block,
-                      const unsigned int /*valid_in_global_last_block*/,
-                      size_t (&prev_selected_count_values)[1],
-                      size_t /*prev_processed*/) -> typename std::enable_if<OnlySelected>::type
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_scatter(ValueType (&values)[ItemsPerThread],
+                       bool (&is_selected)[ItemsPerThread],
+                       OffsetType (&output_indices)[ItemsPerThread],
+                       tuple<SelectType, RejectType> output,
+                       const size_t /*total_size*/,
+                       const OffsetType    selected_prefix,
+                       const OffsetType    selected_in_block,
+                       ScatterStorageType& storage,
+                       const unsigned int /*flat_block_id*/,
+                       const unsigned int flat_block_thread_id,
+                       const bool         is_global_last_block,
+                       const unsigned int /*valid_in_global_last_block*/,
+                       size_t (&prev_selected_count_values)[1],
+                       size_t /*prev_processed*/) -> typename std::enable_if<OnlySelected>::type
 {
     if(selected_in_block > BlockSize)
     {
@@ -614,20 +608,21 @@ template<bool         OnlySelected,
          class OffsetType,
          class OutputType,
          class ScatterStorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE void partition_scatter(ValueType (&values)[ItemsPerThread],
-                                                     bool (&is_selected)[2][ItemsPerThread],
-                                                     OffsetType (&output_indices)[ItemsPerThread],
-                                                     OutputType output,
-                                                     const size_t /*total_size*/,
-                                                     const OffsetType    selected_prefix,
-                                                     const OffsetType    selected_in_block,
-                                                     ScatterStorageType& storage,
-                                                     const unsigned int  flat_block_id,
-                                                     const unsigned int  flat_block_thread_id,
-                                                     const bool          is_global_last_block,
-                                                     const unsigned int  valid_in_global_last_block,
-                                                     size_t (&prev_selected_count_values)[2],
-                                                     size_t prev_processed)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void partition_scatter(ValueType (&values)[ItemsPerThread],
+                       bool (&is_selected)[2][ItemsPerThread],
+                       OffsetType (&output_indices)[ItemsPerThread],
+                       OutputType output,
+                       const size_t /*total_size*/,
+                       const OffsetType    selected_prefix,
+                       const OffsetType    selected_in_block,
+                       ScatterStorageType& storage,
+                       const unsigned int  flat_block_id,
+                       const unsigned int  flat_block_thread_id,
+                       const bool          is_global_last_block,
+                       const unsigned int  valid_in_global_last_block,
+                       size_t (&prev_selected_count_values)[2],
+                       size_t prev_processed)
 {
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
     auto                   scatter_storage = storage.get();
@@ -642,8 +637,8 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void partition_scatter(ValueType (&values)[ItemsPe
     for(unsigned int i = 0; i < ItemsPerThread; i++)
     {
         const unsigned int first_selected_item_index = output_indices[i].x - selected_prefix.x;
-        const unsigned int second_selected_item_index = output_indices[i].y - selected_prefix.y
-            + selected_in_block.x;
+        const unsigned int second_selected_item_index
+            = output_indices[i].y - selected_prefix.y + selected_in_block.x;
         unsigned int scatter_index{};
 
         if(is_selected[0][i])
@@ -657,8 +652,9 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void partition_scatter(ValueType (&values)[ItemsPe
         else
         {
             const unsigned int item_index = (flat_block_thread_id * ItemsPerThread) + i;
-            const unsigned int unselected_item_index = (item_index - first_selected_item_index - second_selected_item_index)
-                + 2*selected_in_block.x + selected_in_block.y;
+            const unsigned int unselected_item_index
+                = (item_index - first_selected_item_index - second_selected_item_index)
+                  + 2 * selected_in_block.x + selected_in_block.y;
             scatter_index = unselected_item_index;
         }
         scatter_storage[scatter_index] = values[i];
@@ -705,10 +701,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void partition_scatter(ValueType (&values)[ItemsPe
     }
 }
 
-template<
-    unsigned int items_per_thread,
-    class offset_type
->
+template<unsigned int items_per_thread, class offset_type>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void convert_selected_to_indices(offset_type (&output_indices)[items_per_thread],
                                  bool (&is_selected)[items_per_thread])
@@ -720,9 +713,7 @@ void convert_selected_to_indices(offset_type (&output_indices)[items_per_thread]
     }
 }
 
-template<
-    unsigned int items_per_thread
->
+template<unsigned int items_per_thread>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void convert_selected_to_indices(uint2 (&output_indices)[items_per_thread],
                                  bool (&is_selected)[2][items_per_thread])
@@ -736,26 +727,28 @@ void convert_selected_to_indices(uint2 (&output_indices)[items_per_thread],
 }
 
 template<class OffsetT>
-ROCPRIM_DEVICE ROCPRIM_INLINE void store_selected_count(size_t* selected_count,
-                                                        size_t (&prev_selected_count_values)[1],
-                                                        const OffsetT selected_prefix,
-                                                        const OffsetT selected_in_block)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void store_selected_count(size_t* selected_count,
+                          size_t (&prev_selected_count_values)[1],
+                          const OffsetT selected_prefix,
+                          const OffsetT selected_in_block)
 {
     selected_count[0] = prev_selected_count_values[0] + selected_prefix + selected_in_block;
 }
 
-ROCPRIM_DEVICE ROCPRIM_INLINE void store_selected_count(size_t* selected_count,
-                                                        size_t (&prev_selected_count_values)[2],
-                                                        const uint2 selected_prefix,
-                                                        const uint2 selected_in_block)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void store_selected_count(size_t* selected_count,
+                          size_t (&prev_selected_count_values)[2],
+                          const uint2 selected_prefix,
+                          const uint2 selected_in_block)
 {
     selected_count[0] = prev_selected_count_values[0] + selected_prefix.x + selected_in_block.x;
     selected_count[1] = prev_selected_count_values[1] + selected_prefix.y + selected_in_block.y;
 }
 
 template<unsigned int Size>
-ROCPRIM_DEVICE void load_selected_count(const size_t* const prev_selected_count,
-                                        size_t (&loaded_values)[Size])
+ROCPRIM_DEVICE
+void load_selected_count(const size_t* const prev_selected_count, size_t (&loaded_values)[Size])
 {
     for(unsigned int i = 0; i < Size; ++i)
     {
@@ -776,10 +769,11 @@ private:
     ValueType values[ItemsPerThread];
 
 public:
-    ROCPRIM_DEVICE void load(ValueIterator                              values_input,
-                             unsigned int                               valid,
-                             unsigned int                               is_global_last_block,
-                             typename BlockLoadValueType::storage_type& load_values)
+    ROCPRIM_DEVICE
+    void load(ValueIterator                              values_input,
+              unsigned int                               valid,
+              unsigned int                               is_global_last_block,
+              typename BlockLoadValueType::storage_type& load_values)
     {
         // Load values and sync threads
         if(is_global_last_block)
@@ -794,19 +788,20 @@ public:
     }
 
     template<class OffsetType, class OutputType, class ScatterStorageType>
-    ROCPRIM_DEVICE void store(bool (&is_selected)[ItemsPerThread],
-                              OffsetType (&output_indices)[ItemsPerThread],
-                              OutputType          values_output,
-                              const size_t        total_size,
-                              const OffsetType    selected_prefix,
-                              const OffsetType    selected_in_block,
-                              ScatterStorageType& storage,
-                              const unsigned int  flat_block_id,
-                              const unsigned int  flat_block_thread_id,
-                              const bool          is_global_last_block,
-                              const unsigned int  valid_in_global_last_block,
-                              size_t (&prev_selected_count_values)[1],
-                              size_t prev_processed)
+    ROCPRIM_DEVICE
+    void store(bool (&is_selected)[ItemsPerThread],
+               OffsetType (&output_indices)[ItemsPerThread],
+               OutputType          values_output,
+               const size_t        total_size,
+               const OffsetType    selected_prefix,
+               const OffsetType    selected_in_block,
+               ScatterStorageType& storage,
+               const unsigned int  flat_block_id,
+               const unsigned int  flat_block_thread_id,
+               const bool          is_global_last_block,
+               const unsigned int  valid_in_global_last_block,
+               size_t (&prev_selected_count_values)[1],
+               size_t prev_processed)
     {
         // Sync threads and store values
         ::rocprim::syncthreads();
@@ -827,19 +822,20 @@ public:
     }
 
     template<class OffsetType, class OutputType, class ScatterStorageType>
-    ROCPRIM_DEVICE void store(bool (&is_selected)[2][ItemsPerThread],
-                              OffsetType (&output_indices)[ItemsPerThread],
-                              OutputType          values_output,
-                              const size_t        total_size,
-                              const OffsetType    selected_prefix,
-                              const OffsetType    selected_in_block,
-                              ScatterStorageType& storage,
-                              const unsigned int  flat_block_id,
-                              const unsigned int  flat_block_thread_id,
-                              const bool          is_global_last_block,
-                              const unsigned int  valid_in_global_last_block,
-                              size_t (&prev_selected_count_values)[2],
-                              size_t prev_processed)
+    ROCPRIM_DEVICE
+    void store(bool (&is_selected)[2][ItemsPerThread],
+               OffsetType (&output_indices)[ItemsPerThread],
+               OutputType          values_output,
+               const size_t        total_size,
+               const OffsetType    selected_prefix,
+               const OffsetType    selected_in_block,
+               ScatterStorageType& storage,
+               const unsigned int  flat_block_id,
+               const unsigned int  flat_block_thread_id,
+               const bool          is_global_last_block,
+               const unsigned int  valid_in_global_last_block,
+               size_t (&prev_selected_count_values)[2],
+               size_t prev_processed)
     {
         // Sync threads and store values
         ::rocprim::syncthreads();
@@ -873,46 +869,48 @@ class partition_values_helper<ItemsPerThread,
                               rocprim::empty_type>
 {
 public:
-    ROCPRIM_DEVICE void
-        load(ValueIterator, unsigned int, unsigned int, typename BlockLoadValueType::storage_type&)
+    ROCPRIM_DEVICE
+    void load(ValueIterator, unsigned int, unsigned int, typename BlockLoadValueType::storage_type&)
     {}
 
     template<class OffsetType, class OutputType, class ScatterStorageType>
-    ROCPRIM_DEVICE void store(bool[ItemsPerThread],
-                              OffsetType[ItemsPerThread],
-                              OutputType,
-                              const size_t,
-                              const OffsetType,
-                              const OffsetType,
-                              ScatterStorageType&,
-                              const unsigned int,
-                              const unsigned int,
-                              const bool,
-                              const unsigned int,
-                              size_t[ItemsPerThread],
-                              size_t)
+    ROCPRIM_DEVICE
+    void store(bool[ItemsPerThread],
+               OffsetType[ItemsPerThread],
+               OutputType,
+               const size_t,
+               const OffsetType,
+               const OffsetType,
+               ScatterStorageType&,
+               const unsigned int,
+               const unsigned int,
+               const bool,
+               const unsigned int,
+               size_t[ItemsPerThread],
+               size_t)
     {}
 
     template<class OffsetType, class OutputType, class ScatterStorageType>
-    ROCPRIM_DEVICE void store(bool[2][ItemsPerThread],
-                              OffsetType[ItemsPerThread],
-                              OutputType,
-                              const size_t,
-                              const OffsetType,
-                              const OffsetType,
-                              ScatterStorageType&,
-                              const unsigned int,
-                              const unsigned int,
-                              const bool,
-                              const unsigned int,
-                              size_t[ItemsPerThread],
-                              size_t)
+    ROCPRIM_DEVICE
+    void store(bool[2][ItemsPerThread],
+               OffsetType[ItemsPerThread],
+               OutputType,
+               const size_t,
+               const OffsetType,
+               const OffsetType,
+               ScatterStorageType&,
+               const unsigned int,
+               const unsigned int,
+               const bool,
+               const unsigned int,
+               size_t[ItemsPerThread],
+               size_t)
     {}
 };
 
-template<select_method SelectMethod,
+template<class ArchConfig,
+         select_method SelectMethod,
          bool          OnlySelected,
-         class Config,
          class Key,
          class Value,
          class FlagType,
@@ -921,7 +919,7 @@ template<select_method SelectMethod,
 struct partition_kernel_impl_
 {
 
-    static constexpr partition_config_params params = device_params<Config>();
+    static constexpr partition_config_params params = ArchConfig::params;
 
     static constexpr auto         block_size       = params.kernel_config.block_size;
     static constexpr auto         items_per_thread = params.kernel_config.items_per_thread;
@@ -937,14 +935,15 @@ struct partition_kernel_impl_
     using block_scan_offset_type
         = ::rocprim::block_scan<OffsetType, block_size, params.block_scan_method>;
     using block_discontinuity_key_type = ::rocprim::block_discontinuity<Key, block_size>;
-    using ordered_block_id = BlockIdWrapper;
+    using ordered_block_id             = BlockIdWrapper;
 
     // Memory required for 2-phase scatter
     using exchange_keys_storage_type   = Key[items_per_block];
     using exchange_values_storage_type = Value[items_per_block];
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH
     using raw_exchange_keys_storage_type = typename detail::raw_storage<exchange_keys_storage_type>;
-    using raw_exchange_values_storage_type = typename detail::raw_storage<exchange_values_storage_type>;
+    using raw_exchange_values_storage_type =
+        typename detail::raw_storage<exchange_values_storage_type>;
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_POP
 
     union storage_type
@@ -1031,9 +1030,9 @@ struct partition_kernel_impl_
         load_selected_count(prev_selected_count, prev_selected_count_values);
 
         const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
-        const auto flat_block_id = block_id.get(flat_block_thread_id, storage.block_id);
+        const auto flat_block_id        = block_id.get(flat_block_thread_id, storage.block_id);
         ::rocprim::syncthreads(); // sync threads to reuse shared memory
-        
+
         // const auto flat_block_id = ::rocprim::detail::block_id<0>();
 
         const auto         block_offset = flat_block_id * items_per_block;
@@ -1175,7 +1174,7 @@ struct partition_kernel_impl_
     }
 };
 
-} // end of detail namespace
+} // namespace detail
 
 END_ROCPRIM_NAMESPACE
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce.hpp
@@ -63,10 +63,10 @@ auto reduce_with_initial(T output, T initial_value, BinaryFunction reduce_op) ->
 }
 
 template<
+    class ArchConfig,
     bool WithInitialValue,
     bool         FitLarger,
     unsigned int FitItems,
-    class Config,
     class ResultType,
     class InputIterator,
     class OutputIterator,
@@ -80,12 +80,12 @@ void block_reduce_kernel_impl(InputIterator input,
                               InitValueType initial_value,
                               BinaryFunction reduce_op)
 {
-    static constexpr reduce_config_params params = device_params<Config>();
+    static constexpr reduce_config_params params = ArchConfig::params;
 
-    constexpr unsigned int block_size = params.reduce_config.block_size;
+    constexpr unsigned int block_size = params.kernel_config.block_size;
     constexpr unsigned int items_per_thread
-        = FitLarger ? params.reduce_config.items_per_thread * FitItems
-                    : ceiling_div(params.reduce_config.items_per_thread, FitItems);
+        = FitLarger ? params.kernel_config.items_per_thread * FitItems
+                    : ceiling_div(params.kernel_config.items_per_thread, FitItems);
 
     using result_type = ResultType;
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
@@ -515,8 +515,8 @@ public:
     }
 };
 
-template<lookback_scan_determinism Determinism,
-         typename Config,
+template<typename ArchConfig,
+         lookback_scan_determinism Determinism,
          typename AccumulatorType,
          typename KeyIterator,
          typename ValueIterator,
@@ -544,8 +544,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto kernel_impl(KeyIterator,
     // No need to build the kernel with sleep on a device that does not require it
 }
 
-template<lookback_scan_determinism Determinism,
-         typename Config,
+template<typename ArchConfig,
+         lookback_scan_determinism Determinism,
          typename AccumulatorType,
          typename KeyIterator,
          typename ValueIterator,
@@ -571,7 +571,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                 const AccumulatorType* const   previous_accumulated)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
-    static constexpr reduce_by_key_config_params params = device_params<Config>();
+    static constexpr reduce_by_key_config_params params = ArchConfig::params;
 
     static constexpr unsigned int         block_size       = params.kernel_config.block_size;
     static constexpr unsigned int         items_per_thread = params.kernel_config.items_per_thread;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
@@ -817,7 +817,7 @@ public:
     }
 };
 
-template<typename Config,
+template<typename ArchConfig,
          typename OffsetCountPairType,
          typename InputIterator,
          typename OffsetsOutputIterator,
@@ -837,7 +837,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     // No need to build the kernel with sleep on a device that does not require it
 }
 
-template<typename Config,
+template<typename ArchConfig,
          typename OffsetCountPairType,
          typename InputIterator,
          typename OffsetsOutputIterator,
@@ -854,7 +854,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                             const size_t              size)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
-    static constexpr non_trivial_runs_config_params params     = device_params<Config>();
+    static constexpr non_trivial_runs_config_params params     = ArchConfig::params;
     static constexpr unsigned int                   block_size = params.kernel_config.block_size;
     static constexpr unsigned int         items_per_thread  = params.kernel_config.items_per_thread;
     static constexpr block_load_method    load_input_method = params.load_input_method;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan.hpp
@@ -100,10 +100,10 @@ auto single_scan_block_scan(T (&input)[ItemsPerThread],
     }
 }
 
-template<lookback_scan_determinism Determinism,
+template<class ArchConfig,
+         lookback_scan_determinism Determinism,
          bool                      Exclusive,
          bool UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
@@ -125,10 +125,10 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto lookback_scan_kernel_impl(InputIterator
     // No need to build the kernel with sleep on a device that does not require it
 }
 
-template<lookback_scan_determinism Determinism,
+template<class ArchConfig,
+         lookback_scan_determinism Determinism,
          bool                      Exclusive,
          bool UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
@@ -150,7 +150,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
 {
     static_assert(std::is_same<AccType, typename LookbackScanState::value_type>::value,
                   "value_type of LookbackScanState must be result_type");
-    static constexpr scan_config_params params = device_params<Config>();
+    static constexpr scan_config_params params = ArchConfig::params;
 
     constexpr auto         block_size       = params.kernel_config.block_size;
     constexpr auto         items_per_thread = params.kernel_config.items_per_thread;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -283,7 +283,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
              typename CompareFunction,
              typename BinaryFunction,
              typename LookbackScanState>
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto device_scan_by_key_kernel_impl(
+    ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto device_scan_by_key_kernel_impl(
         KeyInputIterator                              keys,
         InputIterator                                 values,
         OutputIterator                                output,
@@ -326,7 +326,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto device_scan_by_key_kernel_impl(
         constexpr auto store_method = params.block_store_method;
         using store_unwrap = unwrap_store<block_size, items_per_thread, result_type, store_method>;
 
-    ROCPRIM_SHARED_MEMORY union
+        ROCPRIM_SHARED_MEMORY union
         {
             typename load_flagged::storage_type    load;
             typename block_scan_type::storage_type scan;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -40,219 +40,215 @@ BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
-    template <bool Exclusive,
-              unsigned int block_size,
-              unsigned int items_per_thread,
-              typename key_type,
-              typename result_type,
-              ::rocprim::block_load_method load_keys_method,
-              ::rocprim::block_load_method load_values_method>
-    struct load_values_flagged
+template<bool         Exclusive,
+         unsigned int block_size,
+         unsigned int items_per_thread,
+         typename key_type,
+         typename result_type,
+         ::rocprim::block_load_method load_keys_method,
+         ::rocprim::block_load_method load_values_method>
+struct load_values_flagged
+{
+    using block_load_keys
+        = ::rocprim::block_load<key_type, block_size, items_per_thread, load_keys_method>;
+
+    using block_discontinuity = ::rocprim::block_discontinuity<key_type, block_size>;
+
+    using block_load_values
+        = ::rocprim::block_load<result_type, block_size, items_per_thread, load_keys_method>;
+
+    union storage_type
     {
-        using block_load_keys
-            = ::rocprim::block_load<key_type, block_size, items_per_thread, load_keys_method>;
+        struct
+        {
+            typename block_load_keys::storage_type     load;
+            typename block_discontinuity::storage_type flag;
+        } keys;
+        typename block_load_values::storage_type load_values;
+    };
 
-        using block_discontinuity = ::rocprim::block_discontinuity<key_type, block_size>;
+    // Load flagged values
+    // - if the scan is exclusive, the last item of each segment (range where the keys compare equal)
+    //   is flagged and reset to the initial value. Adding the last item of the range to the
+    //   second to last using `headflag_scan_op_wrapper` will return the initial_value,
+    //   which is exactly what should be saved at the start of the next range.
+    // - if the scan is inclusive, then the first item of each segment is marked, and it will
+    //   restart the scan from that value
+    template<typename KeyIterator, typename ValueIterator, typename CompareFunction>
+    ROCPRIM_DEVICE
+    void load(KeyIterator        keys_input,
+              ValueIterator      values_input,
+              CompareFunction    compare,
+              const result_type  initial_value,
+              const unsigned int flat_block_id,
+              const size_t       starting_block,
+              const size_t       number_of_blocks,
+              const unsigned int flat_thread_id,
+              const size_t       size,
+              rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
+              storage_type& storage)
+    {
+        constexpr static unsigned int items_per_block = items_per_thread * block_size;
+        const unsigned int            block_offset    = flat_block_id * items_per_block;
+        KeyIterator                   block_keys      = keys_input + block_offset;
+        ValueIterator                 block_values    = values_input + block_offset;
 
-        using block_load_values
-            = ::rocprim::block_load<result_type, block_size, items_per_thread, load_keys_method>;
+        key_type    keys[items_per_thread];
+        result_type values[items_per_thread];
+        bool        flags[items_per_thread];
 
-        union storage_type {
-            struct {
-                typename block_load_keys::storage_type     load;
-                typename block_discontinuity::storage_type flag;
-            } keys;
-            typename block_load_values::storage_type load_values;
+        auto not_equal = [compare](const auto& a, const auto& b) mutable { return !compare(a, b); };
+
+        const auto flag_segment_boundaries = [&]()
+        {
+            if(Exclusive)
+            {
+                const key_type tile_successor
+                    = starting_block + flat_block_id < number_of_blocks - 1
+                          ? static_cast<key_type>(block_keys[items_per_block])
+                          : static_cast<key_type>(*block_keys);
+                block_discontinuity{}.flag_tails(flags,
+                                                 tile_successor,
+                                                 keys,
+                                                 not_equal,
+                                                 storage.keys.flag);
+            }
+            else
+            {
+                const key_type tile_predecessor = starting_block + flat_block_id > 0
+                                                      ? static_cast<key_type>(block_keys[-1])
+                                                      : static_cast<key_type>(*block_keys);
+                block_discontinuity{}.flag_heads(flags,
+                                                 tile_predecessor,
+                                                 keys,
+                                                 not_equal,
+                                                 storage.keys.flag);
+            }
         };
 
-        // Load flagged values
-        // - if the scan is exclusive, the last item of each segment (range where the keys compare equal)
-        //   is flagged and reset to the initial value. Adding the last item of the range to the
-        //   second to last using `headflag_scan_op_wrapper` will return the initial_value,
-        //   which is exactly what should be saved at the start of the next range.
-        // - if the scan is inclusive, then the first item of each segment is marked, and it will
-        //   restart the scan from that value
-        template <typename KeyIterator, typename ValueIterator, typename CompareFunction>
-        ROCPRIM_DEVICE void
-            load(KeyIterator        keys_input,
-                 ValueIterator      values_input,
-                 CompareFunction    compare,
-                 const result_type  initial_value,
-                 const unsigned int flat_block_id,
-                 const size_t       starting_block,
-                 const size_t       number_of_blocks,
-                 const unsigned int flat_thread_id,
-                 const size_t       size,
-                 rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
-                 storage_type& storage)
+        if(starting_block + flat_block_id < number_of_blocks - 1)
         {
-            constexpr static unsigned int items_per_block = items_per_thread * block_size;
-            const unsigned int            block_offset    = flat_block_id * items_per_block;
-            KeyIterator                   block_keys      = keys_input + block_offset;
-            ValueIterator                 block_values    = values_input + block_offset;
+            block_load_keys{}.load(block_keys, keys, storage.keys.load);
 
-            key_type    keys[items_per_thread];
-            result_type values[items_per_thread];
-            bool        flags[items_per_thread];
+            flag_segment_boundaries();
+            // Reusing shared memory for loading values
+            ::rocprim::syncthreads();
 
-            auto not_equal
-                = [compare](const auto& a, const auto& b) mutable { return !compare(a, b); };
+            block_load_values{}.load(block_values, values, storage.load_values);
 
-            const auto flag_segment_boundaries = [&]()
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < items_per_thread; ++i)
             {
-                if(Exclusive)
-                {
-                    const key_type tile_successor
-                        = starting_block + flat_block_id < number_of_blocks - 1
-                              ? static_cast<key_type>(block_keys[items_per_block])
-                              : static_cast<key_type>(*block_keys);
-                    block_discontinuity{}.flag_tails(flags,
-                                                     tile_successor,
-                                                     keys,
-                                                     not_equal,
-                                                     storage.keys.flag);
-                }
-                else
-                {
-                    const key_type tile_predecessor = starting_block + flat_block_id > 0
-                                                          ? static_cast<key_type>(block_keys[-1])
-                                                          : static_cast<key_type>(*block_keys);
-                    block_discontinuity{}.flag_heads(flags,
-                                                     tile_predecessor,
-                                                     keys,
-                                                     not_equal,
-                                                     storage.keys.flag);
-                }
-            };
-
-            if(starting_block + flat_block_id < number_of_blocks - 1)
-            {
-                block_load_keys{}.load(
-                    block_keys,
-                    keys,
-                    storage.keys.load
-                );
-
-                flag_segment_boundaries();
-                // Reusing shared memory for loading values
-                ::rocprim::syncthreads();
-
-                block_load_values{}.load(
-                    block_values,
-                    values,
-                    storage.load_values
-                );
-
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i) {
-                    rocprim::get<0>(wrapped_values[i])
-                        = (Exclusive && flags[i]) ? initial_value : values[i];
-                    rocprim::get<1>(wrapped_values[i]) = flags[i];
-                }
-            }
-            else
-            {
-                const unsigned int valid_in_last_block
-                    = static_cast<unsigned int>(size - items_per_block * (number_of_blocks - 1));
-
-                block_load_keys {}.load(
-                    block_keys,
-                    keys,
-                    valid_in_last_block,
-                    *block_keys, // Any value is okay, so discontinuity doesn't access undefined items
-                    storage.keys.load);
-
-                flag_segment_boundaries();
-                // Reusing shared memory for loading values
-                ::rocprim::syncthreads();
-
-                block_load_values{}.load(
-                    block_values,
-                    values,
-                    valid_in_last_block,
-                    storage.load_values
-                );
-
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i) {
-                    if(flat_thread_id * items_per_thread + i >= valid_in_last_block) {
-                        break;
-                    }
-
-                    rocprim::get<0>(wrapped_values[i])
-                        = (Exclusive && flags[i]) ? initial_value : values[i];
-                    rocprim::get<1>(wrapped_values[i]) = flags[i];
-                }
+                rocprim::get<0>(wrapped_values[i])
+                    = (Exclusive && flags[i]) ? initial_value : values[i];
+                rocprim::get<1>(wrapped_values[i]) = flags[i];
             }
         }
-    };
+        else
+        {
+            const unsigned int valid_in_last_block
+                = static_cast<unsigned int>(size - items_per_block * (number_of_blocks - 1));
 
-    template <unsigned int block_size,
-              unsigned int items_per_thread,
-              typename result_type,
-              ::rocprim::block_store_method store_method>
-    struct unwrap_store
+            block_load_keys{}.load(
+                block_keys,
+                keys,
+                valid_in_last_block,
+                *block_keys, // Any value is okay, so discontinuity doesn't access undefined items
+                storage.keys.load);
+
+            flag_segment_boundaries();
+            // Reusing shared memory for loading values
+            ::rocprim::syncthreads();
+
+            block_load_values{}.load(block_values,
+                                     values,
+                                     valid_in_last_block,
+                                     storage.load_values);
+
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < items_per_thread; ++i)
+            {
+                if(flat_thread_id * items_per_thread + i >= valid_in_last_block)
+                {
+                    break;
+                }
+
+                rocprim::get<0>(wrapped_values[i])
+                    = (Exclusive && flags[i]) ? initial_value : values[i];
+                rocprim::get<1>(wrapped_values[i]) = flags[i];
+            }
+        }
+    }
+};
+
+template<unsigned int block_size,
+         unsigned int items_per_thread,
+         typename result_type,
+         ::rocprim::block_store_method store_method>
+struct unwrap_store
+{
+    using block_store_values
+        = ::rocprim::block_store<result_type, block_size, items_per_thread, store_method>;
+
+    using storage_type = typename block_store_values::storage_type;
+
+    template<typename OutputIterator>
+    ROCPRIM_DEVICE
+    void store(OutputIterator     output,
+               const unsigned int flat_block_id,
+               const size_t       starting_block,
+               const size_t       number_of_blocks,
+               const unsigned int flat_thread_id,
+               const size_t       size,
+               const rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
+               storage_type& storage)
     {
-        using block_store_values
-            = ::rocprim::block_store<result_type, block_size, items_per_thread, store_method>;
+        constexpr static unsigned int items_per_block = items_per_thread * block_size;
+        const unsigned int            block_offset    = flat_block_id * items_per_block;
+        OutputIterator                block_output    = output + block_offset;
 
-        using storage_type = typename block_store_values::storage_type;
+        result_type thread_values[items_per_thread];
 
-        template <typename OutputIterator>
-        ROCPRIM_DEVICE void
-            store(OutputIterator     output,
-                  const unsigned int flat_block_id,
-                  const size_t       starting_block,
-                  const size_t       number_of_blocks,
-                  const unsigned int flat_thread_id,
-                  const size_t       size,
-                  const rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
-                  storage_type& storage)
+        if(starting_block + flat_block_id < number_of_blocks - 1)
         {
-            constexpr static unsigned int items_per_block = items_per_thread * block_size;
-            const unsigned int block_offset = flat_block_id * items_per_block;
-            OutputIterator block_output = output + block_offset;
-
-            result_type thread_values[items_per_thread];
-
-            if(starting_block + flat_block_id < number_of_blocks - 1)
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < items_per_thread; ++i)
             {
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i) {
-                    thread_values[i] = rocprim::get<0>(wrapped_values[i]);
-                }
-
-                // Reusing shared memory from scan to perform store
-                rocprim::syncthreads();
-
-                block_store_values {}.store(block_output, thread_values, storage);
+                thread_values[i] = rocprim::get<0>(wrapped_values[i]);
             }
-            else
-            {
-                const unsigned int valid_in_last_block
-                    = static_cast<unsigned int>(size - items_per_block * (number_of_blocks - 1));
 
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i) {
-                    if(flat_thread_id * items_per_thread + i >= valid_in_last_block) {
-                        break;
-                    }
+            // Reusing shared memory from scan to perform store
+            rocprim::syncthreads();
 
-                    thread_values[i] = rocprim::get<0>(wrapped_values[i]);
-                }
-
-                // Reusing shared memory from scan to perform store
-                rocprim::syncthreads();
-
-                block_store_values {}.store(
-                    block_output, thread_values, valid_in_last_block, storage);
-            }
+            block_store_values{}.store(block_output, thread_values, storage);
         }
-    };
+        else
+        {
+            const unsigned int valid_in_last_block
+                = static_cast<unsigned int>(size - items_per_block * (number_of_blocks - 1));
 
-    template<lookback_scan_determinism Determinism,
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < items_per_thread; ++i)
+            {
+                if(flat_thread_id * items_per_thread + i >= valid_in_last_block)
+                {
+                    break;
+                }
+
+                thread_values[i] = rocprim::get<0>(wrapped_values[i]);
+            }
+
+            // Reusing shared memory from scan to perform store
+            rocprim::syncthreads();
+
+            block_store_values{}.store(block_output, thread_values, valid_in_last_block, storage);
+        }
+    }
+};
+
+    template<typename ArchConfig,
+             lookback_scan_determinism Determinism,
              bool                      Exclusive,
-             typename Config,
              typename KeyInputIterator,
              typename InputIterator,
              typename OutputIterator,
@@ -260,7 +256,7 @@ namespace detail
              typename CompareFunction,
              typename BinaryFunction,
              typename LookbackScanState>
-    ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
+ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
         device_scan_by_key_kernel_impl(KeyInputIterator,
                                        InputIterator,
                                        OutputIterator,
@@ -277,9 +273,9 @@ namespace detail
         // No need to build the kernel with sleep on a device that does not require it
     }
 
-    template<lookback_scan_determinism Determinism,
+    template<typename ArchConfig,
+             lookback_scan_determinism Determinism,
              bool                      Exclusive,
-             typename Config,
              typename KeyInputIterator,
              typename InputIterator,
              typename OutputIterator,
@@ -287,7 +283,7 @@ namespace detail
              typename CompareFunction,
              typename BinaryFunction,
              typename LookbackScanState>
-    ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto device_scan_by_key_kernel_impl(
+ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto device_scan_by_key_kernel_impl(
         KeyInputIterator                              keys,
         InputIterator                                 values,
         OutputIterator                                output,
@@ -305,14 +301,14 @@ namespace detail
         static_assert(std::is_same<rocprim::tuple<ResultType, bool>,
                                    typename LookbackScanState::value_type>::value,
                       "value_type of LookbackScanState must be tuple of result type and flag");
-        static constexpr scan_by_key_config_params params = device_params<Config>();
+        static constexpr scan_by_key_config_params params = ArchConfig::params;
 
         constexpr auto block_size         = params.kernel_config.block_size;
         constexpr auto items_per_thread   = params.kernel_config.items_per_thread;
         constexpr auto load_keys_method   = params.block_load_method;
         constexpr auto load_values_method = load_keys_method;
 
-        using key_type = typename std::iterator_traits<KeyInputIterator>::value_type;
+        using key_type     = typename std::iterator_traits<KeyInputIterator>::value_type;
         using load_flagged = load_values_flagged<Exclusive,
                                                  block_size,
                                                  items_per_thread,
@@ -321,7 +317,7 @@ namespace detail
                                                  load_keys_method,
                                                  load_values_method>;
 
-        auto wrapped_op = headflag_scan_op_wrapper<result_type, bool, BinaryFunction>{scan_op};
+        auto wrapped_op    = headflag_scan_op_wrapper<result_type, bool, BinaryFunction>{scan_op};
         using wrapped_type = rocprim::tuple<result_type, bool>;
 
         using block_scan_type
@@ -330,7 +326,7 @@ namespace detail
         constexpr auto store_method = params.block_store_method;
         using store_unwrap = unwrap_store<block_size, items_per_thread, result_type, store_method>;
 
-        ROCPRIM_SHARED_MEMORY union
+    ROCPRIM_SHARED_MEMORY union
         {
             typename load_flagged::storage_type    load;
             typename block_scan_type::storage_type scan;
@@ -342,17 +338,17 @@ namespace detail
 
         // Load input
         wrapped_type wrapped_values[items_per_thread];
-        load_flagged {}.load(keys,
-                             values,
-                             compare,
-                             initial_value,
-                             flat_block_id,
-                             starting_block,
-                             number_of_blocks,
-                             flat_thread_id,
-                             size,
-                             wrapped_values,
-                             storage.load);
+        load_flagged{}.load(keys,
+                            values,
+                            compare,
+                            initial_value,
+                            flat_block_id,
+                            starting_block,
+                            number_of_blocks,
+                            flat_thread_id,
+                            size,
+                            wrapped_values,
+                            storage.load);
 
         // Reusing the storage from load to perform the scan
         ::rocprim::syncthreads();
@@ -366,9 +362,12 @@ namespace detail
             // multi grid launch
             if(previous_last_value != nullptr)
             {
-                if(Exclusive) {
+                if(Exclusive)
+                {
                     rocprim::get<0>(wrapped_initial_value) = rocprim::get<0>(*previous_last_value);
-                } else if (flat_thread_id == 0) {
+                }
+                else if(flat_thread_id == 0)
+                {
                     wrapped_values[0] = wrapped_op(*previous_last_value, wrapped_values[0]);
                 }
             }
@@ -404,26 +403,25 @@ namespace detail
                                           Determinism>{flat_block_id, wrapped_op, scan_state};
 
             // Scan of block values
-            lookback_block_scan<Exclusive, block_scan_type>(
-                wrapped_values,
-                storage.scan,
-                prefix_op,
-                wrapped_op);
+            lookback_block_scan<Exclusive, block_scan_type>(wrapped_values,
+                                                            storage.scan,
+                                                            prefix_op,
+                                                            wrapped_op);
         }
 
         // Store output
         // synchronization is inside the function after unwrapping
-        store_unwrap {}.store(output,
-                              flat_block_id,
-                              starting_block,
-                              number_of_blocks,
-                              flat_thread_id,
-                              size,
-                              wrapped_values,
-                              storage.store);
+        store_unwrap{}.store(output,
+                             flat_block_id,
+                             starting_block,
+                             number_of_blocks,
+                             flat_thread_id,
+                             size,
+                             wrapped_values,
+                             storage.store);
     }
-} // namespace detail
+    } // namespace detail
 
-END_ROCPRIM_NAMESPACE
+    END_ROCPRIM_NAMESPACE
 
 #endif // ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_BY_KEY_HPP_

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
@@ -43,7 +43,7 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config, class InputIterator1, class InputIterator2, class BinaryFunction>
+template<class ArchConfig, class InputIterator1, class InputIterator2, class BinaryFunction>
 ROCPRIM_DEVICE
 void search_kernel_impl(InputIterator1 input,
                         InputIterator2 keys,
@@ -52,7 +52,7 @@ void search_kernel_impl(InputIterator1 input,
                         size_t         keys_size,
                         BinaryFunction compare_function)
 {
-    constexpr search_config_params params = device_params<Config>();
+    constexpr search_config_params params = ArchConfig::params;
 
     constexpr unsigned int block_size       = params.kernel_config.block_size;
     constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -109,7 +109,7 @@ void search_kernel_impl(InputIterator1 input,
     }
 }
 
-template<class Config, class InputIterator1, class InputIterator2, class BinaryFunction>
+template<class ArchConfig, class InputIterator1, class InputIterator2, class BinaryFunction>
 ROCPRIM_DEVICE
 void search_kernel_shared_impl(InputIterator1 input,
                                InputIterator2 keys,
@@ -121,7 +121,7 @@ void search_kernel_shared_impl(InputIterator1 input,
     using value_type = typename std::iterator_traits<InputIterator1>::value_type;
     using key_type   = typename std::iterator_traits<InputIterator2>::value_type;
 
-    constexpr search_config_params params = device_params<Config>();
+    constexpr search_config_params params = ArchConfig::params;
 
     constexpr unsigned int block_size       = params.kernel_config.block_size;
     constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -131,12 +131,14 @@ void search_kernel_shared_impl(InputIterator1 input,
     const unsigned int flat_id       = rocprim::detail::block_thread_id<0>();
     const unsigned int flat_block_id = rocprim::detail::block_id<0>();
 
-    const size_t block_offset = flat_block_id * items_per_block;
-    const size_t offset       = flat_id * items_per_thread;
-    bool find_pattern = false;
+    const size_t                                     block_offset = flat_block_id * items_per_block;
+    const size_t                                     offset       = flat_id * items_per_thread;
+    bool                                             find_pattern = false;
 
-    ROCPRIM_SHARED_MEMORY uninitialized_array<key_type, max_shared_key> local_keys_;
-    ROCPRIM_SHARED_MEMORY uninitialized_array<value_type, items_per_block> local_input_;
+    ROCPRIM_SHARED_MEMORY
+    uninitialized_array<key_type, max_shared_key>    local_keys_;
+    ROCPRIM_SHARED_MEMORY
+    uninitialized_array<value_type, items_per_block> local_input_;
 
     // Check if a key was already found in a place before this block
     if(block_offset > atomic_load(output))
@@ -253,52 +255,104 @@ void search_kernel_shared_impl(InputIterator1 input,
 template<class Config, class InputIterator1, class InputIterator2, class BinaryFunction>
 struct search_impl_kernels
 {
-    static ROCPRIM_KERNEL
-ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-        search_kernel_shared(InputIterator1 input,
-                             InputIterator2 keys,
-                             size_t*        output,
-                             size_t         size,
-                             size_t         keys_size,
-                             BinaryFunction compare_function)
+    inline static hipError_t search_kernel_shared(detail::target_arch arch,
+                                                  InputIterator1 input,
+                                                  InputIterator2 keys,
+                                                  size_t*        output,
+                                                  size_t         size,
+                                                  size_t         keys_size,
+                                                  BinaryFunction compare_function,
+                                                  dim3           grid,
+                                                  dim3           block,
+                                                  size_t         shmem,
+                                                  hipStream_t    stream)
     {
-        search_kernel_shared_impl<Config>(input, keys, output, size, keys_size, compare_function);
+        auto kernel = [=] __device__ (auto arch_config)
+        {
+            search_kernel_shared_impl<decltype(arch_config)>(input,
+                                                            keys,
+                                                            output,
+                                                            size,
+                                                            keys_size,
+                                                            compare_function);
+        };
+
+        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    static ROCPRIM_KERNEL
-ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-        search_kernel(InputIterator1 input,
-                      InputIterator2 keys,
-                      size_t*        output,
-                      size_t         size,
-                      size_t         keys_size,
-                      BinaryFunction compare_function)
+    inline static hipError_t search_kernel(detail::target_arch arch,
+                                           InputIterator1 input,
+                                           InputIterator2 keys,
+                                           size_t*        output,
+                                           size_t         size,
+                                           size_t         keys_size,
+                                           BinaryFunction compare_function,
+                                           dim3           grid,
+                                           dim3           block,
+                                           size_t         shmem,
+                                           hipStream_t    stream)
     {
-        search_kernel_impl<Config>(input, keys, output, size, keys_size, compare_function);
+        auto kernel = [=] __device__ (auto arch_config)
+        {
+            search_kernel_impl<decltype(arch_config)>(input,
+                                                    keys,
+                                                    output,
+                                                    size,
+                                                    keys_size,
+                                                    compare_function);
+        };
+
+        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    static ROCPRIM_KERNEL
-__launch_bounds__(device_params<Config>().kernel_config.block_size)
-    void search_kernel_shared(reverse_iterator<InputIterator1> input,
-                              reverse_iterator<InputIterator2> keys,
-                              size_t*                          output,
-                              size_t                           size,
-                              size_t                           keys_size,
-                              BinaryFunction                   compare_function)
+    inline static hipError_t search_kernel_shared(detail::target_arch arch,
+                                                  reverse_iterator<InputIterator1> input,
+                                                  reverse_iterator<InputIterator2> keys,
+                                                  size_t*                          output,
+                                                  size_t                           size,
+                                                  size_t                           keys_size,
+                                                  BinaryFunction                   compare_function,
+                                                  dim3                             grid,
+                                                  dim3                             block,
+                                                  size_t                           shmem,
+                                                  hipStream_t                      stream)
     {
-        search_kernel_shared_impl<Config>(input, keys, output, size, keys_size, compare_function);
+        auto kernel = [=] __device__ (auto arch_config)
+        {
+            search_kernel_shared_impl<decltype(arch_config)>(input,
+                                                            keys,
+                                                            output,
+                                                            size,
+                                                            keys_size,
+                                                            compare_function);
+        };
+
+        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    static ROCPRIM_KERNEL
-__launch_bounds__(device_params<Config>().kernel_config.block_size)
-    void search_kernel(reverse_iterator<InputIterator1> input,
-                       reverse_iterator<InputIterator2> keys,
-                       size_t*                          output,
-                       size_t                           size,
-                       size_t                           keys_size,
-                       BinaryFunction                   compare_function)
+    inline static hipError_t search_kernel(detail::target_arch arch,
+                                           reverse_iterator<InputIterator1> input,
+                                           reverse_iterator<InputIterator2> keys,
+                                           size_t*                          output,
+                                           size_t                           size,
+                                           size_t                           keys_size,
+                                           BinaryFunction                   compare_function,
+                                           dim3                             grid,
+                                           dim3                             block,
+                                           size_t                           shmem,
+                                           hipStream_t                      stream)
     {
-        search_kernel_impl<Config>(input, keys, output, size, keys_size, compare_function);
+        auto kernel = [=] __device__ (auto arch_config)
+        {
+            search_kernel_impl<decltype(arch_config)>(input,
+                                                    keys,
+                                                    output,
+                                                    size,
+                                                    keys_size,
+                                                    compare_function);
+        };
+
+        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     template<class T>
@@ -349,7 +403,7 @@ hipError_t search_impl(void*          temporary_storage,
     target_arch target_arch;
     ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
 
-    const search_config_params params = dispatch_target_arch<config>(target_arch);
+    const search_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int block_size       = params.kernel_config.block_size;
     const unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -395,25 +449,45 @@ hipError_t search_impl(void*          temporary_storage,
             if constexpr(find_first)
             {
                 start_timer();
-                search_kernels::search_kernel_shared<<<num_blocks, block_size, 0, stream>>>(
-                    input,
-                    keys,
-                    tmp_output,
-                    size,
-                    keys_size,
-                    compare_function);
+                hipError_t launch_err
+                    = search_kernels::search_kernel_shared(target_arch,
+                                                           input,
+                                                           keys,
+                                                           tmp_output,
+                                                           size,
+                                                           keys_size,
+                                                           compare_function,
+                                                           num_blocks,
+                                                           block_size,
+                                                           0,
+                                                           stream);
+
+                if(launch_err != hipSuccess)
+                {
+                    return launch_err;
+                }
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel_shared", size, start);
             }
             else
             {
                 start_timer();
-                search_kernels::search_kernel_shared<<<num_blocks, block_size, 0, stream>>>(
+                hipError_t launch_err = search_kernels::search_kernel_shared(
+                    target_arch,
                     rocprim::make_reverse_iterator(input + size),
                     rocprim::make_reverse_iterator(keys + keys_size),
                     tmp_output,
                     size,
                     keys_size,
-                    compare_function);
+                    compare_function,
+                    num_blocks,
+                    block_size,
+                    0,
+                    stream);
+
+                if(launch_err != hipSuccess)
+                {
+                    return launch_err;
+                }
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel_shared", size, start);
             }
         }
@@ -422,25 +496,45 @@ hipError_t search_impl(void*          temporary_storage,
             if constexpr(find_first)
             {
                 start_timer();
-                search_kernels::search_kernel<<<num_blocks, block_size, 0, stream>>>(
-                    input,
-                    keys,
-                    tmp_output,
-                    size,
-                    keys_size,
-                    compare_function);
+                hipError_t launch_err
+                    = search_kernels::search_kernel(target_arch,
+                                                    input,
+                                                    keys,
+                                                    tmp_output,
+                                                    size,
+                                                    keys_size,
+                                                    compare_function,
+                                                    num_blocks,
+                                                    block_size,
+                                                    0,
+                                                    stream);
+
+                if(launch_err != hipSuccess)
+                {
+                    return launch_err;
+                }
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel", size, start);
             }
             else
             {
                 start_timer();
-                search_kernels::search_kernel<<<num_blocks, block_size, 0, stream>>>(
+                hipError_t launch_err = search_kernels::search_kernel(
+                    target_arch,
                     rocprim::make_reverse_iterator(input + size),
                     rocprim::make_reverse_iterator(keys + keys_size),
                     tmp_output,
                     size,
                     keys_size,
-                    compare_function);
+                    compare_function,
+                    num_blocks,
+                    block_size,
+                    0,
+                    stream);
+
+                if(launch_err != hipSuccess)
+                {
+                    return launch_err;
+                }
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel", size, start);
             }
         }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
@@ -131,14 +131,12 @@ void search_kernel_shared_impl(InputIterator1 input,
     const unsigned int flat_id       = rocprim::detail::block_thread_id<0>();
     const unsigned int flat_block_id = rocprim::detail::block_id<0>();
 
-    const size_t                                     block_offset = flat_block_id * items_per_block;
-    const size_t                                     offset       = flat_id * items_per_thread;
-    bool                                             find_pattern = false;
+    const size_t block_offset = flat_block_id * items_per_block;
+    const size_t offset       = flat_id * items_per_thread;
+    bool find_pattern = false;
 
-    ROCPRIM_SHARED_MEMORY
-    uninitialized_array<key_type, max_shared_key>    local_keys_;
-    ROCPRIM_SHARED_MEMORY
-    uninitialized_array<value_type, items_per_block> local_input_;
+    ROCPRIM_SHARED_MEMORY uninitialized_array<key_type, max_shared_key> local_keys_;
+    ROCPRIM_SHARED_MEMORY uninitialized_array<value_type, items_per_block> local_input_;
 
     // Check if a key was already found in a place before this block
     if(block_offset > atomic_load(output))
@@ -256,56 +254,56 @@ template<class Config, class InputIterator1, class InputIterator2, class BinaryF
 struct search_impl_kernels
 {
     inline static hipError_t launch_search_shared(detail::target_arch arch,
-                                                  InputIterator1 input,
-                                                  InputIterator2 keys,
-                                                  size_t*        output,
-                                                  size_t         size,
-                                                  size_t         keys_size,
-                                                  BinaryFunction compare_function,
-                                                  dim3           grid,
-                                                  dim3           block,
-                                                  size_t         shmem,
-                                                  hipStream_t    stream)
+                                                  InputIterator1      input,
+                                                  InputIterator2      keys,
+                                                  size_t*             output,
+                                                  size_t              size,
+                                                  size_t              keys_size,
+                                                  BinaryFunction      compare_function,
+                                                  dim3                grid,
+                                                  dim3                block,
+                                                  size_t              shmem,
+                                                  hipStream_t         stream)
     {
-        auto kernel = [=] __device__ (auto arch_config)
+        auto kernel = [=](auto arch_config)
         {
             search_kernel_shared_impl<decltype(arch_config)>(input,
-                                                            keys,
-                                                            output,
-                                                            size,
-                                                            keys_size,
-                                                            compare_function);
+                                                             keys,
+                                                             output,
+                                                             size,
+                                                             keys_size,
+                                                             compare_function);
         };
 
         return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     inline static hipError_t launch_search(detail::target_arch arch,
-                                           InputIterator1 input,
-                                           InputIterator2 keys,
-                                           size_t*        output,
-                                           size_t         size,
-                                           size_t         keys_size,
-                                           BinaryFunction compare_function,
-                                           dim3           grid,
-                                           dim3           block,
-                                           size_t         shmem,
-                                           hipStream_t    stream)
+                                           InputIterator1      input,
+                                           InputIterator2      keys,
+                                           size_t*             output,
+                                           size_t              size,
+                                           size_t              keys_size,
+                                           BinaryFunction      compare_function,
+                                           dim3                grid,
+                                           dim3                block,
+                                           size_t              shmem,
+                                           hipStream_t         stream)
     {
-        auto kernel = [=] __device__ (auto arch_config)
+        auto kernel = [=](auto arch_config)
         {
             search_kernel_impl<decltype(arch_config)>(input,
-                                                    keys,
-                                                    output,
-                                                    size,
-                                                    keys_size,
-                                                    compare_function);
+                                                      keys,
+                                                      output,
+                                                      size,
+                                                      keys_size,
+                                                      compare_function);
         };
 
         return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    inline static hipError_t launch_search_shared(detail::target_arch arch,
+    inline static hipError_t launch_search_shared(detail::target_arch              arch,
                                                   reverse_iterator<InputIterator1> input,
                                                   reverse_iterator<InputIterator2> keys,
                                                   size_t*                          output,
@@ -317,20 +315,20 @@ struct search_impl_kernels
                                                   size_t                           shmem,
                                                   hipStream_t                      stream)
     {
-        auto kernel = [=] __device__ (auto arch_config)
+        auto kernel = [=](auto arch_config)
         {
             search_kernel_shared_impl<decltype(arch_config)>(input,
-                                                            keys,
-                                                            output,
-                                                            size,
-                                                            keys_size,
-                                                            compare_function);
+                                                             keys,
+                                                             output,
+                                                             size,
+                                                             keys_size,
+                                                             compare_function);
         };
 
         return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    inline static hipError_t launch_search(detail::target_arch arch,
+    inline static hipError_t launch_search(detail::target_arch              arch,
                                            reverse_iterator<InputIterator1> input,
                                            reverse_iterator<InputIterator2> keys,
                                            size_t*                          output,
@@ -342,14 +340,14 @@ struct search_impl_kernels
                                            size_t                           shmem,
                                            hipStream_t                      stream)
     {
-        auto kernel = [=] __device__ (auto arch_config)
+        auto kernel = [=](auto arch_config)
         {
             search_kernel_impl<decltype(arch_config)>(input,
-                                                    keys,
-                                                    output,
-                                                    size,
-                                                    keys_size,
-                                                    compare_function);
+                                                      keys,
+                                                      output,
+                                                      size,
+                                                      keys_size,
+                                                      compare_function);
         };
 
         return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
@@ -449,29 +447,23 @@ hipError_t search_impl(void*          temporary_storage,
             if constexpr(find_first)
             {
                 start_timer();
-                hipError_t launch_err
-                    = search_kernels::launch_search_shared(target_arch,
-                                                           input,
-                                                           keys,
-                                                           tmp_output,
-                                                           size,
-                                                           keys_size,
-                                                           compare_function,
-                                                           num_blocks,
-                                                           block_size,
-                                                           0,
-                                                           stream);
-
-                if(launch_err != hipSuccess)
-                {
-                    return launch_err;
-                }
+                ROCPRIM_RETURN_ON_ERROR(search_kernels::launch_search_shared(target_arch,
+                                                                             input,
+                                                                             keys,
+                                                                             tmp_output,
+                                                                             size,
+                                                                             keys_size,
+                                                                             compare_function,
+                                                                             num_blocks,
+                                                                             block_size,
+                                                                             0,
+                                                                             stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel_shared", size, start);
             }
             else
             {
                 start_timer();
-                hipError_t launch_err = search_kernels::launch_search_shared(
+                ROCPRIM_RETURN_ON_ERROR(search_kernels::launch_search_shared(
                     target_arch,
                     rocprim::make_reverse_iterator(input + size),
                     rocprim::make_reverse_iterator(keys + keys_size),
@@ -482,12 +474,7 @@ hipError_t search_impl(void*          temporary_storage,
                     num_blocks,
                     block_size,
                     0,
-                    stream);
-
-                if(launch_err != hipSuccess)
-                {
-                    return launch_err;
-                }
+                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel_shared", size, start);
             }
         }
@@ -496,45 +483,34 @@ hipError_t search_impl(void*          temporary_storage,
             if constexpr(find_first)
             {
                 start_timer();
-                hipError_t launch_err
-                    = search_kernels::launch_search(target_arch,
-                                                    input,
-                                                    keys,
-                                                    tmp_output,
-                                                    size,
-                                                    keys_size,
-                                                    compare_function,
-                                                    num_blocks,
-                                                    block_size,
-                                                    0,
-                                                    stream);
-
-                if(launch_err != hipSuccess)
-                {
-                    return launch_err;
-                }
+                ROCPRIM_RETURN_ON_ERROR(search_kernels::launch_search(target_arch,
+                                                                      input,
+                                                                      keys,
+                                                                      tmp_output,
+                                                                      size,
+                                                                      keys_size,
+                                                                      compare_function,
+                                                                      num_blocks,
+                                                                      block_size,
+                                                                      0,
+                                                                      stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel", size, start);
             }
             else
             {
                 start_timer();
-                hipError_t launch_err = search_kernels::launch_search(
-                    target_arch,
-                    rocprim::make_reverse_iterator(input + size),
-                    rocprim::make_reverse_iterator(keys + keys_size),
-                    tmp_output,
-                    size,
-                    keys_size,
-                    compare_function,
-                    num_blocks,
-                    block_size,
-                    0,
-                    stream);
-
-                if(launch_err != hipSuccess)
-                {
-                    return launch_err;
-                }
+                ROCPRIM_RETURN_ON_ERROR(
+                    search_kernels::launch_search(target_arch,
+                                                  rocprim::make_reverse_iterator(input + size),
+                                                  rocprim::make_reverse_iterator(keys + keys_size),
+                                                  tmp_output,
+                                                  size,
+                                                  keys_size,
+                                                  compare_function,
+                                                  num_blocks,
+                                                  block_size,
+                                                  0,
+                                                  stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel", size, start);
             }
         }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
@@ -275,7 +275,7 @@ struct search_impl_kernels
                                                              compare_function);
         };
 
-        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     inline static hipError_t launch_search(detail::target_arch arch,
@@ -300,7 +300,7 @@ struct search_impl_kernels
                                                       compare_function);
         };
 
-        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     inline static hipError_t launch_search_shared(detail::target_arch              arch,
@@ -325,7 +325,7 @@ struct search_impl_kernels
                                                              compare_function);
         };
 
-        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     inline static hipError_t launch_search(detail::target_arch              arch,
@@ -350,7 +350,7 @@ struct search_impl_kernels
                                                       compare_function);
         };
 
-        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     template<class T>

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
@@ -255,7 +255,7 @@ void search_kernel_shared_impl(InputIterator1 input,
 template<class Config, class InputIterator1, class InputIterator2, class BinaryFunction>
 struct search_impl_kernels
 {
-    inline static hipError_t search_kernel_shared(detail::target_arch arch,
+    inline static hipError_t launch_search_shared(detail::target_arch arch,
                                                   InputIterator1 input,
                                                   InputIterator2 keys,
                                                   size_t*        output,
@@ -280,7 +280,7 @@ struct search_impl_kernels
         return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    inline static hipError_t search_kernel(detail::target_arch arch,
+    inline static hipError_t launch_search(detail::target_arch arch,
                                            InputIterator1 input,
                                            InputIterator2 keys,
                                            size_t*        output,
@@ -305,7 +305,7 @@ struct search_impl_kernels
         return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    inline static hipError_t search_kernel_shared(detail::target_arch arch,
+    inline static hipError_t launch_search_shared(detail::target_arch arch,
                                                   reverse_iterator<InputIterator1> input,
                                                   reverse_iterator<InputIterator2> keys,
                                                   size_t*                          output,
@@ -330,7 +330,7 @@ struct search_impl_kernels
         return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    inline static hipError_t search_kernel(detail::target_arch arch,
+    inline static hipError_t launch_search(detail::target_arch arch,
                                            reverse_iterator<InputIterator1> input,
                                            reverse_iterator<InputIterator2> keys,
                                            size_t*                          output,
@@ -450,7 +450,7 @@ hipError_t search_impl(void*          temporary_storage,
             {
                 start_timer();
                 hipError_t launch_err
-                    = search_kernels::search_kernel_shared(target_arch,
+                    = search_kernels::launch_search_shared(target_arch,
                                                            input,
                                                            keys,
                                                            tmp_output,
@@ -471,7 +471,7 @@ hipError_t search_impl(void*          temporary_storage,
             else
             {
                 start_timer();
-                hipError_t launch_err = search_kernels::search_kernel_shared(
+                hipError_t launch_err = search_kernels::launch_search_shared(
                     target_arch,
                     rocprim::make_reverse_iterator(input + size),
                     rocprim::make_reverse_iterator(keys + keys_size),
@@ -497,7 +497,7 @@ hipError_t search_impl(void*          temporary_storage,
             {
                 start_timer();
                 hipError_t launch_err
-                    = search_kernels::search_kernel(target_arch,
+                    = search_kernels::launch_search(target_arch,
                                                     input,
                                                     keys,
                                                     tmp_output,
@@ -518,7 +518,7 @@ hipError_t search_impl(void*          temporary_storage,
             else
             {
                 start_timer();
-                hipError_t launch_err = search_kernels::search_kernel(
+                hipError_t launch_err = search_kernels::launch_search(
                     target_arch,
                     rocprim::make_reverse_iterator(input + size),
                     rocprim::make_reverse_iterator(keys + keys_size),

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search_n.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search_n.hpp
@@ -34,25 +34,24 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config, class InputIterator, class BinaryPredicate>
+template<class InputIterator, class BinaryPredicate>
 struct search_n_impl_kernels
 {
-    static constexpr auto params           = device_params<Config>();
-    static constexpr auto block_size       = params.kernel_config.block_size;
-    static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
-    static constexpr auto items_per_block  = block_size * items_per_thread;
-
-    static ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>()
-                                                    .kernel_config.block_size) void
-        search_n_normal_kernel(
-            InputIterator input,
-            size_t* __restrict__ output,
-            const size_t size,
-            const size_t possible_head_exist_size,
-            const size_t count,
-            const typename std::iterator_traits<InputIterator>::value_type* value,
-            const BinaryPredicate                                           binary_predicate)
+    template<class ArchConfig>
+    static ROCPRIM_DEVICE
+    void search_n_normal_kernel_impl(
+        InputIterator input,
+        size_t* __restrict__ output,
+        const size_t                                                    size,
+        const size_t                                                    possible_head_exist_size,
+        const size_t                                                    count,
+        const typename std::iterator_traits<InputIterator>::value_type* value,
+        const BinaryPredicate                                           binary_predicate)
     {
+        static constexpr auto params           = ArchConfig::params;
+        static constexpr auto block_size       = params.kernel_config.block_size;
+        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+        static constexpr auto items_per_block  = block_size * items_per_thread;
 
         const size_t this_thread_start_idx
             = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
@@ -95,7 +94,9 @@ struct search_n_impl_kernels
         *output = target;
     }
 
-    static ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(block_size) void search_n_find_heads_kernel(
+    template<class ArchConfig>
+    static ROCPRIM_DEVICE
+    void search_n_find_heads_kernel_impl(
         InputIterator                                                   input,
         const size_t                                                    input_size,
         const size_t                                                    possible_head_exist_size,
@@ -104,6 +105,11 @@ struct search_n_impl_kernels
         size_t* __restrict__ unfiltered_heads,
         const size_t group_size)
     {
+        static constexpr auto params           = ArchConfig::params;
+        static constexpr auto block_size       = params.kernel_config.block_size;
+        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+        static constexpr auto items_per_block  = block_size * items_per_thread;
+
         const size_t this_thread_start_idx
             = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
         const size_t this_thread_end_idx
@@ -127,14 +133,20 @@ struct search_n_impl_kernels
         }
     }
 
-    static ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(block_size) void
-        search_n_heads_filter_kernel(const size_t input_size,
-                                     const size_t count,
-                                     const size_t* __restrict__ unfiltered_heads,
-                                     const size_t unfiltered_heads_size,
-                                     size_t* __restrict__ filtered_heads,
-                                     size_t* __restrict__ filtered_heads_size)
+    template<class ArchConfig>
+    static ROCPRIM_DEVICE
+    void search_n_heads_filter_kernel_impl(const size_t input_size,
+                                           const size_t count,
+                                           const size_t* __restrict__ unfiltered_heads,
+                                           const size_t unfiltered_heads_size,
+                                           size_t* __restrict__ filtered_heads,
+                                           size_t* __restrict__ filtered_heads_size)
     {
+        static constexpr auto params           = ArchConfig::params;
+        static constexpr auto block_size       = params.kernel_config.block_size;
+        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+        static constexpr auto items_per_block  = block_size * items_per_thread;
+
         const size_t this_thread_start_idx
             = (block_id<0>() * items_per_block) + (block_thread_id<0>() * items_per_thread);
         const size_t this_thread_end_idx
@@ -163,7 +175,9 @@ struct search_n_impl_kernels
         }
     }
 
-    static ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(block_size) void search_n_discard_heads_kernel(
+    template<class ArchConfig>
+    static ROCPRIM_DEVICE
+    void search_n_discard_heads_kernel_impl(
         InputIterator                                                   input,
         const size_t                                                    input_size,
         const size_t                                                    count,
@@ -172,6 +186,11 @@ struct search_n_impl_kernels
         size_t* __restrict__ filtered_heads,
         size_t* filtered_heads_size)
     {
+        static constexpr auto params           = ArchConfig::params;
+        static constexpr auto block_size       = params.kernel_config.block_size;
+        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+        static constexpr auto items_per_block  = block_size * items_per_thread;
+
         const size_t heads_size = *filtered_heads_size;
         const auto   block_idx  = block_id<0>();
         if(heads_size == 0)
@@ -243,7 +262,7 @@ hipError_t search_n_impl(void*          temporary_storage,
     using input_type       = typename std::iterator_traits<InputIterator>::value_type;
     using output_type      = typename std::iterator_traits<OutputIterator>::value_type;
     using config           = wrapped_search_n_config<Config, input_type>;
-    using search_n_kernels = search_n_impl_kernels<config, InputIterator, BinaryPredicate>;
+    using search_n_kernels = search_n_impl_kernels<InputIterator, BinaryPredicate>;
 
     // The `size` must greater than or equal to `count`
     if(count > size)
@@ -254,7 +273,7 @@ hipError_t search_n_impl(void*          temporary_storage,
     target_arch target_arch;
     ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
 
-    const auto         params           = dispatch_target_arch<config>(target_arch);
+    const auto         params           = dispatch_target_arch<config, false>(target_arch);
     const unsigned int block_size       = params.kernel_config.block_size;
     const unsigned int items_per_thread = params.kernel_config.items_per_thread;
     const unsigned int items_per_block  = block_size * items_per_thread;
@@ -278,6 +297,7 @@ hipError_t search_n_impl(void*          temporary_storage,
 
         // Return end or begin
         search_n_start_timer(start, debug_synchronous);
+        
         search_n_kernels::search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output,
                                                                     count <= 0 ? 0 : size);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_init_kernel", 1, start);
@@ -301,14 +321,23 @@ hipError_t search_n_impl(void*          temporary_storage,
         search_n_start_timer(start, debug_synchronous);
         search_n_kernels::search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output, size);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_init_kernel", 1, start);
-        search_n_kernels::search_n_normal_kernel<<<num_blocks, block_size, 0, stream>>>(
-            input,
-            tmp_output,
-            size,
-            possible_head_exist_size,
-            count,
-            value,
-            binary_predicate);
+
+        auto search_n_normal_kernel = [=] __device__ (auto arch_config)
+        {
+            search_n_kernels::template search_n_normal_kernel_impl<decltype(arch_config)>(
+                input,
+                tmp_output,
+                size,
+                possible_head_exist_size,
+                count,
+                value,
+                binary_predicate);
+        };
+
+        auto search_n_normal_tuned_kernel = configure_kernel<config>(target_arch, search_n_normal_kernel);
+
+        search_n_normal_tuned_kernel.launch(num_blocks, block_size, 0, stream);
+
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_normal_kernel", size, start);
         ROCPRIM_RETURN_ON_ERROR(
             transform(tmp_output, output, 1, identity<output_type>(), stream, debug_synchronous));
@@ -353,8 +382,10 @@ hipError_t search_n_impl(void*          temporary_storage,
 
     // This function processes `possible_head_exist_size` items
     const size_t num_blocks_for_find_heads = ceiling_div(possible_head_exist_size, items_per_block);
-    search_n_kernels::
-        search_n_find_heads_kernel<<<num_blocks_for_find_heads, block_size, 0, stream>>>(
+
+    auto search_n_find_heads_kernel = [=] __device__ (auto arch_config)
+    {
+        search_n_kernels::template search_n_find_heads_kernel_impl<decltype(arch_config)>(
             input,
             size,
             possible_head_exist_size,
@@ -362,20 +393,34 @@ hipError_t search_n_impl(void*          temporary_storage,
             binary_predicate,
             unfiltered_heads,
             count /*group_size*/);
+    };
+
+    auto search_n_find_heads_tuned_kernel = configure_kernel<config>(target_arch, search_n_find_heads_kernel);
+
+    search_n_find_heads_tuned_kernel.launch(num_blocks_for_find_heads, block_size, 0, stream);
+
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_find_heads_kernel",
                                                 possible_head_exist_size,
                                                 start);
 
     // This function processes `num_groups` items
     const size_t num_blocks_for_heads_filter = ceiling_div(num_groups, items_per_block);
-    search_n_kernels::
-        search_n_heads_filter_kernel<<<num_blocks_for_heads_filter, block_size, 0, stream>>>(
+
+    auto search_n_heads_filter_kernel = [=] __device__ (auto arch_config)
+    {
+        search_n_kernels::template search_n_heads_filter_kernel_impl<decltype(arch_config)>(
             size, // It is just a value to decode the heads' index value
             count, // It is just a value to determine whether a certain head is invalid
             unfiltered_heads, // Input heads
             num_groups, // Size of unfiltered_heads
             filtered_heads, // Output
             tmp_output); // Used to store the number of items in `filtered_heads`
+    };
+
+    auto search_n_heads_filter_tuned_kernel = configure_kernel<config>(target_arch, search_n_heads_filter_kernel);
+
+    search_n_heads_filter_tuned_kernel.launch(num_blocks_for_heads_filter, block_size, 0, stream);
+
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_heads_filter_kernel", num_groups, start);
 
     size_t h_filtered_heads_size = 0;
@@ -410,8 +455,10 @@ hipError_t search_n_impl(void*          temporary_storage,
     // So the actual num_blocks_for_discard_heads needed is smaller than the current value
     const size_t num_blocks_for_discard_heads
         = ceiling_div(h_filtered_heads_size * count, items_per_block);
-    search_n_kernels::
-        search_n_discard_heads_kernel<<<num_blocks_for_discard_heads, block_size, 0, stream>>>(
+
+    auto search_n_discard_heads_kernel = [=] __device__ (auto arch_config)
+    {
+        search_n_kernels::template search_n_discard_heads_kernel_impl<decltype(arch_config)>(
             input,
             size,
             count,
@@ -419,6 +466,12 @@ hipError_t search_n_impl(void*          temporary_storage,
             binary_predicate,
             filtered_heads,
             tmp_output); // Currently, `tmp_output` contains the actual size of `filtered_heads`
+    };
+
+    auto search_n_discard_heads_tuned_kernel = configure_kernel<config>(target_arch, search_n_discard_heads_kernel);
+
+    search_n_discard_heads_tuned_kernel.launch(num_blocks_for_discard_heads, block_size, 0, stream);
+
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_discard_heads_kernel ",
                                                 h_filtered_heads_size,
                                                 start);

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search_n.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search_n.hpp
@@ -91,7 +91,7 @@ struct search_n_impl_kernels
                 }
             }
         };
-        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     template<class SizeType>
@@ -145,7 +145,7 @@ struct search_n_impl_kernels
                 }
             }
         };
-        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     inline hipError_t launch_search_n_heads_filter(detail::target_arch arch,
@@ -194,7 +194,7 @@ struct search_n_impl_kernels
                 filtered_heads[atomic_add(filtered_heads_size, 1)] = this_head;
             }
         };
-        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     inline hipError_t launch_search_n_discard_heads(
@@ -262,7 +262,7 @@ struct search_n_impl_kernels
                 }
             }
         };
-        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
     }
 };
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search_n.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search_n.hpp
@@ -34,57 +34,64 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class InputIterator, class BinaryPredicate>
+template<class Config, class InputIterator, class BinaryPredicate>
 struct search_n_impl_kernels
 {
-    template<class ArchConfig>
-    static ROCPRIM_DEVICE
-    void search_n_normal_kernel_impl(
-        InputIterator input,
+    inline hipError_t launch_search_n_normal(
+        detail::target_arch arch,
+        InputIterator       input,
         size_t* __restrict__ output,
         const size_t                                                    size,
         const size_t                                                    possible_head_exist_size,
         const size_t                                                    count,
         const typename std::iterator_traits<InputIterator>::value_type* value,
-        const BinaryPredicate                                           binary_predicate)
+        const BinaryPredicate                                           binary_predicate,
+        dim3                                                            grid,
+        dim3                                                            block,
+        size_t                                                          shmem,
+        hipStream_t                                                     stream)
     {
-        static constexpr auto params           = ArchConfig::params;
-        static constexpr auto block_size       = params.kernel_config.block_size;
-        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
-        static constexpr auto items_per_block  = block_size * items_per_thread;
-
-        const size_t this_thread_start_idx
-            = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
-
-        // Not able to find a sequence equal to or longer than count
-        if(this_thread_start_idx >= possible_head_exist_size)
+        auto kernel = [=](auto arch_config)
         {
-            return;
-        }
+            static constexpr auto params           = decltype(arch_config)::params;
+            static constexpr auto block_size       = params.kernel_config.block_size;
+            static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+            static constexpr auto items_per_block  = block_size * items_per_thread;
 
-        size_t       remaining_count = count;
-        size_t       head            = this_thread_start_idx;
-        const size_t this_thread_end_idx
-            = std::min<size_t>(this_thread_start_idx + items_per_thread, size);
+            const size_t this_thread_start_idx
+                = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
 
-        for(size_t i = this_thread_start_idx;
-            head < this_thread_end_idx && i + remaining_count <= size;
-            ++i)
-        {
-            if(binary_predicate(input[i], *value))
+            // Not able to find a sequence equal to or longer than count
+            if(this_thread_start_idx >= possible_head_exist_size)
             {
-                if(--remaining_count == 0)
+                return;
+            }
+
+            size_t       remaining_count = count;
+            size_t       head            = this_thread_start_idx;
+            const size_t this_thread_end_idx
+                = std::min<size_t>(this_thread_start_idx + items_per_thread, size);
+
+            for(size_t i = this_thread_start_idx;
+                head < this_thread_end_idx && i + remaining_count <= size;
+                ++i)
+            {
+                if(binary_predicate(input[i], *value))
                 {
-                    atomic_min(output, head);
-                    return;
+                    if(--remaining_count == 0)
+                    {
+                        atomic_min(output, head);
+                        return;
+                    }
+                }
+                else
+                {
+                    remaining_count = count;
+                    head            = i + 1;
                 }
             }
-            else
-            {
-                remaining_count = count;
-                head            = i + 1;
-            }
-        }
+        };
+        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
     template<class SizeType>
@@ -94,146 +101,168 @@ struct search_n_impl_kernels
         *output = target;
     }
 
-    template<class ArchConfig>
-    static ROCPRIM_DEVICE
-    void search_n_find_heads_kernel_impl(
+    inline hipError_t launch_search_n_find_heads(
+        detail::target_arch                                             arch,
         InputIterator                                                   input,
         const size_t                                                    input_size,
         const size_t                                                    possible_head_exist_size,
         const typename std::iterator_traits<InputIterator>::value_type* value,
         const BinaryPredicate                                           binary_predicate,
         size_t* __restrict__ unfiltered_heads,
-        const size_t group_size)
+        const size_t group_size,
+        dim3         grid,
+        dim3         block,
+        size_t       shmem,
+        hipStream_t  stream)
     {
-        static constexpr auto params           = ArchConfig::params;
-        static constexpr auto block_size       = params.kernel_config.block_size;
-        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
-        static constexpr auto items_per_block  = block_size * items_per_thread;
-
-        const size_t this_thread_start_idx
-            = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
-        const size_t this_thread_end_idx
-            = std::min<size_t>(this_thread_start_idx + items_per_thread, possible_head_exist_size);
-        for(size_t i = this_thread_start_idx; i < this_thread_end_idx; i++)
+        auto kernel = [=](auto arch_config)
         {
-            if(binary_predicate(input[i], *value))
+            static constexpr auto params           = decltype(arch_config)::params;
+            static constexpr auto block_size       = params.kernel_config.block_size;
+            static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+            static constexpr auto items_per_block  = block_size * items_per_thread;
+
+            const size_t this_thread_start_idx
+                = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
+            const size_t this_thread_end_idx
+                = std::min<size_t>(this_thread_start_idx + items_per_thread,
+                                   possible_head_exist_size);
+            for(size_t i = this_thread_start_idx; i < this_thread_end_idx; i++)
             {
-                if(i == 0)
+                if(binary_predicate(input[i], *value))
                 {
-                    // This item is the first head
-                    // `input_size - i - 1` is the distance to the end
-                    atomic_min(&(unfiltered_heads[i / group_size]), input_size - i - 1);
-                }
-                else if(!binary_predicate(input[i - 1], *value))
-                {
-                    // This item is head
-                    atomic_min(&(unfiltered_heads[i / group_size]), input_size - i - 1);
+                    if(i == 0)
+                    {
+                        // This item is the first head
+                        // `input_size - i - 1` is the distance to the end
+                        atomic_min(&(unfiltered_heads[i / group_size]), input_size - i - 1);
+                    }
+                    else if(!binary_predicate(input[i - 1], *value))
+                    {
+                        // This item is head
+                        atomic_min(&(unfiltered_heads[i / group_size]), input_size - i - 1);
+                    }
                 }
             }
-        }
+        };
+        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    template<class ArchConfig>
-    static ROCPRIM_DEVICE
-    void search_n_heads_filter_kernel_impl(const size_t input_size,
-                                           const size_t count,
-                                           const size_t* __restrict__ unfiltered_heads,
-                                           const size_t unfiltered_heads_size,
-                                           size_t* __restrict__ filtered_heads,
-                                           size_t* __restrict__ filtered_heads_size)
+    inline hipError_t launch_search_n_heads_filter(detail::target_arch arch,
+                                                   const size_t        input_size,
+                                                   const size_t        count,
+                                                   const size_t* __restrict__ unfiltered_heads,
+                                                   const size_t unfiltered_heads_size,
+                                                   size_t* __restrict__ filtered_heads,
+                                                   size_t* __restrict__ filtered_heads_size,
+                                                   dim3        grid,
+                                                   dim3        block,
+                                                   size_t      shmem,
+                                                   hipStream_t stream)
     {
-        static constexpr auto params           = ArchConfig::params;
-        static constexpr auto block_size       = params.kernel_config.block_size;
-        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
-        static constexpr auto items_per_block  = block_size * items_per_thread;
-
-        const size_t this_thread_start_idx
-            = (block_id<0>() * items_per_block) + (block_thread_id<0>() * items_per_thread);
-        const size_t this_thread_end_idx
-            = std::min<size_t>(items_per_thread + this_thread_start_idx, unfiltered_heads_size);
-        for(size_t i = this_thread_start_idx; i < this_thread_end_idx; ++i)
+        auto kernel = [=](auto arch_config)
         {
-            const auto cur_val = unfiltered_heads[i];
-            // This is not a valid head
-            if(cur_val == (size_t)-1)
+            static constexpr auto params           = decltype(arch_config)::params;
+            static constexpr auto block_size       = params.kernel_config.block_size;
+            static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+            static constexpr auto items_per_block  = block_size * items_per_thread;
+
+            const size_t this_thread_start_idx
+                = (block_id<0>() * items_per_block) + (block_thread_id<0>() * items_per_thread);
+            const size_t this_thread_end_idx
+                = std::min<size_t>(items_per_thread + this_thread_start_idx, unfiltered_heads_size);
+            for(size_t i = this_thread_start_idx; i < this_thread_end_idx; ++i)
             {
-                continue;
-            }
-            const size_t this_head = input_size - cur_val - 1;
-            // Other heads
-            if(i + 1 < unfiltered_heads_size)
-            {
-                const auto next_val = unfiltered_heads[i + 1];
-                // Check if this head is valid by calculating the distance between this head and the next head.
-                if((next_val != (size_t)-1)
-                   && (((input_size - next_val - 1) - this_head - 1) < count))
+                const auto cur_val = unfiltered_heads[i];
+                // This is not a valid head
+                if(cur_val == (size_t)-1)
                 {
                     continue;
                 }
+                const size_t this_head = input_size - cur_val - 1;
+                // Other heads
+                if(i + 1 < unfiltered_heads_size)
+                {
+                    const auto next_val = unfiltered_heads[i + 1];
+                    // Check if this head is valid by calculating the distance between this head and the next head.
+                    if((next_val != (size_t)-1)
+                       && (((input_size - next_val - 1) - this_head - 1) < count))
+                    {
+                        continue;
+                    }
+                }
+                filtered_heads[atomic_add(filtered_heads_size, 1)] = this_head;
             }
-            filtered_heads[atomic_add(filtered_heads_size, 1)] = this_head;
-        }
+        };
+        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 
-    template<class ArchConfig>
-    static ROCPRIM_DEVICE
-    void search_n_discard_heads_kernel_impl(
+    inline hipError_t launch_search_n_discard_heads(
+        detail::target_arch                                             arch,
         InputIterator                                                   input,
         const size_t                                                    input_size,
         const size_t                                                    count,
         const typename std::iterator_traits<InputIterator>::value_type* value,
         const BinaryPredicate                                           binary_predicate,
         size_t* __restrict__ filtered_heads,
-        size_t* filtered_heads_size)
+        size_t*     filtered_heads_size,
+        dim3        grid,
+        dim3        block,
+        size_t      shmem,
+        hipStream_t stream)
     {
-        static constexpr auto params           = ArchConfig::params;
-        static constexpr auto block_size       = params.kernel_config.block_size;
-        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
-        static constexpr auto items_per_block  = block_size * items_per_thread;
+        auto kernel = [=](auto arch_config)
+        {
+            static constexpr auto params           = decltype(arch_config)::params;
+            static constexpr auto block_size       = params.kernel_config.block_size;
+            static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+            static constexpr auto items_per_block  = block_size * items_per_thread;
 
-        const size_t heads_size = *filtered_heads_size;
-        const auto   block_idx  = block_id<0>();
-        if(heads_size == 0)
-        {
-            return;
-        }
-        const size_t total_check_size  = heads_size * count /*group_size*/;
-        const size_t num_blocks_needed = ceiling_div(total_check_size, items_per_block);
-        if(block_idx >= num_blocks_needed)
-        {
-            return;
-        }
-
-        const size_t this_thread_start_idx
-            = (block_idx * items_per_block) + (block_thread_id<0>() * items_per_thread);
-        const size_t this_thread_end_idx
-            = std::min<size_t>(items_per_thread + this_thread_start_idx, total_check_size);
-        // The `global_idx` is the index of item in the whole `input`
-        for(size_t global_idx = this_thread_start_idx; global_idx < this_thread_end_idx;
-            global_idx++)
-        {
-            // The id of the group who contains the item on global_idx
-            const size_t group_id = global_idx / count /*group_size*/;
-            if(group_id >= heads_size)
+            const size_t heads_size = *filtered_heads_size;
+            const auto   block_idx  = block_id<0>();
+            if(heads_size == 0)
             {
                 return;
             }
-            const size_t check_head
-                = filtered_heads[group_id]
-                  + 1; // The `head` is already checked, so we check the next value here
-            const size_t check_count = count - 1;
-            const size_t idx         = check_head + (global_idx % count);
+            const size_t total_check_size  = heads_size * count /*group_size*/;
+            const size_t num_blocks_needed = ceiling_div(total_check_size, items_per_block);
+            if(block_idx >= num_blocks_needed)
+            {
+                return;
+            }
 
-            if((idx >= input_size) || (idx >= (check_head + check_count)))
+            const size_t this_thread_start_idx
+                = (block_idx * items_per_block) + (block_thread_id<0>() * items_per_thread);
+            const size_t this_thread_end_idx
+                = std::min<size_t>(items_per_thread + this_thread_start_idx, total_check_size);
+            // The `global_idx` is the index of item in the whole `input`
+            for(size_t global_idx = this_thread_start_idx; global_idx < this_thread_end_idx;
+                global_idx++)
             {
-                return;
+                // The id of the group who contains the item on global_idx
+                const size_t group_id = global_idx / count /*group_size*/;
+                if(group_id >= heads_size)
+                {
+                    return;
+                }
+                const size_t check_head
+                    = filtered_heads[group_id]
+                      + 1; // The `head` is already checked, so we check the next value here
+                const size_t check_count = count - 1;
+                const size_t idx         = check_head + (global_idx % count);
+
+                if((idx >= input_size) || (idx >= (check_head + check_count)))
+                {
+                    return;
+                }
+                if(!binary_predicate(input[idx], *value))
+                {
+                    filtered_heads[group_id] = input_size;
+                    return;
+                }
             }
-            if(!binary_predicate(input[idx], *value))
-            {
-                filtered_heads[group_id] = input_size;
-                return;
-            }
-        }
+        };
+        return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
     }
 };
 
@@ -262,7 +291,7 @@ hipError_t search_n_impl(void*          temporary_storage,
     using input_type       = typename std::iterator_traits<InputIterator>::value_type;
     using output_type      = typename std::iterator_traits<OutputIterator>::value_type;
     using config           = wrapped_search_n_config<Config, input_type>;
-    using search_n_kernels = search_n_impl_kernels<InputIterator, BinaryPredicate>;
+    using search_n_kernels = search_n_impl_kernels<config, InputIterator, BinaryPredicate>;
 
     // The `size` must greater than or equal to `count`
     if(count > size)
@@ -297,7 +326,7 @@ hipError_t search_n_impl(void*          temporary_storage,
 
         // Return end or begin
         search_n_start_timer(start, debug_synchronous);
-        
+
         search_n_kernels::search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output,
                                                                     count <= 0 ? 0 : size);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_init_kernel", 1, start);
@@ -322,22 +351,18 @@ hipError_t search_n_impl(void*          temporary_storage,
         search_n_kernels::search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output, size);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_init_kernel", 1, start);
 
-        auto search_n_normal_kernel = [=] __device__ (auto arch_config)
-        {
-            search_n_kernels::template search_n_normal_kernel_impl<decltype(arch_config)>(
-                input,
-                tmp_output,
-                size,
-                possible_head_exist_size,
-                count,
-                value,
-                binary_predicate);
-        };
-
-        auto search_n_normal_tuned_kernel = configure_kernel<config>(target_arch, search_n_normal_kernel);
-
-        search_n_normal_tuned_kernel.launch(num_blocks, block_size, 0, stream);
-
+        ROCPRIM_RETURN_ON_ERROR(search_n_kernels{}.launch_search_n_normal(target_arch,
+                                                                          input,
+                                                                          tmp_output,
+                                                                          size,
+                                                                          possible_head_exist_size,
+                                                                          count,
+                                                                          value,
+                                                                          binary_predicate,
+                                                                          num_blocks,
+                                                                          block_size,
+                                                                          0,
+                                                                          stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_normal_kernel", size, start);
         ROCPRIM_RETURN_ON_ERROR(
             transform(tmp_output, output, 1, identity<output_type>(), stream, debug_synchronous));
@@ -383,22 +408,18 @@ hipError_t search_n_impl(void*          temporary_storage,
     // This function processes `possible_head_exist_size` items
     const size_t num_blocks_for_find_heads = ceiling_div(possible_head_exist_size, items_per_block);
 
-    auto search_n_find_heads_kernel = [=] __device__ (auto arch_config)
-    {
-        search_n_kernels::template search_n_find_heads_kernel_impl<decltype(arch_config)>(
-            input,
-            size,
-            possible_head_exist_size,
-            value,
-            binary_predicate,
-            unfiltered_heads,
-            count /*group_size*/);
-    };
-
-    auto search_n_find_heads_tuned_kernel = configure_kernel<config>(target_arch, search_n_find_heads_kernel);
-
-    search_n_find_heads_tuned_kernel.launch(num_blocks_for_find_heads, block_size, 0, stream);
-
+    ROCPRIM_RETURN_ON_ERROR(search_n_kernels{}.launch_search_n_find_heads(target_arch,
+                                                                          input,
+                                                                          size,
+                                                                          possible_head_exist_size,
+                                                                          value,
+                                                                          binary_predicate,
+                                                                          unfiltered_heads,
+                                                                          count /*group_size*/,
+                                                                          num_blocks_for_find_heads,
+                                                                          block_size,
+                                                                          0,
+                                                                          stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_find_heads_kernel",
                                                 possible_head_exist_size,
                                                 start);
@@ -406,21 +427,18 @@ hipError_t search_n_impl(void*          temporary_storage,
     // This function processes `num_groups` items
     const size_t num_blocks_for_heads_filter = ceiling_div(num_groups, items_per_block);
 
-    auto search_n_heads_filter_kernel = [=] __device__ (auto arch_config)
-    {
-        search_n_kernels::template search_n_heads_filter_kernel_impl<decltype(arch_config)>(
-            size, // It is just a value to decode the heads' index value
-            count, // It is just a value to determine whether a certain head is invalid
-            unfiltered_heads, // Input heads
-            num_groups, // Size of unfiltered_heads
-            filtered_heads, // Output
-            tmp_output); // Used to store the number of items in `filtered_heads`
-    };
-
-    auto search_n_heads_filter_tuned_kernel = configure_kernel<config>(target_arch, search_n_heads_filter_kernel);
-
-    search_n_heads_filter_tuned_kernel.launch(num_blocks_for_heads_filter, block_size, 0, stream);
-
+    ROCPRIM_RETURN_ON_ERROR(search_n_kernels{}.launch_search_n_heads_filter(
+        target_arch,
+        size, // It is just a value to decode the heads' index value
+        count, // It is just a value to determine whether a certain head is invalid
+        unfiltered_heads, // Input heads
+        num_groups, // Size of unfiltered_heads
+        filtered_heads, // Output
+        tmp_output, // Used to store the number of items in `filtered_heads`
+        num_blocks_for_heads_filter,
+        block_size,
+        0,
+        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_heads_filter_kernel", num_groups, start);
 
     size_t h_filtered_heads_size = 0;
@@ -456,22 +474,19 @@ hipError_t search_n_impl(void*          temporary_storage,
     const size_t num_blocks_for_discard_heads
         = ceiling_div(h_filtered_heads_size * count, items_per_block);
 
-    auto search_n_discard_heads_kernel = [=] __device__ (auto arch_config)
-    {
-        search_n_kernels::template search_n_discard_heads_kernel_impl<decltype(arch_config)>(
-            input,
-            size,
-            count,
-            value,
-            binary_predicate,
-            filtered_heads,
-            tmp_output); // Currently, `tmp_output` contains the actual size of `filtered_heads`
-    };
-
-    auto search_n_discard_heads_tuned_kernel = configure_kernel<config>(target_arch, search_n_discard_heads_kernel);
-
-    search_n_discard_heads_tuned_kernel.launch(num_blocks_for_discard_heads, block_size, 0, stream);
-
+    ROCPRIM_RETURN_ON_ERROR(search_n_kernels{}.launch_search_n_discard_heads(
+        target_arch,
+        input,
+        size,
+        count,
+        value,
+        binary_predicate,
+        filtered_heads,
+        tmp_output, // Currently, `tmp_output` contains the actual size of `filtered_heads`
+        num_blocks_for_discard_heads,
+        block_size,
+        0,
+        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_discard_heads_kernel ",
                                                 h_filtered_heads_size,
                                                 start);

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_radix_sort.hpp
@@ -730,7 +730,7 @@ public:
 };
 
 template<
-    class Config,
+    class ArchConfig,
     bool Descending,
     class KeysInputIterator,
     class KeysOutputIterator,
@@ -752,7 +752,7 @@ void segmented_sort(KeysInputIterator keys_input,
                     unsigned int begin_bit,
                     unsigned int end_bit)
 {
-    static constexpr segmented_radix_sort_config_params params = device_params<Config>();
+    static constexpr segmented_radix_sort_config_params params = ArchConfig::params;
 
     static constexpr unsigned int radix_bits        = params.radix_bits;
     static constexpr unsigned int block_size        = params.kernel_config.block_size;
@@ -863,7 +863,7 @@ void segmented_sort(KeysInputIterator keys_input,
 }
 
 template<
-    class Config,
+    class ArchConfig,
     bool Descending,
     class KeysInputIterator,
     class KeysOutputIterator,
@@ -887,7 +887,7 @@ void segmented_sort_large(KeysInputIterator keys_input,
                           unsigned int begin_bit,
                           unsigned int end_bit)
 {
-    static constexpr segmented_radix_sort_config_params params = device_params<Config>();
+    static constexpr segmented_radix_sort_config_params params = ArchConfig::params;
 
     static constexpr unsigned int radix_bits       = params.radix_bits;
     static constexpr unsigned int block_size       = params.kernel_config.block_size;
@@ -966,7 +966,7 @@ void segmented_sort_large(KeysInputIterator keys_input,
 }
 
 template<
-    class Config,
+    class ArchConfig,
     bool Descending,
     class KeysInputIterator,
     class KeysOutputIterator,
@@ -990,7 +990,7 @@ void segmented_sort_small(KeysInputIterator keys_input,
                           unsigned int begin_bit,
                           unsigned int end_bit)
 {
-    static constexpr segmented_radix_sort_config_params params = device_params<Config>();
+    static constexpr segmented_radix_sort_config_params params = ArchConfig::params;
 
     static constexpr unsigned int block_size = params.warp_sort_config.block_size_small;
     static constexpr unsigned int logical_warp_size
@@ -1045,7 +1045,7 @@ void segmented_sort_small(KeysInputIterator keys_input,
                                  storage);
 }
 
-template<class Config,
+template<class ArchConfig,
          bool Descending,
          class KeysInputIterator,
          class KeysOutputIterator,
@@ -1068,7 +1068,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void segmented_sort_medium(
     unsigned int                                                    begin_bit,
     unsigned int                                                    end_bit)
 {
-    static constexpr segmented_radix_sort_config_params params = device_params<Config>();
+    static constexpr segmented_radix_sort_config_params params = ArchConfig::params;
 
     static constexpr unsigned int block_size = params.warp_sort_config.block_size_medium;
     static constexpr unsigned int logical_warp_size

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_reduce.hpp
@@ -41,7 +41,7 @@ namespace detail
 {
 
 template<
-    class Config,
+    class ArchConfig,
     class InputIterator,
     class OutputIterator,
     class OffsetIterator,
@@ -58,7 +58,7 @@ void segmented_reduce(InputIterator input,
 {
     using offset_type = typename std::iterator_traits<OffsetIterator>::value_type;
 
-    static constexpr reduce_config_params params = device_params<Config>();
+    static constexpr reduce_config_params params = ArchConfig::params;
 
     constexpr unsigned int block_size       = params.kernel_config.block_size;
     constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_reduce.hpp
@@ -66,8 +66,7 @@ void segmented_reduce(InputIterator input,
 
     using reduce_type = ::rocprim::block_reduce<ResultType, block_size, params.block_reduce_method>;
 
-    ROCPRIM_SHARED_MEMORY
-    typename reduce_type::storage_type reduce_storage;
+    ROCPRIM_SHARED_MEMORY typename reduce_type::storage_type reduce_storage;
 
     const unsigned int flat_id    = ::rocprim::detail::block_thread_id<0>();
     const unsigned int segment_id = ::rocprim::detail::block_id<0>();

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_reduce.hpp
@@ -21,8 +21,8 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_SEGMENTED_REDUCE_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_SEGMENTED_REDUCE_HPP_
 
-#include <type_traits>
 #include <iterator>
+#include <type_traits>
 
 #include "../../config.hpp"
 #include "../../detail/various.hpp"
@@ -60,15 +60,16 @@ void segmented_reduce(InputIterator input,
 
     static constexpr reduce_config_params params = device_params<Config>();
 
-    constexpr unsigned int block_size       = params.reduce_config.block_size;
-    constexpr unsigned int items_per_thread = params.reduce_config.items_per_thread;
+    constexpr unsigned int block_size       = params.kernel_config.block_size;
+    constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
     constexpr unsigned int items_per_block  = block_size * items_per_thread;
 
     using reduce_type = ::rocprim::block_reduce<ResultType, block_size, params.block_reduce_method>;
 
-    ROCPRIM_SHARED_MEMORY typename reduce_type::storage_type reduce_storage;
+    ROCPRIM_SHARED_MEMORY
+    typename reduce_type::storage_type reduce_storage;
 
-    const unsigned int flat_id = ::rocprim::detail::block_thread_id<0>();
+    const unsigned int flat_id    = ::rocprim::detail::block_thread_id<0>();
     const unsigned int segment_id = ::rocprim::detail::block_id<0>();
 
     const offset_type begin_offset = begin_offsets[segment_id];
@@ -84,7 +85,7 @@ void segmented_reduce(InputIterator input,
         return;
     }
 
-    ResultType result;
+    ResultType  result;
     offset_type block_offset = begin_offset;
     if(block_offset + static_cast<offset_type>(items_per_block) > end_offset)
     {
@@ -97,7 +98,7 @@ void segmented_reduce(InputIterator input,
         if(flat_id < valid_count)
         {
             offset_type offset = block_offset + flat_id;
-            result = input[offset];
+            result             = input[offset];
             offset += block_size;
             while(offset < end_offset)
             {
@@ -166,7 +167,7 @@ void segmented_reduce(InputIterator input,
     }
 }
 
-} // end of detail namespace
+} // namespace detail
 
 END_ROCPRIM_NAMESPACE
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_segmented_scan.hpp
@@ -110,8 +110,8 @@ auto segmented_scan_block_scan(T (&input)[ItemsPerThread],
 }
 
 template<
+    class ArchConfig,
     bool Exclusive,
-    class Config,
     class ResultType,
     class InputIterator,
     class OutputIterator,
@@ -127,7 +127,7 @@ void segmented_scan(InputIterator input,
                     InitValueType initial_value,
                     BinaryFunction scan_op)
 {
-    static constexpr scan_config_params params = device_params<Config>();
+    static constexpr scan_config_params params = ArchConfig::params;
 
     constexpr auto         block_size       = params.kernel_config.block_size;
     constexpr auto         items_per_thread = params.kernel_config.items_per_thread;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -1018,6 +1018,7 @@ hipError_t is_sleep_scan_state_used(const hipStream_t stream, bool& use_sleep)
 template<typename LookbackScanState>
 constexpr bool is_lookback_kernel_runnable()
 {
+#if !defined(ROCPRIM_TARGET_SPIRV) || ROCPRIM_TARGET_SPIRV == 0
     if(device_target_arch() == target_arch::gfx908)
     {
         // For gfx908 kernels with both version of lookback_scan_state can run: with and without
@@ -1026,6 +1027,9 @@ constexpr bool is_lookback_kernel_runnable()
     }
     // For other GPUs only a kernel without sleep can run
     return !LookbackScanState::use_sleep;
+#else
+    return true;
+#endif
 }
 
 template<typename T>

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
@@ -56,29 +56,37 @@ BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
-template<typename Config,
+
+template<class Config,
          bool InPlace,
          bool Right,
          typename InputIt,
          typename OutputIt,
          typename BinaryFunction>
-void ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(
-    device_params<Config>()
-        .adjacent_difference_kernel_config
-        .block_size) adjacent_difference_kernel(const InputIt        input,
-                                          const OutputIt       output,
-                                          const std::size_t    size,
-                                          const BinaryFunction op,
-                                          const typename std::iterator_traits<InputIt>::value_type*
-                                                            previous_values,
-                                          const std::size_t starting_block)
+inline hipError_t launch_adjacent_difference_for_arch(
+    detail::target_arch                                       arch,
+    const InputIt                                             input,
+    const OutputIt                                            output,
+    const std::size_t                                         size,
+    const BinaryFunction                                      op,
+    const typename std::iterator_traits<InputIt>::value_type* previous_values,
+    const std::size_t                                         starting_block,
+    dim3                                                      grid,
+    dim3                                                      block,
+    size_t                                                    shmem,
+    hipStream_t                                               stream)
 {
-    adjacent_difference_kernel_impl<Config, InPlace, Right>(input,
-                                                            output,
-                                                            size,
-                                                            op,
-                                                            previous_values,
-                                                            starting_block);
+    auto kernel = [=] __device__ (auto arch_config)
+    {
+        adjacent_difference_kernel_impl<decltype(arch_config), InPlace, Right>(input,
+                                                                output,
+                                                                size,
+                                                                op,
+                                                                previous_values,
+                                                                starting_block);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<typename Config,
@@ -111,10 +119,10 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
     }
 
     const detail::adjacent_difference_config_params params
-        = detail::dispatch_target_arch<config>(target_arch);
+        = detail::dispatch_target_arch<config, false>(target_arch);
 
-    const unsigned int block_size       = params.adjacent_difference_kernel_config.block_size;
-    const unsigned int items_per_thread = params.adjacent_difference_kernel_config.items_per_thread;
+    const unsigned int block_size       = params.kernel_config.block_size;
+    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
     const unsigned int items_per_block  = block_size * items_per_thread;
     const std::size_t  num_blocks       = ceiling_div(size, items_per_block);
     const std::size_t  num_previous_values = InPlace && num_blocks >= 2 ? num_blocks - 1 : 0;
@@ -160,7 +168,7 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
         }
     }
 
-    const unsigned int size_limit             = params.adjacent_difference_kernel_config.size_limit;
+    const unsigned int size_limit             = params.kernel_config.size_limit;
     const auto         number_of_blocks_limit = std::max(size_limit / items_per_block, 1u);
     const auto         aligned_size_limit     = number_of_blocks_limit * items_per_block;
 
@@ -195,17 +203,31 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
 
             start = std::chrono::steady_clock::now();
         }
-        hipLaunchKernelGGL(HIP_KERNEL_NAME(adjacent_difference_kernel<config, InPlace, Right>),
-                           dim3(current_blocks),
-                           dim3(block_size),
-                           0,
-                           stream,
-                           input + offset,
-                           output + offset,
-                           size,
-                           op,
-                           previous_values + starting_block,
-                           starting_block);
+        // adjacent_difference_kernel<config, InPlace, Right><<<>>>(input + offset,
+        //                                                          output + offset,
+        //                                                          size,
+        //                                                          op,
+        //                                                          previous_values + starting_block,
+        //                                                          starting_block);
+
+        hipError_t launch_err = launch_adjacent_difference_for_arch<config, InPlace, Right>(
+            target_arch,
+            input + offset,
+            output + offset,
+            size,
+            op,
+            previous_values + starting_block,
+            starting_block,
+            current_blocks,
+            block_size,
+            0,
+            0);
+
+        if(launch_err != hipSuccess)
+        {
+            return launch_err;
+        }
+
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("adjacent_difference_kernel",
                                                     current_size,
                                                     start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
@@ -204,24 +204,18 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
             start = std::chrono::steady_clock::now();
         }
 
-        hipError_t launch_err
-            = launch_adjacent_difference<config, InPlace, Right>(target_arch,
-                                                                 input + offset,
-                                                                 output + offset,
-                                                                 size,
-                                                                 op,
-                                                                 previous_values + starting_block,
-                                                                 starting_block,
-                                                                 current_blocks,
-                                                                 block_size,
-                                                                 0,
-                                                                 stream);
-
-        if(launch_err != hipSuccess)
-        {
-            return launch_err;
-        }
-
+        ROCPRIM_RETURN_ON_ERROR(
+            launch_adjacent_difference<config, InPlace, Right>(target_arch,
+                                                               input + offset,
+                                                               output + offset,
+                                                               size,
+                                                               op,
+                                                               previous_values + starting_block,
+                                                               starting_block,
+                                                               current_blocks,
+                                                               block_size,
+                                                               0,
+                                                               stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("adjacent_difference_kernel",
                                                     current_size,
                                                     start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
@@ -63,7 +63,7 @@ template<class Config,
          typename InputIt,
          typename OutputIt,
          typename BinaryFunction>
-inline hipError_t launch_adjacent_difference_for_arch(
+inline hipError_t launch_adjacent_difference(
     detail::target_arch                                       arch,
     const InputIt                                             input,
     const OutputIt                                            output,
@@ -203,14 +203,8 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
 
             start = std::chrono::steady_clock::now();
         }
-        // adjacent_difference_kernel<config, InPlace, Right><<<>>>(input + offset,
-        //                                                          output + offset,
-        //                                                          size,
-        //                                                          op,
-        //                                                          previous_values + starting_block,
-        //                                                          starting_block);
 
-        hipError_t launch_err = launch_adjacent_difference_for_arch<config, InPlace, Right>(
+        hipError_t launch_err = launch_adjacent_difference<config, InPlace, Right>(
             target_arch,
             input + offset,
             output + offset,
@@ -221,7 +215,7 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
             current_blocks,
             block_size,
             0,
-            0);
+            stream);
 
         if(launch_err != hipSuccess)
         {

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
@@ -86,7 +86,7 @@ inline hipError_t launch_adjacent_difference(
                                                                                starting_block);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<typename Config,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
@@ -76,14 +76,14 @@ inline hipError_t launch_adjacent_difference(
     size_t                                                    shmem,
     hipStream_t                                               stream)
 {
-    auto kernel = [=] __device__ (auto arch_config)
+    auto kernel = [=](auto arch_config)
     {
         adjacent_difference_kernel_impl<decltype(arch_config), InPlace, Right>(input,
-                                                                output,
-                                                                size,
-                                                                op,
-                                                                previous_values,
-                                                                starting_block);
+                                                                               output,
+                                                                               size,
+                                                                               op,
+                                                                               previous_values,
+                                                                               starting_block);
     };
 
     return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
@@ -121,10 +121,10 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
     const detail::adjacent_difference_config_params params
         = detail::dispatch_target_arch<config, false>(target_arch);
 
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const unsigned int items_per_block  = block_size * items_per_thread;
-    const std::size_t  num_blocks       = ceiling_div(size, items_per_block);
+    const unsigned int block_size          = params.kernel_config.block_size;
+    const unsigned int items_per_thread    = params.kernel_config.items_per_thread;
+    const unsigned int items_per_block     = block_size * items_per_thread;
+    const std::size_t  num_blocks          = ceiling_div(size, items_per_block);
     const std::size_t  num_previous_values = InPlace && num_blocks >= 2 ? num_blocks - 1 : 0;
 
     value_type* previous_values;
@@ -204,18 +204,18 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
             start = std::chrono::steady_clock::now();
         }
 
-        hipError_t launch_err = launch_adjacent_difference<config, InPlace, Right>(
-            target_arch,
-            input + offset,
-            output + offset,
-            size,
-            op,
-            previous_values + starting_block,
-            starting_block,
-            current_blocks,
-            block_size,
-            0,
-            stream);
+        hipError_t launch_err
+            = launch_adjacent_difference<config, InPlace, Right>(target_arch,
+                                                                 input + offset,
+                                                                 output + offset,
+                                                                 size,
+                                                                 op,
+                                                                 previous_values + starting_block,
+                                                                 starting_block,
+                                                                 current_blocks,
+                                                                 block_size,
+                                                                 0,
+                                                                 stream);
 
         if(launch_err != hipSuccess)
         {
@@ -283,7 +283,7 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
 ///
 /// // custom binary function
 /// auto binary_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a - b;
 ///     };
@@ -500,7 +500,7 @@ hipError_t adjacent_difference_inplace(void* const          temporary_storage,
 ///
 /// // custom binary function
 /// auto binary_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a - b;
 ///     };

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_find.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_find.hpp
@@ -21,6 +21,7 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_ADJACENT_FIND_HPP_
 #define ROCPRIM_DEVICE_DEVICE_ADJACENT_FIND_HPP_
 
+#include "config_types.hpp"
 #include "detail/device_adjacent_find.hpp"
 #include "detail/device_config_helper.hpp"
 #include "device_adjacent_find_config.hpp"
@@ -87,8 +88,7 @@ hipError_t adjacent_find_impl(void* const       temporary_storage,
     using zip_it_t       = rocprim::zip_iterator<tuple_t>;
     using transform_it_t = rocprim::transform_iterator<zip_it_t, decltype(wrapped_equal_op)>;
 
-    using adjacent_find_kernels = adjacent_find_impl_kernels<config,
-                                                             transform_it_t,
+    using adjacent_find_kernels = adjacent_find_impl_kernels<transform_it_t,
                                                              index_type*,
                                                              reduce_op_type,
                                                              ordered_tile_id_type>;
@@ -136,24 +136,34 @@ hipError_t adjacent_find_impl(void* const       temporary_storage,
         auto transformed_input
             = ::rocprim::make_transform_iterator(wrapped_input, wrapped_equal_op);
 
-        auto adjacent_find_block_reduce_kernel = adjacent_find_kernels::block_reduce_kernel;
-
         target_arch target_arch;
         ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
-        const adjacent_find_config_params params     = dispatch_target_arch<config>(target_arch);
+        const adjacent_find_config_params params     = dispatch_target_arch<config, false>(target_arch);
         const unsigned int                block_size = params.kernel_config.block_size;
         const unsigned int                items_per_thread = params.kernel_config.items_per_thread;
         const unsigned int                items_per_block  = block_size * items_per_thread;
         const unsigned int grid_size        = (size + items_per_block - 1) / items_per_block;
         const unsigned int shared_mem_bytes = 0; /*no dynamic shared mem*/
 
+        auto kernel = [=] __device__ (auto arch_config)
+        {
+            adjacent_find_kernels::template block_reduce_kernel<decltype(arch_config)>(
+                transformed_input,
+                reduce_output,
+                size,
+                reduce_op_type{},
+                ordered_tile_id);
+        };
+
+        auto adjacent_find_block_reduce_kernel = configure_kernel<config>(target_arch, kernel);
+        
         // Get grid size for maximum occupancy, as we may not be able to schedule all the blocks
         // at the same time
         int min_grid_size      = 0;
         int optimal_block_size = 0;
         ROCPRIM_RETURN_ON_ERROR(hipOccupancyMaxPotentialBlockSize(&min_grid_size,
                                                                   &optimal_block_size,
-                                                                  adjacent_find_block_reduce_kernel,
+                                                                  adjacent_find_block_reduce_kernel.kernel,
                                                                   shared_mem_bytes,
                                                                   int(block_size)));
         min_grid_size = std::min(static_cast<unsigned int>(min_grid_size), grid_size);
@@ -164,12 +174,7 @@ hipError_t adjacent_find_impl(void* const       temporary_storage,
         }
 
         // Launch adjacent_find_impl_kernels::block_reduce_kernel
-        adjacent_find_block_reduce_kernel<<<min_grid_size, block_size, shared_mem_bytes, stream>>>(
-            transformed_input,
-            reduce_output,
-            size,
-            reduce_op_type{},
-            ordered_tile_id);
+        adjacent_find_block_reduce_kernel.launch(min_grid_size, block_size, shared_mem_bytes, stream);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(
             "rocprim::detail::adjacent_find::block_reduce_kernel",
             size,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_find.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_find.hpp
@@ -155,7 +155,7 @@ hipError_t adjacent_find_impl(void* const       temporary_storage,
                 ordered_tile_id);
         };
 
-        auto adjacent_find_block_reduce_kernel = configure_kernel<config>(target_arch, kernel);
+        auto adjacent_find_block_reduce_kernel = make_launch_plan<config>(target_arch, kernel);
 
         // Get grid size for maximum occupancy, as we may not be able to schedule all the blocks
         // at the same time

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_find.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_find.hpp
@@ -138,14 +138,14 @@ hipError_t adjacent_find_impl(void* const       temporary_storage,
 
         target_arch target_arch;
         ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
-        const adjacent_find_config_params params     = dispatch_target_arch<config, false>(target_arch);
-        const unsigned int                block_size = params.kernel_config.block_size;
+        const adjacent_find_config_params params = dispatch_target_arch<config, false>(target_arch);
+        const unsigned int                block_size       = params.kernel_config.block_size;
         const unsigned int                items_per_thread = params.kernel_config.items_per_thread;
         const unsigned int                items_per_block  = block_size * items_per_thread;
         const unsigned int grid_size        = (size + items_per_block - 1) / items_per_block;
         const unsigned int shared_mem_bytes = 0; /*no dynamic shared mem*/
 
-        auto kernel = [=] __device__ (auto arch_config)
+        auto kernel = [=](auto arch_config)
         {
             adjacent_find_kernels::template block_reduce_kernel<decltype(arch_config)>(
                 transformed_input,
@@ -156,16 +156,17 @@ hipError_t adjacent_find_impl(void* const       temporary_storage,
         };
 
         auto adjacent_find_block_reduce_kernel = configure_kernel<config>(target_arch, kernel);
-        
+
         // Get grid size for maximum occupancy, as we may not be able to schedule all the blocks
         // at the same time
         int min_grid_size      = 0;
         int optimal_block_size = 0;
-        ROCPRIM_RETURN_ON_ERROR(hipOccupancyMaxPotentialBlockSize(&min_grid_size,
-                                                                  &optimal_block_size,
-                                                                  adjacent_find_block_reduce_kernel.kernel,
-                                                                  shared_mem_bytes,
-                                                                  int(block_size)));
+        ROCPRIM_RETURN_ON_ERROR(
+            hipOccupancyMaxPotentialBlockSize(&min_grid_size,
+                                              &optimal_block_size,
+                                              adjacent_find_block_reduce_kernel.kernel,
+                                              shared_mem_bytes,
+                                              int(block_size)));
         min_grid_size = std::min(static_cast<unsigned int>(min_grid_size), grid_size);
 
         if(debug_synchronous)
@@ -174,7 +175,10 @@ hipError_t adjacent_find_impl(void* const       temporary_storage,
         }
 
         // Launch adjacent_find_impl_kernels::block_reduce_kernel
-        adjacent_find_block_reduce_kernel.launch(min_grid_size, block_size, shared_mem_bytes, stream);
+        adjacent_find_block_reduce_kernel.launch(min_grid_size,
+                                                 block_size,
+                                                 shared_mem_bytes,
+                                                 stream);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(
             "rocprim::detail::adjacent_find::block_reduce_kernel",
             size,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_copy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_copy.hpp
@@ -120,21 +120,22 @@ BEGIN_ROCPRIM_NAMESPACE
 /// //                2nd copy
 /// \endcode
 /// \endparblock
-template<class Config_ = default_config,
+template<class Config = default_config,
          class InputBufferItType,
          class OutputBufferItType,
          class BufferSizeItType>
-ROCPRIM_INLINE static hipError_t batch_copy(void*              temporary_storage,
-                                            size_t&            storage_size,
-                                            InputBufferItType  sources,
-                                            OutputBufferItType destinations,
-                                            BufferSizeItType   sizes,
-                                            uint32_t           num_copies,
-                                            hipStream_t        stream            = hipStreamDefault,
-                                            bool               debug_synchronous = false)
+ROCPRIM_INLINE
+static hipError_t batch_copy(void*              temporary_storage,
+                             size_t&            storage_size,
+                             InputBufferItType  sources,
+                             OutputBufferItType destinations,
+                             BufferSizeItType   sizes,
+                             uint32_t           num_copies,
+                             hipStream_t        stream            = hipStreamDefault,
+                             bool               debug_synchronous = false)
 {
     return detail::
-        batch_memcpy_func<Config_, InputBufferItType, OutputBufferItType, BufferSizeItType, false>(
+        batch_memcpy_func<Config, InputBufferItType, OutputBufferItType, BufferSizeItType, false>(
             temporary_storage,
             storage_size,
             sources,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
@@ -39,7 +39,7 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config, class InputIterator1, class InputIterator2, class BinaryFunction>
+template<class InputIterator1, class InputIterator2, class BinaryFunction>
 struct find_first_of_impl_kernels
 {
     template<class T>
@@ -50,17 +50,17 @@ struct find_first_of_impl_kernels
         ordered_bid.reset();
     }
 
-    static ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-        find_first_of_kernel(InputIterator1           input,
-                             InputIterator2           keys,
-                             size_t*                  output,
-                             size_t                   size,
-                             size_t                   keys_size,
-                             ordered_block_id<size_t> ordered_bid,
-                             BinaryFunction           compare_function)
+    template<typename ArchConfig>
+    static ROCPRIM_DEVICE
+    void find_first_of_kernel(InputIterator1           input,
+                              InputIterator2           keys,
+                              size_t*                  output,
+                              size_t                   size,
+                              size_t                   keys_size,
+                              ordered_block_id<size_t> ordered_bid,
+                              BinaryFunction           compare_function)
     {
-        constexpr find_first_of_config_params params = device_params<Config>();
+        constexpr find_first_of_config_params params = ArchConfig::params;
 
         constexpr unsigned int block_size       = params.kernel_config.block_size;
         constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -105,42 +105,45 @@ struct find_first_of_impl_kernels
 
             unsigned int thread_first_index = identity;
 
-        if(block_offset + items_per_block <= size)
-        {
-            type items[items_per_thread];
-            block_load_direct_striped<block_size>(thread_id, input + block_offset, items);
-            for(size_t key_index = 0; key_index < keys_size; ++key_index)
+            if(block_offset + items_per_block <= size)
             {
-                const key_type key = keys[key_index];
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i)
+                type items[items_per_thread];
+                block_load_direct_striped<block_size>(thread_id, input + block_offset, items);
+                for(size_t key_index = 0; key_index < keys_size; ++key_index)
                 {
-                    if(compare_function(key, items[i]))
+                    const key_type key = keys[key_index];
+                    ROCPRIM_UNROLL
+                    for(unsigned int i = 0; i < items_per_thread; ++i)
                     {
-                        thread_first_index = min(thread_first_index, i);
+                        if(compare_function(key, items[i]))
+                        {
+                            thread_first_index = min(thread_first_index, i);
+                        }
                     }
                 }
             }
-        }
-        else
-        {
-            const unsigned int valid = size - block_offset;
+            else
+            {
+                const unsigned int valid = size - block_offset;
 
-            type items[items_per_thread];
-            block_load_direct_striped<block_size>(thread_id, input + block_offset, items, valid);
-            for(size_t key_index = 0; key_index < keys_size; ++key_index)
-            {
-                const key_type key = keys[key_index];
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i)
+                type items[items_per_thread];
+                block_load_direct_striped<block_size>(thread_id,
+                                                      input + block_offset,
+                                                      items,
+                                                      valid);
+                for(size_t key_index = 0; key_index < keys_size; ++key_index)
                 {
-                    if(i * block_size + thread_id < valid && compare_function(key, items[i]))
+                    const key_type key = keys[key_index];
+                    ROCPRIM_UNROLL
+                    for(unsigned int i = 0; i < items_per_thread; ++i)
                     {
-                        thread_first_index = min(thread_first_index, i);
+                        if(i * block_size + thread_id < valid && compare_function(key, items[i]))
+                        {
+                            thread_first_index = min(thread_first_index, i);
+                        }
                     }
                 }
             }
-        }
 
             if(thread_first_index != identity)
             {
@@ -181,7 +184,7 @@ hipError_t find_first_of_impl(void*          temporary_storage,
     using type   = typename std::iterator_traits<InputIterator1>::value_type;
     using config = wrapped_find_first_of_config<Config, type>;
     using find_first_of_kernels
-        = find_first_of_impl_kernels<config, InputIterator1, InputIterator2, BinaryFunction>;
+        = find_first_of_impl_kernels<InputIterator1, InputIterator2, BinaryFunction>;
 
     target_arch target_arch;
     hipError_t  result = host_target_arch(stream, target_arch);
@@ -189,7 +192,7 @@ hipError_t find_first_of_impl(void*          temporary_storage,
     {
         return result;
     }
-    const find_first_of_config_params params = dispatch_target_arch<config>(target_arch);
+    const find_first_of_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int block_size       = params.kernel_config.block_size;
     const unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -230,7 +233,19 @@ hipError_t find_first_of_impl(void*          temporary_storage,
 
     if(size > 0 && keys_size > 0)
     {
-        auto kernel = find_first_of_kernels::find_first_of_kernel;
+        auto kernel = [=] __device__ (auto arch_config)
+        {
+            find_first_of_kernels::template find_first_of_kernel<decltype(arch_config)>(
+                input,
+                keys,
+                tmp_output,
+                size,
+                keys_size,
+                ordered_bid,
+                compare_function);
+        };
+
+        auto find_first_of_configured_kernel = configure_kernel<config>(target_arch, kernel);
 
         const size_t shared_memory_size = 0;
 
@@ -238,7 +253,7 @@ hipError_t find_first_of_impl(void*          temporary_storage,
         int min_grid_size, max_block_size;
         result = hipOccupancyMaxPotentialBlockSize(&min_grid_size,
                                                    &max_block_size,
-                                                   kernel,
+                                                   find_first_of_configured_kernel.kernel,
                                                    shared_memory_size,
                                                    int(block_size));
         if(result != hipSuccess)
@@ -253,13 +268,7 @@ hipError_t find_first_of_impl(void*          temporary_storage,
         {
             start = std::chrono::steady_clock::now();
         }
-        kernel<<<num_blocks, block_size, shared_memory_size, stream>>>(input,
-                                                                       keys,
-                                                                       tmp_output,
-                                                                       size,
-                                                                       keys_size,
-                                                                       ordered_bid,
-                                                                       compare_function);
+        find_first_of_configured_kernel.launch(num_blocks, block_size, shared_memory_size, stream);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("find_first_of_kernel", size, start);
     }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
@@ -245,7 +245,7 @@ hipError_t find_first_of_impl(void*          temporary_storage,
                 compare_function);
         };
 
-        auto find_first_of_configured_kernel = configure_kernel<config>(target_arch, kernel);
+        auto find_first_of_configured_kernel = make_launch_plan<config>(target_arch, kernel);
 
         const size_t shared_memory_size = 0;
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
@@ -52,13 +52,13 @@ struct find_first_of_impl_kernels
 
     template<typename ArchConfig>
     static ROCPRIM_DEVICE
-    void find_first_of_kernel(InputIterator1           input,
-                              InputIterator2           keys,
-                              size_t*                  output,
-                              size_t                   size,
-                              size_t                   keys_size,
-                              ordered_block_id<size_t> ordered_bid,
-                              BinaryFunction           compare_function)
+    void find_first_of_kernel_impl(InputIterator1           input,
+                                   InputIterator2           keys,
+                                   size_t*                  output,
+                                   size_t                   size,
+                                   size_t                   keys_size,
+                                   ordered_block_id<size_t> ordered_bid,
+                                   BinaryFunction           compare_function)
     {
         constexpr find_first_of_config_params params = ArchConfig::params;
 
@@ -235,7 +235,7 @@ hipError_t find_first_of_impl(void*          temporary_storage,
     {
         auto kernel = [=] __device__ (auto arch_config)
         {
-            find_first_of_kernels::template find_first_of_kernel<decltype(arch_config)>(
+            find_first_of_kernels::template find_first_of_kernel_impl<decltype(arch_config)>(
                 input,
                 keys,
                 tmp_output,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
@@ -233,7 +233,7 @@ hipError_t find_first_of_impl(void*          temporary_storage,
 
     if(size > 0 && keys_size > 0)
     {
-        auto kernel = [=] __device__ (auto arch_config)
+        auto kernel = [=](auto arch_config)
         {
             find_first_of_kernels::template find_first_of_kernel_impl<decltype(arch_config)>(
                 input,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -26,8 +26,8 @@
 #include <iterator>
 #include <type_traits>
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/various.hpp"
 #include "../functional.hpp"
 
@@ -44,33 +44,46 @@ namespace detail
 {
 
 template<class Config, unsigned int ActiveChannels, class Counter>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
-    init_histogram_kernel(fixed_array<Counter*, ActiveChannels>     histogram,
-                          const fixed_array<size_t, ActiveChannels> bins)
+inline hipError_t launch_init_histogram(detail::target_arch                       arch,
+                                        fixed_array<Counter*, ActiveChannels>     histogram,
+                                        const fixed_array<size_t, ActiveChannels> bins,
+                                        dim3                                      grid,
+                                        dim3                                      block,
+                                        size_t                                    shmem,
+                                        hipStream_t                               stream)
 {
-    static constexpr histogram_config_params params = device_params<Config>();
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr histogram_config_params params = decltype(arch_config)::params;
+        init_histogram<params.histogram_config.block_size, ActiveChannels>(histogram, bins);
+    };
 
-    init_histogram<params.histogram_config.block_size, ActiveChannels>(histogram, bins);
+    return execute_launch_plan<Config, decltype(kernel), histogram_config_selector>(arch,
+                                                                                    kernel,
+                                                                                    grid,
+                                                                                    block,
+                                                                                    shmem,
+                                                                                    stream);
 }
 
-template<class Config,
+template<class ArchConfig,
          unsigned int Channels,
          unsigned int ActiveChannels,
          class SampleIterator,
          class Counter,
          class SampleToBinOp>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
-    histogram_shared_kernel(SampleIterator                                   samples,
-                            unsigned int                                     columns,
-                            unsigned int                                     rows,
-                            unsigned int                                     row_stride,
-                            unsigned int                                     rows_per_block,
-                            unsigned int                                     shared_histograms,
-                            fixed_array<Counter*, ActiveChannels>            histogram,
-                            const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                            const fixed_array<size_t, ActiveChannels>        bins)
+ROCPRIM_DEVICE
+void histogram_shared_kernel_impl(SampleIterator                        samples,
+                                  unsigned int                          columns,
+                                  unsigned int                          rows,
+                                  unsigned int                          row_stride,
+                                  unsigned int                          rows_per_block,
+                                  unsigned int                          shared_histograms,
+                                  fixed_array<Counter*, ActiveChannels> histogram,
+                                  const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
+                                  const fixed_array<size_t, ActiveChannels>        bins)
 {
-    static constexpr histogram_config_params params = device_params<Config>();
+    static constexpr histogram_config_params params = ArchConfig::params;
 
 // Temporary fix: issue with dynamic shared memory on windows.
 #ifndef _WIN32
@@ -94,31 +107,101 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.bl
                                      block_histogram);
 }
 
-template<class Config,
-         unsigned int Channels,
+template<unsigned int Channels,
          unsigned int ActiveChannels,
          class SampleIterator,
          class Counter,
          class SampleToBinOp>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram_config.block_size) void
-    histogram_global_kernel(SampleIterator                                   samples,
-                            unsigned int                                     columns,
-                            unsigned int                                     row_stride,
-                            fixed_array<Counter*, ActiveChannels>            histogram,
-                            const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                            const fixed_array<size_t, ActiveChannels>        bins_bits)
+struct HistogramSharedOp
 {
-    static constexpr histogram_config_params params = device_params<Config>();
+    SampleIterator                             samples;
+    unsigned int                               columns;
+    unsigned int                               rows;
+    unsigned int                               row_stride;
+    fixed_array<Counter*, ActiveChannels>      histogram;
+    fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op;
+    fixed_array<size_t, ActiveChannels>        bins;
 
-    histogram_global<params.histogram_config.block_size,
-                     params.histogram_config.items_per_thread,
-                     Channels,
-                     ActiveChannels>(samples,
-                                     columns,
-                                     row_stride,
-                                     histogram,
-                                     sample_to_bin_op,
-                                     bins_bits);
+    unsigned int rows_per_block    = 0;
+    unsigned int shared_histograms = 0;
+
+    template<class ArchConfig>
+    ROCPRIM_DEVICE
+    inline void
+        operator()(ArchConfig) const
+    {
+        histogram_shared_kernel_impl<ArchConfig,
+                                     Channels,
+                                     ActiveChannels,
+                                     SampleIterator,
+                                     Counter,
+                                     SampleToBinOp>(samples,
+                                                    columns,
+                                                    rows,
+                                                    row_stride,
+                                                    rows_per_block,
+                                                    shared_histograms,
+                                                    histogram,
+                                                    sample_to_bin_op,
+                                                    bins);
+    }
+};
+
+template<typename Kernel>
+struct histogram_launch_plan
+{
+    using kernel_type = void (*)(Kernel);
+
+    kernel_type kernel;
+    Kernel      device_callback;
+
+    unsigned int shared_impl_histograms = 0;
+    unsigned int max_grid_size          = 0;
+
+    void launch(dim3 grid, dim3 block, size_t shmem, hipStream_t stream) const
+    {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel), grid, block, shmem, stream, device_callback);
+    }
+};
+
+template<class Config,
+         class Kernel,
+         template<typename, rocprim::detail::target_arch>
+         class LaunchSelector>
+auto make_histogram_launch_plan(rocprim::detail::target_arch arch, Kernel kernel)
+    -> histogram_launch_plan<Kernel>
+{
+    histogram_launch_plan<Kernel> plan{nullptr, std::move(kernel), 0u, 0u};
+
+    bool found = false;
+
+    for_each_arch(
+        [&](auto arch_tag)
+        {
+            constexpr auto Arch = decltype(arch_tag)::value;
+            if(Arch != arch || found)
+                return;
+
+            plan.kernel = trampoline_kernel<Config, Arch, Kernel, LaunchSelector>;
+
+            constexpr auto params = Config::template architecture_config<Arch>::params;
+
+            plan.shared_impl_histograms = params.shared_impl_histograms;
+            plan.max_grid_size          = params.max_grid_size;
+
+            found = true;
+        });
+    if(!found)
+    {
+        constexpr auto Arch = rocprim::detail::target_arch::unknown;
+
+        plan.kernel = trampoline_kernel<Config, Arch, Kernel, LaunchSelector>;
+
+        constexpr auto params       = Config::template architecture_config<Arch>::params;
+        plan.shared_impl_histograms = params.shared_impl_histograms;
+        plan.max_grid_size          = params.max_grid_size;
+    }
+    return plan;
 }
 
 template<class Config,
@@ -127,9 +210,51 @@ template<class Config,
          class SampleIterator,
          class Counter,
          class SampleToBinOp>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>()
-                                         .histogram_global_config.block_size) void
-    histogram_private_global_kernel(SampleIterator                             samples,
+inline hipError_t
+    launch_histogram_global(detail::target_arch                              arch,
+                            SampleIterator                                   samples,
+                            unsigned int                                     columns,
+                            unsigned int                                     row_stride,
+                            fixed_array<Counter*, ActiveChannels>            histogram,
+                            const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
+                            const fixed_array<size_t, ActiveChannels>        bins_bits,
+                            dim3                                             grid,
+                            dim3                                             block,
+                            size_t                                           shmem,
+                            hipStream_t                                      stream)
+{
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr histogram_config_params params = decltype(arch_config)::params;
+
+        histogram_global<params.histogram_config.block_size,
+                         params.histogram_config.items_per_thread,
+                         Channels,
+                         ActiveChannels>(samples,
+                                         columns,
+                                         row_stride,
+                                         histogram,
+                                         sample_to_bin_op,
+                                         bins_bits);
+    };
+
+    return execute_launch_plan<Config, decltype(kernel), histogram_config_selector>(arch,
+                                                                                    kernel,
+                                                                                    grid,
+                                                                                    block,
+                                                                                    shmem,
+                                                                                    stream);
+}
+
+template<class Config,
+         unsigned int Channels,
+         unsigned int ActiveChannels,
+         class SampleIterator,
+         class Counter,
+         class SampleToBinOp>
+inline hipError_t
+    launch_histogram_private_global(detail::target_arch                        arch,
+                                    SampleIterator                             samples,
                                     unsigned int                               columns,
                                     unsigned int                               rows,
                                     unsigned int                               row_stride,
@@ -139,24 +264,38 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>()
                                     fixed_array<size_t, ActiveChannels>        bins,
                                     Counter*                                   private_histograms,
                                     unsigned int                               virtual_max_blocks,
-                                    unsigned int*                              block_id_count)
+                                    unsigned int*                              block_id_count,
+                                    dim3                                       grid,
+                                    dim3                                       block,
+                                    size_t                                     shmem,
+                                    hipStream_t                                stream)
 {
-    static constexpr histogram_config_params params = device_params<Config>();
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr histogram_config_params params = decltype(arch_config)::params;
 
-    histogram_private_global<params.histogram_global_config.block_size,
-                             params.histogram_global_config.items_per_thread,
-                             Channels,
-                             ActiveChannels>(samples,
-                                             columns,
-                                             rows,
-                                             row_stride,
-                                             histogram,
-                                             sample_to_bin_op,
-                                             bins_bits,
-                                             bins,
-                                             private_histograms,
-                                             virtual_max_blocks,
-                                             block_id_count);
+        histogram_private_global<params.histogram_global_config.block_size,
+                                 params.histogram_global_config.items_per_thread,
+                                 Channels,
+                                 ActiveChannels>(samples,
+                                                 columns,
+                                                 rows,
+                                                 row_stride,
+                                                 histogram,
+                                                 sample_to_bin_op,
+                                                 bins_bits,
+                                                 bins,
+                                                 private_histograms,
+                                                 virtual_max_blocks,
+                                                 block_id_count);
+    };
+
+    return execute_launch_plan<Config, decltype(kernel), histogram_global_config_selector>(arch,
+                                                                                           kernel,
+                                                                                           grid,
+                                                                                           block,
+                                                                                           shmem,
+                                                                                           stream);
 }
 
 template<unsigned int Channels,
@@ -182,9 +321,12 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     using config = wrapped_histogram_config<Config, sample_type, Channels, ActiveChannels>;
 
     detail::target_arch target_arch;
-    ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
-
-    const histogram_config_params params = dispatch_target_arch<config>(target_arch);
+    hipError_t          result = host_target_arch(stream, target_arch);
+    if(result != hipSuccess)
+    {
+        return result;
+    }
+    const histogram_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int block_size           = params.histogram_config.block_size;
     const unsigned int items_per_thread     = params.histogram_config.items_per_thread;
@@ -299,12 +441,15 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     {
         start = std::chrono::steady_clock::now();
     }
-    init_histogram_kernel<config, ActiveChannels>
-        <<<dim3(::rocprim::detail::ceiling_div(max_bins, block_size)),
-           dim3(block_size),
-           0,
-           stream>>>(fixed_array<Counter*, ActiveChannels>(histogram),
-                     fixed_array<size_t, ActiveChannels>(bins));
+    ROCPRIM_RETURN_ON_ERROR(launch_init_histogram<config, ActiveChannels>(
+        target_arch,
+        fixed_array<Counter*, ActiveChannels>(histogram),
+        fixed_array<size_t, ActiveChannels>(bins),
+        dim3(::rocprim::detail::ceiling_div(max_bins, block_size)),
+        dim3(block_size),
+        0,
+        stream));
+
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_histogram", max_bins, start);
 
     if(columns == 0 || rows == 0)
@@ -318,12 +463,21 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         {
             start = std::chrono::steady_clock::now();
         }
-        auto kernel = HIP_KERNEL_NAME(histogram_shared_kernel<config,
-                                                              Channels,
-                                                              ActiveChannels,
-                                                              SampleIterator,
-                                                              Counter,
-                                                              SampleToBinOp>);
+
+        HistogramSharedOp<Channels, ActiveChannels, SampleIterator, Counter, SampleToBinOp> op{
+            samples,
+            columns,
+            rows,
+            row_stride,
+            fixed_array<Counter*, ActiveChannels>(histogram),
+            fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
+            fixed_array<size_t, ActiveChannels>(bins),
+            0,
+            0};
+
+        auto plan = make_histogram_launch_plan<config, decltype(op), histogram_config_selector>(
+            target_arch,
+            op);
 
         const size_t block_histogram_bytes = total_shared_bins * sizeof(unsigned int);
 
@@ -333,14 +487,14 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         // memory usage
         unsigned int chosen_shared_histograms = 0;
         int          max_blocks_per_mp        = 0;
-        for(unsigned int n = params.shared_impl_histograms; n >= 1; n--)
+        for(unsigned int n = plan.shared_impl_histograms; n >= 1; n--)
         {
             int blocks_per_mp;
-            ROCPRIM_RETURN_ON_ERROR(
-                hipOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_mp,
-                                                             kernel,
-                                                             block_size,
-                                                             n * block_histogram_bytes));
+            ROCPRIM_RETURN_ON_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                &blocks_per_mp,
+                reinterpret_cast<const void*>(plan.kernel),
+                block_size,
+                n * block_histogram_bytes));
 
             if(blocks_per_mp > max_blocks_per_mp)
             {
@@ -350,11 +504,11 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         }
 
         // Choose minimum grid size needed to achieve the best occupancy
-        int        min_grid_size, max_block_size;
+        int min_grid_size, max_block_size;
         ROCPRIM_RETURN_ON_ERROR(
             hipOccupancyMaxPotentialBlockSize(&min_grid_size,
                                               &max_block_size,
-                                              kernel,
+                                              reinterpret_cast<const void*>(plan.kernel),
                                               chosen_shared_histograms * block_histogram_bytes,
                                               int(block_size)));
 
@@ -365,18 +519,18 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         grid_size.x = std::min(chosen_grid_size, blocks_x);
         grid_size.y = std::min(rows, ::rocprim::detail::ceiling_div(chosen_grid_size, grid_size.x));
         const unsigned int rows_per_block = ::rocprim::detail::ceiling_div(rows, grid_size.y);
-        kernel<<<grid_size,
-                 dim3(block_size, 1),
-                 chosen_shared_histograms * block_histogram_bytes,
-                 stream>>>(samples,
-                           columns,
-                           rows,
-                           row_stride,
-                           rows_per_block,
-                           chosen_shared_histograms,
-                           fixed_array<Counter*, ActiveChannels>(histogram),
-                           fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                           fixed_array<size_t, ActiveChannels>(bins));
+
+        op.shared_histograms = chosen_shared_histograms;
+        op.rows_per_block    = rows_per_block;
+
+        plan.device_callback = op;
+
+        // 4) 发射（无需再做任何按架构分发）
+        plan.launch(grid_size,
+                    dim3(block_size, 1),
+                    chosen_shared_histograms * block_histogram_bytes,
+                    stream);
+
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_shared",
                                                     grid_size.x * grid_size.y * block_size,
                                                     start);
@@ -391,21 +545,24 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             {
                 start = std::chrono::steady_clock::now();
             }
-            histogram_private_global_kernel<config, Channels, ActiveChannels>
-                <<<dim3(global_histogram_grid_size),
-                   dim3(params.histogram_global_config.block_size),
-                   0,
-                   stream>>>(samples,
-                             columns,
-                             rows,
-                             row_stride,
-                             fixed_array<Counter*, ActiveChannels>(histogram),
-                             fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                             fixed_array<size_t, ActiveChannels>(bins_bits),
-                             fixed_array<size_t, ActiveChannels>(bins),
-                             private_histograms,
-                             virtual_max_blocks,
-                             block_id_count);
+            ROCPRIM_RETURN_ON_ERROR(
+                launch_histogram_private_global<config, Channels, ActiveChannels>(
+                    target_arch,
+                    samples,
+                    columns,
+                    rows,
+                    row_stride,
+                    fixed_array<Counter*, ActiveChannels>(histogram),
+                    fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
+                    fixed_array<size_t, ActiveChannels>(bins_bits),
+                    fixed_array<size_t, ActiveChannels>(bins),
+                    private_histograms,
+                    virtual_max_blocks,
+                    block_id_count,
+                    dim3(global_histogram_grid_size),
+                    dim3(params.histogram_global_config.block_size),
+                    0,
+                    stream));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_private_global",
                                                         blocks_x * block_size * rows,
                                                         start);
@@ -416,14 +573,18 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             {
                 start = std::chrono::steady_clock::now();
             }
-            histogram_global_kernel<config, Channels, ActiveChannels>
-                <<<dim3(blocks_x, rows), dim3(block_size, 1), 0, stream>>>(
-                    samples,
-                    columns,
-                    row_stride,
-                    fixed_array<Counter*, ActiveChannels>(histogram),
-                    fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                    fixed_array<size_t, ActiveChannels>(bins_bits));
+            ROCPRIM_RETURN_ON_ERROR(launch_histogram_global<config, Channels, ActiveChannels>(
+                target_arch,
+                samples,
+                columns,
+                row_stride,
+                fixed_array<Counter*, ActiveChannels>(histogram),
+                fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
+                fixed_array<size_t, ActiveChannels>(bins_bits),
+                dim3(blocks_x, rows),
+                dim3(block_size, 1),
+                0,
+                stream));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global",
                                                         blocks_x * block_size * rows,
                                                         start);
@@ -529,8 +690,6 @@ inline hipError_t histogram_range_impl(void*          temporary_storage,
                                                             debug_synchronous);
 }
 
-
-
 } // namespace detail
 
 /// \brief Computes a histogram from a sequence of samples using equal-width bins.
@@ -542,7 +701,7 @@ inline hipError_t histogram_range_impl(void*          temporary_storage,
 /// * Returns the required size of \p temporary_storage in \p storage_size
 /// if \p temporary_storage in a null pointer.
 ///
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `histogram_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam SampleIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam Counter integer type for histogram bin counters.
@@ -645,7 +804,7 @@ inline hipError_t histogram_even(void*          temporary_storage,
 /// * Returns the required size of \p temporary_storage in \p storage_size
 /// if \p temporary_storage in a null pointer.
 ///
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `histogram_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam SampleIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam Counter integer type for histogram bin counters.
@@ -756,7 +915,7 @@ inline hipError_t histogram_even(void*          temporary_storage,
 ///
 /// \tparam Channels number of channels interleaved in the input samples.
 /// \tparam ActiveChannels number of channels being used for computing histograms.
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `histogram_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam SampleIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam Counter integer type for histogram bin counters.
@@ -875,7 +1034,7 @@ inline hipError_t multi_histogram_even(void*          temporary_storage,
 ///
 /// \tparam Channels number of channels interleaved in the input samples.
 /// \tparam ActiveChannels number of channels being used for computing histograms.
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `histogram_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam SampleIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam Counter integer type for histogram bin counters.
@@ -989,7 +1148,7 @@ inline hipError_t multi_histogram_even(void*          temporary_storage,
 /// * Returns the required size of \p temporary_storage in \p storage_size
 /// if \p temporary_storage in a null pointer.
 ///
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `histogram_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam SampleIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam Counter integer type for histogram bin counters.
@@ -1086,7 +1245,7 @@ inline hipError_t histogram_range(void*          temporary_storage,
 /// * Returns the required size of \p temporary_storage in \p storage_size
 /// if \p temporary_storage in a null pointer.
 ///
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `histogram_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam SampleIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam Counter integer type for histogram bin counters.
@@ -1192,7 +1351,7 @@ inline hipError_t histogram_range(void*          temporary_storage,
 ///
 /// \tparam Channels number of channels interleaved in the input samples.
 /// \tparam ActiveChannels number of channels being used for computing histograms.
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `histogram_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam SampleIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam Counter integer type for histogram bin counters.
@@ -1306,7 +1465,7 @@ inline hipError_t multi_histogram_range(void*          temporary_storage,
 ///
 /// \tparam Channels number of channels interleaved in the input samples.
 /// \tparam ActiveChannels number of channels being used for computing histograms.
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `histogram_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam SampleIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam Counter integer type for histogram bin counters.

--- a/projects/rocprim/rocprim/include/rocprim/device/device_memcpy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_memcpy.hpp
@@ -117,21 +117,22 @@ BEGIN_ROCPRIM_NAMESPACE
 /// //                2nd copy
 /// \endcode
 /// \endparblock
-template<class Config_ = default_config,
+template<class Config = default_config,
          class InputBufferItType,
          class OutputBufferItType,
          class BufferSizeItType>
-ROCPRIM_INLINE static hipError_t batch_memcpy(void*              temporary_storage,
-                                              size_t&            storage_size,
-                                              InputBufferItType  sources,
-                                              OutputBufferItType destinations,
-                                              BufferSizeItType   sizes,
-                                              uint32_t           num_copies,
-                                              hipStream_t        stream = hipStreamDefault,
-                                              bool               debug_synchronous = false)
+ROCPRIM_INLINE
+static hipError_t batch_memcpy(void*              temporary_storage,
+                               size_t&            storage_size,
+                               InputBufferItType  sources,
+                               OutputBufferItType destinations,
+                               BufferSizeItType   sizes,
+                               uint32_t           num_copies,
+                               hipStream_t        stream            = hipStreamDefault,
+                               bool               debug_synchronous = false)
 {
     return detail::
-        batch_memcpy_func<Config_, InputBufferItType, OutputBufferItType, BufferSizeItType, true>(
+        batch_memcpy_func<Config, InputBufferItType, OutputBufferItType, BufferSizeItType, true>(
             temporary_storage,
             storage_size,
             sources,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <iterator>
+#include <optional>
 #include <type_traits>
 
 #include "../common.hpp"
@@ -46,19 +47,34 @@ template<class Config,
          class KeysInputIterator1,
          class KeysInputIterator2,
          class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    partition_kernel(IndexIterator      index,
-                     KeysInputIterator1 keys_input1,
-                     KeysInputIterator2 keys_input2,
-                     const size_t       input1_size,
-                     const size_t       input2_size,
-                     const unsigned int spacing,
-                     BinaryFunction     compare_function)
+inline hipError_t launch_partition(detail::target_arch arch,
+                                   IndexIterator       index,
+                                   KeysInputIterator1  keys_input1,
+                                   KeysInputIterator2  keys_input2,
+                                   const size_t        input1_size,
+                                   const size_t        input2_size,
+                                   const unsigned int  spacing,
+                                   BinaryFunction      compare_function,
+                                   dim3                grid,
+                                   dim3                block,
+                                   size_t              shmem,
+                                   hipStream_t         stream)
 {
-    partition_kernel_impl(
-        index, keys_input1, keys_input2, input1_size, input2_size,
-        spacing, compare_function
-    );
+    auto kernel = [=](auto)
+    {
+        partition_kernel_impl<IndexIterator,
+                              KeysInputIterator1,
+                              KeysInputIterator2,
+                              BinaryFunction>(index,
+                                              keys_input1,
+                                              keys_input2,
+                                              input1_size,
+                                              input2_size,
+                                              spacing,
+                                              compare_function);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,
@@ -70,97 +86,103 @@ template<class Config,
          class ValuesInputIterator2,
          class ValuesOutputIterator,
          class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    merge_kernel(IndexIterator        index,
-                 KeysInputIterator1   keys_input1,
-                 KeysInputIterator2   keys_input2,
-                 KeysOutputIterator   keys_output,
-                 ValuesInputIterator1 values_input1,
-                 ValuesInputIterator2 values_input2,
-                 ValuesOutputIterator values_output,
-                 const size_t         input1_size,
-                 const size_t         input2_size,
-                 BinaryFunction       compare_function,
-                 detail::vsmem_t      vsmem)
+inline hipError_t launch_merge(detail::target_arch  arch,
+                               IndexIterator        index,
+                               KeysInputIterator1   keys_input1,
+                               KeysInputIterator2   keys_input2,
+                               KeysOutputIterator   keys_output,
+                               ValuesInputIterator1 values_input1,
+                               ValuesInputIterator2 values_input2,
+                               ValuesOutputIterator values_output,
+                               const size_t         input1_size,
+                               const size_t         input2_size,
+                               BinaryFunction       compare_function,
+                               detail::vsmem_t      vsmem,
+                               dim3                 grid,
+                               dim3                 block,
+                               size_t               shmem,
+                               hipStream_t          stream)
+{
+    auto kernel = [=](auto arch_config) mutable
+    {
+        using key_type   = typename std::iterator_traits<KeysInputIterator1>::value_type;
+        using value_type = typename std::iterator_traits<ValuesInputIterator1>::value_type;
+
+        using merge_kernel_impl_t = merge_kernel_impl_<decltype(arch_config), key_type, value_type>;
+
+        using VSmemHelperT = detail::vsmem_helper_impl<merge_kernel_impl_t>;
+        ROCPRIM_SHARED_MEMORY
+        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        // Get temporary storage
+        typename merge_kernel_impl_t::storage_type& storage
+            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
+
+        merge_kernel_impl_t().merge(index,
+                                    keys_input1,
+                                    keys_input2,
+                                    keys_output,
+                                    values_input1,
+                                    values_input2,
+                                    values_output,
+                                    input1_size,
+                                    input2_size,
+                                    compare_function,
+                                    storage);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+}
+
+template<typename Config, typename Key, typename Value>
+inline size_t get_merge_vsmem_size_per_block(detail::target_arch arch)
+{
+    std::optional<size_t> vsmem_per_block;
+    for_each_arch(
+        [&](auto arch_tag)
+        {
+            constexpr target_arch Arch = decltype(arch_tag)::value;
+            if(Arch != arch || vsmem_per_block)
+                return;
+            using ArchConfig           = typename Config::template architecture_config<Arch>;
+            using merge_kernel_impl_t  = merge_kernel_impl_<ArchConfig, Key, Value>;
+            using merge_vsmem_helper_t = detail::vsmem_helper_impl<merge_kernel_impl_t>;
+            vsmem_per_block            = merge_vsmem_helper_t::vsmem_per_block;
+        });
+
+    if(!vsmem_per_block)
+    {
+        using ArchConfig = typename Config::template architecture_config<target_arch::unknown>;
+        using merge_kernel_impl_t  = merge_kernel_impl_<ArchConfig, Key, Value>;
+        using merge_vsmem_helper_t = detail::vsmem_helper_impl<merge_kernel_impl_t>;
+        vsmem_per_block            = merge_vsmem_helper_t::vsmem_per_block;
+    }
+    return vsmem_per_block.value();
+}
+
+template<class Config,
+         class KeysInputIterator1,
+         class KeysInputIterator2,
+         class KeysOutputIterator,
+         class ValuesInputIterator1,
+         class ValuesInputIterator2,
+         class ValuesOutputIterator,
+         class BinaryFunction>
+inline hipError_t merge_impl(void*                temporary_storage,
+                             size_t&              storage_size,
+                             KeysInputIterator1   keys_input1,
+                             KeysInputIterator2   keys_input2,
+                             KeysOutputIterator   keys_output,
+                             ValuesInputIterator1 values_input1,
+                             ValuesInputIterator2 values_input2,
+                             ValuesOutputIterator values_output,
+                             const size_t         input1_size,
+                             const size_t         input2_size,
+                             BinaryFunction       compare_function,
+                             const hipStream_t    stream,
+                             bool                 debug_synchronous)
+
 {
     using key_type   = typename std::iterator_traits<KeysInputIterator1>::value_type;
-    using value_type = typename std::iterator_traits<ValuesInputIterator1>::value_type;
-
-    using merge_kernel_impl_t = merge_kernel_impl_<Config, key_type, value_type>;
-
-    using VSmemHelperT = detail::vsmem_helper_impl<merge_kernel_impl_t>;
-    ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
-    // Get temporary storage
-    typename merge_kernel_impl_t::storage_type& storage
-        = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
-
-    merge_kernel_impl_t().merge(index,
-                                keys_input1,
-                                keys_input2,
-                                keys_output,
-                                values_input1,
-                                values_input2,
-                                values_output,
-                                input1_size,
-                                input2_size,
-                                compare_function,
-                                storage);
-}
-
-// Templated helper that instantiates merge_kernel_impl_ for an Arch,
-// and puts its vsmem_per_block in the vsmem_size_out member variable.
-template<class Config, class Key, class Value>
-struct merge_vsmem_size_visitor
-{
-    size_t& vsmem_size_out;
-
-    template<target_arch Arch>
-    inline hipError_t operator()() const
-    {
-        using forced_conf_t = force_arch_config<Arch, Config, merge_config_params>;
-
-        using merge_kernel_impl_t = merge_kernel_impl_<forced_conf_t, Key, Value>;
-
-        vsmem_size_out = vsmem_helper_impl<merge_kernel_impl_t>::vsmem_per_block;
-
-        return hipSuccess;
-    }
-};
-
-template<class Config, class Key, class Value>
-inline hipError_t get_merge_vsmem_size_per_block(target_arch target_arch, size_t& vsmem_size)
-{
-    return generic_dispatch_target_arch(target_arch,
-                                        merge_vsmem_size_visitor<Config, Key, Value>{vsmem_size});
-}
-
-template<
-    class Config,
-    class KeysInputIterator1,
-    class KeysInputIterator2,
-    class KeysOutputIterator,
-    class ValuesInputIterator1,
-    class ValuesInputIterator2,
-    class ValuesOutputIterator,
-    class BinaryFunction
->
-inline
-hipError_t merge_impl(void * temporary_storage,
-                      size_t& storage_size,
-                      KeysInputIterator1 keys_input1,
-                      KeysInputIterator2 keys_input2,
-                      KeysOutputIterator keys_output,
-                      ValuesInputIterator1 values_input1,
-                      ValuesInputIterator2 values_input2,
-                      ValuesOutputIterator values_output,
-                      const size_t input1_size,
-                      const size_t input2_size,
-                      BinaryFunction compare_function,
-                      const hipStream_t stream,
-                      bool debug_synchronous)
-
-{
-    using key_type = typename std::iterator_traits<KeysInputIterator1>::value_type;
     using value_type = typename std::iterator_traits<ValuesInputIterator1>::value_type;
 
     using config = wrapped_merge_config<Config, key_type, value_type>;
@@ -171,7 +193,7 @@ hipError_t merge_impl(void * temporary_storage,
     {
         return result;
     }
-    const merge_config_params params = detail::dispatch_target_arch<config>(target_arch);
+    const merge_config_params params = detail::dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int block_size       = params.kernel_config.block_size;
     const unsigned int half_block       = block_size / 2;
@@ -181,14 +203,9 @@ hipError_t merge_impl(void * temporary_storage,
     const unsigned int number_of_blocks
         = ((input1_size + input2_size) + items_per_block - 1) / items_per_block;
 
-    size_t vsmem_size;
-    result = get_merge_vsmem_size_per_block<config, key_type, value_type>(target_arch, vsmem_size);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    vsmem_size *= number_of_blocks;
+    size_t virtual_shared_memory_size
+        = get_merge_vsmem_size_per_block<config, key_type, value_type>(target_arch)
+          * number_of_blocks;
 
     unsigned int* index = nullptr;
     void*         vsmem = nullptr;
@@ -199,7 +216,9 @@ hipError_t merge_impl(void * temporary_storage,
         detail::temp_storage::make_linear_partition(
             detail::temp_storage::ptr_aligned_array(&index, number_of_blocks + 1),
             // vsmem
-            detail::temp_storage::make_partition(&vsmem, vsmem_size, cache_line_size)));
+            detail::temp_storage::make_partition(&vsmem,
+                                                 virtual_shared_memory_size,
+                                                 cache_line_size)));
 
     if(partition_result != hipSuccess || temporary_storage == nullptr)
     {
@@ -223,38 +242,57 @@ hipError_t merge_impl(void * temporary_storage,
 
     const unsigned int partition_blocks = ((number_of_blocks + 1) + half_block - 1) / half_block;
 
-    if(debug_synchronous) start = std::chrono::steady_clock::now();
-    detail::partition_kernel<config>
-        <<<dim3(partition_blocks), dim3(half_block), 0, stream>>>(index,
-                                                                  keys_input1,
-                                                                  keys_input2,
-                                                                  input1_size,
-                                                                  input2_size,
-                                                                  items_per_block,
-                                                                  compare_function);
+    if(debug_synchronous)
+        start = std::chrono::steady_clock::now();
+
+    hipError_t launch_err = launch_partition<config>(target_arch,
+                                                     index,
+                                                     keys_input1,
+                                                     keys_input2,
+                                                     input1_size,
+                                                     input2_size,
+                                                     items_per_block,
+                                                     compare_function,
+                                                     partition_blocks,
+                                                     half_block,
+                                                     0,
+                                                     stream);
+
+    if(launch_err != hipSuccess)
+    {
+        return launch_err;
+    }
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", input1_size, start);
 
-    if(debug_synchronous) start = std::chrono::steady_clock::now();
-    detail::merge_kernel<config>
-        <<<dim3(number_of_blocks), dim3(block_size), 0, stream>>>(index,
-                                                                  keys_input1,
-                                                                  keys_input2,
-                                                                  keys_output,
-                                                                  values_input1,
-                                                                  values_input2,
-                                                                  values_output,
-                                                                  input1_size,
-                                                                  input2_size,
-                                                                  compare_function,
-                                                                  detail::vsmem_t{vsmem});
+    if(debug_synchronous)
+        start = std::chrono::steady_clock::now();
+
+    launch_err = launch_merge<config>(target_arch,
+                                      index,
+                                      keys_input1,
+                                      keys_input2,
+                                      keys_output,
+                                      values_input1,
+                                      values_input2,
+                                      values_output,
+                                      input1_size,
+                                      input2_size,
+                                      compare_function,
+                                      detail::vsmem_t{vsmem},
+                                      dim3(number_of_blocks),
+                                      dim3(block_size),
+                                      0,
+                                      stream);
+    if(launch_err != hipSuccess)
+    {
+        return launch_err;
+    }
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("merge_kernel", input1_size, start);
 
     return hipSuccess;
 }
 
-
-
-} // end of detail namespace
+} // namespace detail
 
 /// \brief Parallel merge primitive for device level.
 ///
@@ -330,33 +368,37 @@ hipError_t merge_impl(void * temporary_storage,
 /// // output: [0, 0, 1, 1, 2, 2, 3, 3]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator1,
-    class InputIterator2,
-    class OutputIterator,
-    class BinaryFunction = ::rocprim::less<typename std::iterator_traits<InputIterator1>::value_type>
->
-inline
-hipError_t merge(void * temporary_storage,
-                 size_t& storage_size,
-                 InputIterator1 input1,
-                 InputIterator2 input2,
-                 OutputIterator output,
-                 const size_t input1_size,
-                 const size_t input2_size,
-                 BinaryFunction compare_function = BinaryFunction(),
-                 const hipStream_t stream = 0,
-                 bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator1,
+         class InputIterator2,
+         class OutputIterator,
+         class BinaryFunction
+         = ::rocprim::less<typename std::iterator_traits<InputIterator1>::value_type>>
+inline hipError_t merge(void*             temporary_storage,
+                        size_t&           storage_size,
+                        InputIterator1    input1,
+                        InputIterator2    input2,
+                        OutputIterator    output,
+                        const size_t      input1_size,
+                        const size_t      input2_size,
+                        BinaryFunction    compare_function  = BinaryFunction(),
+                        const hipStream_t stream            = 0,
+                        bool              debug_synchronous = false)
 {
-    empty_type * values = nullptr;
-    return detail::merge_impl<Config>(
-        temporary_storage, storage_size,
-        input1, input2, output,
-        values, values, values,
-        input1_size, input2_size, compare_function,
-        stream, debug_synchronous
-    );
+    empty_type* values = nullptr;
+    return detail::merge_impl<Config>(temporary_storage,
+                                      storage_size,
+                                      input1,
+                                      input2,
+                                      output,
+                                      values,
+                                      values,
+                                      values,
+                                      input1_size,
+                                      input2_size,
+                                      compare_function,
+                                      stream,
+                                      debug_synchronous);
 }
 
 /// \brief Parallel merge primitive for device level.
@@ -451,38 +493,42 @@ hipError_t merge(void * temporary_storage,
 /// // values_output: [10, 20, 11, 21, 12, 22, 13, 23]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class KeysInputIterator1,
-    class KeysInputIterator2,
-    class KeysOutputIterator,
-    class ValuesInputIterator1,
-    class ValuesInputIterator2,
-    class ValuesOutputIterator,
-    class BinaryFunction = ::rocprim::less<typename std::iterator_traits<KeysInputIterator1>::value_type>
->
-inline
-hipError_t merge(void * temporary_storage,
-                 size_t& storage_size,
-                 KeysInputIterator1 keys_input1,
-                 KeysInputIterator2 keys_input2,
-                 KeysOutputIterator keys_output,
-                 ValuesInputIterator1 values_input1,
-                 ValuesInputIterator2 values_input2,
-                 ValuesOutputIterator values_output,
-                 const size_t input1_size,
-                 const size_t input2_size,
-                 BinaryFunction compare_function = BinaryFunction(),
-                 const hipStream_t stream = 0,
-                 bool debug_synchronous = false)
+template<class Config = default_config,
+         class KeysInputIterator1,
+         class KeysInputIterator2,
+         class KeysOutputIterator,
+         class ValuesInputIterator1,
+         class ValuesInputIterator2,
+         class ValuesOutputIterator,
+         class BinaryFunction
+         = ::rocprim::less<typename std::iterator_traits<KeysInputIterator1>::value_type>>
+inline hipError_t merge(void*                temporary_storage,
+                        size_t&              storage_size,
+                        KeysInputIterator1   keys_input1,
+                        KeysInputIterator2   keys_input2,
+                        KeysOutputIterator   keys_output,
+                        ValuesInputIterator1 values_input1,
+                        ValuesInputIterator2 values_input2,
+                        ValuesOutputIterator values_output,
+                        const size_t         input1_size,
+                        const size_t         input2_size,
+                        BinaryFunction       compare_function  = BinaryFunction(),
+                        const hipStream_t    stream            = 0,
+                        bool                 debug_synchronous = false)
 {
-    return detail::merge_impl<Config>(
-        temporary_storage, storage_size,
-        keys_input1, keys_input2, keys_output,
-        values_input1, values_input2, values_output,
-        input1_size, input2_size, compare_function,
-        stream, debug_synchronous
-    );
+    return detail::merge_impl<Config>(temporary_storage,
+                                      storage_size,
+                                      keys_input1,
+                                      keys_input2,
+                                      keys_output,
+                                      values_input1,
+                                      values_input2,
+                                      values_output,
+                                      input1_size,
+                                      input2_size,
+                                      compare_function,
+                                      stream,
+                                      debug_synchronous);
 }
 
 /// @}

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
@@ -74,7 +74,7 @@ inline hipError_t launch_partition(detail::target_arch arch,
                                               compare_function);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,
@@ -129,7 +129,7 @@ inline hipError_t launch_merge(detail::target_arch  arch,
                                     storage);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<typename Config, typename Key, typename Value>

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
@@ -111,8 +111,7 @@ inline hipError_t launch_merge(detail::target_arch  arch,
         using merge_kernel_impl_t = merge_kernel_impl_<decltype(arch_config), key_type, value_type>;
 
         using VSmemHelperT = detail::vsmem_helper_impl<merge_kernel_impl_t>;
-        ROCPRIM_SHARED_MEMORY
-        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
         // Get temporary storage
         typename merge_kernel_impl_t::storage_type& storage
             = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
@@ -146,7 +145,8 @@ inline size_t get_merge_vsmem_size_per_block(detail::target_arch arch)
             using ArchConfig           = typename Config::template architecture_config<Arch>;
             using merge_kernel_impl_t  = merge_kernel_impl_<ArchConfig, Key, Value>;
             using merge_vsmem_helper_t = detail::vsmem_helper_impl<merge_kernel_impl_t>;
-            vsmem_per_block            = merge_vsmem_helper_t::vsmem_per_block;
+
+            vsmem_per_block = merge_vsmem_helper_t::vsmem_per_block;
         });
 
     if(!vsmem_per_block)
@@ -154,7 +154,8 @@ inline size_t get_merge_vsmem_size_per_block(detail::target_arch arch)
         using ArchConfig = typename Config::template architecture_config<target_arch::unknown>;
         using merge_kernel_impl_t  = merge_kernel_impl_<ArchConfig, Key, Value>;
         using merge_vsmem_helper_t = detail::vsmem_helper_impl<merge_kernel_impl_t>;
-        vsmem_per_block            = merge_vsmem_helper_t::vsmem_per_block;
+
+        vsmem_per_block = merge_vsmem_helper_t::vsmem_per_block;
     }
     return vsmem_per_block.value();
 }
@@ -245,7 +246,7 @@ inline hipError_t merge_impl(void*                temporary_storage,
     if(debug_synchronous)
         start = std::chrono::steady_clock::now();
 
-    hipError_t launch_err = launch_partition<config>(target_arch,
+    ROCPRIM_RETURN_ON_ERROR(launch_partition<config>(target_arch,
                                                      index,
                                                      keys_input1,
                                                      keys_input2,
@@ -256,37 +257,28 @@ inline hipError_t merge_impl(void*                temporary_storage,
                                                      partition_blocks,
                                                      half_block,
                                                      0,
-                                                     stream);
-
-    if(launch_err != hipSuccess)
-    {
-        return launch_err;
-    }
+                                                     stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", input1_size, start);
 
     if(debug_synchronous)
         start = std::chrono::steady_clock::now();
 
-    launch_err = launch_merge<config>(target_arch,
-                                      index,
-                                      keys_input1,
-                                      keys_input2,
-                                      keys_output,
-                                      values_input1,
-                                      values_input2,
-                                      values_output,
-                                      input1_size,
-                                      input2_size,
-                                      compare_function,
-                                      detail::vsmem_t{vsmem},
-                                      dim3(number_of_blocks),
-                                      dim3(block_size),
-                                      0,
-                                      stream);
-    if(launch_err != hipSuccess)
-    {
-        return launch_err;
-    }
+    ROCPRIM_RETURN_ON_ERROR(launch_merge<config>(target_arch,
+                                                 index,
+                                                 keys_input1,
+                                                 keys_input2,
+                                                 keys_output,
+                                                 values_input1,
+                                                 values_input2,
+                                                 values_output,
+                                                 input1_size,
+                                                 input2_size,
+                                                 compare_function,
+                                                 detail::vsmem_t{vsmem},
+                                                 dim3(number_of_blocks),
+                                                 dim3(block_size),
+                                                 0,
+                                                 stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("merge_kernel", input1_size, start);
 
     return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge_inplace.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge_inplace.hpp
@@ -554,7 +554,7 @@ struct merge_inplace_impl
     ROCPRIM_DETAIL_GENERATE_DISPATCH_KERNEL(update_work_tree);
 #undef ROCPRIM_DETAIL_GENERATE_DISPATCH_KERNEL
 
-    static __global__
+    static ROCPRIM_KERNEL
     void block_merge_kernel(iterator_t     data,
                             size_t         num_items,
                             BinaryFunction compare_function,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
@@ -682,14 +682,16 @@ void TAssertEqualGreater()
     static_assert(A >= B, "A not greater or equal to B");
 };
 
-template<class BlockSortConfig, class BlockMergeConfig>
+template<detail::target_arch Arch, class BlockSortConfig, class BlockMergeConfig>
 ROCPRIM_KERNEL
-void device_merge_sort_compile_time_verifier()
+void device_merge_sort_compile_time_verifier_arch()
 {
-    static constexpr merge_sort_block_sort_config_params bs_params
-        = device_params<BlockSortConfig>();
-    static constexpr merge_sort_block_merge_config_params bm_params
-        = device_params<BlockMergeConfig>();
+    using BSArchConfig = typename BlockSortConfig::template architecture_config<Arch>;
+    using BMArchConfig = typename BlockMergeConfig::template architecture_config<Arch>;
+
+    static constexpr auto bs_params = BSArchConfig::params;
+    static constexpr auto bm_params = BMArchConfig::params;
+
     static constexpr unsigned int sort_items_per_block
         = bs_params.kernel_config.block_size * bs_params.kernel_config.items_per_thread;
     static constexpr unsigned int merge_oddeven_items_per_block
@@ -715,21 +717,46 @@ void device_merge_sort_compile_time_verifier()
                   "merge_mergepath_items_per_block");
 }
 
-template<class BlockSortConfig, class BlockMergeConfig, typename key_type, typename value_type>
-inline size_t get_merge_sort_vsmem_size(const size_t size)
+template<class WrappedBSConfig, class WrappedBMConfig>
+inline void device_merge_sort_compile_time_verifier() noexcept
 {
+    static const bool once = []
+    {
+        for_each_arch(
+            [](auto arch_tag)
+            {
+                constexpr auto A = decltype(arch_tag)::value;
+                (void)&device_merge_sort_compile_time_verifier_arch<A,
+                                                                    WrappedBSConfig,
+                                                                    WrappedBMConfig>;
+            });
+        (void)&device_merge_sort_compile_time_verifier_arch<target_arch::unknown,
+                                                            WrappedBSConfig,
+                                                            WrappedBMConfig>;
+        return true;
+    }();
+    (void)once;
+}
 
-    size_t                                               virtual_shared_memory_size = 0;
-    static constexpr merge_sort_block_sort_config_params bs_params
-        = device_params<BlockSortConfig>();
-    static constexpr merge_sort_block_merge_config_params bm_params
-        = device_params<BlockMergeConfig>();
-    using bs_sort_impl = block_sort_impl<key_type,
-                                         value_type,
+template<detail::target_arch Arch,
+         class BlockSortConfig,
+         class BlockMergeConfig,
+         typename Key,
+         typename Value>
+inline size_t merge_sort_vsmem_size_for_arch(size_t size)
+{
+    using BSArchConfig = typename BlockSortConfig::template architecture_config<Arch>;
+    using BMArchConfig = typename BlockMergeConfig::template architecture_config<Arch>;
+
+    static constexpr auto bs_params = BSArchConfig::params;
+    static constexpr auto bm_params = BMArchConfig::params;
+
+    using bs_sort_impl = block_sort_impl<Key,
+                                         Value,
                                          bs_params.kernel_config.block_size,
                                          bs_params.kernel_config.items_per_thread>;
-    using bm_sort_impl = block_merge_impl<key_type,
-                                          value_type,
+    using bm_sort_impl = block_merge_impl<Key,
+                                          Value,
                                           bm_params.merge_mergepath_config.block_size,
                                           bm_params.merge_mergepath_config.items_per_thread>;
 
@@ -744,6 +771,8 @@ inline size_t get_merge_sort_vsmem_size(const size_t size)
         = ceiling_div(size, merge_mergepath_items_per_block);
 
     const bool use_mergepath = size > bm_params.merge_oddeven_config.size_limit;
+
+    size_t virtual_shared_memory_size = 0;
 
     // Check if vsmem is needed
     if(BlockSortVSmemHelperT::vsmem_per_block + MergeSortVSmemHelperT::vsmem_per_block > 0)
@@ -763,6 +792,37 @@ inline size_t get_merge_sort_vsmem_size(const size_t size)
         virtual_shared_memory_size = (std::max)(block_sort_smem_size, merge_smem_size);
     }
     return virtual_shared_memory_size;
+}
+
+template<class BlockSortConfig, class BlockMergeConfig, typename Key, typename Value>
+inline size_t get_merge_sort_vsmem_size(detail::target_arch arch, size_t size) noexcept
+{
+    std::optional<size_t> out;
+
+    for_each_arch(
+        [&](auto arch_tag)
+        {
+            if(out)
+                return;
+            constexpr auto Arch = decltype(arch_tag)::value;
+            if(Arch != arch)
+                return;
+
+            out = merge_sort_vsmem_size_for_arch<Arch,
+                                                 BlockSortConfig,
+                                                 BlockMergeConfig,
+                                                 Key,
+                                                 Value>(size);
+        });
+    if(!out)
+    {
+        out = merge_sort_vsmem_size_for_arch<detail::target_arch::unknown,
+                                             BlockSortConfig,
+                                             BlockMergeConfig,
+                                             Key,
+                                             Value>(size);
+    }
+    return *out;
 }
 
 template<class Config,
@@ -801,9 +861,8 @@ inline hipError_t merge_sort_impl(
     using wrapped_bm_config
         = wrapped_merge_sort_block_merge_config<block_merge_config, key_type, value_type>;
 
-    (void)device_merge_sort_compile_time_verifier<
-        wrapped_bs_config,
-        wrapped_bm_config>; // Some helpful checks during compile-time
+    // Some helpful checks during compile-time
+    device_merge_sort_compile_time_verifier<wrapped_bs_config, wrapped_bm_config>();
 
     unsigned int sort_items_per_block = 1; // We will get this later from the block_sort algorithm
 
@@ -825,6 +884,7 @@ inline hipError_t merge_sort_impl(
     void*  vsmem = nullptr;
     size_t virtual_shared_memory_size
         = get_merge_sort_vsmem_size<wrapped_bs_config, wrapped_bm_config, key_type, value_type>(
+            target_arch,
             size);
 
     // temporary storage needed for both block merge and block sort

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
@@ -88,14 +88,13 @@ inline hipError_t launch_block_sort(detail::target_arch  arch,
         using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
         using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
 
-        using sort_impl    = block_sort_impl<key_type,
-                                             value_type,
-                                             params.kernel_config.block_size,
-                                             params.kernel_config.items_per_thread>;
+        using sort_impl = block_sort_impl<key_type,
+                                          value_type,
+                                          params.kernel_config.block_size,
+                                          params.kernel_config.items_per_thread>;
         using VSmemHelperT = detail::vsmem_helper_impl<sort_impl>;
 
-        ROCPRIM_SHARED_MEMORY
-        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
 
         typename sort_impl::storage_type& storage
             = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
@@ -194,8 +193,7 @@ inline hipError_t launch_device_block_merge_mergepath(detail::target_arch  arch,
                                             params.merge_mergepath_config.items_per_thread>;
 
         using VSmemHelperT = detail::vsmem_helper_impl<merge_impl>;
-        ROCPRIM_SHARED_MEMORY
-        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
 
         typename merge_impl::storage_type& storage
             = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
@@ -401,7 +399,7 @@ inline hipError_t merge_sort_block_merge_impl(
                 if(debug_synchronous)
                     start = std::chrono::steady_clock::now();
                 // Note: shared memory is not used in this kernel so there is no need to pass vsmem
-                hipError_t launch_err = launch_device_block_merge_mergepath_partition<config>(
+                ROCPRIM_RETURN_ON_ERROR(launch_device_block_merge_mergepath_partition<config>(
                     target_arch,
                     keys_input_,
                     size,
@@ -412,11 +410,7 @@ inline hipError_t merge_sort_block_merge_impl(
                     dim3(merge_partition_number_of_blocks),
                     dim3(merge_partition_block_size),
                     0,
-                    stream);
-                if(launch_err != hipSuccess)
-                {
-                    return launch_err;
-                }
+                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(
                     "device_block_merge_mergepath_partition_kernel",
                     merge_num_partitions,
@@ -424,7 +418,7 @@ inline hipError_t merge_sort_block_merge_impl(
 
                 if(debug_synchronous)
                     start = std::chrono::steady_clock::now();
-                launch_err = launch_device_block_merge_mergepath<config>(
+                ROCPRIM_RETURN_ON_ERROR(launch_device_block_merge_mergepath<config>(
                     target_arch,
                     keys_input_,
                     keys_output_,
@@ -440,11 +434,7 @@ inline hipError_t merge_sort_block_merge_impl(
                                        merge_mergepath_block_size),
                     dim3(merge_mergepath_block_size),
                     0,
-                    stream);
-                if(launch_err != hipSuccess)
-                {
-                    return launch_err;
-                }
+                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_block_merge_mergepath_kernel",
                                                             size,
                                                             start);
@@ -456,23 +446,19 @@ inline hipError_t merge_sort_block_merge_impl(
                 // As this kernel is only called with small sizes, it is safe to use 32-bit integers
                 // for size and block.
                 // Note: shared memory is not used in this kernel so there is no need to pass vsmem
-                hipError_t launch_err = launch_device_block_merge_oddeven<config>(
-                    target_arch,
-                    keys_input_,
-                    keys_output_,
-                    values_input_,
-                    values_output_,
-                    static_cast<unsigned int>(size),
-                    static_cast<unsigned int>(block),
-                    compare_function,
-                    dim3(merge_oddeven_number_of_blocks),
-                    dim3(merge_oddeven_block_size),
-                    0,
-                    stream);
-                if(launch_err != hipSuccess)
-                {
-                    return launch_err;
-                }
+                ROCPRIM_RETURN_ON_ERROR(
+                    launch_device_block_merge_oddeven<config>(target_arch,
+                                                              keys_input_,
+                                                              keys_output_,
+                                                              values_input_,
+                                                              values_output_,
+                                                              static_cast<unsigned int>(size),
+                                                              static_cast<unsigned int>(block),
+                                                              compare_function,
+                                                              dim3(merge_oddeven_number_of_blocks),
+                                                              dim3(merge_oddeven_block_size),
+                                                              0,
+                                                              stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_block_merge_oddeven_kernel",
                                                             size,
                                                             start);
@@ -669,7 +655,7 @@ inline hipError_t merge_sort_block_sort(KeysInputIterator    keys_input,
     if(debug_synchronous)
         start = std::chrono::steady_clock::now();
 
-    hipError_t launch_err = launch_block_sort<config>(
+    ROCPRIM_RETURN_ON_ERROR(launch_block_sort<config>(
         target_arch,
         keys_input,
         keys_output,
@@ -682,13 +668,7 @@ inline hipError_t merge_sort_block_sort(KeysInputIterator    keys_input,
         calculate_grid_dim(sort_number_of_blocks, params.kernel_config.block_size),
         dim3(params.kernel_config.block_size),
         0,
-        stream);
-
-    if(launch_err != hipSuccess)
-    {
-        return launch_err;
-    }
-
+        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_sort_kernel", size, start);
 
     return hipSuccess;
@@ -744,14 +724,15 @@ inline size_t get_merge_sort_vsmem_size(const size_t size)
         = device_params<BlockSortConfig>();
     static constexpr merge_sort_block_merge_config_params bm_params
         = device_params<BlockMergeConfig>();
-    using bs_sort_impl          = block_sort_impl<key_type,
-                                                  value_type,
-                                                  bs_params.kernel_config.block_size,
-                                                  bs_params.kernel_config.items_per_thread>;
-    using bm_sort_impl          = block_merge_impl<key_type,
-                                                   value_type,
-                                                   bm_params.merge_mergepath_config.block_size,
-                                                   bm_params.merge_mergepath_config.items_per_thread>;
+    using bs_sort_impl = block_sort_impl<key_type,
+                                         value_type,
+                                         bs_params.kernel_config.block_size,
+                                         bs_params.kernel_config.items_per_thread>;
+    using bm_sort_impl = block_merge_impl<key_type,
+                                          value_type,
+                                          bm_params.merge_mergepath_config.block_size,
+                                          bm_params.merge_mergepath_config.items_per_thread>;
+
     using BlockSortVSmemHelperT = detail::vsmem_helper_impl<bs_sort_impl>;
     using MergeSortVSmemHelperT = detail::vsmem_helper_impl<bm_sort_impl>;
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
@@ -53,54 +53,65 @@ template<class Config,
          class ValuesOutputIterator,
          class OffsetT,
          class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().block_sort_config.block_size) void
-    block_sort_kernel(KeysInputIterator    keys_input,
-                      KeysOutputIterator   keys_output,
-                      ValuesInputIterator  values_input,
-                      ValuesOutputIterator values_output,
-                      const OffsetT        size,
-                      const unsigned int   num_blocks,
-                      BinaryFunction       compare_function,
-                      detail::vsmem_t      vsmem)
+inline hipError_t launch_block_sort(detail::target_arch  arch,
+                                    KeysInputIterator    keys_input,
+                                    KeysOutputIterator   keys_output,
+                                    ValuesInputIterator  values_input,
+                                    ValuesOutputIterator values_output,
+                                    const OffsetT        size,
+                                    const unsigned int   num_blocks,
+                                    BinaryFunction       compare_function,
+                                    detail::vsmem_t      vsmem,
+                                    dim3                 grid,
+                                    dim3                 block,
+                                    size_t               shmem,
+                                    hipStream_t          stream)
 {
-    static constexpr merge_sort_block_sort_config_params params = device_params<Config>();
-
-    constexpr unsigned int items_per_block
-        = params.block_sort_config.block_size * params.block_sort_config.items_per_thread;
-
-    const unsigned int flat_block_id = ::rocprim::flat_block_id();
-    if(flat_block_id >= num_blocks)
+    auto kernel = [=](auto arch_config) mutable
     {
-        return;
-    }
+        constexpr auto params = decltype(arch_config)::params;
 
-    const OffsetT      block_offset        = static_cast<OffsetT>(flat_block_id) * items_per_block;
-    const unsigned int valid_in_last_block = size - block_offset;
-    const bool         is_incomplete_block = flat_block_id == (size / items_per_block);
+        constexpr unsigned int items_per_block
+            = params.kernel_config.block_size * params.kernel_config.items_per_thread;
 
-    // Shared memory or global memory pointer (vsmem)
-    using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
-    using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
+        const unsigned int flat_block_id = ::rocprim::flat_block_id();
+        if(flat_block_id >= num_blocks)
+        {
+            return;
+        }
 
-    using sort_impl = block_sort_impl<key_type,
-                                      value_type,
-                                      params.block_sort_config.block_size,
-                                      params.block_sort_config.items_per_thread>;
-    using VSmemHelperT = detail::vsmem_helper_impl<sort_impl>;
+        const OffsetT      block_offset = static_cast<OffsetT>(flat_block_id) * items_per_block;
+        const unsigned int valid_in_last_block = size - block_offset;
+        const bool         is_incomplete_block = flat_block_id == (size / items_per_block);
 
-    ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
-    typename sort_impl::storage_type&                                  storage
-        = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
+        // Shared memory or global memory pointer (vsmem)
+        using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
+        using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
 
-    // Core part of the block sort kernel
-    sort_impl().sort(valid_in_last_block,
-                     is_incomplete_block,
-                     keys_input + block_offset,
-                     keys_output + block_offset,
-                     values_input + block_offset,
-                     values_output + block_offset,
-                     compare_function,
-                     storage);
+        using sort_impl    = block_sort_impl<key_type,
+                                             value_type,
+                                             params.kernel_config.block_size,
+                                             params.kernel_config.items_per_thread>;
+        using VSmemHelperT = detail::vsmem_helper_impl<sort_impl>;
+
+        ROCPRIM_SHARED_MEMORY
+        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+
+        typename sort_impl::storage_type& storage
+            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
+
+        // Core part of the block sort kernel
+        sort_impl().sort(valid_in_last_block,
+                         is_incomplete_block,
+                         keys_input + block_offset,
+                         keys_output + block_offset,
+                         values_input + block_offset,
+                         values_output + block_offset,
+                         compare_function,
+                         storage);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,
@@ -110,24 +121,39 @@ template<class Config,
          class ValuesOutputIterator,
          class OffsetT,
          class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().merge_oddeven_config.block_size) void
-    device_block_merge_oddeven_kernel(KeysInputIterator    keys_input,
-                                      KeysOutputIterator   keys_output,
-                                      ValuesInputIterator  values_input,
-                                      ValuesOutputIterator values_output,
-                                      const OffsetT        input_size,
-                                      const OffsetT        sorted_block_size,
-                                      BinaryFunction       compare_function)
+inline hipError_t launch_device_block_merge_oddeven(detail::target_arch  arch,
+                                                    KeysInputIterator    keys_input,
+                                                    KeysOutputIterator   keys_output,
+                                                    ValuesInputIterator  values_input,
+                                                    ValuesOutputIterator values_output,
+                                                    const OffsetT        input_size,
+                                                    const OffsetT        sorted_block_size,
+                                                    BinaryFunction       compare_function,
+                                                    dim3                 grid,
+                                                    dim3                 block,
+                                                    size_t               shmem,
+                                                    hipStream_t          stream)
 {
-    static constexpr merge_sort_block_merge_config_params params = device_params<Config>();
-    block_merge_oddeven_kernel<params.merge_oddeven_config.block_size,
-                               params.merge_oddeven_config.items_per_thread>(keys_input,
-                                                                             keys_output,
-                                                                             values_input,
-                                                                             values_output,
-                                                                             input_size,
-                                                                             sorted_block_size,
-                                                                             compare_function);
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr merge_sort_block_merge_config_params params
+            = decltype(arch_config)::params;
+        block_merge_oddeven_kernel<params.merge_oddeven_config.block_size,
+                                   params.merge_oddeven_config.items_per_thread>(keys_input,
+                                                                                 keys_output,
+                                                                                 values_input,
+                                                                                 values_output,
+                                                                                 input_size,
+                                                                                 sorted_block_size,
+                                                                                 compare_function);
+    };
+
+    return launch_kernel<Config, decltype(kernel), merge_oddeven_config_selector>(arch,
+                                                                                  kernel,
+                                                                                  grid,
+                                                                                  block,
+                                                                                  shmem,
+                                                                                  stream);
 }
 
 template<class Config,
@@ -137,97 +163,131 @@ template<class Config,
          class ValuesOutputIterator,
          class OffsetT,
          class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().merge_mergepath_config.block_size) void
-    device_block_merge_mergepath_kernel(KeysInputIterator    keys_input,
-                                        KeysOutputIterator   keys_output,
-                                        ValuesInputIterator  values_input,
-                                        ValuesOutputIterator values_output,
-                                        const OffsetT        input_size,
-                                        const OffsetT        sorted_block_size,
-                                        const unsigned int   num_blocks,
-                                        BinaryFunction       compare_function,
-                                        const OffsetT*       merge_partitions,
-                                        detail::vsmem_t      vsmem)
+inline hipError_t launch_device_block_merge_mergepath(detail::target_arch  arch,
+                                                      KeysInputIterator    keys_input,
+                                                      KeysOutputIterator   keys_output,
+                                                      ValuesInputIterator  values_input,
+                                                      ValuesOutputIterator values_output,
+                                                      const OffsetT        input_size,
+                                                      const OffsetT        sorted_block_size,
+                                                      const unsigned int   num_blocks,
+                                                      BinaryFunction       compare_function,
+                                                      const OffsetT*       merge_partitions,
+                                                      detail::vsmem_t      vsmem,
+                                                      dim3                 grid,
+                                                      dim3                 block,
+                                                      size_t               shmem,
+                                                      hipStream_t          stream)
 {
-    static constexpr merge_sort_block_merge_config_params params = device_params<Config>();
+    auto kernel = [=](auto arch_config) mutable
+    {
+        static constexpr merge_sort_block_merge_config_params params
+            = decltype(arch_config)::params;
 
-    // Shared memory or global memory pointer (vsmem)
-    using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
-    using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
+        // Shared memory or global memory pointer (vsmem)
+        using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
+        using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
 
-    using merge_impl = block_merge_impl<key_type,
-                                        value_type,
-                                        params.merge_mergepath_config.block_size,
-                                        params.merge_mergepath_config.items_per_thread>;
+        using merge_impl = block_merge_impl<key_type,
+                                            value_type,
+                                            params.merge_mergepath_config.block_size,
+                                            params.merge_mergepath_config.items_per_thread>;
 
-    using VSmemHelperT = detail::vsmem_helper_impl<merge_impl>;
-    ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
-    typename merge_impl::storage_type&                                 storage
-        = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
+        using VSmemHelperT = detail::vsmem_helper_impl<merge_impl>;
+        ROCPRIM_SHARED_MEMORY
+        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
 
-    // Core part of block mergepath kernel
-    merge_impl().process_tile(keys_input,
-                              keys_output,
-                              values_input,
-                              values_output,
-                              input_size,
-                              sorted_block_size,
-                              num_blocks,
-                              compare_function,
-                              merge_partitions,
-                              storage);
+        typename merge_impl::storage_type& storage
+            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
+
+        // Core part of block mergepath kernel
+        merge_impl().process_tile(keys_input,
+                                  keys_output,
+                                  values_input,
+                                  values_output,
+                                  input_size,
+                                  sorted_block_size,
+                                  num_blocks,
+                                  compare_function,
+                                  merge_partitions,
+                                  storage);
+    };
+
+    return launch_kernel<Config, decltype(kernel), merge_mergepath_config_selector>(arch,
+                                                                                    kernel,
+                                                                                    grid,
+                                                                                    block,
+                                                                                    shmem,
+                                                                                    stream);
 }
 
 template<typename Config, typename KeysInputIterator, typename OffsetT, typename CompareOpT>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>()
-                                         .merge_mergepath_partition_config.block_size) void
-    device_block_merge_mergepath_partition_kernel(KeysInputIterator  keys,
-                                                  const OffsetT      input_size,
-                                                  const unsigned int num_partitions,
-                                                  OffsetT*           merge_partitions,
-                                                  const CompareOpT   compare_op,
-                                                  const OffsetT      sorted_block_size)
+inline hipError_t launch_device_block_merge_mergepath_partition(detail::target_arch arch,
+                                                                KeysInputIterator   keys,
+                                                                const OffsetT       input_size,
+                                                                const unsigned int  num_partitions,
+                                                                OffsetT*         merge_partitions,
+                                                                const CompareOpT compare_op,
+                                                                const OffsetT    sorted_block_size,
+                                                                dim3             grid,
+                                                                dim3             block,
+                                                                size_t           shmem,
+                                                                hipStream_t      stream)
 {
-    static constexpr merge_sort_block_merge_config_params params = device_params<Config>();
-    static constexpr unsigned int                         items_per_tile
-        = params.merge_mergepath_config.block_size * params.merge_mergepath_config.items_per_thread;
-
-    const unsigned int partition_id
-        = blockIdx.x * params.merge_mergepath_partition_config.block_size + threadIdx.x;
-
-    if(partition_id >= num_partitions)
+    auto kernel = [=](auto arch_config)
     {
-        return;
-    }
+        static constexpr merge_sort_block_merge_config_params params
+            = decltype(arch_config)::params;
+        static constexpr unsigned int items_per_tile
+            = params.merge_mergepath_config.block_size
+              * params.merge_mergepath_config.items_per_thread;
 
-    const unsigned int merged_tiles        = sorted_block_size / items_per_tile;
-    const unsigned int target_merged_tiles = merged_tiles * 2;
-    const unsigned int mask                = target_merged_tiles - 1;
+        const unsigned int partition_id
+            = blockIdx.x * params.merge_mergepath_partition_config.block_size + threadIdx.x;
 
-    // id of the first tile in the current tile-group
-    const unsigned int tilegroup_start_id = ~mask & partition_id;
-    // id of the current tile in the current tile-group
-    const unsigned int local_tile_id = mask & partition_id;
+        if(partition_id >= num_partitions)
+        {
+            return;
+        }
 
-    // index of the first item in the current tile-group
-    const OffsetT tilegroup_start = static_cast<OffsetT>(tilegroup_start_id) * items_per_tile;
+        const unsigned int merged_tiles        = sorted_block_size / items_per_tile;
+        const unsigned int target_merged_tiles = merged_tiles * 2;
+        const unsigned int mask                = target_merged_tiles - 1;
 
-    const OffsetT keys1_beg = rocprim::min(input_size, tilegroup_start);
-    const OffsetT keys1_end = rocprim::min(input_size, tilegroup_start + sorted_block_size);
-    const OffsetT keys2_beg = keys1_end;
-    const OffsetT keys2_end = rocprim::min(input_size, keys2_beg + sorted_block_size);
+        // id of the first tile in the current tile-group
+        const unsigned int tilegroup_start_id = ~mask & partition_id;
+        // id of the current tile in the current tile-group
+        const unsigned int local_tile_id = mask & partition_id;
 
-    const OffsetT partition_at
-        = rocprim::min(keys2_end - keys1_beg, static_cast<OffsetT>(local_tile_id) * items_per_tile);
+        // index of the first item in the current tile-group
+        const OffsetT tilegroup_start = static_cast<OffsetT>(tilegroup_start_id) * items_per_tile;
 
-    const OffsetT partition_diag = ::rocprim::detail::merge_path(keys + keys1_beg,
-                                                                 keys + keys2_beg,
-                                                                 keys1_end - keys1_beg,
-                                                                 keys2_end - keys2_beg,
-                                                                 partition_at,
-                                                                 compare_op);
+        const OffsetT keys1_beg = rocprim::min(input_size, tilegroup_start);
+        const OffsetT keys1_end = rocprim::min(input_size, tilegroup_start + sorted_block_size);
+        const OffsetT keys2_beg = keys1_end;
+        const OffsetT keys2_end = rocprim::min(input_size, keys2_beg + sorted_block_size);
 
-    merge_partitions[partition_id] = keys1_beg + partition_diag;
+        const OffsetT partition_at
+            = rocprim::min(keys2_end - keys1_beg,
+                           static_cast<OffsetT>(local_tile_id) * items_per_tile);
+
+        const OffsetT partition_diag = ::rocprim::detail::merge_path(keys + keys1_beg,
+                                                                     keys + keys2_beg,
+                                                                     keys1_end - keys1_beg,
+                                                                     keys2_end - keys2_beg,
+                                                                     partition_at,
+                                                                     compare_op);
+
+        merge_partitions[partition_id] = keys1_beg + partition_diag;
+    };
+
+    return launch_kernel<Config, decltype(kernel), merge_mergepath_partition_config_selector>(
+        arch,
+        kernel,
+        grid,
+        block,
+        shmem,
+        stream);
 }
 
 // it assumes the temporary storage has been already partitioned
@@ -264,7 +324,8 @@ inline hipError_t merge_sort_block_merge_impl(
     {
         return result;
     }
-    const merge_sort_block_merge_config_params params = dispatch_target_arch<config>(target_arch);
+    const merge_sort_block_merge_config_params params
+        = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int merge_oddeven_block_size = params.merge_oddeven_config.block_size;
     const unsigned int merge_oddeven_items_per_thread
@@ -283,7 +344,8 @@ inline hipError_t merge_sort_block_merge_impl(
     const unsigned int sort_number_of_blocks = ceiling_div(size, sorted_block_size);
     const unsigned int merge_oddeven_number_of_blocks
         = ceiling_div(size, merge_oddeven_items_per_block);
-    const unsigned int merge_mergepath_number_of_blocks = ceiling_div(size, merge_mergepath_items_per_block);
+    const unsigned int merge_mergepath_number_of_blocks
+        = ceiling_div(size, merge_mergepath_items_per_block);
 
     const bool use_mergepath = size > params.merge_oddeven_config.size_limit;
     // variables below used for mergepath
@@ -291,7 +353,7 @@ inline hipError_t merge_sort_block_merge_impl(
     const unsigned int merge_partition_number_of_blocks
         = ceiling_div(merge_num_partitions, merge_partition_block_size);
 
-    if( size == size_t(0) )
+    if(size == size_t(0))
         return hipSuccess;
 
     if(sorted_block_size < std::max(merge_mergepath_items_per_block, merge_oddeven_block_size))
@@ -310,12 +372,15 @@ inline hipError_t merge_sort_block_merge_impl(
         std::cout << "merge_oddeven_items_per_thread: " << merge_oddeven_items_per_thread << '\n';
         std::cout << "merge_oddeven_items_per_block: " << merge_oddeven_items_per_block << '\n';
         std::cout << "merge_mergepath_block_size: " << merge_mergepath_block_size << '\n';
-        std::cout << "merge_mergepath_number_of_blocks: " << merge_mergepath_number_of_blocks << '\n';
-        std::cout << "merge_mergepath_items_per_thread: " << merge_mergepath_items_per_thread << '\n';
+        std::cout << "merge_mergepath_number_of_blocks: " << merge_mergepath_number_of_blocks
+                  << '\n';
+        std::cout << "merge_mergepath_items_per_thread: " << merge_mergepath_items_per_thread
+                  << '\n';
         std::cout << "merge_mergepath_items_per_block: " << merge_mergepath_items_per_block << '\n';
         std::cout << "num_partitions: " << merge_num_partitions << '\n';
         std::cout << "merge_mergepath_partition_block_size: " << merge_partition_block_size << '\n';
-        std::cout << "merge_mergepath_partition_number_of_blocks: " << merge_partition_number_of_blocks << '\n';
+        std::cout << "merge_mergepath_partition_number_of_blocks: "
+                  << merge_partition_number_of_blocks << '\n';
     }
 
     // Start point for time measurements
@@ -336,18 +401,22 @@ inline hipError_t merge_sort_block_merge_impl(
                 if(debug_synchronous)
                     start = std::chrono::steady_clock::now();
                 // Note: shared memory is not used in this kernel so there is no need to pass vsmem
-                hipLaunchKernelGGL(
-                    HIP_KERNEL_NAME(device_block_merge_mergepath_partition_kernel<config>),
-                    dim3(merge_partition_number_of_blocks),
-                    dim3(merge_partition_block_size),
-                    0,
-                    stream,
+                hipError_t launch_err = launch_device_block_merge_mergepath_partition<config>(
+                    target_arch,
                     keys_input_,
                     size,
                     merge_num_partitions,
                     d_merge_partitions,
                     compare_function,
-                    block);
+                    block,
+                    dim3(merge_partition_number_of_blocks),
+                    dim3(merge_partition_block_size),
+                    0,
+                    stream);
+                if(launch_err != hipSuccess)
+                {
+                    return launch_err;
+                }
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(
                     "device_block_merge_mergepath_partition_kernel",
                     merge_num_partitions,
@@ -355,22 +424,27 @@ inline hipError_t merge_sort_block_merge_impl(
 
                 if(debug_synchronous)
                     start = std::chrono::steady_clock::now();
-                hipLaunchKernelGGL(HIP_KERNEL_NAME(device_block_merge_mergepath_kernel<config>),
-                                   calculate_grid_dim(merge_mergepath_number_of_blocks,
-                                                      merge_mergepath_block_size),
-                                   dim3(merge_mergepath_block_size),
-                                   0,
-                                   stream,
-                                   keys_input_,
-                                   keys_output_,
-                                   values_input_,
-                                   values_output_,
-                                   size,
-                                   block,
-                                   merge_mergepath_number_of_blocks,
-                                   compare_function,
-                                   d_merge_partitions,
-                                   vsmem);
+                launch_err = launch_device_block_merge_mergepath<config>(
+                    target_arch,
+                    keys_input_,
+                    keys_output_,
+                    values_input_,
+                    values_output_,
+                    size,
+                    block,
+                    merge_mergepath_number_of_blocks,
+                    compare_function,
+                    d_merge_partitions,
+                    vsmem,
+                    calculate_grid_dim(merge_mergepath_number_of_blocks,
+                                       merge_mergepath_block_size),
+                    dim3(merge_mergepath_block_size),
+                    0,
+                    stream);
+                if(launch_err != hipSuccess)
+                {
+                    return launch_err;
+                }
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_block_merge_mergepath_kernel",
                                                             size,
                                                             start);
@@ -382,18 +456,23 @@ inline hipError_t merge_sort_block_merge_impl(
                 // As this kernel is only called with small sizes, it is safe to use 32-bit integers
                 // for size and block.
                 // Note: shared memory is not used in this kernel so there is no need to pass vsmem
-                hipLaunchKernelGGL(HIP_KERNEL_NAME(device_block_merge_oddeven_kernel<config>),
-                                   dim3(merge_oddeven_number_of_blocks),
-                                   dim3(merge_oddeven_block_size),
-                                   0,
-                                   stream,
-                                   keys_input_,
-                                   keys_output_,
-                                   values_input_,
-                                   values_output_,
-                                   static_cast<unsigned int>(size),
-                                   static_cast<unsigned int>(block),
-                                   compare_function);
+                hipError_t launch_err = launch_device_block_merge_oddeven<config>(
+                    target_arch,
+                    keys_input_,
+                    keys_output_,
+                    values_input_,
+                    values_output_,
+                    static_cast<unsigned int>(size),
+                    static_cast<unsigned int>(block),
+                    compare_function,
+                    dim3(merge_oddeven_number_of_blocks),
+                    dim3(merge_oddeven_block_size),
+                    0,
+                    stream);
+                if(launch_err != hipSuccess)
+                {
+                    return launch_err;
+                }
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_block_merge_oddeven_kernel",
                                                             size,
                                                             start);
@@ -410,7 +489,8 @@ inline hipError_t merge_sort_block_merge_impl(
         {
             error = merge_step(keys, keys_buffer, values, values_buffer);
         }
-        if(error != hipSuccess) return error;
+        if(error != hipSuccess)
+            return error;
     }
 
     if(!temporary_store)
@@ -421,7 +501,8 @@ inline hipError_t merge_sort_block_merge_impl(
                                                 ::rocprim::identity<key_type>(),
                                                 stream,
                                                 debug_synchronous);
-        if(error != hipSuccess) return error;
+        if(error != hipSuccess)
+            return error;
 
         if(with_values)
         {
@@ -431,7 +512,8 @@ inline hipError_t merge_sort_block_merge_impl(
                                                     ::rocprim::identity<value_type>(),
                                                     stream,
                                                     debug_synchronous);
-            if(error != hipSuccess) return error;
+            if(error != hipSuccess)
+                return error;
         }
     }
 
@@ -473,7 +555,8 @@ inline hipError_t merge_sort_block_merge(
     {
         return result;
     }
-    const merge_sort_block_merge_config_params params = dispatch_target_arch<config>(target_arch);
+    const merge_sort_block_merge_config_params params
+        = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int merge_mergepath_block_size = params.merge_mergepath_config.block_size;
     const unsigned int merge_mergepath_items_per_thread
@@ -565,18 +648,18 @@ inline hipError_t merge_sort_block_sort(KeysInputIterator    keys_input,
     {
         return result;
     }
-    const merge_sort_block_sort_config_params params = dispatch_target_arch<config>(target_arch);
+    const merge_sort_block_sort_config_params params
+        = dispatch_target_arch<config, false>(target_arch);
 
-    sort_items_per_block
-        = params.block_sort_config.block_size * params.block_sort_config.items_per_thread;
+    sort_items_per_block = params.kernel_config.block_size * params.kernel_config.items_per_thread;
     const unsigned int sort_number_of_blocks = ceiling_div(size, sort_items_per_block);
 
     if(debug_synchronous)
     {
         std::cout << "-----" << '\n';
         std::cout << "size: " << size << '\n';
-        std::cout << "sort_block_size: " << params.block_sort_config.block_size << '\n';
-        std::cout << "sort_items_per_thread: " << params.block_sort_config.items_per_thread << '\n';
+        std::cout << "sort_block_size: " << params.kernel_config.block_size << '\n';
+        std::cout << "sort_items_per_thread: " << params.kernel_config.items_per_thread << '\n';
         std::cout << "sort_items_per_block: " << sort_items_per_block << '\n';
         std::cout << "sort_number_of_blocks: " << sort_number_of_blocks << '\n';
     }
@@ -586,12 +669,8 @@ inline hipError_t merge_sort_block_sort(KeysInputIterator    keys_input,
     if(debug_synchronous)
         start = std::chrono::steady_clock::now();
 
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(block_sort_kernel<config>),
-        calculate_grid_dim(sort_number_of_blocks, params.block_sort_config.block_size),
-        dim3(params.block_sort_config.block_size),
-        0,
-        stream,
+    hipError_t launch_err = launch_block_sort<config>(
+        target_arch,
         keys_input,
         keys_output,
         values_input,
@@ -599,7 +678,17 @@ inline hipError_t merge_sort_block_sort(KeysInputIterator    keys_input,
         size,
         sort_number_of_blocks,
         compare_function,
-        vsmem);
+        vsmem,
+        calculate_grid_dim(sort_number_of_blocks, params.kernel_config.block_size),
+        dim3(params.kernel_config.block_size),
+        0,
+        stream);
+
+    if(launch_err != hipSuccess)
+    {
+        return launch_err;
+    }
+
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_sort_kernel", size, start);
 
     return hipSuccess;
@@ -607,20 +696,22 @@ inline hipError_t merge_sort_block_sort(KeysInputIterator    keys_input,
 
 // Helpful function that actually prints the values when static_assert fails
 template<unsigned int A, unsigned int B>
-ROCPRIM_DEVICE void TAssertEqualGreater()
+ROCPRIM_DEVICE
+void TAssertEqualGreater()
 {
     static_assert(A >= B, "A not greater or equal to B");
 };
 
 template<class BlockSortConfig, class BlockMergeConfig>
-ROCPRIM_KERNEL void device_merge_sort_compile_time_verifier()
+ROCPRIM_KERNEL
+void device_merge_sort_compile_time_verifier()
 {
     static constexpr merge_sort_block_sort_config_params bs_params
         = device_params<BlockSortConfig>();
     static constexpr merge_sort_block_merge_config_params bm_params
         = device_params<BlockMergeConfig>();
     static constexpr unsigned int sort_items_per_block
-        = bs_params.block_sort_config.block_size * bs_params.block_sort_config.items_per_thread;
+        = bs_params.kernel_config.block_size * bs_params.kernel_config.items_per_thread;
     static constexpr unsigned int merge_oddeven_items_per_block
         = bm_params.merge_oddeven_config.block_size
           * bm_params.merge_oddeven_config.items_per_thread;
@@ -644,81 +735,53 @@ ROCPRIM_KERNEL void device_merge_sort_compile_time_verifier()
                   "merge_mergepath_items_per_block");
 }
 
-// Templated helper that instantiates block_sort_impl and block_merge_impl for an Arch,
-// and puts its vsmem_per_block in the vsmem_size_out member variable.
 template<class BlockSortConfig, class BlockMergeConfig, typename key_type, typename value_type>
-struct merge_sort_vsmem_size_visitor
+inline size_t get_merge_sort_vsmem_size(const size_t size)
 {
-    const size_t size;
-    size_t&      vsmem_size_out;
 
-    template<target_arch Arch>
-    inline hipError_t operator()() const
+    size_t                                               virtual_shared_memory_size = 0;
+    static constexpr merge_sort_block_sort_config_params bs_params
+        = device_params<BlockSortConfig>();
+    static constexpr merge_sort_block_merge_config_params bm_params
+        = device_params<BlockMergeConfig>();
+    using bs_sort_impl          = block_sort_impl<key_type,
+                                                  value_type,
+                                                  bs_params.kernel_config.block_size,
+                                                  bs_params.kernel_config.items_per_thread>;
+    using bm_sort_impl          = block_merge_impl<key_type,
+                                                   value_type,
+                                                   bm_params.merge_mergepath_config.block_size,
+                                                   bm_params.merge_mergepath_config.items_per_thread>;
+    using BlockSortVSmemHelperT = detail::vsmem_helper_impl<bs_sort_impl>;
+    using MergeSortVSmemHelperT = detail::vsmem_helper_impl<bm_sort_impl>;
+
+    // mergepath total number of blocks
+    const unsigned int merge_mergepath_items_per_block
+        = bm_params.merge_mergepath_config.block_size
+          * bm_params.merge_mergepath_config.items_per_thread;
+    const unsigned int merge_mergepath_number_of_blocks
+        = ceiling_div(size, merge_mergepath_items_per_block);
+
+    const bool use_mergepath = size > bm_params.merge_oddeven_config.size_limit;
+
+    // Check if vsmem is needed
+    if(BlockSortVSmemHelperT::vsmem_per_block + MergeSortVSmemHelperT::vsmem_per_block > 0)
     {
-        vsmem_size_out = 0;
 
-        using forced_block_sort_conf_t
-            = force_arch_config<Arch, BlockSortConfig, merge_sort_block_sort_config_params>;
-        using forced_block_merge_conf_t
-            = force_arch_config<Arch, BlockMergeConfig, merge_sort_block_merge_config_params>;
+        // block sort total number of blocks
+        const unsigned int bs_items_per_block
+            = bs_params.kernel_config.block_size * bs_params.kernel_config.items_per_thread;
+        const unsigned int sort_number_of_blocks = ceiling_div(size, bs_items_per_block);
 
-        static constexpr merge_sort_block_sort_config_params bs_params
-            = device_params<forced_block_sort_conf_t>();
-        static constexpr merge_sort_block_merge_config_params bm_params
-            = device_params<forced_block_merge_conf_t>();
-
-        using bs_sort_impl = block_sort_impl<key_type,
-                                             value_type,
-                                             bs_params.block_sort_config.block_size,
-                                             bs_params.block_sort_config.items_per_thread>;
-        using bm_sort_impl = block_merge_impl<key_type,
-                                              value_type,
-                                              bm_params.merge_mergepath_config.block_size,
-                                              bm_params.merge_mergepath_config.items_per_thread>;
-
-        using BlockSortVSmemHelperT = detail::vsmem_helper_impl<bs_sort_impl>;
-        using MergeSortVSmemHelperT = detail::vsmem_helper_impl<bm_sort_impl>;
-
-        // mergepath total number of blocks
-        const unsigned int merge_mergepath_items_per_block
-            = bm_params.merge_mergepath_config.block_size
-              * bm_params.merge_mergepath_config.items_per_thread;
-        const unsigned int merge_mergepath_number_of_blocks
-            = ceiling_div(size, merge_mergepath_items_per_block);
-
-        const bool use_mergepath = size > bm_params.merge_oddeven_config.size_limit;
-
-        // Check if vsmem is needed
-        if(BlockSortVSmemHelperT::vsmem_per_block + MergeSortVSmemHelperT::vsmem_per_block > 0)
-        {
-
-            // block sort total number of blocks
-            const unsigned int bs_items_per_block = bs_params.block_sort_config.block_size
-                                                    * bs_params.block_sort_config.items_per_thread;
-            const unsigned int sort_number_of_blocks = ceiling_div(size, bs_items_per_block);
-
-            // Compute amount of virtual shared memory needed
-            size_t block_sort_smem_size
-                = BlockSortVSmemHelperT::vsmem_per_block * sort_number_of_blocks;
-            size_t merge_smem_size = use_mergepath ? MergeSortVSmemHelperT::vsmem_per_block
-                                                         * merge_mergepath_number_of_blocks
+        // Compute amount of virtual shared memory needed
+        size_t block_sort_smem_size
+            = BlockSortVSmemHelperT::vsmem_per_block * sort_number_of_blocks;
+        size_t merge_smem_size     = use_mergepath ? MergeSortVSmemHelperT::vsmem_per_block
+                                                     * merge_mergepath_number_of_blocks
                                                    : 0;
-            vsmem_size_out         = (std::max)(block_sort_smem_size, merge_smem_size);
-        }
-
-        return hipSuccess;
+        virtual_shared_memory_size = (std::max)(block_sort_smem_size, merge_smem_size);
     }
-};
-
-template<class BlockSortConfig, class BlockMergeConfig, typename key_type, typename value_type>
-inline hipError_t
-    get_merge_sort_vsmem_size(const size_t size, target_arch target_arch, size_t& vsmem_size)
-{
-    return generic_dispatch_target_arch(
-        target_arch,
-        merge_sort_vsmem_size_visitor<BlockSortConfig, BlockMergeConfig, key_type, value_type>{
-            size,
-            vsmem_size});
+    return virtual_shared_memory_size;
 }
 
 template<class Config,
@@ -742,8 +805,8 @@ inline hipError_t merge_sort_impl(
     typename std::iterator_traits<ValuesInputIterator>::value_type* values_double_buffer = nullptr,
     bool                                                            no_allocate_tmp_buffer = false)
 {
-    using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
-    using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
+    using key_type             = typename std::iterator_traits<KeysInputIterator>::value_type;
+    using value_type           = typename std::iterator_traits<ValuesInputIterator>::value_type;
     constexpr bool with_values = !std::is_same<value_type, ::rocprim::empty_type>::value;
 
     static constexpr bool with_custom_config = !std::is_same<Config, default_config>::value;
@@ -770,7 +833,7 @@ inline hipError_t merge_sort_impl(
         return result;
     }
     const merge_sort_block_merge_config_params params
-        = dispatch_target_arch<wrapped_bm_config>(target_arch);
+        = dispatch_target_arch<wrapped_bm_config, false>(target_arch);
     const bool         use_mergepath = size > params.merge_oddeven_config.size_limit;
     const unsigned int merge_mergepath_items_per_block
         = params.merge_mergepath_config.block_size * params.merge_mergepath_config.items_per_thread;
@@ -778,16 +841,10 @@ inline hipError_t merge_sort_impl(
         = ceiling_div(size, merge_mergepath_items_per_block);
 
     // Virtual shared memory part
-    void*  vsmem;
-    size_t vsmem_size;
-    result = get_merge_sort_vsmem_size<wrapped_bs_config, wrapped_bm_config, key_type, value_type>(
-        size,
-        target_arch,
-        vsmem_size);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+    void*  vsmem = nullptr;
+    size_t virtual_shared_memory_size
+        = get_merge_sort_vsmem_size<wrapped_bs_config, wrapped_bm_config, key_type, value_type>(
+            size);
 
     // temporary storage needed for both block merge and block sort
     size_t*     d_merge_partitions = nullptr;
@@ -806,7 +863,9 @@ inline hipError_t merge_sort_impl(
                 detail::temp_storage::ptr_aligned_array(
                     &d_merge_partitions,
                     use_mergepath ? merge_mergepath_number_of_blocks + 1 : 0),
-                detail::temp_storage::make_partition(&vsmem, vsmem_size, cache_line_size)));
+                detail::temp_storage::make_partition(&vsmem,
+                                                     virtual_shared_memory_size,
+                                                     cache_line_size)));
     }
     else
     {
@@ -817,7 +876,9 @@ inline hipError_t merge_sort_impl(
                 detail::temp_storage::ptr_aligned_array(
                     &d_merge_partitions,
                     use_mergepath ? merge_mergepath_number_of_blocks + 1 : 0),
-                detail::temp_storage::make_partition(&vsmem, vsmem_size, cache_line_size)));
+                detail::temp_storage::make_partition(&vsmem,
+                                                     virtual_shared_memory_size,
+                                                     cache_line_size)));
         keys_buffer   = keys_double_buffer;
         values_buffer = values_double_buffer;
     }
@@ -865,9 +926,7 @@ inline hipError_t merge_sort_impl(
     return hipSuccess;
 }
 
-
-
-} // end of detail namespace
+} // namespace detail
 
 /// \brief Parallel merge sort primitive for device level.
 ///
@@ -944,28 +1003,31 @@ inline hipError_t merge_sort_impl(
 /// // keys_output: [0.08, 0.2, 0.3, 0.4, 0.6, 0.65, 0.7, 1]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class KeysInputIterator,
-    class KeysOutputIterator,
-    class BinaryFunction = ::rocprim::less<typename std::iterator_traits<KeysInputIterator>::value_type>
->
-inline
-hipError_t merge_sort(void * temporary_storage,
-                      size_t& storage_size,
-                      KeysInputIterator keys_input,
-                      KeysOutputIterator keys_output,
-                      const size_t size,
-                      BinaryFunction compare_function = BinaryFunction(),
-                      const hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+template<class Config = default_config,
+         class KeysInputIterator,
+         class KeysOutputIterator,
+         class BinaryFunction
+         = ::rocprim::less<typename std::iterator_traits<KeysInputIterator>::value_type>>
+inline hipError_t merge_sort(void*              temporary_storage,
+                             size_t&            storage_size,
+                             KeysInputIterator  keys_input,
+                             KeysOutputIterator keys_output,
+                             const size_t       size,
+                             BinaryFunction     compare_function  = BinaryFunction(),
+                             const hipStream_t  stream            = 0,
+                             bool               debug_synchronous = false)
 {
-    empty_type * values = nullptr;
-    return detail::merge_sort_impl<Config>(
-        temporary_storage, storage_size,
-        keys_input, keys_output, values, values, size,
-        compare_function, stream, debug_synchronous
-    );
+    empty_type* values = nullptr;
+    return detail::merge_sort_impl<Config>(temporary_storage,
+                                           storage_size,
+                                           keys_input,
+                                           keys_output,
+                                           values,
+                                           values,
+                                           size,
+                                           compare_function,
+                                           stream,
+                                           debug_synchronous);
 }
 
 /// \brief Parallel ascending merge sort-by-key primitive for device level.
@@ -1054,31 +1116,34 @@ hipError_t merge_sort(void * temporary_storage,
 /// // values_output: [-1, -2, 2, 3, -4, -5, 7, -8]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class KeysInputIterator,
-    class KeysOutputIterator,
-    class ValuesInputIterator,
-    class ValuesOutputIterator,
-    class BinaryFunction = ::rocprim::less<typename std::iterator_traits<KeysInputIterator>::value_type>
->
-inline
-hipError_t merge_sort(void * temporary_storage,
-                      size_t& storage_size,
-                      KeysInputIterator keys_input,
-                      KeysOutputIterator keys_output,
-                      ValuesInputIterator values_input,
-                      ValuesOutputIterator values_output,
-                      const size_t size,
-                      BinaryFunction compare_function = BinaryFunction(),
-                      const hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+template<class Config = default_config,
+         class KeysInputIterator,
+         class KeysOutputIterator,
+         class ValuesInputIterator,
+         class ValuesOutputIterator,
+         class BinaryFunction
+         = ::rocprim::less<typename std::iterator_traits<KeysInputIterator>::value_type>>
+inline hipError_t merge_sort(void*                temporary_storage,
+                             size_t&              storage_size,
+                             KeysInputIterator    keys_input,
+                             KeysOutputIterator   keys_output,
+                             ValuesInputIterator  values_input,
+                             ValuesOutputIterator values_output,
+                             const size_t         size,
+                             BinaryFunction       compare_function  = BinaryFunction(),
+                             const hipStream_t    stream            = 0,
+                             bool                 debug_synchronous = false)
 {
-    return detail::merge_sort_impl<Config>(
-        temporary_storage, storage_size,
-        keys_input, keys_output, values_input, values_output, size,
-        compare_function, stream, debug_synchronous
-    );
+    return detail::merge_sort_impl<Config>(temporary_storage,
+                                           storage_size,
+                                           keys_input,
+                                           keys_output,
+                                           values_input,
+                                           values_output,
+                                           size,
+                                           compare_function,
+                                           stream,
+                                           debug_synchronous);
 }
 
 /// @}

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
@@ -110,7 +110,7 @@ inline hipError_t launch_block_sort(detail::target_arch  arch,
                          storage);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,
@@ -147,12 +147,12 @@ inline hipError_t launch_device_block_merge_oddeven(detail::target_arch  arch,
                                                                                  compare_function);
     };
 
-    return launch_kernel<Config, decltype(kernel), merge_oddeven_config_selector>(arch,
-                                                                                  kernel,
-                                                                                  grid,
-                                                                                  block,
-                                                                                  shmem,
-                                                                                  stream);
+    return execute_launch_plan<Config, decltype(kernel), merge_oddeven_config_selector>(arch,
+                                                                                        kernel,
+                                                                                        grid,
+                                                                                        block,
+                                                                                        shmem,
+                                                                                        stream);
 }
 
 template<class Config,
@@ -211,12 +211,12 @@ inline hipError_t launch_device_block_merge_mergepath(detail::target_arch  arch,
                                   storage);
     };
 
-    return launch_kernel<Config, decltype(kernel), merge_mergepath_config_selector>(arch,
-                                                                                    kernel,
-                                                                                    grid,
-                                                                                    block,
-                                                                                    shmem,
-                                                                                    stream);
+    return execute_launch_plan<Config, decltype(kernel), merge_mergepath_config_selector>(arch,
+                                                                                          kernel,
+                                                                                          grid,
+                                                                                          block,
+                                                                                          shmem,
+                                                                                          stream);
 }
 
 template<typename Config, typename KeysInputIterator, typename OffsetT, typename CompareOpT>
@@ -279,7 +279,7 @@ inline hipError_t launch_device_block_merge_mergepath_partition(detail::target_a
         merge_partitions[partition_id] = keys1_beg + partition_diag;
     };
 
-    return launch_kernel<Config, decltype(kernel), merge_mergepath_partition_config_selector>(
+    return execute_launch_plan<Config, decltype(kernel), merge_mergepath_partition_config_selector>(
         arch,
         kernel,
         grid,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_nth_element.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_nth_element.hpp
@@ -65,7 +65,7 @@ hipError_t
     {
         return result;
     }
-    const nth_element_config_params params = dispatch_target_arch<config>(target_arch);
+    const nth_element_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     constexpr unsigned int num_partitions        = 3;
     const unsigned int     num_buckets           = params.number_of_buckets;
@@ -141,7 +141,8 @@ hipError_t
         std::cout << "storage_size: " << storage_size << '\n';
     }
 
-    return nth_element_keys_impl<config, num_partitions>(keys,
+    return nth_element_keys_impl<config, num_partitions>(target_arch,
+                                                         keys,
                                                          keys_buffer,
                                                          tree,
                                                          nth,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
+#include <optional>
 #include <type_traits>
 
 #include "../common.hpp"
@@ -104,8 +105,7 @@ inline hipError_t launch_partition(detail::target_arch     arch,
                                                                BlockIdWrapper>;
 
         using VSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
-        ROCPRIM_SHARED_MEMORY
-        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
         // Get temporary storage
         typename partition_kernel_impl_t::storage_type& storage
             = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
@@ -130,29 +130,54 @@ inline hipError_t launch_partition(detail::target_arch     arch,
     return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<select_method SelectMethod,
+template<class Config,
+         select_method SelectMethod,
          bool          OnlySelected,
-         class Config,
          class Key,
          class Value,
          class FlagType,
          class OffsetLookbackScanState,
          class BlockIdWrapper>
-inline size_t get_partition_vsmem_size_per_block()
+inline size_t get_partition_vsmem_size_per_block(detail::target_arch arch)
 {
-    using offset_type             = typename OffsetLookbackScanState::value_type;
-    using partition_kernel_impl_t = partition_kernel_impl_<
-        typename Config::template architecture_config<device_target_arch()>,
-        SelectMethod,
-        OnlySelected,
-        Key,
-        Value,
-        FlagType,
-        offset_type,
-        BlockIdWrapper>;
+    using offset_type = typename OffsetLookbackScanState::value_type;
+    std::optional<size_t> vsmem_per_block;
+    for_each_arch(
+        [&](auto arch_tag)
+        {
+            constexpr target_arch Arch = decltype(arch_tag)::value;
+            if(Arch != arch || vsmem_per_block)
+                return;
 
-    using PartitionVSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
-    return PartitionVSmemHelperT::vsmem_per_block;
+            using ArchConfig               = typename Config::template architecture_config<Arch>;
+            using partition_kernel_impl_t  = partition_kernel_impl_<ArchConfig,
+                                                                   SelectMethod,
+                                                                   OnlySelected,
+                                                                   Key,
+                                                                   Value,
+                                                                   FlagType,
+                                                                   offset_type,
+                                                                   BlockIdWrapper>;
+            using partition_vsmem_helper_t = detail::vsmem_helper_impl<partition_kernel_impl_t>;
+
+            vsmem_per_block = partition_vsmem_helper_t::vsmem_per_block;
+        });
+    if(!vsmem_per_block)
+    {
+        using ArchConfig = typename Config::template architecture_config<target_arch::unknown>;
+        using partition_kernel_impl_t  = partition_kernel_impl_<ArchConfig,
+                                                               SelectMethod,
+                                                               OnlySelected,
+                                                               Key,
+                                                               Value,
+                                                               FlagType,
+                                                               offset_type,
+                                                               BlockIdWrapper>;
+        using partition_vsmem_helper_t = detail::vsmem_helper_impl<partition_kernel_impl_t>;
+
+        vsmem_per_block = partition_vsmem_helper_t::vsmem_per_block;
+    }
+    return vsmem_per_block.value();
 }
 
 template<partition_subalgo SubAlgo,
@@ -261,25 +286,26 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     if(use_sleep)
     {
         virtual_shared_memory_size
-            = get_partition_vsmem_size_per_block<method,
+            = get_partition_vsmem_size_per_block<config,
+                                                 method,
                                                  write_only_selected,
-                                                 config,
                                                  key_type,
                                                  value_type,
                                                  flag_type,
                                                  offset_scan_state_with_sleep_type,
-                                                 block_id_wrapper_type>();
+                                                 block_id_wrapper_type>(target_arch);
     }
     else
     {
-        virtual_shared_memory_size = get_partition_vsmem_size_per_block<method,
-                                                                        write_only_selected,
-                                                                        config,
-                                                                        key_type,
-                                                                        value_type,
-                                                                        flag_type,
-                                                                        offset_scan_state_type,
-                                                                        block_id_wrapper_type>();
+        virtual_shared_memory_size
+            = get_partition_vsmem_size_per_block<config,
+                                                 method,
+                                                 write_only_selected,
+                                                 key_type,
+                                                 value_type,
+                                                 flag_type,
+                                                 offset_scan_state_type,
+                                                 block_id_wrapper_type>(target_arch);
     }
     virtual_shared_memory_size *= number_of_blocks;
 
@@ -414,7 +440,7 @@ inline hipError_t partition_impl(void*                       temporary_storage,
         if(debug_synchronous)
             start = std::chrono::steady_clock::now();
 
-        hipError_t launch_err = with_scan_state(
+        ROCPRIM_RETURN_ON_ERROR(with_scan_state(
             [&](const auto scan_state)
             {
                 return launch_partition<config, method, write_only_selected>(
@@ -438,11 +464,7 @@ inline hipError_t partition_impl(void*                       temporary_storage,
                     0,
                     stream,
                     predicates...);
-            });
-        if(launch_err != hipSuccess)
-        {
-            return launch_err;
-        }
+            }));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", size, start);
 
         std::swap(selected_count, prev_selected_count);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
@@ -26,8 +26,8 @@
 #include <iterator>
 #include <type_traits>
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/temp_storage.hpp"
 #include "../detail/various.hpp"
 #include "../functional.hpp"
@@ -51,9 +51,9 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<select_method SelectMethod,
+template<class Config,
+         select_method SelectMethod,
          bool          OnlySelected,
-         class Config,
          class KeyIterator,
          class ValueIterator,
          class FlagIterator,
@@ -63,96 +63,72 @@ template<select_method SelectMethod,
          class OffsetLookbackScanState,
          class BlockIdWrapper,
          class... UnaryPredicates>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    partition_kernel(KeyIterator                        keys_input,
-                     ValueIterator                      values_input,
-                     FlagIterator                       flags,
-                     OutputKeyIterator                  keys_output,
-                     OutputValueIterator                values_output,
-                     size_t*                            selected_count,
-                     size_t*                            prev_selected_count,
-                     size_t                             prev_processed,
-                     const size_t                       total_size,
-                     InequalityOp                       inequality_op,
-                     OffsetLookbackScanState            offset_scan_state,
-                     const unsigned int                 number_of_blocks,
-                     detail::vsmem_t                    vsmem,
-                     BlockIdWrapper                     block_id,
-                     UnaryPredicates... predicates)
+inline hipError_t launch_partition(detail::target_arch     arch,
+                                   KeyIterator             keys_input,
+                                   ValueIterator           values_input,
+                                   FlagIterator            flags,
+                                   OutputKeyIterator       keys_output,
+                                   OutputValueIterator     values_output,
+                                   size_t*                 selected_count,
+                                   size_t*                 prev_selected_count,
+                                   size_t                  prev_processed,
+                                   const size_t            total_size,
+                                   InequalityOp            inequality_op,
+                                   OffsetLookbackScanState offset_scan_state,
+                                   const unsigned int      number_of_blocks,
+                                   detail::vsmem_t         vsmem,
+                                   BlockIdWrapper          block_id,
+                                   dim3                    grid,
+                                   dim3                    block,
+                                   size_t                  shmem,
+                                   hipStream_t             stream,
+                                   UnaryPredicates... predicates)
 {
-    using offset_type = typename OffsetLookbackScanState::value_type;
-    using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
-    using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
-    using flag_type =
-        typename std::conditional<SelectMethod == select_method::predicated_flag,
-                                  typename std::iterator_traits<FlagIterator>::value_type,
-                                  bool>::type;
-
-    using partition_kernel_impl_t = partition_kernel_impl_<SelectMethod,
-                                                           OnlySelected,
-                                                           Config,
-                                                           key_type,
-                                                           value_type,
-                                                           flag_type,
-                                                           offset_type,
-                                                           BlockIdWrapper>;
-
-    using VSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
-    ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
-    // Get temporary storage
-    typename partition_kernel_impl_t::storage_type& storage
-        = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
-
-    partition_kernel_impl_t().partition(keys_input,
-                                        values_input,
-                                        flags,
-                                        keys_output,
-                                        values_output,
-                                        selected_count,
-                                        prev_selected_count,
-                                        prev_processed,
-                                        total_size,
-                                        inequality_op,
-                                        offset_scan_state,
-                                        number_of_blocks,
-                                        block_id,
-                                        storage,
-                                        predicates...);
-}
-
-// Templated helper that instantiates partition_kernel_impl_ for an Arch,
-// and puts its vsmem_per_block in the vsmem_size_out member variable.
-template<select_method SelectMethod,
-         bool          OnlySelected,
-         class Config,
-         class Key,
-         class Value,
-         class FlagType,
-         class OffsetType,
-         class BlockIdWrapper>
-struct partition_vsmem_size_visitor
-{
-    size_t& vsmem_size_out;
-
-    template<target_arch Arch>
-    inline hipError_t operator()() const
+    auto kernel = [=](auto arch_config) mutable
     {
-        using forced_conf_t = force_arch_config<Arch, Config, partition_config_params>;
+        using offset_type = typename OffsetLookbackScanState::value_type;
+        using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
+        using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
+        using flag_type =
+            typename std::conditional<SelectMethod == select_method::predicated_flag,
+                                      typename std::iterator_traits<FlagIterator>::value_type,
+                                      bool>::type;
 
-        using partition_kernel_impl_t = partition_kernel_impl_<SelectMethod,
+        using partition_kernel_impl_t = partition_kernel_impl_<decltype(arch_config),
+                                                               SelectMethod,
                                                                OnlySelected,
-                                                               forced_conf_t,
-                                                               Key,
-                                                               Value,
-                                                               FlagType,
-                                                               OffsetType,
+                                                               key_type,
+                                                               value_type,
+                                                               flag_type,
+                                                               offset_type,
                                                                BlockIdWrapper>;
 
-        vsmem_size_out = vsmem_helper_impl<partition_kernel_impl_t>::vsmem_per_block;
+        using VSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
+        ROCPRIM_SHARED_MEMORY
+        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        // Get temporary storage
+        typename partition_kernel_impl_t::storage_type& storage
+            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
 
-        return hipSuccess;
-    }
-};
+        partition_kernel_impl_t().partition(keys_input,
+                                            values_input,
+                                            flags,
+                                            keys_output,
+                                            values_output,
+                                            selected_count,
+                                            prev_selected_count,
+                                            prev_processed,
+                                            total_size,
+                                            inequality_op,
+                                            offset_scan_state,
+                                            number_of_blocks,
+                                            block_id,
+                                            storage,
+                                            predicates...);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+}
 
 template<select_method SelectMethod,
          bool          OnlySelected,
@@ -160,19 +136,23 @@ template<select_method SelectMethod,
          class Key,
          class Value,
          class FlagType,
-         class OffsetType,
+         class OffsetLookbackScanState,
          class BlockIdWrapper>
-inline hipError_t get_partition_vsmem_size_per_block(target_arch target_arch, size_t& vsmem_size)
+inline size_t get_partition_vsmem_size_per_block()
 {
-    return generic_dispatch_target_arch(target_arch,
-                                        partition_vsmem_size_visitor<SelectMethod,
-                                                                     OnlySelected,
-                                                                     Config,
-                                                                     Key,
-                                                                     Value,
-                                                                     FlagType,
-                                                                     OffsetType,
-                                                                     BlockIdWrapper>{vsmem_size});
+    using offset_type             = typename OffsetLookbackScanState::value_type;
+    using partition_kernel_impl_t = partition_kernel_impl_<
+        typename Config::template architecture_config<device_target_arch()>,
+        SelectMethod,
+        OnlySelected,
+        Key,
+        Value,
+        FlagType,
+        offset_type,
+        BlockIdWrapper>;
+
+    using PartitionVSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
+    return PartitionVSmemHelperT::vsmem_per_block;
 }
 
 template<partition_subalgo SubAlgo,
@@ -202,8 +182,8 @@ inline hipError_t partition_impl(void*                       temporary_storage,
                                  UnaryPredicates... predicates)
 {
     using offset_type = OffsetT;
-    using key_type = typename std::iterator_traits<KeyIterator>::value_type;
-    using value_type = typename std::iterator_traits<ValueIterator>::value_type;
+    using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
+    using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
 
     using config = wrapped_partition_config<Config, SubAlgo, key_type, value_type>;
 
@@ -231,13 +211,16 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     {
         return result;
     }
-    const partition_config_params params = dispatch_target_arch<config>(target_arch);
+    const partition_config_params params = dispatch_target_arch<config, false>(target_arch);
+
+    using offset_scan_state_type            = detail::lookback_scan_state<offset_type>;
+    using offset_scan_state_with_sleep_type = detail::lookback_scan_state<offset_type, true>;
 
     const unsigned int block_size       = params.kernel_config.block_size;
     const unsigned int items_per_thread = params.kernel_config.items_per_thread;
     const auto         items_per_block  = block_size * items_per_thread;
 
-    static constexpr bool is_three_way = sizeof...(UnaryPredicates) == 2;
+    static constexpr bool         is_three_way        = sizeof...(UnaryPredicates) == 2;
     static constexpr const size_t selected_count_size = is_three_way ? 2 : 1;
 
     const size_t size_limit = params.kernel_config.size_limit;
@@ -249,17 +232,10 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     const unsigned int number_of_blocks
         = static_cast<unsigned int>(::rocprim::detail::ceiling_div(limited_size, items_per_block));
 
-    using block_id_wrapper_type = block_id_wrapper<uint32_t, UsingOrderedBlockId>;
-
     // Calculate required temporary storage
-    void*                                    offset_scan_state_storage;
-    size_t*                                  selected_count;
-    size_t*                                  prev_selected_count;
-    typename block_id_wrapper_type::id_type* block_id_pool;
-    void*                                    vsmem;
-
-    using offset_scan_state_type            = detail::lookback_scan_state<offset_type>;
-    using offset_scan_state_with_sleep_type = detail::lookback_scan_state<offset_type, true>;
+    void*   offset_scan_state_storage;
+    size_t* selected_count;
+    size_t* prev_selected_count;
 
     detail::temp_storage::layout layout{};
     result = offset_scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
@@ -268,26 +244,46 @@ inline hipError_t partition_impl(void*                       temporary_storage,
         return result;
     }
 
+    using block_id_wrapper_type = block_id_wrapper<uint32_t, UsingOrderedBlockId>;
+
+    typename block_id_wrapper_type::id_type* block_id_pool = nullptr;
+
+    bool use_sleep;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleep));
+
+    // vsmem size
+    void*  vsmem                      = nullptr;
+    size_t virtual_shared_memory_size = 0;
     using flag_type =
         typename std::conditional<method == select_method::predicated_flag,
                                   typename std::iterator_traits<FlagIterator>::value_type,
                                   bool>::type;
-
-    size_t vsmem_size;
-    result = get_partition_vsmem_size_per_block<method,
-                                                write_only_selected,
-                                                config,
-                                                key_type,
-                                                value_type,
-                                                flag_type,
-                                                offset_type,
-                                                block_id_wrapper_type>(target_arch, vsmem_size);
-    if(result != hipSuccess)
+    if(use_sleep)
     {
-        return result;
+        virtual_shared_memory_size
+            = get_partition_vsmem_size_per_block<method,
+                                                 write_only_selected,
+                                                 config,
+                                                 key_type,
+                                                 value_type,
+                                                 flag_type,
+                                                 offset_scan_state_with_sleep_type,
+                                                 block_id_wrapper_type>();
     }
+    else
+    {
+        virtual_shared_memory_size = get_partition_vsmem_size_per_block<method,
+                                                                        write_only_selected,
+                                                                        config,
+                                                                        key_type,
+                                                                        value_type,
+                                                                        flag_type,
+                                                                        offset_scan_state_type,
+                                                                        block_id_wrapper_type>();
+    }
+    virtual_shared_memory_size *= number_of_blocks;
 
-    vsmem_size *= number_of_blocks;
+    // temporary storage partition
 
     result = detail::temp_storage::partition(
         temporary_storage,
@@ -303,7 +299,10 @@ inline hipError_t partition_impl(void*                       temporary_storage,
             detail::temp_storage::ptr_aligned_array(&block_id_pool,
                                                     block_id_wrapper_type::get_storage_size()),
             // vsmem
-            detail::temp_storage::make_partition(&vsmem, vsmem_size, cache_line_size)));
+            detail::temp_storage::make_partition(&vsmem,
+                                                 virtual_shared_memory_size,
+                                                 cache_line_size)));
+
     if(result != hipSuccess || temporary_storage == nullptr)
     {
         return result;
@@ -333,9 +332,6 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     {
         return result;
     }
-
-    bool use_sleep;
-    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleep));
 
     // Call the provided function with either offset_scan_state or offset_scan_state_with_sleep based on
     // the value of use_sleep
@@ -381,7 +377,8 @@ inline hipError_t partition_impl(void*                       temporary_storage,
         const unsigned int current_size
             = static_cast<unsigned int>(std::min<size_t>(size - prev_processed, limited_size));
 
-        const unsigned int current_number_of_blocks = ::rocprim::detail::ceiling_div(current_size, items_per_block);
+        const unsigned int current_number_of_blocks
+            = ::rocprim::detail::ceiling_div(current_size, items_per_block);
 
         if(debug_synchronous)
         {
@@ -405,38 +402,47 @@ inline hipError_t partition_impl(void*                       temporary_storage,
                                                     current_number_of_blocks,
                                                     start);
 
-        if (UsingOrderedBlockId)
+        if(UsingOrderedBlockId)
         {
             result = hipMemsetAsync(block_id_pool, 0, sizeof(unsigned int), stream);
-            if (result != hipSuccess)
+            if(result != hipSuccess)
             {
                 return result;
             }
         }
 
-        if(debug_synchronous) start = std::chrono::steady_clock::now();
+        if(debug_synchronous)
+            start = std::chrono::steady_clock::now();
 
-        with_scan_state(
+        hipError_t launch_err = with_scan_state(
             [&](const auto scan_state)
             {
-                partition_kernel<method, write_only_selected, config>
-                    <<<dim3(current_number_of_blocks), dim3(block_size), 0, stream>>>(
-                        keys_input + prev_processed,
-                        values_input + prev_processed,
-                        flags + prev_processed,
-                        keys_output,
-                        values_output,
-                        selected_count,
-                        prev_selected_count,
-                        prev_processed,
-                        size,
-                        inequality_op,
-                        scan_state,
-                        current_number_of_blocks,
-                        detail::vsmem_t{vsmem},
-                        block_id,
-                        predicates...);
+                return launch_partition<config, method, write_only_selected>(
+                    target_arch,
+                    keys_input + prev_processed,
+                    values_input + prev_processed,
+                    flags + prev_processed,
+                    keys_output,
+                    values_output,
+                    selected_count,
+                    prev_selected_count,
+                    prev_processed,
+                    size,
+                    inequality_op,
+                    scan_state,
+                    current_number_of_blocks,
+                    detail::vsmem_t{vsmem},
+                    block_id,
+                    dim3(current_number_of_blocks),
+                    dim3(block_size),
+                    0,
+                    stream,
+                    predicates...);
             });
+        if(launch_err != hipSuccess)
+        {
+            return launch_err;
+        }
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", size, start);
 
         std::swap(selected_count, prev_selected_count);
@@ -456,7 +462,7 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     return hipSuccess;
 }
 
-} // end of detail namespace
+} // namespace detail
 
 /// \brief Two-way parallel select primitive for device level using selection predicate.
 ///
@@ -514,7 +520,7 @@ inline hipError_t partition_impl(void*                       temporary_storage,
 /// #include <rocprim/rocprim.hpp>///
 ///
 /// auto predicate =
-///     [] __device__ (int a) -> bool
+///     [] (int a) -> bool
 ///     {
 ///         return (a%2) == 0;
 ///     };
@@ -563,7 +569,7 @@ template<class Config = default_config,
          class RejectedOutputIterator,
          class SelectedCountOutputIterator,
          class Predicate,
-         bool  UsingOrderedBlockId = false>
+         bool UsingOrderedBlockId = false>
 inline hipError_t partition_two_way(void*                       temporary_storage,
                                     size_t&                     storage_size,
                                     InputIterator               input,
@@ -708,7 +714,7 @@ template<class Config = default_config,
          typename SelectedOutputIterator,
          typename RejectedOutputIterator,
          typename SelectedCountOutputIterator,
-         bool     UsingOrderedBlockId = false>
+         bool UsingOrderedBlockId = false>
 inline hipError_t partition_two_way(void*                       temporary_storage,
                                     size_t&                     storage_size,
                                     InputIterator               input,
@@ -831,23 +837,21 @@ inline hipError_t partition_two_way(void*                       temporary_storag
 /// // output_count: 4
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class FlagIterator,
-    class OutputIterator,
-    class SelectedCountOutputIterator,
-    bool  UsingOrderedBlockId = false>
-inline
-hipError_t partition(void * temporary_storage,
-                     size_t& storage_size,
-                     InputIterator input,
-                     FlagIterator flags,
-                     OutputIterator output,
-                     SelectedCountOutputIterator selected_count_output,
-                     const size_t size,
-                     const hipStream_t stream = 0,
-                     const bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class FlagIterator,
+         class OutputIterator,
+         class SelectedCountOutputIterator,
+         bool UsingOrderedBlockId = false>
+inline hipError_t partition(void*                       temporary_storage,
+                            size_t&                     storage_size,
+                            InputIterator               input,
+                            FlagIterator                flags,
+                            OutputIterator              output,
+                            SelectedCountOutputIterator selected_count_output,
+                            const size_t                size,
+                            const hipStream_t           stream            = 0,
+                            const bool                  debug_synchronous = false)
 {
     using unary_predicate_type = ::rocprim::empty_type; // dummy
     using inequality_op_type   = ::rocprim::empty_type; // dummy
@@ -930,7 +934,7 @@ hipError_t partition(void * temporary_storage,
 /// #include <rocprim/rocprim.hpp>///
 ///
 /// auto predicate =
-///     [] __device__ (int a) -> bool
+///     [] (int a) -> bool
 ///     {
 ///         return (a%2) == 0;
 ///     };
@@ -967,23 +971,21 @@ hipError_t partition(void * temporary_storage,
 /// // output_count: 4
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class SelectedCountOutputIterator,
-    class UnaryPredicate,
-    bool  UsingOrderedBlockId = false>
-inline
-hipError_t partition(void * temporary_storage,
-                     size_t& storage_size,
-                     InputIterator input,
-                     OutputIterator output,
-                     SelectedCountOutputIterator selected_count_output,
-                     const size_t size,
-                     UnaryPredicate predicate,
-                     const hipStream_t stream = 0,
-                     const bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class SelectedCountOutputIterator,
+         class UnaryPredicate,
+         bool UsingOrderedBlockId = false>
+inline hipError_t partition(void*                       temporary_storage,
+                            size_t&                     storage_size,
+                            InputIterator               input,
+                            OutputIterator              output,
+                            SelectedCountOutputIterator selected_count_output,
+                            const size_t                size,
+                            UnaryPredicate              predicate,
+                            const hipStream_t           stream            = 0,
+                            const bool                  debug_synchronous = false)
 {
     using flag_type          = ::rocprim::empty_type; //dummy
     using inequality_op_type = ::rocprim::empty_type; //dummy
@@ -1094,12 +1096,12 @@ hipError_t partition(void * temporary_storage,
 /// #include <rocprim/rocprim.hpp>
 ///
 /// auto first_predicate =
-///     [] __device__ (int a) -> bool
+///     [] (int a) -> bool
 ///     {
 ///         return (a%2) == 0;
 ///     };
 /// auto second_predicate =
-///     [] __device__ (int a) -> bool
+///     [] (int a) -> bool
 ///     {
 ///         return (a%3) == 0;
 ///     };
@@ -1145,46 +1147,42 @@ hipError_t partition(void * temporary_storage,
 /// // output_count:       [4, 1]
 /// \endcode
 /// \endparblock
-template <
-    class Config = default_config,
-    typename InputIterator,
-    typename FirstOutputIterator,
-    typename SecondOutputIterator,
-    typename UnselectedOutputIterator,
-    typename SelectedCountOutputIterator,
-    typename FirstUnaryPredicate,
-    typename SecondUnaryPredicate,
-    bool     UsingOrderedBlockId = false>
-inline
-hipError_t partition_three_way(void * temporary_storage,
-                               size_t& storage_size,
-                               InputIterator input,
-                               FirstOutputIterator output_first_part,
-                               SecondOutputIterator output_second_part,
-                               UnselectedOutputIterator output_unselected,
-                               SelectedCountOutputIterator selected_count_output,
-                               const size_t size,
-                               FirstUnaryPredicate select_first_part_op,
-                               SecondUnaryPredicate select_second_part_op,
-                               const hipStream_t stream = 0,
-                               const bool debug_synchronous = false)
+template<class Config = default_config,
+         typename InputIterator,
+         typename FirstOutputIterator,
+         typename SecondOutputIterator,
+         typename UnselectedOutputIterator,
+         typename SelectedCountOutputIterator,
+         typename FirstUnaryPredicate,
+         typename SecondUnaryPredicate,
+         bool UsingOrderedBlockId = false>
+inline hipError_t partition_three_way(void*                       temporary_storage,
+                                      size_t&                     storage_size,
+                                      InputIterator               input,
+                                      FirstOutputIterator         output_first_part,
+                                      SecondOutputIterator        output_second_part,
+                                      UnselectedOutputIterator    output_unselected,
+                                      SelectedCountOutputIterator selected_count_output,
+                                      const size_t                size,
+                                      FirstUnaryPredicate         select_first_part_op,
+                                      SecondUnaryPredicate        select_second_part_op,
+                                      const hipStream_t           stream            = 0,
+                                      const bool                  debug_synchronous = false)
 {
     // Dummy flag type
-    using flag_type = ::rocprim::empty_type;
-    flag_type * flags = nullptr;
+    using flag_type  = ::rocprim::empty_type;
+    flag_type* flags = nullptr;
     // Dummy inequality operation
     using inequality_op_type = ::rocprim::empty_type;
-    using offset_type = uint2;
-    using output_key_iterator_tuple = tuple<
-        FirstOutputIterator,
-        SecondOutputIterator,
-        UnselectedOutputIterator>;
+    using offset_type        = uint2;
+    using output_key_iterator_tuple
+        = tuple<FirstOutputIterator, SecondOutputIterator, UnselectedOutputIterator>;
     using output_value_iterator_tuple
         = tuple<::rocprim::empty_type*, ::rocprim::empty_type*, ::rocprim::empty_type*>;
-    rocprim::empty_type* const no_input_values = nullptr; // key only
-    const output_value_iterator_tuple no_output_values {nullptr, nullptr, nullptr}; // key only
+    rocprim::empty_type* const        no_input_values = nullptr; // key only
+    const output_value_iterator_tuple no_output_values{nullptr, nullptr, nullptr}; // key only
 
-    output_key_iterator_tuple output{ output_first_part, output_second_part, output_unselected };
+    output_key_iterator_tuple output{output_first_part, output_second_part, output_unselected};
 
     return detail::partition_impl<detail::partition_subalgo::partition_three_way,
                                   UsingOrderedBlockId,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
@@ -127,7 +127,7 @@ inline hipError_t launch_partition(detail::target_arch     arch,
                                             predicates...);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -26,13 +26,13 @@
 #include <type_traits>
 #include <utility>
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/temp_storage.hpp"
 #include "../detail/various.hpp"
 
-#include "../intrinsics.hpp"
 #include "../functional.hpp"
+#include "../intrinsics.hpp"
 #include "../types.hpp"
 
 #include "../type_traits.hpp"
@@ -75,43 +75,70 @@ struct decomposer_max_bits
 {};
 
 template<class Size>
-using offset_type_t = std::conditional_t<
-    sizeof(Size) <= 4,
-    unsigned int,
-    size_t
->;
+using offset_type_t = std::conditional_t<sizeof(Size) <= 4, unsigned int, size_t>;
 
 template<class Config, bool Descending, class KeysInputIterator, class Offset, class Decomposer>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram.block_size) void
-    onesweep_histograms_kernel(KeysInputIterator  keys_input,
-                               Offset*            global_digit_counts,
-                               const Offset       size,
-                               const Offset       full_blocks,
-                               Decomposer         decomposer,
-                               const unsigned int begin_bit,
-                               const unsigned int end_bit)
+inline hipError_t launch_onesweep_histograms(detail::target_arch arch,
+                                             KeysInputIterator   keys_input,
+                                             Offset*             global_digit_counts,
+                                             const Offset        size,
+                                             const Offset        full_blocks,
+                                             Decomposer          decomposer,
+                                             const unsigned int  begin_bit,
+                                             const unsigned int  end_bit,
+                                             dim3                grid,
+                                             dim3                block,
+                                             size_t              shmem,
+                                             hipStream_t         stream)
 {
-    static constexpr radix_sort_onesweep_config_params params = device_params<Config>();
-    onesweep_histograms<params.histogram.block_size,
-                        params.histogram.items_per_thread,
-                        params.radix_bits_per_place,
-                        Descending>(keys_input,
-                                    global_digit_counts,
-                                    size,
-                                    full_blocks,
-                                    decomposer,
-                                    begin_bit,
-                                    end_bit);
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr radix_sort_onesweep_config_params params = decltype(arch_config)::params;
+        onesweep_histograms<params.histogram.block_size,
+                            params.histogram.items_per_thread,
+                            params.radix_bits_per_place,
+                            Descending>(keys_input,
+                                        global_digit_counts,
+                                        size,
+                                        full_blocks,
+                                        decomposer,
+                                        begin_bit,
+                                        end_bit);
+    };
+
+    return execute_launch_plan<Config,
+                               decltype(kernel),
+                               radix_sort_onesweep_histogram_config_selector>(arch,
+                                                                              kernel,
+                                                                              grid,
+                                                                              block,
+                                                                              shmem,
+                                                                              stream);
 }
 
 template<class Config, class Offset>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram.block_size) void
-    onesweep_scan_histograms_kernel(Offset* global_digit_offsets)
+inline hipError_t launch_onesweep_scan_histograms(detail::target_arch arch,
+                                                  Offset*             global_digit_offsets,
+                                                  dim3                grid,
+                                                  dim3                block,
+                                                  size_t              shmem,
+                                                  hipStream_t         stream)
 {
-    static constexpr radix_sort_onesweep_config_params params = device_params<Config>();
-    onesweep_scan_histograms<params.histogram.block_size, params.radix_bits_per_place>(
-        global_digit_offsets);
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr radix_sort_onesweep_config_params params = decltype(arch_config)::params;
+        onesweep_scan_histograms<params.histogram.block_size, params.radix_bits_per_place>(
+            global_digit_offsets);
+    };
+
+    return execute_launch_plan<Config,
+                               decltype(kernel),
+                               radix_sort_onesweep_histogram_config_selector>(arch,
+                                                                              kernel,
+                                                                              grid,
+                                                                              block,
+                                                                              shmem,
+                                                                              stream);
 }
 
 template<class Config,
@@ -141,7 +168,8 @@ hipError_t radix_sort_onesweep_global_offsets(KeysInputIterator keys_input,
     {
         return result;
     }
-    const radix_sort_onesweep_config_params params = dispatch_target_arch<config>(target_arch);
+    const radix_sort_onesweep_config_params params
+        = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int items_per_block
         = params.histogram.block_size * params.histogram.items_per_thread;
@@ -168,18 +196,19 @@ hipError_t radix_sort_onesweep_global_offsets(KeysInputIterator keys_input,
     }
 
     // Compute a histogram for each digit.
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_histograms_kernel<config, Descending>),
-                       dim3(blocks),
-                       dim3(params.histogram.block_size),
-                       0,
-                       stream,
-                       keys_input,
-                       global_digit_offsets,
-                       size,
-                       full_blocks,
-                       decomposer,
-                       begin_bit,
-                       end_bit);
+    ROCPRIM_RETURN_ON_ERROR(
+        launch_onesweep_histograms<config, Descending>(target_arch,
+                                                       keys_input,
+                                                       global_digit_offsets,
+                                                       size,
+                                                       full_blocks,
+                                                       decomposer,
+                                                       begin_bit,
+                                                       end_bit,
+                                                       dim3(blocks),
+                                                       dim3(params.histogram.block_size),
+                                                       0,
+                                                       stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("compute_global_digit_histograms", size, start);
 
     // Scan each histogram separately to get the final offsets.
@@ -188,13 +217,13 @@ hipError_t radix_sort_onesweep_global_offsets(KeysInputIterator keys_input,
         start = std::chrono::steady_clock::now();
     }
 
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_scan_histograms_kernel<config>),
-                       dim3(digit_places), // One block for every digit place.
-                       dim3(params.histogram.block_size),
-                       0,
-                       stream,
-                       global_digit_offsets);
-
+    ROCPRIM_RETURN_ON_ERROR(launch_onesweep_scan_histograms<config>(
+        target_arch,
+        global_digit_offsets,
+        dim3(digit_places), // One block for every digit place.
+        dim3(params.histogram.block_size),
+        0,
+        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("scan_global_digit_histograms", bins, start);
     return hipSuccess;
 }
@@ -207,37 +236,53 @@ template<class Config,
          class ValuesOutputIterator,
          class Offset,
          class Decomposer>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().sort.block_size) void
-    onesweep_iteration_kernel(KeysInputIterator        keys_input,
-                              KeysOutputIterator       keys_output,
-                              ValuesInputIterator      values_input,
-                              ValuesOutputIterator     values_output,
-                              const unsigned int       size,
-                              Offset*                  global_digit_offsets_in,
-                              Offset*                  global_digit_offsets_out,
-                              onesweep_lookback_state* lookback_states,
-                              Decomposer               decomposer,
-                              const unsigned int       bit,
-                              const unsigned int       current_radix_bits,
-                              const unsigned int       full_blocks)
+inline hipError_t launch_onesweep_iteration(detail::target_arch      arch,
+                                            KeysInputIterator        keys_input,
+                                            KeysOutputIterator       keys_output,
+                                            ValuesInputIterator      values_input,
+                                            ValuesOutputIterator     values_output,
+                                            const unsigned int       size,
+                                            Offset*                  global_digit_offsets_in,
+                                            Offset*                  global_digit_offsets_out,
+                                            onesweep_lookback_state* lookback_states,
+                                            Decomposer               decomposer,
+                                            const unsigned int       bit,
+                                            const unsigned int       current_radix_bits,
+                                            const unsigned int       full_blocks,
+                                            dim3                     grid,
+                                            dim3                     block,
+                                            size_t                   shmem,
+                                            hipStream_t              stream)
 {
-    static constexpr radix_sort_onesweep_config_params params = device_params<Config>();
-    onesweep_iteration<params.sort.block_size,
-                       params.sort.items_per_thread,
-                       params.radix_bits_per_place,
-                       Descending,
-                       params.radix_rank_algorithm>(keys_input,
-                                                    keys_output,
-                                                    values_input,
-                                                    values_output,
-                                                    size,
-                                                    global_digit_offsets_in,
-                                                    global_digit_offsets_out,
-                                                    lookback_states,
-                                                    decomposer,
-                                                    bit,
-                                                    current_radix_bits,
-                                                    full_blocks);
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr auto params = decltype(arch_config)::params;
+
+        onesweep_iteration<params.sort.block_size,
+                           params.sort.items_per_thread,
+                           params.radix_bits_per_place,
+                           Descending,
+                           params.radix_rank_algorithm>(keys_input,
+                                                        keys_output,
+                                                        values_input,
+                                                        values_output,
+                                                        size,
+                                                        global_digit_offsets_in,
+                                                        global_digit_offsets_out,
+                                                        lookback_states,
+                                                        decomposer,
+                                                        bit,
+                                                        current_radix_bits,
+                                                        full_blocks);
+    };
+
+    return execute_launch_plan<Config, decltype(kernel), radix_sort_onesweep_sort_config_selector>(
+        arch,
+        kernel,
+        grid,
+        block,
+        shmem,
+        stream);
 }
 
 template<class Config,
@@ -277,7 +322,8 @@ hipError_t radix_sort_onesweep_iteration(
     {
         return result;
     }
-    const radix_sort_onesweep_config_params params = dispatch_target_arch<config>(target_arch);
+    const radix_sort_onesweep_config_params params
+        = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int items_per_block = params.sort.block_size * params.sort.items_per_thread;
     const unsigned int current_radix_bits
@@ -294,8 +340,8 @@ hipError_t radix_sort_onesweep_iteration(
 
     for(Offset batch = 0; batch < batches; ++batch)
     {
-        const Offset       offset             = batch * items_per_batch;
-        const Offset       items_left         = size - offset;
+        const Offset       offset     = batch * items_per_batch;
+        const Offset       items_left = size - offset;
         const unsigned int current_batch_size
             = static_cast<unsigned int>(::rocprim::min<Offset>(items_left, items_per_batch));
         const unsigned int blocks
@@ -332,85 +378,88 @@ hipError_t radix_sort_onesweep_iteration(
 
         if(from_input && to_output)
         {
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_iteration_kernel<config, Descending>),
-                               dim3(blocks),
-                               dim3(params.sort.block_size),
-                               0,
-                               stream,
-                               keys_input + offset,
-                               keys_output,
-                               values_input + offset,
-                               values_output,
-                               current_batch_size,
-                               global_digit_offsets_in,
-                               global_digit_offsets_out,
-                               lookback_states,
-                               decomposer,
-                               bit,
-                               current_radix_bits,
-                               full_blocks);
+            ROCPRIM_RETURN_ON_ERROR(
+                launch_onesweep_iteration<config, Descending>(target_arch,
+                                                              keys_input + offset,
+                                                              keys_output,
+                                                              values_input + offset,
+                                                              values_output,
+                                                              current_batch_size,
+                                                              global_digit_offsets_in,
+                                                              global_digit_offsets_out,
+                                                              lookback_states,
+                                                              decomposer,
+                                                              bit,
+                                                              current_radix_bits,
+                                                              full_blocks,
+                                                              dim3(blocks),
+                                                              dim3(params.sort.block_size),
+                                                              0,
+                                                              stream));
         }
         else if(from_input)
         {
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_iteration_kernel<config, Descending>),
-                               dim3(blocks),
-                               dim3(params.sort.block_size),
-                               0,
-                               stream,
-                               keys_input + offset,
-                               keys_tmp,
-                               values_input + offset,
-                               values_tmp,
-                               current_batch_size,
-                               global_digit_offsets_in,
-                               global_digit_offsets_out,
-                               lookback_states,
-                               decomposer,
-                               bit,
-                               current_radix_bits,
-                               full_blocks);
+            ROCPRIM_RETURN_ON_ERROR(
+                launch_onesweep_iteration<config, Descending>(target_arch,
+                                                              keys_input + offset,
+                                                              keys_tmp,
+                                                              values_input + offset,
+                                                              values_tmp,
+                                                              current_batch_size,
+                                                              global_digit_offsets_in,
+                                                              global_digit_offsets_out,
+                                                              lookback_states,
+                                                              decomposer,
+                                                              bit,
+                                                              current_radix_bits,
+                                                              full_blocks,
+                                                              dim3(blocks),
+                                                              dim3(params.sort.block_size),
+                                                              0,
+                                                              stream));
         }
         else if(to_output)
         {
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_iteration_kernel<config, Descending>),
-                               dim3(blocks),
-                               dim3(params.sort.block_size),
-                               0,
-                               stream,
-                               keys_tmp + offset,
-                               keys_output,
-                               values_tmp + offset,
-                               values_output,
-                               current_batch_size,
-                               global_digit_offsets_in,
-                               global_digit_offsets_out,
-                               lookback_states,
-                               decomposer,
-                               bit,
-                               current_radix_bits,
-                               full_blocks);
+            ROCPRIM_RETURN_ON_ERROR(
+                launch_onesweep_iteration<config, Descending>(target_arch,
+                                                              keys_tmp + offset,
+                                                              keys_output,
+                                                              values_tmp + offset,
+                                                              values_output,
+                                                              current_batch_size,
+                                                              global_digit_offsets_in,
+                                                              global_digit_offsets_out,
+                                                              lookback_states,
+                                                              decomposer,
+                                                              bit,
+                                                              current_radix_bits,
+                                                              full_blocks,
+                                                              dim3(blocks),
+                                                              dim3(params.sort.block_size),
+                                                              0,
+                                                              stream));
         }
         else
         {
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_iteration_kernel<config, Descending>),
-                               dim3(blocks),
-                               dim3(params.sort.block_size),
-                               0,
-                               stream,
-                               keys_output + offset,
-                               keys_tmp,
-                               values_output + offset,
-                               values_tmp,
-                               current_batch_size,
-                               global_digit_offsets_in,
-                               global_digit_offsets_out,
-                               lookback_states,
-                               decomposer,
-                               bit,
-                               current_radix_bits,
-                               full_blocks);
+            ROCPRIM_RETURN_ON_ERROR(
+                launch_onesweep_iteration<config, Descending>(target_arch,
+                                                              keys_output + offset,
+                                                              keys_tmp,
+                                                              values_output + offset,
+                                                              values_tmp,
+                                                              current_batch_size,
+                                                              global_digit_offsets_in,
+                                                              global_digit_offsets_out,
+                                                              lookback_states,
+                                                              decomposer,
+                                                              bit,
+                                                              current_radix_bits,
+                                                              full_blocks,
+                                                              dim3(blocks),
+                                                              dim3(params.sort.block_size),
+                                                              0,
+                                                              stream));
         }
-
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("onesweep_iteration", size, start);
 
         std::swap(global_digit_offsets_in, global_digit_offsets_out);
@@ -456,7 +505,8 @@ hipError_t radix_sort_onesweep_impl(
     {
         return result;
     }
-    const radix_sort_onesweep_config_params params = dispatch_target_arch<config>(target_arch);
+    const radix_sort_onesweep_config_params params
+        = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int sort_items_per_block = params.sort.block_size * params.sort.items_per_thread;
     const unsigned int radix_size_per_place = 1u << params.radix_bits_per_place;
@@ -666,7 +716,10 @@ hipError_t
     using block_sort_config = typename std::conditional<use_default_small_block_sort,
                                                         default_block_sort_config,
                                                         typename Config::single_sort_config>::type;
-
+    bool using_spirv        = false;
+#if defined(ROCPRIM_TARGET_SPIRV)
+    using_spirv = true;
+#endif
     if(::rocprim::is_floating_point<key_type>::value
        && ((begin_bit != 0) || (end_bit != sizeof(key_type) * 8)))
     {
@@ -703,8 +756,8 @@ hipError_t
     }
     // For sizeof(key_type) <= 2, onesweep is 2x/3x faster (also with values) when
     // input_size > 100K, so don't use radix_sort_merge_sort then.
-    else if(static_cast<size_t>(size) <= merge_sort_limit
-            && (sizeof(key_type) > 2 || size < 100000))
+    else if(static_cast<size_t>(size) <= merge_sort_limit && (sizeof(key_type) > 2 || size < 100000)
+            && !using_spirv)
     {
         is_result_in_output = true;
         // note: Config::merge_sort_config may be default_config
@@ -747,8 +800,6 @@ hipError_t
                                                                      debug_synchronous);
     }
 }
-
-
 
 } // end namespace detail
 
@@ -850,8 +901,8 @@ hipError_t radix_sort_keys(void*              temporary_storage,
                            bool               debug_synchronous = false)
 {
     static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
-    empty_type * values = nullptr;
-    bool ignored;
+    empty_type* values = nullptr;
+    bool        ignored;
     return detail::radix_sort_impl<Config, false>(temporary_storage,
                                                   storage_size,
                                                   keys_input,
@@ -967,9 +1018,9 @@ hipError_t radix_sort_keys(void*               temporary_storage,
                            bool                debug_synchronous = false)
 {
     static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
-    empty_type * values = nullptr;
-    bool         is_result_in_output;
-    hipError_t   error = detail::radix_sort_impl<Config, false>(temporary_storage,
+    empty_type* values = nullptr;
+    bool        is_result_in_output;
+    hipError_t  error = detail::radix_sort_impl<Config, false>(temporary_storage,
                                                               storage_size,
                                                               keys.current(),
                                                               keys.current(),

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -22,7 +22,6 @@
 #define ROCPRIM_DEVICE_DEVICE_REDUCE_HPP_
 
 #include <algorithm>
-#include <future>
 #include <iostream>
 #include <iterator>
 #include <type_traits>
@@ -56,24 +55,23 @@ template<class Config,
          class InitValueType,
          class BinaryFunction>
 inline hipError_t launch_block_reduce(detail::target_arch arch,
-                                               InputIterator       input,
-                                               const size_t        size,
-                                               OutputIterator      output,
-                                               InitValueType       initial_value,
-                                               BinaryFunction      reduce_op,
-                                               dim3                grid,
-                                               dim3                block,
-                                               size_t              shmem,
-                                               hipStream_t         stream)
+                                      InputIterator       input,
+                                      const size_t        size,
+                                      OutputIterator      output,
+                                      InitValueType       initial_value,
+                                      BinaryFunction      reduce_op,
+                                      dim3                grid,
+                                      dim3                block,
+                                      size_t              shmem,
+                                      hipStream_t         stream)
 {
-    auto kernel = [=] __device__ (auto arch_config)
+    auto kernel = [=](auto arch_config)
     {
-        block_reduce_kernel_impl<decltype(arch_config), WithInitialValue, FitLarger, FitItems, ResultType>(
-            input,
-            size,
-            output,
-            initial_value,
-            reduce_op);
+        block_reduce_kernel_impl<decltype(arch_config),
+                                 WithInitialValue,
+                                 FitLarger,
+                                 FitItems,
+                                 ResultType>(input, size, output, initial_value, reduce_op);
     };
 
     return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
@@ -89,39 +87,41 @@ inline hipError_t launch_block_reduce(detail::target_arch arch,
         auto _end = std::chrono::steady_clock::now();                                        \
         auto _d   = std::chrono::duration_cast<std::chrono::duration<double>>(_end - start); \
         std::cout << " " << _d.count() * 1000 << " ms" << '\n';                              \
-    }                                                                                        \
+    }
 
-#define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                       \
-    do                                                                                    \
-    {                                                                                     \
-        detail::target_arch target_arch;                                                  \
-        hipError_t          result = detail::host_target_arch(stream, target_arch);       \
-        if(result != hipSuccess)                                                          \
-        {                                                                                 \
-            return result;                                                                \
-        }                                                                                 \
-        if(debug_synchronous)                                                             \
-        {                                                                                 \
-            start = std::chrono::steady_clock::now();                                     \
-        }                                                                                 \
-                                                                                          \
-        hipError_t launch_err =                                                                        \
-            launch_block_reduce<config, WithInitialValue, fit_larger, fit_items, result_type> \
-                (target_arch,                                                                          \
-                input,                                                                                \
-                size,                                                                                 \
-                output,                                                                               \
-                initial_value,                                                                        \
-                reduce_op,                                                                            \
-                dim3(1),                                                                              \
-                dim3(block_size), 0, stream);                                                         \
-        if(launch_err != hipSuccess)                                                                  \
-        {                                                                                             \
-            return result;                                                                            \
-        }                                                                                             \
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);              \
-    }                                                                                                 \
-    while(0)                                                                                          \
+#define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                              \
+    do                                                                                           \
+    {                                                                                            \
+        detail::target_arch target_arch;                                                         \
+        hipError_t          result = detail::host_target_arch(stream, target_arch);              \
+        if(result != hipSuccess)                                                                 \
+        {                                                                                        \
+            return result;                                                                       \
+        }                                                                                        \
+        if(debug_synchronous)                                                                    \
+        {                                                                                        \
+            start = std::chrono::steady_clock::now();                                            \
+        }                                                                                        \
+                                                                                                 \
+        hipError_t launch_err                                                                    \
+            = launch_block_reduce<config, WithInitialValue, fit_larger, fit_items, result_type>( \
+                target_arch,                                                                     \
+                input,                                                                           \
+                size,                                                                            \
+                output,                                                                          \
+                initial_value,                                                                   \
+                reduce_op,                                                                       \
+                dim3(1),                                                                         \
+                dim3(block_size),                                                                \
+                0,                                                                               \
+                stream);                                                                         \
+        if(launch_err != hipSuccess)                                                             \
+        {                                                                                        \
+            return result;                                                                       \
+        }                                                                                        \
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);         \
+    }                                                                                            \
+    while(0)
 
 template<bool WithInitialValue, // true when inital_value should be used in reduction
          class Config,
@@ -220,13 +220,17 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             {
                 start = std::chrono::steady_clock::now();
             }
-            const hipError_t error = launch_block_reduce<config, false, true, 1, result_type>
-                (target_arch,
-                    input + offset,
-                    current_size,
-                    block_prefixes + i * number_of_blocks_limit,
-                    initial_value,
-                    reduce_op,dim3(current_blocks), dim3(block_size), 0, stream);
+            const hipError_t error = launch_block_reduce<config, false, true, 1, result_type>(
+                target_arch,
+                input + offset,
+                current_size,
+                block_prefixes + i * number_of_blocks_limit,
+                initial_value,
+                reduce_op,
+                dim3(current_blocks),
+                dim3(block_size),
+                0,
+                stream);
 
             if(error != hipSuccess)
             {
@@ -372,7 +376,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
 ///
 /// // custom reduce function
 /// auto min_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a < b ? a : b;
 ///     };
@@ -408,7 +412,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
 /// #include <rocprim/rocprim.hpp>
 ///
 /// auto min_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a < b ? a : b;
 ///     };
@@ -420,7 +424,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
 ///
 /// // Use a transform iterator to specifiy a custom accumulator type
 /// auto input_iterator = rocprim::make_transform_iterator(
-///     input, [] __device__ (T in) { return static_cast<int>(in); });
+///     input, [] (T in) { return static_cast<int>(in); });
 ///
 /// size_t temporary_storage_size_bytes;
 /// void * temporary_storage_ptr = nullptr;
@@ -552,7 +556,7 @@ inline hipError_t reduce(void*               temporary_storage,
 ///
 /// // Use a transform iterator to specifiy a custom accumulator type
 /// auto input_iterator = rocprim::make_transform_iterator(
-///     input, [] __device__ (T in) { return static_cast<int>(in); });
+///     input, [] (T in) { return static_cast<int>(in); });
 ///
 /// size_t temporary_storage_size_bytes;
 /// void * temporary_storage_ptr = nullptr;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -22,14 +22,15 @@
 #define ROCPRIM_DEVICE_DEVICE_REDUCE_HPP_
 
 #include <algorithm>
+#include <future>
 #include <iostream>
 #include <iterator>
 #include <type_traits>
 
 #include "config_types.hpp"
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/temp_storage.hpp"
 #include "../detail/various.hpp"
 
@@ -45,80 +46,91 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<bool         WithInitialValue,
+template<class Config,
+         bool         WithInitialValue,
          bool         FitLarger,
          unsigned int FitItems,
-         class Config,
          class ResultType,
          class InputIterator,
          class OutputIterator,
          class InitValueType,
          class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().reduce_config.block_size) void
-    block_reduce_kernel(InputIterator  input,
-                        const size_t   size,
-                        OutputIterator output,
-                        InitValueType  initial_value,
-                        BinaryFunction reduce_op)
+inline hipError_t launch_block_reduce_for_arch(detail::target_arch arch,
+                                               InputIterator       input,
+                                               const size_t        size,
+                                               OutputIterator      output,
+                                               InitValueType       initial_value,
+                                               BinaryFunction      reduce_op,
+                                               dim3                grid,
+                                               dim3                block,
+                                               size_t              shmem,
+                                               hipStream_t         stream)
 {
-    block_reduce_kernel_impl<WithInitialValue, FitLarger, FitItems, Config, ResultType>(
-        input,
-        size,
-        output,
-        initial_value,
-        reduce_op);
+    auto kernel = [=] __device__ (auto arch_config)
+    {
+        block_reduce_kernel_impl<decltype(arch_config), WithInitialValue, FitLarger, FitItems, ResultType>(
+            input,
+            size,
+            output,
+            initial_value,
+            reduce_op);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-#define ROCPRIM_DETAIL_HIP_SYNC(name, size, start) \
-    if(debug_synchronous) \
-    { \
-        std::cout << name << "(" << size << ")"; \
-        auto _error = hipStreamSynchronize(stream); \
-        if(_error != hipSuccess) return _error; \
-        auto _end = std::chrono::steady_clock::now(); \
-        auto _d = std::chrono::duration_cast<std::chrono::duration<double>>(_end - start); \
-        std::cout << " " << _d.count() * 1000 << " ms" << '\n'; \
-    }
+#define ROCPRIM_DETAIL_HIP_SYNC(name, size, start)                                           \
+    if(debug_synchronous)                                                                    \
+    {                                                                                        \
+        std::cout << name << "(" << size << ")";                                             \
+        auto _error = hipStreamSynchronize(stream);                                          \
+        if(_error != hipSuccess)                                                             \
+            return _error;                                                                   \
+        auto _end = std::chrono::steady_clock::now();                                        \
+        auto _d   = std::chrono::duration_cast<std::chrono::duration<double>>(_end - start); \
+        std::cout << " " << _d.count() * 1000 << " ms" << '\n';                              \
+    }                                                                                        \
 
 #define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                       \
     do                                                                                    \
     {                                                                                     \
+        detail::target_arch target_arch;                                                  \
+        hipError_t          result = detail::host_target_arch(stream, target_arch);       \
         if(debug_synchronous)                                                             \
         {                                                                                 \
             start = std::chrono::steady_clock::now();                                     \
         }                                                                                 \
                                                                                           \
-        block_reduce_kernel<WithInitialValue, fit_larger, fit_items, config, result_type> \
-            <<<dim3(1), dim3(block_size), 0, stream>>>(input,                             \
-                                                       size,                              \
-                                                       output,                            \
-                                                       initial_value,                     \
-                                                       reduce_op);                        \
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);  \
-    }                                                                                     \
-    while(0)
+        launch_block_reduce_for_arch<config, WithInitialValue, fit_larger, fit_items, result_type> \
+            (target_arch,                                                                          \
+             input,                                                                               \
+             size,                                                                                 \
+             output,                                                                               \
+             initial_value,                                                                        \
+             reduce_op,                                                                            \
+             dim3(1),                                                                              \
+             dim3(block_size), 0, stream);                                                         \
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);           \
+    }                                                                                              \
+    while(0)                                                                                       \
 
-
-template<
-    bool WithInitialValue, // true when inital_value should be used in reduction
-    class Config,
-    class InputIterator,
-    class OutputIterator,
-    class InitValueType,
-    class BinaryFunction
->
-inline
-hipError_t reduce_impl(void * temporary_storage,
-                       size_t& storage_size,
-                       InputIterator input,
-                       OutputIterator output,
-                       const InitValueType initial_value,
-                       const size_t size,
-                       BinaryFunction reduce_op,
-                       const hipStream_t stream,
-                       bool debug_synchronous)
+template<bool WithInitialValue, // true when inital_value should be used in reduction
+         class Config,
+         class InputIterator,
+         class OutputIterator,
+         class InitValueType,
+         class BinaryFunction>
+inline hipError_t reduce_impl(void*               temporary_storage,
+                              size_t&             storage_size,
+                              InputIterator       input,
+                              OutputIterator      output,
+                              const InitValueType initial_value,
+                              const size_t        size,
+                              BinaryFunction      reduce_op,
+                              const hipStream_t   stream,
+                              bool                debug_synchronous)
 {
-    using input_type = typename std::iterator_traits<InputIterator>::value_type;
+    using input_type  = typename std::iterator_traits<InputIterator>::value_type;
     using result_type = ::rocprim::accumulator_t<BinaryFunction, input_type>;
 
     using config = wrapped_reduce_config<Config, result_type>;
@@ -126,10 +138,10 @@ hipError_t reduce_impl(void * temporary_storage,
     detail::target_arch target_arch;
     ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
 
-    const reduce_config_params params = dispatch_target_arch<config>(target_arch);
+    const reduce_config_params params = dispatch_target_arch<config, false>(target_arch);
 
-    const unsigned int block_size       = params.reduce_config.block_size;
-    const unsigned int items_per_thread = params.reduce_config.items_per_thread;
+    const unsigned int block_size       = params.kernel_config.block_size;
+    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
     const auto         items_per_block  = block_size * items_per_thread;
 
     const size_t number_of_blocks  = (size + items_per_block - 1) / items_per_block;
@@ -170,7 +182,7 @@ hipError_t reduce_impl(void * temporary_storage,
     // Start point for time measurements
     std::chrono::steady_clock::time_point start;
 
-    const auto size_limit             = params.reduce_config.size_limit;
+    const auto size_limit             = params.kernel_config.size_limit;
     const auto number_of_blocks_limit = ::rocprim::max<size_t>(size_limit / items_per_block, 1);
 
     if(debug_synchronous)
@@ -199,13 +211,13 @@ hipError_t reduce_impl(void * temporary_storage,
             {
                 start = std::chrono::steady_clock::now();
             }
-            block_reduce_kernel<false, true, 1, config, result_type>
-                <<<dim3(current_blocks), dim3(block_size), 0, stream>>>(
+            launch_block_reduce_for_arch<config, false, true, 1, result_type>
+                (target_arch,
                     input + offset,
                     current_size,
                     block_prefixes + i * number_of_blocks_limit,
                     initial_value,
-                    reduce_op);
+                    reduce_op,dim3(current_blocks), dim3(block_size), 0, stream);
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", current_size, start);
         }
 
@@ -306,7 +318,7 @@ hipError_t reduce_impl(void * temporary_storage,
 /// * By default, the input type is used for accumulation. A custom type
 /// can be specified using <tt>rocprim::transform_iterator</tt>, see the example below.
 ///
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `reduce_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam InputIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam OutputIterator random-access iterator type of the output range. Must meet the
@@ -455,7 +467,7 @@ inline hipError_t reduce(void*               temporary_storage,
 /// * By default, the input type is used for accumulation. A custom type
 /// can be specified using <tt>rocprim::transform_iterator</tt>, see the example below.
 ///
-/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `reduce_config`.
+/// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `kernel_config`.
 /// \tparam InputIterator random-access iterator type of the input range. Must meet the
 /// requirements of a C++ InputIterator concept. It can be a simple pointer type.
 /// \tparam OutputIterator random-access iterator type of the output range. Must meet the

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -74,7 +74,7 @@ inline hipError_t launch_block_reduce(detail::target_arch arch,
                                  ResultType>(input, size, output, initial_value, reduce_op);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 #define ROCPRIM_DETAIL_HIP_SYNC(name, size, start)                                           \

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -89,38 +89,34 @@ inline hipError_t launch_block_reduce(detail::target_arch arch,
         std::cout << " " << _d.count() * 1000 << " ms" << '\n';                              \
     }
 
-#define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                              \
-    do                                                                                           \
-    {                                                                                            \
-        detail::target_arch target_arch;                                                         \
-        hipError_t          result = detail::host_target_arch(stream, target_arch);              \
-        if(result != hipSuccess)                                                                 \
-        {                                                                                        \
-            return result;                                                                       \
-        }                                                                                        \
-        if(debug_synchronous)                                                                    \
-        {                                                                                        \
-            start = std::chrono::steady_clock::now();                                            \
-        }                                                                                        \
-                                                                                                 \
-        hipError_t launch_err                                                                    \
-            = launch_block_reduce<config, WithInitialValue, fit_larger, fit_items, result_type>( \
-                target_arch,                                                                     \
-                input,                                                                           \
-                size,                                                                            \
-                output,                                                                          \
-                initial_value,                                                                   \
-                reduce_op,                                                                       \
-                dim3(1),                                                                         \
-                dim3(block_size),                                                                \
-                0,                                                                               \
-                stream);                                                                         \
-        if(launch_err != hipSuccess)                                                             \
-        {                                                                                        \
-            return result;                                                                       \
-        }                                                                                        \
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);         \
-    }                                                                                            \
+#define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                            \
+    do                                                                                         \
+    {                                                                                          \
+        detail::target_arch target_arch;                                                       \
+        hipError_t          result = detail::host_target_arch(stream, target_arch);            \
+        if(result != hipSuccess)                                                               \
+        {                                                                                      \
+            return result;                                                                     \
+        }                                                                                      \
+        if(debug_synchronous)                                                                  \
+        {                                                                                      \
+            start = std::chrono::steady_clock::now();                                          \
+        }                                                                                      \
+                                                                                               \
+        ROCPRIM_RETURN_ON_ERROR(                                                               \
+            launch_block_reduce<config, WithInitialValue, fit_larger, fit_items, result_type>( \
+                target_arch,                                                                   \
+                input,                                                                         \
+                size,                                                                          \
+                output,                                                                        \
+                initial_value,                                                                 \
+                reduce_op,                                                                     \
+                dim3(1),                                                                       \
+                dim3(block_size),                                                              \
+                0,                                                                             \
+                stream));                                                                      \
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);       \
+    }                                                                                          \
     while(0)
 
 template<bool WithInitialValue, // true when inital_value should be used in reduction

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -55,7 +55,7 @@ template<class Config,
          class OutputIterator,
          class InitValueType,
          class BinaryFunction>
-inline hipError_t launch_block_reduce_for_arch(detail::target_arch arch,
+inline hipError_t launch_block_reduce(detail::target_arch arch,
                                                InputIterator       input,
                                                const size_t        size,
                                                OutputIterator      output,
@@ -96,23 +96,32 @@ inline hipError_t launch_block_reduce_for_arch(detail::target_arch arch,
     {                                                                                     \
         detail::target_arch target_arch;                                                  \
         hipError_t          result = detail::host_target_arch(stream, target_arch);       \
+        if(result != hipSuccess)                                                          \
+        {                                                                                 \
+            return result;                                                                \
+        }                                                                                 \
         if(debug_synchronous)                                                             \
         {                                                                                 \
             start = std::chrono::steady_clock::now();                                     \
         }                                                                                 \
                                                                                           \
-        launch_block_reduce_for_arch<config, WithInitialValue, fit_larger, fit_items, result_type> \
-            (target_arch,                                                                          \
-             input,                                                                                \
-             size,                                                                                 \
-             output,                                                                               \
-             initial_value,                                                                        \
-             reduce_op,                                                                            \
-             dim3(1),                                                                              \
-             dim3(block_size), 0, stream);                                                         \
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);           \
-    }                                                                                              \
-    while(0)                                                                                       \
+        hipError_t launch_err =                                                                        \
+            launch_block_reduce<config, WithInitialValue, fit_larger, fit_items, result_type> \
+                (target_arch,                                                                          \
+                input,                                                                                \
+                size,                                                                                 \
+                output,                                                                               \
+                initial_value,                                                                        \
+                reduce_op,                                                                            \
+                dim3(1),                                                                              \
+                dim3(block_size), 0, stream);                                                         \
+        if(launch_err != hipSuccess)                                                                  \
+        {                                                                                             \
+            return result;                                                                            \
+        }                                                                                             \
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);              \
+    }                                                                                                 \
+    while(0)                                                                                          \
 
 template<bool WithInitialValue, // true when inital_value should be used in reduction
          class Config,
@@ -211,7 +220,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             {
                 start = std::chrono::steady_clock::now();
             }
-            const hipError_t error = launch_block_reduce_for_arch<config, false, true, 1, result_type>
+            const hipError_t error = launch_block_reduce<config, false, true, 1, result_type>
                 (target_arch,
                     input + offset,
                     current_size,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -103,7 +103,7 @@ inline hipError_t launch_block_reduce_for_arch(detail::target_arch arch,
                                                                                           \
         launch_block_reduce_for_arch<config, WithInitialValue, fit_larger, fit_items, result_type> \
             (target_arch,                                                                          \
-             input,                                                                               \
+             input,                                                                                \
              size,                                                                                 \
              output,                                                                               \
              initial_value,                                                                        \
@@ -211,13 +211,18 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             {
                 start = std::chrono::steady_clock::now();
             }
-            launch_block_reduce_for_arch<config, false, true, 1, result_type>
+            const hipError_t error = launch_block_reduce_for_arch<config, false, true, 1, result_type>
                 (target_arch,
                     input + offset,
                     current_size,
                     block_prefixes + i * number_of_blocks_limit,
                     initial_value,
                     reduce_op,dim3(current_blocks), dim3(block_size), 0, stream);
+
+            if(error != hipSuccess)
+            {
+                return error;
+            }
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", current_size, start);
         }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -139,7 +139,7 @@ inline hipError_t launch_reduce_by_key(detail::target_arch          arch,
                                                                        previous_accumulated);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<lookback_scan_determinism Determinism,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -92,8 +92,8 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
     init_lookback_scan_state(lookback_scan_state, number_of_blocks, flat_thread_id);
 }
 
-template<lookback_scan_determinism Determinism,
-         typename Config,
+template<typename Config,
+         lookback_scan_determinism Determinism,
          typename AccumulatorType,
          typename KeyIterator,
          typename ValueIterator,
@@ -103,34 +103,43 @@ template<lookback_scan_determinism Determinism,
          typename CompareFunction,
          typename BinaryOp,
          typename LookbackScanState>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    reduce_by_key_kernel(const KeyIterator            keys_input,
-                         const ValueIterator          values_input,
-                         const UniqueIterator         unique_keys,
-                         const ReductionIterator      reductions,
-                         const UniqueCountIterator    unique_count,
-                         const BinaryOp               reduce_op,
-                         const CompareFunction        compare,
-                         const LookbackScanState      scan_state,
-                         const std::size_t            starting_block,
-                         const std::size_t            total_number_of_blocks,
-                         const std::size_t            size,
-                         const std::size_t* const     global_head_count,
-                         const AccumulatorType* const previous_accumulated)
+inline hipError_t launch_reduce_by_key(detail::target_arch          arch,
+                                       const KeyIterator            keys_input,
+                                       const ValueIterator          values_input,
+                                       const UniqueIterator         unique_keys,
+                                       const ReductionIterator      reductions,
+                                       const UniqueCountIterator    unique_count,
+                                       const BinaryOp               reduce_op,
+                                       const CompareFunction        compare,
+                                       const LookbackScanState      scan_state,
+                                       const std::size_t            starting_block,
+                                       const std::size_t            total_number_of_blocks,
+                                       const std::size_t            size,
+                                       const std::size_t* const     global_head_count,
+                                       const AccumulatorType* const previous_accumulated,
+                                       dim3                         grid,
+                                       dim3                         block,
+                                       size_t                       shmem,
+                                       hipStream_t                  stream)
 {
-    reduce_by_key::kernel_impl<Determinism, Config>(keys_input,
-                                                    values_input,
-                                                    unique_keys,
-                                                    reductions,
-                                                    unique_count,
-                                                    reduce_op,
-                                                    compare,
-                                                    scan_state,
-                                                    starting_block,
-                                                    total_number_of_blocks,
-                                                    size,
-                                                    global_head_count,
-                                                    previous_accumulated);
+    auto kernel = [=] __device__ (auto arch_config)
+    {
+        reduce_by_key::kernel_impl<decltype(arch_config), Determinism>(keys_input,
+                                                                       values_input,
+                                                                       unique_keys,
+                                                                       reductions,
+                                                                       unique_count,
+                                                                       reduce_op,
+                                                                       compare,
+                                                                       scan_state,
+                                                                       starting_block,
+                                                                       total_number_of_blocks,
+                                                                       size,
+                                                                       global_head_count,
+                                                                       previous_accumulated);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<lookback_scan_determinism Determinism,
@@ -162,7 +171,7 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
     {
         return result;
     }
-    const reduce_by_key_config_params params = dispatch_target_arch<config>(target_arch);
+    const reduce_by_key_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     using scan_state_type
         = reduce_by_key::lookback_scan_state_t<accumulator_type, /*UseSleep=*/false>;
@@ -309,21 +318,25 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
         with_scan_state(
             [&](const auto scan_state)
             {
-                reduce_by_key_kernel<Determinism, config>
-                    <<<dim3(number_of_blocks_launch), dim3(block_size), 0, stream>>>(
-                        keys_input + offset,
-                        values_input + offset,
-                        unique_output,
-                        aggregates_output,
-                        unique_count_output,
-                        reduce_op,
-                        key_compare_op,
-                        scan_state,
-                        i * number_of_blocks,
-                        total_number_of_blocks,
-                        size,
-                        i > 0 ? d_global_head_count : nullptr,
-                        i > 0 ? d_previous_accumulated : nullptr);
+                hipError_t launch_err = launch_reduce_by_key<config, Determinism>(
+                    target_arch,
+                    keys_input + offset,
+                    values_input + offset,
+                    unique_output,
+                    aggregates_output,
+                    unique_count_output,
+                    reduce_op,
+                    key_compare_op,
+                    scan_state,
+                    i * number_of_blocks,
+                    total_number_of_blocks,
+                    size,
+                    i > 0 ? d_global_head_count : nullptr,
+                    i > 0 ? d_previous_accumulated : nullptr,
+                    dim3(number_of_blocks_launch),
+                    dim3(block_size),
+                    0,
+                    stream);
             });
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_kernel", current_size, start);
     }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -122,7 +122,7 @@ inline hipError_t launch_reduce_by_key(detail::target_arch          arch,
                                        size_t                       shmem,
                                        hipStream_t                  stream)
 {
-    auto kernel = [=] __device__ (auto arch_config)
+    auto kernel = [=](auto arch_config)
     {
         reduce_by_key::kernel_impl<decltype(arch_config), Determinism>(keys_input,
                                                                        values_input,
@@ -315,10 +315,10 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
                                                     number_of_blocks_launch,
                                                     start);
 
-        with_scan_state(
+        ROCPRIM_RETURN_ON_ERROR(with_scan_state(
             [&](const auto scan_state)
             {
-                hipError_t launch_err = launch_reduce_by_key<config, Determinism>(
+                return launch_reduce_by_key<config, Determinism>(
                     target_arch,
                     keys_input + offset,
                     values_input + offset,
@@ -337,7 +337,7 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
                     dim3(block_size),
                     0,
                     stream);
-            });
+            }));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_kernel", current_size, start);
     }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
@@ -100,22 +100,32 @@ template<typename Config,
          typename CountsOutputIterator,
          typename RunsCountOutputIterator,
          typename LookbackScanState>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    non_trivial_kernel(const InputIterator           input,
-                       const OffsetsOutputIterator   offsets_output,
-                       const CountsOutputIterator    counts_output,
-                       const RunsCountOutputIterator runs_count_output,
-                       const LookbackScanState       scan_state,
-                       const std::size_t             grid_size,
-                       const std::size_t             size)
+inline hipError_t launch_non_trivial(detail::target_arch           arch,
+                                     const InputIterator           input,
+                                     const OffsetsOutputIterator   offsets_output,
+                                     const CountsOutputIterator    counts_output,
+                                     const RunsCountOutputIterator runs_count_output,
+                                     const LookbackScanState       scan_state,
+                                     const std::size_t             grid_size,
+                                     const std::size_t             size,
+                                     dim3                          grid,
+                                     dim3                          block,
+                                     size_t                        shmem,
+                                     hipStream_t                   stream)
 {
-    run_length_encode::non_trivial_kernel_impl<Config, OffsetCountPairType>(input,
-                                                                            offsets_output,
-                                                                            counts_output,
-                                                                            runs_count_output,
-                                                                            scan_state,
-                                                                            grid_size,
-                                                                            size);
+    auto kernel = [=] __device__ (auto arch_config)
+    {
+    run_length_encode::non_trivial_kernel_impl<decltype(arch_config), OffsetCountPairType>(
+        input,
+        offsets_output,
+        counts_output,
+        runs_count_output,
+        scan_state,
+        grid_size,
+        size);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<typename Config,
@@ -149,7 +159,7 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
     detail::target_arch target_arch;
     ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
 
-    const non_trivial_runs_config_params params     = dispatch_target_arch<config>(target_arch);
+    const non_trivial_runs_config_params params = dispatch_target_arch<config, false>(target_arch);
     const unsigned int                   block_size = params.kernel_config.block_size;
     const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
     const std::size_t  grid_size       = detail::ceiling_div(size, items_per_block);
@@ -177,11 +187,12 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
 
     scan_state_type            scan_state{};
     scan_state_with_sleep_type scan_state_with_sleep{};
-    ROCPRIM_RETURN_ON_ERROR(scan_state_type::create(scan_state, scan_state_storage, grid_size, stream));
+    ROCPRIM_RETURN_ON_ERROR(
+        scan_state_type::create(scan_state, scan_state_storage, grid_size, stream));
     ROCPRIM_RETURN_ON_ERROR(scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                       scan_state_storage,
-                                                       grid_size,
-                                                       stream));
+                                                               scan_state_storage,
+                                                               grid_size,
+                                                               stream));
 
     auto with_scan_state
         = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
@@ -238,20 +249,20 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
     with_scan_state(
         [&](const auto scan_state)
         {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(
-                    run_length_encode::non_trivial_kernel<config, offset_count_pair_type>),
-                dim3(grid_size),
-                dim3(block_size),
-                0,
-                stream,
-                input + 0,
-                offsets_output,
-                counts_output,
-                runs_count_output,
-                scan_state,
-                grid_size,
-                size);
+            hipError_t launch_err
+                = run_length_encode::launch_non_trivial<config, offset_count_pair_type>(
+                    target_arch,
+                    input + 0,
+                    offsets_output,
+                    counts_output,
+                    runs_count_output,
+                    scan_state,
+                    grid_size,
+                    size,
+                    dim3(grid_size),
+                    dim3(block_size),
+                    0,
+                    stream);
         });
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("run_length_encode::non_trivial_kernel",
                                                 size,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
@@ -125,7 +125,7 @@ inline hipError_t launch_non_trivial(detail::target_arch           arch,
             size);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<typename Config,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
@@ -113,16 +113,16 @@ inline hipError_t launch_non_trivial(detail::target_arch           arch,
                                      size_t                        shmem,
                                      hipStream_t                   stream)
 {
-    auto kernel = [=] __device__ (auto arch_config)
+    auto kernel = [=](auto arch_config)
     {
-    run_length_encode::non_trivial_kernel_impl<decltype(arch_config), OffsetCountPairType>(
-        input,
-        offsets_output,
-        counts_output,
-        runs_count_output,
-        scan_state,
-        grid_size,
-        size);
+        run_length_encode::non_trivial_kernel_impl<decltype(arch_config), OffsetCountPairType>(
+            input,
+            offsets_output,
+            counts_output,
+            runs_count_output,
+            scan_state,
+            grid_size,
+            size);
     };
 
     return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
@@ -246,24 +246,23 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
                                                 grid_size,
                                                 start);
 
-    with_scan_state(
+    ROCPRIM_RETURN_ON_ERROR(with_scan_state(
         [&](const auto scan_state)
         {
-            hipError_t launch_err
-                = run_length_encode::launch_non_trivial<config, offset_count_pair_type>(
-                    target_arch,
-                    input + 0,
-                    offsets_output,
-                    counts_output,
-                    runs_count_output,
-                    scan_state,
-                    grid_size,
-                    size,
-                    dim3(grid_size),
-                    dim3(block_size),
-                    0,
-                    stream);
-        });
+            return run_length_encode::launch_non_trivial<config, offset_count_pair_type>(
+                target_arch,
+                input + 0,
+                offsets_output,
+                counts_output,
+                runs_count_output,
+                scan_state,
+                grid_size,
+                size,
+                dim3(grid_size),
+                dim3(block_size),
+                0,
+                stream);
+        }));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("run_length_encode::non_trivial_kernel",
                                                 size,
                                                 start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
@@ -47,9 +47,9 @@ namespace detail
 {
 
 // Single kernel scan (performs scan on one thread block only)
-template<bool Exclusive,
+template<class ArchConfig,
+         bool Exclusive,
          bool UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
@@ -60,7 +60,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void single_scan_kernel_impl(InputIterator  
                                                                  OutputIterator output,
                                                                  BinaryFunction scan_op)
 {
-    static constexpr scan_config_params params = device_params<Config>();
+    static constexpr scan_config_params params = ArchConfig::params;
 
     constexpr unsigned int block_size       = params.kernel_config.block_size;
     constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -94,66 +94,83 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void single_scan_kernel_impl(InputIterator  
     block_store_type().store(output, values, input_size, storage.store);
 }
 
-template<bool Exclusive,
+template<class Config,
+         bool Exclusive,
          bool UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
          class InitValueType,
          class AccType>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    single_scan_kernel(InputIterator       input,
-                       const size_t        size,
-                       const InitValueType initial_value,
-                       OutputIterator      output,
-                       BinaryFunction      scan_op)
+inline hipError_t launch_single_scan(detail::target_arch arch,
+                                     InputIterator       input,
+                                     const size_t        size,
+                                     const InitValueType initial_value,
+                                     OutputIterator      output,
+                                     BinaryFunction      scan_op,
+                                     dim3                grid,
+                                     dim3                block,
+                                     size_t              shmem,
+                                     hipStream_t         stream)
 {
-    single_scan_kernel_impl<Exclusive, UseInitialValue, Config>(
-        input,
-        size,
-        static_cast<AccType>(get_input_value(initial_value)),
-        output,
-        scan_op);
+    auto kernel = [=](auto arch_config)
+    {
+        single_scan_kernel_impl<decltype(arch_config), Exclusive, UseInitialValue>(
+            input,
+            size,
+            static_cast<AccType>(get_input_value(initial_value)),
+            output,
+            scan_op);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 // Single pass (look-back kernels)
-
-template<lookback_scan_determinism Determinism,
+template<class Config,
+         lookback_scan_determinism Determinism,
          bool                      Exclusive,
          bool                      UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
          class InitValueType,
          class AccType,
          class LookBackScanState>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    lookback_scan_kernel(InputIterator      input,
-                         OutputIterator     output,
-                         const size_t       size,
-                         InitValueType      initial_value,
-                         BinaryFunction     scan_op,
-                         LookBackScanState  lookback_scan_state,
-                         const unsigned int number_of_blocks,
-                         AccType*           previous_last_element = nullptr,
-                         AccType*           new_last_element      = nullptr,
-                         bool               override_first_value  = false,
-                         bool               save_last_value       = false)
+inline hipError_t launch_lookback_scan(detail::target_arch arch,
+                                       InputIterator       input,
+                                       OutputIterator      output,
+                                       const size_t        size,
+                                       InitValueType       initial_value,
+                                       BinaryFunction      scan_op,
+                                       LookBackScanState   lookback_scan_state,
+                                       const unsigned int  number_of_blocks,
+                                       dim3                grid,
+                                       dim3                block,
+                                       size_t              shmem,
+                                       hipStream_t         stream,
+                                       AccType*            previous_last_element = nullptr,
+                                       AccType*            new_last_element      = nullptr,
+                                       bool                override_first_value  = false,
+                                       bool                save_last_value       = false)
 {
-    lookback_scan_kernel_impl<Determinism, Exclusive, UseInitialValue, Config>(
-        input,
-        output,
-        size,
-        static_cast<AccType>(get_input_value(initial_value)),
-        scan_op,
-        lookback_scan_state,
-        number_of_blocks,
-        previous_last_element,
-        new_last_element,
-        override_first_value,
-        save_last_value);
+    auto kernel = [=](auto arch_config)
+    {
+        lookback_scan_kernel_impl<decltype(arch_config), Determinism, Exclusive, UseInitialValue>(
+            input,
+            output,
+            size,
+            static_cast<AccType>(get_input_value(initial_value)),
+            scan_op,
+            lookback_scan_state,
+            number_of_blocks,
+            previous_last_element,
+            new_last_element,
+            override_first_value,
+            save_last_value);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<lookback_scan_determinism Determinism,
@@ -183,7 +200,7 @@ inline auto scan_impl(void*               temporary_storage,
     {
         return result;
     }
-    const scan_config_params params = dispatch_target_arch<config>(target_arch);
+    const scan_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     using scan_state_type            = detail::lookback_scan_state<AccType>;
     using scan_state_with_sleep_type = detail::lookback_scan_state<AccType, true>;
@@ -318,30 +335,34 @@ inline auto scan_impl(void*               temporary_storage,
                 std::cout << "items_per_block " << items_per_block << '\n';
             }
 
-            with_scan_state(
+            ROCPRIM_RETURN_ON_ERROR(with_scan_state(
                 [&](const auto scan_state)
                 {
-                    lookback_scan_kernel<Determinism,
-                                         Exclusive,
-                                         UseInitialValue,
-                                         config,
-                                         InputIterator,
-                                         OutputIterator,
-                                         BinaryFunction,
-                                         InitValueType,
-                                         AccType>
-                        <<<dim3(grid_size), dim3(block_size), 0, stream>>>(input + offset,
-                                                                           output + offset,
-                                                                           current_size,
-                                                                           initial_value,
-                                                                           scan_op,
-                                                                           scan_state,
-                                                                           number_of_blocks,
-                                                                           previous_last_element,
-                                                                           new_last_element,
-                                                                           i != size_t(0),
-                                                                           number_of_launch > 1);
-                });
+                    return launch_lookback_scan<config,
+                                                Determinism,
+                                                Exclusive,
+                                                UseInitialValue,
+                                                InputIterator,
+                                                OutputIterator,
+                                                BinaryFunction,
+                                                InitValueType,
+                                                AccType>(target_arch,
+                                                         input + offset,
+                                                         output + offset,
+                                                         current_size,
+                                                         initial_value,
+                                                         scan_op,
+                                                         scan_state,
+                                                         number_of_blocks,
+                                                         dim3(grid_size),
+                                                         dim3(block_size),
+                                                         0,
+                                                         stream,
+                                                         previous_last_element,
+                                                         new_last_element,
+                                                         i != size_t(0),
+                                                         number_of_launch > 1);
+                }));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("lookback_scan_kernel",
                                                         current_size,
                                                         start);
@@ -349,14 +370,12 @@ inline auto scan_impl(void*               temporary_storage,
             // Swap the last_elements
             if(number_of_launch > 1)
             {
-                hipError_t error = ::rocprim::transform(new_last_element,
-                                                        previous_last_element,
-                                                        1,
-                                                        ::rocprim::identity<AccType>(),
-                                                        stream,
-                                                        debug_synchronous);
-                if(error != hipSuccess)
-                    return error;
+                ROCPRIM_RETURN_ON_ERROR(::rocprim::transform(new_last_element,
+                                                             previous_last_element,
+                                                             1,
+                                                             ::rocprim::identity<AccType>(),
+                                                             stream,
+                                                             debug_synchronous));
             }
         }
     }
@@ -371,15 +390,23 @@ inline auto scan_impl(void*               temporary_storage,
             start = std::chrono::steady_clock::now();
         }
 
-        single_scan_kernel<Exclusive, // flag for exclusive scan operation
-                           UseInitialValue,
-                           config,
-                           InputIterator,
-                           OutputIterator,
-                           BinaryFunction,
-                           InitValueType,
-                           AccType>
-            <<<dim3(1), dim3(block_size), 0, stream>>>(input, size, initial_value, output, scan_op);
+        ROCPRIM_RETURN_ON_ERROR(launch_single_scan<config,
+                                                   Exclusive, // flag for exclusive scan operation
+                                                   UseInitialValue,
+                                                   InputIterator,
+                                                   OutputIterator,
+                                                   BinaryFunction,
+                                                   InitValueType,
+                                                   AccType>(target_arch,
+                                                            input,
+                                                            size,
+                                                            initial_value,
+                                                            output,
+                                                            scan_op,
+                                                            dim3(1),
+                                                            dim3(block_size),
+                                                            0,
+                                                            stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("single_scan_kernel", size, start);
     }
     return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
@@ -123,7 +123,7 @@ inline hipError_t launch_single_scan(detail::target_arch arch,
             scan_op);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 // Single pass (look-back kernels)
@@ -170,7 +170,7 @@ inline hipError_t launch_lookback_scan(detail::target_arch arch,
             save_last_value);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<lookback_scan_determinism Determinism,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
@@ -520,7 +520,8 @@ inline hipError_t inclusive_scan(void*             temporary_storage,
 {
     // AccType may be const or a reference. Get the non-const, non-reference type.
     // This is necessary because we may need to assign to instances of this type or create pointers to it.
-    using safe_acc_type = typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
+    using safe_acc_type =
+        typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
 
     // input_type() is a dummy initial value (not used)
     return detail::scan_impl<detail::lookback_scan_determinism::default_determinism,
@@ -727,7 +728,8 @@ inline hipError_t deterministic_inclusive_scan(void*             temporary_stora
 {
     // AccType may be const or a reference. Get the non-const, non-reference type.
     // This is necessary because we may need to assign to instances of this type or create pointers to it.
-    using safe_acc_type = typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
+    using safe_acc_type =
+        typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
 
     return detail::scan_impl<detail::lookback_scan_determinism::deterministic,
                              false,
@@ -855,7 +857,7 @@ inline hipError_t deterministic_inclusive_scan(void*             temporary_stora
 ///
 /// // custom scan function
 /// auto min_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a < b ? a : b;
 ///     };
@@ -905,7 +907,8 @@ inline hipError_t exclusive_scan(void*               temporary_storage,
 {
     // AccType may be const or a reference. Get the non-const, non-reference type.
     // This is necessary because we may need to assign to instances of this type or create pointers to it.
-    using safe_acc_type = typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
+    using safe_acc_type =
+        typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
 
     return detail::scan_impl<detail::lookback_scan_determinism::default_determinism,
                              true,
@@ -953,7 +956,8 @@ inline hipError_t deterministic_exclusive_scan(void*               temporary_sto
 {
     // AccType may be const or a reference. Get the non-const, non-reference type.
     // This is necessary because we may need to assign to instances of this type or create pointers to it.
-    using safe_acc_type = typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
+    using safe_acc_type =
+        typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
 
     return detail::scan_impl<detail::lookback_scan_determinism::deterministic,
                              true,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -92,7 +92,7 @@ inline hipError_t
             previous_last_value);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<lookback_scan_determinism Determinism,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -21,8 +21,8 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_SCAN_BY_KEY_HPP_
 #define ROCPRIM_DEVICE_DEVICE_SCAN_BY_KEY_HPP_
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/temp_storage.hpp"
 #include "../detail/various.hpp"
 #include "../functional.hpp"
@@ -46,9 +46,9 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<lookback_scan_determinism Determinism,
+template<typename Config,
+         lookback_scan_determinism Determinism,
          bool                      Exclusive,
-         typename Config,
          typename KeyInputIterator,
          typename InputIterator,
          typename OutputIterator,
@@ -57,8 +57,9 @@ template<lookback_scan_determinism Determinism,
          typename BinaryFunction,
          typename LookbackScanState,
          typename AccType>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    device_scan_by_key_kernel(const KeyInputIterator                       keys,
+inline hipError_t
+    launch_device_scan_by_key(detail::target_arch                          arch,
+                              const KeyInputIterator                       keys,
                               const InputIterator                          values,
                               const OutputIterator                         output,
                               const InitialValueType                       initial_value,
@@ -68,22 +69,31 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block
                               const size_t                                 size,
                               const size_t                                 starting_block,
                               const size_t                                 number_of_blocks,
-                              const ::rocprim::tuple<AccType, bool>* const previous_last_value)
+                              const ::rocprim::tuple<AccType, bool>* const previous_last_value,
+                              dim3                                         grid,
+                              dim3                                         block,
+                              size_t                                       shmem,
+                              hipStream_t                                  stream)
 {
-    device_scan_by_key_kernel_impl<Determinism, Exclusive, Config>(
-        keys,
-        values,
-        output,
-        static_cast<AccType>(get_input_value(initial_value)),
-        compare,
-        scan_op,
-        scan_state,
-        size,
-        starting_block,
-        number_of_blocks,
-        previous_last_value);
-}
 
+    auto kernel = [=](auto arch_config)
+    {
+        device_scan_by_key_kernel_impl<decltype(arch_config), Determinism, Exclusive>(
+            keys,
+            values,
+            output,
+            static_cast<AccType>(get_input_value(initial_value)),
+            compare,
+            scan_op,
+            scan_state,
+            size,
+            starting_block,
+            number_of_blocks,
+            previous_last_value);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+}
 
 template<lookback_scan_determinism Determinism,
          bool                      Exclusive,
@@ -117,7 +127,7 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
     {
         return result;
     }
-    const scan_by_key_config_params params = dispatch_target_arch<config>(target_arch);
+    const scan_by_key_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     using wrapped_type = ::rocprim::tuple<AccType, bool>;
 
@@ -260,15 +270,11 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
         {
             start = std::chrono::steady_clock::now();
         }
-        with_scan_state(
+        ROCPRIM_RETURN_ON_ERROR(with_scan_state(
             [&](auto& scan_state)
             {
-                hipLaunchKernelGGL(
-                    HIP_KERNEL_NAME(device_scan_by_key_kernel<Determinism, Exclusive, config>),
-                    dim3(scan_blocks),
-                    dim3(block_size),
-                    0,
-                    stream,
+                return launch_device_scan_by_key<config, Determinism, Exclusive>(
+                    target_arch,
                     keys + offset,
                     input + offset,
                     output + offset,
@@ -279,8 +285,12 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                     size,
                     i * number_of_blocks,
                     total_number_of_blocks,
-                    i > 0 ? as_const_ptr(previous_last_value) : nullptr);
-            });
+                    i > 0 ? as_const_ptr(previous_last_value) : nullptr,
+                    dim3(scan_blocks),
+                    dim3(block_size),
+                    0,
+                    stream);
+            }));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
                                                     current_size,
                                                     start);
@@ -288,8 +298,7 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
     return hipSuccess;
 }
 
-
-}
+} // namespace detail
 
 /// \addtogroup devicemodule
 /// @{

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
@@ -93,7 +93,7 @@ inline hipError_t launch_segmented_sort(
                                                           end_bit);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,
@@ -141,7 +141,7 @@ inline hipError_t launch_segmented_sort_large(
                                                                 end_bit);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,
@@ -189,14 +189,14 @@ inline hipError_t launch_segmented_sort_small(
                                                                 end_bit);
     };
 
-    return launch_kernel<Config,
-                         decltype(kernel),
-                         segmented_radix_sort_warp_sort_small_config_selector>(arch,
-                                                                               kernel,
-                                                                               grid,
-                                                                               block,
-                                                                               shmem,
-                                                                               stream);
+    return execute_launch_plan<Config,
+                               decltype(kernel),
+                               segmented_radix_sort_warp_sort_small_config_selector>(arch,
+                                                                                     kernel,
+                                                                                     grid,
+                                                                                     block,
+                                                                                     shmem,
+                                                                                     stream);
 }
 
 template<class Config,
@@ -244,14 +244,14 @@ inline hipError_t launch_segmented_sort_medium(
                                                                  end_bit);
     };
 
-    return launch_kernel<Config,
-                         decltype(kernel),
-                         segmented_radix_sort_warp_sort_meduim_config_selector>(arch,
-                                                                                kernel,
-                                                                                grid,
-                                                                                block,
-                                                                                shmem,
-                                                                                stream);
+    return execute_launch_plan<Config,
+                               decltype(kernel),
+                               segmented_radix_sort_warp_sort_meduim_config_selector>(arch,
+                                                                                      kernel,
+                                                                                      grid,
+                                                                                      block,
+                                                                                      shmem,
+                                                                                      stream);
 }
 
 struct Partitioner

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
@@ -27,13 +27,13 @@
 #include <utility>
 #include <vector>
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/various.hpp"
 #include "config_types.hpp"
 
-#include "../intrinsics.hpp"
 #include "../functional.hpp"
+#include "../intrinsics.hpp"
 #include "../types.hpp"
 
 #include "../block/block_load.hpp"
@@ -58,8 +58,8 @@ template<class Config,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class OffsetIterator>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void segmented_sort_kernel(
+inline hipError_t launch_segmented_sort(
+    detail::target_arch                                             arch,
     KeysInputIterator                                               keys_input,
     typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
     KeysOutputIterator                                              keys_output,
@@ -71,20 +71,29 @@ ROCPRIM_KERNEL
     OffsetIterator                                                  end_offsets,
     unsigned int                                                    iterations,
     unsigned int                                                    begin_bit,
-    unsigned int                                                    end_bit)
+    unsigned int                                                    end_bit,
+    dim3                                                            grid,
+    dim3                                                            block,
+    size_t                                                          shmem,
+    hipStream_t                                                     stream)
 {
-    segmented_sort<Config, Descending>(keys_input,
-                                       keys_tmp,
-                                       keys_output,
-                                       values_input,
-                                       values_tmp,
-                                       values_output,
-                                       to_output,
-                                       begin_offsets,
-                                       end_offsets,
-                                       iterations,
-                                       begin_bit,
-                                       end_bit);
+    auto kernel = [=](auto arch_config)
+    {
+        segmented_sort<decltype(arch_config), Descending>(keys_input,
+                                                          keys_tmp,
+                                                          keys_output,
+                                                          values_input,
+                                                          values_tmp,
+                                                          values_output,
+                                                          to_output,
+                                                          begin_offsets,
+                                                          end_offsets,
+                                                          iterations,
+                                                          begin_bit,
+                                                          end_bit);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,
@@ -95,38 +104,44 @@ template<class Config,
          class ValuesOutputIterator,
          class SegmentIndexIterator,
          class OffsetIterator>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(
-    device_params<Config>()
-        .kernel_config
-        .block_size) void
-    segmented_sort_large_kernel(
-        KeysInputIterator                                               keys_input,
-        typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
-        KeysOutputIterator                                              keys_output,
-        ValuesInputIterator                                             values_input,
-        typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
-        ValuesOutputIterator                                            values_output,
-        bool                                                            to_output,
-        SegmentIndexIterator                                            segment_indices,
-        OffsetIterator                                                  begin_offsets,
-        OffsetIterator                                                  end_offsets,
-        unsigned int                                                    iterations,
-        unsigned int                                                    begin_bit,
-        unsigned int                                                    end_bit)
+inline hipError_t launch_segmented_sort_large(
+    detail::target_arch                                             arch,
+    KeysInputIterator                                               keys_input,
+    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
+    KeysOutputIterator                                              keys_output,
+    ValuesInputIterator                                             values_input,
+    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
+    ValuesOutputIterator                                            values_output,
+    bool                                                            to_output,
+    SegmentIndexIterator                                            segment_indices,
+    OffsetIterator                                                  begin_offsets,
+    OffsetIterator                                                  end_offsets,
+    unsigned int                                                    iterations,
+    unsigned int                                                    begin_bit,
+    unsigned int                                                    end_bit,
+    dim3                                                            grid,
+    dim3                                                            block,
+    size_t                                                          shmem,
+    hipStream_t                                                     stream)
 {
-    segmented_sort_large<Config, Descending>(keys_input,
-                                             keys_tmp,
-                                             keys_output,
-                                             values_input,
-                                             values_tmp,
-                                             values_output,
-                                             to_output,
-                                             segment_indices,
-                                             begin_offsets,
-                                             end_offsets,
-                                             iterations,
-                                             begin_bit,
-                                             end_bit);
+    auto kernel = [=](auto arch_config)
+    {
+        segmented_sort_large<decltype(arch_config), Descending>(keys_input,
+                                                                keys_tmp,
+                                                                keys_output,
+                                                                values_input,
+                                                                values_tmp,
+                                                                values_output,
+                                                                to_output,
+                                                                segment_indices,
+                                                                begin_offsets,
+                                                                end_offsets,
+                                                                iterations,
+                                                                begin_bit,
+                                                                end_bit);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,
@@ -137,31 +152,51 @@ template<class Config,
          class ValuesOutputIterator,
          class SegmentIndexIterator,
          class OffsetIterator>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(
-    device_params<Config>()
-        .warp_sort_config
-        .block_size_small) void
-    segmented_sort_small_kernel(
-        KeysInputIterator                                               keys_input,
-        typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
-        KeysOutputIterator                                              keys_output,
-        ValuesInputIterator                                             values_input,
-        typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
-        ValuesOutputIterator                                            values_output,
-        bool                                                            to_output,
-        unsigned int                                                    num_segments,
-        SegmentIndexIterator                                            segment_indices,
-        OffsetIterator                                                  begin_offsets,
-        OffsetIterator                                                  end_offsets,
-        unsigned int                                                    begin_bit,
-        unsigned int                                                    end_bit)
+inline hipError_t launch_segmented_sort_small(
+    detail::target_arch                                             arch,
+    KeysInputIterator                                               keys_input,
+    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
+    KeysOutputIterator                                              keys_output,
+    ValuesInputIterator                                             values_input,
+    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
+    ValuesOutputIterator                                            values_output,
+    bool                                                            to_output,
+    unsigned int                                                    num_segments,
+    SegmentIndexIterator                                            segment_indices,
+    OffsetIterator                                                  begin_offsets,
+    OffsetIterator                                                  end_offsets,
+    unsigned int                                                    begin_bit,
+    unsigned int                                                    end_bit,
+    dim3                                                            grid,
+    dim3                                                            block,
+    size_t                                                          shmem,
+    hipStream_t                                                     stream)
 {
-    segmented_sort_small<Config, Descending>(
-        keys_input, keys_tmp, keys_output, values_input, values_tmp, values_output,
-        to_output, num_segments, segment_indices,
-        begin_offsets, end_offsets,
-        begin_bit, end_bit
-    );
+    auto kernel = [=](auto arch_config)
+    {
+        segmented_sort_small<decltype(arch_config), Descending>(keys_input,
+                                                                keys_tmp,
+                                                                keys_output,
+                                                                values_input,
+                                                                values_tmp,
+                                                                values_output,
+                                                                to_output,
+                                                                num_segments,
+                                                                segment_indices,
+                                                                begin_offsets,
+                                                                end_offsets,
+                                                                begin_bit,
+                                                                end_bit);
+    };
+
+    return launch_kernel<Config,
+                         decltype(kernel),
+                         segmented_radix_sort_warp_sort_small_config_selector>(arch,
+                                                                               kernel,
+                                                                               grid,
+                                                                               block,
+                                                                               shmem,
+                                                                               stream);
 }
 
 template<class Config,
@@ -172,38 +207,51 @@ template<class Config,
          class ValuesOutputIterator,
          class SegmentIndexIterator,
          class OffsetIterator>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(
-    device_params<Config>()
-        .warp_sort_config
-        .block_size_medium) void
-    segmented_sort_medium_kernel(
-        KeysInputIterator                                               keys_input,
-        typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
-        KeysOutputIterator                                              keys_output,
-        ValuesInputIterator                                             values_input,
-        typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
-        ValuesOutputIterator                                            values_output,
-        bool                                                            to_output,
-        unsigned int                                                    num_segments,
-        SegmentIndexIterator                                            segment_indices,
-        OffsetIterator                                                  begin_offsets,
-        OffsetIterator                                                  end_offsets,
-        unsigned int                                                    begin_bit,
-        unsigned int                                                    end_bit)
+inline hipError_t launch_segmented_sort_medium(
+    detail::target_arch                                             arch,
+    KeysInputIterator                                               keys_input,
+    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
+    KeysOutputIterator                                              keys_output,
+    ValuesInputIterator                                             values_input,
+    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
+    ValuesOutputIterator                                            values_output,
+    bool                                                            to_output,
+    unsigned int                                                    num_segments,
+    SegmentIndexIterator                                            segment_indices,
+    OffsetIterator                                                  begin_offsets,
+    OffsetIterator                                                  end_offsets,
+    unsigned int                                                    begin_bit,
+    unsigned int                                                    end_bit,
+    dim3                                                            grid,
+    dim3                                                            block,
+    size_t                                                          shmem,
+    hipStream_t                                                     stream)
 {
-    segmented_sort_medium<Config, Descending>(keys_input,
-                                              keys_tmp,
-                                              keys_output,
-                                              values_input,
-                                              values_tmp,
-                                              values_output,
-                                              to_output,
-                                              num_segments,
-                                              segment_indices,
-                                              begin_offsets,
-                                              end_offsets,
-                                              begin_bit,
-                                              end_bit);
+    auto kernel = [=](auto arch_config)
+    {
+        segmented_sort_medium<decltype(arch_config), Descending>(keys_input,
+                                                                 keys_tmp,
+                                                                 keys_output,
+                                                                 values_input,
+                                                                 values_tmp,
+                                                                 values_output,
+                                                                 to_output,
+                                                                 num_segments,
+                                                                 segment_indices,
+                                                                 begin_offsets,
+                                                                 end_offsets,
+                                                                 begin_bit,
+                                                                 end_bit);
+    };
+
+    return launch_kernel<Config,
+                         decltype(kernel),
+                         segmented_radix_sort_warp_sort_meduim_config_selector>(arch,
+                                                                                kernel,
+                                                                                grid,
+                                                                                block,
+                                                                                shmem,
+                                                                                stream);
 }
 
 struct Partitioner
@@ -265,47 +313,45 @@ struct Partitioner
     }
 };
 
-template<
-    class Config,
-    bool Descending,
-    class KeysInputIterator,
-    class KeysOutputIterator,
-    class ValuesInputIterator,
-    class ValuesOutputIterator,
-    class OffsetIterator
->
-inline
-hipError_t segmented_radix_sort_impl(void * temporary_storage,
-                                     size_t& storage_size,
-                                     KeysInputIterator keys_input,
-                                     typename std::iterator_traits<KeysInputIterator>::value_type * keys_tmp,
-                                     KeysOutputIterator keys_output,
-                                     ValuesInputIterator values_input,
-                                     typename std::iterator_traits<ValuesInputIterator>::value_type * values_tmp,
-                                     ValuesOutputIterator values_output,
-                                     unsigned int size,
-                                     bool& is_result_in_output,
-                                     unsigned int segments,
-                                     OffsetIterator begin_offsets,
-                                     OffsetIterator end_offsets,
-                                     unsigned int begin_bit,
-                                     unsigned int end_bit,
-                                     hipStream_t stream,
-                                     bool debug_synchronous)
+template<class Config,
+         bool Descending,
+         class KeysInputIterator,
+         class KeysOutputIterator,
+         class ValuesInputIterator,
+         class ValuesOutputIterator,
+         class OffsetIterator>
+inline hipError_t segmented_radix_sort_impl(
+    void*                                                           temporary_storage,
+    size_t&                                                         storage_size,
+    KeysInputIterator                                               keys_input,
+    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
+    KeysOutputIterator                                              keys_output,
+    ValuesInputIterator                                             values_input,
+    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
+    ValuesOutputIterator                                            values_output,
+    unsigned int                                                    size,
+    bool&                                                           is_result_in_output,
+    unsigned int                                                    segments,
+    OffsetIterator                                                  begin_offsets,
+    OffsetIterator                                                  end_offsets,
+    unsigned int                                                    begin_bit,
+    unsigned int                                                    end_bit,
+    hipStream_t                                                     stream,
+    bool                                                            debug_synchronous)
 {
-    using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;
-    using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
-    using segment_index_type = unsigned int;
+    using key_type               = typename std::iterator_traits<KeysInputIterator>::value_type;
+    using value_type             = typename std::iterator_traits<ValuesInputIterator>::value_type;
+    using segment_index_type     = unsigned int;
     using segment_index_iterator = counting_iterator<segment_index_type>;
 
     static_assert(
-        std::is_same<key_type, typename std::iterator_traits<KeysOutputIterator>::value_type>::value,
-        "KeysInputIterator and KeysOutputIterator must have the same value_type"
-    );
+        std::is_same<key_type,
+                     typename std::iterator_traits<KeysOutputIterator>::value_type>::value,
+        "KeysInputIterator and KeysOutputIterator must have the same value_type");
     static_assert(
-        std::is_same<value_type, typename std::iterator_traits<ValuesOutputIterator>::value_type>::value,
-        "ValuesInputIterator and ValuesOutputIterator must have the same value_type"
-    );
+        std::is_same<value_type,
+                     typename std::iterator_traits<ValuesOutputIterator>::value_type>::value,
+        "ValuesInputIterator and ValuesOutputIterator must have the same value_type");
 
     using config = wrapped_segmented_radix_sort_config<Config, key_type, value_type>;
 
@@ -317,7 +363,7 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
     }
 
     const detail::segmented_radix_sort_config_params params
-        = detail::dispatch_target_arch<config>(target_arch);
+        = detail::dispatch_target_arch<config, false>(target_arch);
 
     static constexpr bool with_values = !std::is_same<value_type, ::rocprim::empty_type>::value;
     const bool            partitioning_allowed     = params.warp_sort_config.partitioning_allowed;
@@ -343,7 +389,8 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
     };
     const auto medium_segment_selector = [=](const unsigned int segment_index) mutable -> bool
     {
-        const unsigned int segment_length = end_offsets[segment_index] - begin_offsets[segment_index];
+        const unsigned int segment_length
+            = end_offsets[segment_index] - begin_offsets[segment_index];
         return segment_length > max_small_segment_length;
     };
 
@@ -486,25 +533,27 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
         if(large_segment_count > 0)
         {
             std::chrono::steady_clock::time_point start;
-            if(debug_synchronous) start = std::chrono::steady_clock::now();
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_sort_large_kernel<config, Descending>),
-                               dim3(large_segment_count),
-                               dim3(params.kernel_config.block_size),
-                               0,
-                               stream,
-                               keys_input,
-                               keys_tmp,
-                               keys_output,
-                               values_input,
-                               values_tmp,
-                               values_output,
-                               to_output,
-                               large_segment_indices_output,
-                               begin_offsets,
-                               end_offsets,
-                               iterations,
-                               begin_bit,
-                               end_bit);
+            if(debug_synchronous)
+                start = std::chrono::steady_clock::now();
+            ROCPRIM_RETURN_ON_ERROR(launch_segmented_sort_large<config, Descending>(
+                target_arch,
+                keys_input,
+                keys_tmp,
+                keys_output,
+                values_input,
+                values_tmp,
+                values_output,
+                to_output,
+                large_segment_indices_output,
+                begin_offsets,
+                end_offsets,
+                iterations,
+                begin_bit,
+                end_bit,
+                dim3(large_segment_count),
+                dim3(params.kernel_config.block_size),
+                0,
+                stream));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort:large_segments",
                                                         large_segment_count,
                                                         start);
@@ -516,52 +565,55 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
             std::chrono::steady_clock::time_point start;
             if(debug_synchronous)
                 start = std::chrono::steady_clock::now();
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_sort_medium_kernel<config, Descending>),
-                               dim3(medium_segment_grid_size),
-                               dim3(params.warp_sort_config.block_size_medium),
-                               0,
-                               stream,
-                               keys_input,
-                               keys_tmp,
-                               keys_output,
-                               values_input,
-                               values_tmp,
-                               values_output,
-                               is_result_in_output,
-                               medium_segment_count,
-                               medium_segment_indices_output,
-                               begin_offsets,
-                               end_offsets,
-                               begin_bit,
-                               end_bit);
+            ROCPRIM_RETURN_ON_ERROR(launch_segmented_sort_medium<config, Descending>(
+                target_arch,
+                keys_input,
+                keys_tmp,
+                keys_output,
+                values_input,
+                values_tmp,
+                values_output,
+                is_result_in_output,
+                medium_segment_count,
+                medium_segment_indices_output,
+                begin_offsets,
+                end_offsets,
+                begin_bit,
+                end_bit,
+                dim3(medium_segment_grid_size),
+                dim3(params.warp_sort_config.block_size_medium),
+                0,
+                stream));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort:medium_segments",
                                                         medium_segment_count,
                                                         start);
         }
         if(small_segment_count > 0)
         {
-            const auto small_segment_grid_size = ::rocprim::detail::ceiling_div(small_segment_count,
-                                                                                small_segments_per_block);
+            const auto small_segment_grid_size
+                = ::rocprim::detail::ceiling_div(small_segment_count, small_segments_per_block);
             std::chrono::steady_clock::time_point start;
-            if(debug_synchronous) start = std::chrono::steady_clock::now();
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_sort_small_kernel<config, Descending>),
-                               dim3(small_segment_grid_size),
-                               dim3(params.warp_sort_config.block_size_small),
-                               0,
-                               stream,
-                               keys_input,
-                               keys_tmp,
-                               keys_output,
-                               values_input,
-                               values_tmp,
-                               values_output,
-                               is_result_in_output,
-                               small_segment_count,
-                               small_segment_indices_output,
-                               begin_offsets,
-                               end_offsets,
-                               begin_bit,
-                               end_bit);
+            if(debug_synchronous)
+                start = std::chrono::steady_clock::now();
+            ROCPRIM_RETURN_ON_ERROR(launch_segmented_sort_small<config, Descending>(
+                target_arch,
+                keys_input,
+                keys_tmp,
+                keys_output,
+                values_input,
+                values_tmp,
+                values_output,
+                is_result_in_output,
+                small_segment_count,
+                small_segment_indices_output,
+                begin_offsets,
+                end_offsets,
+                begin_bit,
+                end_bit,
+                dim3(small_segment_grid_size),
+                dim3(params.warp_sort_config.block_size_small),
+                0,
+                stream));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort:small_segments",
                                                         small_segment_count,
                                                         start);
@@ -570,30 +622,30 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
     else
     {
         std::chrono::steady_clock::time_point start;
-        if(debug_synchronous) start = std::chrono::steady_clock::now();
-        hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_sort_kernel<config, Descending>),
-                           dim3(segments),
-                           dim3(params.kernel_config.block_size),
-                           0,
-                           stream,
-                           keys_input,
-                           keys_tmp,
-                           keys_output,
-                           values_input,
-                           values_tmp,
-                           values_output,
-                           to_output,
-                           begin_offsets,
-                           end_offsets,
-                           iterations,
-                           begin_bit,
-                           end_bit);
+        if(debug_synchronous)
+            start = std::chrono::steady_clock::now();
+        ROCPRIM_RETURN_ON_ERROR(
+            launch_segmented_sort<config, Descending>(target_arch,
+                                                      keys_input,
+                                                      keys_tmp,
+                                                      keys_output,
+                                                      values_input,
+                                                      values_tmp,
+                                                      values_output,
+                                                      to_output,
+                                                      begin_offsets,
+                                                      end_offsets,
+                                                      iterations,
+                                                      begin_bit,
+                                                      end_bit,
+                                                      dim3(segments),
+                                                      dim3(params.kernel_config.block_size),
+                                                      0,
+                                                      stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort", segments, start);
     }
     return hipSuccess;
 }
-
-
 
 } // end namespace detail
 
@@ -691,38 +743,43 @@ hipError_t segmented_radix_sort_impl(void * temporary_storage,
 /// // keys_output: [0.3, 0.6, 0.65, 0.08, 0.2, 0.4, 0.7, 1]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class KeysInputIterator,
-    class KeysOutputIterator,
-    class OffsetIterator,
-    class Key = typename std::iterator_traits<KeysInputIterator>::value_type
->
-inline
-hipError_t segmented_radix_sort_keys(void * temporary_storage,
-                                     size_t& storage_size,
-                                     KeysInputIterator keys_input,
-                                     KeysOutputIterator keys_output,
-                                     unsigned int size,
-                                     unsigned int segments,
-                                     OffsetIterator begin_offsets,
-                                     OffsetIterator end_offsets,
-                                     unsigned int begin_bit = 0,
-                                     unsigned int end_bit = 8 * sizeof(Key),
-                                     hipStream_t stream = 0,
-                                     bool debug_synchronous = false)
+template<class Config = default_config,
+         class KeysInputIterator,
+         class KeysOutputIterator,
+         class OffsetIterator,
+         class Key = typename std::iterator_traits<KeysInputIterator>::value_type>
+inline hipError_t segmented_radix_sort_keys(void*              temporary_storage,
+                                            size_t&            storage_size,
+                                            KeysInputIterator  keys_input,
+                                            KeysOutputIterator keys_output,
+                                            unsigned int       size,
+                                            unsigned int       segments,
+                                            OffsetIterator     begin_offsets,
+                                            OffsetIterator     end_offsets,
+                                            unsigned int       begin_bit         = 0,
+                                            unsigned int       end_bit           = 8 * sizeof(Key),
+                                            hipStream_t        stream            = 0,
+                                            bool               debug_synchronous = false)
 {
-    empty_type * values = nullptr;
-    bool ignored;
-    return detail::segmented_radix_sort_impl<Config, false>(
-        temporary_storage, storage_size,
-        keys_input, nullptr, keys_output,
-        values, nullptr, values,
-        size, ignored,
-        segments, begin_offsets, end_offsets,
-        begin_bit, end_bit,
-        stream, debug_synchronous
-    );
+    empty_type* values = nullptr;
+    bool        ignored;
+    return detail::segmented_radix_sort_impl<Config, false>(temporary_storage,
+                                                            storage_size,
+                                                            keys_input,
+                                                            nullptr,
+                                                            keys_output,
+                                                            values,
+                                                            nullptr,
+                                                            values,
+                                                            size,
+                                                            ignored,
+                                                            segments,
+                                                            begin_offsets,
+                                                            end_offsets,
+                                                            begin_bit,
+                                                            end_bit,
+                                                            stream,
+                                                            debug_synchronous);
 }
 
 /// \brief Parallel descending radix sort primitive for device level.
@@ -819,38 +876,43 @@ hipError_t segmented_radix_sort_keys(void * temporary_storage,
 /// // keys_output: [6, 3, 5, 8, 7, 4, 2, 1]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class KeysInputIterator,
-    class KeysOutputIterator,
-    class OffsetIterator,
-    class Key = typename std::iterator_traits<KeysInputIterator>::value_type
->
-inline
-hipError_t segmented_radix_sort_keys_desc(void * temporary_storage,
-                                          size_t& storage_size,
-                                          KeysInputIterator keys_input,
-                                          KeysOutputIterator keys_output,
-                                          unsigned int size,
-                                          unsigned int segments,
-                                          OffsetIterator begin_offsets,
-                                          OffsetIterator end_offsets,
-                                          unsigned int begin_bit = 0,
-                                          unsigned int end_bit = 8 * sizeof(Key),
-                                          hipStream_t stream = 0,
-                                          bool debug_synchronous = false)
+template<class Config = default_config,
+         class KeysInputIterator,
+         class KeysOutputIterator,
+         class OffsetIterator,
+         class Key = typename std::iterator_traits<KeysInputIterator>::value_type>
+inline hipError_t segmented_radix_sort_keys_desc(void*              temporary_storage,
+                                                 size_t&            storage_size,
+                                                 KeysInputIterator  keys_input,
+                                                 KeysOutputIterator keys_output,
+                                                 unsigned int       size,
+                                                 unsigned int       segments,
+                                                 OffsetIterator     begin_offsets,
+                                                 OffsetIterator     end_offsets,
+                                                 unsigned int       begin_bit = 0,
+                                                 unsigned int       end_bit   = 8 * sizeof(Key),
+                                                 hipStream_t        stream    = 0,
+                                                 bool               debug_synchronous = false)
 {
-    empty_type * values = nullptr;
-    bool ignored;
-    return detail::segmented_radix_sort_impl<Config, true>(
-        temporary_storage, storage_size,
-        keys_input, nullptr, keys_output,
-        values, nullptr, values,
-        size, ignored,
-        segments, begin_offsets, end_offsets,
-        begin_bit, end_bit,
-        stream, debug_synchronous
-    );
+    empty_type* values = nullptr;
+    bool        ignored;
+    return detail::segmented_radix_sort_impl<Config, true>(temporary_storage,
+                                                           storage_size,
+                                                           keys_input,
+                                                           nullptr,
+                                                           keys_output,
+                                                           values,
+                                                           nullptr,
+                                                           values,
+                                                           size,
+                                                           ignored,
+                                                           segments,
+                                                           begin_offsets,
+                                                           end_offsets,
+                                                           begin_bit,
+                                                           end_bit,
+                                                           stream,
+                                                           debug_synchronous);
 }
 
 /// \brief Parallel ascending radix sort-by-key primitive for device level.
@@ -963,41 +1025,46 @@ hipError_t segmented_radix_sort_keys_desc(void * temporary_storage,
 /// // values_output: [2, -5, -4, -1, -2, 3, 7, -8]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class KeysInputIterator,
-    class KeysOutputIterator,
-    class ValuesInputIterator,
-    class ValuesOutputIterator,
-    class OffsetIterator,
-    class Key = typename std::iterator_traits<KeysInputIterator>::value_type
->
-inline
-hipError_t segmented_radix_sort_pairs(void * temporary_storage,
-                                      size_t& storage_size,
-                                      KeysInputIterator keys_input,
-                                      KeysOutputIterator keys_output,
-                                      ValuesInputIterator values_input,
-                                      ValuesOutputIterator values_output,
-                                      unsigned int size,
-                                      unsigned int segments,
-                                      OffsetIterator begin_offsets,
-                                      OffsetIterator end_offsets,
-                                      unsigned int begin_bit = 0,
-                                      unsigned int end_bit = 8 * sizeof(Key),
-                                      hipStream_t stream = 0,
-                                      bool debug_synchronous = false)
+template<class Config = default_config,
+         class KeysInputIterator,
+         class KeysOutputIterator,
+         class ValuesInputIterator,
+         class ValuesOutputIterator,
+         class OffsetIterator,
+         class Key = typename std::iterator_traits<KeysInputIterator>::value_type>
+inline hipError_t segmented_radix_sort_pairs(void*                temporary_storage,
+                                             size_t&              storage_size,
+                                             KeysInputIterator    keys_input,
+                                             KeysOutputIterator   keys_output,
+                                             ValuesInputIterator  values_input,
+                                             ValuesOutputIterator values_output,
+                                             unsigned int         size,
+                                             unsigned int         segments,
+                                             OffsetIterator       begin_offsets,
+                                             OffsetIterator       end_offsets,
+                                             unsigned int         begin_bit = 0,
+                                             unsigned int         end_bit   = 8 * sizeof(Key),
+                                             hipStream_t          stream    = 0,
+                                             bool                 debug_synchronous = false)
 {
     bool ignored;
-    return detail::segmented_radix_sort_impl<Config, false>(
-        temporary_storage, storage_size,
-        keys_input, nullptr, keys_output,
-        values_input, nullptr, values_output,
-        size, ignored,
-        segments, begin_offsets, end_offsets,
-        begin_bit, end_bit,
-        stream, debug_synchronous
-    );
+    return detail::segmented_radix_sort_impl<Config, false>(temporary_storage,
+                                                            storage_size,
+                                                            keys_input,
+                                                            nullptr,
+                                                            keys_output,
+                                                            values_input,
+                                                            nullptr,
+                                                            values_output,
+                                                            size,
+                                                            ignored,
+                                                            segments,
+                                                            begin_offsets,
+                                                            end_offsets,
+                                                            begin_bit,
+                                                            end_bit,
+                                                            stream,
+                                                            debug_synchronous);
 }
 
 /// \brief Parallel descending radix sort-by-key primitive for device level.
@@ -1107,41 +1174,46 @@ hipError_t segmented_radix_sort_pairs(void * temporary_storage,
 /// // values_output: [-5, 2, -4, -8, 7, 3, -1, -2]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class KeysInputIterator,
-    class KeysOutputIterator,
-    class ValuesInputIterator,
-    class ValuesOutputIterator,
-    class OffsetIterator,
-    class Key = typename std::iterator_traits<KeysInputIterator>::value_type
->
-inline
-hipError_t segmented_radix_sort_pairs_desc(void * temporary_storage,
-                                           size_t& storage_size,
-                                           KeysInputIterator keys_input,
-                                           KeysOutputIterator keys_output,
-                                           ValuesInputIterator values_input,
-                                           ValuesOutputIterator values_output,
-                                           unsigned int size,
-                                           unsigned int segments,
-                                           OffsetIterator begin_offsets,
-                                           OffsetIterator end_offsets,
-                                           unsigned int begin_bit = 0,
-                                           unsigned int end_bit = 8 * sizeof(Key),
-                                           hipStream_t stream = 0,
-                                           bool debug_synchronous = false)
+template<class Config = default_config,
+         class KeysInputIterator,
+         class KeysOutputIterator,
+         class ValuesInputIterator,
+         class ValuesOutputIterator,
+         class OffsetIterator,
+         class Key = typename std::iterator_traits<KeysInputIterator>::value_type>
+inline hipError_t segmented_radix_sort_pairs_desc(void*                temporary_storage,
+                                                  size_t&              storage_size,
+                                                  KeysInputIterator    keys_input,
+                                                  KeysOutputIterator   keys_output,
+                                                  ValuesInputIterator  values_input,
+                                                  ValuesOutputIterator values_output,
+                                                  unsigned int         size,
+                                                  unsigned int         segments,
+                                                  OffsetIterator       begin_offsets,
+                                                  OffsetIterator       end_offsets,
+                                                  unsigned int         begin_bit = 0,
+                                                  unsigned int         end_bit   = 8 * sizeof(Key),
+                                                  hipStream_t          stream    = 0,
+                                                  bool                 debug_synchronous = false)
 {
     bool ignored;
-    return detail::segmented_radix_sort_impl<Config, true>(
-        temporary_storage, storage_size,
-        keys_input, nullptr, keys_output,
-        values_input, nullptr, values_output,
-        size, ignored,
-        segments, begin_offsets, end_offsets,
-        begin_bit, end_bit,
-        stream, debug_synchronous
-    );
+    return detail::segmented_radix_sort_impl<Config, true>(temporary_storage,
+                                                           storage_size,
+                                                           keys_input,
+                                                           nullptr,
+                                                           keys_output,
+                                                           values_input,
+                                                           nullptr,
+                                                           values_output,
+                                                           size,
+                                                           ignored,
+                                                           segments,
+                                                           begin_offsets,
+                                                           end_offsets,
+                                                           begin_bit,
+                                                           end_bit,
+                                                           stream,
+                                                           debug_synchronous);
 }
 
 /// \brief Parallel ascending radix sort primitive for device level.
@@ -1242,35 +1314,38 @@ hipError_t segmented_radix_sort_pairs_desc(void * temporary_storage,
 /// // keys.current(): [0.3, 0.6, 0.65, 0.08, 0.2, 0.4, 0.7, 1]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class Key,
-    class OffsetIterator
->
-inline
-hipError_t segmented_radix_sort_keys(void * temporary_storage,
-                                     size_t& storage_size,
-                                     double_buffer<Key>& keys,
-                                     unsigned int size,
-                                     unsigned int segments,
-                                     OffsetIterator begin_offsets,
-                                     OffsetIterator end_offsets,
-                                     unsigned int begin_bit = 0,
-                                     unsigned int end_bit = 8 * sizeof(Key),
-                                     hipStream_t stream = 0,
-                                     bool debug_synchronous = false)
+template<class Config = default_config, class Key, class OffsetIterator>
+inline hipError_t segmented_radix_sort_keys(void*               temporary_storage,
+                                            size_t&             storage_size,
+                                            double_buffer<Key>& keys,
+                                            unsigned int        size,
+                                            unsigned int        segments,
+                                            OffsetIterator      begin_offsets,
+                                            OffsetIterator      end_offsets,
+                                            unsigned int        begin_bit         = 0,
+                                            unsigned int        end_bit           = 8 * sizeof(Key),
+                                            hipStream_t         stream            = 0,
+                                            bool                debug_synchronous = false)
 {
-    empty_type * values = nullptr;
-    bool is_result_in_output;
-    hipError_t error = detail::segmented_radix_sort_impl<Config, false>(
-        temporary_storage, storage_size,
-        keys.current(), keys.current(), keys.alternate(),
-        values, values, values,
-        size, is_result_in_output,
-        segments, begin_offsets, end_offsets,
-        begin_bit, end_bit,
-        stream, debug_synchronous
-    );
+    empty_type* values = nullptr;
+    bool        is_result_in_output;
+    hipError_t  error = detail::segmented_radix_sort_impl<Config, false>(temporary_storage,
+                                                                        storage_size,
+                                                                        keys.current(),
+                                                                        keys.current(),
+                                                                        keys.alternate(),
+                                                                        values,
+                                                                        values,
+                                                                        values,
+                                                                        size,
+                                                                        is_result_in_output,
+                                                                        segments,
+                                                                        begin_offsets,
+                                                                        end_offsets,
+                                                                        begin_bit,
+                                                                        end_bit,
+                                                                        stream,
+                                                                        debug_synchronous);
     if(temporary_storage != nullptr && is_result_in_output)
     {
         keys.swap();
@@ -1376,35 +1451,38 @@ hipError_t segmented_radix_sort_keys(void * temporary_storage,
 /// // keys.current(): [6, 3, 5, 8, 7, 4, 2, 1]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class Key,
-    class OffsetIterator
->
-inline
-hipError_t segmented_radix_sort_keys_desc(void * temporary_storage,
-                                          size_t& storage_size,
-                                          double_buffer<Key>& keys,
-                                          unsigned int size,
-                                          unsigned int segments,
-                                          OffsetIterator begin_offsets,
-                                          OffsetIterator end_offsets,
-                                          unsigned int begin_bit = 0,
-                                          unsigned int end_bit = 8 * sizeof(Key),
-                                          hipStream_t stream = 0,
-                                          bool debug_synchronous = false)
+template<class Config = default_config, class Key, class OffsetIterator>
+inline hipError_t segmented_radix_sort_keys_desc(void*               temporary_storage,
+                                                 size_t&             storage_size,
+                                                 double_buffer<Key>& keys,
+                                                 unsigned int        size,
+                                                 unsigned int        segments,
+                                                 OffsetIterator      begin_offsets,
+                                                 OffsetIterator      end_offsets,
+                                                 unsigned int        begin_bit = 0,
+                                                 unsigned int        end_bit   = 8 * sizeof(Key),
+                                                 hipStream_t         stream    = 0,
+                                                 bool                debug_synchronous = false)
 {
-    empty_type * values = nullptr;
-    bool is_result_in_output;
-    hipError_t error = detail::segmented_radix_sort_impl<Config, true>(
-        temporary_storage, storage_size,
-        keys.current(), keys.current(), keys.alternate(),
-        values, values, values,
-        size, is_result_in_output,
-        segments, begin_offsets, end_offsets,
-        begin_bit, end_bit,
-        stream, debug_synchronous
-    );
+    empty_type* values = nullptr;
+    bool        is_result_in_output;
+    hipError_t  error = detail::segmented_radix_sort_impl<Config, true>(temporary_storage,
+                                                                       storage_size,
+                                                                       keys.current(),
+                                                                       keys.current(),
+                                                                       keys.alternate(),
+                                                                       values,
+                                                                       values,
+                                                                       values,
+                                                                       size,
+                                                                       is_result_in_output,
+                                                                       segments,
+                                                                       begin_offsets,
+                                                                       end_offsets,
+                                                                       begin_bit,
+                                                                       end_bit,
+                                                                       stream,
+                                                                       debug_synchronous);
     if(temporary_storage != nullptr && is_result_in_output)
     {
         keys.swap();
@@ -1524,36 +1602,38 @@ hipError_t segmented_radix_sort_keys_desc(void * temporary_storage,
 /// // values.current(): [2, -5, -4, -1, -2, 3, 7, -8]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class Key,
-    class Value,
-    class OffsetIterator
->
-inline
-hipError_t segmented_radix_sort_pairs(void * temporary_storage,
-                                      size_t& storage_size,
-                                      double_buffer<Key>& keys,
-                                      double_buffer<Value>& values,
-                                      unsigned int size,
-                                      unsigned int segments,
-                                      OffsetIterator begin_offsets,
-                                      OffsetIterator end_offsets,
-                                      unsigned int begin_bit = 0,
-                                      unsigned int end_bit = 8 * sizeof(Key),
-                                      hipStream_t stream = 0,
-                                      bool debug_synchronous = false)
+template<class Config = default_config, class Key, class Value, class OffsetIterator>
+inline hipError_t segmented_radix_sort_pairs(void*                 temporary_storage,
+                                             size_t&               storage_size,
+                                             double_buffer<Key>&   keys,
+                                             double_buffer<Value>& values,
+                                             unsigned int          size,
+                                             unsigned int          segments,
+                                             OffsetIterator        begin_offsets,
+                                             OffsetIterator        end_offsets,
+                                             unsigned int          begin_bit = 0,
+                                             unsigned int          end_bit   = 8 * sizeof(Key),
+                                             hipStream_t           stream    = 0,
+                                             bool                  debug_synchronous = false)
 {
-    bool is_result_in_output;
-    hipError_t error = detail::segmented_radix_sort_impl<Config, false>(
-        temporary_storage, storage_size,
-        keys.current(), keys.current(), keys.alternate(),
-        values.current(), values.current(), values.alternate(),
-        size, is_result_in_output,
-        segments, begin_offsets, end_offsets,
-        begin_bit, end_bit,
-        stream, debug_synchronous
-    );
+    bool       is_result_in_output;
+    hipError_t error = detail::segmented_radix_sort_impl<Config, false>(temporary_storage,
+                                                                        storage_size,
+                                                                        keys.current(),
+                                                                        keys.current(),
+                                                                        keys.alternate(),
+                                                                        values.current(),
+                                                                        values.current(),
+                                                                        values.alternate(),
+                                                                        size,
+                                                                        is_result_in_output,
+                                                                        segments,
+                                                                        begin_offsets,
+                                                                        end_offsets,
+                                                                        begin_bit,
+                                                                        end_bit,
+                                                                        stream,
+                                                                        debug_synchronous);
     if(temporary_storage != nullptr && is_result_in_output)
     {
         keys.swap();
@@ -1668,36 +1748,38 @@ hipError_t segmented_radix_sort_pairs(void * temporary_storage,
 /// // values.current(): [-5, 2, -4, -8, 7, 3, -1, -2]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class Key,
-    class Value,
-    class OffsetIterator
->
-inline
-hipError_t segmented_radix_sort_pairs_desc(void * temporary_storage,
-                                           size_t& storage_size,
-                                           double_buffer<Key>& keys,
-                                           double_buffer<Value>& values,
-                                           unsigned int size,
-                                           unsigned int segments,
-                                           OffsetIterator begin_offsets,
-                                           OffsetIterator end_offsets,
-                                           unsigned int begin_bit = 0,
-                                           unsigned int end_bit = 8 * sizeof(Key),
-                                           hipStream_t stream = 0,
-                                           bool debug_synchronous = false)
+template<class Config = default_config, class Key, class Value, class OffsetIterator>
+inline hipError_t segmented_radix_sort_pairs_desc(void*                 temporary_storage,
+                                                  size_t&               storage_size,
+                                                  double_buffer<Key>&   keys,
+                                                  double_buffer<Value>& values,
+                                                  unsigned int          size,
+                                                  unsigned int          segments,
+                                                  OffsetIterator        begin_offsets,
+                                                  OffsetIterator        end_offsets,
+                                                  unsigned int          begin_bit = 0,
+                                                  unsigned int          end_bit   = 8 * sizeof(Key),
+                                                  hipStream_t           stream    = 0,
+                                                  bool                  debug_synchronous = false)
 {
-    bool is_result_in_output;
-    hipError_t error = detail::segmented_radix_sort_impl<Config, true>(
-        temporary_storage, storage_size,
-        keys.current(), keys.current(), keys.alternate(),
-        values.current(), values.current(), values.alternate(),
-        size, is_result_in_output,
-        segments, begin_offsets, end_offsets,
-        begin_bit, end_bit,
-        stream, debug_synchronous
-    );
+    bool       is_result_in_output;
+    hipError_t error = detail::segmented_radix_sort_impl<Config, true>(temporary_storage,
+                                                                       storage_size,
+                                                                       keys.current(),
+                                                                       keys.current(),
+                                                                       keys.alternate(),
+                                                                       values.current(),
+                                                                       values.current(),
+                                                                       values.alternate(),
+                                                                       size,
+                                                                       is_result_in_output,
+                                                                       segments,
+                                                                       begin_offsets,
+                                                                       end_offsets,
+                                                                       begin_bit,
+                                                                       end_bit,
+                                                                       stream,
+                                                                       debug_synchronous);
     if(temporary_storage != nullptr && is_result_in_output)
     {
         keys.swap();

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
@@ -25,8 +25,8 @@
 #include <iterator>
 #include <type_traits>
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/various.hpp"
 #include "../functional.hpp"
 
@@ -48,7 +48,7 @@ template<class Config,
          class OffsetIterator,
          class ResultType,
          class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().reduce_config.block_size) void
+ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
     segmented_reduce_kernel(InputIterator  input,
                             OutputIterator output,
                             OffsetIterator begin_offsets,
@@ -56,35 +56,28 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().reduce_config.block
                             BinaryFunction reduce_op,
                             ResultType     initial_value)
 {
-    segmented_reduce<Config>(
-        input, output,
-        begin_offsets, end_offsets,
-        reduce_op, initial_value
-    );
+    segmented_reduce<Config>(input, output, begin_offsets, end_offsets, reduce_op, initial_value);
 }
 
-template<
-    class Config,
-    class InputIterator,
-    class OutputIterator,
-    class OffsetIterator,
-    class InitValueType,
-    class BinaryFunction
->
-inline
-hipError_t segmented_reduce_impl(void * temporary_storage,
-                                 size_t& storage_size,
-                                 InputIterator input,
-                                 OutputIterator output,
-                                 unsigned int segments,
-                                 OffsetIterator begin_offsets,
-                                 OffsetIterator end_offsets,
-                                 BinaryFunction reduce_op,
-                                 InitValueType initial_value,
-                                 hipStream_t stream,
-                                 bool debug_synchronous)
+template<class Config,
+         class InputIterator,
+         class OutputIterator,
+         class OffsetIterator,
+         class InitValueType,
+         class BinaryFunction>
+inline hipError_t segmented_reduce_impl(void*          temporary_storage,
+                                        size_t&        storage_size,
+                                        InputIterator  input,
+                                        OutputIterator output,
+                                        unsigned int   segments,
+                                        OffsetIterator begin_offsets,
+                                        OffsetIterator end_offsets,
+                                        BinaryFunction reduce_op,
+                                        InitValueType  initial_value,
+                                        hipStream_t    stream,
+                                        bool           debug_synchronous)
 {
-    using input_type = typename std::iterator_traits<InputIterator>::value_type;
+    using input_type  = typename std::iterator_traits<InputIterator>::value_type;
     using result_type = ::rocprim::accumulator_t<BinaryFunction, input_type>;
 
     using config = wrapped_segmented_reduce_config<Config, result_type>;
@@ -97,7 +90,7 @@ hipError_t segmented_reduce_impl(void * temporary_storage,
     }
     const reduce_config_params params = dispatch_target_arch<config>(target_arch);
 
-    const unsigned int block_size = params.reduce_config.block_size;
+    const unsigned int block_size = params.kernel_config.block_size;
 
     if(temporary_storage == nullptr)
     {
@@ -107,27 +100,30 @@ hipError_t segmented_reduce_impl(void * temporary_storage,
         return hipSuccess;
     }
 
-    if( segments == 0u )
+    if(segments == 0u)
         return hipSuccess;
 
     std::chrono::steady_clock::time_point start;
 
-    if(debug_synchronous) start = std::chrono::steady_clock::now();
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(segmented_reduce_kernel<config>),
-        dim3(segments), dim3(block_size), 0, stream,
-        input, output,
-        begin_offsets, end_offsets,
-        reduce_op, static_cast<result_type>(initial_value)
-    );
+    if(debug_synchronous)
+        start = std::chrono::steady_clock::now();
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_reduce_kernel<config>),
+                       dim3(segments),
+                       dim3(block_size),
+                       0,
+                       stream,
+                       input,
+                       output,
+                       begin_offsets,
+                       end_offsets,
+                       reduce_op,
+                       static_cast<result_type>(initial_value));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_reduce", segments, start);
 
     return hipSuccess;
 }
 
-
-
-} // end of detail namespace
+} // namespace detail
 
 /// \brief Parallel segmented reduction primitive for device level.
 ///
@@ -222,34 +218,36 @@ hipError_t segmented_reduce_impl(void * temporary_storage,
 /// // output: [4, 6, 1]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class OffsetIterator,
-    class BinaryFunction = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>,
-    class InitValueType = typename std::iterator_traits<InputIterator>::value_type
->
-inline
-hipError_t segmented_reduce(void * temporary_storage,
-                            size_t& storage_size,
-                            InputIterator input,
-                            OutputIterator output,
-                            unsigned int segments,
-                            OffsetIterator begin_offsets,
-                            OffsetIterator end_offsets,
-                            BinaryFunction reduce_op = BinaryFunction(),
-                            InitValueType initial_value = InitValueType(),
-                            hipStream_t stream = 0,
-                            bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class OffsetIterator,
+         class BinaryFunction
+         = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>,
+         class InitValueType = typename std::iterator_traits<InputIterator>::value_type>
+inline hipError_t segmented_reduce(void*          temporary_storage,
+                                   size_t&        storage_size,
+                                   InputIterator  input,
+                                   OutputIterator output,
+                                   unsigned int   segments,
+                                   OffsetIterator begin_offsets,
+                                   OffsetIterator end_offsets,
+                                   BinaryFunction reduce_op         = BinaryFunction(),
+                                   InitValueType  initial_value     = InitValueType(),
+                                   hipStream_t    stream            = 0,
+                                   bool           debug_synchronous = false)
 {
-    return detail::segmented_reduce_impl<Config>(
-        temporary_storage, storage_size,
-        input, output,
-        segments, begin_offsets, end_offsets,
-        reduce_op, initial_value,
-        stream, debug_synchronous
-    );
+    return detail::segmented_reduce_impl<Config>(temporary_storage,
+                                                 storage_size,
+                                                 input,
+                                                 output,
+                                                 segments,
+                                                 begin_offsets,
+                                                 end_offsets,
+                                                 reduce_op,
+                                                 initial_value,
+                                                 stream,
+                                                 debug_synchronous);
 }
 
 /// @}

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
@@ -70,7 +70,7 @@ inline hipError_t launch_segmented_reduce(detail::target_arch arch,
                                                 initial_value);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
@@ -183,7 +183,7 @@ inline hipError_t segmented_reduce_impl(void*          temporary_storage,
 ///
 /// // custom reduce function
 /// auto min_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a < b ? a : b;
 ///     };

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
@@ -48,15 +48,29 @@ template<class Config,
          class OffsetIterator,
          class ResultType,
          class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    segmented_reduce_kernel(InputIterator  input,
-                            OutputIterator output,
-                            OffsetIterator begin_offsets,
-                            OffsetIterator end_offsets,
-                            BinaryFunction reduce_op,
-                            ResultType     initial_value)
+inline hipError_t launch_segmented_reduce(detail::target_arch arch,
+                                          InputIterator       input,
+                                          OutputIterator      output,
+                                          OffsetIterator      begin_offsets,
+                                          OffsetIterator      end_offsets,
+                                          BinaryFunction      reduce_op,
+                                          ResultType          initial_value,
+                                          dim3                grid,
+                                          dim3                block,
+                                          size_t              shmem,
+                                          hipStream_t         stream)
 {
-    segmented_reduce<Config>(input, output, begin_offsets, end_offsets, reduce_op, initial_value);
+    auto kernel = [=](auto arch_config)
+    {
+        segmented_reduce<decltype(arch_config)>(input,
+                                                output,
+                                                begin_offsets,
+                                                end_offsets,
+                                                reduce_op,
+                                                initial_value);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class Config,
@@ -88,7 +102,7 @@ inline hipError_t segmented_reduce_impl(void*          temporary_storage,
     {
         return result;
     }
-    const reduce_config_params params = dispatch_target_arch<config>(target_arch);
+    const reduce_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int block_size = params.kernel_config.block_size;
 
@@ -107,17 +121,17 @@ inline hipError_t segmented_reduce_impl(void*          temporary_storage,
 
     if(debug_synchronous)
         start = std::chrono::steady_clock::now();
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_reduce_kernel<config>),
-                       dim3(segments),
-                       dim3(block_size),
-                       0,
-                       stream,
-                       input,
-                       output,
-                       begin_offsets,
-                       end_offsets,
-                       reduce_op,
-                       static_cast<result_type>(initial_value));
+    ROCPRIM_RETURN_ON_ERROR(launch_segmented_reduce<config>(target_arch,
+                                                            input,
+                                                            output,
+                                                            begin_offsets,
+                                                            end_offsets,
+                                                            reduce_op,
+                                                            static_cast<result_type>(initial_value),
+                                                            dim3(segments),
+                                                            dim3(block_size),
+                                                            0,
+                                                            stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_reduce", segments, start);
 
     return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_scan.hpp
@@ -103,7 +103,7 @@ inline hipError_t launch_segmented_scan(detail::target_arch arch,
             scan_op);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<bool Exclusive,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_scan.hpp
@@ -72,28 +72,38 @@ struct transform_op_t
     }
 };
 
-template<bool Exclusive,
-         class Config,
+template<class Config,
+         bool Exclusive,
          class ResultType,
          class InputIterator,
          class OutputIterator,
          class OffsetIterator,
          class InitValueType,
          class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
-    segmented_scan_kernel(InputIterator  input,
-                          OutputIterator output,
-                          OffsetIterator begin_offsets,
-                          OffsetIterator end_offsets,
-                          InitValueType  initial_value,
-                          BinaryFunction scan_op)
+inline hipError_t launch_segmented_scan(detail::target_arch arch,
+                                        InputIterator       input,
+                                        OutputIterator      output,
+                                        OffsetIterator      begin_offsets,
+                                        OffsetIterator      end_offsets,
+                                        InitValueType       initial_value,
+                                        BinaryFunction      scan_op,
+                                        dim3                grid,
+                                        dim3                block,
+                                        size_t              shmem,
+                                        hipStream_t         stream)
 {
-    segmented_scan<Exclusive, Config, ResultType>(input,
-                                                  output,
-                                                  begin_offsets,
-                                                  end_offsets,
-                                                  static_cast<ResultType>(initial_value),
-                                                  scan_op);
+    auto kernel = [=](auto arch_config)
+    {
+        segmented_scan<decltype(arch_config), Exclusive, ResultType>(
+            input,
+            output,
+            begin_offsets,
+            end_offsets,
+            static_cast<ResultType>(initial_value),
+            scan_op);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<bool Exclusive,
@@ -126,7 +136,7 @@ inline hipError_t segmented_scan_impl(void*               temporary_storage,
     {
         return result;
     }
-    const scan_config_params params = dispatch_target_arch<config>(target_arch);
+    const scan_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int block_size = params.kernel_config.block_size;
 
@@ -144,17 +154,17 @@ inline hipError_t segmented_scan_impl(void*               temporary_storage,
     std::chrono::steady_clock::time_point start;
     if(debug_synchronous)
         start = std::chrono::steady_clock::now();
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_scan_kernel<Exclusive, config, result_type>),
-                       dim3(segments),
-                       dim3(block_size),
-                       0,
-                       stream,
-                       input,
-                       output,
-                       begin_offsets,
-                       end_offsets,
-                       initial_value,
-                       scan_op);
+    ROCPRIM_RETURN_ON_ERROR(launch_segmented_scan<config, Exclusive, result_type>(target_arch,
+                                                                                  input,
+                                                                                  output,
+                                                                                  begin_offsets,
+                                                                                  end_offsets,
+                                                                                  initial_value,
+                                                                                  scan_op,
+                                                                                  dim3(segments),
+                                                                                  dim3(block_size),
+                                                                                  0,
+                                                                                  stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_scan", segments, start);
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_scan.hpp
@@ -25,14 +25,14 @@
 #include <iterator>
 #include <type_traits>
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/various.hpp"
 
-#include "../iterator/zip_iterator.hpp"
+#include "../iterator/counting_iterator.hpp"
 #include "../iterator/discard_iterator.hpp"
 #include "../iterator/transform_iterator.hpp"
-#include "../iterator/counting_iterator.hpp"
+#include "../iterator/zip_iterator.hpp"
 #include "../types/tuple.hpp"
 
 #include "detail/config/device_scan.hpp"
@@ -88,35 +88,34 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
                           InitValueType  initial_value,
                           BinaryFunction scan_op)
 {
-    segmented_scan<Exclusive, Config, ResultType>(
-        input, output, begin_offsets, end_offsets,
-        static_cast<ResultType>(initial_value), scan_op
-    );
+    segmented_scan<Exclusive, Config, ResultType>(input,
+                                                  output,
+                                                  begin_offsets,
+                                                  end_offsets,
+                                                  static_cast<ResultType>(initial_value),
+                                                  scan_op);
 }
 
-template<
-    bool Exclusive,
-    class Config,
-    class InputIterator,
-    class OutputIterator,
-    class OffsetIterator,
-    class InitValueType,
-    class BinaryFunction
->
-inline
-hipError_t segmented_scan_impl(void * temporary_storage,
-                               size_t& storage_size,
-                               InputIterator input,
-                               OutputIterator output,
-                               unsigned int segments,
-                               OffsetIterator begin_offsets,
-                               OffsetIterator end_offsets,
-                               const InitValueType initial_value,
-                               BinaryFunction scan_op,
-                               hipStream_t stream,
-                               bool debug_synchronous)
+template<bool Exclusive,
+         class Config,
+         class InputIterator,
+         class OutputIterator,
+         class OffsetIterator,
+         class InitValueType,
+         class BinaryFunction>
+inline hipError_t segmented_scan_impl(void*               temporary_storage,
+                                      size_t&             storage_size,
+                                      InputIterator       input,
+                                      OutputIterator      output,
+                                      unsigned int        segments,
+                                      OffsetIterator      begin_offsets,
+                                      OffsetIterator      end_offsets,
+                                      const InitValueType initial_value,
+                                      BinaryFunction      scan_op,
+                                      hipStream_t         stream,
+                                      bool                debug_synchronous)
 {
-    using input_type = typename std::iterator_traits<InputIterator>::value_type;
+    using input_type  = typename std::iterator_traits<InputIterator>::value_type;
     using result_type = typename std::conditional<Exclusive, InitValueType, input_type>::type;
 
     using config = wrapped_scan_config<Config, input_type>;
@@ -139,25 +138,28 @@ hipError_t segmented_scan_impl(void * temporary_storage,
         return hipSuccess;
     }
 
-    if( segments == 0u )
+    if(segments == 0u)
         return hipSuccess;
 
     std::chrono::steady_clock::time_point start;
-    if(debug_synchronous) start = std::chrono::steady_clock::now();
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(segmented_scan_kernel<Exclusive, config, result_type>),
-        dim3(segments), dim3(block_size), 0, stream,
-        input, output,
-        begin_offsets, end_offsets,
-        initial_value, scan_op
-    );
+    if(debug_synchronous)
+        start = std::chrono::steady_clock::now();
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_scan_kernel<Exclusive, config, result_type>),
+                       dim3(segments),
+                       dim3(block_size),
+                       0,
+                       stream,
+                       input,
+                       output,
+                       begin_offsets,
+                       end_offsets,
+                       initial_value,
+                       scan_op);
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_scan", segments, start);
     return hipSuccess;
 }
 
-
-
-} // end of detail namespace
+} // namespace detail
 
 /// \brief Parallel segmented inclusive scan primitive for device level.
 ///
@@ -214,7 +216,7 @@ hipError_t segmented_scan_impl(void * temporary_storage,
 ///
 /// // custom scan function
 /// auto min_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a < b ? a : b;
 ///     };
@@ -244,33 +246,37 @@ hipError_t segmented_scan_impl(void * temporary_storage,
 /// // output: [4, 4, 6, 2, 5, 1, 1, 1]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class OffsetIterator,
-    class BinaryFunction = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>
->
-inline
-hipError_t segmented_inclusive_scan(void * temporary_storage,
-                                    size_t& storage_size,
-                                    InputIterator input,
-                                    OutputIterator output,
-                                    unsigned int segments,
-                                    OffsetIterator begin_offsets,
-                                    OffsetIterator end_offsets,
-                                    BinaryFunction scan_op = BinaryFunction(),
-                                    hipStream_t stream = 0,
-                                    bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class OffsetIterator,
+         class BinaryFunction
+         = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>>
+inline hipError_t segmented_inclusive_scan(void*          temporary_storage,
+                                           size_t&        storage_size,
+                                           InputIterator  input,
+                                           OutputIterator output,
+                                           unsigned int   segments,
+                                           OffsetIterator begin_offsets,
+                                           OffsetIterator end_offsets,
+                                           BinaryFunction scan_op           = BinaryFunction(),
+                                           hipStream_t    stream            = 0,
+                                           bool           debug_synchronous = false)
 {
-    using input_type = typename std::iterator_traits<InputIterator>::value_type;
+    using input_type  = typename std::iterator_traits<InputIterator>::value_type;
     using result_type = input_type;
 
-    return detail::segmented_scan_impl<false, Config>(
-        temporary_storage, storage_size,
-        input, output, segments, begin_offsets, end_offsets, result_type(),
-        scan_op, stream, debug_synchronous
-    );
+    return detail::segmented_scan_impl<false, Config>(temporary_storage,
+                                                      storage_size,
+                                                      input,
+                                                      output,
+                                                      segments,
+                                                      begin_offsets,
+                                                      end_offsets,
+                                                      result_type(),
+                                                      scan_op,
+                                                      stream,
+                                                      debug_synchronous);
 }
 
 /// \brief Parallel segmented exclusive scan primitive for device level.
@@ -330,7 +336,7 @@ hipError_t segmented_inclusive_scan(void * temporary_storage,
 ///
 /// // custom scan function
 /// auto min_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a < b ? a : b;
 ///     };
@@ -363,32 +369,36 @@ hipError_t segmented_inclusive_scan(void * temporary_storage,
 /// // output: [9, 4, 9, 6, 9, 5, 1, 1]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class OffsetIterator,
-    class InitValueType,
-    class BinaryFunction = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>
->
-inline
-hipError_t segmented_exclusive_scan(void * temporary_storage,
-                                    size_t& storage_size,
-                                    InputIterator input,
-                                    OutputIterator output,
-                                    unsigned int segments,
-                                    OffsetIterator begin_offsets,
-                                    OffsetIterator end_offsets,
-                                    const InitValueType initial_value,
-                                    BinaryFunction scan_op = BinaryFunction(),
-                                    hipStream_t stream = 0,
-                                    bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class OffsetIterator,
+         class InitValueType,
+         class BinaryFunction
+         = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>>
+inline hipError_t segmented_exclusive_scan(void*               temporary_storage,
+                                           size_t&             storage_size,
+                                           InputIterator       input,
+                                           OutputIterator      output,
+                                           unsigned int        segments,
+                                           OffsetIterator      begin_offsets,
+                                           OffsetIterator      end_offsets,
+                                           const InitValueType initial_value,
+                                           BinaryFunction      scan_op           = BinaryFunction(),
+                                           hipStream_t         stream            = 0,
+                                           bool                debug_synchronous = false)
 {
-    return detail::segmented_scan_impl<true, Config>(
-        temporary_storage, storage_size,
-        input, output, segments, begin_offsets, end_offsets, initial_value,
-        scan_op, stream, debug_synchronous
-    );
+    return detail::segmented_scan_impl<true, Config>(temporary_storage,
+                                                     storage_size,
+                                                     input,
+                                                     output,
+                                                     segments,
+                                                     begin_offsets,
+                                                     end_offsets,
+                                                     initial_value,
+                                                     scan_op,
+                                                     stream,
+                                                     debug_synchronous);
 }
 
 /// \brief Parallel segmented inclusive scan primitive for device level.
@@ -468,39 +478,37 @@ hipError_t segmented_exclusive_scan(void * temporary_storage,
 /// // output: [1, 3, 6, 4, 9, 6, 13, 21]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class HeadFlagIterator,
-    class BinaryFunction = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>
->
-inline
-hipError_t segmented_inclusive_scan(void * temporary_storage,
-                                    size_t& storage_size,
-                                    InputIterator input,
-                                    OutputIterator output,
-                                    HeadFlagIterator head_flags,
-                                    size_t size,
-                                    BinaryFunction scan_op = BinaryFunction(),
-                                    hipStream_t stream = 0,
-                                    bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class HeadFlagIterator,
+         class BinaryFunction
+         = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>>
+inline hipError_t segmented_inclusive_scan(void*            temporary_storage,
+                                           size_t&          storage_size,
+                                           InputIterator    input,
+                                           OutputIterator   output,
+                                           HeadFlagIterator head_flags,
+                                           size_t           size,
+                                           BinaryFunction   scan_op           = BinaryFunction(),
+                                           hipStream_t      stream            = 0,
+                                           bool             debug_synchronous = false)
 {
-    using input_type = typename std::iterator_traits<InputIterator>::value_type;
+    using input_type  = typename std::iterator_traits<InputIterator>::value_type;
     using result_type = input_type;
-    using flag_type = typename std::iterator_traits<HeadFlagIterator>::value_type;
-    using headflag_scan_op_wrapper_type =
-        detail::headflag_scan_op_wrapper<
-            result_type, flag_type, BinaryFunction
-        >;
+    using flag_type   = typename std::iterator_traits<HeadFlagIterator>::value_type;
+    using headflag_scan_op_wrapper_type
+        = detail::headflag_scan_op_wrapper<result_type, flag_type, BinaryFunction>;
 
     return inclusive_scan<Config>(
-        temporary_storage, storage_size,
+        temporary_storage,
+        storage_size,
         rocprim::make_zip_iterator(rocprim::make_tuple(input, head_flags)),
         rocprim::make_zip_iterator(rocprim::make_tuple(output, rocprim::make_discard_iterator())),
-        size, headflag_scan_op_wrapper_type(scan_op),
-        stream, debug_synchronous
-    );
+        size,
+        headflag_scan_op_wrapper_type(scan_op),
+        stream,
+        debug_synchronous);
 }
 
 /// \brief Parallel segmented exclusive scan primitive for device level.
@@ -583,32 +591,28 @@ hipError_t segmented_inclusive_scan(void * temporary_storage,
 /// // output: [9, 10, 12, 9, 13, 9, 15, 22]
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class InitValueType,
-    class HeadFlagIterator,
-    class BinaryFunction = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>
->
-inline
-hipError_t segmented_exclusive_scan(void * temporary_storage,
-                                    size_t& storage_size,
-                                    InputIterator input,
-                                    OutputIterator output,
-                                    HeadFlagIterator head_flags,
-                                    const InitValueType initial_value,
-                                    size_t size,
-                                    BinaryFunction scan_op = BinaryFunction(),
-                                    hipStream_t stream = 0,
-                                    bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class InitValueType,
+         class HeadFlagIterator,
+         class BinaryFunction
+         = ::rocprim::plus<typename std::iterator_traits<InputIterator>::value_type>>
+inline hipError_t segmented_exclusive_scan(void*               temporary_storage,
+                                           size_t&             storage_size,
+                                           InputIterator       input,
+                                           OutputIterator      output,
+                                           HeadFlagIterator    head_flags,
+                                           const InitValueType initial_value,
+                                           size_t              size,
+                                           BinaryFunction      scan_op           = BinaryFunction(),
+                                           hipStream_t         stream            = 0,
+                                           bool                debug_synchronous = false)
 {
     using result_type = InitValueType;
-    using flag_type = typename std::iterator_traits<HeadFlagIterator>::value_type;
-    using headflag_scan_op_wrapper_type =
-        detail::headflag_scan_op_wrapper<
-            result_type, flag_type, BinaryFunction
-        >;
+    using flag_type   = typename std::iterator_traits<HeadFlagIterator>::value_type;
+    using headflag_scan_op_wrapper_type
+        = detail::headflag_scan_op_wrapper<result_type, flag_type, BinaryFunction>;
     using transform_op
         = detail::transform_op_t<InputIterator, HeadFlagIterator, result_type, flag_type>;
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
@@ -220,7 +220,7 @@ inline hipError_t select(void*                       temporary_storage,
 /// #include <rocprim/rocprim.hpp>
 ///
 /// auto predicate =
-///     [] __device__ (int a) -> bool
+///     [](int a) -> bool
 ///     {
 ///         return (a % 2) == 0;
 ///     };
@@ -361,7 +361,7 @@ inline hipError_t select(void*                       temporary_storage,
 /// #include <rocprim/rocprim.hpp>
 ///
 /// auto predicate =
-///     [] __device__ (int a) -> bool
+///     [](int a) -> bool
 ///     {
 ///         return (a % 2) == 0;
 ///     };

--- a/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
@@ -21,12 +21,12 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_SELECT_HPP_
 #define ROCPRIM_DEVICE_DEVICE_SELECT_HPP_
 
-#include <type_traits>
 #include <iterator>
+#include <type_traits>
 
 #include "../config.hpp"
-#include "../detail/various.hpp"
 #include "../detail/binary_op_wrappers.hpp"
+#include "../detail/various.hpp"
 
 #include "../iterator/transform_iterator.hpp"
 
@@ -36,11 +36,6 @@ BEGIN_ROCPRIM_NAMESPACE
 
 /// \addtogroup devicemodule
 /// @{
-
-namespace detail
-{
-
-} // end detail namespace
 
 /// \brief Parallel select primitive for device level using range of flags.
 ///
@@ -123,29 +118,26 @@ namespace detail
 /// // output_count: 4
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class FlagIterator,
-    class OutputIterator,
-    class SelectedCountOutputIterator,
-    bool UsingOrderedBlockId = false
->
-inline
-hipError_t select(void * temporary_storage,
-                  size_t& storage_size,
-                  InputIterator input,
-                  FlagIterator flags,
-                  OutputIterator output,
-                  SelectedCountOutputIterator selected_count_output,
-                  const size_t size,
-                  const hipStream_t stream = 0,
-                  const bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class FlagIterator,
+         class OutputIterator,
+         class SelectedCountOutputIterator,
+         bool UsingOrderedBlockId = false>
+inline hipError_t select(void*                       temporary_storage,
+                         size_t&                     storage_size,
+                         InputIterator               input,
+                         FlagIterator                flags,
+                         OutputIterator              output,
+                         SelectedCountOutputIterator selected_count_output,
+                         const size_t                size,
+                         const hipStream_t           stream            = 0,
+                         const bool                  debug_synchronous = false)
 {
     // Dummy unary predicate
     using unary_predicate_type = ::rocprim::empty_type;
     // Dummy inequality operation
-    using inequality_op_type = ::rocprim::empty_type;
+    using inequality_op_type             = ::rocprim::empty_type;
     using offset_type                    = size_t;
     rocprim::empty_type* const no_values = nullptr; // key only
 
@@ -156,21 +148,21 @@ hipError_t select(void * temporary_storage,
     const output_value_iterator_tuple no_output_values{nullptr, nullptr}; // key only
 
     return detail::partition_impl<detail::partition_subalgo::select_flag,
-                                 UsingOrderedBlockId,
-                                 Config,
-                                 offset_type>(temporary_storage,
-                                              storage_size,
-                                              input,
-                                              no_values,
-                                              flags,
-                                              output_tuple,
-                                              no_output_values,
-                                              selected_count_output,
-                                              size,
-                                              inequality_op_type(),
-                                              stream,
-                                              debug_synchronous,
-                                              unary_predicate_type());
+                                  UsingOrderedBlockId,
+                                  Config,
+                                  offset_type>(temporary_storage,
+                                               storage_size,
+                                               input,
+                                               no_values,
+                                               flags,
+                                               output_tuple,
+                                               no_output_values,
+                                               selected_count_output,
+                                               size,
+                                               inequality_op_type(),
+                                               stream,
+                                               debug_synchronous,
+                                               unary_predicate_type());
 }
 
 /// \brief Parallel select primitive for device level using selection operator.
@@ -261,30 +253,28 @@ hipError_t select(void * temporary_storage,
 /// // output_count: 4
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class SelectedCountOutputIterator,
-    class UnaryPredicate,
-    bool UsingOrderedBlockId = false>
-inline
-hipError_t select(void * temporary_storage,
-                  size_t& storage_size,
-                  InputIterator input,
-                  OutputIterator output,
-                  SelectedCountOutputIterator selected_count_output,
-                  const size_t size,
-                  UnaryPredicate predicate,
-                  const hipStream_t stream = 0,
-                  const bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class SelectedCountOutputIterator,
+         class UnaryPredicate,
+         bool UsingOrderedBlockId = false>
+inline hipError_t select(void*                       temporary_storage,
+                         size_t&                     storage_size,
+                         InputIterator               input,
+                         OutputIterator              output,
+                         SelectedCountOutputIterator selected_count_output,
+                         const size_t                size,
+                         UnaryPredicate              predicate,
+                         const hipStream_t           stream            = 0,
+                         const bool                  debug_synchronous = false)
 {
     // Dummy flag type
-    using flag_type = ::rocprim::empty_type;
+    using flag_type   = ::rocprim::empty_type;
     using offset_type = size_t;
-    flag_type * flags = nullptr;
+    flag_type* flags  = nullptr;
     // Dummy inequality operation
-    using inequality_op_type = ::rocprim::empty_type;
+    using inequality_op_type             = ::rocprim::empty_type;
     rocprim::empty_type* const no_values = nullptr; // key only
 
     using output_key_iterator_tuple = tuple<OutputIterator, ::rocprim::empty_type>;
@@ -411,7 +401,7 @@ template<class Config = default_config,
          class OutputIterator,
          class SelectedCountOutputIterator,
          class UnaryPredicate,
-         bool  UsingOrderedBlockId = false>
+         bool UsingOrderedBlockId = false>
 inline hipError_t select(void*                       temporary_storage,
                          size_t&                     storage_size,
                          InputIterator               input,
@@ -530,30 +520,29 @@ inline hipError_t select(void*                       temporary_storage,
 /// // output_count: 5
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class UniqueCountOutputIterator,
-    class EqualityOp = ::rocprim::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
-    bool  UsingOrderedBlockId = false>
-inline
-hipError_t unique(void * temporary_storage,
-                  size_t& storage_size,
-                  InputIterator input,
-                  OutputIterator output,
-                  UniqueCountOutputIterator unique_count_output,
-                  const size_t size,
-                  EqualityOp equality_op = EqualityOp(),
-                  const hipStream_t stream = 0,
-                  const bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class UniqueCountOutputIterator,
+         class EqualityOp
+         = ::rocprim::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
+         bool UsingOrderedBlockId = false>
+inline hipError_t unique(void*                     temporary_storage,
+                         size_t&                   storage_size,
+                         InputIterator             input,
+                         OutputIterator            output,
+                         UniqueCountOutputIterator unique_count_output,
+                         const size_t              size,
+                         EqualityOp                equality_op       = EqualityOp(),
+                         const hipStream_t         stream            = 0,
+                         const bool                debug_synchronous = false)
 {
     // Dummy unary predicate
     using unary_predicate_type = ::rocprim::empty_type;
-    using offset_type = unsigned int;
+    using offset_type          = unsigned int;
     // Dummy flag type
-    using flag_type = ::rocprim::empty_type;
-    const flag_type * flags = nullptr;
+    using flag_type                      = ::rocprim::empty_type;
+    const flag_type*           flags     = nullptr;
     rocprim::empty_type* const no_values = nullptr; // key only
 
     // Convert equality operator to inequality operator
@@ -566,21 +555,21 @@ hipError_t unique(void * temporary_storage,
     const output_value_iterator_tuple no_output_values{nullptr, nullptr}; // key only
 
     return detail::partition_impl<detail::partition_subalgo::select_unique,
-                                 UsingOrderedBlockId,
-                                 Config,
-                                 offset_type>(temporary_storage,
-                                              storage_size,
-                                              input,
-                                              no_values,
-                                              flags,
-                                              output_tuple,
-                                              no_output_values,
-                                              unique_count_output,
-                                              size,
-                                              inequality_op,
-                                              stream,
-                                              debug_synchronous,
-                                              unary_predicate_type());
+                                  UsingOrderedBlockId,
+                                  Config,
+                                  offset_type>(temporary_storage,
+                                               storage_size,
+                                               input,
+                                               no_values,
+                                               flags,
+                                               output_tuple,
+                                               no_output_values,
+                                               unique_count_output,
+                                               size,
+                                               inequality_op,
+                                               stream,
+                                               debug_synchronous,
+                                               unary_predicate_type());
 }
 
 /// \brief Device-level parallel unique by key primitive.
@@ -632,15 +621,15 @@ hipError_t unique(void * temporary_storage,
 /// \param [in] stream [optional] HIP stream object. The default is \p 0 (default stream).
 /// \param [in] debug_synchronous [optional] If true, synchronization after every kernel
 /// launch is forced in order to check for errors. The default value is \p false.
-template <typename Config = default_config,
-          typename KeyIterator,
-          typename ValueIterator,
-          typename OutputKeyIterator,
-          typename OutputValueIterator,
-          typename UniqueCountOutputIterator,
-          typename EqualityOp
-          = ::rocprim::equal_to<typename std::iterator_traits<KeyIterator>::value_type>,
-          bool     UsingOrderedBlockId = false>
+template<typename Config = default_config,
+         typename KeyIterator,
+         typename ValueIterator,
+         typename OutputKeyIterator,
+         typename OutputValueIterator,
+         typename UniqueCountOutputIterator,
+         typename EqualityOp
+         = ::rocprim::equal_to<typename std::iterator_traits<KeyIterator>::value_type>,
+         bool UsingOrderedBlockId = false>
 inline hipError_t unique_by_key(void*                           temporary_storage,
                                 size_t&                         storage_size,
                                 const KeyIterator               keys_input,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -27,6 +27,7 @@
 #include "../iterator/zip_iterator.hpp"
 #include "../types/tuple.hpp"
 
+#include "config_types.hpp"
 #include "detail/device_transform.hpp"
 #include "device_transform_config.hpp"
 
@@ -43,31 +44,13 @@ BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
-constexpr const char* arch_name(target_arch a)
-{
-    switch(a)
-    {
-        case target_arch::gfx803: return "gfx803";
-        case target_arch::gfx900: return "gfx900";
-        case target_arch::gfx906: return "gfx906";
-        case target_arch::gfx908: return "gfx908";
-        case target_arch::gfx90a: return "gfx90a";
-        case target_arch::gfx942: return "gfx942";
-        case target_arch::gfx1030: return "gfx1030";
-        case target_arch::gfx1100: return "gfx1100";
-        case target_arch::gfx1102: return "gfx1102";
-        case target_arch::gfx1200: return "gfx1200";
-        case target_arch::gfx1201: return "gfx1201";
-        default: return "unknown";
-    }
-}
 
 // Trampoline that is fully specialized at compile-time for a single GPU architecture.
 // By instantiating this template once per supported `target_arch`,the correct tuned config
 // will be derived from the template
 template<target_arch Arch,
-         bool        IsPointer,
          class Config,
+         bool IsPointer,
          class ResultType,
          class InputIt,
          class OutputIt,
@@ -79,21 +62,18 @@ void transform_trampoline(InputIt in, size_t n, OutputIt out, UnaryOp op)
     // Pull the per-arch tuned parameters into constexpr scope
     constexpr auto p = Config::template architecture_config<Arch>::params;
 
-    // if(threadIdx.x == 0 && blockIdx.x == 0)
-    // {
-    //     printf("[transform][%s] block=%u  items/thread=%u\n",
-    //            arch_name(Arch),
-    //            p.kernel_config.block_size,
-    //            p.kernel_config.items_per_thread);
-    // }
-
     // Delegate to the real implementation, with the correct constants
-    detail::transform_kernel_impl<
-        IsPointer,
-        Config::template architecture_config<Arch>::params.kernel_config.block_size,
-        Config::template architecture_config<Arch>::params.kernel_config.items_per_thread,
-        Config::template architecture_config<Arch>::params.load_type,
-        ResultType>(in, n, out, op);
+#ifndef ROCPRIM_EXPERIMENTAL_SPIRV
+    if constexpr(Arch == device_target_arch())
+#endif
+    {
+        detail::transform_kernel_impl<
+            IsPointer,
+            Config::template architecture_config<Arch>::params.kernel_config.block_size,
+            Config::template architecture_config<Arch>::params.kernel_config.items_per_thread,
+            Config::template architecture_config<Arch>::params.load_type,
+            ResultType>(in, n, out, op);
+    }
 }
 
 // Host-side helper running at run-time, picking the trampoline whose template
@@ -121,42 +101,23 @@ inline hipError_t launch_transform_for_arch(target_arch arch,
     {
         constexpr target_arch A = decltype(arch_tag)::value;
         if(A != arch || launched)
+        {
             return;
+        }
 
-        constexpr auto     cfg              = Config::template architecture_config<A>::params;
-        constexpr unsigned block_size       = cfg.kernel_config.block_size;
-        constexpr unsigned items_per_thread = cfg.kernel_config.items_per_thread;
-        constexpr size_t   items_per_block  = block_size * items_per_thread;
-
-        const dim3 block(block_size);
-        const dim3 grid((n + items_per_block - 1) / items_per_block);
-
-        // std::cout << "[transform] pick " << detail::arch_name(A) << "  block=" << block.x
-        //           << "  items=" << items_per_thread << "  grid=" << grid.x << '\n';
-
-        transform_trampoline<A, IsPointer, Config, ResultType>
+        transform_trampoline<A, Config, IsPointer, ResultType>
             <<<grid, block, 0, s>>>(in, n, out, op);
 
         launched = true;
     };
 
     // Enumerate every architecture for which we have a tuned config
-    try_launch(std::integral_constant<target_arch, target_arch::gfx803>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx900>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx906>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx908>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx90a>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx942>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx1030>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx1100>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx1102>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx1200>{});
-    try_launch(std::integral_constant<target_arch, target_arch::gfx1201>{});
+    detail::for_each_arch(try_launch);
 
     // Fallback for unknown architectures
     if(!launched)
     {
-        transform_trampoline<target_arch::unknown, IsPointer, Config, ResultType>
+        transform_trampoline<target_arch::unknown, Config, IsPointer, ResultType>
             <<<grid, block, 0, s>>>(in, n, out, op);
     }
     return hipSuccess;
@@ -191,7 +152,7 @@ inline hipError_t transform_impl(InputIterator     input,
         return result;
     }
     const detail::transform_config_params params
-        = detail::dispatch_target_arch<config>(target_arch);
+        = detail::dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int block_size       = params.kernel_config.block_size;
     const unsigned int items_per_thread = params.kernel_config.items_per_thread;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -32,6 +32,7 @@
 #include "device_transform_config.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <iostream>
 #include <iterator>
 #include <tuple>
@@ -45,82 +46,35 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-// Trampoline that is fully specialized at compile-time for a single GPU architecture.
-// By instantiating this template once per supported `target_arch`,the correct tuned config
-// will be derived from the template
-template<target_arch Arch,
-         class Config,
-         bool IsPointer,
-         class ResultType,
-         class InputIt,
-         class OutputIt,
-         class UnaryOp>
-__global__
-__launch_bounds__(Config::template architecture_config<Arch>::params.kernel_config.block_size)
-void transform_trampoline(InputIt in, size_t n, OutputIt out, UnaryOp op)
-{
-    // Pull the per-arch tuned parameters into constexpr scope
-    constexpr auto p = Config::template architecture_config<Arch>::params;
-
-    // Delegate to the real implementation, with the correct constants
-#ifndef ROCPRIM_EXPERIMENTAL_SPIRV
-    if constexpr(Arch == device_target_arch())
-#endif
-    {
-        detail::transform_kernel_impl<
-            IsPointer,
-            Config::template architecture_config<Arch>::params.kernel_config.block_size,
-            Config::template architecture_config<Arch>::params.kernel_config.items_per_thread,
-            Config::template architecture_config<Arch>::params.load_type,
-            ResultType>(in, n, out, op);
-    }
-}
-
-// Host-side helper running at run-time, picking the trampoline whose template
-// argument `Arch` matches the actual GPU we are executing on.
 template<class Config,
          bool IsPointer,
          class ResultType,
          class InputIt,
          class OutputIt,
          class UnaryOp>
-__host__
-inline hipError_t launch_transform_for_arch(target_arch arch,
-                                            InputIt     in,
-                                            OutputIt    out,
-                                            size_t      n,
-                                            UnaryOp     op,
-                                            dim3        grid,
-                                            dim3        block,
-                                            hipStream_t s)
+inline hipError_t launch_transform_for_arch(detail::target_arch arch,
+                                            InputIt             in,
+                                            OutputIt            out,
+                                            size_t              n,
+                                            UnaryOp             op,
+                                            dim3                grid,
+                                            dim3                block,
+                                            size_t              shmem,
+                                            hipStream_t         stream)
 {
-    bool launched = false;
-
-    // Lambda that instantiates & launches the right trampoline
-    auto try_launch = [&](auto arch_tag)
+    auto kernel = [=] __device__ (auto arch_config)
     {
-        constexpr target_arch A = decltype(arch_tag)::value;
-        if(A != arch || launched)
-        {
-            return;
-        }
+        constexpr auto device_params = decltype(arch_config)::params;
 
-        transform_trampoline<A, Config, IsPointer, ResultType>
-            <<<grid, block, 0, s>>>(in, n, out, op);
-
-        launched = true;
+        detail::transform_kernel_impl<
+            IsPointer,
+            device_params.kernel_config.block_size,
+            device_params.kernel_config.items_per_thread,
+            device_params.load_type,
+            ResultType>(in, n, out, op);
     };
 
-    // Enumerate every architecture for which we have a tuned config
-    detail::for_each_arch(try_launch);
-
-    // Fallback for unknown architectures
-    if(!launched)
-    {
-        transform_trampoline<target_arch::unknown, Config, IsPointer, ResultType>
-            <<<grid, block, 0, s>>>(in, n, out, op);
-    }
-    return hipSuccess;
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<bool IsPointer,
@@ -187,14 +141,21 @@ inline hipError_t transform_impl(InputIterator     input,
             start = std::chrono::steady_clock::now();
         }
 
-        launch_transform_for_arch<config, IsPointer, result_type>(target_arch,
-                                                                  input + offset,
-                                                                  output + offset,
-                                                                  current_size,
-                                                                  transform_op,
-                                                                  current_blocks,
-                                                                  block_size,
-                                                                  stream);
+        hipError_t launch_err
+            = launch_transform_for_arch<config, IsPointer, result_type>(target_arch,
+                                                                        input + offset,
+                                                                        output + offset,
+                                                                        current_size,
+                                                                        transform_op,
+                                                                        current_blocks,
+                                                                        block_size,
+                                                                        0,
+                                                                        stream);
+
+        if(launch_err != hipSuccess)
+        {
+            return launch_err;
+        }
 
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("transform_kernel", current_size, start);
     }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -43,6 +43,24 @@ BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
+constexpr const char* arch_name(target_arch a)
+{
+    switch(a)
+    {
+        case target_arch::gfx803: return "gfx803";
+        case target_arch::gfx900: return "gfx900";
+        case target_arch::gfx906: return "gfx906";
+        case target_arch::gfx908: return "gfx908";
+        case target_arch::gfx90a: return "gfx90a";
+        case target_arch::gfx942: return "gfx942";
+        case target_arch::gfx1030: return "gfx1030";
+        case target_arch::gfx1100: return "gfx1100";
+        case target_arch::gfx1102: return "gfx1102";
+        case target_arch::gfx1200: return "gfx1200";
+        case target_arch::gfx1201: return "gfx1201";
+        default: return "unknown";
+    }
+}
 
 // Trampoline that is fully specialized at compile-time for a single GPU architecture.
 // By instantiating this template once per supported `target_arch`,the correct tuned config
@@ -60,6 +78,14 @@ void transform_trampoline(InputIt in, size_t n, OutputIt out, UnaryOp op)
 {
     // Pull the per-arch tuned parameters into constexpr scope
     constexpr auto p = Config::template architecture_config<Arch>::params;
+
+    // if(threadIdx.x == 0 && blockIdx.x == 0)
+    // {
+    //     printf("[transform][%s] block=%u  items/thread=%u\n",
+    //            arch_name(Arch),
+    //            p.kernel_config.block_size,
+    //            p.kernel_config.items_per_thread);
+    // }
 
     // Delegate to the real implementation, with the correct constants
     detail::transform_kernel_impl<
@@ -94,12 +120,24 @@ inline hipError_t launch_transform_for_arch(target_arch arch,
     auto try_launch = [&](auto arch_tag)
     {
         constexpr target_arch A = decltype(arch_tag)::value;
-        if(A == arch && !launched)
-        {
-            transform_trampoline<A, IsPointer, Config, ResultType>
-                <<<grid, block, 0, s>>>(in, n, out, op);
-            launched = true;
-        }
+        if(A != arch || launched)
+            return;
+
+        constexpr auto     cfg              = Config::template architecture_config<A>::params;
+        constexpr unsigned block_size       = cfg.kernel_config.block_size;
+        constexpr unsigned items_per_thread = cfg.kernel_config.items_per_thread;
+        constexpr size_t   items_per_block  = block_size * items_per_thread;
+
+        const dim3 block(block_size);
+        const dim3 grid((n + items_per_block - 1) / items_per_block);
+
+        // std::cout << "[transform] pick " << detail::arch_name(A) << "  block=" << block.x
+        //           << "  items=" << items_per_thread << "  grid=" << grid.x << '\n';
+
+        transform_trampoline<A, IsPointer, Config, ResultType>
+            <<<grid, block, 0, s>>>(in, n, out, op);
+
+        launched = true;
     };
 
     // Enumerate every architecture for which we have a tuned config
@@ -193,8 +231,8 @@ inline hipError_t transform_impl(InputIterator     input,
                                                                   output + offset,
                                                                   current_size,
                                                                   transform_op,
-                                                                  dim3(current_blocks),
-                                                                  dim3(block_size),
+                                                                  current_blocks,
+                                                                  block_size,
                                                                   stream);
 
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("transform_kernel", current_size, start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -44,21 +44,84 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<bool IsPointer,
+// Trampoline that is fully specialized at compile-time for a single GPU architecture.
+// By instantiating this template once per supported `target_arch`,the correct tuned config
+// will be derived from the template
+template<target_arch Arch,
+         bool        IsPointer,
          class Config,
          class ResultType,
-         class InputIterator,
-         class OutputIterator,
-         class UnaryFunction>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void transform_kernel(
-    InputIterator input, const size_t size, OutputIterator output, UnaryFunction transform_op)
+         class InputIt,
+         class OutputIt,
+         class UnaryOp>
+__global__
+__launch_bounds__(Config::template architecture_config<Arch>::params.kernel_config.block_size)
+void transform_trampoline(InputIt in, size_t n, OutputIt out, UnaryOp op)
 {
-    transform_kernel_impl<IsPointer,
-                          device_params<Config>().kernel_config.block_size,
-                          device_params<Config>().kernel_config.items_per_thread,
-                          device_params<Config>().load_type,
-                          ResultType>(input, size, output, transform_op);
+    // Pull the per-arch tuned parameters into constexpr scope
+    constexpr auto p = Config::template architecture_config<Arch>::params;
+
+    // Delegate to the real implementation, with the correct constants
+    detail::transform_kernel_impl<
+        IsPointer,
+        Config::template architecture_config<Arch>::params.kernel_config.block_size,
+        Config::template architecture_config<Arch>::params.kernel_config.items_per_thread,
+        Config::template architecture_config<Arch>::params.load_type,
+        ResultType>(in, n, out, op);
+}
+
+// Host-side helper running at run-time, picking the trampoline whose template
+// argument `Arch` matches the actual GPU we are executing on.
+template<class Config,
+         bool IsPointer,
+         class ResultType,
+         class InputIt,
+         class OutputIt,
+         class UnaryOp>
+__host__
+inline hipError_t launch_transform_for_arch(target_arch arch,
+                                            InputIt     in,
+                                            OutputIt    out,
+                                            size_t      n,
+                                            UnaryOp     op,
+                                            dim3        grid,
+                                            dim3        block,
+                                            hipStream_t s)
+{
+    bool launched = false;
+
+    // Lambda that instantiates & launches the right trampoline
+    auto try_launch = [&](auto arch_tag)
+    {
+        constexpr target_arch A = decltype(arch_tag)::value;
+        if(A == arch && !launched)
+        {
+            transform_trampoline<A, IsPointer, Config, ResultType>
+                <<<grid, block, 0, s>>>(in, n, out, op);
+            launched = true;
+        }
+    };
+
+    // Enumerate every architecture for which we have a tuned config
+    try_launch(std::integral_constant<target_arch, target_arch::gfx803>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx900>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx906>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx908>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx90a>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx942>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx1030>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx1100>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx1102>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx1200>{});
+    try_launch(std::integral_constant<target_arch, target_arch::gfx1201>{});
+
+    // Fallback for unknown architectures
+    if(!launched)
+    {
+        transform_trampoline<target_arch::unknown, IsPointer, Config, ResultType>
+            <<<grid, block, 0, s>>>(in, n, out, op);
+    }
+    return hipSuccess;
 }
 
 template<bool IsPointer,
@@ -125,11 +188,14 @@ inline hipError_t transform_impl(InputIterator     input,
             start = std::chrono::steady_clock::now();
         }
 
-        detail::transform_kernel<IsPointer, config, result_type>
-            <<<dim3(current_blocks), dim3(block_size), 0, stream>>>(input + offset,
-                                                                    current_size,
-                                                                    output + offset,
-                                                                    transform_op);
+        launch_transform_for_arch<config, IsPointer, result_type>(target_arch,
+                                                                  input + offset,
+                                                                  output + offset,
+                                                                  current_size,
+                                                                  transform_op,
+                                                                  dim3(current_blocks),
+                                                                  dim3(block_size),
+                                                                  stream);
 
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("transform_kernel", current_size, start);
     }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -52,15 +52,15 @@ template<class Config,
          class InputIt,
          class OutputIt,
          class UnaryOp>
-inline hipError_t launch_transform_for_arch(detail::target_arch arch,
-                                            InputIt             in,
-                                            OutputIt            out,
-                                            size_t              n,
-                                            UnaryOp             op,
-                                            dim3                grid,
-                                            dim3                block,
-                                            size_t              shmem,
-                                            hipStream_t         stream)
+inline hipError_t launch_transform(detail::target_arch arch,
+                                   InputIt             in,
+                                   OutputIt            out,
+                                   size_t              n,
+                                   UnaryOp             op,
+                                   dim3                grid,
+                                   dim3                block,
+                                   size_t              shmem,
+                                   hipStream_t         stream)
 {
     auto kernel = [=] __device__ (auto arch_config)
     {
@@ -141,16 +141,15 @@ inline hipError_t transform_impl(InputIterator     input,
             start = std::chrono::steady_clock::now();
         }
 
-        hipError_t launch_err
-            = launch_transform_for_arch<config, IsPointer, result_type>(target_arch,
-                                                                        input + offset,
-                                                                        output + offset,
-                                                                        current_size,
-                                                                        transform_op,
-                                                                        current_blocks,
-                                                                        block_size,
-                                                                        0,
-                                                                        stream);
+        hipError_t launch_err = launch_transform<config, IsPointer, result_type>(target_arch,
+                                                                                 input + offset,
+                                                                                 output + offset,
+                                                                                 current_size,
+                                                                                 transform_op,
+                                                                                 current_blocks,
+                                                                                 block_size,
+                                                                                 0,
+                                                                                 stream);
 
         if(launch_err != hipSuccess)
         {

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -62,16 +62,15 @@ inline hipError_t launch_transform(detail::target_arch arch,
                                    size_t              shmem,
                                    hipStream_t         stream)
 {
-    auto kernel = [=] __device__ (auto arch_config)
+    auto kernel = [=](auto arch_config)
     {
         constexpr auto params = decltype(arch_config)::params;
 
-        detail::transform_kernel_impl<
-            IsPointer,
-            params.kernel_config.block_size,
-            params.kernel_config.items_per_thread,
-            params.load_type,
-            ResultType>(in, n, out, op);
+        detail::transform_kernel_impl<IsPointer,
+                                      params.kernel_config.block_size,
+                                      params.kernel_config.items_per_thread,
+                                      params.load_type,
+                                      ResultType>(in, n, out, op);
     };
 
     return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
@@ -141,7 +140,7 @@ inline hipError_t transform_impl(InputIterator     input,
             start = std::chrono::steady_clock::now();
         }
 
-        hipError_t launch_err = launch_transform<config, IsPointer, result_type>(target_arch,
+        ROCPRIM_RETURN_ON_ERROR(launch_transform<config, IsPointer, result_type>(target_arch,
                                                                                  input + offset,
                                                                                  output + offset,
                                                                                  current_size,
@@ -149,13 +148,7 @@ inline hipError_t transform_impl(InputIterator     input,
                                                                                  current_blocks,
                                                                                  block_size,
                                                                                  0,
-                                                                                 stream);
-
-        if(launch_err != hipSuccess)
-        {
-            return launch_err;
-        }
-
+                                                                                 stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("transform_kernel", current_size, start);
     }
 
@@ -200,7 +193,7 @@ inline hipError_t transform_impl(InputIterator     input,
 ///
 /// // custom transform function
 /// auto transform_op =
-///     [] __device__ (int a) -> int
+///     [] (int a) -> int
 ///     {
 ///         return a + 5;
 ///     };
@@ -279,7 +272,7 @@ inline hipError_t transform(InputIterator     input,
 ///
 /// // custom transform function
 /// auto transform_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a + b;
 ///     };
@@ -355,7 +348,7 @@ inline hipError_t transform(InputIterator1    input1,
 ///
 /// // custom transform function
 /// auto transform_op =
-///     [] __device__ (int a, int b, int c) -> int
+///     [] (int a, int b, int c) -> int
 ///     {
 ///         return a + b + c;
 ///     };

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -73,7 +73,7 @@ inline hipError_t launch_transform(detail::target_arch arch,
                                       ResultType>(in, n, out, op);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<bool IsPointer,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -64,13 +64,13 @@ inline hipError_t launch_transform_for_arch(detail::target_arch arch,
 {
     auto kernel = [=] __device__ (auto arch_config)
     {
-        constexpr auto device_params = decltype(arch_config)::params;
+        constexpr auto params = decltype(arch_config)::params;
 
         detail::transform_kernel_impl<
             IsPointer,
-            device_params.kernel_config.block_size,
-            device_params.kernel_config.items_per_thread,
-            device_params.load_type,
+            params.kernel_config.block_size,
+            params.kernel_config.items_per_thread,
+            params.load_type,
             ResultType>(in, n, out, op);
     };
 

--- a/projects/rocprim/rocprim/include/rocprim/device/specialization/device_radix_block_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/specialization/device_radix_block_sort.hpp
@@ -37,25 +37,40 @@ template<class Config,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Decomposer>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().block_size) void
-    radix_sort_block_sort_kernel(KeysInputIterator    keys_input,
-                                 KeysOutputIterator   keys_output,
-                                 ValuesInputIterator  values_input,
-                                 ValuesOutputIterator values_output,
-                                 unsigned int         size,
-                                 Decomposer           decomposer,
-                                 unsigned int         bit,
-                                 unsigned int         current_radix_bits)
+inline hipError_t launch_radix_sort_block_sort(detail::target_arch  arch,
+                                               KeysInputIterator    keys_input,
+                                               KeysOutputIterator   keys_output,
+                                               ValuesInputIterator  values_input,
+                                               ValuesOutputIterator values_output,
+                                               unsigned int         size,
+                                               Decomposer           decomposer,
+                                               unsigned int         bit,
+                                               unsigned int         current_radix_bits,
+                                               dim3                 grid,
+                                               dim3                 block,
+                                               size_t               shmem,
+                                               hipStream_t          stream)
 {
-    static constexpr kernel_config_params params = device_params<Config>();
-    sort_single<params.block_size, params.items_per_thread, Descending>(keys_input,
-                                                                        keys_output,
-                                                                        values_input,
-                                                                        values_output,
-                                                                        size,
-                                                                        decomposer,
-                                                                        bit,
-                                                                        current_radix_bits);
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr auto params = decltype(arch_config)::params;
+
+        sort_single<params.block_size, params.items_per_thread, Descending>(keys_input,
+                                                                            keys_output,
+                                                                            values_input,
+                                                                            values_output,
+                                                                            size,
+                                                                            decomposer,
+                                                                            bit,
+                                                                            current_radix_bits);
+    };
+
+    return execute_launch_plan<Config, decltype(kernel), radix_sort_config_selector>(arch,
+                                                                                     kernel,
+                                                                                     grid,
+                                                                                     block,
+                                                                                     shmem,
+                                                                                     stream);
 }
 
 template<class Config,
@@ -88,7 +103,7 @@ inline hipError_t radix_sort_block_sort(KeysInputIterator    keys_input,
     {
         return result;
     }
-    const kernel_config_params params = dispatch_target_arch<config>(target_arch);
+    const kernel_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     sort_items_per_block                     = params.block_size * params.items_per_thread;
     const unsigned int sort_number_of_blocks = ceiling_div(size, sort_items_per_block);
@@ -112,15 +127,20 @@ inline hipError_t radix_sort_block_sort(KeysInputIterator    keys_input,
         start = std::chrono::steady_clock::now();
     }
 
-    radix_sort_block_sort_kernel<config, Descending>
-        <<<dim3(sort_number_of_blocks), dim3(params.block_size), 0, stream>>>(keys_input,
-                                                                              keys_output,
-                                                                              values_input,
-                                                                              values_output,
-                                                                              size,
-                                                                              decomposer,
-                                                                              bit,
-                                                                              current_radix_bits);
+    ROCPRIM_RETURN_ON_ERROR(
+        launch_radix_sort_block_sort<config, Descending>(target_arch,
+                                                         keys_input,
+                                                         keys_output,
+                                                         values_input,
+                                                         values_output,
+                                                         size,
+                                                         decomposer,
+                                                         bit,
+                                                         current_radix_bits,
+                                                         dim3(sort_number_of_blocks),
+                                                         dim3(params.block_size),
+                                                         0,
+                                                         stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("radix_sort_block_sort_kernel", size, start);
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/specialization/device_radix_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/specialization/device_radix_merge_sort.hpp
@@ -231,7 +231,7 @@ hipError_t radix_sort_merge_impl(
                                                                     value_type>;
 
     // Some helpful checks during compile-time
-    (void)device_merge_sort_compile_time_verifier<wrapped_bs_config, wrapped_bm_config>;
+    device_merge_sort_compile_time_verifier<wrapped_bs_config, wrapped_bm_config>();
 
     // We will get this later from the block_sort algorithm
     unsigned int sort_items_per_block

--- a/projects/rocprim/test/rocprim/CMakeLists.txt
+++ b/projects/rocprim/test/rocprim/CMakeLists.txt
@@ -300,6 +300,7 @@ add_rocprim_test_parallel("rocprim.device_radix_sort" test_device_radix_sort.cpp
 add_rocprim_test("rocprim.device_reduce_by_key" test_device_reduce_by_key.cpp)
 add_rocprim_test("rocprim.device_reduce" test_device_reduce.cpp)
 add_rocprim_test("rocprim.device_run_length_encode" test_device_run_length_encode.cpp)
+add_rocprim_test("rocprim.device_scan_by_key" test_device_scan_by_key.cpp)
 add_rocprim_test("rocprim.device_scan" test_device_scan.cpp)
 add_rocprim_test("rocprim.device_search" test_device_search.cpp)
 add_rocprim_test_parallel("rocprim.device_segmented_radix_sort" test_device_segmented_radix_sort.cpp.in)

--- a/projects/rocprim/test/rocprim/CMakeLists.txt
+++ b/projects/rocprim/test/rocprim/CMakeLists.txt
@@ -414,11 +414,11 @@ if(NOT WIN32)
   string(REPLACE ";" " " NM_ARGS_STR "${NM_ARGS}")
   add_test(
     NAME "rocprim.linking_lib1_symbols"
-    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking_lib1> | grep -c -P \"(rocprim::(?!ROCPRIM_${rocprim_VERSION_NUMBER}_NS))|trampoline|init_lookback_scan_state_kernel\""
+    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking_lib1> | grep -c -P \"(rocprim::(?!ROCPRIM_${rocprim_VERSION_NUMBER}_NS))|kernel\""
   )
   add_test(
     NAME "rocprim.linking_lib2_symbols"
-    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking_lib2> | grep -c -P \"(rocprim::(?!ROCPRIM_300201_NS))|trampoline|init_lookback_scan_state_kernel\""
+    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking_lib2> | grep -c -P \"(rocprim::(?!ROCPRIM_300201_NS))|kernel\""
   )
   add_test(
     NAME "rocprim.linking_symbols"

--- a/projects/rocprim/test/rocprim/CMakeLists.txt
+++ b/projects/rocprim/test/rocprim/CMakeLists.txt
@@ -408,18 +408,21 @@ if(NOT WIN32)
   #  * there are symbols in the rocprim namespace but not in the inline namespace with the
   #    corresponding rocPRIM version;
   #  * any kernels are visible (usually they have "kernel" in their names).
+
+  # The current compiler ignores `__attribute__((__visibility__("hidden")))` for executables,
+  # but not for libraries, so we remove the `|kernel` from the regex in rocprim.linking_symbols.
   string(REPLACE ";" " " NM_ARGS_STR "${NM_ARGS}")
   add_test(
     NAME "rocprim.linking_lib1_symbols"
-    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking_lib1> | grep -c -P \"(rocprim::(?!ROCPRIM_${rocprim_VERSION_NUMBER}_NS))|kernel\""
+    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking_lib1> | grep -c -P \"(rocprim::(?!ROCPRIM_${rocprim_VERSION_NUMBER}_NS))|trampoline|init_lookback_scan_state_kernel\""
   )
   add_test(
     NAME "rocprim.linking_lib2_symbols"
-    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking_lib2> | grep -c -P \"(rocprim::(?!ROCPRIM_300201_NS))|kernel\""
+    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking_lib2> | grep -c -P \"(rocprim::(?!ROCPRIM_300201_NS))|trampoline|init_lookback_scan_state_kernel\""
   )
   add_test(
     NAME "rocprim.linking_symbols"
-    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking> | grep -c -P \"(rocprim::(?!ROCPRIM_${rocprim_VERSION_NUMBER}_NS))|kernel\""
+    COMMAND sh -c "${CMAKE_NM} ${NM_ARGS_STR} $<TARGET_FILE:test_linking> | grep -c -P \"(rocprim::(?!ROCPRIM_${rocprim_VERSION_NUMBER}_NS))\""
   )
   set_tests_properties(
     "rocprim.linking_lib1_symbols"

--- a/projects/rocprim/test/rocprim/test_device_batch_memcpy.cpp
+++ b/projects/rocprim/test/rocprim/test_device_batch_memcpy.cpp
@@ -264,7 +264,7 @@ TYPED_TEST(RocprimDeviceBatchMemcpyTests, SizeAndTypeVariation)
     ASSERT_EQ(success, hipSuccess);
 
     const rocprim::detail::batch_memcpy_config_params params
-        = rocprim::detail::dispatch_target_arch<config>(target_arch);
+        = rocprim::detail::dispatch_target_arch<config, false>(target_arch);
 
     const int32_t wlev_min_size = params.wlev_size_threshold;
     const int32_t blev_min_size = params.blev_size_threshold;

--- a/projects/rocprim/test/rocprim/test_device_scan.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan.cpp
@@ -465,38 +465,34 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
 
             grid_size = number_of_blocks;
 
-            with_scan_state(
+            const auto launch_err = with_scan_state(
                 [&](const auto scan_state)
                 {
-                    ROCPRIM_RETURN_ON_ERROR(
-                        rocprim::detail::launch_lookback_scan<
-                            config,
-                            deterministic
-                                ? rocprim::detail::lookback_scan_determinism::deterministic
-                                : rocprim::detail::lookback_scan_determinism::nondeterministic,
-                            Exclusive,
-                            use_initial_value,
-                            decltype(input_iterator),
-                            U*,
-                            scan_op_type,
-                            acc_type,
-                            acc_type>(target_arch,
-                                      input_iterator,
-                                      d_output.get(),
-                                      size,
-                                      initial_value,
-                                      scan_op,
-                                      scan_state,
-                                      number_of_blocks,
-                                      dim3(grid_size),
-                                      dim3(block_size),
-                                      0,
-                                      stream,
-                                      previous_last_element,
-                                      new_last_element,
-                                      false,
-                                      false));
+                    return rocprim::detail::launch_lookback_scan < config,
+                           deterministic
+                               ? rocprim::detail::lookback_scan_determinism::deterministic
+                               : rocprim::detail::lookback_scan_determinism::nondeterministic,
+                           Exclusive, use_initial_value, decltype(input_iterator), U*, scan_op_type,
+                           acc_type,
+                           acc_type > (target_arch,
+                                       input_iterator,
+                                       d_output.get(),
+                                       size,
+                                       initial_value,
+                                       scan_op,
+                                       scan_state,
+                                       number_of_blocks,
+                                       dim3(grid_size),
+                                       dim3(block_size),
+                                       0,
+                                       stream,
+                                       previous_last_element,
+                                       new_last_element,
+                                       false,
+                                       false);
                 });
+
+            ASSERT_EQ(hipSuccess, launch_err);
 
             if(TestFixture::use_graphs)
             {
@@ -696,36 +692,33 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
 
         grid_size = number_of_blocks;
 
-        with_scan_state(
+        const auto launch_err = with_scan_state(
             [&](const auto scan_state)
             {
-                return rocprim::detail::launch_lookback_scan<
-                    config,
-                    deterministic ? rocprim::detail::lookback_scan_determinism::deterministic
-                                  : rocprim::detail::lookback_scan_determinism::nondeterministic,
-                    Exclusive,
-                    use_initial_value,
-                    decltype(input_iterator),
-                    U*,
-                    scan_op_type,
-                    acc_type,
-                    acc_type>(target_arch,
-                              input_iterator,
-                              d_output.get(),
-                              size,
-                              initial_value,
-                              scan_op,
-                              scan_state,
-                              number_of_blocks,
-                              dim3(grid_size),
-                              dim3(block_size),
-                              0,
-                              stream,
-                              previous_last_element,
-                              new_last_element,
-                              false,
-                              false);
+                return rocprim::detail::launch_lookback_scan < config,
+                       deterministic ? rocprim::detail::lookback_scan_determinism::deterministic
+                                     : rocprim::detail::lookback_scan_determinism::nondeterministic,
+                       Exclusive, use_initial_value, decltype(input_iterator), U*, scan_op_type,
+                       acc_type,
+                       acc_type > (target_arch,
+                                   input_iterator,
+                                   d_output.get(),
+                                   size,
+                                   initial_value,
+                                   scan_op,
+                                   scan_state,
+                                   number_of_blocks,
+                                   dim3(grid_size),
+                                   dim3(block_size),
+                                   0,
+                                   stream,
+                                   previous_last_element,
+                                   new_last_element,
+                                   false,
+                                   false);
             });
+
+        ASSERT_EQ(hipSuccess, launch_err);
 
         if(TestFixture::use_graphs)
         {
@@ -744,8 +737,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
 
         common::device_ptr<U> d_output_complete(grid_size);
         with_scan_state(
-            [&](const auto scan_state)
-            {
+            [&](const auto scan_state) {
                 complete_value<<<dim3(grid_size), dim3(1), 0, stream>>>(d_output_complete.get(),
                                                                         scan_state);
             });
@@ -1101,13 +1093,13 @@ public:
     class conditional_discard_value
     {
     public:
-        __host__ __device__
-        explicit conditional_discard_value(T* const value, bool keep)
+        __host__ __device__ explicit conditional_discard_value(T* const value, bool keep)
             : value_{value}, keep_{keep}
         {}
 
         __host__ __device__
-        conditional_discard_value& operator=(T value)
+        conditional_discard_value&
+            operator=(T value)
         {
             if(keep_)
             {
@@ -1130,18 +1122,16 @@ public:
     using reference         = conditional_discard_value;
     using pointer           = conditional_discard_value*;
     using iterator_category = std::random_access_iterator_tag;
-    using difference_type   = std::ptrdiff_t;
+    using difference_type = std::ptrdiff_t;
 
-    __host__ __device__
-    single_index_iterator(T* value, size_t expected_index, size_t index = 0)
+    __host__ __device__ single_index_iterator(T* value, size_t expected_index, size_t index = 0)
         : value_{value}, expected_index_{expected_index}, index_{index}
     {}
 
+    __host__ __device__ single_index_iterator(const single_index_iterator&) = default;
     __host__ __device__
-    single_index_iterator(const single_index_iterator&)
-        = default;
-    __host__ __device__
-    single_index_iterator& operator=(const single_index_iterator&)
+    single_index_iterator&
+        operator=(const single_index_iterator&)
         = default;
 
     // clang-format off
@@ -1388,12 +1378,9 @@ public:
     using reference         = CheckValue;
     using pointer           = CheckValue*;
     using iterator_category = std::random_access_iterator_tag;
-    using difference_type   = std::ptrdiff_t;
+    using difference_type = std::ptrdiff_t;
 
-    ROCPRIM_HOST_DEVICE
-    check_run_iterator(const args_t args)
-        : current_index_(0), args_(args)
-    {}
+    ROCPRIM_HOST_DEVICE check_run_iterator(const args_t args) : current_index_(0), args_(args) {}
 
     ROCPRIM_HOST_DEVICE
     bool operator==(const check_run_iterator& rhs) const
@@ -1406,61 +1393,72 @@ public:
         return !(*this == rhs);
     }
     ROCPRIM_HOST_DEVICE
-    reference operator*()
+    reference
+        operator*()
     {
         return value_type{current_index_, args_};
     }
     ROCPRIM_HOST_DEVICE
-    reference operator[](const difference_type distance) const
+    reference
+        operator[](const difference_type distance) const
     {
         return *(*this + distance);
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator& operator+=(const difference_type rhs)
+    check_run_iterator&
+        operator+=(const difference_type rhs)
     {
         current_index_ += rhs;
         return *this;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator& operator-=(const difference_type rhs)
+    check_run_iterator&
+        operator-=(const difference_type rhs)
     {
         current_index_ -= rhs;
         return *this;
     }
     ROCPRIM_HOST_DEVICE
-    difference_type operator-(const check_run_iterator& rhs) const
+    difference_type
+        operator-(const check_run_iterator& rhs) const
     {
         return current_index_ - rhs.current_index_;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator operator+(const difference_type rhs) const
+    check_run_iterator
+        operator+(const difference_type rhs) const
     {
         return check_run_iterator(*this) += rhs;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator operator-(const difference_type rhs) const
+    check_run_iterator
+        operator-(const difference_type rhs) const
     {
         return check_run_iterator(*this) -= rhs;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator& operator++()
+    check_run_iterator&
+        operator++()
     {
         ++current_index_;
         return *this;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator& operator--()
+    check_run_iterator&
+        operator--()
     {
         --current_index_;
         return *this;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator operator++(int)
+    check_run_iterator
+        operator++(int)
     {
         return ++check_run_iterator{*this};
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator operator--(int)
+    check_run_iterator
+        operator--(int)
     {
         return --check_run_iterator{*this};
     }
@@ -1480,7 +1478,8 @@ struct check_value_inclusive
     rocprim::tuple<size_t, unsigned int*> args_; // run_length, incorrect flag
 
     ROCPRIM_HOST_DEVICE
-    size_t                                operator=(const size_t value)
+    size_t
+        operator=(const size_t value)
     {
         const size_t run_start    = current_index_ - (current_index_ % rocprim::get<0>(args_));
         const size_t index_in_run = current_index_ - run_start + 1;
@@ -1501,10 +1500,11 @@ struct check_value_exclusive
 {
     size_t current_index_{};
     rocprim::tuple<size_t, size_t, unsigned int*>
-           args_; // run_length, initial_value, incorrect flag
+        args_; // run_length, initial_value, incorrect flag
 
     ROCPRIM_HOST_DEVICE
-    size_t operator=(const size_t value)
+    size_t
+        operator=(const size_t value)
     {
         const size_t run_start    = current_index_ - (current_index_ % rocprim::get<0>(args_));
         const size_t index_in_run = current_index_ - run_start;

--- a/projects/rocprim/test/rocprim/test_device_scan.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan.cpp
@@ -312,7 +312,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
     rocprim::detail::target_arch target_arch;
     HIP_CHECK(host_target_arch(stream, target_arch));
     const rocprim::detail::scan_config_params params
-        = rocprim::detail::dispatch_target_arch<config>(target_arch);
+        = rocprim::detail::dispatch_target_arch<config, false>(target_arch);
 
     // For non-associative operations in inclusive scan
     // intermediate results use the type of input iterator, then
@@ -468,29 +468,34 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
             with_scan_state(
                 [&](const auto scan_state)
                 {
-                    rocprim::detail::lookback_scan_kernel<
-                        deterministic
-                            ? rocprim::detail::lookback_scan_determinism::deterministic
-                            : rocprim::detail::lookback_scan_determinism::nondeterministic,
-                        Exclusive,
-                        use_initial_value,
-                        config,
-                        decltype(input_iterator),
-                        U*,
-                        scan_op_type,
-                        acc_type,
-                        acc_type>
-                        <<<dim3(grid_size), dim3(block_size), 0, stream>>>(input_iterator,
-                                                                           d_output.get(),
-                                                                           size,
-                                                                           initial_value,
-                                                                           scan_op,
-                                                                           scan_state,
-                                                                           number_of_blocks,
-                                                                           previous_last_element,
-                                                                           new_last_element,
-                                                                           false,
-                                                                           false);
+                    ROCPRIM_RETURN_ON_ERROR(
+                        rocprim::detail::launch_lookback_scan<
+                            config,
+                            deterministic
+                                ? rocprim::detail::lookback_scan_determinism::deterministic
+                                : rocprim::detail::lookback_scan_determinism::nondeterministic,
+                            Exclusive,
+                            use_initial_value,
+                            decltype(input_iterator),
+                            U*,
+                            scan_op_type,
+                            acc_type,
+                            acc_type>(target_arch,
+                                      input_iterator,
+                                      d_output.get(),
+                                      size,
+                                      initial_value,
+                                      scan_op,
+                                      scan_state,
+                                      number_of_blocks,
+                                      dim3(grid_size),
+                                      dim3(block_size),
+                                      0,
+                                      stream,
+                                      previous_last_element,
+                                      new_last_element,
+                                      false,
+                                      false));
                 });
 
             if(TestFixture::use_graphs)
@@ -547,7 +552,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
     rocprim::detail::target_arch target_arch;
     HIP_CHECK(host_target_arch(stream, target_arch));
     const rocprim::detail::scan_config_params params
-        = rocprim::detail::dispatch_target_arch<config>(target_arch);
+        = rocprim::detail::dispatch_target_arch<config, false>(target_arch);
 
     // For non-associative operations in inclusive scan
     // intermediate results use the type of input iterator, then
@@ -694,28 +699,32 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
         with_scan_state(
             [&](const auto scan_state)
             {
-                rocprim::detail::lookback_scan_kernel<
+                return rocprim::detail::launch_lookback_scan<
+                    config,
                     deterministic ? rocprim::detail::lookback_scan_determinism::deterministic
                                   : rocprim::detail::lookback_scan_determinism::nondeterministic,
                     Exclusive,
                     use_initial_value,
-                    config,
                     decltype(input_iterator),
                     U*,
                     scan_op_type,
                     acc_type,
-                    acc_type>
-                    <<<dim3(grid_size), dim3(block_size), 0, stream>>>(input_iterator,
-                                                                       d_output.get(),
-                                                                       size,
-                                                                       initial_value,
-                                                                       scan_op,
-                                                                       scan_state,
-                                                                       number_of_blocks,
-                                                                       previous_last_element,
-                                                                       new_last_element,
-                                                                       false,
-                                                                       false);
+                    acc_type>(target_arch,
+                              input_iterator,
+                              d_output.get(),
+                              size,
+                              initial_value,
+                              scan_op,
+                              scan_state,
+                              number_of_blocks,
+                              dim3(grid_size),
+                              dim3(block_size),
+                              0,
+                              stream,
+                              previous_last_element,
+                              new_last_element,
+                              false,
+                              false);
             });
 
         if(TestFixture::use_graphs)
@@ -735,7 +744,8 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
 
         common::device_ptr<U> d_output_complete(grid_size);
         with_scan_state(
-            [&](const auto scan_state) {
+            [&](const auto scan_state)
+            {
                 complete_value<<<dim3(grid_size), dim3(1), 0, stream>>>(d_output_complete.get(),
                                                                         scan_state);
             });
@@ -1091,13 +1101,13 @@ public:
     class conditional_discard_value
     {
     public:
-        __host__ __device__ explicit conditional_discard_value(T* const value, bool keep)
+        __host__ __device__
+        explicit conditional_discard_value(T* const value, bool keep)
             : value_{value}, keep_{keep}
         {}
 
         __host__ __device__
-        conditional_discard_value&
-            operator=(T value)
+        conditional_discard_value& operator=(T value)
         {
             if(keep_)
             {
@@ -1120,16 +1130,18 @@ public:
     using reference         = conditional_discard_value;
     using pointer           = conditional_discard_value*;
     using iterator_category = std::random_access_iterator_tag;
-    using difference_type = std::ptrdiff_t;
+    using difference_type   = std::ptrdiff_t;
 
-    __host__ __device__ single_index_iterator(T* value, size_t expected_index, size_t index = 0)
+    __host__ __device__
+    single_index_iterator(T* value, size_t expected_index, size_t index = 0)
         : value_{value}, expected_index_{expected_index}, index_{index}
     {}
 
-    __host__ __device__ single_index_iterator(const single_index_iterator&) = default;
     __host__ __device__
-    single_index_iterator&
-        operator=(const single_index_iterator&)
+    single_index_iterator(const single_index_iterator&)
+        = default;
+    __host__ __device__
+    single_index_iterator& operator=(const single_index_iterator&)
         = default;
 
     // clang-format off
@@ -1376,9 +1388,12 @@ public:
     using reference         = CheckValue;
     using pointer           = CheckValue*;
     using iterator_category = std::random_access_iterator_tag;
-    using difference_type = std::ptrdiff_t;
+    using difference_type   = std::ptrdiff_t;
 
-    ROCPRIM_HOST_DEVICE check_run_iterator(const args_t args) : current_index_(0), args_(args) {}
+    ROCPRIM_HOST_DEVICE
+    check_run_iterator(const args_t args)
+        : current_index_(0), args_(args)
+    {}
 
     ROCPRIM_HOST_DEVICE
     bool operator==(const check_run_iterator& rhs) const
@@ -1391,72 +1406,61 @@ public:
         return !(*this == rhs);
     }
     ROCPRIM_HOST_DEVICE
-    reference
-        operator*()
+    reference operator*()
     {
         return value_type{current_index_, args_};
     }
     ROCPRIM_HOST_DEVICE
-    reference
-        operator[](const difference_type distance) const
+    reference operator[](const difference_type distance) const
     {
         return *(*this + distance);
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator&
-        operator+=(const difference_type rhs)
+    check_run_iterator& operator+=(const difference_type rhs)
     {
         current_index_ += rhs;
         return *this;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator&
-        operator-=(const difference_type rhs)
+    check_run_iterator& operator-=(const difference_type rhs)
     {
         current_index_ -= rhs;
         return *this;
     }
     ROCPRIM_HOST_DEVICE
-    difference_type
-        operator-(const check_run_iterator& rhs) const
+    difference_type operator-(const check_run_iterator& rhs) const
     {
         return current_index_ - rhs.current_index_;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator
-        operator+(const difference_type rhs) const
+    check_run_iterator operator+(const difference_type rhs) const
     {
         return check_run_iterator(*this) += rhs;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator
-        operator-(const difference_type rhs) const
+    check_run_iterator operator-(const difference_type rhs) const
     {
         return check_run_iterator(*this) -= rhs;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator&
-        operator++()
+    check_run_iterator& operator++()
     {
         ++current_index_;
         return *this;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator&
-        operator--()
+    check_run_iterator& operator--()
     {
         --current_index_;
         return *this;
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator
-        operator++(int)
+    check_run_iterator operator++(int)
     {
         return ++check_run_iterator{*this};
     }
     ROCPRIM_HOST_DEVICE
-    check_run_iterator
-        operator--(int)
+    check_run_iterator operator--(int)
     {
         return --check_run_iterator{*this};
     }
@@ -1476,8 +1480,7 @@ struct check_value_inclusive
     rocprim::tuple<size_t, unsigned int*> args_; // run_length, incorrect flag
 
     ROCPRIM_HOST_DEVICE
-    size_t
-        operator=(const size_t value)
+    size_t                                operator=(const size_t value)
     {
         const size_t run_start    = current_index_ - (current_index_ % rocprim::get<0>(args_));
         const size_t index_in_run = current_index_ - run_start + 1;
@@ -1498,11 +1501,10 @@ struct check_value_exclusive
 {
     size_t current_index_{};
     rocprim::tuple<size_t, size_t, unsigned int*>
-        args_; // run_length, initial_value, incorrect flag
+           args_; // run_length, initial_value, incorrect flag
 
     ROCPRIM_HOST_DEVICE
-    size_t
-        operator=(const size_t value)
+    size_t operator=(const size_t value)
     {
         const size_t run_start    = current_index_ - (current_index_ % rocprim::get<0>(args_));
         const size_t index_in_run = current_index_ - run_start;

--- a/projects/rocprim/test/rocprim/test_device_scan.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan.cpp
@@ -66,31 +66,13 @@
 #include <utility>
 #include <vector>
 
-struct default_config_helper
-{
-    template<bool /* ByKey */>
-    using type = ::rocprim::default_config;
-};
-
 template<unsigned int SizeLimit>
-struct size_limit_config_helper
-{
-    template<bool ByKey>
-    using type = std::conditional_t<
-        ByKey,
-        rocprim::scan_by_key_config<256,
-                                    16,
-                                    rocprim::block_load_method::block_load_transpose,
-                                    rocprim::block_store_method::block_store_transpose,
-                                    rocprim::block_scan_algorithm::using_warp_scan,
-                                    SizeLimit>,
-        rocprim::scan_config<256,
-                             16,
-                             rocprim::block_load_method::block_load_transpose,
-                             rocprim::block_store_method::block_store_transpose,
-                             rocprim::block_scan_algorithm::using_warp_scan,
-                             SizeLimit>>;
-};
+using size_limit_config = rocprim::scan_config<256,
+                                               16,
+                                               rocprim::block_load_method::block_load_transpose,
+                                               rocprim::block_store_method::block_store_transpose,
+                                               rocprim::block_scan_algorithm::using_warp_scan,
+                                               SizeLimit>;
 
 // Params for tests
 template<class InputType,
@@ -99,7 +81,7 @@ template<class InputType,
          // Tests output iterator with void value_type (OutputIterator concept)
          // scan-by-key primitives don't support output iterator with void value_type
          bool UseIdentityIteratorIfSupported = false,
-         typename ConfigHelper               = default_config_helper,
+         typename ConfigHelper               = rocprim::default_config,
          bool UseGraphs                      = false,
          bool Deterministic                  = false,
          bool UseInitialValue                = false>
@@ -141,32 +123,6 @@ constexpr hipError_t invoke_exclusive_scan(Args&&... args)
     }
 }
 
-template<bool Deterministic, typename Config = rocprim::default_config, typename... Args>
-constexpr hipError_t invoke_inclusive_scan_by_key(Args&&... args)
-{
-    if(Deterministic)
-    {
-        return rocprim::deterministic_inclusive_scan_by_key<Config>(std::forward<Args>(args)...);
-    }
-    else
-    {
-        return rocprim::inclusive_scan_by_key<Config>(std::forward<Args>(args)...);
-    }
-}
-
-template<bool Deterministic, typename Config = rocprim::default_config, typename... Args>
-constexpr hipError_t invoke_exclusive_scan_by_key(Args&&... args)
-{
-    if(Deterministic)
-    {
-        return rocprim::deterministic_exclusive_scan_by_key<Config>(std::forward<Args>(args)...);
-    }
-    else
-    {
-        return rocprim::exclusive_scan_by_key<Config>(std::forward<Args>(args)...);
-    }
-}
-
 // ---------------------------------------------------------
 // Test for scan ops taking single input value
 // ---------------------------------------------------------
@@ -192,18 +148,18 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
     DeviceScanParams<unsigned short>,
     DeviceScanParams<short, int>,
     DeviceScanParams<int>,
-    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config_helper<512>>,
+    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config<512>>,
     DeviceScanParams<float, float, rocprim::maximum<float>>,
-    DeviceScanParams<float, float, rocprim::plus<float>, false, size_limit_config_helper<1024>>,
+    DeviceScanParams<float, float, rocprim::plus<float>, false, size_limit_config<1024>>,
     DeviceScanParams<float,
                      float,
                      rocprim::plus<float>,
                      false,
-                     size_limit_config_helper<1024>,
+                     size_limit_config<1024>,
                      false,
                      true>,
-    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config_helper<524288>>,
-    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config_helper<1048576>>,
+    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config<524288>>,
+    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config<1048576>>,
     DeviceScanParams<int8_t, int8_t, rocprim::maximum<int8_t>>,
     DeviceScanParams<uint8_t, uint8_t, rocprim::maximum<uint8_t>, false>,
     DeviceScanParams<rocprim::half, rocprim::half, rocprim::maximum<rocprim::half>>,
@@ -211,7 +167,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     default_config_helper,
+                     rocprim::default_config,
                      false,
                      true>,
     DeviceScanParams<rocprim::bfloat16, rocprim::bfloat16, rocprim::maximum<rocprim::bfloat16>>,
@@ -219,7 +175,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     default_config_helper,
+                     rocprim::default_config,
                      false,
                      true>,
     // Large
@@ -233,7 +189,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      double,
                      rocprim::plus<double>,
                      false,
-                     default_config_helper,
+                     rocprim::default_config,
                      true,
                      true>,
     DeviceScanParams<signed char, long, rocprim::plus<long>>,
@@ -247,19 +203,19 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      common::custom_type<double, double, true>,
                      rocprim::plus<common::custom_type<double, double, true>>,
                      false,
-                     default_config_helper,
+                     rocprim::default_config,
                      true>,
     DeviceScanParams<common::custom_type<int, int, true>>,
     DeviceScanParams<test_utils::custom_test_array_type<long long, 5>>,
     DeviceScanParams<test_utils::custom_test_array_type<int, 10>>,
     // With graphs
-    DeviceScanParams<int, int, rocprim::plus<int>, false, default_config_helper, true>,
+    DeviceScanParams<int, int, rocprim::plus<int>, false, rocprim::default_config, true>,
     // With initial values
     DeviceScanParams<int,
                      int,
                      rocprim::plus<int>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -267,7 +223,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      int,
                      rocprim::maximum<int>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -275,7 +231,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      int,
                      rocprim::minimum<int>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -283,7 +239,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -291,7 +247,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      rocprim::half,
                      rocprim::minimum<rocprim::half>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -299,7 +255,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -307,7 +263,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      rocprim::bfloat16,
                      rocprim::minimum<rocprim::bfloat16>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -315,7 +271,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>>;
@@ -348,7 +304,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
     const bool deterministic     = TestFixture::deterministic;
     const bool use_initial_value = TestFixture::use_initial_value;
 
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config = typename TestFixture::config_helper;
     using config = rocprim::detail::wrapped_scan_config<Config, acc_type>;
 
     hipStream_t stream = hipStreamDefault;
@@ -472,7 +428,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
             // Call the provided function with either scan_state or scan_state_with_sleep based on
             // the value of use_sleep
             bool use_sleep;
-            HIP_CHECK(rocprim::detail::is_sleep_scan_state_used(stream, use_sleep))
+            HIP_CHECK(rocprim::detail::is_sleep_scan_state_used(stream, use_sleep));
             auto with_scan_state = [use_sleep, scan_state, scan_state_with_sleep](
                                        auto&& func) mutable -> decltype(auto)
             {
@@ -583,7 +539,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
     const bool deterministic     = TestFixture::deterministic;
     const bool use_initial_value = TestFixture::use_initial_value;
 
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config = typename TestFixture::config_helper;
     using config = rocprim::detail::wrapped_scan_config<Config, acc_type>;
 
     hipStream_t stream = hipStreamDefault;
@@ -698,7 +654,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
         // Call the provided function with either scan_state or scan_state_with_sleep based on
         // the value of use_sleep
         bool use_sleep;
-        HIP_CHECK(rocprim::detail::is_sleep_scan_state_used(stream, use_sleep))
+        HIP_CHECK(rocprim::detail::is_sleep_scan_state_used(stream, use_sleep));
         auto with_scan_state
             = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
         {
@@ -815,7 +771,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
-    
+
     // Default
     hipStream_t stream = 0;
     if(TestFixture::use_graphs)
@@ -885,7 +841,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
     static constexpr bool deterministic         = TestFixture::deterministic;
     static constexpr bool use_initial_value     = TestFixture::use_initial_value;
 
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config = typename TestFixture::config_helper;
 
     // Default
     hipStream_t stream = 0;
@@ -1034,7 +990,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
     static constexpr bool use_identity_iterator = TestFixture::use_identity_iterator;
     static constexpr bool deterministic         = TestFixture::deterministic;
 
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config = typename TestFixture::config_helper;
 
     // Default
     hipStream_t stream = 0;
@@ -1119,249 +1075,6 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
                         test_utils::assert_near(output[i], expected[i], single_op_precision * i));
                 }
             }
-        }
-    }
-
-    if(TestFixture::use_graphs)
-    {
-        HIP_CHECK(hipStreamDestroy(stream));
-    }
-}
-
-TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
-{
-    // scan-by-key does not support output iterator with void value_type
-    using T = typename TestFixture::input_type;
-    using K = unsigned int; // Key type
-    using U = typename TestFixture::output_type;
-
-    using scan_op_type = typename TestFixture::scan_op_type;
-    // If scan_op_type is rocprim::plus and input_type is bfloat16 or half,
-    // use float as device-side accumulator and double as host-side accumulator
-    using is_plus_op = test_utils::is_plus_operator<scan_op_type>;
-    using acc_type   = typename accum_type<T, scan_op_type>::type;
-
-    constexpr float single_op_precision = is_plus_op::value ? test_utils::precision<acc_type> : 0;
-
-    const bool debug_synchronous = TestFixture::debug_synchronous;
-    const bool deterministic     = TestFixture::deterministic;
-    using Config                 = typename TestFixture::config_helper::template type<true>;
-
-    // Default
-    hipStream_t stream = 0;
-    if(TestFixture::use_graphs)
-    {
-        // Default stream does not support hipGraph stream capture, so create one
-        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-    }
-
-    int device_id = test_common_utils::obtain_device_from_ctest();
-    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
-    HIP_CHECK(hipSetDevice(device_id));
-
-    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
-    {
-        unsigned int seed_value
-            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
-        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
-
-        for(auto size : test_utils::get_sizes(seed_value))
-        {
-            if(single_op_precision * (size - 1) > 0.5)
-            {
-                std::cout << "Test is skipped from size " << size
-                          << " on, potential error of summation is more than 0.5 of the result "
-                             "with current or larger size"
-                          << std::endl;
-                break;
-            }
-
-            SCOPED_TRACE(testing::Message() << "with size = " << size);
-
-            const bool use_unique_keys = bool(test_utils::get_random_value<int>(0, 1, seed_value));
-
-            // Generate data
-            std::vector<T> input = test_utils::get_random_data<T>(size, 0, 9, seed_value);
-            std::vector<K> keys;
-            if(use_unique_keys)
-            {
-                keys = test_utils::get_random_data<K>(size, 0, 16, seed_value);
-                std::sort(keys.begin(), keys.end());
-            }
-            else
-            {
-                keys = test_utils::get_random_data<K>(size, 0, 3, seed_value);
-            }
-
-            common::device_ptr<T> d_input(input);
-            common::device_ptr<K> d_keys(keys);
-            common::device_ptr<U> d_output(input.size());
-
-            // Scan function
-            scan_op_type scan_op;
-            // Key compare function
-            rocprim::equal_to<K> keys_compare_op;
-
-            // Calculate expected results on host
-            std::vector<U> expected(input.size());
-            test_utils::host_inclusive_scan_by_key(input.begin(),
-                                                   input.end(),
-                                                   keys.begin(),
-                                                   expected.begin(),
-                                                   scan_op,
-                                                   keys_compare_op);
-
-            auto input_iterator
-                = rocprim::make_transform_iterator(d_input.get(),
-                                                   [](T in) { return static_cast<acc_type>(in); });
-
-            test_utils::test_kernel_wrapper(
-                [&](void* temp_storage, size_t& storage_bytes)
-                {
-                    return invoke_inclusive_scan_by_key<deterministic, Config>(temp_storage,
-                                                                               storage_bytes,
-                                                                               d_keys.get(),
-                                                                               input_iterator,
-                                                                               d_output.get(),
-                                                                               input.size(),
-                                                                               scan_op,
-                                                                               keys_compare_op,
-                                                                               stream,
-                                                                               debug_synchronous);
-                },
-                stream,
-                TestFixture::use_graphs);
-
-            // Copy output to host
-            const auto output = d_output.load();
-
-            // Check if output values are as expected
-            ASSERT_NO_FATAL_FAILURE(
-                test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
-        }
-    }
-
-    if(TestFixture::use_graphs)
-    {
-        HIP_CHECK(hipStreamDestroy(stream));
-    }
-}
-
-TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
-{
-    // scan-by-key does not support output iterator with void value_type
-    using T = typename TestFixture::input_type;
-    using K = unsigned int; // Key type
-    using U = typename TestFixture::output_type;
-
-    using scan_op_type = typename TestFixture::scan_op_type;
-    // If scan_op_type is rocprim::plus and input_type is bfloat16 or half,
-    // use float as device-side accumulator and double as host-side accumulator
-    using is_plus_op = test_utils::is_plus_operator<scan_op_type>;
-    using acc_type   = typename accum_type<T, scan_op_type>::type;
-
-    acc_type        initial_value;
-    constexpr float single_op_precision = is_plus_op::value ? test_utils::precision<acc_type> : 0;
-
-    const bool debug_synchronous = TestFixture::debug_synchronous;
-    const bool deterministic     = TestFixture::deterministic;
-    using Config                 = typename TestFixture::config_helper::template type<true>;
-
-    // Default
-    hipStream_t stream = 0;
-    if(TestFixture::use_graphs)
-    {
-        // Default stream does not support hipGraph stream capture, so create one
-        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-    }
-
-    int device_id = test_common_utils::obtain_device_from_ctest();
-    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
-    HIP_CHECK(hipSetDevice(device_id));
-
-    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
-    {
-        unsigned int seed_value
-            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
-        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
-
-        for(auto size : test_utils::get_sizes(seed_value))
-        {
-            if(single_op_precision * (size - 1) > 0.5)
-            {
-                std::cout << "Test is skipped from size " << size
-                          << " on, potential error of summation is more than 0.5 of the result "
-                             "with current or larger size"
-                          << std::endl;
-                break;
-            }
-
-            SCOPED_TRACE(testing::Message() << "with size = " << size);
-
-            const bool use_unique_keys = bool(test_utils::get_random_value<int>(0, 1, seed_value));
-
-            // Generate data
-            initial_value        = test_utils::get_random_value<acc_type>(1, 100, seed_value);
-            std::vector<T> input = test_utils::get_random_data<T>(size, 0, 9, seed_value);
-            std::vector<K> keys;
-            if(use_unique_keys)
-            {
-                keys = test_utils::get_random_data<K>(size, 0, 16, seed_value);
-                std::sort(keys.begin(), keys.end());
-            }
-            else
-            {
-                keys = test_utils::get_random_data<K>(size, 0, 3, seed_value);
-            }
-
-            common::device_ptr<T> d_input(input);
-            common::device_ptr<K> d_keys(keys);
-            common::device_ptr<U> d_output(input.size());
-
-            // Scan function
-            scan_op_type scan_op;
-
-            // Key compare function
-            rocprim::equal_to<K> keys_compare_op;
-
-            // Calculate expected results on host
-            std::vector<U> expected(input.size());
-            test_utils::host_exclusive_scan_by_key(input.begin(),
-                                                   input.end(),
-                                                   keys.begin(),
-                                                   initial_value,
-                                                   expected.begin(),
-                                                   scan_op,
-                                                   keys_compare_op);
-
-            auto input_iterator
-                = rocprim::make_transform_iterator(d_input.get(),
-                                                   [](T in) { return static_cast<acc_type>(in); });
-
-            test_utils::test_kernel_wrapper(
-                [&](void* temp_storage, size_t& storage_bytes)
-                {
-                    return invoke_exclusive_scan_by_key<deterministic, Config>(temp_storage,
-                                                                               storage_bytes,
-                                                                               d_keys.get(),
-                                                                               input_iterator,
-                                                                               d_output.get(),
-                                                                               initial_value,
-                                                                               input.size(),
-                                                                               scan_op,
-                                                                               keys_compare_op,
-                                                                               stream,
-                                                                               debug_synchronous);
-                },
-                stream,
-                TestFixture::use_graphs);
-
-            // Copy output to host
-            const auto output = d_output.load();
-
-            // Check if output values are as expected
-            ASSERT_NO_FATAL_FAILURE(
-                test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
         }
     }
 
@@ -1803,157 +1516,6 @@ struct check_value_exclusive
     }
 };
 
-using check_run_inclusive_iterator
-    = check_run_iterator<check_value_inclusive, size_t, unsigned int*>;
-using check_run_exclusive_iterator
-    = check_run_iterator<check_value_exclusive, size_t, size_t, unsigned int*>;
-
-/// \p brief Provides a skeleton to both the inclusive and exclusive scan large indices tests.
-/// The call to the appropriate scan function must be implemented in \p scan_by_key_fun.
-template<class ScanByKeyFun, bool UseGraphs = false>
-void large_indices_scan_by_key_test(ScanByKeyFun scan_by_key_fun)
-{
-    const int device_id = test_common_utils::obtain_device_from_ctest();
-    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
-    HIP_CHECK(hipSetDevice(device_id));
-
-    constexpr bool debug_synchronous = false;
-    hipStream_t    stream            = 0;
-    if(UseGraphs)
-    {
-        // Default stream does not support hipGraph stream capture, so create one
-        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-    }
-
-    const int seed_value = rand();
-    SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
-
-    const auto size = test_utils::get_large_sizes(seed_value).back();
-    SCOPED_TRACE(testing::Message() << "with size = " << size);
-
-    common::device_ptr<unsigned int> d_incorrect_flag(1);
-    HIP_CHECK(hipMemset(d_incorrect_flag.get(), 0, sizeof(unsigned int)));
-
-    const size_t run_length = test_utils::get_random_value<size_t>(1, 10000, seed_value);
-    SCOPED_TRACE(testing::Message() << "with run_length = " << run_length);
-
-    const auto keys_input = rocprim::make_transform_iterator(rocprim::counting_iterator<size_t>(0),
-                                                             [run_length](const auto value)
-                                                             { return value / run_length; });
-    const auto values_input = rocprim::counting_iterator<size_t>(0);
-
-    test_utils::test_kernel_wrapper(
-        [&](void* temp_storage, size_t& storage_bytes)
-        {
-            return scan_by_key_fun(temp_storage,
-                                   storage_bytes,
-                                   keys_input,
-                                   values_input,
-                                   run_length,
-                                   d_incorrect_flag.get(),
-                                   size,
-                                   stream,
-                                   debug_synchronous,
-                                   seed_value);
-        },
-        stream,
-        UseGraphs);
-
-    const auto incorrect_flag = d_incorrect_flag.load()[0];
-
-    ASSERT_EQ(0, incorrect_flag);
-
-    if(UseGraphs)
-    {
-        HIP_CHECK(hipStreamDestroy(stream));
-    }
-}
-
-template<bool UseGraphs = false>
-void testLargeIndicesInclusiveScanByKey()
-{
-    auto inclusive_scan_by_key = [](void*         d_temp_storage,
-                                    size_t&       temp_storage_size_bytes,
-                                    auto          keys_input,
-                                    auto          values_input,
-                                    size_t        run_length,
-                                    unsigned int* d_incorrect_flag,
-                                    size_t        size,
-                                    hipStream_t   stream,
-                                    bool          debug_synchronous,
-                                    int /*seed_value*/) -> hipError_t
-    {
-        const check_run_inclusive_iterator output_it(
-            rocprim::make_tuple(run_length, d_incorrect_flag));
-
-        return rocprim::inclusive_scan_by_key(d_temp_storage,
-                                              temp_storage_size_bytes,
-                                              keys_input,
-                                              values_input,
-                                              output_it,
-                                              size,
-                                              rocprim::plus<size_t>{},
-                                              rocprim::equal_to<size_t>{},
-                                              stream,
-                                              debug_synchronous);
-    };
-    large_indices_scan_by_key_test<decltype(inclusive_scan_by_key), UseGraphs>(
-        inclusive_scan_by_key);
-}
-
-TEST(RocprimDeviceScanTests, LargeIndicesInclusiveScanByKey)
-{
-    testLargeIndicesInclusiveScanByKey();
-}
-
-TEST(RocprimDeviceScanTests, LargeIndicesInclusiveScanByKeyWithGraphs)
-{
-    testLargeIndicesInclusiveScanByKey<true>();
-}
-
-template<bool UseGraphs = false>
-void testLargeIndicesExclusiveScanByKey()
-{
-    auto exclusive_scan_by_key = [](void*         d_temp_storage,
-                                    size_t&       temp_storage_size_bytes,
-                                    auto          keys_input,
-                                    auto          values_input,
-                                    size_t        run_length,
-                                    unsigned int* d_incorrect_flag,
-                                    size_t        size,
-                                    hipStream_t   stream,
-                                    bool          debug_synchronous,
-                                    int           seed_value) -> hipError_t
-    {
-        const size_t initial_value = test_utils::get_random_value<size_t>(0, 10000, seed_value);
-        const check_run_exclusive_iterator output_it(
-            rocprim::make_tuple(run_length, initial_value, d_incorrect_flag));
-        return rocprim::exclusive_scan_by_key(d_temp_storage,
-                                              temp_storage_size_bytes,
-                                              keys_input,
-                                              values_input,
-                                              output_it,
-                                              initial_value,
-                                              size,
-                                              rocprim::plus<size_t>{},
-                                              rocprim::equal_to<size_t>{},
-                                              stream,
-                                              debug_synchronous);
-    };
-    large_indices_scan_by_key_test<decltype(exclusive_scan_by_key), UseGraphs>(
-        exclusive_scan_by_key);
-}
-
-TEST(RocprimDeviceScanTests, LargeIndicesExclusiveScanByKey)
-{
-    testLargeIndicesExclusiveScanByKey();
-}
-
-TEST(RocprimDeviceScanTests, LargeIndicesExclusiveScanByKeyWithGraphs)
-{
-    testLargeIndicesExclusiveScanByKey<true>();
-}
-
 using RocprimDeviceScanFutureTestsParams = ::testing::Types<
     DeviceScanParams<char>,
     DeviceScanParams<int>,
@@ -1961,7 +1523,7 @@ using RocprimDeviceScanFutureTestsParams = ::testing::Types<
     DeviceScanParams<double, double, rocprim::plus<double>, true>,
     DeviceScanParams<common::custom_type<int, int, true>>,
     DeviceScanParams<test_utils::custom_test_array_type<long long, 5>>,
-    DeviceScanParams<int, int, ::rocprim::plus<int>, false, default_config_helper, true>>;
+    DeviceScanParams<int, int, ::rocprim::plus<int>, false, rocprim::default_config, true>>;
 
 template<typename Params>
 class RocprimDeviceScanFutureTests : public RocprimDeviceScanTests<Params>
@@ -1981,7 +1543,7 @@ TYPED_TEST(RocprimDeviceScanFutureTests, ExclusiveScan)
     const bool            debug_synchronous     = TestFixture::debug_synchronous;
     static constexpr bool use_identity_iterator = TestFixture::use_identity_iterator;
     const bool            deterministic         = TestFixture::deterministic;
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config                                = typename TestFixture::config_helper;
 
     const int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);

--- a/projects/rocprim/test/rocprim/test_device_scan_by_key.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan_by_key.cpp
@@ -66,11 +66,6 @@
 #include <utility>
 #include <vector>
 
-struct default_config_helper
-{
-    using type = ::rocprim::default_config;
-};
-
 template<unsigned int SizeLimit>
 using size_limit_config
     = rocprim::scan_by_key_config<256,

--- a/projects/rocprim/test/rocprim/test_device_scan_by_key.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan_by_key.cpp
@@ -1,0 +1,846 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "../common_test_header.hpp"
+
+#include "../../common/utils_custom_type.hpp"
+#include "../../common/utils_device_ptr.hpp"
+
+// Required test headers
+#include "bounds_checking_iterator.hpp"
+#include "identity_iterator.hpp"
+#include "test_utils.hpp"
+#include "test_utils_assertions.hpp"
+#include "test_utils_custom_test_types.hpp"
+#include "test_utils_data_generation.hpp"
+#include "test_utils_hipgraphs.hpp"
+
+// Required rocprim headers
+#include <rocprim/block/block_load.hpp>
+#include <rocprim/block/block_scan.hpp>
+#include <rocprim/block/block_store.hpp>
+#include <rocprim/config.hpp>
+#include <rocprim/device/config_types.hpp>
+#include <rocprim/device/detail/device_config_helper.hpp>
+#include <rocprim/device/detail/device_scan_common.hpp>
+#include <rocprim/device/detail/lookback_scan_state.hpp>
+#include <rocprim/device/device_reduce.hpp>
+#include <rocprim/device/device_scan.hpp>
+#include <rocprim/device/device_scan_by_key.hpp>
+#include <rocprim/device/device_scan_config.hpp>
+#include <rocprim/functional.hpp>
+#include <rocprim/intrinsics/atomic.hpp>
+#include <rocprim/iterator/constant_iterator.hpp>
+#include <rocprim/iterator/counting_iterator.hpp>
+#include <rocprim/iterator/transform_iterator.hpp>
+#include <rocprim/types.hpp>
+#include <rocprim/types/future_value.hpp>
+#include <rocprim/types/tuple.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <stdint.h>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+struct default_config_helper
+{
+    using type = ::rocprim::default_config;
+};
+
+template<unsigned int SizeLimit>
+using size_limit_config
+    = rocprim::scan_by_key_config<256,
+                                  16,
+                                  rocprim::block_load_method::block_load_transpose,
+                                  rocprim::block_store_method::block_store_transpose,
+                                  rocprim::block_scan_algorithm::using_warp_scan,
+                                  SizeLimit>;
+
+// Params for tests
+template<class InputType,
+         class OutputType = InputType,
+         class ScanOp     = ::rocprim::plus<InputType>,
+         // Tests output iterator with void value_type (OutputIterator concept)
+         // scan-by-key primitives don't support output iterator with void value_type
+         bool UseIdentityIteratorIfSupported = false,
+         typename ConfigHelper               = rocprim::default_config,
+         bool UseGraphs                      = false,
+         bool Deterministic                  = false,
+         bool UseInitialValue                = false>
+struct DeviceScanByKeyParams
+{
+    using input_type                            = InputType;
+    using output_type                           = OutputType;
+    using scan_op_type                          = ScanOp;
+    static constexpr bool use_identity_iterator = UseIdentityIteratorIfSupported;
+    using config_helper                         = ConfigHelper;
+    static constexpr bool use_graphs            = UseGraphs;
+    static constexpr bool deterministic         = Deterministic;
+    static constexpr bool use_initial_value     = UseInitialValue;
+};
+
+template<bool Deterministic, typename Config = rocprim::default_config, typename... Args>
+constexpr hipError_t invoke_inclusive_scan_by_key(Args&&... args)
+{
+    if(Deterministic)
+    {
+        return rocprim::deterministic_inclusive_scan_by_key<Config>(std::forward<Args>(args)...);
+    }
+    else
+    {
+        return rocprim::inclusive_scan_by_key<Config>(std::forward<Args>(args)...);
+    }
+}
+
+template<bool Deterministic, typename Config = rocprim::default_config, typename... Args>
+constexpr hipError_t invoke_exclusive_scan_by_key(Args&&... args)
+{
+    if(Deterministic)
+    {
+        return rocprim::deterministic_exclusive_scan_by_key<Config>(std::forward<Args>(args)...);
+    }
+    else
+    {
+        return rocprim::exclusive_scan_by_key<Config>(std::forward<Args>(args)...);
+    }
+}
+
+// ---------------------------------------------------------
+// Test for scan ops taking single input value
+// ---------------------------------------------------------
+
+template<class Params>
+class RocprimDeviceScanTests : public ::testing::Test
+{
+public:
+    using input_type                            = typename Params::input_type;
+    using output_type                           = typename Params::output_type;
+    using scan_op_type                          = typename Params::scan_op_type;
+    const bool            debug_synchronous     = false;
+    static constexpr bool use_identity_iterator = Params::use_identity_iterator;
+    using config_helper                         = typename Params::config_helper;
+    bool                  use_graphs            = Params::use_graphs;
+    static constexpr bool deterministic         = Params::deterministic;
+    static constexpr bool use_initial_value     = Params::use_initial_value;
+};
+
+using RocprimDeviceScanTestsParams = ::testing::Types<
+    // Small
+    DeviceScanByKeyParams<char>,
+    DeviceScanByKeyParams<unsigned short>,
+    DeviceScanByKeyParams<short, int>,
+    DeviceScanByKeyParams<int>,
+    DeviceScanByKeyParams<int, int, rocprim::plus<int>, false, size_limit_config<512>>,
+    DeviceScanByKeyParams<float, float, rocprim::maximum<float>>,
+    DeviceScanByKeyParams<float, float, rocprim::plus<float>, false, size_limit_config<1024>>,
+    DeviceScanByKeyParams<float,
+                          float,
+                          rocprim::plus<float>,
+                          false,
+                          size_limit_config<1024>,
+                          false,
+                          true>,
+    DeviceScanByKeyParams<int, int, rocprim::plus<int>, false, size_limit_config<524288>>,
+    DeviceScanByKeyParams<int, int, rocprim::plus<int>, false, size_limit_config<1048576>>,
+    DeviceScanByKeyParams<int8_t, int8_t, rocprim::maximum<int8_t>>,
+    DeviceScanByKeyParams<uint8_t, uint8_t, rocprim::maximum<uint8_t>, false>,
+    DeviceScanByKeyParams<rocprim::half, rocprim::half, rocprim::maximum<rocprim::half>>,
+    DeviceScanByKeyParams<rocprim::half,
+                          float,
+                          rocprim::plus<float>,
+                          false,
+                          rocprim::default_config,
+                          false,
+                          true>,
+    DeviceScanByKeyParams<rocprim::bfloat16,
+                          rocprim::bfloat16,
+                          rocprim::maximum<rocprim::bfloat16>>,
+    DeviceScanByKeyParams<rocprim::bfloat16,
+                          float,
+                          rocprim::plus<float>,
+                          false,
+                          rocprim::default_config,
+                          false,
+                          true>,
+    // Large
+    DeviceScanByKeyParams<int, double, rocprim::plus<int>>,
+    DeviceScanByKeyParams<int, double, rocprim::plus<double>, false>,
+    DeviceScanByKeyParams<int, long long, rocprim::plus<long long>>,
+    DeviceScanByKeyParams<unsigned int, unsigned long long, rocprim::plus<unsigned long long>>,
+    DeviceScanByKeyParams<long long, long long, rocprim::maximum<long long>>,
+    DeviceScanByKeyParams<double, double, rocprim::plus<double>, true>,
+    DeviceScanByKeyParams<double,
+                          double,
+                          rocprim::plus<double>,
+                          false,
+                          rocprim::default_config,
+                          true,
+                          true>,
+    DeviceScanByKeyParams<signed char, long, rocprim::plus<long>>,
+    DeviceScanByKeyParams<float, double, rocprim::minimum<double>>,
+    DeviceScanByKeyParams<common::custom_type<int, int, true>>,
+    DeviceScanByKeyParams<common::custom_type<double, double, true>,
+                          common::custom_type<double, double, true>,
+                          rocprim::plus<common::custom_type<double, double, true>>,
+                          true>,
+    DeviceScanByKeyParams<common::custom_type<double, double, true>,
+                          common::custom_type<double, double, true>,
+                          rocprim::plus<common::custom_type<double, double, true>>,
+                          false,
+                          rocprim::default_config,
+                          true>,
+    DeviceScanByKeyParams<common::custom_type<int, int, true>>,
+    DeviceScanByKeyParams<test_utils::custom_test_array_type<long long, 5>>,
+    DeviceScanByKeyParams<test_utils::custom_test_array_type<int, 10>>,
+    // With graphs
+    DeviceScanByKeyParams<int, int, rocprim::plus<int>, false, rocprim::default_config, true>,
+    // With initial values
+    DeviceScanByKeyParams<int,
+                          int,
+                          rocprim::plus<int>,
+                          false,
+                          size_limit_config<524288>,
+                          false,
+                          true,
+                          true>,
+    DeviceScanByKeyParams<int,
+                          int,
+                          rocprim::maximum<int>,
+                          false,
+                          size_limit_config<524288>,
+                          false,
+                          true,
+                          true>,
+    DeviceScanByKeyParams<int,
+                          int,
+                          rocprim::minimum<int>,
+                          false,
+                          size_limit_config<524288>,
+                          false,
+                          true,
+                          true>,
+    DeviceScanByKeyParams<float,
+                          float,
+                          rocprim::plus<float>,
+                          false,
+                          size_limit_config<524288>,
+                          false,
+                          true,
+                          true>,
+    DeviceScanByKeyParams<rocprim::half,
+                          rocprim::half,
+                          rocprim::minimum<rocprim::half>,
+                          false,
+                          size_limit_config<524288>,
+                          false,
+                          true,
+                          true>,
+    DeviceScanByKeyParams<rocprim::half,
+                          float,
+                          rocprim::plus<float>,
+                          false,
+                          size_limit_config<524288>,
+                          false,
+                          true,
+                          true>,
+    DeviceScanByKeyParams<rocprim::bfloat16,
+                          rocprim::bfloat16,
+                          rocprim::minimum<rocprim::bfloat16>,
+                          false,
+                          size_limit_config<524288>,
+                          false,
+                          true,
+                          true>,
+    DeviceScanByKeyParams<rocprim::bfloat16,
+                          float,
+                          rocprim::plus<float>,
+                          false,
+                          size_limit_config<524288>,
+                          false,
+                          true,
+                          true>>;
+
+// Use float for accumulation of bfloat16 and half inputs if operator is plus
+template<typename input_type, typename input_op_type>
+struct accum_type
+{
+    static constexpr bool is_low_precision
+        = std::is_same<input_type, ::rocprim::half>::value
+          || std::is_same<input_type, ::rocprim::bfloat16>::value;
+    static constexpr bool is_plus = test_utils::is_plus_operator<input_op_type>::value;
+    using type = typename std::conditional_t<is_low_precision && is_plus, float, input_type>;
+};
+
+TYPED_TEST_SUITE(RocprimDeviceScanTests, RocprimDeviceScanTestsParams);
+
+TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
+{
+    // scan-by-key does not support output iterator with void value_type
+    using T = typename TestFixture::input_type;
+    using K = unsigned int; // Key type
+    using U = typename TestFixture::output_type;
+
+    using scan_op_type = typename TestFixture::scan_op_type;
+    // If scan_op_type is rocprim::plus and input_type is bfloat16 or half,
+    // use float as device-side accumulator and double as host-side accumulator
+    using is_plus_op = test_utils::is_plus_operator<scan_op_type>;
+    using acc_type   = typename accum_type<T, scan_op_type>::type;
+
+    constexpr float single_op_precision = is_plus_op::value ? test_utils::precision<acc_type> : 0;
+
+    const bool debug_synchronous = TestFixture::debug_synchronous;
+    const bool deterministic     = TestFixture::deterministic;
+
+    using Config = typename TestFixture::config_helper;
+
+    // Default
+    hipStream_t stream = 0;
+    if(TestFixture::use_graphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
+
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        for(auto size : test_utils::get_sizes(seed_value))
+        {
+            if(single_op_precision * (size - 1) > 0.5)
+            {
+                std::cout << "Test is skipped from size " << size
+                          << " on, potential error of summation is more than 0.5 of the result "
+                             "with current or larger size"
+                          << std::endl;
+                break;
+            }
+
+            SCOPED_TRACE(testing::Message() << "with size = " << size);
+
+            const bool use_unique_keys = bool(test_utils::get_random_value<int>(0, 1, seed_value));
+
+            // Generate data
+            std::vector<T> input = test_utils::get_random_data<T>(size, 0, 9, seed_value);
+            std::vector<K> keys;
+            if(use_unique_keys)
+            {
+                keys = test_utils::get_random_data<K>(size, 0, 16, seed_value);
+                std::sort(keys.begin(), keys.end());
+            }
+            else
+            {
+                keys = test_utils::get_random_data<K>(size, 0, 3, seed_value);
+            }
+
+            common::device_ptr<T> d_input(input);
+            common::device_ptr<K> d_keys(keys);
+            common::device_ptr<U> d_output(input.size());
+
+            // Scan function
+            scan_op_type scan_op;
+            // Key compare function
+            rocprim::equal_to<K> keys_compare_op;
+
+            // Calculate expected results on host
+            std::vector<U> expected(input.size());
+            test_utils::host_inclusive_scan_by_key(input.begin(),
+                                                   input.end(),
+                                                   keys.begin(),
+                                                   expected.begin(),
+                                                   scan_op,
+                                                   keys_compare_op);
+
+            auto input_iterator
+                = rocprim::make_transform_iterator(d_input.get(),
+                                                   [](T in) { return static_cast<acc_type>(in); });
+
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    return invoke_inclusive_scan_by_key<deterministic, Config>(temp_storage,
+                                                                               storage_bytes,
+                                                                               d_keys.get(),
+                                                                               input_iterator,
+                                                                               d_output.get(),
+                                                                               input.size(),
+                                                                               scan_op,
+                                                                               keys_compare_op,
+                                                                               stream,
+                                                                               debug_synchronous);
+                },
+                stream,
+                TestFixture::use_graphs);
+
+            // Copy output to host
+            const auto output = d_output.load();
+
+            // Check if output values are as expected
+            ASSERT_NO_FATAL_FAILURE(
+                test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+        }
+    }
+
+    if(TestFixture::use_graphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
+    }
+}
+
+TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
+{
+    // scan-by-key does not support output iterator with void value_type
+    using T = typename TestFixture::input_type;
+    using K = unsigned int; // Key type
+    using U = typename TestFixture::output_type;
+
+    using scan_op_type = typename TestFixture::scan_op_type;
+    // If scan_op_type is rocprim::plus and input_type is bfloat16 or half,
+    // use float as device-side accumulator and double as host-side accumulator
+    using is_plus_op = test_utils::is_plus_operator<scan_op_type>;
+    using acc_type   = typename accum_type<T, scan_op_type>::type;
+
+    acc_type        initial_value;
+    constexpr float single_op_precision = is_plus_op::value ? test_utils::precision<acc_type> : 0;
+
+    const bool debug_synchronous = TestFixture::debug_synchronous;
+    const bool deterministic     = TestFixture::deterministic;
+
+    using Config = typename TestFixture::config_helper;
+
+    // Default
+    hipStream_t stream = 0;
+    if(TestFixture::use_graphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
+
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
+    {
+        unsigned int seed_value
+            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+        for(auto size : test_utils::get_sizes(seed_value))
+        {
+            if(single_op_precision * (size - 1) > 0.5)
+            {
+                std::cout << "Test is skipped from size " << size
+                          << " on, potential error of summation is more than 0.5 of the result "
+                             "with current or larger size"
+                          << std::endl;
+                break;
+            }
+
+            SCOPED_TRACE(testing::Message() << "with size = " << size);
+
+            const bool use_unique_keys = bool(test_utils::get_random_value<int>(0, 1, seed_value));
+
+            // Generate data
+            initial_value        = test_utils::get_random_value<acc_type>(1, 100, seed_value);
+            std::vector<T> input = test_utils::get_random_data<T>(size, 0, 9, seed_value);
+            std::vector<K> keys;
+            if(use_unique_keys)
+            {
+                keys = test_utils::get_random_data<K>(size, 0, 16, seed_value);
+                std::sort(keys.begin(), keys.end());
+            }
+            else
+            {
+                keys = test_utils::get_random_data<K>(size, 0, 3, seed_value);
+            }
+
+            common::device_ptr<T> d_input(input);
+            common::device_ptr<K> d_keys(keys);
+            common::device_ptr<U> d_output(input.size());
+
+            // Scan function
+            scan_op_type scan_op;
+
+            // Key compare function
+            rocprim::equal_to<K> keys_compare_op;
+
+            // Calculate expected results on host
+            std::vector<U> expected(input.size());
+            test_utils::host_exclusive_scan_by_key(input.begin(),
+                                                   input.end(),
+                                                   keys.begin(),
+                                                   initial_value,
+                                                   expected.begin(),
+                                                   scan_op,
+                                                   keys_compare_op);
+
+            auto input_iterator
+                = rocprim::make_transform_iterator(d_input.get(),
+                                                   [](T in) { return static_cast<acc_type>(in); });
+
+            test_utils::test_kernel_wrapper(
+                [&](void* temp_storage, size_t& storage_bytes)
+                {
+                    return invoke_exclusive_scan_by_key<deterministic, Config>(temp_storage,
+                                                                               storage_bytes,
+                                                                               d_keys.get(),
+                                                                               input_iterator,
+                                                                               d_output.get(),
+                                                                               initial_value,
+                                                                               input.size(),
+                                                                               scan_op,
+                                                                               keys_compare_op,
+                                                                               stream,
+                                                                               debug_synchronous);
+                },
+                stream,
+                TestFixture::use_graphs);
+
+            // Copy output to host
+            const auto output = d_output.load();
+
+            // Check if output values are as expected
+            ASSERT_NO_FATAL_FAILURE(
+                test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+        }
+    }
+
+    if(TestFixture::use_graphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
+    }
+}
+
+/// \brief This iterator keeps track of the current index. Upon dereference, a \p CheckValue object
+/// is created and besides the current index, the provided \p rocprim::tuple<Args...> is passed
+/// to its constructor.
+template<class CheckValue, class... Args>
+class check_run_iterator
+{
+public:
+    using args_t            = rocprim::tuple<Args...>;
+    using value_type        = CheckValue;
+    using reference         = CheckValue;
+    using pointer           = CheckValue*;
+    using iterator_category = std::random_access_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+
+    ROCPRIM_HOST_DEVICE check_run_iterator(const args_t args) : current_index_(0), args_(args) {}
+
+    ROCPRIM_HOST_DEVICE
+    bool operator==(const check_run_iterator& rhs) const
+    {
+        return current_index_ == rhs.current_index_;
+    }
+    ROCPRIM_HOST_DEVICE
+    bool operator!=(const check_run_iterator& rhs) const
+    {
+        return !(*this == rhs);
+    }
+    ROCPRIM_HOST_DEVICE
+    reference
+        operator*()
+    {
+        return value_type{current_index_, args_};
+    }
+    ROCPRIM_HOST_DEVICE
+    reference
+        operator[](const difference_type distance) const
+    {
+        return *(*this + distance);
+    }
+    ROCPRIM_HOST_DEVICE
+    check_run_iterator&
+        operator+=(const difference_type rhs)
+    {
+        current_index_ += rhs;
+        return *this;
+    }
+    ROCPRIM_HOST_DEVICE
+    check_run_iterator&
+        operator-=(const difference_type rhs)
+    {
+        current_index_ -= rhs;
+        return *this;
+    }
+    ROCPRIM_HOST_DEVICE
+    difference_type
+        operator-(const check_run_iterator& rhs) const
+    {
+        return current_index_ - rhs.current_index_;
+    }
+    ROCPRIM_HOST_DEVICE
+    check_run_iterator
+        operator+(const difference_type rhs) const
+    {
+        return check_run_iterator(*this) += rhs;
+    }
+    ROCPRIM_HOST_DEVICE
+    check_run_iterator
+        operator-(const difference_type rhs) const
+    {
+        return check_run_iterator(*this) -= rhs;
+    }
+    ROCPRIM_HOST_DEVICE
+    check_run_iterator&
+        operator++()
+    {
+        ++current_index_;
+        return *this;
+    }
+    ROCPRIM_HOST_DEVICE
+    check_run_iterator&
+        operator--()
+    {
+        --current_index_;
+        return *this;
+    }
+    ROCPRIM_HOST_DEVICE
+    check_run_iterator
+        operator++(int)
+    {
+        return ++check_run_iterator{*this};
+    }
+    ROCPRIM_HOST_DEVICE
+    check_run_iterator
+        operator--(int)
+    {
+        return --check_run_iterator{*this};
+    }
+
+private:
+    size_t current_index_;
+    args_t args_;
+};
+
+/// \brief Checks if the \p size_t values written to it are part of the expected sequence.
+/// The expected sequence is the sequence [0, 1, 2, 3, ...) inclusively scanned in runs of
+/// \p run_length.
+/// If a discrepancy is found, \p incorrect_flag is atomically set to 1.
+struct check_value_inclusive
+{
+    size_t                                current_index_{};
+    rocprim::tuple<size_t, unsigned int*> args_; // run_length, incorrect flag
+
+    ROCPRIM_HOST_DEVICE
+    size_t
+        operator=(const size_t value)
+    {
+        const size_t run_start    = current_index_ - (current_index_ % rocprim::get<0>(args_));
+        const size_t index_in_run = current_index_ - run_start + 1;
+        const size_t expected_sum = (run_start + current_index_) * index_in_run / 2;
+        if(value != expected_sum)
+        {
+            rocprim::detail::atomic_store(rocprim::get<1>(args_), 1);
+        }
+        return value;
+    }
+};
+
+/// \brief Checks if the \p size_t values written to it are part of the expected sequence.
+/// The expected sequence is the sequence [0, 1, 2, 3, ...) exclusively scanned in runs of
+/// \p run_length, with \p initial_value.
+/// If a discrepancy is found, \p incorrect_flag is atomically set to 1.
+struct check_value_exclusive
+{
+    size_t current_index_{};
+    rocprim::tuple<size_t, size_t, unsigned int*>
+        args_; // run_length, initial_value, incorrect flag
+
+    ROCPRIM_HOST_DEVICE
+    size_t
+        operator=(const size_t value)
+    {
+        const size_t run_start    = current_index_ - (current_index_ % rocprim::get<0>(args_));
+        const size_t index_in_run = current_index_ - run_start;
+        const size_t expected_sum
+            = rocprim::get<1>(args_) + (run_start + current_index_ - 1) * index_in_run / 2;
+        if(value != expected_sum)
+        {
+            rocprim::detail::atomic_store(rocprim::get<2>(args_), 1);
+        }
+        return value;
+    }
+};
+
+using check_run_inclusive_iterator
+    = check_run_iterator<check_value_inclusive, size_t, unsigned int*>;
+using check_run_exclusive_iterator
+    = check_run_iterator<check_value_exclusive, size_t, size_t, unsigned int*>;
+
+/// \p brief Provides a skeleton to both the inclusive and exclusive scan large indices tests.
+/// The call to the appropriate scan function must be implemented in \p scan_by_key_fun.
+template<class ScanByKeyFun, bool UseGraphs = false>
+void large_indices_scan_by_key_test(ScanByKeyFun scan_by_key_fun)
+{
+    const int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    constexpr bool debug_synchronous = false;
+    hipStream_t    stream            = 0;
+    if(UseGraphs)
+    {
+        // Default stream does not support hipGraph stream capture, so create one
+        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
+    }
+
+    const int seed_value = rand();
+    SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
+
+    const auto size = test_utils::get_large_sizes(seed_value).back();
+    SCOPED_TRACE(testing::Message() << "with size = " << size);
+
+    common::device_ptr<unsigned int> d_incorrect_flag(1);
+    HIP_CHECK(hipMemset(d_incorrect_flag.get(), 0, sizeof(unsigned int)));
+
+    const size_t run_length = test_utils::get_random_value<size_t>(1, 10000, seed_value);
+    SCOPED_TRACE(testing::Message() << "with run_length = " << run_length);
+
+    const auto keys_input = rocprim::make_transform_iterator(rocprim::counting_iterator<size_t>(0),
+                                                             [run_length](const auto value)
+                                                             { return value / run_length; });
+    const auto values_input = rocprim::counting_iterator<size_t>(0);
+
+    test_utils::test_kernel_wrapper(
+        [&](void* temp_storage, size_t& storage_bytes)
+        {
+            return scan_by_key_fun(temp_storage,
+                                   storage_bytes,
+                                   keys_input,
+                                   values_input,
+                                   run_length,
+                                   d_incorrect_flag.get(),
+                                   size,
+                                   stream,
+                                   debug_synchronous,
+                                   seed_value);
+        },
+        stream,
+        UseGraphs);
+
+    const auto incorrect_flag = d_incorrect_flag.load()[0];
+
+    ASSERT_EQ(0, incorrect_flag);
+
+    if(UseGraphs)
+    {
+        HIP_CHECK(hipStreamDestroy(stream));
+    }
+}
+
+template<bool UseGraphs = false>
+void testLargeIndicesInclusiveScanByKey()
+{
+    auto inclusive_scan_by_key = [](void*         d_temp_storage,
+                                    size_t&       temp_storage_size_bytes,
+                                    auto          keys_input,
+                                    auto          values_input,
+                                    size_t        run_length,
+                                    unsigned int* d_incorrect_flag,
+                                    size_t        size,
+                                    hipStream_t   stream,
+                                    bool          debug_synchronous,
+                                    int /*seed_value*/) -> hipError_t
+    {
+        const check_run_inclusive_iterator output_it(
+            rocprim::make_tuple(run_length, d_incorrect_flag));
+
+        return rocprim::inclusive_scan_by_key(d_temp_storage,
+                                              temp_storage_size_bytes,
+                                              keys_input,
+                                              values_input,
+                                              output_it,
+                                              size,
+                                              rocprim::plus<size_t>{},
+                                              rocprim::equal_to<size_t>{},
+                                              stream,
+                                              debug_synchronous);
+    };
+    large_indices_scan_by_key_test<decltype(inclusive_scan_by_key), UseGraphs>(
+        inclusive_scan_by_key);
+}
+
+TEST(RocprimDeviceScanTests, LargeIndicesInclusiveScanByKey)
+{
+    testLargeIndicesInclusiveScanByKey();
+}
+
+TEST(RocprimDeviceScanTests, LargeIndicesInclusiveScanByKeyWithGraphs)
+{
+    testLargeIndicesInclusiveScanByKey<true>();
+}
+
+template<bool UseGraphs = false>
+void testLargeIndicesExclusiveScanByKey()
+{
+    auto exclusive_scan_by_key = [](void*         d_temp_storage,
+                                    size_t&       temp_storage_size_bytes,
+                                    auto          keys_input,
+                                    auto          values_input,
+                                    size_t        run_length,
+                                    unsigned int* d_incorrect_flag,
+                                    size_t        size,
+                                    hipStream_t   stream,
+                                    bool          debug_synchronous,
+                                    int           seed_value) -> hipError_t
+    {
+        const size_t initial_value = test_utils::get_random_value<size_t>(0, 10000, seed_value);
+        const check_run_exclusive_iterator output_it(
+            rocprim::make_tuple(run_length, initial_value, d_incorrect_flag));
+        return rocprim::exclusive_scan_by_key(d_temp_storage,
+                                              temp_storage_size_bytes,
+                                              keys_input,
+                                              values_input,
+                                              output_it,
+                                              initial_value,
+                                              size,
+                                              rocprim::plus<size_t>{},
+                                              rocprim::equal_to<size_t>{},
+                                              stream,
+                                              debug_synchronous);
+    };
+    large_indices_scan_by_key_test<decltype(exclusive_scan_by_key), UseGraphs>(
+        exclusive_scan_by_key);
+}
+
+TEST(RocprimDeviceScanTests, LargeIndicesExclusiveScanByKey)
+{
+    testLargeIndicesExclusiveScanByKey();
+}
+
+TEST(RocprimDeviceScanTests, LargeIndicesExclusiveScanByKeyWithGraphs)
+{
+    testLargeIndicesExclusiveScanByKey<true>();
+}

--- a/projects/rocprim/test/rocprim/test_device_search_n.cpp
+++ b/projects/rocprim/test/rocprim/test_device_search_n.cpp
@@ -909,7 +909,8 @@ TYPED_TEST(RocprimDeviceSearchNTests, NoiseTest_1block)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
+            const auto params
+                = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;
@@ -1029,7 +1030,8 @@ TYPED_TEST(RocprimDeviceSearchNTests, NoiseTest_2block)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
+            const auto params
+                = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;
@@ -1149,7 +1151,8 @@ TYPED_TEST(RocprimDeviceSearchNTests, NoiseTest_3block)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
+            const auto params
+                = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;
@@ -1269,7 +1272,8 @@ TYPED_TEST(RocprimDeviceSearchNTests, MultiResult1)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
+            const auto params
+                = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;
@@ -1390,7 +1394,8 @@ TYPED_TEST(RocprimDeviceSearchNTests, MultiResult2)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
+            const auto params
+                = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;

--- a/projects/rocprim/test/rocprim/test_device_search_n.cpp
+++ b/projects/rocprim/test/rocprim/test_device_search_n.cpp
@@ -909,7 +909,7 @@ TYPED_TEST(RocprimDeviceSearchNTests, NoiseTest_1block)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config>(target_arch);
+            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;
@@ -1029,7 +1029,7 @@ TYPED_TEST(RocprimDeviceSearchNTests, NoiseTest_2block)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config>(target_arch);
+            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;
@@ -1149,7 +1149,7 @@ TYPED_TEST(RocprimDeviceSearchNTests, NoiseTest_3block)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config>(target_arch);
+            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;
@@ -1269,7 +1269,7 @@ TYPED_TEST(RocprimDeviceSearchNTests, MultiResult1)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config>(target_arch);
+            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;
@@ -1390,7 +1390,7 @@ TYPED_TEST(RocprimDeviceSearchNTests, MultiResult2)
             hipStream_t                  stream = 0; // default
             rocprim::detail::target_arch target_arch;
             HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
-            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config>(target_arch);
+            const auto params = rocprim::detail::dispatch_target_arch<wrapped_config, false>(target_arch);
             const unsigned int block_size       = params.kernel_config.block_size;
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const unsigned int items_per_block  = block_size * items_per_thread;

--- a/projects/rocprim/test/rocprim/test_linking_new_scan.hpp
+++ b/projects/rocprim/test/rocprim/test_linking_new_scan.hpp
@@ -49,8 +49,8 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<bool Exclusive,
-         class Config,
+template<class ArchConfig,
+         bool Exclusive,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
@@ -65,7 +65,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void single_scan_kernel_impl(InputIterator  
     (void)initial_value;
     (void)scan_op;
 
-    static constexpr scan_config_params params = device_params<Config>();
+    static constexpr scan_config_params params = ArchConfig::params;
 
     constexpr unsigned int block_size       = params.kernel_config.block_size;
     constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -78,25 +78,35 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void single_scan_kernel_impl(InputIterator  
     block_store_direct_striped<block_size>(flat_block_thread_id(), output, values, input_size);
 }
 
-template<bool Exclusive,
-         class Config,
+template<class Config,
+         bool Exclusive,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
          class InitValueType,
          class AccType>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    single_scan_kernel(InputIterator       input,
-                       const size_t        size,
-                       const InitValueType initial_value,
-                       OutputIterator      output,
-                       BinaryFunction      scan_op)
+inline hipError_t launch_single_scan(detail::target_arch arch,
+                                     InputIterator       input,
+                                     const size_t        size,
+                                     const InitValueType initial_value,
+                                     OutputIterator      output,
+                                     BinaryFunction      scan_op,
+                                     dim3                grid,
+                                     dim3                block,
+                                     size_t              shmem,
+                                     hipStream_t         stream)
 {
-    single_scan_kernel_impl<Exclusive, Config>(input,
-                                               size,
-                                               static_cast<AccType>(get_input_value(initial_value)),
-                                               output,
-                                               scan_op);
+    auto kernel = [=](auto arch_config)
+    {
+        single_scan_kernel_impl<decltype(arch_config), Exclusive>(
+            input,
+            size,
+            static_cast<AccType>(get_input_value(initial_value)),
+            output,
+            scan_op);
+    };
+
+    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<lookback_scan_determinism Determinism,
@@ -127,7 +137,7 @@ inline auto scan_impl(void*               temporary_storage,
     {
         return result;
     }
-    const scan_config_params params = dispatch_target_arch<config>(target_arch);
+    const scan_config_params params = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int block_size       = params.kernel_config.block_size;
     const unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -145,14 +155,22 @@ inline auto scan_impl(void*               temporary_storage,
         return hipErrorInvalidValue;
     }
 
-    single_scan_kernel<Exclusive,
-                       config,
-                       InputIterator,
-                       OutputIterator,
-                       BinaryFunction,
-                       InitValueType,
-                       AccType>
-        <<<dim3(1), dim3(block_size), 0, stream>>>(input, size, initial_value, output, scan_op);
+    ROCPRIM_RETURN_ON_ERROR(launch_single_scan<config,
+                                               Exclusive,
+                                               InputIterator,
+                                               OutputIterator,
+                                               BinaryFunction,
+                                               InitValueType,
+                                               AccType>(target_arch,
+                                                        input,
+                                                        size,
+                                                        initial_value,
+                                                        output,
+                                                        scan_op,
+                                                        dim3(1),
+                                                        dim3(block_size),
+                                                        0,
+                                                        stream));
     return hipGetLastError();
 }
 

--- a/projects/rocprim/test/rocprim/test_linking_new_scan.hpp
+++ b/projects/rocprim/test/rocprim/test_linking_new_scan.hpp
@@ -106,7 +106,7 @@ inline hipError_t launch_single_scan(detail::target_arch arch,
             scan_op);
     };
 
-    return launch_kernel<Config>(arch, kernel, grid, block, shmem, stream);
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<lookback_scan_determinism Determinism,


### PR DESCRIPTION
This PR adds support for using tuned config when compiling and targeting SPIR-V. 

At build time, we instantiate a small `trampoline_kernel` per supported arch. Each `trampoline_kernel` embeds the correct `__launch_bounds__` via a pluggable `config_selector` (`config_selector` is introduced to match the correct `config` for algorithms that have respective `config`s for multiple kernels, like in [`device_batch_memcpy`](https://github.com/StreamHPC/rocm-libraries/blob/44b6d8e3a092b2b62fe45fabdaaddc406e323422/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp#L426)). 

At runtime, the host queries the stream’s device `arch` once, chooses the matching `trampoline_kernel` (`make_launch_plan`, which is introduced because there are cases where we need to refer to the kernel before launching it, like in [`device_adjacent_find`](https://github.com/StreamHPC/rocm-libraries/blob/44b6d8e3a092b2b62fe45fabdaaddc406e323422/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_find.hpp#L167)), and launches it with the user’s device lambda. On device, a cheap `constexpr` check ensures only the “right” specialization actually runs. This preserves launch-bounds, and avoids device-side feature tests like `__builtin_amdgcn_processor_is`.