### PR TITLE
Add origami label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -86,6 +86,10 @@
 - changed-files:
   - any-glob-to-any-file: 'shared/tensile/**/*'
 
+"shared: origami":
+- changed-files:
+  - any-glob-to-any-file: 'shared/origami/**/*'
+
 documentation:
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
## Motivation

Adds support for automatic labeling of origami-related changes so that origami CI will trigger when the origami label is applied to a PR.

## Technical Details

Updated `.github/labeler.yml` to include a new label mapping for origami. This follows the same pattern as other shared components (e.g., tensile, rocroller).

## Test Plan

- Confirmed that labeler configuration matches the format used for other projects.
- Will validate with a PR that has file changes in shared/origami/**/* and ensuring the shared: origami label is automatically applied.

## Test Result

- Pending validation via PR test. 
- Expected result: shared: origami label is applied automatically, enabling origami CI when attached.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
