### PR TITLE
[hipblaslt] Correct logic for enabling preload kernel arguments in tensilelite

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -3273,7 +3273,8 @@ class Solution(collections.abc.Mapping):
     #Need to force disabling PreloadKernArgs if compiler does not support
     #Can not just reject the solution since the user library may find any solutions
     if state["PreloadKernArgs"]:
-      if not (rocmVersion.major >= 6 and rocmVersion.patch >= 32650 and (isa == (9, 0, 10) or isa[:2] == (9, 4) or isa == (9, 5, 0))):
+      if (rocmVersion.major < 6 or (rocmVersion.major == 6 and rocmVersion.patch < 32650)) or \
+          not (isa == (9, 0, 10) or isa[:2] == (9, 4) or isa == (9, 5, 0)):
         #print("Force to Disable PreloadKernArgs since this hipcc version doesn't support",)
         state["PreloadKernArgs"] = 0
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This change corrects a logic error in determining whether the compiler supports Preload Kernel Arguments (PKA) based on the hipcc version. Incorrectly disabling PKA in certain compiler versions led to performance degradation. By revising the detection logic, this fix ensures PKA is properly enabled when supported, avoiding kernel performance drop.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Fixes a logic error in code gen when determining whether the compiler supports Preload Kernel Arguments (PKA). The previous implementation incorrectly assessed PKA support, leading to unintended performance issues.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Tested hipblaslt in staging environment 2361, which previously reproduced the performance drop. Compared results against mainline build 16493 after applying the fix. The testings are based on gfx90a and gfx942.

## Test Result

<!-- Briefly summarize test outcomes. -->
All selected kernels correctly enabled PKA, and the observed performance drop was resolved.
<img width="785" height="96" alt="image" src="https://github.com/user-attachments/assets/a53d398d-52a0-4829-bc8c-051b7d8ccc95" />

## Submission Checklist
* Fix patch
* Test verification

## Tickets:
* [](https://ontrack-internal.amd.com/browse/SWDEV-509683)

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
