### PR TITLE
[hipblaslt] Add dependency for gtest config yamls and gtest data command

### DIFF
--- a/projects/hipblaslt/clients/tests/CMakeLists.txt
+++ b/projects/hipblaslt/clients/tests/CMakeLists.txt
@@ -11,6 +11,14 @@ add_custom_command(
                                         -I "${CMAKE_CURRENT_SOURCE_DIR}/../common/include"
                                         "${CMAKE_CURRENT_SOURCE_DIR}/data/hipblaslt_gtest.yaml"
                                         -o ${HIPBLASLT_TEST_DATA}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hipblaslt_gentest.py
+                                        ${CMAKE_CURRENT_SOURCE_DIR}/data/hipblaslt_common.yaml
+                                        ${CMAKE_CURRENT_SOURCE_DIR}/data/matmul_common.yaml
+                                        ${CMAKE_CURRENT_SOURCE_DIR}/data/matmul_gtest.yaml
+                                        ${CMAKE_CURRENT_SOURCE_DIR}/data/auxiliary_gtest.yaml
+                                        ${CMAKE_CURRENT_SOURCE_DIR}/data/smoke_gtest.yaml
+                                        ${CMAKE_CURRENT_SOURCE_DIR}/data/rocroller_gtest.yaml
+
 )
 
 add_custom_target(hipblaslt-test-data DEPENDS ${HIPBLASLT_TEST_DATA})


### PR DESCRIPTION
## Motivation

gtest data cannot be re-generated if gtest config yaml is modified and execute make under build/release

## Technical Details

add back the dependency

## Test Plan

gtest data can be re-generated 

## Test Result

as expected

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
