### PR TITLE
[hipBLASLt] Fix wrong occupancy of the GlobalWrite for the MBSK kernel.

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/AsmStoreState.py
+++ b/projects/hipblaslt/tensilelite/Tensile/AsmStoreState.py
@@ -374,6 +374,9 @@ class StoreState:
             numVgprs = int(ceil(kernel["ProblemType"]["ComputeDataType"].numRegisters()))
             self.numVgprsPerElement += numVgprs * gwvw + (numVgprs * min(gwvw, 2)) # Loaded data
 
+        if kernel["_GlobalAccumulation"] == "MultipleBufferSingleKernel":
+            self.numVgprsPerElement += self.cfg.numVgprsPerAddr   # addrGSUSyncVgprs
+
         # Calculate align
         self.align = 1
         # align adjustment


### PR DESCRIPTION


Fix the incorrect occupancy for the MBSK kernel

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

 added the required amount of VGPR to the numVgprsPerElement.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The MBSK kernels in the test.yaml can work properly.
[test.yaml](https://github.com/user-attachments/files/22016991/test.yaml)

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
