### PR TITLE
Add cstring header include to texture_cache_iterator

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projects/rocPRIM/en/latest/](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/).
 
+## rocPRIM 4.0.1 for ROCm 7.0.1
+
+### Resolved issues
+
+* Fixed compilation issue when using `rocprim::texture_cache_iterator`.
+
 ## rocPRIM 4.0.0 for ROCm 7.0
 
 ### Added

--- a/projects/rocprim/CMakeLists.txt
+++ b/projects/rocprim/CMakeLists.txt
@@ -180,7 +180,7 @@ if(BUILD_CODE_COVERAGE)
 endif()
 
 # Setup VERSION
-set(VERSION_STRING "4.0.0")
+set(VERSION_STRING "4.0.1")
 rocm_setup_version(VERSION ${VERSION_STRING})
 math(EXPR rocprim_VERSION_NUMBER "${rocprim_VERSION_MAJOR} * 100000 + ${rocprim_VERSION_MINOR} * 100 + ${rocprim_VERSION_PATCH}")
 

--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -23,6 +23,7 @@
 
 #include <iterator>
 #include <cstddef>
+#include <cstring>
 #include <type_traits>
 
 #include "../config.hpp"


### PR DESCRIPTION
Do not merge in this PR until given PM approval as it is targeting ROCm 7.0.1.

## Motivation

If a user includes the texture_cache_iterator header in some way without also including cstring, then compilation will fail.

## Technical Details

In https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp#L178 rocprim references memset, which requires the cstring header.  It is not included in the texture_cache_iterator header, leading to the compilation failure.

## Test Plan

Even an empty program that includes the rocprim header will fail to compile as the main rocprim header includes texture_cache_iterator.hpp:

```
#include <rocprim/rocprim.hpp>

int main() { 
  return 0;  
}
```
## Test Result

The above compiles with this fix.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
