### PR TITLE
[rocRoller] Adding 'N-ary' and 'Concatenate' expression

### DIFF
--- a/shared/rocroller/lib/include/rocRoller/Expression.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Expression.hpp
@@ -543,6 +543,37 @@ namespace rocRoller
             int      width          = 0;
         };
 
+        struct Nary
+        {
+            std::vector<ExpressionPtr> operands;
+            std::string                comment = "";
+
+            template <typename T>
+            requires std::derived_from<T, Nary>
+            inline T& copyParams(const T& other)
+            {
+                return static_cast<T&>(*this);
+            }
+        };
+
+        template <typename T>
+        concept CNary = requires { requires std::derived_from<T, Nary>; };
+
+        struct Concatenate : Nary
+        {
+            constexpr static inline auto            Type       = Category::Value;
+            constexpr static inline EvaluationTimes EvalTimes  = EvaluationTimes::All();
+            constexpr static inline int             Complexity = 1;
+
+            DataType destinationType = DataType::None;
+
+            inline Concatenate& copyParams(const Concatenate& other)
+            {
+                destinationType = other.destinationType;
+                return Nary::copyParams(other);
+            }
+        };
+
         /**
          * @brief Register value from the coordinate graph.
          *

--- a/shared/rocroller/lib/include/rocRoller/Expression.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Expression.hpp
@@ -561,6 +561,17 @@ namespace rocRoller
         {
             requires std::derived_from<T, Nary>;
         };
+
+        /**
+         * @brief Perform bitwise concatenation among all operands.
+         * 
+         * Each operand must be dword aligned and the total number of operands'
+         * registers must be equal to the number of registers for
+         * 'destinationType'.
+         *
+         * All operands should have register type of literal, scalar or
+         * vector.
+         */
         struct Concatenate : Nary
         {
             constexpr static inline auto            Type       = Category::Value;

--- a/shared/rocroller/lib/include/rocRoller/Expression.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Expression.hpp
@@ -557,8 +557,10 @@ namespace rocRoller
         };
 
         template <typename T>
-        concept CNary = requires { requires std::derived_from<T, Nary>; };
-
+        concept CNary = requires
+        {
+            requires std::derived_from<T, Nary>;
+        };
         struct Concatenate : Nary
         {
             constexpr static inline auto            Type       = Category::Value;

--- a/shared/rocroller/lib/include/rocRoller/Expression_fwd.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Expression_fwd.hpp
@@ -90,6 +90,8 @@ namespace rocRoller
 
         struct Convert;
 
+        struct Concatenate;
+
         template <DataType DATATYPE>
         struct SRConvert;
 
@@ -123,6 +125,8 @@ namespace rocRoller
             LessThanEqual,
             Equal,
             NotEqual,
+
+            Concatenate,
 
             // --- Stochastic Rounding Convert (also binary) ---
             SRConvert<DataType::FP8>,

--- a/shared/rocroller/lib/include/rocRoller/Expression_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Expression_impl.hpp
@@ -377,6 +377,8 @@ namespace rocRoller
 
         EXPRESSION_INFO(Convert);
 
+        EXPRESSION_INFO(Concatenate);
+
         EXPRESSION_INFO_CUSTOM(SRConvert<DataType::FP8>, "SRConvert_FP8");
         EXPRESSION_INFO_CUSTOM(SRConvert<DataType::BF8>, "SRConvert_BF8");
 
@@ -474,6 +476,18 @@ namespace rocRoller
 
                 return matA & matB & matC & scaleA & scaleB & ScaledMatrixMultiply::EvalTimes;
             }
