### PR TITLE
Drop amdgpu-windows-interop checkout from therock-ci-windows.yml.

### DIFF
--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -39,7 +39,7 @@ jobs:
           sparse-checkout: |
             .github
             ${{ inputs.subtree_checkout }}
-      
+
       - name: Checkout TheRock repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -73,13 +73,6 @@ jobs:
         run: |
           git config --global core.longpaths true
           python ./TheRock/build_tools/fetch_sources.py --jobs 96 --no-include-math-libs
-
-      - name: Checkout closed source AMDGPU/ROCm interop library folder
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: nod-ai/amdgpu-windows-interop
-          path: amdgpu-windows-interop
-          lfs: true
 
       - name: Configure Projects
         env:


### PR DESCRIPTION
See https://github.com/ROCm/TheRock/pull/1342, this step should no longer be needed.