### PR TITLE
[rocPRIM] Fix hip version check for hipStreamLegacy usage (#1336)

### DIFF
--- a/projects/rocprim/test/rocprim/test_config_dispatch.cpp
+++ b/projects/rocprim/test/rocprim/test_config_dispatch.cpp
@@ -70,20 +70,23 @@ TEST(RocprimConfigDispatchTests, HostMatchesDevice)
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    const hipStream_t stream = 0;
+    // Test with both the default stream (0) and in hipStreamLegacy,
+    // since they take different code paths through rocprim::detail::get_device_from_stream.
+    for (const hipStream_t stream : {static_cast<hipStream_t>(hipStreamDefault), hipStreamLegacy})
+    {
+        target_arch host_arch;
+        HIP_CHECK(rocprim::detail::host_target_arch(stream, host_arch));
 
-    target_arch host_arch;
-    HIP_CHECK(rocprim::detail::host_target_arch(stream, host_arch));
+        common::device_ptr<target_arch> device_arch_ptr(1);
 
-    common::device_ptr<target_arch> device_arch_ptr(1);
+        hipLaunchKernelGGL(write_target_arch, dim3(1), dim3(1), 0, stream, device_arch_ptr.get());
+        HIP_CHECK(hipGetLastError());
 
-    hipLaunchKernelGGL(write_target_arch, dim3(1), dim3(1), 0, stream, device_arch_ptr.get());
-    HIP_CHECK(hipGetLastError());
+        const auto device_arch = device_arch_ptr.load_value_at(0);
 
-    const auto device_arch = device_arch_ptr.load_value_at(0);
-
-    ASSERT_NE(host_arch, target_arch::invalid);
-    ASSERT_EQ(host_arch, device_arch);
+        ASSERT_NE(host_arch, target_arch::invalid);
+        ASSERT_EQ(host_arch, device_arch);
+    }
 }
 
 TEST(RocprimConfigDispatchTests, ParseCommonArches)


### PR DESCRIPTION
## Motivation

The rocPRIM function `get_device_from_stream` was failing when `hipStreamLegacy` was passed in as the stream argument. As a result, several rocPRIM and rocThrust functions that depend on `hipStreamLegacy` also fail when it is used.

## Technical Details

`hipStreamLegacy` was added in HIP 6.2. The existing check that determines whether the HIP installation supports it contained a bug. This caused the issue to recur in ROCm 7.0. Fixing the check resolves the problem. The fix has already been incorporated into the develop branch - this change cherry-picks a new unit test that was added to the release/rocm-rel-7.0 branch to exercise the change.

## Test Plan

Build and run the test_config_dispatch test target.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
