### PR TITLE
[rocPRIM] Add missing in texture cache iterator header

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -24,6 +24,7 @@
 #include <iterator>
 #include <cstddef>
 #include <type_traits>
+#include <cstring>
 
 #include "../config.hpp"
 #include "../detail/various.hpp"


### PR DESCRIPTION
## Motivation

When including the rocPRIM header `iterator/texture_cache_iterator.hpp`, in some situations the compiler would report that the `memset` function could not found. It could also report that the `memset` candidate in `rocm/include/hip/amd_detail/amd_device_functions.h` was not viable because it is a device function that cannot be called directly from the host.

## Technical Details

rocPRIM's texture cache iterator header was missing an: `#include <cstring>`.

## Test Plan

Build and run the following simple reproducer on gfx1100 using a recent build. It should build without any error messages.
```
#include <rocprim/rocprim.hpp>
#include <stdio.h>
int main()
{ 
  return 0;
}
```

## Test Result

No error messages observed on compilation.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
