### PR TITLE
[rocPRIM] Avoid indirect copy-assignment on user-defined iterator in device_histogram

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -520,10 +520,8 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         grid_size.y = std::min(rows, ::rocprim::detail::ceiling_div(chosen_grid_size, grid_size.x));
         const unsigned int rows_per_block = ::rocprim::detail::ceiling_div(rows, grid_size.y);
 
-        op.shared_histograms = chosen_shared_histograms;
-        op.rows_per_block    = rows_per_block;
-
-        plan.device_callback = op;
+        plan.device_callback.shared_histograms = chosen_shared_histograms;
+        plan.device_callback.rows_per_block    = rows_per_block;
 
         // 4) 发射（无需再做任何按架构分发）
         plan.launch(grid_size,


### PR DESCRIPTION
## Motivation

`rocprim::detail::histogram_impl` was performing copy-assignment using a variable of type `HistogramSharedOp`. `HistogramSharedOp` contains a data member called `samples` that is set to a user-defined iterator. If this user-defined iterator contains non-copy-assignable members, then `histogram_impl`'s copy-assignment statement can fail to build.

## Technical Details

Since the purpose copy-assignment is to set some values in `HistogramSharedOp::device_callback`, we can just copy-assign those individual values directly and avoid the copy-assignment of the samples member.

## Test Plan

Build and run device_histogram unit tests. Ensure all tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
