### PR TITLE
[hipblaslt] Add missing copyright headers for hipBLASLt files

### DIFF
--- a/projects/hipblaslt/clients/samples/04_hipblaslt_gemm_bias/sample_hipblaslt_gemm_bias.cpp
+++ b/projects/hipblaslt/clients/samples/04_hipblaslt_gemm_bias/sample_hipblaslt_gemm_bias.cpp
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ *
+ * Copyright © Advanced Micro Devices, Inc., or its affiliates.
+ * SPDX-License-Identifier: MIT
+ *
+ *******************************************************************************/
+
 #include <hip/hip_runtime.h>
 #include <hipblaslt/hipblaslt.h>
 #include <iostream>

--- a/projects/hipblaslt/clients/scripts/performance/git_info.py
+++ b/projects/hipblaslt/clients/scripts/performance/git_info.py
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 """
 This module is used to create git info file,
 if it is not found in output_folder_location specified by the end user.

--- a/projects/hipblaslt/clients/scripts/performance/specs.py
+++ b/projects/hipblaslt/clients/scripts/performance/specs.py
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 from pathlib import Path
 import re
 import socket
@@ -174,7 +177,7 @@ def get_sbios_info() -> str:
     except Exception:
         sbios_info = 'None'
     return sbios_info
-    
+
 
 def get_machine_specs(filename: str, devicenum: int = 0):
     """

--- a/projects/hipblaslt/clients/tests/src/hipblaslt_gtest_ext_op.cpp
+++ b/projects/hipblaslt/clients/tests/src/hipblaslt_gtest_ext_op.cpp
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ *
+ * Copyright © Advanced Micro Devices, Inc., or its affiliates.
+ * SPDX-License-Identifier: MIT
+ *
+ *******************************************************************************/
+
 #include <algorithm>
 #include <cstdlib>
 #include <gtest/gtest.h>

--- a/projects/hipblaslt/docs/cleanup_text.sh
+++ b/projects/hipblaslt/docs/cleanup_text.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 # Script to clean up RST and other text files
 # By Lee Killough
 

--- a/projects/hipblaslt/tensilelite/Tensile/CustomYamlLoader.py
+++ b/projects/hipblaslt/tensilelite/Tensile/CustomYamlLoader.py
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 import yaml
 from pathlib import Path
 

--- a/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/origami_grid_test.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/origami_grid_test.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 import argparse
 import origami
 import math
@@ -88,7 +91,7 @@ def main():
         origami.datatype_to_bits(origami.string_to_datatype(args.type_acc)) // 8,
         args.occupancy,
         hardware,
-        args.dynamic_grid_version        
+        args.dynamic_grid_version
     )
 
     print(f"Best grid : {winner_grid}")

--- a/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/origami_module.cpp
+++ b/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/origami_module.cpp
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ *
+ * Copyright © Advanced Micro Devices, Inc., or its affiliates.
+ * SPDX-License-Identifier: MIT
+ *
+ *******************************************************************************/
+
 #include <Tensile/analytical/Hardware.hpp>
 #include <Tensile/analytical/StreamK.hpp>
 #include <Tensile/analytical/Utils.hpp>

--- a/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/origami_test.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/origami_test.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 import argparse
 import origami
 

--- a/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/setup.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Utilities/origami/setup.py
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 # setup.py
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/format.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/format.hpp
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ *
+ * Copyright © Advanced Micro Devices, Inc., or its affiliates.
+ * SPDX-License-Identifier: MIT
+ *
+ *******************************************************************************/
+
 #pragma once
 #include <iomanip>
 #include <sstream>

--- a/projects/hipblaslt/tensilelite/rocisa/setup.py
+++ b/projects/hipblaslt/tensilelite/rocisa/setup.py
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 import glob
 import os
 import shutil

--- a/projects/hipblaslt/tensilelite/rocisa/tox.ini
+++ b/projects/hipblaslt/tensilelite/rocisa/tox.ini
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 [tox]
 envlist = py38, py39, py310
 

--- a/projects/hipblaslt/tensilelite/src/analytical/StreamK.cpp
+++ b/projects/hipblaslt/tensilelite/src/analytical/StreamK.cpp
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ *
+ * Copyright © Advanced Micro Devices, Inc., or its affiliates.
+ * SPDX-License-Identifier: MIT
+ *
+ *******************************************************************************/
+
 #include <Tensile/analytical/Hardware.hpp>
 #include <Tensile/analytical/StreamK.hpp>
 #include <Tensile/analytical/Utils.hpp>

--- a/projects/hipblaslt/tensilelite/tox.ini
+++ b/projects/hipblaslt/tensilelite/tox.ini
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 [tox]
 envlist = py35,py36,py27,lint
 labels =
@@ -40,7 +43,7 @@ commands = flake8 {toxinidir}/Tensile
 description = "Formats code so developers don't have to"
 skip_install = true
 deps = black==24.4
-commands = 
+commands =
     black \
       --line-length=100 \
       {toxinidir}/Tensile/Common \
@@ -52,7 +55,7 @@ commands =
 description = "Sorts import statements for less merge conflicts"
 skip_install = true
 deps = isort==5.13.2
-commands = 
+commands =
     isort \
       --profile=black \
       {toxinidir}/Tensile/Common \


### PR DESCRIPTION
## Summary

This MR adds missing copyright and SPDX license headers to various hipblaslt open source files, including C++, Python, and shell scripts. The update ensures compliance with open source licensing requirements.

## Technical Details

- Added or updated copyright and SPDX headers in:
    - C++ source files
    - Python scripts and modules
    - Shell scripts
- Affected files include clients, scripts, tests, tensilelite modules, and setup/config files.
- No functional code changes; only header/license updates.
- Relevant links:
    - [[SWDEV-553030] Palamida scan remediation [ROCM 7.1] - hipblaslt - [copyright] - INTERNAL](https://ontrack-internal.amd.com/browse/SWDEV-553030)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
