### PR TITLE
[hipCUB][CCCL 2.8 Parity] fix: fix-rocthrust-stable_sort_by_key-hang

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -40,6 +40,8 @@
 #include "../../block/block_scan.hpp"
 #include "../../block/block_store_func.hpp"
 
+#include "ordered_block_id.hpp"
+
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
@@ -1068,7 +1070,7 @@ struct onesweep_iteration_helper
 
     static constexpr unsigned int digits_per_thread = radix_rank_type::digits_per_thread;
 
-    union storage_type_
+    union data_storage
     {
         typename radix_rank_type::storage_type rank;
         struct
@@ -1080,6 +1082,12 @@ struct onesweep_iteration_helper
                 Value ordered_block_values[items_per_block];
             };
         };
+    };
+
+    struct storage_type_
+    {
+        data_storage                                          data;
+        typename ordered_block_id<unsigned int>::storage_type ordered_bid;
     };
 
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH
@@ -1103,10 +1111,11 @@ struct onesweep_iteration_helper
                   const unsigned int       bit,
                   const unsigned int       current_radix_bits,
                   const unsigned int       valid_items,
-                  storage_type_&           storage)
+                  data_storage&            storage,
+                  unsigned int             ordered_bid)
     {
         const unsigned int flat_id      = ::rocprim::detail::block_thread_id<0>();
-        const unsigned int block_id     = ::rocprim::detail::block_id<0>();
+        const unsigned int block_id     = ordered_bid;
         const unsigned int block_offset = block_id * items_per_block;
 
         // Load keys into private memory, and encode them to unsigned integers.
@@ -1361,7 +1370,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                        Decomposer               decomposer,
                        const unsigned int       bit,
                        const unsigned int       current_radix_bits,
-                       const unsigned int       full_blocks)
+                       const unsigned int       full_blocks,
+                    ordered_block_id<unsigned int> ordered_bid)
 {
     using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
     using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
@@ -1376,10 +1386,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                      RadixRankAlgorithm,
                                                                      Decomposer>;
 
-    constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
-    const unsigned int block_id = ::rocprim::detail::block_id<0>();
-
     ROCPRIM_SHARED_MEMORY typename onesweep_iteration_helper_type::storage_type storage;
+
+    constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
+    const unsigned int     thread_id       = ::rocprim::detail::block_thread_id<0>();
+    const unsigned int     block_id        = ordered_bid.get(thread_id, storage.get().ordered_bid);
 
     if(block_id < full_blocks)
     {
@@ -1394,7 +1405,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                  bit,
                                                                  current_radix_bits,
                                                                  items_per_block,
-                                                                 storage.get());
+                                                                 storage.get().data,
+                                                                 block_id);
     }
     else
     {
@@ -1410,7 +1422,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                   bit,
                                                                   current_radix_bits,
                                                                   valid_in_last_block,
-                                                                  storage.get());
+                                                                  storage.get().data,
+                                                                  block_id);
     }
 }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -199,6 +199,13 @@ hipError_t radix_sort_onesweep_global_offsets(KeysInputIterator keys_input,
     return hipSuccess;
 }
 
+template<class T>
+ROCPRIM_KERNEL
+void init_onesweep_iteration_kernel(ordered_block_id<T> ordered_bid)
+{
+    ordered_bid.reset();
+}
+
 template<class Config,
          bool Descending,
          class KeysInputIterator,
@@ -208,18 +215,19 @@ template<class Config,
          class Offset,
          class Decomposer>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().sort.block_size) void
-    onesweep_iteration_kernel(KeysInputIterator        keys_input,
-                              KeysOutputIterator       keys_output,
-                              ValuesInputIterator      values_input,
-                              ValuesOutputIterator     values_output,
-                              const unsigned int       size,
-                              Offset*                  global_digit_offsets_in,
-                              Offset*                  global_digit_offsets_out,
-                              onesweep_lookback_state* lookback_states,
-                              Decomposer               decomposer,
-                              const unsigned int       bit,
-                              const unsigned int       current_radix_bits,
-                              const unsigned int       full_blocks)
+    onesweep_iteration_kernel(KeysInputIterator              keys_input,
+                              KeysOutputIterator             keys_output,
+                              ValuesInputIterator            values_input,
+                              ValuesOutputIterator           values_output,
+                              const unsigned int             size,
+                              Offset*                        global_digit_offsets_in,
+                              Offset*                        global_digit_offsets_out,
+                              onesweep_lookback_state*       lookback_states,
+                              Decomposer                     decomposer,
+                              const unsigned int             bit,
+                              const unsigned int             current_radix_bits,
+                              const unsigned int             full_blocks,
+                              ordered_block_id<unsigned int> ordered_bid)
 {
     static constexpr radix_sort_onesweep_config_params params = device_params<Config>();
     onesweep_iteration<params.sort.block_size,
@@ -237,7 +245,8 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().sort.block_size) vo
                                                     decomposer,
                                                     bit,
                                                     current_radix_bits,
