### PR TITLE
hipFFT update for FFTW3 library search

### DIFF
--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -57,8 +57,31 @@ find_package( Boost REQUIRED)
 
 set( Boost_USE_STATIC_LIBS OFF )
 
-
+# searching FFTW with FindFFTW.cmake that is provided by project
+# because distro versions of FFTW does not include the cmake specific
+# helper files
 find_package( FFTW 3.0 REQUIRED MODULE COMPONENTS FLOAT DOUBLE )
+if( FFTW_FOUND )
+  message(STATUS "FFTW found by FindFFTW.cmake")
+else()
+  # searching fftw versions build from source code which contain
+  # cmake helper files like FFTW3Config.cmake
+  find_package(FFTW3 CONFIG QUIET )
+  find_package(FFTW3f CONFIG QUIET )
+  if( FFTW3_FOUND AND FFTW3f_FOUND )
+    message(STATUS "FFTW3 found by using the FFTW3Config.cmake")
+    get_target_property(fftw3_libs FFTW3::fftw3 IMPORTED_LOCATION_RELEASE)
+    get_target_property(fftw3f_libs FFTW3::fftw3f IMPORTED_LOCATION_RELEASE)
+
+    set (FFTW_FOUND ${FFTW3_FOUND})
+    set (FFTW_INCLUDE_DIRS ${FFTW3_INCLUDE_DIRS})
+    set (FFTW_LIBRARIES ${fftw3_libs} )
+    list( APPEND FFTW_LIBRARIES ${fftw3f_libs} )
+  endif()
+endif()
+message(STATUS "FFTW_FOUND: ${FFTW_FOUND}")
+message(STATUS "FFTW_INCLUDE_DIRS: ${FFTW_INCLUDE_DIRS}")
+message(STATUS "FFTW_LIBRARIES: ${FFTW_LIBRARIES}")
 
 set( BUILD_WITH_LIB "ROCM" CACHE STRING "Build ${PROJECT_NAME} with ROCM or CUDA libraries" )
 


### PR DESCRIPTION
Try to find the FFTW
1) By using an FindFFTW.cmake provided by the hipFFT project
2) By using the cmake's own search mechanism that utilites the
   FFTW3Config.cmake that is provided by the upstream FFTW source code.
    
FindFFTW.cmake is needed in case where the FFTW is installed
from the Linux distro specific packages that does not often
include the FFTW3Config.cmake and other cmake helper files.
    
Another search mechanism is used for example when building the
hipFFT in TheRock system where the FFTW 3.3.10 is also build from the
sources and we want to link against that version.