### PR TITLE
Use workgroupMappingDim in rocroller_host

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
@@ -35,6 +35,7 @@
 #include "utility.hpp"
 
 #include <rocRoller/CommandSolution.hpp>
+#include <rocRoller/CommandParameters.hpp>
 #include <rocRoller/Expression.hpp>
 #include <rocRoller/KernelGraph/CoordinateGraph/Dimension.hpp>
 #include <rocRoller/TensorDescriptor.hpp>

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
@@ -1377,7 +1377,7 @@ std::shared_ptr<GemmKernel> genGemmKernel(std::shared_ptr<SolutionParameters> ge
             "Only 0 (M) or 1 (N) are supported dimensions for workgroup mapping.",
             ShowValue(dim));
 
-        params->workgroupMapping = {dim, nullptr};
+        params->workgroupMappingDim = dim;
     }
 
     if(gemm->workgroupRemapXCC)


### PR DESCRIPTION
Resolving this patch: https://github.com/ROCm/TheRock/blob/main/patches/amd-mainline/rocm-libraries/0021-Use-workgroupMappingDim-in-rocroller_host.patch
