### PR TITLE
[rocBLAS] Updated to use hipEventSynchronize() for rocblas-bench timing

### DIFF
--- a/projects/rocblas/clients/common/client_utility.cpp
+++ b/projects/rocblas/clients/common/client_utility.cpp
@@ -303,7 +303,6 @@ double get_time_us_sync(hipStream_t stream)
         {
             THROW_IF_HIP_ERROR(hipEventCreate(&start));
             THROW_IF_HIP_ERROR(hipEventCreate(&stop));
-            THROW_IF_HIP_ERROR(hipStreamSynchronize(stream));
             THROW_IF_HIP_ERROR(hipEventRecord(start, stream));
 
             return 0.0;
@@ -311,7 +310,7 @@ double get_time_us_sync(hipStream_t stream)
         else
         {
             THROW_IF_HIP_ERROR(hipEventRecord(stop, stream));
-            THROW_IF_HIP_ERROR(hipStreamSynchronize(stream));
+            THROW_IF_HIP_ERROR(hipEventSynchronize(stop));
 
             float milliseconds = 0;
             THROW_IF_HIP_ERROR(hipEventElapsedTime(&milliseconds, start, stop));


### PR DESCRIPTION
## Motivation

[LWPMLSE-861](https://ontrack-internal.amd.com/browse/LWPMLSE-861) Use HipEvents API to get more accurate timing for the benchmark

## Technical Details

- Replaced the hipStreamSynchronize() with hipEventSynchronize() API

## Test Plan

- Validate rocBLAS build using the './install.sh -dc -a auto' command
- Execute './rocblas-test --gtest_filter=*pre_checkin*'
- Execute the following bench commands 
   ``` bash
          #!/bin/bash
          #
          #export AMD_LOG_LEVEL=7
          
          export ROCBLAS_STREAM_ORDER_ALLOC=1  # 0- no stream order allocation ; 1 - use stream order 
          export ROCBLAS_BENCH_STREAM_SYNC=0    # 0 - no hipStreamSynchronize ; 1 - use hipStreamSynchronize
          ./rocblas-bench -f dot -r d --initialization rand_int -n 1000 -i 1000 -j 1000
          ./rocblas-bench -f dot -r d --initialization rand_int -n 1000 -i 1000 -j 1000
          ./rocblas-bench -f dot -r d --initialization rand_int -n 1000 -i 1000 -j 1000
          
          ./rocblas-bench -f dot -r s --initialization rand_int -n 10000002 -i 1000 -j 1000
          ./rocblas-bench -f dot -r s --initialization rand_int -n 10000002 -i 1000 -j 1000
          ./rocblas-bench -f dot -r s --initialization rand_int -n 10000002 -i 1000 -j 1000
  ```
## Test Result
  - rocBLAS Build successful 
  - rocblas-test pre_checkin passed
  - hipEventSynchronize() provides better benchmark timing when stream-ordered allocations are used

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
