### PR TITLE
[hipCUB] Avoid hipcub exclusive scan fallback on Windows

### DIFF
--- a/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -722,7 +722,7 @@ void test_radix_rank_with_prefix_sum_output()
 
                     ++histogram[bit_rep];
                 }
-                #if defined(_GLIBCXX_RELEASE) && (GLIBCXX_RELEASE >= 9)
+                #if defined(_WIN32) || (defined(_GLIBCXX_RELEASE) && (GLIBCXX_RELEASE >= 9))
                     std::exclusive_scan(histogram.begin(),
                                         histogram.end(),
                                         pfs_expected.begin() + pfs_offset,


### PR DESCRIPTION


## Motivation

We recently added a fallback exclusive scan to hipCUB's block_radix_rank unit tests. The fallback is used on Debian10, where we only have experimental C++17 support (which does not include std::exclusive_scan).

Windows, does not define the preprocessor symbols that we check to determine whether or not the fallback is necessary. This can result in a build error.

## Technical Details

This change avoids invoking the fallback function on Windows.

## Test Plan

Build and hipCUB's run test_hipcub_block_radix_rank target on Windows.

## Test Result

All tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
