### PR TITLE
Enable stream-k grid sweep in hipblaslt-bench

### DIFF
--- a/projects/hipblaslt/clients/bench/include/program_options.hpp
+++ b/projects/hipblaslt/clients/bench/include/program_options.hpp
@@ -389,6 +389,12 @@ namespace roc
                     match = argc && sscanf(*argv, "%" SCNu32, &val) == 1;
                     ptr->actual_value(val);
                 }
+                else if(auto* ptr = dynamic_cast<valueVec<uint64_t>*>(m_val.get()))
+                {
+                    uint64_t val;
+                    match = argc && sscanf(*argv, "%" SCNu64, &val) == 1;
+                    ptr->actual_value(val);
+                }
                 else if(auto* ptr = dynamic_cast<valueVec<int64_t>*>(m_val.get()))
                 {
                     int64_t val;
@@ -584,6 +590,15 @@ namespace roc
                         else if(dynamic_cast<const valueVec<uint32_t>*>(val))
                         {
                             auto& vec = dynamic_cast<const valueVec<uint32_t>*>(val)->get_value();
+                            left << vec[0];
+                            for(size_t i = 1; i < vec.size(); i++)
+                            {
+                                left << ", " << vec[i];
+                            }
+                        }
+                        else if(dynamic_cast<const valueVec<uint64_t>*>(val))
+                        {
+                            auto& vec = dynamic_cast<const valueVec<uint64_t>*>(val)->get_value();
                             left << vec[0];
                             for(size_t i = 1; i < vec.size(); i++)
                             {

--- a/projects/hipblaslt/clients/bench/src/client.cpp
+++ b/projects/hipblaslt/clients/bench/src/client.cpp
@@ -308,6 +308,8 @@ try
     std::vector<int64_t>  lda, ldb, ldc, ldd, lde;
     std::vector<int64_t>  stride_a, stride_b, stride_c, stride_d, stride_e;
     std::vector<uint32_t> gsu_vector, wgm_vector;
+    std::vector<uint64_t> skgrid_vector;
+    
     arg.init(); // set all defaults
     const char* tuningEnv          = getenv("HIPBLASLT_TUNING_FILE");
     const char* tuningMaxWorkSpace = getenv("HIPBLASLT_TUNING_USER_MAX_WORKSPACE");
@@ -618,6 +620,10 @@ try
         ("wgm",
          valueVec<uint32_t>(&wgm_vector),
          "[Tuning parameter] Set workgroup mapping for a solution, 0 is use solution's default value. (Only support GEMM + api_method mix or cpp)")
+        
+        ("skgrid",
+         valueVec<uint64_t>(&skgrid_vector),
+         "[Tuning parameter] Set stream-K grid for a solution. Given preference over env flag. If not specified use the default workflow.(Only support GEMM + api_method mix or cpp)")
 
         ("flush",
         value<bool>(&arg.flush)->default_value(tuningEnv ? true : false),
@@ -701,7 +707,7 @@ try
     }
     if((max_gsu > 0) && ((api_method == 0) || arg.grouped_gemm))
     {
-        hipblaslt_cerr << "Currently split K only supports GEMM + api_method mix or cpp."
+        hipblaslt_cerr << "Currently gsu only supports GEMM + api_method mix or cpp."
                        << std::endl;
         return 1;
     }
@@ -728,7 +734,29 @@ try
                        << std::endl;
         return 1;
     }
-
+    uint32_t max_skgrid = 0;
+    if(skgrid_vector.size() > MAX_SUPPORTED_NUM_PROBLEMS)
+    {
+        hipblaslt_cerr << "Too many sk grid parameters, maximum is: " << MAX_SUPPORTED_NUM_PROBLEMS
+                       << std::endl;
+        return 1;
+    }
+    for(size_t i = 0; i < skgrid_vector.size(); i++)
+    {
+        if(skgrid_vector[i] < 0 || skgrid_vector[i] > std::numeric_limits<uint32_t>::max())
+        {
+            hipblaslt_cerr << "Invalid stream-k grid value" << skgrid_vector[i] << ". Expected in range [1, " << std::numeric_limits<uint32_t>::max() << "]" << std::endl;
+            return 1;
+        }
+        arg.skgrid_vector[i] = skgrid_vector[i];
+        max_skgrid           = max(max_skgrid, arg.skgrid_vector[i]);
+    }
+    if(max_skgrid > 0 && api_method == 0)
+    {
+        hipblaslt_cerr << "Currently streamk grid only supports api_method mix or cpp."
+                       << std::endl;
+        return 1;
+    }
     // transfer local variable state
     ArgumentModel_set_log_function_name(log_function_name);
 

--- a/projects/hipblaslt/clients/common/include/argument_model.hpp
+++ b/projects/hipblaslt/clients/common/include/argument_model.hpp
@@ -169,6 +169,7 @@ public:
                   const Arguments&            arg,
                   uint32_t                    splitK,
                   uint32_t                    wgm,
+                  uint32_t                    skgrid,
                   double                      gpu_us,
                   double                      flush_us,
                   double                      gflops,
@@ -249,6 +250,8 @@ public:
             print("splitK", splitK);
         if(wgm > 0)
             print("wgm", wgm);
+        if(skgrid > 0)
+            print("stream-k grid", skgrid);
 
         // Printing rotating buffer even if it is set to default value
         print("rotating_buffer", arg.rotating);

--- a/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
+++ b/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
@@ -174,6 +174,7 @@ struct Arguments
     // tuning
     int32_t gsu_vector[MAX_SUPPORTED_NUM_PROBLEMS]; // This is for client
     int32_t wgm_vector[MAX_SUPPORTED_NUM_PROBLEMS]; // This is for client
+    int32_t skgrid_vector[MAX_SUPPORTED_NUM_PROBLEMS]; // This is for client
 
     // print
     bool print_solution_found;
@@ -278,6 +279,7 @@ struct Arguments
     OPER(skip_slow_solution_ratio) SEP\
     OPER(gsu_vector) SEP             \
     OPER(wgm_vector) SEP             \
+    OPER(skgrid_vector) SEP          \
     OPER(print_solution_found) SEP   \
     OPER(print_kernel_info) SEP      \
     OPER(flush) SEP                  \

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -2467,6 +2467,7 @@ void testing_matmul_with_bias(const Arguments& arg,
     // Remove duplicate
     std::vector<uint32_t> gsu_vector;
     std::vector<uint32_t> wgm_vector;
+    std::vector<uint32_t> skgrid_vector;
     for(int32_t i = 0; i < MAX_SUPPORTED_NUM_PROBLEMS; i++)
     {
         if(arg.gsu_vector[i] == -1)
@@ -2479,21 +2480,32 @@ void testing_matmul_with_bias(const Arguments& arg,
             break;
         wgm_vector.push_back(arg.wgm_vector[i]);
     }
+    for(int32_t i = 0; i < MAX_SUPPORTED_NUM_PROBLEMS; i++)
+    {
+        if(arg.skgrid_vector[i] == -1)
+            break;
+        skgrid_vector.push_back(arg.skgrid_vector[i]);
+    }
+
     std::set<uint32_t> remove_duplicate(gsu_vector.begin(), gsu_vector.end());
     gsu_vector.assign(remove_duplicate.begin(), remove_duplicate.end());
     remove_duplicate = std::set<uint32_t>(wgm_vector.begin(), wgm_vector.end());
     wgm_vector.assign(remove_duplicate.begin(), remove_duplicate.end());
+    remove_duplicate = std::set<uint32_t>(skgrid_vector.begin(), skgrid_vector.end());
+    skgrid_vector.assign(remove_duplicate.begin(), remove_duplicate.end());    
     std::vector<hipblaslt_ext::GemmTuning> tuningVec;
     if(arg.use_ext)
     {
         for(size_t wgm = 0; wgm < wgm_vector.size(); wgm++)
             for(size_t gsu = 0; gsu < gsu_vector.size(); gsu++)
-            {
-                hipblaslt_ext::GemmTuning tuning;
-                tuning.setSplitK(gsu_vector[gsu]);
-                tuning.setWgm(wgm_vector[wgm]);
-                tuningVec.push_back(tuning);
-            }
+                for(size_t skgrid = 0; skgrid < skgrid_vector.size(); skgrid++)
+                {
+                    hipblaslt_ext::GemmTuning tuning;
+                    tuning.setSplitK(gsu_vector[gsu]);
+                    tuning.setWgm(wgm_vector[wgm]);
+                    tuning.setSKGrid(skgrid_vector[skgrid]);
+                    tuningVec.push_back(tuning);
+                }
     }
     else
     {
@@ -3974,6 +3986,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                     arg,
                     (uint32_t)tuningVec[heuristicTuningIndex[sol]].getSplitK(),
                     (uint32_t)tuningVec[heuristicTuningIndex[sol]].getWgm(),
+                    (uint32_t)tuningVec[heuristicTuningIndex[sol]].getSKGrid(),
                     gpu_time_used,
                     flush_time_used,
                     flops,
@@ -4032,6 +4045,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                 arg,
                 (uint32_t)tuningVec[heuristicTuningIndex[best_sol]].getSplitK(),
                 (uint32_t)tuningVec[heuristicTuningIndex[best_sol]].getWgm(),
+                (uint32_t)tuningVec[heuristicTuningIndex[best_sol]].getSKGrid(),
                 best_gpu_time,
                 flush_time_used,
                 best_flops,

--- a/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
+++ b/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
@@ -145,6 +145,11 @@ void Arguments::init()
     {
         wgm_vector[i] = -1;
     }
+    skgrid_vector[0] = 0;
+    for(int32_t i = 1; i < MAX_SUPPORTED_NUM_PROBLEMS; i++)
+    {
+        skgrid_vector[i] = -1;
+    }
 
     print_solution_found = false;
     flush                = false;

--- a/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
+++ b/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
@@ -568,6 +568,7 @@ Arguments:
   - skip_slow_solution_ratio: c_float
   - gsu_vector: c_int32*32
   - wgm_vector: c_int32*32
+  - skgrid_vector: c_int32*32
   - print_solution_found: c_bool
   - print_kernel_info: c_bool
   - flush: c_bool
@@ -676,6 +677,7 @@ Defaults:
   skip_slow_solution_ratio: 0.0
   gsu_vector: 0
   wgm_vector: 0
+  skgrid_vector: 0
   print_solution_found: false
   print_kernel_info: false
   flush: false

--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -1963,6 +1963,23 @@ Tests:
   beta: 2.0
   unit_check: 1
 
+- name: matmul_extapi_algo_method_tuning_skgrid
+  category: pre_checkin
+  function:
+    matmul: *hpa_half_precision
+  matrix_size:
+    - { M:  4096, N:  4096, K:  40 }
+    - { M:  1024, N:  1024, K:  80 }
+  transA_transB: *transA_transB_range
+  algo_method: [2]
+  use_ext: [1]
+  use_ext_setproblem: [0]
+  grouped_gemm: [0]
+  skgrid_vector: [[0], [4], [9], [16]]
+  alpha: 1
+  beta: 2.0
+  unit_check: 1
+
 - name: matmul_extapi_algo_method_grouped_gemm_tuning_wgm
   category: pre_checkin
   function:

--- a/projects/hipblaslt/clients/tests/hipblaslt_gentest.py
+++ b/projects/hipblaslt/clients/tests/hipblaslt_gentest.py
@@ -388,11 +388,17 @@ def instantiate(test):
       wgm_vector[0] = 0
     test['wgm_vector'] = wgm_vector
 
+    skgrid_vector = [-1 for _ in range(32)]
+    if 'skgrid_vector' in test:
+      skgrid_vector[0] = test['skgrid_vector']
+    else:
+      skgrid_vector[0] = 0
+    test['skgrid_vector'] = skgrid_vector
 
     # Any Arguments fields declared as enums (a_type, b_type, etc.)
     enum_args = [decl[0] for decl in param['Arguments']._fields_
                  if decl[1].__module__ == '__main__']
-    array_value_args = ["gsu_vector", "wgm_vector"]
+    array_value_args = ["gsu_vector", "wgm_vector", "skgrid_vector"]
 
     try:
         setdefaults(test)

--- a/projects/hipblaslt/clients/tests/src/matmul_gtest.cpp
+++ b/projects/hipblaslt/clients/tests/src/matmul_gtest.cpp
@@ -178,6 +178,8 @@ namespace
                     name << "_GSU" << (int)arg.gsu_vector[0];
                 if(arg.wgm_vector[0])
                     name << "_WGM" << (int)arg.wgm_vector[0];
+                if(arg.skgrid_vector[0])
+                    name << "_SKG" << (int)arg.skgrid_vector[0];
             }
 
             return std::move(name);

--- a/projects/hipblaslt/library/include/hipblaslt/hipblaslt-ext.hpp
+++ b/projects/hipblaslt/library/include/hipblaslt/hipblaslt-ext.hpp
@@ -233,9 +233,13 @@ namespace hipblaslt_ext
         HIPBLASLT_EXPORT void setWgm(
             int16_t
                 wgm); //!< Set the value of workgroup mapping, 0 is off (use the workgroup mapping inside the solution).
+        HIPBLASLT_EXPORT void setSKGrid(
+            uint32_t
+                skgrid); //!< Set the value of stream-K grid, 0 is off (use the skgrid mapping inside the solution or from env variable).
 
         HIPBLASLT_EXPORT uint16_t getSplitK() const; //!< Value of splitK.
         HIPBLASLT_EXPORT int16_t  getWgm() const; //!< Value of workgroup mapping.
+        HIPBLASLT_EXPORT uint32_t getSKGrid() const; //!< Value of Stream-K Grid.
     private:
         friend GemmInstance;
         class GemmTuningImpl;

--- a/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext.cpp
@@ -412,6 +412,7 @@ namespace hipblaslt_ext
     public:
         uint16_t splitK = 0;
         int16_t  wgm    = 0;
+        uint32_t  skgrid = 0;
     };
 
     GemmTuning::GemmTuning()
@@ -445,6 +446,11 @@ namespace hipblaslt_ext
         pimpl->wgm = wgm;
     }
 
+    void GemmTuning::setSKGrid(uint32_t skgrid)
+    {
+        pimpl->skgrid = skgrid;
+    }
+
     uint16_t GemmTuning::getSplitK() const
     {
         return pimpl->splitK;
@@ -453,6 +459,11 @@ namespace hipblaslt_ext
     int16_t GemmTuning::getWgm() const
     {
         return pimpl->wgm;
+    }
+
+    uint32_t GemmTuning::getSKGrid() const
+    {
+        return pimpl->skgrid;
     }
 
     class GemmInputs::GemmInputsImpl

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
@@ -659,6 +659,7 @@ namespace rocblaslt
     public:
         uint16_t gsu = 0;
         int16_t  wgm = 0;
+        uint32_t skgrid = 0;
     };
 
     struct RocGemmInputsV2

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -757,6 +757,8 @@ namespace
             problem.getParams().gsu() ? std::to_string(problem.getParams().gsu()) : "",
             problem.getParams().wgm() ? "--wgm" : "",
             problem.getParams().wgm() ? std::to_string(problem.getParams().wgm()) : "",
+            problem.getParams().skgrid() ? "--skgrid" : "",
+            problem.getParams().skgrid() ? std::to_string(problem.getParams().skgrid()) : "",
             "--compute_type",
             tensileComputeInputType_to_bench_string(problem.computeType(),
                                                     problem.f32XdlMathOp(),
@@ -1075,6 +1077,9 @@ namespace
                                                : "",
             problem.gemms[0].getParams().wgm() ? "--wgm" : "",
             problem.gemms[0].getParams().wgm() ? std::to_string(problem.gemms[0].getParams().wgm())
+                                               : "",
+            problem.gemms[0].getParams().skgrid() ? "--skgrid" : "",
+            problem.gemms[0].getParams().skgrid() ? std::to_string(problem.gemms[0].getParams().skgrid())
                                                : "",
             "--compute_type",
             tensileComputeInputType_to_bench_string(problem.gemms[0].computeType(),
@@ -2739,6 +2744,7 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
             {
                 data->problem.setParams().setGSU(tuning->gsu);
                 data->problem.setParams().setWgm(tuning->wgm);
+                data->problem.setParams().setSKGrid(tuning->skgrid);
                 std::stringstream ss;
                 if(!solution->checkInternalArgumentsSupport(data->problem, ss, true))
                 {
@@ -2784,6 +2790,7 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
             {
                 data->problem.gemms[0].setParams().setGSU(tuning->gsu);
                 data->problem.gemms[0].setParams().setWgm(tuning->wgm);
+                data->problem.gemms[0].setParams().setSKGrid(tuning->skgrid);
                 std::stringstream ss;
                 if(!solution->checkInternalArgumentsSupport(data->problem.gemms[0], ss, true))
                 {
@@ -2795,6 +2802,7 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
                 {
                     data->problem.gemms[i].setParams().setGSU(tuning->gsu);
                     data->problem.gemms[i].setParams().setWgm(tuning->wgm);
+                    data->problem.gemms[i].setParams().setSKGrid(tuning->skgrid);
                 }
             }
             else
@@ -3562,6 +3570,7 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle       handle,
         {
             tensile_prob.setParams().setGSU(tuning->gsu);
             tensile_prob.setParams().setWgm(tuning->wgm);
+            tensile_prob.setParams().setSKGrid(tuning->skgrid);
             std::stringstream ss;
             if(!solution->checkInternalArgumentsSupport(tensile_prob, ss, true))
             {
@@ -3647,6 +3656,7 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle       handle,
         {
             tensile_prob.gemms[0].setParams().setGSU(tuning->gsu);
             tensile_prob.gemms[0].setParams().setWgm(tuning->wgm);
+            tensile_prob.gemms[0].setParams().setSKGrid(tuning->skgrid);
             std::stringstream ss;
             if(!solution->checkInternalArgumentsSupport(tensile_prob.gemms[0], ss, true))
             {
@@ -3658,6 +3668,7 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle       handle,
             {
                 tensile_prob.gemms[i].setParams().setGSU(tuning->gsu);
                 tensile_prob.gemms[i].setParams().setWgm(tuning->wgm);
+                tensile_prob.gemms[i].setParams().setSKGrid(tuning->skgrid);
             }
         }
         else
@@ -3895,6 +3906,7 @@ std::string getKernelNameFromData(rocblaslt_handle             handle,
 
     int                                        gsu = 0;
     int                                        wgm = 0;
+    int                                     skgrid = 0;
     std::vector<TensileLite::KernelInvocation> kernels;
 
     if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GEMM)
@@ -3903,6 +3915,7 @@ std::string getKernelNameFromData(rocblaslt_handle             handle,
         kernels                               = data->kernels;
         gsu                                   = data->problem.getParams().gsu();
         wgm                                   = data->problem.getParams().wgm();
+        skgrid                                = data->problem.getParams().skgrid();
     }
     else if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GROUPED_GEMM)
     {
@@ -3940,6 +3953,7 @@ std::string getSolutionNameFromData(rocblaslt_handle             handle,
 
     int gsu           = 0;
     int wgm           = 0;
+    int skgrid   = 0;
     int solutionIndex = -1;
 
     std::shared_ptr<TensileLite::Hardware> hardware;
@@ -3952,6 +3966,7 @@ std::string getSolutionNameFromData(rocblaslt_handle             handle,
         solutionIndex                         = data->algoIndex;
         gsu                                   = data->problem.getParams().gsu();
         wgm                                   = data->problem.getParams().wgm();
+        skgrid                                = data->problem.getParams().skgrid();
     }
     else if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GROUPED_GEMM)
     {
@@ -3960,6 +3975,7 @@ std::string getSolutionNameFromData(rocblaslt_handle             handle,
         solutionIndex = data->algoIndex;
         gsu           = data->problem.gemms[0].getParams().gsu();
         wgm           = data->problem.gemms[0].getParams().wgm();
+        skgrid        = data->problem.gemms[0].getParams().skgrid();
     }
     if(solutionIndex == -1)
         return "";

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblem.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblem.hpp
@@ -58,6 +58,16 @@ namespace TensileLite
             return m_gsu;
         }
 
+        void setSKGrid(uint32_t skgrid)
+        {
+            m_skgrid = skgrid;
+        }
+
+        uint32_t skgrid() const
+        {
+            return m_skgrid;
+        }
+
         void setGSUC(bool gsuc)
         {
             m_gsuc = gsuc;
@@ -158,6 +168,7 @@ namespace TensileLite
         int16_t          m_gsu            = 0; // default value
         bool             m_gsuc           = false; // default value
         bool             m_gsuwgmrr       = false; // default value
+        uint32_t         m_skgrid         = 0; // default value
         int16_t          m_wgm            = 0; // default value
         uint16_t         m_wgmxcc         = 0; // default value
         int16_t          m_wgmxccg        = 0; // default value

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -3012,9 +3012,13 @@ namespace TensileLite
         assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
         size_t cuCount = pAMDGPU->computeUnitCount;
 
-        // User-specified grid size for Stream-K kernel.
-        if(pAMDGPU->skFixedGrid > 0)
+        if(problem.getParams().skgrid() > 0){
+            // sk grid set via hipblaslt-bench given precedence over ENV FLAG.
+            skGrid =  static_cast<size_t>(problem.getParams().skgrid());
+        }
+        else if(pAMDGPU->skFixedGrid > 0)
         {
+            // User-specified grid size for Stream-K kernel.
             skGrid = pAMDGPU->skFixedGrid;
         }
         else if (pAMDGPU->skDynamicGrid > 0)


### PR DESCRIPTION
The changes in this PR enable setting stream-k grid via hipblaslt-bench. 

Run via CLI - 

>./hipblaslt-bench -m 16 -n 16 -k 4096 --transA T --transB N --a_type bf16_r --b_type bf16_r --c_type bf16_r --d_type bf16_r --activation_type none --compute_type f32_r --device 0 --api_method cpp --skgrid 19


Run via --yaml option

1. Sweep across a range with increment of 1
>{function: matmul, transA: N, transB: N, a_type: bf16_r, b_type: bf16_r, c_type: bf16_r, d_type: bf16_r, scale_type: f32_r, compute_type: c_f32_r, M: 1, N: 128, K: 32, ldc: 1, ldd: 1, lda: 1, ldb: 32, initialization: trig_float, alpha: 1, beta: 0, iters: 10, cold_iters: 2, use_gpu_timer: 1, flush: true, rotating: 512, skgrid_vector: 2..25 , use_ext: true}

2. Sweep across a range with custom increment value
>{function: matmul, transA: N, transB: N, a_type: bf16_r, b_type: bf16_r, c_type: bf16_r, d_type: bf16_r, scale_type: f32_r, compute_type: c_f32_r, M: 1, N: 128, K: 32, ldc: 1, ldd: 1, lda: 1, ldb: 32, initialization: trig_float, alpha: 1, beta: 0, iters: 10, cold_iters: 2, use_gpu_timer: 1, flush: true, rotating: 512, skgrid_vector: 2..250..100 , use_ext: true}

3. Specify a list of values
>{function: matmul, transA: N, transB: N, a_type: bf16_r, b_type: bf16_r, c_type: bf16_r, d_type: bf16_r, scale_type: f32_r, compute_type: c_f32_r, M: 1, N: 128, K: 32, ldc: 1, ldd: 1, lda: 1, ldb: 32, initialization: trig_float, alpha: 1, beta: 0, iters: 10, cold_iters: 2, use_gpu_timer: 1, flush: true, rotating: 512, skgrid_vector: [[23], [45], [3]] , use_ext: true}

This is a continuation of the PR - https://github.com/ROCm/rocm-libraries/pull/1266 with some additional changes to enable larger stream-k grid range.

