### PR TITLE
hipFFT remove hardcoding to /opt/rocm if ROCM_PATH is defined

### DIFF
--- a/projects/hipfft/CMakeLists.txt
+++ b/projects/hipfft/CMakeLists.txt
@@ -39,8 +39,15 @@ endif()
 
 
 # Workarounds..
-list( APPEND CMAKE_PREFIX_PATH /opt/rocm/llvm /opt/rocm )
-list( APPEND CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip /opt/rocm/lib/cmake/hip /opt/rocm/hip/cmake )
+if (DEFINED ENV{ROCM_PATH})
+  list( APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH} )
+  list( APPEND CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${ROCM_PATH}/lib/cmake/hip ${ROCM_PATH}/hip/cmake )
+else()
+  if(EXISTS "/opt/rocm")
+    list( APPEND CMAKE_PREFIX_PATH /opt/rocm/llvm /opt/rocm )
+    list( APPEND CMAKE_MODULE_PATH /opt/rocm/lib/cmake/hip /opt/rocm/hip/cmake )
+  endif()
+endif()
 
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.

--- a/projects/hipfft/CMakeLists.txt
+++ b/projects/hipfft/CMakeLists.txt
@@ -38,10 +38,9 @@ else()
 endif()
 
 
-# Workarounds..
 if (DEFINED ENV{ROCM_PATH})
   list( APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH} )
-  list( APPEND CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${ROCM_PATH}/lib/cmake/hip ${ROCM_PATH}/hip/cmake )
+  list( APPEND CMAKE_MODULE_PATH ${ROCM_PATH}/lib/cmake/hip ${ROCM_PATH}/hip/cmake )
 else()
   if(EXISTS "/opt/rocm")
     list( APPEND CMAKE_PREFIX_PATH /opt/rocm/llvm /opt/rocm )


### PR DESCRIPTION
If ROCM_PATH is set, use the path specified by it for setting the CMAKE_PREFIX_PATH and CMAKE_MODULE_PATH instead of hard-coding them always to be located under /opt/rocm.

## Motivation

ROCM may be installed nowadays in multiple different locations and all hard-codings to /opt/rocm should
be removed. TheRock for example allows installing the SDK inside the python venv from the python wheels.
