### PR TITLE
TEST: Revert "[hipCUB][CCCL2.8 parity] Resolve match thread level reduction to cub"

### DIFF
--- a/projects/hipcub/CHANGELOG.md
+++ b/projects/hipcub/CHANGELOG.md
@@ -5,8 +5,6 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
 ## hipCUB-4.1.0 for ROCm 7.1
 
 ### Added
-
-* Exposed Thread-level reduction API `hipcub::ThreadReduce`.
 * Added `::hipcub::extents`, with limited parity to C++23's `std::extents`. Only `static extents` is supported; `dynamic extents` is not. Helper structs have been created to perform computations on `::hipcub::extents` only when the backend is rocPRIM. For the CUDA backend, similar functionality exists.
 * Added `projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_mdspan.hpp` to support `::hipcub::extents`.
 * Added `::hipcub::ForEachInExtents` API.
@@ -19,7 +17,6 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
     * `MONOREPO` - this options is intended to be used if you are building hipCUB from within a copy of the rocm-libraries repository that you have cloned (and therefore already contains rocPRIM). When selected, the build will try find the dependency in the local repository tree. If it cannot be found, the build will attempt to use git to perform a sparse-checkout of rocPRIM. If that also fails, it will fall back to using the `DOWNLOAD` option described above.
     
 ### Removed
-
 * Removed `TexRefInputIterator`, which was removed from CUB after CCCL's 2.6.0 release. This API should have already been removed, but somehow it remained and was not tested.
 * Deprecated `hipcub::ConstantInputIterator`, use `rocprim::constant_iterator` or `rocthrust::constant_iterator` instead.
 * Deprecated `hipcub::CountingInputIterator`, use `rocprim::counting_iterator` or `rocthrust::counting_iterator` instead.

--- a/projects/hipcub/CMakeLists.txt
+++ b/projects/hipcub/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
-cmake_policy(VERSION 3.18...3.25)
+cmake_policy(VERSION 3.18...3.21)
 
 # --------------------------------------
 # Update these variables at release time

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
@@ -38,11 +38,8 @@
 #include <rocprim/type_traits.hpp> // IWYU pragma: export
 #include <rocprim/type_traits_functions.hpp>
 
-#include <hip/hip_bf16.h>
-
 BEGIN_HIPCUB_NAMESPACE
 
-// TODO: this is deprecated in cub, we should also mark this as deprecated when we have libhipcxx
 struct Equality
 {
     template<class T, class U>
@@ -52,7 +49,6 @@ struct Equality
     }
 };
 
-// TODO: this is deprecated in cub, we should also mark this as deprecated when we have libhipcxx
 struct Inequality
 {
     template<class T, class U>
@@ -62,7 +58,6 @@ struct Inequality
     }
 };
 
-// TODO: this is deprecated in cub, we should also mark this as deprecated when we have libhipcxx
 template <class EqualityOp>
 struct InequalityWrapper
 {
@@ -78,7 +73,6 @@ struct InequalityWrapper
     }
 };
 
-// TODO: this is deprecated in cub, we should also mark this as deprecated when we have libhipcxx
 struct Sum
 {
     template<class T, class U>
@@ -88,7 +82,6 @@ struct Sum
     }
 };
 
-// TODO: this is deprecated in cub, we should also mark this as deprecated when we have libhipcxx
 struct Difference
 {
     template<class T, class U>
@@ -98,7 +91,6 @@ struct Difference
     }
 };
 
-// TODO: this is deprecated in cub, we should also mark this as deprecated when we have libhipcxx
 struct Division
 {
     template<class T, class U>
@@ -108,7 +100,6 @@ struct Division
     }
 };
 
-// TODO: this is deprecated in cub, we should also mark this as deprecated when we have libhipcxx
 struct Max
 {
     template<class T, class U>
@@ -120,7 +111,6 @@ struct Max
     }
 };
 
