### PR TITLE
Update rocPRIM version number for ROCm 7.1 release

### DIFF
--- a/projects/rocprim/CMakeLists.txt
+++ b/projects/rocprim/CMakeLists.txt
@@ -169,7 +169,7 @@ if(BUILD_CODE_COVERAGE)
 endif()
 
 # Setup VERSION
-set(VERSION_STRING "4.0.0")
+set(VERSION_STRING "4.1.0")
 rocm_setup_version(VERSION ${VERSION_STRING})
 math(EXPR rocprim_VERSION_NUMBER "${rocprim_VERSION_MAJOR} * 100000 + ${rocprim_VERSION_MINOR} * 100 + ${rocprim_VERSION_PATCH}")
 


### PR DESCRIPTION
## Motivation

We need to update rocPRIM's internal version number for the ROCm 7.1 release.

## Technical Details

This change bumps the version number to 4.1.0.

## Test Plan

Build rocPRIM as usual, ensure there are no build errors.

## Test Result

No build errors observed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
