### PR TITLE
[rocThrust] Remove obsolete architectures from default list

### DIFF
--- a/projects/rocthrust/CMakeLists.txt
+++ b/projects/rocthrust/CMakeLists.txt
@@ -108,7 +108,7 @@ else()
       )
     else()
       rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-        TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
+        TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
       )
     endif()
     set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)


### PR DESCRIPTION
## Motivation

The size of our fat binary (as generated by building with all default architectures enabled) is growing large enough that it is causing linking issues for some of our libraries.

## Technical Details

This change removes gfx803 and gfx900 from the list of default architectures to build for. This should help reduce the size of the fat binary.

## Test Plan

Build rocThrust for all default architectures. Ensure there are no build errors.

## Test Result

No build errors observed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