-// TODO: this is deprecated in cub, we should also mark this as deprecated when we have libhipcxx
 struct Min
 {
     template<class T, class U>
@@ -279,296 +269,6 @@ BinaryFlip<BinaryOpT> MakeBinaryFlip(BinaryOpT binary_op)
 {
     return BinaryFlip<BinaryOpT>(binary_op);
 }
-
-namespace internal
-{
-
-template<typename T>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Min instead.")]] SimdMin
-{
-    static_assert(false, "Unsupported specialization");
-};
-
-template<>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Min instead.")]] SimdMin<int16_t>
-{
-    using simd_type = int32_t;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    constexpr uint32_t
-        operator()(int32_t t, int32_t u) const
-    {
-        return HIPCUB_MIN(t, u);
-    }
-};
-
-template<>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Min instead.")]] SimdMin<uint16_t>
-{
-    using simd_type = uint32_t;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    constexpr uint32_t
-        operator()(uint32_t t, uint32_t u) const
-    {
-        return HIPCUB_MIN(t, u);
-    }
-};
-
-template<>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Min instead.")]] SimdMin<__half>
-{
-    using simd_type = __half2;
-
-    // This function is not constexpr because the operator< of __half does not produce a constant expression
-    HIPCUB_HOST_DEVICE __forceinline__
-    __half2
-        operator()(__half2 t, __half2 u) const
-    {
-        return HIPCUB_MIN(t, u);
-    }
-};
-
-template<>
-struct [[deprecated("SIMD intrinsics are currently not supported on HIP, use Min "
-                    "instead.")]] SimdMin<__hip_bfloat16>
-{
-    using simd_type = __hip_bfloat162;
-
-    // This function is not constexpr because the operator< of __half does not produce a constant expression
-    HIPCUB_HOST_DEVICE __forceinline__
-    __hip_bfloat162
-        operator()(__hip_bfloat162 t, __hip_bfloat162 u) const
-    {
-        return HIPCUB_MIN(t, u);
-    }
-};
-
-template<typename T>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Max instead.")]] SimdMax
-{
-    static_assert(false, "Unsupported specialization");
-};
-
-template<>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Max instead.")]] SimdMax<int16_t>
-{
-    using simd_type = int32_t;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    constexpr uint32_t
-        operator()(int32_t t, int32_t u) const
-    {
-        return HIPCUB_MAX(t, u);
-    }
-};
-
-template<>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Max instead.")]] SimdMax<uint16_t>
-{
-    using simd_type = uint32_t;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    constexpr uint32_t
-        operator()(uint32_t t, uint32_t u) const
-    {
-        return HIPCUB_MAX(t, u);
-    }
-};
-
-template<>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Max instead.")]] SimdMax<__half>
-{
-    using simd_type = __half2;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    __half2
-        operator()(__half2 t, __half2 u) const
-    {
-        return HIPCUB_MAX(t, u);
-    }
-};
-
-template<>
-struct [[deprecated("SIMD intrinsics are currently not supported on HIP, use Max "
-                    "instead.")]] SimdMax<__hip_bfloat16>
-{
-    using simd_type = __hip_bfloat162;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    __hip_bfloat162
-        operator()(__hip_bfloat162 t, __hip_bfloat162 u) const
-    {
-        return HIPCUB_MAX(t, u);
-    }
-};
-
-template<typename T>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Sum instead.")]] SimdSum
-{
-    static_assert(false, "Unsupported specialization");
-};
-
-template<>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Sum instead.")]] SimdSum<int16_t>
-{
-    using simd_type = int32_t;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    constexpr uint32_t
-        operator()(int32_t t, int32_t u) const
-    {
-        return t + u;
-    }
-};
-
-template<>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Sum instead.")]] SimdSum<uint16_t>
-{
-    using simd_type = uint32_t;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    constexpr uint32_t
-        operator()(uint32_t t, uint32_t u) const
-    {
-        return t + u;
-    }
-};
-
-template<>
-struct [[deprecated(
-    "SIMD intrinsics are currently not supported on HIP, use Sum instead.")]] SimdSum<__half>
-{
-    using simd_type = __half2;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    __half2
-        operator()(__half2 t, __half2 u) const
-    {
-        return t + u;
-    }
-};
-
-template<>
-struct [[deprecated("SIMD intrinsics are currently not supported on HIP, use Sum "
-                    "instead.")]] SimdSum<__hip_bfloat16>
-{
-    using simd_type = __hip_bfloat162;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    __hip_bfloat162
-        operator()(__hip_bfloat162 t, __hip_bfloat162 u) const
-    {
-        return t + u;
-    }
-};
-
-// TODO: Mul is not available in hipcub. Use hip::std::multiplies from libhipcxx in the future.
-
-template<typename T>
-struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP, so "
-                    "this operator will multiply 2 input values directly")]] SimdMul
-{
-    static_assert(false, "Unsupported specialization");
-};
-
-template<>
-struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP, so "
-                    "this operator will multiply 2 input values directly")]] SimdMul<int16_t>
-{
-    using simd_type = int32_t;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    constexpr uint32_t
-        operator()(int32_t t, int32_t u) const
-    {
-        return t * u;
-    }
-};
-
-template<>
-struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP, so "
-                    "this operator will multiply 2 input values directly")]] SimdMul<uint16_t>
-{
-    using simd_type = uint32_t;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    constexpr uint32_t
-        operator()(uint32_t t, uint32_t u) const
-    {
-        return t * u;
-    }
-};
-
-template<>
-struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP, so "
-                    "this operator will multiply 2 input values directly")]] SimdMul<__half>
-{
-    using simd_type = __half2;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    __half2
-        operator()(__half2 t, __half2 u) const
-    {
-        return t * u;
-    }
-};
-
-template<>
-struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP, so "
-                    "this operator will multiply 2 input values directly")]] SimdMul<__hip_bfloat16>
-{
-    using simd_type = __hip_bfloat162;
-
-    HIPCUB_HOST_DEVICE __forceinline__
-    __hip_bfloat162
-        operator()(__hip_bfloat162 t, __hip_bfloat162 u) const
-    {
-        return t * u;
-    }
-};
-
-template<typename ReduceOp, typename T>
-struct HipOperatorToSimdOperator
-{
-    static_assert(false, "Unsupported specialization");
-};
-
-template<typename T>
-struct HipOperatorToSimdOperator<Min, T>
-{
-    using type      = SimdMin<T>;
-    using simd_type = typename type::simd_type;
-};
-
-template<typename T>
-struct HipOperatorToSimdOperator<Max, T>
-{
-    using type      = SimdMax<T>;
-    using simd_type = typename type::simd_type;
-};
-
-template<typename T>
-struct HipOperatorToSimdOperator<Sum, T>
-{
-    using type      = SimdSum<T>;
-    using simd_type = typename type::simd_type;
-};
-
-// TODO: Mul is not available in hipcub. Use hip::std::multiplies from libhipcxx in the future.
-
-} // namespace internal
 
 namespace detail
 {

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_reduce.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_reduce.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2025, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2024, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -34,159 +34,55 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-namespace internal
-{
+/// Internal namespace (to prevent ADL mishaps between static functions when mixing different CUB installations)
+namespace internal {
 
-template<typename AccumType, typename InputType, typename ReductionOp, typename PrefixType>
-[[nodiscard]]
-__device__ __forceinline__
-AccumType
-    ThreadReduceSequential(const InputType& input, ReductionOp reduction_op, PrefixType prefix)
+template <
+    int         LENGTH,
+    typename    T,
+    typename    ReductionOp,
+    bool        NoPrefix = false>
+__device__ __forceinline__ T ThreadReduce(
+    T*           input,
+    ReductionOp reduction_op,
+    T           prefix = T(0))
 {
-    AccumType     retval = static_cast<AccumType>(prefix);
-    constexpr int length = ::hipcub::detail::static_size_v<InputType>();
-#pragma unroll
-    for(int i = 0; i < length; ++i)
-    {
+    T retval;
+    if(NoPrefix)
+        retval = input[0];
+    else
+        retval = prefix;
+
+    #pragma unroll
+    for (int i = 0 + NoPrefix; i < LENGTH; ++i)
         retval = reduction_op(retval, input[i]);
-    }
+
     return retval;
 }
 
-template<typename AccumType, typename InputType, typename ReductionOp>
-[[nodiscard]]
-__device__ __forceinline__
-AccumType ThreadReduceSequential(const InputType& input, ReductionOp reduction_op)
+template <
+    int         LENGTH,
+    typename    T,
+    typename    ReductionOp>
+__device__ __forceinline__ T ThreadReduce(
+    T           (&input)[LENGTH],
+    ReductionOp reduction_op,
+    T           prefix)
 {
-    AccumType     retval = input[0];
-    constexpr int length = ::hipcub::detail::static_size_v<InputType>();
-#pragma unroll
-    for(int i = 1; i < length; ++i)
-    {
-        retval = reduction_op(retval, input[i]);
-    }
-    return retval;
+    return ThreadReduce<LENGTH, false>((T*)input, reduction_op, prefix);
 }
 
-// This function is not used, it is just here for compatibility
-template<typename AccumType, typename InputType, typename ReductionOp>
-[[nodiscard]] [[deprecated("This function is an internal API, using it directly is not "
-                           "recommended.")]]
-__device__ __forceinline__
-AccumType ThreadReduceBinaryTree(const InputType& input, ReductionOp reduction_op)
+template <
+    int         LENGTH,
+    typename    T,
+    typename    ReductionOp>
+__device__ __forceinline__ T ThreadReduce(
+    T           (&input)[LENGTH],
+    ReductionOp reduction_op)
 {
-    constexpr auto length = ::hipcub::detail::static_size_v<InputType>();
-#pragma unroll
-    for(int i = 1; i < length; i *= 2)
-    {
-#pragma unroll
-        for(int j = 0; j + i < length; j += i * 2)
-        {
-            input[j] = reduction_op(input[j], input[j + i]);
-        }
-    }
-    return input[0];
+    return ThreadReduce<LENGTH, true>((T*)input, reduction_op);
 }
 
-template<typename AccumType, typename InputType, typename ReductionOp>
-[[nodiscard]] [[deprecated("This function is an internal API, using it directly is not "
-                           "recommended.")]]
-__device__ __forceinline__
-AccumType ThreadReduceTernaryTree(const InputType& input, ReductionOp reduction_op)
-{
-    constexpr auto length = ::hipcub::detail::static_size_v<InputType>();
-#pragma unroll
-    for(int i = 1; i < length; i *= 3)
-    {
-#pragma unroll
-        for(int j = 0; j + i < length; j += i * 3)
-        {
-            auto value = reduction_op(input[j], input[j + i]);
-            input[j]   = (j + i * 2 < length) ? reduction_op(value, input[j + i * 2]) : value;
-        }
-    }
-    return input[0];
-}
-
-// TODO: we should also implement ThreadReduceSimd after simd intrinsics are available.
-
-} // namespace internal
-
-template<typename InputType,
-         typename ReductionOp,
-         typename ValueType = typename ::std::remove_cv<typename ::std::remove_reference<
-             decltype(::std::declval<InputType>()[0])>::type>::type,
-         typename AccumType = ::rocprim::accumulator_t<ReductionOp, ValueType>>
-[[nodiscard]]
-__device__ __forceinline__
-AccumType ThreadReduce(const InputType& input, ReductionOp reduction_op)
-{
-    static_assert(::hipcub::detail::is_fixed_size_random_access_range<InputType>::value,
-                  "InputType must support the subscript operator[] and have a compile-time size");
-    static_assert(std::is_invocable<ReductionOp, ValueType, ValueType>::value,
-                  "ReductionOp must be invocable with operator()(ValueType, ValueType)");
-    return ::hipcub::internal::ThreadReduceSequential<AccumType>(input, reduction_op);
-}
-
-template<typename InputType,
-         typename ReductionOp,
-         typename PrefixType,
-         typename ValueType = typename ::std::remove_cv<typename ::std::remove_reference<
-             decltype(::std::declval<InputType>()[0])>::type>::type,
-         typename AccumType = ::rocprim::accumulator_t<ReductionOp, ValueType, PrefixType>>
-[[nodiscard]]
-__device__ __forceinline__
-AccumType ThreadReduce(const InputType& input, ReductionOp reduction_op, PrefixType prefix)
-{
-    static_assert(::hipcub::detail::is_fixed_size_random_access_range<InputType>::value,
-                  "InputType must support the subscript operator[] and have a compile-time size");
-    static_assert(std::is_invocable<ReductionOp, ValueType, ValueType>::value,
-                  "ReductionOp must be invocable with operator()(ValueType, ValueType)");
-    constexpr auto length = ::hipcub::detail::static_size_v<InputType>();
-    return ::hipcub::internal::ThreadReduceSequential<AccumType>(input, reduction_op, prefix);
-}
-
-template<int Length,
-         typename T,
-         typename ReductionOp,
-         typename AccumType = ::rocprim::accumulator_t<ReductionOp, T>>
-[[nodiscard]]
-__device__ __forceinline__
-AccumType ThreadReduce(const T* input, ReductionOp reduction_op)
-{
-    static_assert(Length > 0, "Length must be greater than 0");
-    static_assert(std::is_invocable<ReductionOp, T, T>::value,
-                  "ReductionOp must have the binary call operator: operator(V1, V2)");
-    auto array = reinterpret_cast<const T(*)[Length]>(input);
-    return ::hipcub::ThreadReduce(*array, reduction_op);
-}
-
-template<int Length,
-         typename T,
-         typename ReductionOp,
-         typename PrefixType,
-         typename AccumType = ::rocprim::accumulator_t<ReductionOp, T, PrefixType>,
-         typename std::enable_if<(Length > 0), int>::type = 0>
-[[nodiscard]]
-__device__ __forceinline__
-AccumType ThreadReduce(const T* input, ReductionOp reduction_op, PrefixType prefix)
-{
-    static_assert(std::is_invocable<ReductionOp, T, T>::value,
-                  "ReductionOp must have the binary call operator: operator(V1, V2)");
-    auto array = reinterpret_cast<const T(*)[Length]>(input);
-    return ::hipcub::ThreadReduce(*array, reduction_op, prefix);
-}
-
-template<int Length,
-         typename T,
-         typename ReductionOp,
-         typename PrefixType,
-         typename std::enable_if<(Length == 0), int>::type = 0>
-[[nodiscard]]
-__device__ __forceinline__
-T ThreadReduce(const T*, ReductionOp, PrefixType prefix)
-{
-    return prefix;
 }
 
 END_HIPCUB_NAMESPACE

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_type.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/util_type.hpp
@@ -979,46 +979,6 @@ using common_type_t = typename common_type<Ts...>::type;
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-namespace detail
-{
-
-template<typename T, typename = void>
-struct is_fixed_size_random_access_range : ::std::false_type
-{};
-
-template<typename T, size_t N>
-struct is_fixed_size_random_access_range<T[N], void> : ::std::true_type
-{};
-
-template<typename T>
-struct is_fixed_size_random_access_range<T, void_t<decltype(std::declval<T&>()[0])>>
-    : ::std::true_type
-{};
-
-// TODO: for is_fixed_size_random_access_range we also need to support array span and extents after we can use libhipcxx.
-template<typename T>
-using is_fixed_size_random_access_range_t = typename is_fixed_size_random_access_range<T>::type;
-
-template<typename T, typename = void>
-struct static_size
-{
-    static_assert(false, "static_size not supported for this type");
-};
-
-template<typename T, size_t N>
-struct static_size<T[N], void> : ::std::integral_constant<int, N>
-{};
-
-template<typename T>
-[[nodiscard]]
-__host__ __device__ __forceinline__
-constexpr size_t static_size_v()
-{
-    return static_size<T>::value;
-}
-
-} // namespace detail
-
 END_HIPCUB_NAMESPACE
 
 #endif // HIPCUB_ROCPRIM_UTIL_TYPE_HPP_

--- a/projects/hipcub/test/hipcub/test_hipcub_block_exchange.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_block_exchange.cpp
@@ -935,7 +935,7 @@ TYPED_TEST(HipcubBlockExchangeTests, ScatterToStripedGuarded)
         device_output,
         device_ranks);
 
-    [[maybe_unused]] type* host_output = new type[size];
+    type* host_output = new type[size];
     HIP_CHECK(hipMemcpy(host_output, device_output, sizeof(type) * size, hipMemcpyDeviceToHost));
 
     for(size_t i = 0; i < size; i++)

--- a/projects/hipcub/test/hipcub/test_hipcub_thread.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_thread.cpp
@@ -481,8 +481,7 @@ void thread_reduce_kernel(Type* const device_input, Type* device_output)
 {
     size_t input_index = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * Length;
     size_t output_index = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * Length;
-    device_output[output_index]
-        = hipcub::ThreadReduce<Length>(&device_input[input_index], sum_op());
+    device_output[output_index] = hipcub::internal::ThreadReduce<Length>(&device_input[input_index], sum_op());
 }
 
 TYPED_TEST(HipcubThreadOperationTests, Reduction)


### PR DESCRIPTION
Reverts ROCm/rocm-libraries#1095.

May be required to unblock pytorch build.  root cause is still being determined.  Testing to see if reverting this PR breaks any component builds.  Do not merge