### PR TITLE
[hipblas] fix CMakeLists.txt syntax error for windows build

### DIFF
--- a/projects/hipblas/clients/benchmarks/CMakeLists.txt
+++ b/projects/hipblas/clients/benchmarks/CMakeLists.txt
@@ -45,7 +45,7 @@ set( hipblas_benchmark_common
 
 if(NOT WIN32)
   add_executable( hipblas-bench ${hipblas_bench_source} ${hipblas_benchmark_common} $<TARGET_OBJECTS:hipblas_fortran_client>)
-elseif()
+else()
   add_executable( hipblas-bench ${hipblas_bench_source} ${hipblas_benchmark_common} )
 endif()
 

--- a/projects/hipblas/clients/gtest/CMakeLists.txt
+++ b/projects/hipblas/clients/gtest/CMakeLists.txt
@@ -115,7 +115,7 @@ set( hipblas_test_common
 
 if(NOT WIN32)
   add_executable( hipblas-test ${hipblas_test_source} ${hipblas_solver_test_source} ${hipblas_test_common} $<TARGET_OBJECTS:hipblas_fortran_client> )
-elseif()
+else()
   add_executable( hipblas-test ${hipblas_test_source} ${hipblas_solver_test_source} ${hipblas_test_common} )
 endif()
 


### PR DESCRIPTION
Re: Scott's comments in https://github.com/ROCm/rocm-libraries/pull/1126