### PR TITLE
[python 3.13 compat] Explicitly install setuptools in rocblas venv setup.

### DIFF
--- a/projects/rocblas/cmake/virtualenv.cmake
+++ b/projects/rocblas/cmake/virtualenv.cmake
@@ -58,10 +58,10 @@ function(virtualenv_install)
             message(FATAL_ERROR ${rc})
         endif()
 
-        message("${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging")
+        message("${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging setuptools")
         execute_process(
             RESULT_VARIABLE rc
-            COMMAND ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging
+            COMMAND ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} -m pip install --upgrade packaging setuptools
         )
         if(rc)
             message(FATAL_ERROR ${rc})


### PR DESCRIPTION
We really need to complete the removal of this venv management as part of the build because it has multiple problems. But this change minimally makes it continue to function with python 3.13 when `setuptools` has not been manually installed in the system global site packages. Again, the chain of assumptions here is not great but at least is functional now.

Fixes https://github.com/ROCm/TheRock/issues/1452
