### PR TITLE
[hipblaslt] Reject DTL for loads less than 32bits

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -780,6 +780,10 @@ class Solution(collections.abc.Mapping):
       reject(state, printRejectionReason, "b128 DirectToLds not supported")
       return False
 
+    if numBytesPerLoad < 4:
+      reject(state, printRejectionReason, "DirectToLds not supported for loads less than 32bits")
+      return False
+
     # so far MFMA only (TODO: enable non MFMA case)
     if not state["EnableMatrixInstruction"]:
       reject(state, printRejectionReason, "DirectToLds is for MatrixInstruction only for now (tentative)")

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -935,3 +935,27 @@ BenchmarkProblems:
         - ProblemSizes:
           - Range: [[65], [123], [1], [1,123,512]]
           - Range: [[4096], [8192], [1], [64,64,384]]
+    - # Check DTL for load width less than 32bits
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [1]
+        - GlobalReadVectorWidthB: [1]
+        - DirectToLds: [0, 1]
+        - LdsPadA: [0, 8]
+        - LdsPadB: [0, 8]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[65], [123], [1], [1,123,512]]


### PR DESCRIPTION
## Motivation

Reject solutions which generate DTL loads with load width less than 32bits.

## Technical Details

## Test Plan

Added test case which previously caused some assembler issues due to 16b DTL loads.

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
