### PR TITLE
Benchmark all autotuned types

### DIFF
--- a/projects/rocprim/.gitlab/run_benchmarks.py
+++ b/projects/rocprim/.gitlab/run_benchmarks.py
@@ -56,7 +56,7 @@ def run_benchmarks(benchmark_context):
 
     success = True
     benchmark_names = [name for name in os.listdir(benchmark_context.benchmark_dir) if is_benchmark_executable(name)]
-    print('The following benchmarks will be ran:\n{}'.format('\n'.join(benchmark_names)), file=sys.stderr, flush=True)
+    print('The following benchmarks will be run:\n{}'.format('\n'.join(benchmark_names)), file=sys.stderr, flush=True)
     for benchmark_name in benchmark_names:
         results_json_name = f'{benchmark_name}_{benchmark_context.gpu_architecture}.json'
 

--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -7,6 +7,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 ### Added
 
 * Added `get_sreg_lanemask_lt`, `get_sreg_lanemask_le`, `get_sreg_lanemask_gt` and `get_sreg_lanemask_ge`.
+* Added missing benchmarks so that every autotuned type is now covered.
 
 ### Upcoming changes
 

--- a/projects/rocprim/benchmark/CMakeLists.txt
+++ b/projects/rocprim/benchmark/CMakeLists.txt
@@ -21,6 +21,8 @@
 # SOFTWARE.
 
 option(BENCHMARK_CONFIG_TUNING "Benchmark device-level functions using various configs" OFF)
+option(BENCHMARK_AUTOTUNED_TYPES_ONLY "Benchmark autotuned types only, which lowers the benchmarking runtime" OFF)
+
 include(../cmake/ConfigAutotune.cmake)
 include(ConfigAutotuneSettings.cmake)
 
@@ -74,6 +76,10 @@ function(add_rocprim_benchmark BENCHMARK_SOURCE)
 
   if(BUILD_NAIVE_BENCHMARK)
     target_compile_definitions(${BENCHMARK_TARGET} PUBLIC BUILD_NAIVE_BENCHMARK)
+  endif()
+
+  if(BENCHMARK_AUTOTUNED_TYPES_ONLY)
+    target_compile_definitions(${BENCHMARK_TARGET} PUBLIC BENCHMARK_AUTOTUNED_TYPES_ONLY)
   endif()
 
   target_link_libraries(${BENCHMARK_TARGET}

--- a/projects/rocprim/benchmark/benchmark_device_adjacent_difference.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_adjacent_difference.cpp
@@ -58,23 +58,28 @@ int main(int argc, char* argv[])
     benchmark_utils::executor executor(argc, argv, 2 * benchmark_utils::GiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    CREATE_BENCHMARKS(rocprim::int128_t);
+    CREATE_BENCHMARKS(int64_t);
+    CREATE_BENCHMARKS(int);
+    CREATE_BENCHMARKS(short);
+    CREATE_BENCHMARKS(int8_t);
+    CREATE_BENCHMARKS(double);
+    CREATE_BENCHMARKS(float);
+    CREATE_BENCHMARKS(rocprim::half);
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARKS(uint8_t);
+    CREATE_BENCHMARKS(rocprim::uint128_t);
+
+    // Not tuned custom types
     using custom_float2  = common::custom_type<float, float>;
     using custom_double2 = common::custom_type<double, double>;
 
-    CREATE_BENCHMARKS(int);
-    CREATE_BENCHMARKS(std::int64_t);
-
-    CREATE_BENCHMARKS(uint8_t);
-    CREATE_BENCHMARKS(rocprim::half);
-
-    CREATE_BENCHMARKS(float);
-    CREATE_BENCHMARKS(double);
-
     CREATE_BENCHMARKS(custom_float2);
     CREATE_BENCHMARKS(custom_double2);
-
-    CREATE_BENCHMARKS(rocprim::int128_t);
-    CREATE_BENCHMARKS(rocprim::uint128_t);
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_adjacent_difference.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_adjacent_difference.parallel.hpp
@@ -73,9 +73,10 @@ struct device_adjacent_difference_benchmark : public benchmark_utils::autotune_i
 
         using namespace std::string_literals;
         return bench_naming::format_name(
-            "{lvl:device,algo:adjacent_difference" + (Left ? ""s : "_right"s)
-            + (Aliasing == common::api_variant::no_alias ? ""s : "_inplace"s) + ",value_type:"
-            + std::string(Traits<T>::name()) + ",cfg:" + config_name<Config>() + "}");
+            "{lvl:device,algo:adjacent_difference"
+            + (Aliasing == common::api_variant::no_alias ? ""s : "_inplace"s) + ",is_left:"
+            + (Left ? "true"s : "false"s) + ",value_type:" + std::string(Traits<T>::name())
+            + ",cfg:" + config_name<Config>() + "}");
     }
 
     void run(benchmark_utils::state&& state) override

