### PR TITLE
Update files in MIOpen that are missing a copyright

### DIFF
--- a/projects/miopen/script/sccache_wrapper.sh
+++ b/projects/miopen/script/sccache_wrapper.sh
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 #!/bin/bash
 set -e
 COMPILERS_HASH_DIR=${COMPILERS_HASH_DIR:-"/tmp/.sccache"}

--- a/projects/miopen/src/conv/invokers/impl_gemm.cpp
+++ b/projects/miopen/src/conv/invokers/impl_gemm.cpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include <miopen/conv/invokers/impl_gemm.hpp>
 
 #include <miopen/conv/data_invoke_params.hpp>

--- a/projects/miopen/src/conv/invokers/impl_gemm_dynamic.cpp
+++ b/projects/miopen/src/conv/invokers/impl_gemm_dynamic.cpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include <miopen/buffer_info.hpp>
 #include <miopen/conv/invokers/impl_gemm_dynamic.hpp>
 #include <miopen/conv/data_invoke_params.hpp>

--- a/projects/miopen/src/include/miopen/allocator.hpp
+++ b/projects/miopen/src/include/miopen/allocator.hpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef GUARD_MLOPEN_ALLOCATOR_HPP
 #define GUARD_MLOPEN_ALLOCATOR_HPP
 

--- a/projects/miopen/src/include/miopen/check_numerics.hpp
+++ b/projects/miopen/src/include/miopen/check_numerics.hpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef GUARD_MIOPEN_CHECK_NUMERICS_HPP
 #define GUARD_MIOPEN_CHECK_NUMERICS_HPP
 

--- a/projects/miopen/src/include/miopen/fusion_plan.hpp
+++ b/projects/miopen/src/include/miopen/fusion_plan.hpp
@@ -1,3 +1,5 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #ifndef MIOPEN_GUARD_MLOPEN_FUSION_PLAN_HPP
 #define MIOPEN_GUARD_MLOPEN_FUSION_PLAN_HPP

--- a/projects/miopen/src/include/miopen/md5.hpp
+++ b/projects/miopen/src/include/miopen/md5.hpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef GUARD_MLOPEN_MD5_HPP
 #define GUARD_MLOPEN_MD5_HPP
 

--- a/projects/miopen/src/include/miopen/op_kernel_args.hpp
+++ b/projects/miopen/src/include/miopen/op_kernel_args.hpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef MIOPEN_GUARD_MLOPEN_OP_KERNEL_ARGS_HPP
 #define MIOPEN_GUARD_MLOPEN_OP_KERNEL_ARGS_HPP
 

--- a/projects/miopen/src/include/miopen/reduce_tunables.hpp
+++ b/projects/miopen/src/include/miopen/reduce_tunables.hpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef REDUCE_TUNABLES_HPP
 #define REDUCE_TUNABLES_HPP
 

--- a/projects/miopen/src/include/miopen/tmp_dir.hpp
+++ b/projects/miopen/src/include/miopen/tmp_dir.hpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef MIOPEN_GUARD_MLOPEN_TMP_DIR_HPP
 #define MIOPEN_GUARD_MLOPEN_TMP_DIR_HPP
 

--- a/projects/miopen/src/kernels/activation_functions.h
+++ b/projects/miopen/src/kernels/activation_functions.h
@@ -1,3 +1,5 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #ifndef MIOPEN_NRN_OP_ID
 #define MIOPEN_NRN_OP_ID 0

--- a/projects/miopen/src/kernels/batchnorm_functions.h
+++ b/projects/miopen/src/kernels/batchnorm_functions.h
@@ -1,3 +1,5 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include "bfloat16_dev.hpp"
 

--- a/projects/miopen/src/kernels/data_ops.h
+++ b/projects/miopen/src/kernels/data_ops.h
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundef"
 #define UNUSED __attribute__((__unused__))

--- a/projects/miopen/src/kernels/kernels_batch.cpp.in
+++ b/projects/miopen/src/kernels/kernels_batch.cpp.in
@@ -1,1 +1,4 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include "${KERNEL_SRC_HPP_FILENAME}"

--- a/projects/miopen/src/kernels/reduction_functions.h
+++ b/projects/miopen/src/kernels/reduction_functions.h
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef GUARD_REDUCTION_FUNCTIONS_H
 #define GUARD_REDUCTION_FUNCTIONS_H
 

--- a/projects/miopen/src/kernels/static_composable_kernel/include/utility/amd_buffer_intrinsics.hpp
+++ b/projects/miopen/src/kernels/static_composable_kernel/include/utility/amd_buffer_intrinsics.hpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef CK_AMD_BUFFER_INTRINSIC_HPP
 #define CK_AMD_BUFFER_INTRINSIC_HPP
 

