### PR TITLE
[hipblaslt] Guard rotatingNum >= 0 to prevent incorrect loop range

### DIFF
--- a/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
@@ -2491,6 +2491,10 @@ namespace TensileLite
                 int32_t rotatingNum
                     = min(maxRotatingBufferNum, ceil((float)m_rotatingBuffer / rotatingSize))
                       - 1; // Minus the original buffer.
+
+                // <= 0 means no rotating buffer
+                rotatingNum = max(0, rotatingNum);
+
                 int32_t totalRotatingSizeNeeded = rotatingNum * rotatingSize;
                 std::cout << "Rotating buffer set to: " << m_rotatingBuffer
                           << ". Rotating num: " << rotatingNum << std::endl;
@@ -2549,6 +2553,10 @@ namespace TensileLite
                 int32_t rotatingNum
                     = min(maxRotatingBufferNum, ceil((float)m_rotatingBuffer / rotatingSize))
                       - 1; // Minus the original buffer.
+
+                // <= 0 means no rotating buffer
+                rotatingNum = max(0, rotatingNum);
+
                 int32_t totalRotatingSizeNeeded = rotatingNum * rotatingSize;
                 std::cout << "Rotating buffer set to: " << m_rotatingBuffer
                           << ". Rotating num: " << rotatingNum << std::endl;

--- a/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
@@ -2492,7 +2492,7 @@ namespace TensileLite
                     = min(maxRotatingBufferNum, ceil((float)m_rotatingBuffer / rotatingSize))
                       - 1; // Minus the original buffer.
 
-                // <= 0 means no rotating buffer
+                // <= 0 means don't rotating
                 rotatingNum = max(0, rotatingNum);
 
                 int32_t totalRotatingSizeNeeded = rotatingNum * rotatingSize;
@@ -2554,7 +2554,7 @@ namespace TensileLite
                     = min(maxRotatingBufferNum, ceil((float)m_rotatingBuffer / rotatingSize))
                       - 1; // Minus the original buffer.
 
-                // <= 0 means no rotating buffer
+                // <= 0 means don't rotating
                 rotatingNum = max(0, rotatingNum);
 
                 int32_t totalRotatingSizeNeeded = rotatingNum * rotatingSize;


### PR DESCRIPTION
rotatingNum can be -1 when maxRotatingBufferNum is zero, which occurs in the case: warmupInvocations = 0, syncs = 1, enq = 0.

Ensure it is at least zero before processing.