+
+            template <CNary Expr>
+            EvaluationTimes operator()(Expr const& expr) const
+            {
+                EvaluationTimes result = Expr::EvalTimes;
+                for(auto const& operand : expr.operands)
+                {
+                    result = result & call(operand);
+                }
+                return result;
+            }
+
             template <CTernary Expr>
             EvaluationTimes operator()(Expr const& expr) const
             {

--- a/shared/rocroller/lib/include/rocRoller/InstructionValues/Register.hpp
+++ b/shared/rocroller/lib/include/rocRoller/InstructionValues/Register.hpp
@@ -236,19 +236,12 @@ namespace rocRoller
              *   v->subset({1})
              *
              * would give v1, a single 32-bit register.
-             *
-             *   v->subset(1, 2)
-             *
-             * would give v2, a multi-register value consisting of two 32-bit registers and
-             * starting from the 2nd register. 
              */
             template <std::ranges::forward_range T>
             ValuePtr subset(T const& indices) const;
 
             template <std::integral T>
             ValuePtr subset(std::initializer_list<T> indices) const;
-
-            ValuePtr subset(int start, int length) const;
 
             /**
              * Splits the registers allocated into individual values.

--- a/shared/rocroller/lib/include/rocRoller/InstructionValues/Register.hpp
+++ b/shared/rocroller/lib/include/rocRoller/InstructionValues/Register.hpp
@@ -236,12 +236,19 @@ namespace rocRoller
              *   v->subset({1})
              *
              * would give v1, a single 32-bit register.
+             *
+             *   v->subset(1, 2)
+             *
+             * would give v2, a multi-register value consisting of two 32-bit registers and
+             * starting from the 2nd register. 
              */
             template <std::ranges::forward_range T>
             ValuePtr subset(T const& indices) const;
 
             template <std::integral T>
             ValuePtr subset(std::initializer_list<T> indices) const;
+
+            ValuePtr subset(int start, int length) const;
 
             /**
              * Splits the registers allocated into individual values.

--- a/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
@@ -939,6 +939,17 @@ namespace rocRoller
             return subset<std::initializer_list<T>>(indices);
         }
 
+        inline ValuePtr Value::subset(int start, int length) const
+        {
+            std::vector<int> coords;
+            coords.reserve(length);
+            for(int i = 0; i < length; ++i)
+            {
+                coords.push_back(start + i);
+            }
+            return subset(coords);
+        }
+
         template <std::ranges::forward_range T>
         inline ValuePtr Value::element(T const& indices) const
         {

--- a/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
@@ -939,17 +939,6 @@ namespace rocRoller
             return subset<std::initializer_list<T>>(indices);
         }
 
-        inline ValuePtr Value::subset(int start, int length) const
-        {
-            std::vector<int> coords;
-            coords.reserve(length);
-            for(int i = 0; i < length; ++i)
-            {
-                coords.push_back(start + i);
-            }
-            return subset(coords);
-        }
-
         template <std::ranges::forward_range T>
         inline ValuePtr Value::element(T const& indices) const
         {

--- a/shared/rocroller/lib/include/rocRoller/Serialization/CoordinateGraph.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Serialization/CoordinateGraph.hpp
@@ -243,8 +243,6 @@ namespace rocRoller
         {
         };
 
-        ROCROLLER_SERIALIZE_VECTOR(false, Expression::ExpressionPtr);
-
         template <typename IO, typename Context>
         struct MappingTraits<KernelGraph::CoordinateGraph::PiecewiseAffineJoin, IO, Context>
         {

--- a/shared/rocroller/lib/include/rocRoller/Serialization/Expression.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Serialization/Expression.hpp
@@ -32,6 +32,7 @@
 #include <rocRoller/KernelGraph/ControlGraph/Operation.hpp>
 #include <rocRoller/KernelGraph/CoordinateGraph/Dimension.hpp>
 #include <rocRoller/Serialization/Base.hpp>
+#include <rocRoller/Serialization/Containers.hpp>
 #include <rocRoller/Serialization/Enum.hpp>
 #include <rocRoller/Serialization/HasTraits.hpp>
 #include <rocRoller/Serialization/Variant.hpp>
@@ -176,6 +177,47 @@ namespace rocRoller
             }
 
             static void mapping(IO& io, TExp& val)
+            {
+                AssertFatal((std::same_as<EmptyContext, Context>));
+
+                Context ctx;
+                mapping(io, val, ctx);
+            }
+        };
+
+        ROCROLLER_SERIALIZE_VECTOR(false, Expression::ExpressionPtr);
+
+        template <Expression::CNary Expr, typename IO, typename Context>
+        struct MappingTraits<Expr, IO, Context>
+        {
+            using iot = IOTraits<IO>;
+
+            static void mapping(IO& io, Expr& exp, Context& ctx)
+            {
+                iot::mapRequired(io, "operands", exp.operands, ctx);
+            }
+
+            static void mapping(IO& io, Expr& val)
+            {
+                AssertFatal((std::same_as<EmptyContext, Context>));
+
+                Context ctx;
+                mapping(io, val, ctx);
+            }
+        };
+
+        template <typename IO, typename Context>
+        struct MappingTraits<Expression::Concatenate, IO, Context>
+        {
+            using iot = IOTraits<IO>;
+
+            static void mapping(IO& io, Expression::Concatenate& exp, Context& ctx)
+            {
+                iot::mapRequired(io, "operands", exp.operands, ctx);
+                iot::mapRequired(io, "dataType", exp.destinationType, ctx);
+            }
+
+            static void mapping(IO& io, Expression::Concatenate& val)
             {
                 AssertFatal((std::same_as<EmptyContext, Context>));
 

--- a/shared/rocroller/lib/include/rocRoller/Serialization/Expression.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Serialization/Expression.hpp
@@ -55,6 +55,8 @@ namespace rocRoller
             static const bool flow = true;
         };
 
+        ROCROLLER_SERIALIZE_VECTOR(false, Expression::ExpressionPtr);
+
         template <Expression::CBinary TExp, typename IO, typename Context>
         struct MappingTraits<TExp, IO, Context>
         {
@@ -184,8 +186,6 @@ namespace rocRoller
                 mapping(io, val, ctx);
             }
         };
-
-        ROCROLLER_SERIALIZE_VECTOR(false, Expression::ExpressionPtr);
 
         template <Expression::CNary Expr, typename IO, typename Context>
         struct MappingTraits<Expr, IO, Context>

--- a/shared/rocroller/lib/include/rocRoller/Serialization/Expression.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Serialization/Expression.hpp
@@ -214,7 +214,7 @@ namespace rocRoller
             static void mapping(IO& io, Expression::Concatenate& exp, Context& ctx)
             {
                 iot::mapRequired(io, "operands", exp.operands, ctx);
-                iot::mapRequired(io, "dataType", exp.destinationType, ctx);
+                iot::mapRequired(io, "dataType", exp.destinationType);
             }
 
             static void mapping(IO& io, Expression::Concatenate& val)

--- a/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
+++ b/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
@@ -110,6 +110,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(Register::ValuePtr const& value) const
             {
                 return equivalent(value->expression(), m_target->expression())
@@ -212,6 +220,14 @@ namespace rocRoller
                     cpy.r2hs = call(expr.r2hs);
                 }
                 return std::make_shared<Expression>(cpy);
+            }
+
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
             }
 
             ExpressionPtr operator()(Register::ValuePtr const& value) const
@@ -447,6 +463,74 @@ namespace rocRoller
                                                       : tree.at(r2hsLoc).expr,
                     }
                                                      .copyParams(expr)),
+                    deps,
+                    consolidationCount,
+                });
+
+                setComment(tree.back().expr, getComment(expr));
+
+                return tree;
+            }
+
+            template <CNary Expr>
+            ExpressionTree operator()(Expr const& expr) const
+            {
+                std::vector<ExpressionTree> operandTrees;
+                std::set<int>               deps;
+                std::vector<int>            operandLocs;
+                int                         consolidationCount = 0;
+
+                if(expr.operands.empty())
+                {
+                    return {};
+                }
+
+                operandTrees.reserve(expr.operands.size());
+                operandLocs.reserve(expr.operands.size());
+
+                for(auto const& operand : expr.operands)
+                {
+                    ExpressionTree operandTree = generateTree(operand);
+                    if(operandTree.empty())
+                    {
+                        return {};
+                    }
+                    operandTrees.push_back(std::move(operandTree));
+                }
+
+                ExpressionTree tree = operandTrees.at(0);
+                operandLocs.push_back(tree.size() - 1);
+                deps.insert(tree.size() - 1);
+
+                for(size_t i = 1; i < expr.operands.size(); ++i)
+                {
+                    auto combo = combine(tree, operandTrees.at(i));
+                    tree       = std::get<0>(combo);
+                    int loc    = std::get<1>(combo);
+                    operandLocs.push_back(loc);
+                    deps.insert(loc);
+                    consolidationCount += std::get<2>(combo);
+                }
+
+                for(size_t i = 0; i < expr.operands.size(); ++i)
+                {
+                    int loc = operandLocs.at(i);
+                    consolidationCount += tree.at(loc).consolidationCount;
+                }
+
+                std::vector<ExpressionPtr> nodeOperands;
+                nodeOperands.reserve(expr.operands.size());
+                for(size_t i = 0; i < expr.operands.size(); ++i)
+                {
+                    int loc = operandLocs.at(i);
+                    nodeOperands.push_back(canUseAsReg(tree.at(loc))
+                                               ? tree.at(loc).reg->expression()
+                                               : tree.at(loc).expr);
+                }
+
+                tree.push_back(ExpressionNode{
+                    nullptr,
+                    std::make_shared<Expression>(Expr{std::move(nodeOperands)}.copyParams(expr)),
                     deps,
                     consolidationCount,
                 });

--- a/shared/rocroller/lib/source/Expression.cpp
+++ b/shared/rocroller/lib/source/Expression.cpp
@@ -88,6 +88,24 @@ namespace rocRoller
                 return matA && matB && matC && scaleA && scaleB;
             }
 
+            template <CNary Expr>
+            bool operator()(Expr const& a, Expr const& b)
+            {
+                if(a.operands.size() != b.operands.size())
+                {
+                    return false;
+                }
+
+                bool result = true;
+                for(size_t i = 0; i < a.operands.size(); ++i)
+                {
+                    auto const& operandA = a.operands.at(i);
+                    auto const& operandB = b.operands.at(i);
+                    result               = result && call(operandA, operandB);
+                }
+                return result;
+            }
+
             template <CTernary T>
             bool operator()(T const& a, T const& b)
             {
@@ -283,6 +301,24 @@ namespace rocRoller
                 return matA && matB && matC && scaleA && scaleB;
             }
 
+            template <CNary Expr>
+            bool operator()(Expr const& a, Expr const& b)
+            {
+                if(a.operands.size() != b.operands.size())
+                {
+                    return false;
+                }
+
+                bool result = true;
+                for(size_t i = 0; i < a.operands.size(); ++i)
+                {
+                    auto const& operandA = a.operands.at(i);
+                    auto const& operandB = b.operands.at(i);
+                    result               = result && call(operandA, operandB);
+                }
+                return result;
+            }
+
             template <CTernary T>
             bool operator()(T const& a, T const& b)
             {
@@ -445,7 +481,8 @@ namespace rocRoller
             bool        throwIfNotSupported = true;
 
             template <typename Expr>
-            requires(CUnary<Expr> || CBinary<Expr> || CTernary<Expr>) void operator()(Expr& expr)
+            requires(CUnary<Expr> || CBinary<Expr> || CTernary<Expr> || CNary<Expr>)
+            void operator()(Expr& expr)
             {
                 expr.comment = std::move(comment);
             }
@@ -641,6 +678,17 @@ namespace rocRoller
             int operator()(Expr const& expr) const
             {
                 return Expr::Complexity + call(expr.lhs) + call(expr.r1hs) + call(expr.r2hs);
+            }
+
+            template <CNary Expr>
+            int operator()(Expr const& expr) const
+            {
+                auto complexity = Expr::Complexity;
+                for(auto const& operand : expr.operands)
+                {
+                    complexity = complexity + call(operand);
+                }
+                return complexity;
             }
 
             int operator()(ScaledMatrixMultiply const& expr) const

--- a/shared/rocroller/lib/source/Expression.cpp
+++ b/shared/rocroller/lib/source/Expression.cpp
@@ -481,8 +481,8 @@ namespace rocRoller
             bool        throwIfNotSupported = true;
 
             template <typename Expr>
-            requires(CUnary<Expr> || CBinary<Expr> || CTernary<Expr> || CNary<Expr>)
-            void operator()(Expr& expr)
+            requires(CUnary<Expr> || CBinary<Expr> || CTernary<Expr> || CNary<Expr>) void
+                operator()(Expr& expr)
             {
                 expr.comment = std::move(comment);
             }

--- a/shared/rocroller/lib/source/ExpressionTransformations/CombineShifts.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/CombineShifts.cpp
@@ -102,6 +102,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(ScaledMatrixMultiply const& expr) const
             {
                 auto cpy = expr;

--- a/shared/rocroller/lib/source/ExpressionTransformations/ConvertPropagation.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/ConvertPropagation.cpp
@@ -88,6 +88,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(Conditional const& expr) const
             {
                 auto cpy = expr;
@@ -198,6 +206,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             template <CValue Value>
             ExpressionPtr operator()(Value const& expr) const
             {
@@ -276,6 +292,14 @@ namespace rocRoller
                 cpy.r1hs = call(expr.r1hs);
                 cpy.r2hs = call(expr.r2hs);
                 return std::make_shared<Expression>(cpy);
+            }
+
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
             }
 
             template <CValue Value>

--- a/shared/rocroller/lib/source/ExpressionTransformations/DataFlowTagPropagation.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/DataFlowTagPropagation.cpp
@@ -64,6 +64,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr)
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             template <CTernary Expr>
             ExpressionPtr operator()(Expr const& expr)
             {

--- a/shared/rocroller/lib/source/ExpressionTransformations/FastDivision.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/FastDivision.cpp
@@ -495,6 +495,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(Divide const& expr) const
             {
                 auto lhs          = call(expr.lhs);

--- a/shared/rocroller/lib/source/ExpressionTransformations/FastMultiplication.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/FastMultiplication.cpp
@@ -166,6 +166,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(Multiply const& expr) const
             {
                 auto origResultType = resultVariableType(expr);

--- a/shared/rocroller/lib/source/ExpressionTransformations/FuseAssociative.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/FuseAssociative.cpp
@@ -223,6 +223,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             template <CShift Expr>
             ExpressionPtr operator()(Expr const& expr) const
             {

--- a/shared/rocroller/lib/source/ExpressionTransformations/FuseTernary.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/FuseTernary.cpp
@@ -65,6 +65,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(ScaledMatrixMultiply const& expr) const
             {
                 ScaledMatrixMultiply cpy = expr;

--- a/shared/rocroller/lib/source/ExpressionTransformations/LaunchTimeSubExpressions.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/LaunchTimeSubExpressions.cpp
@@ -199,6 +199,22 @@ namespace rocRoller
                 }
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr)
+            {
+                {
+                    auto launchResult = maybeLaunchEval(expr);
+                    if(launchResult)
+                        return launchResult;
+                }
+
+                {
+                    auto cpy = expr;
+                    std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                    return std::make_shared<Expression>(std::move(cpy));
+                }
+            }
+
             ExpressionPtr operator()(CommandArgumentPtr const& expr)
             {
                 // For a Value, if we still have a CommandArgument, we need to

--- a/shared/rocroller/lib/source/ExpressionTransformations/LowerBitfieldValues.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/LowerBitfieldValues.cpp
@@ -78,6 +78,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(ScaledMatrixMultiply const& expr) const
             {
                 ScaledMatrixMultiply cpy = expr;

--- a/shared/rocroller/lib/source/ExpressionTransformations/LowerExponential.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/LowerExponential.cpp
@@ -107,6 +107,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             // e^x = exp2(x * log2(e));
             ExpressionPtr operator()(Exponential const& expr) const
             {

--- a/shared/rocroller/lib/source/ExpressionTransformations/LowerPRNG.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/LowerPRNG.cpp
@@ -78,6 +78,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(ScaledMatrixMultiply const& expr) const
             {
                 ScaledMatrixMultiply cpy = expr;

--- a/shared/rocroller/lib/source/ExpressionTransformations/LowerUnsignedArithmeticShiftR.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/LowerUnsignedArithmeticShiftR.cpp
@@ -103,6 +103,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(ArithmeticShiftR const& expr) const
             {
                 auto lhs = call(expr.lhs);

--- a/shared/rocroller/lib/source/ExpressionTransformations/PositionalArgumentPropagation.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/PositionalArgumentPropagation.cpp
@@ -66,6 +66,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr)
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             template <CTernary Expr>
             ExpressionPtr operator()(Expr const& expr)
             {

--- a/shared/rocroller/lib/source/ExpressionTransformations/RestoreCommandArguments.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/RestoreCommandArguments.cpp
@@ -106,6 +106,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             ExpressionPtr operator()(AssemblyKernelArgumentPtr const& expr) const
             {
                 if(expr->expression)

--- a/shared/rocroller/lib/source/ExpressionTransformations/Simplify.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/Simplify.cpp
@@ -517,6 +517,14 @@ namespace rocRoller
                 return std::make_shared<Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression>(std::move(cpy));
+            }
+
             template <CValue Value>
             ExpressionPtr operator()(Value const& expr) const
             {

--- a/shared/rocroller/lib/source/Expression_contains.cpp
+++ b/shared/rocroller/lib/source/Expression_contains.cpp
@@ -67,6 +67,13 @@ namespace rocRoller
                 return call(expr.lhs) || call(expr.r1hs) || call(expr.r2hs);
             }
 
+            template <CNary U>
+            requires(!std::same_as<T, U>) bool operator()(U const& expr)
+            {
+                return std::ranges::any_of(expr.operands,
+                                           [this](auto const& operand) { return call(operand); });
+            }
+
             template <std::same_as<ScaledMatrixMultiply> U>
             requires(!std::same_as<T, U>) bool operator()(U const& expr)
             {
@@ -162,6 +169,14 @@ namespace rocRoller
             {
                 return identical(expr, subExpr) || call(expr.lhs) || call(expr.r1hs)
                        || call(expr.r2hs);
+            }
+
+            template <CNary Expr>
+            bool operator()(Expr const& expr) const
+            {
+                return identical(expr, subExpr)
+                       || std::ranges::any_of(
+                           expr.operands, [this](auto const& operand) { return call(operand); });
             }
 
             template <CValue U>

--- a/shared/rocroller/lib/source/Expression_evaluate.cpp
+++ b/shared/rocroller/lib/source/Expression_evaluate.cpp
@@ -67,6 +67,11 @@ namespace rocRoller
                 return EvaluateDetail::evaluateOp(expr, arg);
             }
 
+            CommandArgumentValue operator()(Concatenate const& expr)
+            {
+                throw std::runtime_error("N-ary operation present in runtime expression");
+            }
+
             CommandArgumentValue operator()(BitFieldExtract const& expr)
             {
                 throw std::runtime_error("BitFieldExtract present in runtime expression.");

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -1056,8 +1056,9 @@ namespace rocRoller
                     auto        length
                         = DataTypeInfo::Get(operandResultType.varType.dataType).registerCount;
 
-                    auto operandDest = dest->subset(offset, length);
-                    offset           = offset + length;
+                    auto operandDest
+                        = dest->subset(iota<int>(offset, offset + length).to<std::vector>());
+                    offset = offset + length;
 
                     co_yield call(operandDest, operand);
                 }

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -1043,9 +1043,13 @@ namespace rocRoller
                 }
                 else
                 {
-                    AssertFatal(DataTypeInfo::Get(destResultType.varType).registerCount
-                                    == dest->registerCount(),
-                                "Destination size mismatch");
+                    auto const expectDestRegisterCount
+                        = DataTypeInfo::Get(destResultType.varType).registerCount;
+                    auto const actualDestRegisterCount = dest->registerCount();
+                    AssertFatal(expectDestRegisterCount == actualDestRegisterCount,
+                                "Destination size mismatch.",
+                                ShowValue(expectDestRegisterCount),
+                                ShowValue(actualDestRegisterCount));
                 }
 
                 unsigned offset = 0;

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -1028,6 +1028,41 @@ namespace rocRoller
                 co_yield smm->mul(dest, rA, rB, rC, rScaleA, rScaleB, mi, maybeScaleBlockSize);
             }
 
+            Generator<Instruction> operator()(Register::ValuePtr& dest, Concatenate const& expr)
+            {
+                auto                    destResultType = resultType(expr);
+                std::vector<ResultType> operandResultTypes;
+                std::ranges::transform(expr.operands,
+                                       std::back_inserter(operandResultTypes),
+                                       [](auto const& operand) { return resultType(operand); });
+
+                if(dest == nullptr)
+                {
+                    dest = Register::Value::Placeholder(
+                        m_context, destResultType.regType, destResultType.varType, 1);
+                }
+                else
+                {
+                    AssertFatal(DataTypeInfo::Get(destResultType.varType).registerCount
+                                    == dest->registerCount(),
+                                "Destination size mismatch");
+                }
+
+                unsigned offset = 0;
+                for(size_t i = 0; i < expr.operands.size(); ++i)
+                {
+                    auto const& operand           = expr.operands[i];
+                    auto const& operandResultType = operandResultTypes[i];
+                    auto        length
+                        = DataTypeInfo::Get(operandResultType.varType.dataType).registerCount;
+
+                    auto operandDest = dest->subset(offset, length);
+                    offset           = offset + length;
+
+                    co_yield call(operandDest, operand);
+                }
+            }
+
             Generator<Instruction> operator()(Register::ValuePtr& dest, WaveTilePtr const& expr)
             {
                 Throw<FatalError>("WaveTile can only appear as an argument to MatrixMultiply.");

--- a/shared/rocroller/lib/source/Expression_referencedKernelArguments.cpp
+++ b/shared/rocroller/lib/source/Expression_referencedKernelArguments.cpp
@@ -66,6 +66,11 @@ namespace rocRoller
                 call(expr.r2hs);
             }
 
+            void operator()(CNary auto const& expr)
+            {
+                std::ranges::for_each(expr.operands, [this](auto const& op) { call(op); });
+            }
+
             void operator()(ScaledMatrixMultiply const& expr)
             {
                 call(expr.matA);

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -353,16 +353,10 @@ namespace rocRoller
                           + DataTypeInfo::Get(operandVariableType.dataType).registerCount;
                 }
 
-                if(expectedNumRegister != actualNumRegister)
-                {
-                    Throw<FatalError>("Length mismatch. ",
-                                      ShowValue(expr.destinationType),
-                                      " expects ",
-                                      ShowValue(expectedNumRegister),
-                                      " registers but ",
-                                      ShowValue(actualNumRegister),
-                                      " is provided");
-                }
+                AssertFatal(expectedNumRegister == actualNumRegister,
+                            ShowValue(expr.destinationType),
+                            ShowValue(expectedNumRegister),
+                            ShowValue(actualNumRegister));
 
                 return {registerType, variableType};
             }

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -325,6 +325,48 @@ namespace rocRoller
                 return {Register::Type::Scalar, varType};
             }
 
+            ResultType operator()(Concatenate const& expr)
+            {
+                auto         registerType = Register::Type::Literal;
+                VariableType variableType{expr.destinationType};
+
+                auto expectedNumRegister   = DataTypeInfo::Get(expr.destinationType).registerCount;
+                unsigned actualNumRegister = 0;
+
+                for(auto const& operand : expr.operands)
+                {
+                    auto&& [operandRegisterType, operandVariableType] = call(operand);
+                    switch(operandRegisterType)
+                    {
+                    case Register::Type::Literal:
+                    case Register::Type::Scalar:
+                    case Register::Type::Vector:
+                        break;
+                    default:
+                        Throw<FatalError>("Invalid register type for for combine",
+                                          ShowValue(operand));
+                    }
+
+                    registerType = Register::PromoteType(registerType, operandRegisterType);
+                    actualNumRegister
+                        = actualNumRegister
+                          + DataTypeInfo::Get(operandVariableType.dataType).registerCount;
+                }
+
+                if(expectedNumRegister != actualNumRegister)
+                {
+                    Throw<FatalError>("Length mismatch. ",
+                                      ShowValue(expr.destinationType),
+                                      " expects ",
+                                      ShowValue(expectedNumRegister),
+                                      " registers but ",
+                                      ShowValue(actualNumRegister),
+                                      " is provided");
+                }
+
+                return {registerType, variableType};
+            }
+
             ResultType operator()(CommandArgumentPtr const& expr)
             {
                 if(expr == nullptr)

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -343,8 +343,9 @@ namespace rocRoller
                     case Register::Type::Vector:
                         break;
                     default:
-                        Throw<FatalError>("Invalid register type for for combine",
-                                          ShowValue(operand));
+                        Throw<FatalError>(
+                            "Invalid register type for concatenate expression operands",
+                            ShowValue(operand));
                     }
 
                     registerType = Register::PromoteType(registerType, operandRegisterType);

--- a/shared/rocroller/lib/source/Expression_toString.cpp
+++ b/shared/rocroller/lib/source/Expression_toString.cpp
@@ -76,22 +76,16 @@ namespace rocRoller
             template <CNary Expr>
             std::string operator()(Expr const& expr) const
             {
-                std::string result = concatenate(ExpressionInfo<Expr>::name(), "(");
-                bool        first  = true;
-                for(auto const& operand : expr.operands)
-                {
-                    if(first)
-                    {
-                        result = concatenate(result, call(operand));
-                        first  = false;
-                    }
-                    else
-                    {
-                        result = concatenate(result, ", ", call(operand));
-                    }
-                }
-                result = concatenate(result, ")");
-                return result;
+                std::ostringstream stream;
+                stream << ExpressionInfo<Expr>::name() << '(';
+
+                auto operandToStrings = std::ranges::views::transform(
+                    expr.operands, [this](auto const& operand) { return call(operand); });
+                streamJoin(stream, operandToStrings, ", ");
+
+                stream << ')';
+
+                return stream.str();
             }
 
             std::string operator()(BitFieldExtract const& expr) const

--- a/shared/rocroller/lib/source/Expression_toString.cpp
+++ b/shared/rocroller/lib/source/Expression_toString.cpp
@@ -73,6 +73,27 @@ namespace rocRoller
                 return concatenate(ExpressionInfo<Expr>::name(), "(", call(expr.arg), ")");
             }
 
+            template <CNary Expr>
+            std::string operator()(Expr const& expr) const
+            {
+                std::string result = concatenate(ExpressionInfo<Expr>::name(), "(");
+                bool        first  = true;
+                for(auto const& operand : expr.operands)
+                {
+                    if(first)
+                    {
+                        result = concatenate(result, call(operand));
+                        first  = false;
+                    }
+                    else
+                    {
+                        result = concatenate(result, ", ", call(operand));
+                    }
+                }
+                result = concatenate(result, ")");
+                return result;
+            }
+
             std::string operator()(BitFieldExtract const& expr) const
             {
                 return concatenate(ExpressionInfo<BitFieldExtract>::name(),

--- a/shared/rocroller/lib/source/KernelGraph/ControlFlowRWTracer.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/ControlFlowRWTracer.cpp
@@ -110,6 +110,12 @@ namespace rocRoller::KernelGraph
             }
         }
 
+        template <Expression::CNary Expr>
+        void operator()(Expr const& expr)
+        {
+            std::ranges::for_each(expr.operands, [this](auto const& op) { call(op); });
+        }
+
         void operator()(Expression::DataFlowTag const& expr)
         {
             tags.insert(expr.tag);

--- a/shared/rocroller/lib/source/KernelGraph/Reindexer.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Reindexer.cpp
@@ -120,6 +120,14 @@ namespace rocRoller
                 return std::make_shared<Expression::Expression>(cpy);
             }
 
+            template <Expression::CNary Expr>
+            Expression::ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression::Expression>(std::move(cpy));
+            }
+
             Expression::ExpressionPtr operator()(CommandArgumentPtr const& expr) const
             {
                 return std::make_shared<Expression::Expression>(expr);

--- a/shared/rocroller/lib/source/KernelGraph/Transformations/CleanArguments.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Transformations/CleanArguments.cpp
@@ -133,6 +133,14 @@ namespace rocRoller
                 return std::make_shared<Expression::Expression>(cpy);
             }
 
+            template <CNary Expr>
+            ExpressionPtr operator()(Expr const& expr) const
+            {
+                auto cpy = expr;
+                std::ranges::for_each(cpy.operands, [this](auto& op) { op = call(op); });
+                return std::make_shared<Expression::Expression>(std::move(cpy));
+            }
+
             // Finds the AssemblyKernelArgument with the same name as the provided
             // CommandArgument.
             ExpressionPtr operator()(CommandArgumentPtr const& expr) const

--- a/shared/rocroller/lib/source/ReplaceKernelArgs.cpp
+++ b/shared/rocroller/lib/source/ReplaceKernelArgs.cpp
@@ -82,6 +82,16 @@ namespace rocRoller
                 m_lastResult = std::make_shared<Expression>(expr);
             }
 
+            template <CNary T>
+            Generator<Instruction> operator()(T expr)
+            {
+                for(auto&& operand : expr.operands)
+                {
+                    co_yield call(operand);
+                }
+                m_lastResult = std::make_shared<Expression>(std::move(expr));
+            }
+
             Generator<Instruction> operator()(ScaledMatrixMultiply expr)
             {
                 co_yield call(expr.matA);

--- a/shared/rocroller/test/catch/CMakeLists.txt
+++ b/shared/rocroller/test/catch/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(rocroller-tests-catch
         "${CMAKE_CURRENT_SOURCE_DIR}/LoadPackedTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MEMObserverTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MultipleLDSAllocationTest.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/NaryExpressionTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/RandomNumberExpressionTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/RandomNumberGenerationTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/RegisterTagManagerTest.cpp"

--- a/shared/rocroller/test/catch/NaryExpressionTest.cpp
+++ b/shared/rocroller/test/catch/NaryExpressionTest.cpp
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2024-2025 AMD ROCm(TM) Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <rocRoller/CodeGen/ArgumentLoader.hpp>
+#include <rocRoller/CodeGen/CopyGenerator.hpp>
+#include <rocRoller/CodeGen/MemoryInstructions.hpp>
+#include <rocRoller/Context.hpp>
+#include <rocRoller/InstructionValues/Register.hpp>
+
+#include <common/Utilities.hpp>
+
+#include "CustomMatchers.hpp"
+#include "TestContext.hpp"
+#include "TestKernels.hpp"
+
+#include <catch2/catch_test_case_info.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/interfaces/catch_interfaces_testcase.hpp>
+
+using namespace rocRoller;
+
+namespace ExpressionTest
+{
+    template <Register::Type OperandARegisterType,
+              Register::Type OperandBRegisterType,
+              Register::Type ResultRegisterType,
+              DataType       OperandDataType,
+              DataType       ResultDataType>
+    struct ConcatenateExpressionKernel : public AssemblyTestKernel
+    {
+        explicit ConcatenateExpressionKernel(ContextPtr context)
+            : AssemblyTestKernel(context)
+        {
+            REQUIRE(DataTypeInfo::Get(OperandDataType).registerCount * 2
+                    == DataTypeInfo::Get(ResultDataType).registerCount);
+        }
+
+        Generator<Instruction> codegen()
+        {
+            Register::ValuePtr s_result;
+            Register::ValuePtr s_operandA;
+            Register::ValuePtr s_operandB;
+
+            co_yield m_context->argLoader()->getValue("result", s_result);
+            co_yield m_context->argLoader()->getValue("operandA", s_operandA);
+            co_yield m_context->argLoader()->getValue("operandB", s_operandB);
+
+            auto result   = Register::Value::Placeholder(m_context,
+                                                       rocRoller::Register::Type::Vector,
+                                                       {ResultDataType, PointerType::PointerGlobal},
+                                                       1);
+            auto operandA = s_operandA->placeholder(OperandARegisterType, {});
+            auto operandB = s_operandB->placeholder(OperandBRegisterType, {});
+
+            co_yield result->allocate();
+            co_yield operandA->allocate();
+            co_yield operandB->allocate();
+            co_yield m_context->copier()->copy(result, s_result);
+            co_yield m_context->copier()->copy(operandA, s_operandA);
+            co_yield m_context->copier()->copy(operandB, s_operandB);
+
+            Register::ValuePtr v;
+            co_yield Expression::generate(
+                v,
+                std::make_shared<Expression::Expression>(Expression::Concatenate{
+                    {{operandA->expression(), operandB->expression()}}, ResultDataType}),
+                m_context);
+
+            REQUIRE(v->regType() == ResultRegisterType);
+
+            auto vv = v->placeholder(Register::Type::Vector, {});
+            co_yield m_context->copier()->copy(vv, v);
+            co_yield m_context->mem()->storeGlobal(
+                result, vv, 0, DataTypeInfo::Get(DataType::UInt64).elementBytes);
+        }
+
+        void generate() override
+        {
+            auto k = m_context->kernel();
+
+            k->addArgument({.name          = "result",
+                            .variableType  = {DataType::UInt64, PointerType::PointerGlobal},
+                            .dataDirection = DataDirection::WriteOnly});
+            k->addArgument({.name          = "operandA",
+                            .variableType  = DataType::UInt32,
+                            .dataDirection = DataDirection::ReadOnly});
+            k->addArgument({.name          = "operandB",
+                            .variableType  = DataType::UInt32,
+                            .dataDirection = DataDirection::ReadOnly});
+
+            m_context->schedule(k->preamble());
+            m_context->schedule(k->prolog());
+            m_context->schedule(codegen());
+            m_context->schedule(k->postamble());
+            m_context->schedule(k->amdgpu_metadata());
+        }
+    };
+
+    TEST_CASE("Run concatenate expression kernel with scalars", "[expression][gpu]")
+    {
+        auto          context        = TestContext::ForTestDevice();
+        std::uint32_t a              = 0xaaaaaaaaul;
+        std::uint32_t b              = 0xbbbbbbbbul;
+        std::uint64_t expectedResult = 0xbbbbbbbbaaaaaaaaull;
+        auto          result         = make_shared_device<uint64_t>();
+        ConcatenateExpressionKernel<rocRoller::Register::Type::Scalar,
+                                    rocRoller::Register::Type::Scalar,
+                                    rocRoller::Register::Type::Scalar,
+                                    DataType::UInt32,
+                                    DataType::UInt64>
+            kernel(context.get());
+        kernel({}, result.get(), a, b);
+        REQUIRE_THAT(result, HasDeviceScalarEqualTo(expectedResult));
+    }
+
+    TEST_CASE("Run concatenate expression kernel with vectors", "[expression][gpu]")
+    {
+        auto          context        = TestContext::ForTestDevice();
+        std::uint32_t a              = 0xaaaaaaaaul;
+        std::uint32_t b              = 0xbbbbbbbbul;
+        std::uint64_t expectedResult = 0xbbbbbbbbaaaaaaaaull;
+        auto          result         = make_shared_device<uint64_t>();
+        ConcatenateExpressionKernel<rocRoller::Register::Type::Vector,
+                                    rocRoller::Register::Type::Vector,
+                                    rocRoller::Register::Type::Vector,
+                                    DataType::UInt32,
+                                    DataType::UInt64>
+            kernel(context.get());
+        kernel({}, result.get(), a, b);
+        REQUIRE_THAT(result, HasDeviceScalarEqualTo(expectedResult));
+    }
+
+    TEST_CASE("Run concatenate expression kernel with mixed scalars and vectors",
+              "[expression][gpu]")
+    {
+        auto          context        = TestContext::ForTestDevice();
+        std::uint32_t a              = 0xaaaaaaaaul;
+        std::uint32_t b              = 0xbbbbbbbbul;
+        std::uint64_t expectedResult = 0xbbbbbbbbaaaaaaaaull;
+        auto          result         = make_shared_device<uint64_t>();
+        ConcatenateExpressionKernel<rocRoller::Register::Type::Scalar,
+                                    rocRoller::Register::Type::Vector,
+                                    rocRoller::Register::Type::Vector,
+                                    DataType::UInt32,
+                                    DataType::UInt64>
+            kernel(context.get());
+        kernel({}, result.get(), a, b);
+        REQUIRE_THAT(result, HasDeviceScalarEqualTo(expectedResult));
+    }
+}


### PR DESCRIPTION
## Motivation

Adding N-nary expression and `Concatenate` expression. The `Concatenate` expression will be the first n-ary expression that perform bitwise concatenation among all its operands. For example,
```
Concatenate(0xaaaaaaaa, 0xbbbbbbbb) = 0xbbbbbbbbaaaaaaaa
```
Currently, all operands for the `Concatenate` expression must be dword aligned (32-bits) and `Concatenate` expression assumes,
- all operands will have result value count equals to one,
- all operands will have 'literal', 'scalar' or 'vector' result register type.

## Technical Details

- Adding `N-ary` base class and `Concatenate` class to expressions
- Fixing various visitors by adding handler for `N-ary` expressions
- Adding type-infer and code generation for `Concatenate` expression

## Test Plan

Unit tests has been added to catch2 tests.

## Test Result

Passes all unit tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
