### PR TITLE
Fix typos in hipblaslt build system

### DIFF
--- a/projects/hipblaslt/device-library/CMakeLists.txt
+++ b/projects/hipblaslt/device-library/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TENSILELITE_KEEP_BUILD_TMP OFF CACHE STRING "Keep temporary build directory 
 set(TENSILELITE_LIBLOGIC_PATH "" CACHE STRING "Path to library logic files (will use 'library' if unset).")
 set(TENSILELITE_LIBRARY_FORMAT "" CACHE STRING "Format of master solution library files (msgpack or yaml).")
 set(TENSILELITE_ASM_DEBUG "" CACHE STRING "Keep debug information for built code objects.")
-set(TEN SILE LITE_LOGIC_FILTER "" CACHE STRING "Cutomsized logic filter, default is *, i.e. all logics.")
+set(TENSILELITE_LOGIC_FILTER "" CACHE STRING "Cutomsized logic filter, default is *, i.e. all logics.")
 set(TENSILELITE_NO_COMPRESS "" CACHE STRING "Do not compress device code object files.")
 set(TENSILELITE_EXPERIMENTAL "" CACHE STRING "Process experimental logic files.")
 

--- a/projects/hipblaslt/install.sh
+++ b/projects/hipblaslt/install.sh
@@ -764,7 +764,7 @@ pushd .
     tensile_opt="${tensile_opt} -DHIPBLASLT_ENABLE_DEVICE=OFF"
   else
     if [[ -n "${tensile_logic}" ]]; then
-      tensile_opt="${tensile_opt} -D{HIPBLASLT_LIBLOGIC_PATH}=${tensile_logic}"
+      tensile_opt="${tensile_opt} -D{TENSILELITE_LIBLOGIC_PATH}=${tensile_logic}"
     fi
     # tensile_opt="${tensile_opt} -DTensile_CODE_OBJECT_VERSION=${tensile_cov}"
     if [[ ${tensile_threads} != $(nproc) ]]; then


### PR DESCRIPTION
## Motivation

Reenable install script option. 

## Technical Details

- The wrong variable name was used for setting the logic path in the install script.
- Fixed a typo for logic filter.

## Test Plan

CI pipelines

## Test Result
