### PR TITLE
[hipblaslt] Avoid extra pre-shuffle overheads when running benchmarks without validation

### DIFF
--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -1987,14 +1987,17 @@ void testing_matmul_with_bias(const Arguments& arg,
             CHECK_HIP_ERROR(synchronize(hC[i], dC[i]));
         }
 
-        if(do_swizzle_a)
+        // if we are not going to do verify / validation, we don't need to do extra swizzle (pre-shuffle).
+        // In customers' real case, they will do the swizzle (pre-shuffle) in advance.
+        // In order to reduce the overhead of doing the pre-shuffle, we can choose not to do it when no --verify / -v
+        if(do_swizzle_a && (arg.unit_check || arg.norm_check || arg.allclose_check))
         {
             HipHostBuffer tmp(TiA, size_dA[i]);
             swizzle_tensor_type(tmp, hA[i], TiA, arg, num_batches[i], M[i], K[i], lda[i], false);
             CHECK_HIP_ERROR(synchronize(dA[i], tmp, block_count));
         }
 
-        if(do_swizzle_b)
+        if(do_swizzle_b && (arg.unit_check || arg.norm_check || arg.allclose_check))
         {
             HipHostBuffer tmp(TiB, size_dB[i]);
             swizzle_tensor_type(tmp, hB[i], TiB, arg, num_batches[i], N[i], K[i], ldb[i], false);

--- a/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
@@ -936,8 +936,11 @@ namespace TensileLite
                         auto numAllocatedElements = problem.tensors()[i].totalAllocatedElements();
                         auto numAllocatedBytes    = problem.tensors()[i].totalAllocatedBytes();
 
-                        if((problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A)
-                           || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B))
+                        bool needSwizzle
+                            = (problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A)
+                              || (problem.swizzleTensorB()
+                                  && i == ContractionProblemGemm::TENSOR::B);
+                        if(needSwizzle)
                         {
                             //TODO: support more swizzle types,
                             //      currently, if A then it means MiM = 16, if B then it means MiN = 16
@@ -947,6 +950,9 @@ namespace TensileLite
                                 problem.tensors()[i], MiM_N, MiK, PackK);
                             numAllocatedBytes
                                 = numAllocatedElements * rocisa::GetElementSize(dataType);
+
+                            // std::cout << "DataInitialization- needSwizzle: numAllocatedElements:"
+                            //           << numAllocatedElements << std::endl;
                         }
 
                         pristine.maxElements = std::max(pristine.maxElements, numAllocatedElements);
@@ -1492,8 +1498,10 @@ namespace TensileLite
                 {
                     padding = pUnit.maxElements - problem.tensors()[i].totalAllocatedElements();
 
-                    if((problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A)
-                       || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B))
+                    bool needSwizzle
+                        = (problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A)
+                          || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B);
+                    if(needSwizzle)
                     {
                         //TODO: support more swizzle types,
                         //      currently, if A then it means MiM = 16, if B then it means MiN = 16
@@ -2055,7 +2063,8 @@ namespace TensileLite
 
                 void* ptr{};
 
-                if(needSwizzle)
+                // When needSwizzle, if no need to do validation, we can save the time doing data-relayout
+                if(needSwizzle && m_elementsToValidate)
                 {
                     using Tensor = Tensor::Manipulation::Tensor;
                     // currently, if A then it means MiM = 16, if B then it means MiN = 16
@@ -2070,6 +2079,7 @@ namespace TensileLite
                     auto swizzleKey
                         = std::make_tuple(toBitWidth(desc.dataType()), unrolledSize, tiledSize);
 
+                    // Cache-hit
                     if(g_swizzleCache.count(swizzleKey))
                     {
                         if(swizzleKey != g_swizzleCache.back())
@@ -2086,6 +2096,7 @@ namespace TensileLite
                             ptr = p.gpuInput.valid.get();
                         }
                     }
+                    // No Cache-hit, do pre-shuffle...
                     else
                     {
                         auto tmpTensor = Tensor({tiledSize, unrolledSize}, desc.elementBytes());
@@ -2108,6 +2119,8 @@ namespace TensileLite
                                                permuted.getDesc().flattenSize(),
                                                hipMemcpyHostToDevice);
                         g_swizzleCache.emplace(swizzleKey, std::move(permuted));
+                        // std::cout << "needSwizzle and do permute- Copied elems:"
+                        //           << paddedTensor.getDesc().flattenSize() << std::endl;
                     }
                 }
                 else
@@ -2117,6 +2130,10 @@ namespace TensileLite
                                            p.cpuInput.valid.get(),
                                            p.maxElements,
                                            hipMemcpyHostToDevice);
+                    // if(needSwizzle)
+                    //     std::cout
+                    //         << "needSwizzle but no validation- don't do pre-shuffle: Copied elems:"
+                    //         << p.maxElements << std::endl;
                 }
 
                 if(ptr == nullptr)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When tuning/benchmarking swizzling kernels. The client sides (Both in tensilelite and hipblaslt) need to do extra memory re-layout (pre-shuffle) in order to make sure we pass then validations. But the memory OP takes quite significant time. 

In our practicing, we often "do no validation" when tuning, and "do validation" in the LibraryClient stage. The point is that if we are working to get the times/flops of kernels only, we usually manually comment out the codes of "pre-shuffle" part to reduce the overhead. But once we need to do validation, the work is unavoidable. 

This PR is doing this for us: if no validation, then don't put extra effort on pre-shuffling, otherwise it is a must. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Only do permute (a.k.a., data re-layout, pre-shuffle...etc) when we need to do validation (in hipblaslt-bench, -v or --verify).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Already covered by CI since tox and gtest will do validation.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
