### PR TITLE
Temporarily disable __half specializations of Simd operators

### DIFF
--- a/projects/hipcub/CHANGELOG.md
+++ b/projects/hipcub/CHANGELOG.md
@@ -41,7 +41,7 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
 
 ### Known issues
 
-* The '__half' template specializations of SimdMin are currently disabled due to possible build issues with PyTorch.
+* The '__half' template specializations of Simd operators are currently disabled due to possible build issues with PyTorch.
 
 ## hipCUB-4.0.0 for ROCm 7.0
 

--- a/projects/hipcub/CHANGELOG.md
+++ b/projects/hipcub/CHANGELOG.md
@@ -30,6 +30,7 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
 * Deprecated hipCUB macros: `HIPCUB_MAX`, `HIPCUB_MIN`, `HIPCUB_QUOTIENT_FLOOR`, `HIPCUB_QUOTIENT_CEILING`, `HIPCUB_ROUND_UP_NEAREST` and `HIPCUB_ROUND_DOWN_NEAREST`.
 
 ### Changed
+
 * Changed include headers to avoid relative includes that have slipped in.
 * Changed `CUDA_STANDARD` for tests in `test/hipcub`, due to C++17 APIs such as `std::exclusive_scan` is used in some tests. Still use `CUDA_STANDARD 14` for `test/extra`.
 * Changed `CCCL_MINIMUM_VERSION` to `2.8.2` to align with CUB.
@@ -37,6 +38,10 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
 * Add support for large num_items `DeviceScan`, `DevicePartition` and `Reduce::{ArgMin, ArgMax}`.
 * Added tests for large num_items.
 * The previous dependency-related build option `DEPENDENCIES_FORCE_DOWNLOAD` has been renamed `EXTERNAL_DEPS_FORCE_DOWNLOAD` to differentiate it from the new rocPRIM dependency option described above. It's behaviour remains the same - it forces non-ROCm dependencies (Google Benchmark and Google Test) to be downloaded instead of searching for existing installed packages. This option defaults to `OFF`.
+
+### Known issues
+
+* The '__half' template specializations of SimdMin are currently disabled due to possible build issues with PyTorch.
 
 ## hipCUB-4.0.0 for ROCm 7.0
 

--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
@@ -317,7 +317,7 @@ struct [[deprecated(
         return HIPCUB_MIN(t, u);
     }
 };
-
+/*
 template<>
 struct [[deprecated(
     "SIMD intrinsics are currently not supported on HIP, use Min instead.")]] SimdMin<__half>
@@ -332,7 +332,7 @@ struct [[deprecated(
         return HIPCUB_MIN(t, u);
     }
 };
-
+*/
 template<>
 struct [[deprecated("SIMD intrinsics are currently not supported on HIP, use Min "
                     "instead.")]] SimdMin<__hip_bfloat16>
@@ -383,6 +383,7 @@ struct [[deprecated(
     }
 };
 
+/*
 template<>
 struct [[deprecated(
     "SIMD intrinsics are currently not supported on HIP, use Max instead.")]] SimdMax<__half>
@@ -396,6 +397,7 @@ struct [[deprecated(
         return HIPCUB_MAX(t, u);
     }
 };
+*/
 
 template<>
 struct [[deprecated("SIMD intrinsics are currently not supported on HIP, use Max "
@@ -445,7 +447,7 @@ struct [[deprecated(
         return t + u;
     }
 };
-
+/*
 template<>
 struct [[deprecated(
     "SIMD intrinsics are currently not supported on HIP, use Sum instead.")]] SimdSum<__half>
@@ -459,6 +461,7 @@ struct [[deprecated(
         return t + u;
     }
 };
+*/
 
 template<>
 struct [[deprecated("SIMD intrinsics are currently not supported on HIP, use Sum "
@@ -511,6 +514,7 @@ struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP
     }
 };
 
+/*
 template<>
 struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP, so "
                     "this operator will multiply 2 input values directly")]] SimdMul<__half>
@@ -524,6 +528,7 @@ struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP
         return t * u;
     }
 };
+*/
 
 template<>
 struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP, so "


### PR DESCRIPTION
## Motivation

Currently pytorch has a build issue with the new Simd<__half> operators.  While it is probably a compiler bug, it blocks pytorch builds.  This PR reverts the triggering addition of the Simd<__half> operators to unblock pytorch builds while the investigation is underway.

## Technical Details

Comments out the affected operators.

## Test Plan

Verified pytorch build works.

## Test Result

Pytorch build works.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
