### PR TITLE
[hipFFT] Remove conditional from body of test's target_include_directories cmake clause

### DIFF
--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -183,9 +183,6 @@ foreach( target ${TEST_TARGETS} )
     $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${FFTW_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${hip_INCLUDE_DIRS}>
-    if( HIPFFT_BUILD_SCOPE )
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/include>
-    endif()
   )
 
   target_link_libraries( ${target}


### PR DESCRIPTION
I believe such conditionals cannot be used within `target_include_directories`.

Current build lines on `develop` (when building hipfft's and its clients) are polluted, _e.g._ see the parts between `**` delimiters in the copy-pasted following example:
`/opt/rocm/llvm/bin/amdclang++ -DUSE_HIPRAND -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__=1 -I/src/rocm-libraries/projects/hipfft/clients/tests/**if -I"/src/rocm-libraries/projects/hipfft/clients/tests/(" -I/src/rocm-libraries/projects/hipfft/clients/tests/HIPFFT_BUILD_SCOPE -I"/src/rocm-libraries/projects/hipfft/clients/tests/)" -I/src/rocm-libraries/projects/hipfft/clients/tests/../../library/include -I/src/rocm-libraries/projects/hipfft/clients/tests/endif** -I/src/rocm-libraries/projects/hipfft/library/include -I/src/rocm-libraries/projects/hipfft/build/include/hipfft -I/src/rocm-libraries/projects/hipfft/build/include [...]`

I also think it's not necessary to explicitly add the intended inclusion to the `cmake` logic, as mentioned in [that comment](https://github.com/ROCm/hipFFT/pull/173#discussion_r2244150513).