--- a/projects/miopen/src/ocl/fusionopconvocl.cpp
+++ b/projects/miopen/src/ocl/fusionopconvocl.cpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include <miopen/fusion.hpp>
 
 namespace miopen {

--- a/projects/miopen/test/gtest/attention_golden.hpp
+++ b/projects/miopen/test/gtest/attention_golden.hpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include <string_view>
 
 // json_attention_golden_data calculated with pytorch

--- a/projects/miopen/test/gtest/conv_api.cpp
+++ b/projects/miopen/test/gtest/conv_api.cpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include <iostream>
 #include <miopen/miopen.h>
 #include <miopen/errors.hpp>

--- a/projects/miopen/test/gtest/cpu_multi_head_attention.cpp
+++ b/projects/miopen/test/gtest/cpu_multi_head_attention.cpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include "cpu_multi_head_attention.hpp"
 
 struct CPU_Mha_FP32 : test::cpu::CPUMHATest<float, float>

--- a/projects/miopen/test/gtest/dumpTensorTest.cpp
+++ b/projects/miopen/test/gtest/dumpTensorTest.cpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include <iostream>
 #include <limits>
 

--- a/projects/miopen/test/gtest/perf_config_HipImplicitGemm3DGroupFwdXdlops.cpp
+++ b/projects/miopen/test/gtest/perf_config_HipImplicitGemm3DGroupFwdXdlops.cpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include <gtest/gtest.h>
 #include <gtest/group_conv.hpp>
 

--- a/projects/miopen/test/gtest/tuna_net.cpp
+++ b/projects/miopen/test/gtest/tuna_net.cpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include <gtest/ai_heuristics.hpp>
 #include <miopen/conv/heuristics/ai_heuristics.hpp>
 #include "../tensor_holder.hpp"

--- a/projects/miopen/test/nightlies/JenkinsfileNightlyAux
+++ b/projects/miopen/test/nightlies/JenkinsfileNightlyAux
@@ -1,3 +1,5 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 def rocmnode(name) {
     def node_name = 'rocmtest'

--- a/projects/miopen/test/nightlies/JenkinsfileNightlyConv2D
+++ b/projects/miopen/test/nightlies/JenkinsfileNightlyConv2D
@@ -1,3 +1,5 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 def rocmnode(name) {
     def node_name = 'rocmtest'

--- a/projects/miopen/test/nightlies/JenkinsfileNightlyConv2Daux
+++ b/projects/miopen/test/nightlies/JenkinsfileNightlyConv2Daux
@@ -1,3 +1,5 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 def rocmnode(name) {
     def node_name = 'rocmtest'

--- a/projects/miopen/test/nightlies/JenkinsfileNightlyFastFullConv2D
+++ b/projects/miopen/test/nightlies/JenkinsfileNightlyFastFullConv2D
@@ -1,3 +1,5 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 def rocmnode(name) {
     def node_name = 'rocmtest'

--- a/projects/miopen/test/nightlies/JenkinsfileNightlyFusions
+++ b/projects/miopen/test/nightlies/JenkinsfileNightlyFusions
@@ -1,3 +1,5 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 def rocmnode(name) {
     def node_name = 'rocmtest'

--- a/projects/miopen/test/nightlies/JenkinsfileNightlyRNN
+++ b/projects/miopen/test/nightlies/JenkinsfileNightlyRNN
@@ -1,3 +1,5 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 def rocmnode(name) {
     def node_name = 'rocmtest'

--- a/projects/miopen/test/nightlies/JenkinsfileNightlyReduce
+++ b/projects/miopen/test/nightlies/JenkinsfileNightlyReduce
@@ -1,4 +1,5 @@
-
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 def rocmnode(name) {
     def node_name = 'rocmtest'

--- a/projects/miopen/test/nightlies/JenkinsfileNightlyTensorOps
+++ b/projects/miopen/test/nightlies/JenkinsfileNightlyTensorOps
@@ -1,4 +1,5 @@
-
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 def rocmnode(name) {
     def node_name = 'rocmtest'

--- a/projects/miopen/test/perf_models/resnet50_v1.5.sh
+++ b/projects/miopen/test/perf_models/resnet50_v1.5.sh
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 #!/bin/bash
 # usage: resnet50_v1.5.sh <prec> <bs> [<cast1>] [<cast2>]
 # where prec is the precision arg for the driver command

--- a/projects/miopen/tools/sqlite2txt/main.cpp
+++ b/projects/miopen/tools/sqlite2txt/main.cpp
@@ -1,3 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include <sqlite3.h>
 
 #include <functional>


### PR DESCRIPTION
## Motivation

This PR is to update the AMD authored files in MIOpen that do not have copyrights as specified in ticket SWDEV-553033 "Palamida scan remediation [ROCM 7.1] - miopen - [copyright]".

## Technical Details

No functional changes in this PR.

## Test Plan

 - Rerun the Palamida scan to verify that all flagged files have been addressed.