--- a/projects/rocprim/benchmark/benchmark_device_adjacent_find.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_adjacent_find.cpp
@@ -54,29 +54,35 @@ int main(int argc, char* argv[])
     benchmark_utils::executor executor(argc, argv, 2 * benchmark_utils::GiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    CREATE_ADJACENT_FIND_BENCHMARKS(rocprim::int128_t)
+    CREATE_ADJACENT_FIND_BENCHMARKS(int64_t)
+    CREATE_ADJACENT_FIND_BENCHMARKS(int)
+    CREATE_ADJACENT_FIND_BENCHMARKS(short)
+    CREATE_ADJACENT_FIND_BENCHMARKS(int8_t)
+    CREATE_ADJACENT_FIND_BENCHMARKS(double)
+    CREATE_ADJACENT_FIND_BENCHMARKS(float)
+    CREATE_ADJACENT_FIND_BENCHMARKS(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_ADJACENT_FIND_BENCHMARKS(int16_t)
+    CREATE_ADJACENT_FIND_BENCHMARKS(int32_t)
+    CREATE_ADJACENT_FIND_BENCHMARKS(rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2          = common::custom_type<float, float>;
     using custom_double2         = common::custom_type<double, double>;
     using custom_int2            = common::custom_type<int, int>;
     using custom_char_double     = common::custom_type<char, double>;
     using custom_longlong_double = common::custom_type<long long, double>;
 
-    // Tuned types
-    CREATE_ADJACENT_FIND_BENCHMARKS(int8_t)
-    CREATE_ADJACENT_FIND_BENCHMARKS(int16_t)
-    CREATE_ADJACENT_FIND_BENCHMARKS(int32_t)
-    CREATE_ADJACENT_FIND_BENCHMARKS(int64_t)
-    CREATE_ADJACENT_FIND_BENCHMARKS(rocprim::half)
-    CREATE_ADJACENT_FIND_BENCHMARKS(float)
-    CREATE_ADJACENT_FIND_BENCHMARKS(double)
-    CREATE_ADJACENT_FIND_BENCHMARKS(rocprim::int128_t)
-    CREATE_ADJACENT_FIND_BENCHMARKS(rocprim::uint128_t)
-
-    // Custom types
     CREATE_ADJACENT_FIND_BENCHMARKS(custom_float2)
     CREATE_ADJACENT_FIND_BENCHMARKS(custom_double2)
     CREATE_ADJACENT_FIND_BENCHMARKS(custom_int2)
     CREATE_ADJACENT_FIND_BENCHMARKS(custom_char_double)
     CREATE_ADJACENT_FIND_BENCHMARKS(custom_longlong_double)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_binary_search.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_binary_search.cpp
@@ -45,45 +45,70 @@
     #include <stdint.h>
 #endif
 
-#define CREATE_BENCHMARK(T, K, SORTED, SUBALGORITHM)                                       \
-    executor.queue_fn(                                                                     \
-        bench_naming::format_name("{lvl:device,algo:" + SUBALGORITHM{}.name()              \
-                                  + ",key_type:" #T ",needle_distribution:" #K "_percent_" \
-                                  + std::string(SORTED ? "sorted" : "random")              \
-                                  + "_needles,cfg:default_config}")                        \
-            .c_str(),                                                                      \
-        [=](benchmark_utils::state&& state)                                                \
-        {                                                                                  \
-            device_binary_search_benchmark<SUBALGORITHM, T, size_t, K, SORTED>().run(      \
-                std::forward<benchmark_utils::state>(state));                              \
+#define CREATE_BENCHMARK(VALUE_TYPE, OUTPUT_TYPE, K, SORTED, SUBALGORITHM)                     \
+    executor.queue_fn(                                                                         \
+        bench_naming::format_name("{lvl:device,algo:" + SUBALGORITHM{}.name()                  \
+                                  + ",key_type:" #VALUE_TYPE ",needle_distribution:" #K "_percent_"     \
+                                  + std::string(SORTED ? "sorted" : "random")                  \
+                                  + "_needles,cfg:default_config}")                            \
+            .c_str(),                                                                          \
+        [=](benchmark_utils::state&& state)                                                    \
+        {                                                                                      \
+            device_binary_search_benchmark<SUBALGORITHM, VALUE_TYPE, OUTPUT_TYPE, K, SORTED>() \
+                .run(std::forward<benchmark_utils::state>(state));                             \
         });
 
-#define BENCHMARK_ALGORITHMS(T, K, SORTED)                     \
-    CREATE_BENCHMARK(T, K, SORTED, binary_search_subalgorithm) \
-    CREATE_BENCHMARK(T, K, SORTED, lower_bound_subalgorithm)   \
-    CREATE_BENCHMARK(T, K, SORTED, upper_bound_subalgorithm)
+#define BENCHMARK_ALGORITHMS(VALUE_TYPE, OUTPUT_TYPE, K, SORTED)                     \
+    CREATE_BENCHMARK(VALUE_TYPE, OUTPUT_TYPE, K, SORTED, binary_search_subalgorithm) \
+    CREATE_BENCHMARK(VALUE_TYPE, OUTPUT_TYPE, K, SORTED, lower_bound_subalgorithm)   \
+    CREATE_BENCHMARK(VALUE_TYPE, OUTPUT_TYPE, K, SORTED, upper_bound_subalgorithm)
 
-#define BENCHMARK_TYPE(type)             \
-    BENCHMARK_ALGORITHMS(type, 10, true) \
-    BENCHMARK_ALGORITHMS(type, 10, false)
+#define BENCHMARK_TYPE(VALUE_TYPE)                     \
+    BENCHMARK_ALGORITHMS(VALUE_TYPE, size_t, 10, true) \
+    BENCHMARK_ALGORITHMS(VALUE_TYPE, size_t, 10, false)
+
+#define BENCHMARK_TYPE_TUNING(VALUE_TYPE, OUTPUT_TYPE)      \
+    BENCHMARK_ALGORITHMS(VALUE_TYPE, OUTPUT_TYPE, 10, true) \
+    BENCHMARK_ALGORITHMS(VALUE_TYPE, OUTPUT_TYPE, 10, false)
+
+// All of the limited tuned types
+#define BENCHMARK_TYPES_TUNING(VALUE_TYPE)               \
+    BENCHMARK_TYPE_TUNING(VALUE_TYPE, rocprim::int128_t) \
+    BENCHMARK_TYPE_TUNING(VALUE_TYPE, int64_t)           \
+    BENCHMARK_TYPE_TUNING(VALUE_TYPE, int)               \
+    BENCHMARK_TYPE_TUNING(VALUE_TYPE, short)             \
+    BENCHMARK_TYPE_TUNING(VALUE_TYPE, int8_t)
 
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    BENCHMARK_TYPES_TUNING(rocprim::int128_t)
+    BENCHMARK_TYPES_TUNING(int64_t)
+    BENCHMARK_TYPES_TUNING(int)
+    BENCHMARK_TYPES_TUNING(short)
+    BENCHMARK_TYPES_TUNING(int8_t)
+    BENCHMARK_TYPES_TUNING(double)
+    BENCHMARK_TYPES_TUNING(float)
+    BENCHMARK_TYPES_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    BENCHMARK_TYPE(float)
+    BENCHMARK_TYPE(double)
+    BENCHMARK_TYPE(uint8_t)
+    BENCHMARK_TYPE(rocprim::half)
+    BENCHMARK_TYPE(rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2  = common::custom_type<float, float>;
     using custom_double2 = common::custom_type<double, double>;
 
-    BENCHMARK_TYPE(float)
-    BENCHMARK_TYPE(double)
-    BENCHMARK_TYPE(int8_t)
-    BENCHMARK_TYPE(uint8_t)
-    BENCHMARK_TYPE(rocprim::half)
-    BENCHMARK_TYPE(rocprim::int128_t)
-    BENCHMARK_TYPE(rocprim::uint128_t)
     BENCHMARK_TYPE(custom_float2)
     BENCHMARK_TYPE(custom_double2)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_binary_search.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_binary_search.cpp
@@ -45,18 +45,9 @@
     #include <stdint.h>
 #endif
 
-#define CREATE_BENCHMARK(VALUE_TYPE, OUTPUT_TYPE, K, SORTED, SUBALGORITHM)                     \
-    executor.queue_fn(                                                                         \
-        bench_naming::format_name("{lvl:device,algo:" + SUBALGORITHM{}.name()                  \
-                                  + ",key_type:" #VALUE_TYPE ",needle_distribution:" #K "_percent_"     \
-                                  + std::string(SORTED ? "sorted" : "random")                  \
-                                  + "_needles,cfg:default_config}")                            \
-            .c_str(),                                                                          \
-        [=](benchmark_utils::state&& state)                                                    \
-        {                                                                                      \
-            device_binary_search_benchmark<SUBALGORITHM, VALUE_TYPE, OUTPUT_TYPE, K, SORTED>() \
-                .run(std::forward<benchmark_utils::state>(state));                             \
-        });
+#define CREATE_BENCHMARK(VALUE_TYPE, OUTPUT_TYPE, K, SORTED, SUBALGORITHM) \
+    executor.queue_instance(                                               \
+        device_binary_search_benchmark<SUBALGORITHM, VALUE_TYPE, OUTPUT_TYPE, K, SORTED>());
 
 #define BENCHMARK_ALGORITHMS(VALUE_TYPE, OUTPUT_TYPE, K, SORTED)                     \
     CREATE_BENCHMARK(VALUE_TYPE, OUTPUT_TYPE, K, SORTED, binary_search_subalgorithm) \

--- a/projects/rocprim/benchmark/benchmark_device_binary_search.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_binary_search.cpp
@@ -45,17 +45,17 @@
     #include <stdint.h>
 #endif
 
-#define CREATE_BENCHMARK(T, K, SORTED, SUBALGORITHM)                                  \
-    executor.queue_fn(                                                                \
-        bench_naming::format_name("{lvl:device,algo:" + SUBALGORITHM{}.name()         \
-                                  + ",key_type:" #T ",subalgo:" #K "_percent_"        \
-                                  + std::string(SORTED ? "sorted" : "random")         \
-                                  + "_needles,cfg:default_config}")                   \
-            .c_str(),                                                                 \
-        [=](benchmark_utils::state&& state)                                           \
-        {                                                                             \
-            device_binary_search_benchmark<SUBALGORITHM, T, size_t, K, SORTED>().run( \
-                std::forward<benchmark_utils::state>(state));                         \
+#define CREATE_BENCHMARK(T, K, SORTED, SUBALGORITHM)                                       \
+    executor.queue_fn(                                                                     \
+        bench_naming::format_name("{lvl:device,algo:" + SUBALGORITHM{}.name()              \
+                                  + ",key_type:" #T ",needle_distribution:" #K "_percent_" \
+                                  + std::string(SORTED ? "sorted" : "random")              \
+                                  + "_needles,cfg:default_config}")                        \
+            .c_str(),                                                                      \
+        [=](benchmark_utils::state&& state)                                                \
+        {                                                                                  \
+            device_binary_search_benchmark<SUBALGORITHM, T, size_t, K, SORTED>().run(      \
+                std::forward<benchmark_utils::state>(state));                              \
         });
 
 #define BENCHMARK_ALGORITHMS(T, K, SORTED)                     \

--- a/projects/rocprim/benchmark/benchmark_device_find_first_of.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_find_first_of.cpp
@@ -63,20 +63,28 @@ int main(int argc, char* argv[])
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 2);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    CREATE_BENCHMARK(rocprim::int128_t)
+    CREATE_BENCHMARK(int64_t)
+    CREATE_BENCHMARK(int)
+    CREATE_BENCHMARK(short)
     CREATE_BENCHMARK(int8_t)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
     CREATE_BENCHMARK(int16_t)
     CREATE_BENCHMARK(int32_t)
     CREATE_BENCHMARK(float)
-    CREATE_BENCHMARK(int64_t)
     CREATE_BENCHMARK(double)
-    CREATE_BENCHMARK(rocprim::int128_t)
     CREATE_BENCHMARK(rocprim::uint128_t)
 
+    // Not tuned custom types
     using custom_int2            = common::custom_type<int, int>;
     using custom_longlong_double = common::custom_type<long long, double>;
 
     CREATE_BENCHMARK(custom_int2)
     CREATE_BENCHMARK(custom_longlong_double)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_merge.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_merge.cpp
@@ -44,41 +44,54 @@
 
 #define CREATE_BENCHMARK(...) executor.queue_instance(device_merge_benchmark<__VA_ARGS__>());
 
+#define CREATE_BENCHMARK_TYPE_TUNING(KeyType)      \
+    CREATE_BENCHMARK(KeyType, rocprim::empty_type) \
+    CREATE_BENCHMARK(KeyType, rocprim::int128_t)   \
+    CREATE_BENCHMARK(KeyType, long long)           \
+    CREATE_BENCHMARK(KeyType, int)                 \
+    CREATE_BENCHMARK(KeyType, short)               \
+    CREATE_BENCHMARK(KeyType, int8_t)
+
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::int128_t)
+    CREATE_BENCHMARK_TYPE_TUNING(long long)
+    CREATE_BENCHMARK_TYPE_TUNING(int)
+    CREATE_BENCHMARK_TYPE_TUNING(short)
+    CREATE_BENCHMARK_TYPE_TUNING(int8_t)
+    CREATE_BENCHMARK_TYPE_TUNING(double)
+    CREATE_BENCHMARK_TYPE_TUNING(float)
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARK(uint8_t)
+    CREATE_BENCHMARK(rocprim::uint128_t)
+
+    CREATE_BENCHMARK(uint8_t, uint8_t)
+    CREATE_BENCHMARK(rocprim::half, rocprim::half)
+    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_int2      = common::custom_type<int, int>;
     using custom_double2   = common::custom_type<double, double>;
     using huge_float2_1024 = common::custom_huge_type<1024, float, float>;
     using huge_float2_2048 = common::custom_huge_type<2048, float, float>;
 
-    CREATE_BENCHMARK(int)
-    CREATE_BENCHMARK(long long)
-    CREATE_BENCHMARK(int8_t)
-    CREATE_BENCHMARK(uint8_t)
-    CREATE_BENCHMARK(rocprim::half)
-    CREATE_BENCHMARK(short)
     CREATE_BENCHMARK(custom_int2)
     CREATE_BENCHMARK(custom_double2)
-    CREATE_BENCHMARK(rocprim::int128_t)
-    CREATE_BENCHMARK(rocprim::uint128_t)
     CREATE_BENCHMARK(huge_float2_1024)
     CREATE_BENCHMARK(huge_float2_2048)
 
-    CREATE_BENCHMARK(int, int)
-    CREATE_BENCHMARK(long long, long long)
-    CREATE_BENCHMARK(int8_t, int8_t)
-    CREATE_BENCHMARK(uint8_t, uint8_t)
-    CREATE_BENCHMARK(rocprim::half, rocprim::half)
-    CREATE_BENCHMARK(short, short)
     CREATE_BENCHMARK(custom_int2, custom_int2)
     CREATE_BENCHMARK(custom_double2, custom_double2)
-    CREATE_BENCHMARK(rocprim::int128_t, rocprim::int128_t)
-    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)
     CREATE_BENCHMARK(huge_float2_1024, huge_float2_1024)
     CREATE_BENCHMARK(huge_float2_2048, huge_float2_2048)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_merge_sort_block_merge.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_merge_sort_block_merge.cpp
@@ -44,40 +44,48 @@
 #define CREATE_BENCHMARK(...) \
     executor.queue_instance(device_merge_sort_block_merge_benchmark<__VA_ARGS__>());
 
+#define CREATE_BENCHMARK_TYPE_TUNING(KeyType)      \
+    CREATE_BENCHMARK(KeyType, rocprim::empty_type) \
+    CREATE_BENCHMARK(KeyType, rocprim::int128_t)   \
+    CREATE_BENCHMARK(KeyType, long long)           \
+    CREATE_BENCHMARK(KeyType, int)                 \
+    CREATE_BENCHMARK(KeyType, short)               \
+    CREATE_BENCHMARK(KeyType, int8_t)
+
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
-    CREATE_BENCHMARK(int)
-    CREATE_BENCHMARK(long long)
-    CREATE_BENCHMARK(int8_t)
+    // Tuned types
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::int128_t)
+    CREATE_BENCHMARK_TYPE_TUNING(long long)
+    CREATE_BENCHMARK_TYPE_TUNING(int)
+    CREATE_BENCHMARK_TYPE_TUNING(short)
+    CREATE_BENCHMARK_TYPE_TUNING(int8_t)
+    CREATE_BENCHMARK_TYPE_TUNING(double)
+    CREATE_BENCHMARK_TYPE_TUNING(float)
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
     CREATE_BENCHMARK(uint8_t)
-    CREATE_BENCHMARK(rocprim::half)
-    CREATE_BENCHMARK(short)
-    CREATE_BENCHMARK(rocprim::int128_t)
     CREATE_BENCHMARK(rocprim::uint128_t)
 
+    // Not tuned custom types
     using custom_float2          = common::custom_type<float, float>;
     using custom_double2         = common::custom_type<double, double>;
     using custom_int2            = common::custom_type<int, int>;
     using custom_char_double     = common::custom_type<char, double>;
     using custom_longlong_double = common::custom_type<long long, double>;
 
-    CREATE_BENCHMARK(int, float)
-    CREATE_BENCHMARK(long long, double)
-    CREATE_BENCHMARK(int8_t, int8_t)
-    CREATE_BENCHMARK(uint8_t, uint8_t)
-    CREATE_BENCHMARK(rocprim::half, rocprim::half)
-    CREATE_BENCHMARK(short, short)
     CREATE_BENCHMARK(int, custom_float2)
     CREATE_BENCHMARK(long long, custom_double2)
     CREATE_BENCHMARK(custom_double2, custom_double2)
     CREATE_BENCHMARK(custom_int2, custom_double2)
     CREATE_BENCHMARK(custom_int2, custom_char_double)
     CREATE_BENCHMARK(custom_int2, custom_longlong_double)
-    CREATE_BENCHMARK(rocprim::int128_t, rocprim::int128_t)
-    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_merge_sort_block_sort.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_merge_sort_block_sort.cpp
@@ -44,20 +44,41 @@
 #define CREATE_BENCHMARK(...) \
     executor.queue_instance(device_merge_sort_block_sort_benchmark<__VA_ARGS__>());
 
+#define CREATE_BENCHMARK_TYPE_TUNING(KeyType)      \
+    CREATE_BENCHMARK(KeyType, rocprim::empty_type) \
+    CREATE_BENCHMARK(KeyType, rocprim::int128_t)   \
+    CREATE_BENCHMARK(KeyType, long long)           \
+    CREATE_BENCHMARK(KeyType, int)                 \
+    CREATE_BENCHMARK(KeyType, short)               \
+    CREATE_BENCHMARK(KeyType, int8_t)
+
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
-    CREATE_BENCHMARK(int)
-    CREATE_BENCHMARK(long long)
-    CREATE_BENCHMARK(int8_t)
+    // Tuned types
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::int128_t)
+    CREATE_BENCHMARK_TYPE_TUNING(long long)
+    CREATE_BENCHMARK_TYPE_TUNING(int)
+    CREATE_BENCHMARK_TYPE_TUNING(short)
+    CREATE_BENCHMARK_TYPE_TUNING(int8_t)
+    CREATE_BENCHMARK_TYPE_TUNING(double)
+    CREATE_BENCHMARK_TYPE_TUNING(float)
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
     CREATE_BENCHMARK(uint8_t)
-    CREATE_BENCHMARK(rocprim::half)
-    CREATE_BENCHMARK(short)
-    CREATE_BENCHMARK(rocprim::int128_t)
     CREATE_BENCHMARK(rocprim::uint128_t)
 
+    CREATE_BENCHMARK(int, float)
+    CREATE_BENCHMARK(long long, double)
+    CREATE_BENCHMARK(uint8_t, uint8_t)
+    CREATE_BENCHMARK(rocprim::half, rocprim::half)
+    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2          = common::custom_type<float, float>;
     using custom_double2         = common::custom_type<double, double>;
     using custom_int2            = common::custom_type<int, int>;
@@ -65,12 +86,6 @@ int main(int argc, char* argv[])
     using custom_longlong_double = common::custom_type<long long, double>;
     using custom_char_short      = common::custom_type<char, short>;
 
-    CREATE_BENCHMARK(int, float)
-    CREATE_BENCHMARK(long long, double)
-    CREATE_BENCHMARK(int8_t, int8_t)
-    CREATE_BENCHMARK(uint8_t, uint8_t)
-    CREATE_BENCHMARK(rocprim::half, rocprim::half)
-    CREATE_BENCHMARK(short, short)
     CREATE_BENCHMARK(int, custom_float2)
     CREATE_BENCHMARK(long long, custom_double2)
     CREATE_BENCHMARK(custom_double2, custom_double2)
@@ -78,8 +93,7 @@ int main(int argc, char* argv[])
     CREATE_BENCHMARK(custom_int2, custom_char_double)
     CREATE_BENCHMARK(custom_int2, custom_longlong_double)
     CREATE_BENCHMARK(int, custom_char_short)
-    CREATE_BENCHMARK(rocprim::int128_t, rocprim::int128_t)
-    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_partition.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_partition.cpp
@@ -90,69 +90,65 @@
     CREATE_PARTITION_THREE_WAY_BENCHMARK(type, partition_three_way_probability::p050_p075) \
     CREATE_PARTITION_THREE_WAY_BENCHMARK(type, partition_three_way_probability::p075_p100)
 
+#define BENCHMARK_TYPES_TUNING(T)          \
+    BENCHMARK_FLAG_TYPE(T, int8_t)         \
+    BENCHMARK_PREDICATE_TYPE(T)            \
+    BENCHMARK_TWO_WAY_FLAG_TYPE(T, int8_t) \
+    BENCHMARK_TWO_WAY_PREDICATE_TYPE(T)    \
+    BENCHMARK_THREE_WAY_TYPE(T)
+
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    BENCHMARK_TYPES_TUNING(rocprim::int128_t)
+    BENCHMARK_TYPES_TUNING(int64_t)
+    BENCHMARK_TYPES_TUNING(int)
+    BENCHMARK_TYPES_TUNING(short)
+    BENCHMARK_TYPES_TUNING(int8_t)
+    BENCHMARK_TYPES_TUNING(double)
+    BENCHMARK_TYPES_TUNING(float)
+    BENCHMARK_TYPES_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    BENCHMARK_FLAG_TYPE(uint8_t, uint8_t)
+    BENCHMARK_FLAG_TYPE(rocprim::uint128_t, uint8_t)
+
+    BENCHMARK_PREDICATE_TYPE(uint8_t)
+    BENCHMARK_PREDICATE_TYPE(rocprim::uint128_t)
+
+    BENCHMARK_TWO_WAY_FLAG_TYPE(uint8_t, uint8_t)
+    BENCHMARK_TWO_WAY_FLAG_TYPE(rocprim::uint128_t, uint8_t)
+
+    BENCHMARK_TWO_WAY_PREDICATE_TYPE(uint8_t)
+    BENCHMARK_TWO_WAY_PREDICATE_TYPE(rocprim::uint128_t)
+
+    BENCHMARK_THREE_WAY_TYPE(uint8_t)
+    BENCHMARK_THREE_WAY_TYPE(rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_double2    = common::custom_type<double, double>;
     using custom_int_double = common::custom_type<int, double>;
     using huge_float2       = common::custom_huge_type<1024, float, float>;
 
-    BENCHMARK_FLAG_TYPE(int, unsigned char)
-    BENCHMARK_FLAG_TYPE(float, unsigned char)
-    BENCHMARK_FLAG_TYPE(double, unsigned char)
-    BENCHMARK_FLAG_TYPE(uint8_t, uint8_t)
-    BENCHMARK_FLAG_TYPE(int8_t, int8_t)
-    BENCHMARK_FLAG_TYPE(rocprim::half, int8_t)
     BENCHMARK_FLAG_TYPE(custom_double2, unsigned char)
-    BENCHMARK_FLAG_TYPE(rocprim::int128_t, int8_t)
-    BENCHMARK_FLAG_TYPE(rocprim::uint128_t, uint8_t)
     BENCHMARK_FLAG_TYPE(huge_float2, uint8_t)
 
-    BENCHMARK_PREDICATE_TYPE(int)
-    BENCHMARK_PREDICATE_TYPE(float)
-    BENCHMARK_PREDICATE_TYPE(double)
-    BENCHMARK_PREDICATE_TYPE(uint8_t)
-    BENCHMARK_PREDICATE_TYPE(int8_t)
-    BENCHMARK_PREDICATE_TYPE(rocprim::half)
     BENCHMARK_PREDICATE_TYPE(custom_int_double)
-    BENCHMARK_PREDICATE_TYPE(rocprim::int128_t)
-    BENCHMARK_PREDICATE_TYPE(rocprim::uint128_t)
     BENCHMARK_PREDICATE_TYPE(huge_float2)
 
-    BENCHMARK_TWO_WAY_FLAG_TYPE(int, unsigned char)
-    BENCHMARK_TWO_WAY_FLAG_TYPE(float, unsigned char)
-    BENCHMARK_TWO_WAY_FLAG_TYPE(double, unsigned char)
-    BENCHMARK_TWO_WAY_FLAG_TYPE(uint8_t, uint8_t)
-    BENCHMARK_TWO_WAY_FLAG_TYPE(int8_t, int8_t)
-    BENCHMARK_TWO_WAY_FLAG_TYPE(rocprim::half, int8_t)
     BENCHMARK_TWO_WAY_FLAG_TYPE(custom_double2, unsigned char)
-    BENCHMARK_TWO_WAY_FLAG_TYPE(rocprim::int128_t, int8_t)
-    BENCHMARK_TWO_WAY_FLAG_TYPE(rocprim::uint128_t, uint8_t)
     BENCHMARK_TWO_WAY_FLAG_TYPE(huge_float2, uint8_t)
 
-    BENCHMARK_TWO_WAY_PREDICATE_TYPE(int)
-    BENCHMARK_TWO_WAY_PREDICATE_TYPE(float)
-    BENCHMARK_TWO_WAY_PREDICATE_TYPE(double)
-    BENCHMARK_TWO_WAY_PREDICATE_TYPE(uint8_t)
-    BENCHMARK_TWO_WAY_PREDICATE_TYPE(int8_t)
-    BENCHMARK_TWO_WAY_PREDICATE_TYPE(rocprim::half)
     BENCHMARK_TWO_WAY_PREDICATE_TYPE(custom_int_double)
-    BENCHMARK_TWO_WAY_PREDICATE_TYPE(rocprim::int128_t)
-    BENCHMARK_TWO_WAY_PREDICATE_TYPE(rocprim::uint128_t)
     BENCHMARK_TWO_WAY_PREDICATE_TYPE(huge_float2)
 
-    BENCHMARK_THREE_WAY_TYPE(int)
-    BENCHMARK_THREE_WAY_TYPE(float)
-    BENCHMARK_THREE_WAY_TYPE(double)
-    BENCHMARK_THREE_WAY_TYPE(uint8_t)
-    BENCHMARK_THREE_WAY_TYPE(int8_t)
-    BENCHMARK_THREE_WAY_TYPE(rocprim::half)
     BENCHMARK_THREE_WAY_TYPE(custom_int_double)
-    BENCHMARK_THREE_WAY_TYPE(rocprim::int128_t)
-    BENCHMARK_THREE_WAY_TYPE(rocprim::uint128_t)
     BENCHMARK_THREE_WAY_TYPE(huge_float2)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_radix_sort_block_sort.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_radix_sort_block_sort.cpp
@@ -44,35 +44,49 @@
 #define CREATE_BENCHMARK(...) \
     executor.queue_instance(device_radix_sort_block_sort_benchmark<__VA_ARGS__>());
 
+#define CREATE_BENCHMARK_TYPE_TUNING(KeyType)      \
+    CREATE_BENCHMARK(KeyType, rocprim::empty_type) \
+    CREATE_BENCHMARK(KeyType, rocprim::int128_t)   \
+    CREATE_BENCHMARK(KeyType, long long)           \
+    CREATE_BENCHMARK(KeyType, int)                 \
+    CREATE_BENCHMARK(KeyType, short)               \
+    CREATE_BENCHMARK(KeyType, int8_t)
+
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
-    CREATE_BENCHMARK(int)
-    CREATE_BENCHMARK(long long)
-    CREATE_BENCHMARK(int8_t)
+    // Tuned types
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::int128_t)
+    CREATE_BENCHMARK_TYPE_TUNING(long long)
+    CREATE_BENCHMARK_TYPE_TUNING(int)
+    CREATE_BENCHMARK_TYPE_TUNING(short)
+    CREATE_BENCHMARK_TYPE_TUNING(int8_t)
+    CREATE_BENCHMARK_TYPE_TUNING(double)
+    CREATE_BENCHMARK_TYPE_TUNING(float)
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
     CREATE_BENCHMARK(uint8_t)
-    CREATE_BENCHMARK(rocprim::half)
-    CREATE_BENCHMARK(short)
-    CREATE_BENCHMARK(rocprim::int128_t)
     CREATE_BENCHMARK(rocprim::uint128_t)
 
+    CREATE_BENCHMARK(int, float)
+    CREATE_BENCHMARK(long long, double)
+    CREATE_BENCHMARK(uint8_t, uint8_t)
+    CREATE_BENCHMARK(rocprim::half, rocprim::half)
+    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2      = common::custom_type<float, float>;
     using custom_double2     = common::custom_type<double, double>;
     using custom_char_double = common::custom_type<char, double>;
 
-    CREATE_BENCHMARK(int, float)
-    CREATE_BENCHMARK(long long, double)
-    CREATE_BENCHMARK(int8_t, int8_t)
-    CREATE_BENCHMARK(uint8_t, uint8_t)
-    CREATE_BENCHMARK(rocprim::half, rocprim::half)
-    CREATE_BENCHMARK(short, short)
     CREATE_BENCHMARK(int, custom_float2)
     CREATE_BENCHMARK(int, custom_char_double)
     CREATE_BENCHMARK(long long, custom_double2)
-    CREATE_BENCHMARK(rocprim::int128_t, rocprim::int128_t)
-    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_radix_sort_onesweep.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_radix_sort_onesweep.cpp
@@ -30,45 +30,60 @@
 #include <string>
 #include <vector>
 
-#define CREATE_RADIX_SORT_BENCHMARK(...) \
+#define CREATE_BENCHMARK(...) \
     executor.queue_instance(device_radix_sort_onesweep_benchmark<__VA_ARGS__>());
+
+#define CREATE_BENCHMARK_TYPE_TUNING(KeyType)      \
+    CREATE_BENCHMARK(KeyType, rocprim::empty_type) \
+    CREATE_BENCHMARK(KeyType, rocprim::int128_t)   \
+    CREATE_BENCHMARK(KeyType, long long)           \
+    CREATE_BENCHMARK(KeyType, int)                 \
+    CREATE_BENCHMARK(KeyType, short)               \
+    CREATE_BENCHMARK(KeyType, int8_t)
 
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
-    CREATE_RADIX_SORT_BENCHMARK(int)
-    CREATE_RADIX_SORT_BENCHMARK(float)
-    CREATE_RADIX_SORT_BENCHMARK(long long)
-    CREATE_RADIX_SORT_BENCHMARK(int8_t)
-    CREATE_RADIX_SORT_BENCHMARK(uint8_t)
-    CREATE_RADIX_SORT_BENCHMARK(rocprim::half)
-    CREATE_RADIX_SORT_BENCHMARK(short)
-    CREATE_RADIX_SORT_BENCHMARK(rocprim::int128_t)
-    CREATE_RADIX_SORT_BENCHMARK(rocprim::uint128_t)
+    // Tuned types
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::int128_t)
+    CREATE_BENCHMARK_TYPE_TUNING(long long)
+    CREATE_BENCHMARK_TYPE_TUNING(int)
+    CREATE_BENCHMARK_TYPE_TUNING(short)
+    CREATE_BENCHMARK_TYPE_TUNING(int8_t)
+    CREATE_BENCHMARK_TYPE_TUNING(double)
+    CREATE_BENCHMARK_TYPE_TUNING(float)
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::half)
 
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARK(uint8_t)
+    CREATE_BENCHMARK(rocprim::uint128_t)
+
+    CREATE_BENCHMARK(int, float)
+    CREATE_BENCHMARK(int, double)
+    CREATE_BENCHMARK(int, float2)
+    CREATE_BENCHMARK(int, double2)
+
+    CREATE_BENCHMARK(long long, float)
+    CREATE_BENCHMARK(long long, double)
+    CREATE_BENCHMARK(long long, float2)
+    CREATE_BENCHMARK(long long, double2)
+
+    CREATE_BENCHMARK(uint8_t, uint8_t)
+    CREATE_BENCHMARK(rocprim::half, rocprim::half)
+    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2  = common::custom_type<float, float>;
     using custom_double2 = common::custom_type<double, double>;
 
-    CREATE_RADIX_SORT_BENCHMARK(int, float)
-    CREATE_RADIX_SORT_BENCHMARK(int, double)
-    CREATE_RADIX_SORT_BENCHMARK(int, float2)
-    CREATE_RADIX_SORT_BENCHMARK(int, custom_float2)
-    CREATE_RADIX_SORT_BENCHMARK(int, double2)
-    CREATE_RADIX_SORT_BENCHMARK(int, custom_double2)
-
-    CREATE_RADIX_SORT_BENCHMARK(long long, float)
-    CREATE_RADIX_SORT_BENCHMARK(long long, double)
-    CREATE_RADIX_SORT_BENCHMARK(long long, float2)
-    CREATE_RADIX_SORT_BENCHMARK(long long, custom_float2)
-    CREATE_RADIX_SORT_BENCHMARK(long long, double2)
-    CREATE_RADIX_SORT_BENCHMARK(long long, custom_double2)
-    CREATE_RADIX_SORT_BENCHMARK(int8_t, int8_t)
-    CREATE_RADIX_SORT_BENCHMARK(uint8_t, uint8_t)
-    CREATE_RADIX_SORT_BENCHMARK(rocprim::half, rocprim::half)
-    CREATE_RADIX_SORT_BENCHMARK(rocprim::int128_t, rocprim::int128_t)
-    CREATE_RADIX_SORT_BENCHMARK(rocprim::uint128_t, rocprim::uint128_t)
+    CREATE_BENCHMARK(int, custom_float2)
+    CREATE_BENCHMARK(int, custom_double2)
+    CREATE_BENCHMARK(long long, custom_float2)
+    CREATE_BENCHMARK(long long, custom_double2)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_reduce.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_reduce.cpp
@@ -42,32 +42,35 @@
     #include <stdint.h>
 #endif
 
-#define CREATE_BENCHMARK(T, REDUCE_OP) \
-    executor.queue_instance(device_reduce_benchmark<T, REDUCE_OP>());
+#define CREATE_BENCHMARK(T) executor.queue_instance(device_reduce_benchmark<T, rocprim::plus<T>>());
 
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 512 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    CREATE_BENCHMARK(rocprim::int128_t)
+    CREATE_BENCHMARK(int64_t)
+    CREATE_BENCHMARK(int)
+    CREATE_BENCHMARK(short)
+    CREATE_BENCHMARK(int8_t)
+    CREATE_BENCHMARK(double)
+    CREATE_BENCHMARK(float)
+    CREATE_BENCHMARK(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARK(uint8_t)
+    CREATE_BENCHMARK(rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2  = common::custom_type<float, float>;
     using custom_double2 = common::custom_type<double, double>;
 
-    CREATE_BENCHMARK(int, rocprim::plus<int>)
-    CREATE_BENCHMARK(long long, rocprim::plus<long long>)
-
-    CREATE_BENCHMARK(float, rocprim::plus<float>)
-    CREATE_BENCHMARK(double, rocprim::plus<double>)
-
-    CREATE_BENCHMARK(int8_t, rocprim::plus<int8_t>)
-    CREATE_BENCHMARK(uint8_t, rocprim::plus<uint8_t>)
-    CREATE_BENCHMARK(rocprim::half, rocprim::plus<rocprim::half>)
-
-    CREATE_BENCHMARK(custom_float2, rocprim::plus<custom_float2>)
-    CREATE_BENCHMARK(custom_double2, rocprim::plus<custom_double2>)
-
-    CREATE_BENCHMARK(rocprim::int128_t, rocprim::plus<rocprim::int128_t>)
-    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::plus<rocprim::uint128_t>)
+    CREATE_BENCHMARK(custom_float2)
+    CREATE_BENCHMARK(custom_double2)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_reduce_by_key.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_reduce_by_key.parallel.hpp
@@ -241,14 +241,14 @@ struct device_reduce_by_key_benchmark_generator
     CREATE_BENCHMARK_TYPE(KEY, double)
 
 // All of the tuned types
-#define CREATE_BENCHMARK_TYPE_TUNING(KEY)          \
-    CREATE_BENCHMARK_TYPE(KEY, rocprim::int128_t)  \
-    CREATE_BENCHMARK_TYPE(KEY, int64_t)            \
-    CREATE_BENCHMARK_TYPE(KEY, int)            \
-    CREATE_BENCHMARK_TYPE(KEY, short)            \
-    CREATE_BENCHMARK_TYPE(KEY, int8_t)             \
-    CREATE_BENCHMARK_TYPE(KEY, double) \
-    CREATE_BENCHMARK_TYPE(KEY, float)              \
+#define CREATE_BENCHMARK_TYPE_TUNING(KEY)         \
+    CREATE_BENCHMARK_TYPE(KEY, rocprim::int128_t) \
+    CREATE_BENCHMARK_TYPE(KEY, int64_t)           \
+    CREATE_BENCHMARK_TYPE(KEY, int)               \
+    CREATE_BENCHMARK_TYPE(KEY, short)             \
+    CREATE_BENCHMARK_TYPE(KEY, int8_t)            \
+    CREATE_BENCHMARK_TYPE(KEY, double)            \
+    CREATE_BENCHMARK_TYPE(KEY, float)             \
     CREATE_BENCHMARK_TYPE(KEY, rocprim::half)
 
 template<bool Deterministic>

--- a/projects/rocprim/benchmark/benchmark_device_reduce_by_key.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_reduce_by_key.parallel.hpp
@@ -230,7 +230,7 @@ struct device_reduce_by_key_benchmark_generator
     CREATE_BENCHMARK(KEY, VALUE, 10)      \
     CREATE_BENCHMARK(KEY, VALUE, 1000)
 
-// some of the tuned types
+// Some of the tuned types
 #define CREATE_BENCHMARK_TYPES(KEY)                \
     CREATE_BENCHMARK_TYPE(KEY, int8_t)             \
     CREATE_BENCHMARK_TYPE(KEY, rocprim::half)      \
@@ -240,33 +240,43 @@ struct device_reduce_by_key_benchmark_generator
     CREATE_BENCHMARK_TYPE(KEY, float)              \
     CREATE_BENCHMARK_TYPE(KEY, double)
 
-// all of the tuned types
+// All of the tuned types
 #define CREATE_BENCHMARK_TYPE_TUNING(KEY)          \
-    CREATE_BENCHMARK_TYPE(KEY, int8_t)             \
-    CREATE_BENCHMARK_TYPE(KEY, int16_t)            \
-    CREATE_BENCHMARK_TYPE(KEY, int32_t)            \
-    CREATE_BENCHMARK_TYPE(KEY, int64_t)            \
     CREATE_BENCHMARK_TYPE(KEY, rocprim::int128_t)  \
-    CREATE_BENCHMARK_TYPE(KEY, rocprim::uint128_t) \
-    CREATE_BENCHMARK_TYPE(KEY, rocprim::half)      \
+    CREATE_BENCHMARK_TYPE(KEY, int64_t)            \
+    CREATE_BENCHMARK_TYPE(KEY, int)            \
+    CREATE_BENCHMARK_TYPE(KEY, short)            \
+    CREATE_BENCHMARK_TYPE(KEY, int8_t)             \
+    CREATE_BENCHMARK_TYPE(KEY, double) \
     CREATE_BENCHMARK_TYPE(KEY, float)              \
-    CREATE_BENCHMARK_TYPE(KEY, double)
+    CREATE_BENCHMARK_TYPE(KEY, rocprim::half)
 
 template<bool Deterministic>
 void add_benchmarks(benchmark_utils::executor& executor)
 {
-    // tuned types
-    CREATE_BENCHMARK_TYPES(int8_t)
-    CREATE_BENCHMARK_TYPES(int16_t)
-    CREATE_BENCHMARK_TYPE_TUNING(int32_t)
+    // Tuned types
+    CREATE_BENCHMARK_TYPE_TUNING(rocprim::int128_t)
     CREATE_BENCHMARK_TYPE_TUNING(int64_t)
-    CREATE_BENCHMARK_TYPES(rocprim::half)
-    CREATE_BENCHMARK_TYPES(float)
-    CREATE_BENCHMARK_TYPES(double)
-    CREATE_BENCHMARK_TYPES(rocprim::int128_t)
-    CREATE_BENCHMARK_TYPES(rocprim::uint128_t)
+    CREATE_BENCHMARK_TYPE_TUNING(int)
+    CREATE_BENCHMARK_TYPE_TUNING(short)
+    CREATE_BENCHMARK_TYPE_TUNING(int8_t)
 
-    // custom types
+#ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARK_TYPE(rocprim::int128_t, rocprim::uint128_t)
+    CREATE_BENCHMARK_TYPE(int, rocprim::uint128_t)
+    CREATE_BENCHMARK_TYPE(short, rocprim::uint128_t)
+    CREATE_BENCHMARK_TYPES(int8_t)
+    CREATE_BENCHMARK_TYPES(double)
+    CREATE_BENCHMARK_TYPES(float)
+    CREATE_BENCHMARK_TYPES(rocprim::half)
+    CREATE_BENCHMARK_TYPES(int16_t)
+    CREATE_BENCHMARK_TYPES(rocprim::uint128_t)
+    CREATE_BENCHMARK_TYPE_TUNING(int32_t)
+    CREATE_BENCHMARK_TYPE(int32_t, int16_t)
+    CREATE_BENCHMARK_TYPE(int32_t, rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2  = common::custom_type<float, float>;
     using custom_double2 = common::custom_type<double, double>;
 
@@ -275,6 +285,7 @@ void add_benchmarks(benchmark_utils::executor& executor)
 
     CREATE_BENCHMARK_TYPE(long long, custom_float2)
     CREATE_BENCHMARK_TYPE(long long, custom_double2)
+#endif
 }
 
 #endif // ROCPRIM_BENCHMARK_DEVICE_REDUCE_BY_KEY_PARALLEL_HPP_

--- a/projects/rocprim/benchmark/benchmark_device_run_length_encode.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_run_length_encode.cpp
@@ -36,39 +36,36 @@
 #include <string>
 #include <vector>
 
-#define CREATE_ENCODE_BENCHMARK(T, ML) \
-    executor.queue_instance(device_run_length_encode_benchmark<T, ML>());
-
-template<size_t MaxLength>
-void add_encode_benchmarks(benchmark_utils::executor& executor)
-{
-    using custom_float2  = common::custom_type<float, float>;
-    using custom_double2 = common::custom_type<double, double>;
-
-    // all tuned types
-    CREATE_ENCODE_BENCHMARK(int8_t, MaxLength)
-    CREATE_ENCODE_BENCHMARK(int16_t, MaxLength)
-    CREATE_ENCODE_BENCHMARK(int32_t, MaxLength)
-    CREATE_ENCODE_BENCHMARK(int64_t, MaxLength)
-    CREATE_ENCODE_BENCHMARK(rocprim::int128_t, MaxLength)
-    CREATE_ENCODE_BENCHMARK(rocprim::uint128_t, MaxLength)
-    CREATE_ENCODE_BENCHMARK(rocprim::half, MaxLength)
-    CREATE_ENCODE_BENCHMARK(float, MaxLength)
-    CREATE_ENCODE_BENCHMARK(double, MaxLength)
-    // custom types
-    CREATE_ENCODE_BENCHMARK(custom_float2, MaxLength)
-    CREATE_ENCODE_BENCHMARK(custom_double2, MaxLength)
-}
+#define CREATE_BENCHMARK(T)                                               \
+    executor.queue_instance(device_run_length_encode_benchmark<T, 10>()); \
+    executor.queue_instance(device_run_length_encode_benchmark<T, 1000>());
 
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 2 * benchmark_utils::GiB, 10, 10);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    CREATE_BENCHMARK(rocprim::int128_t)
+    CREATE_BENCHMARK(int64_t)
+    CREATE_BENCHMARK(int32_t)
+    CREATE_BENCHMARK(int16_t)
+    CREATE_BENCHMARK(int8_t)
+    CREATE_BENCHMARK(double)
+    CREATE_BENCHMARK(float)
+    CREATE_BENCHMARK(rocprim::half)
 
-    add_encode_benchmarks<1000>(executor);
-    add_encode_benchmarks<10>(executor);
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARK(rocprim::uint128_t)
 
+    // Not tuned custom types
+    using custom_float2  = common::custom_type<float, float>;
+    using custom_double2 = common::custom_type<double, double>;
+
+    CREATE_BENCHMARK(custom_float2)
+    CREATE_BENCHMARK(custom_double2)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_run_length_encode_non_trivial_runs.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_run_length_encode_non_trivial_runs.cpp
@@ -42,39 +42,38 @@
 #include <string>
 #include <vector>
 
-// CHANGE
-#define CREATE_NON_TRIVIAL_RUNS_BENCHMARK(T, ML) \
-    executor.queue_instance(device_non_trivial_runs_benchmark<T, ML>());
-
-template<size_t MaxLength>
-void add_non_trivial_runs_benchmarks(benchmark_utils::executor& executor)
-{
-    using custom_float2  = common::custom_type<float, float>;
-    using custom_double2 = common::custom_type<double, double>;
-
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(int8_t, MaxLength)
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(int16_t, MaxLength)
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(int32_t, MaxLength)
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(int64_t, MaxLength)
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(rocprim::int128_t, MaxLength)
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(rocprim::uint128_t, MaxLength)
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(rocprim::half, MaxLength)
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(float, MaxLength)
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(double, MaxLength)
-    // custom types
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(custom_float2, MaxLength)
-    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(custom_double2, MaxLength)
-}
+#define CREATE_NON_TRIVIAL_RUNS_BENCHMARK(T)                              \
+    executor.queue_instance(device_non_trivial_runs_benchmark<T, 16>());  \
+    executor.queue_instance(device_non_trivial_runs_benchmark<T, 256>()); \
+    executor.queue_instance(device_non_trivial_runs_benchmark<T, 4096>());
 
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 2 * benchmark_utils::GiB, 10, 5);
-    // Add benchmarks
-#ifndef BENCHMARK_CONFIG_TUNING
 
-    add_non_trivial_runs_benchmarks<16>(executor);
-    add_non_trivial_runs_benchmarks<256>(executor);
-    add_non_trivial_runs_benchmarks<4096>(executor);
+#ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(rocprim::int128_t)
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(int64_t)
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(int32_t)
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(int16_t)
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(int8_t)
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(double)
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(float)
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(rocprim::uint128_t)
+
+    // Not tuned custom types
+    using custom_float2  = common::custom_type<float, float>;
+    using custom_double2 = common::custom_type<double, double>;
+
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(custom_float2)
+    CREATE_NON_TRIVIAL_RUNS_BENCHMARK(custom_double2)
+    #endif
 #endif
+
     executor.run();
 }

