### PR TITLE
[hipfft-test] do not use nullptrs for pointers to workarea sizes to be discarded + clear externally-managed work areas while runtime is initialized

### DIFF
--- a/projects/hipfft/clients/hipfft_params.h
+++ b/projects/hipfft/clients/hipfft_params.h
@@ -1549,12 +1549,14 @@ private:
     hipfftResult_t create_make_plan_Nd()
     {
         auto ret = create_with_pre_make();
+
         if(ret != HIPFFT_SUCCESS)
             return ret;
         // do not register plan's worksizes as "auto-allocated" if auto-allocation was explicitly prevented
-        size_t* worksize_ptr = is_preventing_auto_allocation_at_generation()
-                                   ? nullptr
-                                   : auto_allocated_worksizes.data();
+        std::vector<size_t> tmp_worksize(get_num_used_gpus());
+        size_t*             worksize_ptr = is_preventing_auto_allocation_at_generation()
+                                               ? tmp_worksize.data()
+                                               : auto_allocated_worksizes.data();
         switch(dim())
         {
         case 1:
@@ -1581,10 +1583,11 @@ private:
         if(ret != HIPFFT_SUCCESS)
             return ret;
         // do not register plan's worksizes as "auto-allocated" if auto-allocation was explicitly prevented
-        size_t* worksize_ptr = is_preventing_auto_allocation_at_generation()
-                                   ? nullptr
-                                   : auto_allocated_worksizes.data();
-        auto    layout_args  = make_valid_layout_args_for_plan_many<int>();
+        std::vector<size_t> tmp_worksize(get_num_used_gpus());
+        size_t*             worksize_ptr = is_preventing_auto_allocation_at_generation()
+                                               ? tmp_worksize.data()
+                                               : auto_allocated_worksizes.data();
+        auto                layout_args  = make_valid_layout_args_for_plan_many<int>();
         return hipfftMakePlanMany(plan,
                                   dim(),
                                   int_length.data(),
@@ -1606,10 +1609,11 @@ private:
             return ret;
 
         // do not register plan's worksizes as "auto-allocated" if auto-allocation was explicitly prevented
-        size_t* worksize_ptr = is_preventing_auto_allocation_at_generation()
-                                   ? nullptr
-                                   : auto_allocated_worksizes.data();
-        auto    layout_args  = make_valid_layout_args_for_plan_many<long long int>();
+        std::vector<size_t> tmp_worksize(get_num_used_gpus());
+        size_t*             worksize_ptr = is_preventing_auto_allocation_at_generation()
+                                               ? tmp_worksize.data()
+                                               : auto_allocated_worksizes.data();
+        auto                layout_args  = make_valid_layout_args_for_plan_many<long long int>();
         return hipfftMakePlanMany64(plan,
                                     dim(),
                                     ll_length.data(),
@@ -1654,11 +1658,12 @@ private:
             return ret;
 
         // do not register plan's worksizes as "auto-allocated" if auto-allocation was explicitly prevented
-        size_t* worksize_ptr  = is_preventing_auto_allocation_at_generation()
-                                    ? nullptr
-                                    : auto_allocated_worksizes.data();
-        auto    executionType = get_xt_api_execution_type();
-        auto    layout_args   = make_valid_layout_args_for_plan_many<long long int>();
+        std::vector<size_t> tmp_worksize(get_num_used_gpus());
+        size_t*             worksize_ptr  = is_preventing_auto_allocation_at_generation()
+                                                ? tmp_worksize.data()
+                                                : auto_allocated_worksizes.data();
+        auto                executionType = get_xt_api_execution_type();
+        auto                layout_args   = make_valid_layout_args_for_plan_many<long long int>();
         return hipfftXtMakePlanMany(plan,
                                     dim(),
                                     ll_length.data(),


### PR DESCRIPTION
This fixes failures for `hipfft-test` with CUDA backend for tests added in https://github.com/ROCm/hipFFT/pull/160.