-                                                    full_blocks);
+                                                    full_blocks,
+                                                    ordered_bid);
 }
 
 template<class Config,
@@ -264,6 +273,7 @@ hipError_t radix_sort_onesweep_iteration(
     Decomposer                                                      decomposer,
     const unsigned int                                              bit,
     const unsigned int                                              end_bit,
+    ordered_block_id<unsigned int>                                  ordered_bid,
     const hipStream_t                                               stream,
     const bool                                                      debug_synchronous)
 {
@@ -330,6 +340,14 @@ hipError_t radix_sort_onesweep_iteration(
             start = std::chrono::steady_clock::now();
         }
 
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(init_onesweep_iteration_kernel),
+                           1,
+                           1,
+                           0,
+                           stream,
+                           ordered_bid);
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_onesweep_iteration_kernel", size, start);
+
         if(from_input && to_output)
         {
             hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_iteration_kernel<config, Descending>),
@@ -348,7 +366,8 @@ hipError_t radix_sort_onesweep_iteration(
                                decomposer,
                                bit,
                                current_radix_bits,
-                               full_blocks);
+                               full_blocks,
+                               ordered_bid);
         }
         else if(from_input)
         {
@@ -368,7 +387,8 @@ hipError_t radix_sort_onesweep_iteration(
                                decomposer,
                                bit,
                                current_radix_bits,
-                               full_blocks);
+                               full_blocks,
+                               ordered_bid);
         }
         else if(to_output)
         {
@@ -388,7 +408,8 @@ hipError_t radix_sort_onesweep_iteration(
                                decomposer,
                                bit,
                                current_radix_bits,
-                               full_blocks);
+                               full_blocks,
+                               ordered_bid);
         }
         else
         {
@@ -408,7 +429,8 @@ hipError_t radix_sort_onesweep_iteration(
                                decomposer,
                                bit,
                                current_radix_bits,
-                               full_blocks);
+                               full_blocks,
+                               ordered_bid);
         }
 
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("onesweep_iteration", size, start);
@@ -447,7 +469,7 @@ hipError_t radix_sort_onesweep_impl(
     using key_type    = typename std::iterator_traits<KeysInputIterator>::value_type;
     using value_type  = typename std::iterator_traits<ValuesInputIterator>::value_type;
     using offset_type = offset_type_t<Size>;
-
+    using ordered_bid_type = ordered_block_id<unsigned int>;
     using config = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
 
     detail::target_arch target_arch;
@@ -478,6 +500,7 @@ hipError_t radix_sort_onesweep_impl(
     onesweep_lookback_state* lookback_states;
     key_type*                keys_tmp_storage;
     value_type*              values_tmp_storage;
+    ordered_bid_type::id_type* ordered_bid_storage;
 
     const hipError_t partition_result = detail::temp_storage::partition(
         temporary_storage,
@@ -491,7 +514,9 @@ hipError_t radix_sort_onesweep_impl(
                                                     !no_allocate_tmp_buffer ? size : 0),
             detail::temp_storage::ptr_aligned_array(&values_tmp_storage,
                                                     !no_allocate_tmp_buffer && with_values ? size
-                                                                                           : 0)));
+                                                                                           : 0),
+            detail::temp_storage::make_partition(&ordered_bid_storage,
+                                                 ordered_bid_type::get_temp_storage_layout())));
 
     if(partition_result != hipSuccess || temporary_storage == nullptr)
     {
@@ -500,6 +525,8 @@ hipError_t radix_sort_onesweep_impl(
 
     if(size == 0)
         return hipSuccess;
+
+    auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
 
     if(debug_synchronous)
     {
@@ -592,6 +619,7 @@ hipError_t radix_sort_onesweep_impl(
             decomposer,
             bit,
             end_bit,
+            ordered_bid,
             stream,
             debug_synchronous);
         if(error != hipSuccess)


### PR DESCRIPTION
This issue occurs when launching more MPI processes of `rocthrust::stable_sort_by_key` than the number of GPUs. From the information I have, it only happens on MI300 (`even.hip` can also be reproduced on MI210. but my understanding is that these are two separate issues.)

The issue may be caused by the different hardware architecture design of the MI300, which has two command processors. We encountered a similar problem with the algorithms that use `lookback_scan`. The behavior this time is similar: the algorithm `rocthrust::stable_sort_by_key` calls `rocprim::radix_sort`, which has its own `lookback_scan` implementation. The previous issue was resolved by introducing atomic operations into the algorithm, so this PR applies the same idea to fix the problem for `rocthrust::stable_sort_by_key`.  

However, we still cannot reproduce the problem on our side. I tried the reproducer from last time (modified to use `radix_sort`) as well as the MIP reproducer sent by @umfranzw on MI300X, but was unable to reproduce it. It could be that the MI300X I used was a virtual machine, which may physically have more GPUs than the ones accessible to us. However, I tried running a command like `mpirun -np 90 ./repro 27000000 45`, and it still didn’t hang.  

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