--- a/projects/rocprim/benchmark/benchmark_device_scan.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_scan.parallel.hpp
@@ -275,32 +275,45 @@ struct device_scan_benchmark_generator
 
 #else
 
-    #define CREATE_EXCL_INCL_BENCHMARK(EXCL, T, SCAN_OP) \
-        executor.queue_instance(device_scan_benchmark<EXCL, T, SCAN_OP, Deterministic>());
+    #define CREATE_EXCL_INCL_BENCHMARK(EXCL, T) \
+        executor.queue_instance(device_scan_benchmark<EXCL, T, rocprim::plus<T>, Deterministic>());
 
-    #define CREATE_BENCHMARK(T, SCAN_OP)              \
-        CREATE_EXCL_INCL_BENCHMARK(false, T, SCAN_OP) \
-        CREATE_EXCL_INCL_BENCHMARK(true, T, SCAN_OP)
+    #define CREATE_BENCHMARK(T)              \
+        CREATE_EXCL_INCL_BENCHMARK(false, T) \
+        CREATE_EXCL_INCL_BENCHMARK(true, T)
+
+    #define BENCHMARK_TYPE_TUNING(T) \
+        executor.queue_instance(device_scan_benchmark<false, T, rocprim::plus<T>, false>());
 
 template<bool Deterministic>
 void add_benchmarks(benchmark_utils::executor& executor)
 {
+    // Tuned types
+    BENCHMARK_TYPE_TUNING(rocprim::int128_t)
+    BENCHMARK_TYPE_TUNING(int64_t)
+    BENCHMARK_TYPE_TUNING(int)
+    BENCHMARK_TYPE_TUNING(short)
+    BENCHMARK_TYPE_TUNING(int8_t)
+    BENCHMARK_TYPE_TUNING(double)
+    BENCHMARK_TYPE_TUNING(float)
+    BENCHMARK_TYPE_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARK(float)
+    CREATE_BENCHMARK(double)
+    CREATE_BENCHMARK(float2)
+    CREATE_BENCHMARK(double2)
+    CREATE_BENCHMARK(uint8_t)
+    CREATE_BENCHMARK(rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2  = common::custom_type<float, float>;
     using custom_double2 = common::custom_type<double, double>;
 
-    CREATE_BENCHMARK(int, rocprim::plus<int>)
-    CREATE_BENCHMARK(float, rocprim::plus<float>)
-    CREATE_BENCHMARK(double, rocprim::plus<double>)
-    CREATE_BENCHMARK(long long, rocprim::plus<long long>)
-    CREATE_BENCHMARK(float2, rocprim::plus<float2>)
-    CREATE_BENCHMARK(custom_float2, rocprim::plus<custom_float2>)
-    CREATE_BENCHMARK(double2, rocprim::plus<double2>)
-    CREATE_BENCHMARK(custom_double2, rocprim::plus<custom_double2>)
-    CREATE_BENCHMARK(int8_t, rocprim::plus<int8_t>)
-    CREATE_BENCHMARK(uint8_t, rocprim::plus<uint8_t>)
-    CREATE_BENCHMARK(rocprim::half, rocprim::plus<rocprim::half>)
-    CREATE_BENCHMARK(rocprim::int128_t, rocprim::plus<rocprim::int128_t>)
-    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::plus<rocprim::uint128_t>)
+    CREATE_BENCHMARK(custom_float2)
+    CREATE_BENCHMARK(custom_double2)
+    #endif
 }
 
 #endif // BENCHMARK_CONFIG_TUNING

