### PR TITLE
[MIOpen] Fix bug with zero LDS at navi

### DIFF
--- a/projects/miopen/src/kernels/block_reduce.hpp
+++ b/projects/miopen/src/kernels/block_reduce.hpp
@@ -44,7 +44,8 @@ enum class ReduceThreadDim : int32_t
 template <uint32_t WARP_SIZE, BinaryOp_t Op, uint64_t reduce_size, ReduceThreadDim thread_dim>
 __device__ FLOAT_ACCUM block_reduce_warp(FLOAT_ACCUM val)
 {
-    static __shared__ FLOAT_ACCUM shared[reduce_size / WARP_SIZE];
+    // non-zero size
+    static __shared__ FLOAT_ACCUM shared[(reduce_size + WARP_SIZE - 1) / WARP_SIZE];
     uint64_t tid = 0;
     if(static_cast<int32_t>(thread_dim) & static_cast<int32_t>(ReduceThreadDim::X))
         tid += threadIdx.x;


### PR DESCRIPTION
## Motivation

The code build failed due to a zero-size LDS array being defined in one of the code branches

## Technical Details

Rounded to non-zero value

## Test Plan

navi31
./miopen_gtest --gtest_filter=*Full/GPU_PReLU_bwd_FP32.Test/0*

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
