### PR TITLE
Revert "enable extop gtest for gfx11/12 (#1316)"

### DIFF
--- a/projects/hipblaslt/clients/samples/22_hipblaslt_ext_op_layernorm/sample_hipblaslt_ext_op_layernorm.cpp
+++ b/projects/hipblaslt/clients/samples/22_hipblaslt_ext_op_layernorm/sample_hipblaslt_ext_op_layernorm.cpp
@@ -46,6 +46,16 @@ void simpleLayerNorm(hipDataType type,
 
 int main()
 {
+    int             deviceId;
+    hipDeviceProp_t deviceProperties;
+    static_cast<void>(hipGetDevice(&deviceId));
+    static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
+    if(gpu_arch_match(deviceProperties.gcnArchName, "1[12]\\d{2}"))
+    {
+        std::cout << "This arch doesn't support Layernorm op yet" << std::endl;
+        return 0;
+    }
+
     LayerNormRunner<float> runnerF32(135, 345);
 
     runnerF32.run([&runnerF32] {

--- a/projects/hipblaslt/clients/tests/src/hipblaslt_gtest_ext_op.cpp
+++ b/projects/hipblaslt/clients/tests/src/hipblaslt_gtest_ext_op.cpp
@@ -153,6 +153,13 @@ TEST_P(ExtOpSoftmaxTest, softmaxSuccess)
     float* gpuInput{};
     float* gpuOutput{};
 
+    int             deviceId;
+    hipDeviceProp_t deviceProperties;
+    static_cast<void>(hipGetDevice(&deviceId));
+    static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
+    if(gpu_arch_match(deviceProperties.gcnArchName, "1[12]\\d{2}"))
+        return;
+
     auto err          = hipMalloc(&gpuInput, m * n * sizeof(float));
     err               = hipMalloc(&gpuOutput, m * n * sizeof(float));
     err               = hipMemcpyHtoD(gpuInput, input.data(), m * n * sizeof(float));
@@ -195,6 +202,13 @@ TEST_P(ExtOpLayerNormTest, layernormSuccess)
     float* gpuInput{};
     float* gpuGamma{};
     float* gpuBeta{};
+
+    int             deviceId;
+    hipDeviceProp_t deviceProperties;
+    static_cast<void>(hipGetDevice(&deviceId));
+    static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
+    if(gpu_arch_match(deviceProperties.gcnArchName, "1[12]\\d{2}"))
+        return;
 
     auto err = hipMalloc(&gpuOutput, m * n * sizeof(float));
     err      = hipMalloc(&gpuMean, m * sizeof(float));
@@ -299,6 +313,12 @@ void AMaxTest(hipDataType type, hipDataType dtype, std::size_t m, std::size_t n)
 TEST_P(ExtOpAMaxTest, amaxSuccess)
 {
     AMaxTestData    testdata = GetParam();
+    int             deviceId;
+    hipDeviceProp_t deviceProperties;
+    static_cast<void>(hipGetDevice(&deviceId));
+    static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
+    if(gpu_arch_match(deviceProperties.gcnArchName, "1[12]\\d{2}"))
+        return;
 
     if(testdata.type == HIP_R_32F && testdata.dtype == HIP_R_32F)
     {

--- a/projects/hipblaslt/device-library/extops/CMakeLists.txt
+++ b/projects/hipblaslt/device-library/extops/CMakeLists.txt
@@ -12,14 +12,10 @@ list(REMOVE_DUPLICATES archs)
 set(extop_cp_depends "")
 
 foreach(arch IN LISTS archs)
-    set(WAVEFRONT "-mwavefrontsize64")
-    if(arch MATCHES "^gfx1[12][0-9][0-9]$")
-        set(WAVEFRONT "-mno-wavefrontsize64")
-    endif()
     add_library(extop-obj-${arch} OBJECT)
     target_compile_options(extop-obj-${arch}
         PRIVATE
-            -Wno-unused-command-line-argument -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=${arch} ${WAVEFRONT} -c
+            -Wno-unused-command-line-argument -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=${arch} -mwavefrontsize64 -c
     )
     target_sources(extop-obj-${arch}
         PRIVATE

--- a/projects/hipblaslt/tensilelite/AMaxGenerator.py
+++ b/projects/hipblaslt/tensilelite/AMaxGenerator.py
@@ -20,7 +20,7 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-from rocisa.code import Label, Module, RegSet, TextBlock, ValueSet, SrdUpperValue
+from rocisa.code import Label, Module, RegSet, TextBlock, ValueSet
 from rocisa.container import EXEC, VCC, DSModifiers, MUBUFModifiers, vgpr, sgpr
 from rocisa.enum import RegisterType
 from rocisa.register import RegisterPool
@@ -39,7 +39,6 @@ from Tensile.Common.Utilities import _global_ti
 from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx, gfxToIsa
 from Tensile.Common.DataType import DataType
 from Tensile.Common.GlobalParameters import restoreDefaultGlobalParameters, assignGlobalParameters
-from Tensile.Common.Types import IsaVersion
 from Tensile.Toolchain.Validators import ToolchainDefaults, validateToolchain
 
 def kernel_header(name: str, gfx_arch: str, vgpr: int, sgpr: int, lds: int):
@@ -70,8 +69,6 @@ def kernel_header(name: str, gfx_arch: str, vgpr: int, sgpr: int, lds: int):
     header += f'  .amdhsa_system_vgpr_workitem_id 0\n'
     header += f'  .amdhsa_float_denorm_mode_32 3\n'
     header += f'  .amdhsa_float_denorm_mode_16_64 3\n'
-    if _global_ti.getArchCaps()["HasWave32"]:
-        header += f'  .amdhsa_wavefront_size32 1\n'
     header += f'.end_amdhsa_kernel\n'
     header += f'.text\n'
     return header
@@ -115,9 +112,7 @@ class AMaxKernelGenerator:
                  num_workitems: int,
                  num_load_count: int,
                  num_load_size: int,
-                 wavefront_size: int,
                  arch: str,
-                 isa: IsaVersion,
                  is_scale: bool):
         self.i_type = i_type
         self.o_type = o_type
@@ -126,11 +121,6 @@ class AMaxKernelGenerator:
         self.num_workitems = num_workitems
         self.num_load_count = num_load_count
         self.num_load_size = num_load_size
-        self.wavefront_size = wavefront_size
-        self.laneSGPRCount = 2 if wavefront_size == 64 else 1
-        self.SMovBX = ri.SMovB64 if wavefront_size == 64 else ri.SMovB32
-        self.SAndBX = ri.SAndB64 if wavefront_size == 64 else ri.SAndB32
-        self.srdUpperValue = SrdUpperValue(isa)
         self.sgpr_pool = RegisterPool(24, RegisterType.Sgpr, True)
         self.vgpr_pool = RegisterPool(40, RegisterType.Vgpr, True)
         self.sgpr_pool.add(0, 23) #TODO: estimate this
@@ -146,7 +136,7 @@ class AMaxKernelGenerator:
     def lds_usage_byte(self) -> int:
         # used in reduce inter wave mean and invvar
         # 4 data * half_wave_num * bpe
-        return 4 * (self.num_workitems // self.wavefront_size // 2) * self.bpe
+        return 4 * (self.num_workitems // 64 // 2) * self.bpe
 
     @property
     def func_name(self):
@@ -328,7 +318,7 @@ class AMaxKernelGenerator:
             mod.add(RegSet("s", "sgpr"+skey, self.sgprs[skey]))
         mod.addSpaceLine()
 
-        mod.add(ValueSet("Srd127_96", self.srdUpperValue.getValue(), format=1))
+        mod.add(ValueSet("Srd127_96", "0x00020000", format=-1))
         mod.addSpaceLine()
         mod.addSpaceLine()
         return mod
@@ -351,6 +341,7 @@ class AMaxKernelGenerator:
         mod.addSpaceLine()
         mod.addSpaceLine()
         return mod
+
 
     def init_param(self) -> Module:
         mod = Module("init_param")
@@ -431,14 +422,12 @@ class AMaxKernelGenerator:
         return mod
 
 
-    def max_per_data(self, i, onlyOneElement = False) -> Module:
+    def max_per_data(self, i) -> Module:
         mod = Module("max_per_data")
         if (self.i_type.isHalf()):
             mod.add(ri.VMaxF16(vgpr("Output"), vgpr("Output"), vgpr(f"Value+{i}", isAbs=True)))
-            # On non-Ecc hardware, the top 16 bits are dirty
-            if not onlyOneElement:
-                mod.add(ri.VLShiftRightB32(vgpr(f"Value+{i}"), 16, vgpr(f"Value+{i}")))
-                mod.add(ri.VMaxF16(vgpr("Output"), vgpr("Output"), vgpr(f"Value+{i}", isAbs=True)))
+            mod.add(ri.VLShiftRightB32(vgpr(f"Value+{i}"), 16, vgpr(f"Value+{i}")))
+            mod.add(ri.VMaxF16(vgpr("Output"), vgpr("Output"), vgpr(f"Value+{i}", isAbs=True)))
         elif (self.i_type.isSingle()):
             mod.add(ri.VMaxF32(vgpr("Output"), vgpr("Output"), vgpr(f"Value+{i}", isAbs=True)))
         return mod
@@ -584,7 +573,7 @@ class AMaxKernelGenerator:
             mod.add(BufferLoadx1(vgpr("Value"), vgpr("Offset"), sgpr("Src",4), 0, MUBUFModifiers(offen=True)))
             mod.add(ri.SWaitCnt(vlcnt=0))
             mod.addSpaceLine()
-            mod.add(self.max_per_data(0, onlyOneElement=True))
+            mod.add(self.max_per_data(0))
             mod.addSpaceLine()
             mod.add(self.scale_per_data(0))
             mod.addSpaceLine()
@@ -610,13 +599,13 @@ class AMaxKernelGenerator:
         mod.add(ri.SAndB32(sgpr("MainLoop"), sgpr("SizeLength"), self.num_workitems-1))
         mod.add(ri.VCmpLtU32(VCC(), vgpr("Serial"), sgpr("MainLoop")))
         mod.add(ri.SCBranchVCCZ(label_sum_end.getLabelName()))
-        mod.add(self.SMovBX(EXEC(), VCC()))
+        mod.add(ri.SMovB64(EXEC(), VCC()))
         mod.add(ri.SNop(1))
         BufferLoadx1 = self.global_read_inst_type(1)
         mod.add(BufferLoadx1(vgpr("Value"), vgpr("Offset"), sgpr("Src",4), 0, MUBUFModifiers(offen=True)))
         mod.add(ri.SWaitCnt(vlcnt=0))
         mod.addSpaceLine()
-        mod.add(self.max_per_data(0, onlyOneElement=True))
+        mod.add(self.max_per_data(0))
         mod.addSpaceLine()
         mod.add(self.scale_per_data(0))
         mod.addSpaceLine()
@@ -624,7 +613,7 @@ class AMaxKernelGenerator:
             mod.add(ri.BufferStoreB8(vgpr("OutputD"),
                                      vgpr("OffsetD"), sgpr("DstD",4), 0, MUBUFModifiers(offen=True)))
             mod.addSpaceLine()
-        mod.add(self.SMovBX(EXEC(), "-1"))
+        mod.add(ri.SMovB64(EXEC(), "-1"))
         mod.add(ri.SNop(1))
         mod.add(label_sum_end)
         mod.addSpaceLine()
@@ -650,7 +639,7 @@ class AMaxKernelGenerator:
         mod.add(label)
         mod.addSpaceLine()
         mod.add(ri.VAddU32(vgpr("Tmp"), sgpr("Tmp"), vgpr("Serial")))
-        mod.add(ri.VAndB32(vgpr("Tmp"), self.wavefront_size-1, vgpr("Tmp")))
+        mod.add(ri.VAndB32(vgpr("Tmp"), 63, vgpr("Tmp")))
         mod.add(ri.VLShiftLeftB32(vgpr("Tmp"), 0x2, vgpr("Tmp")))
         mod.addSpaceLine()
         mod.add(ri.DSBPermuteB32(vgpr("OutputB"), vgpr("Tmp"), vgpr("Output")))
@@ -658,7 +647,7 @@ class AMaxKernelGenerator:
         mod.addSpaceLine()
         mod.add(self.merge_sum())
         mod.add(ri.SLShiftLeftB32(sgpr("Tmp"), 1, sgpr("Tmp")))
-        mod.add(ri.SCmpLtU32(sgpr("Tmp"), self.wavefront_size))
+        mod.add(ri.SCmpLtU32(sgpr("Tmp"), 64))
         mod.add(ri.SCBranchSCC1(label.getLabelName()))
         mod.addSpaceLine()
         return mod
@@ -672,16 +661,16 @@ class AMaxKernelGenerator:
         label_end   = Label("end", f'end')
         mod = Module("inter_wave_reduction")
         mod.addComment0("inter_wave_reduction")
-        mod.add(ri.VLShiftRightB32(vgpr("Widx"), int(log2(self.wavefront_size)), vgpr("Serial")))
-        mod.add(ri.SMovB32(sgpr("Offset"), self.num_workitems // self.wavefront_size))
+        mod.add(ri.VLShiftRightB32(vgpr("Widx"), 6, vgpr("Serial")))
+        mod.add(ri.SMovB32(sgpr("Offset"), self.num_workitems // 64))
         mod.add(label_inter)
         mod.add(ri.SLShiftRightB32(sgpr("Offset"), 1, sgpr("Offset")))
         mod.add(ri.SCmpEQU32(sgpr("Offset"), 0))
         mod.add(ri.SCBranchSCC1(label_end.getLabelName()))
         mod.add(ri.SLShiftLeftB32(sgpr("Tmp"), 1, sgpr("Offset")))
-        mod.add(ri.VCmpLtU32(sgpr("Tmp+2",self.laneSGPRCount), vgpr("Widx"), sgpr("Tmp")))
-        mod.add(ri.VCmpGEU32(sgpr("Tmp+4",self.laneSGPRCount), vgpr("Widx"), sgpr("Offset")))
-        mod.add(self.SAndBX(VCC(), sgpr("Tmp+2",self.laneSGPRCount), sgpr("Tmp+4",self.laneSGPRCount)))
+        mod.add(ri.VCmpLtU32(sgpr("Tmp+2",2), vgpr("Widx"), sgpr("Tmp")))
+        mod.add(ri.VCmpGEU32(sgpr("Tmp+4",2), vgpr("Widx"), sgpr("Offset")))
+        mod.add(ri.SAndB64(VCC(), sgpr("Tmp+2",2), sgpr("Tmp+4",2)))
         mod.add(ri.SCBranchVCCNZ(label_upper.getLabelName()))
         mod.add(ri.VCmpLtU32(VCC(), vgpr("Widx"), sgpr("Offset")))
         mod.add(ri.SCBranchVCCNZ(label_lower.getLabelName()))
@@ -870,13 +859,12 @@ if __name__ == '__main__':
         toolchain_path = validateToolchain(ToolchainDefaults.CXX_COMPILER)
 
     _global_ti.init(isa, toolchain_path, False)
-    waveFrontSize = 32 if isa[0] in [11, 12] else 64
-    _global_ti.setKernel(isa, waveFrontSize)
-    amax = AMaxKernelGenerator(DataType(t), DataType(d), DataType(s), w, c, 4, waveFrontSize, arch, isa, is_scale)
+    _global_ti.setKernel(isa, 64)
+    amax = AMaxKernelGenerator(DataType(t), DataType(d), DataType(s), w, c, 4, arch, is_scale)
     kernel_body = amax.amax_kernel_body()
     args = amax.kernel_args()
     func_name = amax.func_name
-    meta = KernelMeta(func_name, amax.vgpr_pool.size(), amax.sgpr_pool.size(), 0, amax.lds_usage_byte, waveFrontSize, w, 8, args)
+    meta = KernelMeta(func_name, amax.vgpr_pool.size(), amax.sgpr_pool.size(), 0, amax.lds_usage_byte, 64, w, 8, args)
     meta.update_args_offsets()
     k_str = '\n'.join([kernel_header(func_name, arch, amax.vgpr_pool.size(), amax.sgpr_pool.size(), amax.lds_usage_byte),
                        meta_str((meta,)),

--- a/projects/hipblaslt/tensilelite/LayerNormGenerator.py
+++ b/projects/hipblaslt/tensilelite/LayerNormGenerator.py
@@ -20,7 +20,7 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-from rocisa.code import Label, Module, RegSet, TextBlock, ValueSet, SrdUpperValue
+from rocisa.code import Label, Module, RegSet, TextBlock, ValueSet
 from rocisa.container import EXEC, VCC, DSModifiers, MUBUFModifiers, vgpr, sgpr
 from rocisa.enum import RegisterType
 from rocisa.register import RegisterPool
@@ -40,7 +40,6 @@ from Tensile.Common.Utilities import _global_ti
 from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx, gfxToIsa
 from Tensile.Common.DataType import DataType
 from Tensile.Common.GlobalParameters import assignGlobalParameters, restoreDefaultGlobalParameters
-from Tensile.Common.Types import IsaVersion
 from Tensile.Toolchain.Validators import ToolchainDefaults, validateToolchain
 
 def kernel_header(name: str, gfx_arch: str, vgpr: int, sgpr: int, lds: int):
@@ -71,8 +70,6 @@ def kernel_header(name: str, gfx_arch: str, vgpr: int, sgpr: int, lds: int):
     header += f'  .amdhsa_system_vgpr_workitem_id 0\n'
     header += f'  .amdhsa_float_denorm_mode_32 3\n'
     header += f'  .amdhsa_float_denorm_mode_16_64 3\n'
-    if _global_ti.getArchCaps()["HasWave32"]:
-        header += f'  .amdhsa_wavefront_size32 1\n'
     header += f'.end_amdhsa_kernel\n'
     header += f'.text\n'
     return header
@@ -117,20 +114,13 @@ class LayerNormKernelGenerator:
                  num_load_count: int,
                  num_load_size: int,
                  sweep_once: int,
-                 wavefront_size: int,
-                 arch: str,
-                 isa: IsaVersion):
+                 arch: str):
         self.io_type = io_type
         self.bpe = io_type.numBytes()
         self.num_workitems = num_workitems
         self.num_load_count = num_load_count
         self.num_load_size = num_load_size
         self.sweep_once = sweep_once
-        self.wavefront_size = wavefront_size
-        self.laneSGPRCount = 2 if wavefront_size == 64 else 1
-        self.SMovBX = ri.SMovB64 if wavefront_size == 64 else ri.SMovB32
-        self.SAndBX = ri.SAndB64 if wavefront_size == 64 else ri.SAndB32
-        self.srdUpperValue = SrdUpperValue(isa)
         self.sgpr_pool = RegisterPool(24, RegisterType.Sgpr, True)
         self.vgpr_pool = RegisterPool(40, RegisterType.Vgpr, True)
         self.sgpr_pool.add(0, 23) #TODO: estimate this
@@ -145,7 +135,7 @@ class LayerNormKernelGenerator:
     def lds_usage_byte(self) -> int:
         # used in reduce inter wave mean and invvar
         # 4 data * half_wave_num * bpe
-        return 4 * (self.num_workitems // self.wavefront_size // 2) * self.bpe
+        return 4 * (self.num_workitems // 64 // 2) * self.bpe
 
     @property
     def func_name(self):
@@ -251,7 +241,7 @@ class LayerNormKernelGenerator:
             mod.add(RegSet("s", "sgpr"+skey, self.sgprs[skey]))
         mod.addSpaceLine()
 
-        mod.add(ValueSet("Srd127_96", self.srdUpperValue.getValue(), format=1))
+        mod.add(ValueSet("Srd127_96", "0x00020000", format=-1))
         mod.add(ValueSet("BufferLimit", "0xffffffff", format=-1))
         mod.addSpaceLine()
 
@@ -270,10 +260,9 @@ class LayerNormKernelGenerator:
         mod.add(ri.SLoadB32(sgpr("SizeLength"),       sgpr("KernelArg", 2), 52))
         mod.add(ri.SLoadB32(sgpr("Eps"),              sgpr("KernelArg", 2), 56))
         mod.add(ri.SWaitCnt(kmcnt=0))
-        if _global_ti.getArchCaps()["WorkGroupIdFromTTM"]:
-            mod.add(ri.SAndB32(dst=sgpr("WorkGroup1"), src0=hex(0xFFFF), src1="ttmp7"))
         mod.addSpaceLine()
         return mod
+
 
     def init_param(self) -> Module:
         mod = Module("defineVariables")
@@ -342,7 +331,7 @@ class LayerNormKernelGenerator:
         if self.sweep_once:
             mod.add(ri.VCmpLtU32(VCC(), vgpr("Index"), sgpr("SizeLength")))
             #mod.add(ri.SCBranchddVCCZ(label_sum_end.getLabelName()))
-            mod.add(self.SMovBX(EXEC(), VCC()))
+            mod.add(ri.SMovB64(EXEC(), VCC()))
             mod.add(ri.SNop(1))
         mod.add(ri.VAddF32(vgpr("Count"), vgpr("Count"), 1.0))
         mod.add(ri.VSubF32(vgpr("Tmp"), val, vgpr("Mean")))  # delta
@@ -354,7 +343,7 @@ class LayerNormKernelGenerator:
         mod.add(ri.VMulF32(vgpr("Tmp"), vgpr("Tmp"), vgpr("Tmp+1")))
         mod.add(ri.VAddF32(vgpr("Invvar"), vgpr("Invvar"), vgpr("Tmp")))
         if self.sweep_once:
-            mod.add(self.SMovBX(EXEC(), "-1"))
+            mod.add(ri.SMovB64(EXEC(), "-1"))
             mod.add(ri.SNop(1))
             mod.add(ri.VAddU32(vgpr("Index"), vgpr("Index"), 1))
         mod.addSpaceLine()
@@ -444,13 +433,13 @@ class LayerNormKernelGenerator:
         mod.add(ri.SAndB32(sgpr("MainLoop"), sgpr("SizeLength"), self.num_workitems-1))
         mod.add(ri.VCmpLtU32(VCC(), vgpr("Serial"), sgpr("MainLoop")))
         mod.add(ri.SCBranchVCCZ(label_sum_end.getLabelName()))
-        mod.add(self.SMovBX(EXEC(), VCC()))
+        mod.add(ri.SMovB64(EXEC(), VCC()))
         mod.add(ri.SNop(1))
         mod.add(ri.BufferLoadB32(vgpr("Value"), vgpr("Offset"), sgpr("Src",4), 0, MUBUFModifiers(offen=True)))
         mod.add(ri.SWaitCnt(vlcnt=0))
         mod.addSpaceLine()
         mod.add(self.sum_per_data(vgpr("Value")))
-        mod.add(self.SMovBX(EXEC(), "-1"))
+        mod.add(ri.SMovB64(EXEC(), "-1"))
         mod.add(ri.SNop(1))
         mod.add(label_sum_end)
         mod.addSpaceLine()
@@ -466,7 +455,7 @@ class LayerNormKernelGenerator:
         mod.add(ri.VSubF32(vgpr("Tmp"), vgpr("MeanB"), vgpr("MeanA")))
         mod.add(ri.VAddF32(vgpr("Count"), vgpr("CountA"), vgpr("CountB")))
         mod.add(ri.VCmpGTF32(VCC(), vgpr("Count"), 0))
-        mod.add(self.SMovBX(EXEC(), VCC()))
+        mod.add(ri.SMovB64(EXEC(), VCC()))
         mod.add(ri.SNop(1))
         mod.add(ri.VRcpF32(vgpr("Tmp+3"), vgpr("Count")))
         mod.add(ri.SNop(waitState=0, comment="1 wait states"))
@@ -482,7 +471,7 @@ class LayerNormKernelGenerator:
         mod.add(ri.VMulF32(vgpr("Tmp"), vgpr("Tmp"), vgpr("Tmp+2")))
         mod.add(ri.VMulF32(vgpr("Tmp"), vgpr("Tmp"), vgpr("Count")))
         mod.add(ri.VAddF32(vgpr("Invvar"), vgpr("Invvar"), vgpr("Tmp")))
-        mod.add(self.SMovBX(EXEC(), "-1"))
+        mod.add(ri.SMovB64(EXEC(), "-1"))
         mod.add(ri.SNop(1))
         return mod
 
@@ -495,7 +484,7 @@ class LayerNormKernelGenerator:
         mod.add(label)
         mod.addSpaceLine()
         mod.add(ri.VAddU32(vgpr("Tmp"), sgpr("Tmp"), vgpr("Serial")))
-        mod.add(ri.VAndB32(vgpr("Tmp"), self.wavefront_size-1, vgpr("Tmp")))
+        mod.add(ri.VAndB32(vgpr("Tmp"), 63, vgpr("Tmp")))
         mod.add(ri.VLShiftLeftB32(vgpr("Tmp"), 0x2, vgpr("Tmp")))
         mod.addSpaceLine()
         mod.add(ri.DSBPermuteB32(vgpr("CountB"), vgpr("Tmp"), vgpr("Count")))
@@ -505,7 +494,7 @@ class LayerNormKernelGenerator:
         mod.addSpaceLine()
         mod.add(self.merge_sum())
         mod.add(ri.SLShiftLeftB32(sgpr("Tmp"), 1, sgpr("Tmp")))
-        mod.add(ri.SCmpLtU32(sgpr("Tmp"), self.wavefront_size))
+        mod.add(ri.SCmpLtU32(sgpr("Tmp"), 64))
         mod.add(ri.SCBranchSCC1(label.getLabelName()))
         mod.addSpaceLine()
         return mod
@@ -519,16 +508,16 @@ class LayerNormKernelGenerator:
         label_end   = Label("end", f'end')
         mod = Module("inter_wave_reduction")
         mod.addComment0("inter_wave_reduction")
-        mod.add(ri.VLShiftRightB32(vgpr("Widx"), int(log2(self.wavefront_size)), vgpr("Serial")))
-        mod.add(ri.SMovB32(sgpr("Offset"), self.num_workitems // self.wavefront_size))
+        mod.add(ri.VLShiftRightB32(vgpr("Widx"), 6, vgpr("Serial")))
+        mod.add(ri.SMovB32(sgpr("Offset"), self.num_workitems // 64))
         mod.add(label_inter)
         mod.add(ri.SLShiftRightB32(sgpr("Offset"), 1, sgpr("Offset")))
         mod.add(ri.SCmpEQU32(sgpr("Offset"), 0))
         mod.add(ri.SCBranchSCC1(label_end.getLabelName()))
         mod.add(ri.SLShiftLeftB32(sgpr("Tmp"), 1, sgpr("Offset")))
-        mod.add(ri.VCmpLtU32(sgpr("Tmp+2", self.laneSGPRCount), vgpr("Widx"), sgpr("Tmp")))
-        mod.add(ri.VCmpGEU32(sgpr("Tmp+4", self.laneSGPRCount), vgpr("Widx"), sgpr("Offset")))
-        mod.add(self.SAndBX(VCC(), sgpr("Tmp+2", self.laneSGPRCount), sgpr("Tmp+4", self.laneSGPRCount)))
+        mod.add(ri.VCmpLtU32(sgpr("Tmp+2",2), vgpr("Widx"), sgpr("Tmp")))
+        mod.add(ri.VCmpGEU32(sgpr("Tmp+4",2), vgpr("Widx"), sgpr("Offset")))
+        mod.add(ri.SAndB64(VCC(), sgpr("Tmp+2",2), sgpr("Tmp+4",2)))
         mod.add(ri.SCBranchVCCNZ(label_upper.getLabelName()))
         mod.add(ri.VCmpLtU32(VCC(), vgpr("Widx"), sgpr("Offset")))
         mod.add(ri.SCBranchVCCNZ(label_lower.getLabelName()))
@@ -759,7 +748,7 @@ class LayerNormKernelGenerator:
             mod.addSpaceLine()
 
             mod.add(ri.BufferStoreB32(vgpr("Value"), vgpr("Offset"), sgpr("Dst",4), 0, MUBUFModifiers(offen=True)))
-            mod.add(ri.SWaitCnt(vscnt=0))
+            mod.add(ri.SWaitCnt(vlcnt=0))
             mod.add(ri.SMovB32(sgpr("Tmp"), self.num_workitems * self.bpe))
             mod.add(ri.VAddU32(vgpr("Offset"), vgpr("Offset"), sgpr("Tmp")))
             mod.addSpaceLine()
@@ -773,7 +762,7 @@ class LayerNormKernelGenerator:
         mod.add(ri.SAndB32(sgpr("MainLoop"), sgpr("SizeLength"), self.num_workitems-1))
         mod.add(ri.VCmpLtU32(VCC(), vgpr("Serial"), sgpr("MainLoop")))
         mod.add(ri.SCBranchVCCZ(label_layernorm_end.getLabelName()))
-        mod.add(self.SMovBX(EXEC(), VCC()))
+        mod.add(ri.SMovB64(EXEC(), VCC()))
         mod.add(ri.SNop(1))
         mod.add(ri.BufferLoadB32(vgpr("Value"), vgpr("Offset"), sgpr("Src",4), 0, MUBUFModifiers(offen=True)))
         mod.add(ri.SWaitCnt(vlcnt=0))
@@ -798,8 +787,8 @@ class LayerNormKernelGenerator:
         mod.addSpaceLine()
 
         mod.add(ri.BufferStoreB32(vgpr("Value"), vgpr("Offset"), sgpr("Dst",4), 0, MUBUFModifiers(offen=True)))
-        mod.add(ri.SWaitCnt(vscnt=0))
-        mod.add(self.SMovBX(EXEC(), "-1"))
+        mod.add(ri.SWaitCnt(vlcnt=0))
+        mod.add(ri.SMovB64(EXEC(), "-1"))
         mod.add(ri.SNop(1))
         mod.add(label_layernorm_end)
         mod.addSpaceLine()
@@ -948,13 +937,12 @@ if __name__ == '__main__':
         toolchain_path = validateToolchain(ToolchainDefaults.CXX_COMPILER)
 
     _global_ti.init(isa, toolchain_path, False)
-    waveFrontSize = 32 if isa[0] in [11, 12] else 64
-    _global_ti.setKernel(isa, waveFrontSize)
-    layernorm = LayerNormKernelGenerator(DataType('S'), w, c, 4, sweep_once, waveFrontSize, arch, isa)
+    _global_ti.setKernel(isa, 64)
+    layernorm = LayerNormKernelGenerator(DataType('S'), w, c, 4, sweep_once, arch)
     kernel_body = layernorm.layernorm_kernel_body()
     args = layernorm.kernel_args()
     func_name = layernorm.func_name
-    meta = KernelMeta(func_name, layernorm.vgpr_pool.size(), layernorm.sgpr_pool.size(), 0, layernorm.lds_usage_byte, waveFrontSize, w, 8, args)
+    meta = KernelMeta(func_name, layernorm.vgpr_pool.size(), layernorm.sgpr_pool.size(), 0, layernorm.lds_usage_byte, 64, w, 8, args)
     meta.update_args_offsets()
     k_str = '\n'.join([kernel_header(func_name, arch, layernorm.vgpr_pool.size(), layernorm.sgpr_pool.size(), layernorm.lds_usage_byte),
                        meta_str((meta,)),

--- a/projects/hipblaslt/tensilelite/SoftmaxGenerator.py
+++ b/projects/hipblaslt/tensilelite/SoftmaxGenerator.py
@@ -20,7 +20,7 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-from rocisa.code import Module, TextBlock, Label, SrdUpperValue
+from rocisa.code import Module, TextBlock, Label
 from rocisa.container import EXEC, VCC, MUBUFModifiers, vgpr, sgpr
 from rocisa.enum import RegisterType
 from rocisa.functions import vectorStaticDivideAndRemainder, vectorStaticMultiply, \
@@ -43,7 +43,6 @@ from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx, gfxTo
 from Tensile.Common.DataType import DataType
 from Tensile.Common.GlobalParameters import restoreDefaultGlobalParameters, assignGlobalParameters
 from Tensile.Common.RegisterPool import allocTmpGpr
-from Tensile.Common.Types import IsaVersion
 from Tensile.Toolchain.Validators import ToolchainDefaults, validateToolchain
 
 def record_num_calls(f):
@@ -76,15 +75,13 @@ def asm_func(func_name: str, module: Module):
         module.add(TextBlock(f'.size {func_name}, {end_label_name} - {func_name}\n'))
 
 @contextmanager
-def auto_exec_scope(sgpr_pool: RegisterPool, module: Module, wavefront_size: int):
-    SMovBX = ri.SMovB64 if wavefront_size == 64 else ri.SMovB32
-    laneSGPRCount = 2 if wavefront_size == 64 else 1
+def auto_exec_scope(sgpr_pool: RegisterPool, module: Module):
     try:
-        tmp_exec_reg_idx = sgpr_pool.checkOutAligned(laneSGPRCount, laneSGPRCount)
-        module.add(SMovBX(sgpr(tmp_exec_reg_idx, laneSGPRCount), EXEC()))
+        tmp_exec_reg_idx = sgpr_pool.checkOutAligned(2, 2)
+        module.add(ri.SMovB64(sgpr(tmp_exec_reg_idx, 2), EXEC()))
         yield
     finally:
-        module.add(SMovBX(EXEC(), sgpr(tmp_exec_reg_idx, laneSGPRCount)))
+        module.add(ri.SMovB64(EXEC(), sgpr(tmp_exec_reg_idx, 2)))
         sgpr_pool.checkIn(tmp_exec_reg_idx)
 
 class SoftmaxKernelGenerator:
@@ -96,18 +93,11 @@ class SoftmaxKernelGenerator:
                  num_cols: int,
                  num_rows: int,
                  num_workitems: int,
-                 wavefront_size: int,
-                 arch: str,
-                 isa: IsaVersion):
+                 arch: str):
         self.io_type = io_type
         self.num_cols = num_cols
         self.num_rows = num_rows
         self.num_workitems = num_workitems
-        self.wavefront_size = wavefront_size
-        self.laneSGPRCount = 2 if wavefront_size == 64 else 1
-        self.SMovBX = ri.SMovB64 if wavefront_size == 64 else ri.SMovB32
-        self.SAndBX = ri.SAndB64 if wavefront_size == 64 else ri.SAndB32
-        self.srdUpperValue = SrdUpperValue(isa)
         self.sgpr_pool = RegisterPool(18, RegisterType.Sgpr, True)
         self.vgpr_pool = RegisterPool(10, RegisterType.Vgpr, True)
         self.sgpr_pool.addRange(3, 17) #TODO: estimate this
@@ -220,7 +210,7 @@ class SoftmaxKernelGenerator:
     @property
     def srd_const(self) -> str:
         if self.io_type.isSingle():
-            return hex(self.srdUpperValue.getValue())
+            return hex(0x20000)
 
         raise NotImplementedError
 
@@ -249,8 +239,6 @@ class SoftmaxKernelGenerator:
         module.add(ri.SMovB32(sgpr(output_srd_idx + 2), sgpr(num_elem_reg_idx)))
         module.add(ri.SMovB32(sgpr(input_srd_idx + 3), self.srd_const))
         module.add(ri.SMovB32(sgpr(output_srd_idx + 3), self.srd_const))
-        if _global_ti.getArchCaps()["WorkGroupIdFromTTM"]:
-            module.add(ri.SMovB32(dst=sgpr(self.wg_id_reg_idx), src="ttmp9"))
         self.sgpr_pool.checkIn(num_elem_reg_idx)
         return module, input_srd_idx, output_srd_idx, m_reg_idx, n_reg_idx
 
@@ -450,16 +438,16 @@ class SoftmaxKernelGenerator:
             reduction_col_reg_idx = self.vgpr_pool.checkOut(1)
 
             for i in range(num_iter):
-                with auto_exec_scope(self.sgpr_pool, module, self.wavefront_size):
+                with auto_exec_scope(self.sgpr_pool, module):
                     s = self.num_cols >> (i + 1)
                     assert s > 0
                     cmp_byte_rel_offset = s * self.bpe
                     module.add(ri.VAddU32(vgpr(reduction_col_reg_idx), hex(s), vgpr(col_reg_idx)))
-                    module.add(ri.VCmpLeU32(sgpr(cmp_res_reg_idx, self.laneSGPRCount), vgpr(col_reg_idx), sgpr(n_reg_idx)))
+                    module.add(ri.VCmpLeU32(sgpr(cmp_res_reg_idx, 2), vgpr(col_reg_idx), sgpr(n_reg_idx)))
                     module.add(ri.VCmpGtU32(VCC(), hex(s), vgpr(col_reg_idx)))
-                    module.add(self.SAndBX(sgpr(cmp_res_reg_idx, self.laneSGPRCount), sgpr(cmp_res_reg_idx, self.laneSGPRCount), VCC()))
+                    module.add(ri.SAndB64(sgpr(cmp_res_reg_idx, 2), sgpr(cmp_res_reg_idx, 2), VCC()))
                     module.add(ri.VCmpLtU32(VCC(), vgpr(reduction_col_reg_idx), sgpr(n_reg_idx)))
-                    module.add(self.SAndBX(EXEC(), sgpr(cmp_res_reg_idx, self.laneSGPRCount), VCC()))
+                    module.add(ri.SAndB64(EXEC(), sgpr(cmp_res_reg_idx, 2), VCC()))
                     module.add(ri.VAddU32(vgpr(r_reg_idx), hex(cmp_byte_rel_offset), vgpr(l_reg_idx)))
                     module.add(self.lds_sum(l_reg_idx, r_reg_idx))
 
@@ -491,16 +479,16 @@ class SoftmaxKernelGenerator:
             reduction_col_reg_idx = self.vgpr_pool.checkOut(1)
 
             for i in range(num_iter):
-                with auto_exec_scope(self.sgpr_pool, module, self.wavefront_size):
+                with auto_exec_scope(self.sgpr_pool, module):
                     s = self.num_cols >> (i + 1)
                     assert s > 0
                     cmp_byte_rel_offset = s * self.bpe
                     module.add(ri.VAddU32(vgpr(reduction_col_reg_idx), hex(s), vgpr(col_reg_idx)))
-                    module.add(ri.VCmpLeU32(sgpr(cmp_res_reg_idx, self.laneSGPRCount), vgpr(col_reg_idx), sgpr(n_reg_idx)))
+                    module.add(ri.VCmpLeU32(sgpr(cmp_res_reg_idx, 2), vgpr(col_reg_idx), sgpr(n_reg_idx)))
                     module.add(ri.VCmpGtU32(VCC(), hex(s), vgpr(col_reg_idx)))
-                    module.add(self.SAndBX(sgpr(cmp_res_reg_idx, self.laneSGPRCount), sgpr(cmp_res_reg_idx, self.laneSGPRCount), VCC()))
+                    module.add(ri.SAndB64(sgpr(cmp_res_reg_idx, 2), sgpr(cmp_res_reg_idx, 2), VCC()))
                     module.add(ri.VCmpLtU32(VCC(), vgpr(reduction_col_reg_idx), sgpr(n_reg_idx)))
-                    module.add(self.SAndBX(EXEC(), sgpr(cmp_res_reg_idx, self.laneSGPRCount), VCC()))
+                    module.add(ri.SAndB64(EXEC(), sgpr(cmp_res_reg_idx, 2), VCC()))
                     module.add(ri.VAddU32(vgpr(r_reg_idx), hex(cmp_byte_rel_offset), vgpr(l_reg_idx)))
                     module.add(self.lds_max(l_reg_idx, r_reg_idx))
 
@@ -555,7 +543,7 @@ class SoftmaxKernelGenerator:
         if self.debug_label:
             module.add(Label('global_write_data', 'global write begins'))
 
-        with auto_exec_scope(self.sgpr_pool, module, self.wavefront_size):
+        with auto_exec_scope(self.sgpr_pool, module):
             col_reg_idx = self.vgpr_pool.checkOut(1)
             module.add(vectorStaticRemainder(-1, col_reg_idx, self.t_id_reg_idx, self.num_cols, None, None))
             module.add(ri.VCmpXLtU32(VCC(), vgpr(col_reg_idx), sgpr(n_reg_idx)))
@@ -628,8 +616,6 @@ def kernel_rodata(name: str, gfx_arch: Tuple[int, int, int]):
         header += f'.amdhsa_accum_offset 8\n'
     header += f'.amdhsa_next_free_vgpr .amdgcn.next_free_vgpr\n'
     header += f'.amdhsa_next_free_sgpr .amdgcn.next_free_sgpr\n'
-    if _global_ti.getArchCaps()["HasWave32"]:
-        header += f'.amdhsa_wavefront_size32 1\n'
     header += f'.end_amdhsa_kernel\n'
     return header
 
@@ -722,13 +708,12 @@ if __name__ == '__main__':
         toolchain_path = validateToolchain(ToolchainDefaults.CXX_COMPILER)
 
     _global_ti.init(isa, toolchain_path, False)
-    waveFrontSize = 32 if isa[0] in [11, 12] else 64
-    _global_ti.setKernel(isa, waveFrontSize)
-    softmax = SoftmaxKernelGenerator(DataType('S'), n, m, 256, waveFrontSize, arch, isa)
+    _global_ti.setKernel(isa, 64)
+    softmax = SoftmaxKernelGenerator(DataType('S'), n, m, 256, arch)
     kernel_body = softmax.softmax_kernel_body()
     args = softmax.kernel_args()
     func_name = softmax.func_name
-    meta = KernelMeta(func_name, softmax.vgpr_pool.size(), softmax.sgpr_pool.size(), 0, softmax.lds_usage_byte, waveFrontSize, 256, 8, args)
+    meta = KernelMeta(func_name, softmax.vgpr_pool.size(), softmax.sgpr_pool.size(), 0, softmax.lds_usage_byte, 64, 256, 8, args)
     meta.update_args_offsets()
     k_str = '\n'.join([kernel_header(func_name, arch),
                        str(kernel_body),


### PR DESCRIPTION
This reverts commit 0ad52e3c01d85b01c45ef0f42f17af677e14de9c.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
