### PR TITLE
[hipblastlt] Fixed rotating num = -1 case

### DIFF
--- a/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
@@ -62,6 +62,7 @@ namespace TensileLite
             , m_flushTimeUs(flushTimeUs)
             , m_skip_slow_solution_ratio(args["skip-slow-solution-ratio"].as<float>())
             , m_skip_slow_solution(0)
+            , m_skiprun_from_map(0)
             , m_numSolutionSkip(0)
             , m_prob_sol_map(args["prob-sol-map"].as<prob_sol_map>())
         {

--- a/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
@@ -2491,6 +2491,10 @@ namespace TensileLite
                 int32_t rotatingNum
                     = min(maxRotatingBufferNum, ceil((float)m_rotatingBuffer / rotatingSize))
                       - 1; // Minus the original buffer.
+
+                // <= 0 means don't rotating
+                rotatingNum = max(0, rotatingNum);
+
                 int32_t totalRotatingSizeNeeded = rotatingNum * rotatingSize;
                 std::cout << "Rotating buffer set to: " << m_rotatingBuffer
                           << ". Rotating num: " << rotatingNum << std::endl;
@@ -2549,6 +2553,10 @@ namespace TensileLite
                 int32_t rotatingNum
                     = min(maxRotatingBufferNum, ceil((float)m_rotatingBuffer / rotatingSize))
                       - 1; // Minus the original buffer.
+
+                // <= 0 means don't rotating
+                rotatingNum = max(0, rotatingNum);
+
                 int32_t totalRotatingSizeNeeded = rotatingNum * rotatingSize;
                 std::cout << "Rotating buffer set to: " << m_rotatingBuffer
                           << ". Rotating num: " << rotatingNum << std::endl;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fixed a bug caused by #1274 
A bool flag is not inited as False. it has chances in some corner cases that lead rotating num = -1

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
In DataInitialization.cpp:
```
                int32_t rotatingNum
                    = min(maxRotatingBufferNum, ceil((float)m_rotatingBuffer / rotatingSize))
                      - 1; // Minus the original buffer.
```
The failure is caused when rotatingNum = min(**0**, XXX) - 1 (= -1), which means maxRotatingBufferNum is 0.

Tracing back to main.cpp (tensilelite-client)
```
                size_t warmupInvocations    = listeners.numWarmupRuns();
                size_t syncs                = listeners.numSyncs();
                size_t enq                  = listeners.numEnqueuesPerSync();
                size_t maxRotatingBufferNum = max(warmupInvocations, syncs * enq);
```
The failure is caused when all three values are 0. And from #1274 , BenchmarkTimer.cpp:
```
        size_t BenchmarkTimer::numEnqueuesPerSync()
        {
            // No need to run when
            // 1. this solution is skip_from_map (restore-from-log) or
            // 2. m_skip_slow_solution
            if(m_skiprun_from_map || m_skip_slow_solution)
                return 0;
```
`m_skiprun_from_map` is set to false in `preSolution()`, but `numEnqueuesPerSync()` is before `preSolution()`.
So it could be any value (true or false), when it is true, then it returns 0. 
In some extreme conditions (no validation, no warmup), it is possible that the **rotating num = min(0,XXX) -1 (which is -1)**
The correct coding should be init the bool to false in the constructor. (set to false in preSolution() is just a "reset")

But in fact, #1458: guard the rotating num value >= 0, which should be also included in this PR.
Since it still possible that someone set Warmup = 0, Sync = 0, Enqueues = 0 and NoValidation. 
For example, here is a malicious setting of GlobalParameters:
```
  NumElementsToValidate: 0
  MaxEnqueuesPerSync: 0
  EnqueuesPerSync: 0
  NumWarmups: 0
  SyncsPerBenchmark: 0
```
This is a malicious and meaningless setting. It runs nothing. But this will also cause the rotating-num = -1 and seg-fault. So I also picked #1458 to prevent this. 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Locally tested rotate_mode0.yaml and rotate_mode1.yaml. But still wait for CI to finish.

## Test Result

<!-- Briefly summarize test outcomes. -->
Local test passed. But still wait for CI to finish.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
