### PR TITLE
Adjust exclusions in .pre-commit-config.yaml.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,23 @@
+# Pre-commit (https://pre-commit.com) configuration for assorted lint checks.
+#
+# See https://pre-commit.com/hooks.html for more hooks.
+
+# Top level exclusions from all hooks. Some of these could be moved into more
+# specific exclusions like check-yaml and clang-format, but for large generated
+# files even simple hooks like trailing-whitespace can be expensive.
+#
+# Note the yaml multiline literal and (?x) regex flag used here, see
+# https://pre-commit.com/#regular-expressions.
 exclude: |
-    third_party/
-    build/
-    build-.*/
-    _build/
-    projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile
+  (?x)
+    # Large yaml files
+    projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/.*|
+    # Large (20k+ LOC) source files
+    projects/hipblaslt/tensilelite/Tensile/CustomKernels/.*|
+    # Generated test yaml files
+    projects/hipblaslt/tensilelite/Tensile/Tests/.*|
+    # Large source files
+    projects/miopen/src/kernels/.*
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,10 @@ exclude: |
     # Generated test yaml files
     projects/hipblaslt/tensilelite/Tensile/Tests/.*|
     # Large source files
-    projects/miopen/src/kernels/.*
+    projects/miopen/src/kernels/.*|
+    # Generated files (see rocrand/tools/ _generator.cpp files)
+    projects/rocrand/library/.*precomputed\.(cpp|h)|
+    projects/rocrand/library/.*constants\.(cpp|h)
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@
 # https://pre-commit.com/#regular-expressions.
 exclude: |
   (?x)
+    # These subprojects are not yet migrated to the superrepo and have alterate
+    # sources of truth, so do not run checks on their code.
+    projects/composablekernel/.*|
+    projects/hipsolver/.*|
+    projects/rocsolver/.*|
     # Large yaml files
     projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/.*|
     # Large (20k+ LOC) source files


### PR DESCRIPTION
## Motivation

Progress on https://github.com/ROCm/rocm-libraries/issues/1480. This gets us closer to being able to run pre-commit across the whole project and then enable it continuously. Having consistent automated style checks will make contributing to multiple subprojects at a time significantly easier.

## Technical Details

This fixes the top level excludes in the pre-commit config file per the documentation at https://pre-commit.com/#regular-expressions and a search through similar files across github: https://github.com/search?q=path%3A%2F%5C.pre-commit-config.yaml%24%2F+%2F%5Eexclude%2F&type=code.

## Test Plan

Ran
```
pre-commit run trailing-whitespace --all-files
pre-commit run end-of-file-fixer --all-files
```

and observed that files on the exclude paths were not modified.

I'll send separate PRs with the changes from running those commands (`1794 files changed, 97673 insertions(+), 98287 deletions(-)`) then move on to running the more expensive and interesting hooks like clang-format (for C/C++), black (for Python), and check-yaml.

## Test Result

See above

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