--- a/projects/rocprim/benchmark/benchmark_device_scan_by_key.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_scan_by_key.parallel.hpp
@@ -328,29 +328,57 @@ struct device_scan_by_key_benchmark_generator
         CREATE_BY_KEY_BENCHMARK(EXCL, T, SCAN_OP, 4096)  \
         CREATE_BY_KEY_BENCHMARK(EXCL, T, SCAN_OP, 65536)
 
-    #define CREATE_BENCHMARK(T, SCAN_OP)              \
-        CREATE_EXCL_INCL_BENCHMARK(false, T, SCAN_OP) \
-        CREATE_EXCL_INCL_BENCHMARK(true, T, SCAN_OP)
+    #define CREATE_BENCHMARK(T)                                \
+        CREATE_EXCL_INCL_BENCHMARK(false, T, rocprim::plus<T>) \
+        CREATE_EXCL_INCL_BENCHMARK(true, T, rocprim::plus<T>)
+
+    #define BENCHMARK_TYPE_TUNING(KEY_TYPE, VALUE_TYPE)                                   \
+        executor.queue_instance(device_scan_by_key_benchmark<false,                       \
+                                                             KEY_TYPE,                    \
+                                                             VALUE_TYPE,                  \
+                                                             rocprim::plus<VALUE_TYPE>,   \
+                                                             rocprim::equal_to<KEY_TYPE>, \
+                                                             1024,                        \
+                                                             false>());
+
+    // All of the limited tuned types
+    #define BENCHMARK_TYPES_TUNING(KEY_TYPE)               \
+        BENCHMARK_TYPE_TUNING(KEY_TYPE, rocprim::int128_t) \
+        BENCHMARK_TYPE_TUNING(KEY_TYPE, int64_t)           \
+        BENCHMARK_TYPE_TUNING(KEY_TYPE, int)               \
+        BENCHMARK_TYPE_TUNING(KEY_TYPE, short)             \
+        BENCHMARK_TYPE_TUNING(KEY_TYPE, int8_t)
 
 template<bool Deterministic>
 void add_benchmarks(benchmark_utils::executor& executor)
 {
+    // Tuned types
+    BENCHMARK_TYPES_TUNING(rocprim::int128_t)
+    BENCHMARK_TYPES_TUNING(int64_t)
+    BENCHMARK_TYPES_TUNING(int)
+    BENCHMARK_TYPES_TUNING(short)
+    BENCHMARK_TYPES_TUNING(int8_t)
+    BENCHMARK_TYPES_TUNING(double)
+    BENCHMARK_TYPES_TUNING(float)
+    BENCHMARK_TYPES_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARK(float)
+    CREATE_BENCHMARK(double)
+    CREATE_BENCHMARK(float2)
+    CREATE_BENCHMARK(double2)
+    CREATE_BENCHMARK(uint8_t)
+    CREATE_BENCHMARK(rocprim::half)
+    CREATE_BENCHMARK(rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2  = common::custom_type<float, float>;
     using custom_double2 = common::custom_type<double, double>;
 
-    CREATE_BENCHMARK(int, rocprim::plus<int>)
-    CREATE_BENCHMARK(float, rocprim::plus<float>)
-    CREATE_BENCHMARK(double, rocprim::plus<double>)
-    CREATE_BENCHMARK(long long, rocprim::plus<long long>)
-    CREATE_BENCHMARK(float2, rocprim::plus<float2>)
-    CREATE_BENCHMARK(custom_float2, rocprim::plus<custom_float2>)
-    CREATE_BENCHMARK(double2, rocprim::plus<double2>)
-    CREATE_BENCHMARK(custom_double2, rocprim::plus<custom_double2>)
-    CREATE_BENCHMARK(int8_t, rocprim::plus<int8_t>)
-    CREATE_BENCHMARK(uint8_t, rocprim::plus<uint8_t>)
-    CREATE_BENCHMARK(rocprim::half, rocprim::plus<rocprim::half>)
-    CREATE_BENCHMARK(rocprim::int128_t, rocprim::plus<rocprim::int128_t>)
-    CREATE_BENCHMARK(rocprim::uint128_t, rocprim::plus<rocprim::uint128_t>)
+    CREATE_BENCHMARK(custom_float2)
+    CREATE_BENCHMARK(custom_double2)
+    #endif
 }
 
 #endif // BENCHMARK_CONFIG_TUNING

--- a/projects/rocprim/benchmark/benchmark_device_search_n.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_search_n.cpp
@@ -46,20 +46,27 @@ int main(int argc, char* argv[])
     benchmark_utils::executor executor(argc, argv, 2 * benchmark_utils::GiB, 10, 10);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    CREATE_BENCHMARKS(rocprim::int128_t)
+    CREATE_BENCHMARKS(int64_t)
+    CREATE_BENCHMARKS(int32_t)
+    CREATE_BENCHMARKS(int16_t)
+    CREATE_BENCHMARKS(int8_t)
+    CREATE_BENCHMARKS(double)
+    CREATE_BENCHMARKS(float)
+    CREATE_BENCHMARKS(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARKS(rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_int2            = common::custom_type<int>;
     using custom_longlong_double = common::custom_type<long long, double>;
 
     CREATE_BENCHMARKS(custom_int2)
     CREATE_BENCHMARKS(custom_longlong_double)
-    CREATE_BENCHMARKS(int8_t)
-    CREATE_BENCHMARKS(int16_t)
-    CREATE_BENCHMARKS(int32_t)
-    CREATE_BENCHMARKS(int64_t)
-    CREATE_BENCHMARKS(rocprim::int128_t)
-    CREATE_BENCHMARKS(rocprim::uint128_t)
-    CREATE_BENCHMARKS(rocprim::half)
-    CREATE_BENCHMARKS(float)
-    CREATE_BENCHMARKS(double)
+    #endif
 #endif
 
     // Run benchmarks

--- a/projects/rocprim/benchmark/benchmark_device_segmented_radix_sort_keys.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_segmented_radix_sort_keys.cpp
@@ -80,14 +80,21 @@ int main(int argc, char* argv[])
     benchmark_utils::executor executor(argc, argv, bytes, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
-    add_benchmarks<float>(executor, bytes);
-    add_benchmarks<double>(executor, bytes);
-    add_benchmarks<int8_t>(executor, bytes);
-    add_benchmarks<uint8_t>(executor, bytes);
-    add_benchmarks<rocprim::half>(executor, bytes);
-    add_benchmarks<int>(executor, bytes);
+    // Tuned types
     add_benchmarks<rocprim::int128_t>(executor, bytes);
+    add_benchmarks<int64_t>(executor, bytes);
+    add_benchmarks<int>(executor, bytes);
+    add_benchmarks<short>(executor, bytes);
+    add_benchmarks<int8_t>(executor, bytes);
+    add_benchmarks<double>(executor, bytes);
+    add_benchmarks<float>(executor, bytes);
+    add_benchmarks<rocprim::half>(executor, bytes);
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    add_benchmarks<uint8_t>(executor, bytes);
     add_benchmarks<rocprim::uint128_t>(executor, bytes);
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_segmented_radix_sort_pairs.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_segmented_radix_sort_pairs.cpp
@@ -80,6 +80,16 @@ void add_benchmarks(benchmark_utils::executor& executor, size_t bytes)
     }
 }
 
+#define BENCHMARK_TYPE_TUNING(KEY_TYPE, VALUE_TYPE) \
+    add_benchmarks<KEY_TYPE, VALUE_TYPE>(executor, bytes);
+
+#define BENCHMARK_TYPES_TUNING(KEY_TYPE)               \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, rocprim::int128_t) \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, int64_t)           \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, int)               \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, short)             \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, int8_t)
+
 int main(int argc, char* argv[])
 {
     size_t bytes = 128 * benchmark_utils::MiB;
@@ -87,18 +97,31 @@ int main(int argc, char* argv[])
     benchmark_utils::executor executor(argc, argv, bytes, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    BENCHMARK_TYPES_TUNING(rocprim::int128_t)
+    BENCHMARK_TYPES_TUNING(int64_t)
+    BENCHMARK_TYPES_TUNING(int)
+    BENCHMARK_TYPES_TUNING(short)
+    BENCHMARK_TYPES_TUNING(int8_t)
+    BENCHMARK_TYPES_TUNING(double)
+    BENCHMARK_TYPES_TUNING(float)
+    BENCHMARK_TYPES_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    add_benchmarks<int, float>(executor, bytes);
+    add_benchmarks<long long, double>(executor, bytes);
+    add_benchmarks<uint8_t, uint8_t>(executor, bytes);
+    add_benchmarks<rocprim::half, rocprim::half>(executor, bytes);
+    add_benchmarks<rocprim::uint128_t, rocprim::uint128_t>(executor, bytes);
+
+    // Not tuned custom types
     using custom_float2  = common::custom_type<float, float>;
     using custom_double2 = common::custom_type<double, double>;
 
-    add_benchmarks<int, float>(executor, bytes);
-    add_benchmarks<long long, double>(executor, bytes);
-    add_benchmarks<int8_t, int8_t>(executor, bytes);
-    add_benchmarks<uint8_t, uint8_t>(executor, bytes);
-    add_benchmarks<rocprim::half, rocprim::half>(executor, bytes);
     add_benchmarks<int, custom_float2>(executor, bytes);
     add_benchmarks<long long, custom_double2>(executor, bytes);
-    add_benchmarks<rocprim::int128_t, rocprim::int128_t>(executor, bytes);
-    add_benchmarks<rocprim::uint128_t, rocprim::uint128_t>(executor, bytes);
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_segmented_reduce.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_segmented_reduce.cpp
@@ -56,19 +56,28 @@ int main(int argc, char* argv[])
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    BENCHMARK_TYPE(rocprim::int128_t)
+    BENCHMARK_TYPE(int64_t)
+    BENCHMARK_TYPE(int)
+    BENCHMARK_TYPE(short)
+    BENCHMARK_TYPE(int8_t)
+    BENCHMARK_TYPE(double)
+    BENCHMARK_TYPE(float)
+    BENCHMARK_TYPE(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    BENCHMARK_TYPE(uint8_t)
+    BENCHMARK_TYPE(rocprim::uint128_t)
+
+    // Not tuned custom types
     using custom_float2  = common::custom_type<float, float>;
     using custom_double2 = common::custom_type<double, double>;
 
-    BENCHMARK_TYPE(float)
-    BENCHMARK_TYPE(double)
-    BENCHMARK_TYPE(int8_t)
-    BENCHMARK_TYPE(uint8_t)
-    BENCHMARK_TYPE(rocprim::half)
-    BENCHMARK_TYPE(int)
     BENCHMARK_TYPE(custom_float2)
     BENCHMARK_TYPE(custom_double2)
-    BENCHMARK_TYPE(rocprim::int128_t)
-    BENCHMARK_TYPE(rocprim::uint128_t)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_select.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_select.cpp
@@ -70,69 +70,74 @@
     CREATE_UNIQUE_BY_KEY_BENCHMARK(K, V, select_probability::p050) \
     CREATE_UNIQUE_BY_KEY_BENCHMARK(K, V, select_probability::p075)
 
+#define BENCHMARK_TYPE_TUNING(KEY_TYPE, VALUE_TYPE)    \
+    BENCHMARK_UNIQUE_BY_KEY_TYPE(KEY_TYPE, VALUE_TYPE) \
+    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(KEY_TYPE, VALUE_TYPE)
+
+#define BENCHMARK_TYPES_TUNING(KEY_TYPE)               \
+    BENCHMARK_SELECT_FLAG_TYPE(KEY_TYPE, char)         \
+    BENCHMARK_SELECT_PREDICATE_TYPE(KEY_TYPE)          \
+    BENCHMARK_UNIQUE_TYPE(KEY_TYPE)                    \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, rocprim::int128_t) \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, int64_t)           \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, int)               \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, short)             \
+    BENCHMARK_TYPE_TUNING(KEY_TYPE, int8_t)
+
 int main(int argc, char* argv[])
 {
     benchmark_utils::executor executor(argc, argv, 128 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
+    // Tuned types
+    BENCHMARK_TYPES_TUNING(rocprim::int128_t)
+    BENCHMARK_TYPES_TUNING(int64_t)
+    BENCHMARK_TYPES_TUNING(int)
+    BENCHMARK_TYPES_TUNING(short)
+    BENCHMARK_TYPES_TUNING(int8_t)
+    BENCHMARK_TYPES_TUNING(double)
+    BENCHMARK_TYPES_TUNING(float)
+    BENCHMARK_TYPES_TUNING(rocprim::half)
+
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    BENCHMARK_SELECT_FLAG_TYPE(uint8_t, uint8_t)
+    BENCHMARK_SELECT_FLAG_TYPE(rocprim::uint128_t, unsigned char)
+
+    BENCHMARK_SELECT_PREDICATE_TYPE(uint8_t)
+    BENCHMARK_SELECT_PREDICATE_TYPE(rocprim::uint128_t)
+
+    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(uint8_t, uint8_t)
+    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(rocprim::uint128_t, unsigned char)
+
+    BENCHMARK_UNIQUE_TYPE(uint8_t)
+    BENCHMARK_UNIQUE_TYPE(rocprim::uint128_t)
+
+    BENCHMARK_UNIQUE_BY_KEY_TYPE(float, double)
+    BENCHMARK_UNIQUE_BY_KEY_TYPE(uint8_t, uint8_t)
+    BENCHMARK_UNIQUE_BY_KEY_TYPE(int8_t, double)
+    BENCHMARK_UNIQUE_BY_KEY_TYPE(rocprim::half, rocprim::half)
+    BENCHMARK_UNIQUE_BY_KEY_TYPE(rocprim::uint128_t, rocprim::int128_t)
+
+    // Not tuned custom types
     using custom_double2    = common::custom_type<double, double>;
     using custom_int_double = common::custom_type<int, double>;
     using huge_float2       = common::custom_huge_type<1024, float, float>;
 
-    BENCHMARK_SELECT_FLAG_TYPE(int, unsigned char)
-    BENCHMARK_SELECT_FLAG_TYPE(float, unsigned char)
-    BENCHMARK_SELECT_FLAG_TYPE(double, unsigned char)
-    BENCHMARK_SELECT_FLAG_TYPE(uint8_t, uint8_t)
-    BENCHMARK_SELECT_FLAG_TYPE(int8_t, int8_t)
-    BENCHMARK_SELECT_FLAG_TYPE(rocprim::half, int8_t)
     BENCHMARK_SELECT_FLAG_TYPE(custom_double2, unsigned char)
-    BENCHMARK_SELECT_FLAG_TYPE(rocprim::int128_t, unsigned char)
-    BENCHMARK_SELECT_FLAG_TYPE(rocprim::uint128_t, unsigned char)
-    BENCHMARK_SELECT_FLAG_TYPE(huge_float2, unsigned char)
-
-    BENCHMARK_SELECT_PREDICATE_TYPE(int)
-    BENCHMARK_SELECT_PREDICATE_TYPE(float)
-    BENCHMARK_SELECT_PREDICATE_TYPE(double)
-    BENCHMARK_SELECT_PREDICATE_TYPE(uint8_t)
-    BENCHMARK_SELECT_PREDICATE_TYPE(int8_t)
-    BENCHMARK_SELECT_PREDICATE_TYPE(rocprim::half)
-    BENCHMARK_SELECT_PREDICATE_TYPE(custom_int_double)
-    BENCHMARK_SELECT_PREDICATE_TYPE(rocprim::int128_t)
-    BENCHMARK_SELECT_PREDICATE_TYPE(rocprim::uint128_t)
-    BENCHMARK_SELECT_PREDICATE_TYPE(huge_float2)
-
-    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(int, unsigned char)
-    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(float, unsigned char)
-    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(double, unsigned char)
-    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(uint8_t, uint8_t)
-    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(int8_t, int8_t)
-    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(rocprim::half, int8_t)
     BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(custom_double2, unsigned char)
-    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(rocprim::int128_t, unsigned char)
-    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(rocprim::uint128_t, unsigned char)
-    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(huge_float2, unsigned char)
-
-    BENCHMARK_UNIQUE_TYPE(int)
-    BENCHMARK_UNIQUE_TYPE(float)
-    BENCHMARK_UNIQUE_TYPE(double)
-    BENCHMARK_UNIQUE_TYPE(uint8_t)
-    BENCHMARK_UNIQUE_TYPE(int8_t)
-    BENCHMARK_UNIQUE_TYPE(rocprim::half)
-    BENCHMARK_UNIQUE_TYPE(custom_int_double)
-    BENCHMARK_UNIQUE_TYPE(rocprim::int128_t)
-    BENCHMARK_UNIQUE_TYPE(rocprim::uint128_t)
-    BENCHMARK_UNIQUE_TYPE(huge_float2)
-
-    BENCHMARK_UNIQUE_BY_KEY_TYPE(int, int)
-    BENCHMARK_UNIQUE_BY_KEY_TYPE(float, double)
     BENCHMARK_UNIQUE_BY_KEY_TYPE(double, custom_double2)
-    BENCHMARK_UNIQUE_BY_KEY_TYPE(uint8_t, uint8_t)
-    BENCHMARK_UNIQUE_BY_KEY_TYPE(int8_t, double)
-    BENCHMARK_UNIQUE_BY_KEY_TYPE(rocprim::half, rocprim::half)
+
+    BENCHMARK_SELECT_PREDICATE_TYPE(custom_int_double)
+    BENCHMARK_UNIQUE_TYPE(custom_int_double)
     BENCHMARK_UNIQUE_BY_KEY_TYPE(custom_int_double, custom_int_double)
-    BENCHMARK_UNIQUE_BY_KEY_TYPE(rocprim::int128_t, rocprim::int128_t)
-    BENCHMARK_UNIQUE_BY_KEY_TYPE(rocprim::uint128_t, rocprim::int128_t)
+
+    BENCHMARK_SELECT_FLAG_TYPE(huge_float2, unsigned char)
+    BENCHMARK_SELECT_PREDICATE_TYPE(huge_float2)
+    BENCHMARK_SELECT_PREDICATED_FLAG_TYPE(huge_float2, unsigned char)
+    BENCHMARK_UNIQUE_TYPE(huge_float2)
     BENCHMARK_UNIQUE_BY_KEY_TYPE(huge_float2, huge_float2)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_transform.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_transform.cpp
@@ -52,29 +52,34 @@ int main(int argc, char* argv[])
     benchmark_utils::executor executor(argc, argv, 512 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
-    using custom_float2  = common::custom_type<float, float>;
-    using custom_double2 = common::custom_type<double, double>;
+    // Tuned types
+    CREATE_BENCHMARK(rocprim::int128_t)
+    CREATE_BENCHMARK(int64_t)
     CREATE_BENCHMARK(int)
-    CREATE_BENCHMARK(long long)
-
+    CREATE_BENCHMARK(short)
     CREATE_BENCHMARK(int8_t)
-    CREATE_BENCHMARK(uint8_t)
+    CREATE_BENCHMARK(double)
+    CREATE_BENCHMARK(float)
     CREATE_BENCHMARK(rocprim::half)
 
-    CREATE_BENCHMARK(float)
-    CREATE_BENCHMARK(double)
-
-    CREATE_BENCHMARK(custom_float2)
-    CREATE_BENCHMARK(custom_double2)
-
-    CREATE_BENCHMARK(rocprim::int128_t)
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARK(uint8_t)
     CREATE_BENCHMARK(rocprim::uint128_t)
 
     CREATE_BENCHMARK_BINARY(int)
     CREATE_BENCHMARK_BINARY(float)
     CREATE_BENCHMARK_BINARY(int8_t)
     CREATE_BENCHMARK_BINARY(rocprim::int128_t)
+
+    // Not tuned custom types
+    using custom_float2  = common::custom_type<float, float>;
+    using custom_double2 = common::custom_type<double, double>;
+
+    CREATE_BENCHMARK(custom_float2)
+    CREATE_BENCHMARK(custom_double2)
     CREATE_BENCHMARK_BINARY(custom_double2)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/benchmark/benchmark_device_transform_pointer.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_transform_pointer.cpp
@@ -49,23 +49,28 @@ int main(int argc, char* argv[])
     benchmark_utils::executor executor(argc, argv, 512 * benchmark_utils::MiB, 10, 5);
 
 #ifndef BENCHMARK_CONFIG_TUNING
-    using custom_float2  = common::custom_type<float, float>;
-    using custom_double2 = common::custom_type<double, double>;
+    // Tuned types
+    CREATE_BENCHMARK(rocprim::int128_t)
+    CREATE_BENCHMARK(int64_t)
     CREATE_BENCHMARK(int)
-    CREATE_BENCHMARK(long long)
-
+    CREATE_BENCHMARK(short)
     CREATE_BENCHMARK(int8_t)
-    CREATE_BENCHMARK(uint8_t)
+    CREATE_BENCHMARK(double)
+    CREATE_BENCHMARK(float)
     CREATE_BENCHMARK(rocprim::half)
 
-    CREATE_BENCHMARK(float)
-    CREATE_BENCHMARK(double)
+    #ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY
+    // Not tuned types
+    CREATE_BENCHMARK(uint8_t)
+    CREATE_BENCHMARK(rocprim::uint128_t)
+
+    // Not tuned custom types
+    using custom_float2  = common::custom_type<float, float>;
+    using custom_double2 = common::custom_type<double, double>;
 
     CREATE_BENCHMARK(custom_float2)
     CREATE_BENCHMARK(custom_double2)
-
-    CREATE_BENCHMARK(rocprim::int128_t)
-    CREATE_BENCHMARK(rocprim::uint128_t)
+    #endif
 #endif
 
     executor.run();

--- a/projects/rocprim/scripts/autotune/create_optimization.py
+++ b/projects/rocprim/scripts/autotune/create_optimization.py
@@ -370,9 +370,6 @@ class Algorithm:
         if 'target_arch::gfx908' in self.architectures:
             self.architectures['target_arch::unknown'] = copy.deepcopy(self.architectures['target_arch::gfx908'])
             self.architectures['target_arch::unknown'].arch_name = 'target_arch::unknown'
-            if 'target_arch::gfx90a' not in self.architectures:
-                self.architectures['target_arch::gfx90a'] = copy.deepcopy(self.architectures['target_arch::gfx908'])
-                self.architectures['target_arch::gfx90a'].arch_name = 'target_arch::gfx90a'
 
         algorithm_template = env.get_template(self.cpp_configuration_template_name)
         rendered_template = algorithm_template.render(all_architectures=self.architectures.values())


### PR DESCRIPTION
## Scope
In order for the new `apply_config_improvements.py` script to work ([PR](https://github.com/ROCm/rocm-libraries/pull/497)), benchmarks need to run *all* autotuned types. This is because the Python script compares the throughputs of different configs using their benchmark results. Every autotuned type is a specialization in a config.

In order to avoid roughly doubling the number of benchmarks run, I've wrapped the old benchmarks in `#ifndef BENCHMARK_AUTOTUNED_TYPES_ONLY`. This means that by default, both the old and new benchmarks will be run. Pass `-DBENCHMARK_AUTOTUNED_TYPES_ONLY=ON` to `cmake` if you only want to benchmark the autotuned types. This logic can be inverted if desired, but I went for my current choice as I didn't feel like asking AMD's permission to *disable* some existing benchmarks by default.

Some of the old benchmarks check the throughput of custom structs, which is smart, so in the future we should *also* autotune custom structs. I have created an internal task for this in StreamHPC. Once this is done, we can remove all the old benchmarks.

## Notes for the reviewer
I recommend clicking through the individual commits, rather than looking at the Changes tab, since there was a lot of duplicate work.

I have checked that the benchmarks CI job still passes in StreamHPC's CI.