### PR TITLE
[hipblaslt] Fix config lapack config error

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -53,6 +53,7 @@ if(HIPBLASLT_ENABLE_CLIENT)
     option(HIPBLASLT_ENABLE_SAMPLES "Build client samples." ON)
     # rocm-smi is not presently available on Windows so we do not require it.
     cmake_dependent_option(HIPBLASLT_ENABLE_ROCM_SMI "Require rocm_smi." ON "NOT WIN32" OFF)
+    option(HIPBLASLT_ENABLE_BLIS "Enable BLIS support." ON)
 endif()
 
 if(HIPBLASLT_ENABLE_HOST OR TENSILELITE_ENABLE_HOST)
@@ -66,7 +67,6 @@ endif()
 if(HIPBLASLT_ENABLE_HOST)
     option(HIPBLASLT_BUILD_SHARED_LIBS "Build the hipblaslt library as shared vs static" ON)
     option(HIPBLASLT_ENABLE_ROCROLLER "Use RocRoller library." ON)
-    option(HIPBLASLT_ENABLE_BLIS "Enable BLIS support." ON)
     cmake_dependent_option(HIPBLASLT_ENABLE_MARKER "Use the marker library." ON "NOT WIN32" OFF)
     option(HIPBLASLT_ENABLE_HIPBLAS_DIRECT "Use the hipblas header directly." OFF)
 endif()
@@ -114,6 +114,7 @@ else()
 endif()
 
 if(HIPBLASLT_ENABLE_CLIENT)
+    enable_language(Fortran)
     if(HIPBLASLT_ENABLE_BLIS)
         find_package(BLIS REQUIRED)
     endif()
@@ -408,7 +409,7 @@ if(HIPBLASLT_ENABLE_CLIENT)
 
 endif()
 
-if(HIPBLASLT_BUILD_TESTING OR BUILD_TESTING)
+if(HIPBLASLT_ENABLE_CLIENT AND (HIPBLASLT_BUILD_TESTING OR BUILD_TESTING))
     rocm_install(
         TARGETS hipblaslt-test
         COMPONENT tests
@@ -424,7 +425,7 @@ if(HIPBLASLT_BUILD_TESTING OR BUILD_TESTING)
     )
 endif()
 
-if(HIPBLASLT_ENABLE_SAMPLES)
+if(HIPBLASLT_ENABLE_CLIENT AND HIPBLASLT_ENABLE_SAMPLES)
     install(
         TARGETS
             sample_hipblaslt_gemm

--- a/projects/hipblaslt/install.sh
+++ b/projects/hipblaslt/install.sh
@@ -858,7 +858,7 @@ pushd .
   fi
 
   if [[ "${build_clients}" == false ]]; then
-    cmake_client_options="HIPBLASLT_ENABLE_CLIENTS=OFF"
+    cmake_client_options=" -DHIPBLASLT_ENABLE_CLIENT=OFF"
   else
     if [[ ( "${use_system_packages}" == false ) && ( "${install_dependencies}" == true ) ]]; then
         cmake_client_options=" -DBLAS_LIBRARIES=/usr/local/lib/libblas.a -DLAPACK_LIBRARIES='/usr/local/lib/liblapack.a;/usr/local/lib/libblas.a' -DBLA_STATIC=ON"


### PR DESCRIPTION
## Motivation

Fixes hipblaslt configure failure related to lapack and cleans up client related config options.

## Technical Details

- Fixes option name typo in the install script.
- Cleans up the build system logic to ensure client related targets aren't built or installed when disabling the client.
- Need to enable fortran when building the client so we correctly find blas libs.

## Test Plan

Tested locally and in the pipelines.

## Test Result

One spurious tox test failure on 90a.