### PR TITLE
[hipfft-test] avoid invalid write past free in case of failing stream-division test + fix some compilation warnings

### DIFF
--- a/projects/hipfft/clients/hipfft_params.h
+++ b/projects/hipfft/clients/hipfft_params.h
@@ -1233,7 +1233,7 @@ private:
             // the plan wasn't created first
             const size_t num_values_to_check
                 = plan == INVALID_PLAN_HANDLE ? 1 : worksize_estimate.size();
-            for(auto idx = 0; ret == HIPFFT_SUCCESS && idx < num_values_to_check; idx++)
+            for(size_t idx = 0; ret == HIPFFT_SUCCESS && idx < num_values_to_check; idx++)
             {
                 ret = worksize_estimate[idx] != absurd_init_worksize_estimate
                           ? HIPFFT_SUCCESS

--- a/projects/hipfft/clients/tests/multi_stream_test.cpp
+++ b/projects/hipfft/clients/tests/multi_stream_test.cpp
@@ -301,11 +301,6 @@ public:
     }
 };
 
-static void mark_stream_work_done_callback(hipStream_t, hipError_t, void* usr_ptr)
-{
-    *(static_cast<int*>(usr_ptr)) = 1; // raise integer flag
-};
-
 template <typename real_data_type>
 static void init_data(hostbuf&                       hostbuffer,
                       const ParamsForMultiStreamDFT& params,
@@ -323,7 +318,7 @@ static void init_data(hostbuf&                       hostbuffer,
                     const std::vector<size_t>& h,
                     const std::vector<size_t>& l) {
         real_data_type ret = 0;
-        for(auto i = 0; i < k.size(); i++)
+        for(size_t i = 0; i < k.size(); i++)
             ret += static_cast<real_data_type>((k[i] * h[i]) % l[i])
                    / static_cast<real_data_type>(l[i]);
         return 2.0 * M_PI * ret;
@@ -475,31 +470,64 @@ TEST_P(multiStreamTest, impulseSignalOnOutput)
     if(!parameters.is_supported())
         GTEST_SKIP() << "Test not supported yet";
     // RAII encapsulation struct for hip streams:
-    struct raii_stream_t
+    struct sub_dft_stream_t
     {
+    private:
+        bool sub_dft_is_done;
+        bool cb_is_enqueued;
+
+    public:
         struct init_failure : public std::exception
         {
         };
-
         hipStream_t hip_stream;
-        raii_stream_t()
+        sub_dft_stream_t()
+            : sub_dft_is_done(false)
+            , cb_is_enqueued(false)
         {
             auto ret = hipStreamCreate(&hip_stream);
             if(ret != hipSuccess)
                 throw init_failure();
         }
-        ~raii_stream_t()
+        hipError_t enqueue_host_callback()
         {
+            if(cb_is_enqueued)
+                throw std::runtime_error("a callback is already enqueued for this stream");
+            auto mark_stream_work_done_callback = [](hipStream_t, hipError_t, void* work_done_ptr) {
+                *(static_cast<bool*>(work_done_ptr)) = true; // raise flag
+            };
+            const auto hip_status = hipStreamAddCallback(
+                hip_stream, mark_stream_work_done_callback, &sub_dft_is_done, 0 /* must be 0 */);
+            if(hip_status == hipSuccess)
+                cb_is_enqueued = true;
+            return hip_status;
+        }
+
+        ~sub_dft_stream_t()
+        {
+            if(cb_is_enqueued)
+            {
+                (void)hipStreamSynchronize(hip_stream);
+            }
             (void)hipStreamDestroy(hip_stream);
+        }
+
+        bool done() const
+        {
+            return sub_dft_is_done;
+        }
+        void reset_flags()
+        {
+            sub_dft_is_done = cb_is_enqueued = false;
         }
     };
     // create the test streams
-    std::vector<raii_stream_t> test_streams;
+    std::vector<sub_dft_stream_t> test_streams;
     try
     {
         test_streams.resize(ParamsForMultiStreamDFT::num_streams);
     }
-    catch(const raii_stream_t::init_failure& e)
+    catch(const sub_dft_stream_t::init_failure& e)
     {
         n_hip_failures++;
         info.str("");
@@ -640,7 +668,7 @@ TEST_P(multiStreamTest, impulseSignalOnOutput)
     // a (host) callback invoked upon completion of every stream's task.
     void* step_stream_input_data_ptr  = nullptr;
     void* step_stream_output_data_ptr = nullptr;
-    for(auto step_id = 0; step_id < ParamsForMultiStreamDFT::num_steps; step_id++)
+    for(size_t step_id = 0; step_id < ParamsForMultiStreamDFT::num_steps; step_id++)
     {
         const size_t elementary_itype_size
             = parameters.real_scalar_type_size()
@@ -664,9 +692,7 @@ TEST_P(multiStreamTest, impulseSignalOnOutput)
             step_stream_output_data_ptr
                 = step_id == 1 || !parameters.is_inverse() ? output_buf.data() : input_buf.data();
         }
-        // define integer flags for each stream being used
-        std::vector<int> stream_is_done(ParamsForMultiStreamDFT::num_streams, 0);
-        for(auto stream_id = 0; stream_id < ParamsForMultiStreamDFT::num_streams; stream_id++)
+        for(size_t stream_id = 0; stream_id < ParamsForMultiStreamDFT::num_streams; stream_id++)
         {
             hipfft_params& dft_op = sub_dft[step_id][stream_id];
             fft_error_code
@@ -676,10 +702,8 @@ TEST_P(multiStreamTest, impulseSignalOnOutput)
                 GTEST_FAIL() << "execution failed for step id " << step_id << " and stream id "
                              << stream_id;
             }
-            hip_error_code = hipStreamAddCallback(test_streams[stream_id].hip_stream,
-                                                  mark_stream_work_done_callback,
-                                                  stream_is_done.data() + stream_id,
-                                                  0 /* must be 0 */);
+
+            hip_error_code = test_streams[stream_id].enqueue_host_callback();
             if(hip_error_code != hipSuccess)
             {
                 n_hip_failures++;
@@ -706,9 +730,9 @@ TEST_P(multiStreamTest, impulseSignalOnOutput)
         size_t           time_waited_us            = 0;
         constexpr size_t sleep_time_us             = 1000; // 1 ms
         constexpr size_t failure_time_threshold_us = 10000000; // 10^7 us := 10 s
-        while(std::any_of(stream_is_done.begin(),
-                          stream_is_done.end(),
-                          [](const decltype(stream_is_done)::value_type& val) { return val == 0; })
+        while(std::any_of(test_streams.begin(),
+                          test_streams.end(),
+                          [](const sub_dft_stream_t& stream) { return !stream.done(); })
               && time_waited_us <= failure_time_threshold_us)
         {
 #ifdef WIN32
@@ -723,6 +747,13 @@ TEST_P(multiStreamTest, impulseSignalOnOutput)
             // The added callback probably was never invoked, i.e., the above set_stream
             // was not taken into consideration by some sub_dft plan.
             GTEST_FAIL() << "Time limit exceeded";
+        }
+        else
+        {
+            for(auto& stream : test_streams)
+            {
+                stream.reset_flags();
+            }
         }
     }
     // verify results:


### PR DESCRIPTION
This addresses possible invalid writes past free in case of failures for multi-stream hipfft tests.
Some compilation warnings are addressed, too (comparisons between signed and unsigned integers).