### PR TITLE
Enabling DPP for SPIR-V

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -146,12 +146,17 @@
     #define ROCPRIM_MAX_ATOMIC_SIZE 16
 #endif
 
+#if defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1
+    #define SPIRV_CONSTEXPR
+#else
+    #define SPIRV_CONSTEXPR constexpr
+#endif
+
 // DPP is supported only after Volcanic Islands (GFX8+)
 // Only defined when support is present, in contrast to ROCPRIM_DETAIL_USE_DPP, which should be
 // always defined
 #if defined(__HIP_DEVICE_COMPILE__) && defined(__AMDGCN__) \
-    && (!defined(__GFX6__) && !defined(__GFX7__))          \
-    && !(defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1)
+    && (!defined(__GFX6__) && !defined(__GFX7__))
     #define ROCPRIM_DETAIL_HAS_DPP 1
 #endif
 
@@ -160,14 +165,6 @@
     #define ROCPRIM_DETAIL_USE_DPP 1
 #else
     #define ROCPRIM_DETAIL_USE_DPP 0
-#endif
-
-#if defined(ROCPRIM_DETAIL_HAS_DPP) && (defined(__GFX8__) || defined(__GFX9__))
-    #define ROCPRIM_DETAIL_HAS_DPP_BROADCAST 1
-#endif
-
-#if defined(ROCPRIM_DETAIL_HAS_DPP) && (defined(__GFX8__) || defined(__GFX9__))
-    #define ROCPRIM_DETAIL_HAS_DPP_WF 1
 #endif
 
 #if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS) && !defined(ROCPRIM_TARGET_SPIRV)
@@ -274,5 +271,8 @@
         ROCPRIM_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
     #define ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_POP ROCPRIM_CLANG_SUPPRESS_WARNING_POP
 #endif
+
+#define ROCPRIM_HAS_DPP() __builtin_amdgcn_is_invocable(__builtin_amdgcn_mov_dpp)
+#define ROCPRIM_HAS_PERMLANE() __builtin_amdgcn_is_invocable(__builtin_amdgcn_permlane16)
 
 #endif // ROCPRIM_CONFIG_HPP_

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -147,9 +147,9 @@
 #endif
 
 #if defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1
-    #define SPIRV_CONSTEXPR
+    #define ROCPRIM_SPIRV_CONSTEXPR
 #else
-    #define SPIRV_CONSTEXPR constexpr
+    #define ROCPRIM_SPIRV_CONSTEXPR constexpr
 #endif
 
 // DPP is supported only after Volcanic Islands (GFX8+)

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -272,7 +272,23 @@
     #define ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_POP ROCPRIM_CLANG_SUPPRESS_WARNING_POP
 #endif
 
-#define ROCPRIM_HAS_DPP() __builtin_amdgcn_is_invocable(__builtin_amdgcn_mov_dpp)
-#define ROCPRIM_HAS_PERMLANE() __builtin_amdgcn_is_invocable(__builtin_amdgcn_permlane16)
+#if __has_builtin(__builtin_amdgcn_is_invocable)
+    #define ROCPRIM_HAS_DPP() __builtin_amdgcn_is_invocable(__builtin_amdgcn_mov_dpp)
+    #define ROCPRIM_HAS_PERMLANE() __builtin_amdgcn_is_invocable(__builtin_amdgcn_permlane16)
+#elif defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1
+    #define ROCPRIM_HAS_DPP() false
+    #define ROCPRIM_HAS_PERMLANE() false
+#else
+    #if defined(ROCPRIM_DETAIL_HAS_DPP) && ROCPRIM_DETAIL_HAS_DPP == 1
+        #define ROCPRIM_HAS_DPP() true
+    #else
+        #define ROCPRIM_HAS_DPP() false
+    #endif
+    #if defined(__GFX8__) || defined(__GFX9__)
+        #define ROCPRIM_HAS_PERMLANE() false
+    #else
+        #define ROCPRIM_HAS_PERMLANE() true
+    #endif
+#endif
 
 #endif // ROCPRIM_CONFIG_HPP_

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -128,13 +128,14 @@ T lookback_reduce_forward_init(F scan_op, T block_prefix, unsigned int valid_ite
     T prefix = block_prefix;
     for(unsigned int i = 0; i < valid_items; ++i)
     {
-        if SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+        // If ROCPRIM_HAS_PERMLANE() is true, DPP_WF_RL1 is not available.
+        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
             prefix = warp_shuffle_down(prefix, 1, ::rocprim::arch::wavefront::size());
         }
         else
         {
-            if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
+            if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
             {
                 prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
             }
@@ -154,9 +155,10 @@ template<typename F, typename T>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 T lookback_reduce_forward(F scan_op, T prefix, T block_prefix)
 {
-    if SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+    // If ROCPRIM_HAS_PERMLANE() is true, DPP_WF_RL1 is not available.
+    if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
     {
-        if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
+        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
         {
             // If we can't rotate or shift the entire wavefront in one instruction,
             // iterate over rows of 16 lanes and use warp_readlane to communicate across rows.
@@ -189,7 +191,7 @@ T lookback_reduce_forward(F scan_op, T prefix, T block_prefix)
     }
     else
     {
-        if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
+        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
         {
             for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
             {

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -128,11 +128,21 @@ T lookback_reduce_forward_init(F scan_op, T block_prefix, unsigned int valid_ite
     T prefix = block_prefix;
     for(unsigned int i = 0; i < valid_items; ++i)
     {
-#ifdef ROCPRIM_DETAIL_HAS_DPP_WF
-        prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
-#else
-        prefix = warp_shuffle_down(prefix, 1, ::rocprim::arch::wavefront::size());
-#endif
+        if SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+        {
+            prefix = warp_shuffle_down(prefix, 1, ::rocprim::arch::wavefront::size());
+        }
+        else
+        {
+            if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
+            {
+                prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
+            }
+            else
+            {
+                prefix = warp_shuffle_down(prefix, 1, ::rocprim::arch::wavefront::size());
+            }
+        }
         prefix = scan_op(prefix, block_prefix);
     }
     return prefix;
@@ -144,39 +154,60 @@ template<typename F, typename T>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 T lookback_reduce_forward(F scan_op, T prefix, T block_prefix)
 {
-#ifdef ROCPRIM_DETAIL_HAS_DPP_WF
-    for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+    if SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
     {
-        prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
-        prefix = scan_op(prefix, block_prefix);
-    }
-#elif ROCPRIM_DETAIL_USE_DPP == 1
-    // If we can't rotate or shift the entire wavefront in one instruction,
-    // iterate over rows of 16 lanes and use warp_readlane to communicate across rows.
-    constexpr const int row_size = 16;
-
-    for(int j = ::rocprim::arch::wavefront::size(); j > 0; j -= row_size)
-    {
-        prefix = warp_readlane(
-            prefix,
-            j /* automatically taken modulo ::rocprim::arch::wavefront::size(), first read is lane 0 */);
-        prefix = scan_op(prefix, block_prefix);
-
-        ROCPRIM_UNROLL
-        for(int i = 0; i < row_size - 1; ++i)
+        if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
         {
-            prefix = warp_move_dpp<T, 0x101 /* DPP_ROW_SL1 */>(prefix);
-            prefix = scan_op(prefix, block_prefix);
+            // If we can't rotate or shift the entire wavefront in one instruction,
+            // iterate over rows of 16 lanes and use warp_readlane to communicate across rows.
+            constexpr const int row_size = 16;
+
+            for(int j = ::rocprim::arch::wavefront::size(); j > 0; j -= row_size)
+            {
+                prefix = warp_readlane(
+                    prefix,
+                    j /* automatically taken modulo ::rocprim::arch::wavefront::size(), first read is lane 0 */);
+                prefix = scan_op(prefix, block_prefix);
+
+                ROCPRIM_UNROLL
+                for(int i = 0; i < row_size - 1; ++i)
+                {
+                    prefix = warp_move_dpp<T, 0x101 /* DPP_ROW_SL1 */>(prefix);
+                    prefix = scan_op(prefix, block_prefix);
+                }
+            }
+        }
+        else
+        {
+            // If no DPP available at all, fall back to shuffles.
+            for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+            {
+                prefix = warp_shuffle(prefix, lane_id() + 1, ::rocprim::arch::wavefront::size());
+                prefix = scan_op(prefix, block_prefix);
+            }
         }
     }
-#else
-    // If no DPP available at all, fall back to shuffles.
-    for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+    else
     {
-        prefix = warp_shuffle(prefix, lane_id() + 1, ::rocprim::arch::wavefront::size());
-        prefix = scan_op(prefix, block_prefix);
+        if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
+        {
+            for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+            {
+                prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
+                prefix = scan_op(prefix, block_prefix);
+            }
+        }
+        else
+        {
+            // If no DPP available at all, fall back to shuffles.
+            for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+            {
+                prefix = warp_shuffle(prefix, lane_id() + 1, ::rocprim::arch::wavefront::size());
+                prefix = scan_op(prefix, block_prefix);
+            }
+        }
     }
-#endif
+
     return prefix;
 }
 

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_crosslane.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_crosslane.hpp
@@ -37,10 +37,100 @@ template<class T,
          unsigned int VirtualWaveSize,
          bool         UseAllReduce,
          bool         UseDPP = ROCPRIM_DETAIL_USE_DPP>
-using warp_reduce_crosslane =
-    typename std::conditional<UseDPP,
-                              warp_reduce_dpp<T, VirtualWaveSize, UseAllReduce>,
-                              warp_reduce_shuffle<T, VirtualWaveSize, UseAllReduce>>::type;
+class warp_reduce_crosslane
+{
+private:
+    template<class F>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void dispatch(F&& f)
+    {
+        if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
+        {
+            if constexpr(UseDPP)
+            {
+                f(warp_reduce_dpp<T, VirtualWaveSize, UseAllReduce>{});
+            }
+        }
+        else
+        {
+            f(warp_reduce_shuffle<T, VirtualWaveSize, UseAllReduce>{});
+        }
+    }
+
+public:
+    using storage_type = detail::empty_storage_type;
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void reduce(T input, T& output, BinaryFunction reduce_op)
+    {
+        dispatch([&](auto warp_reduce_impl) { warp_reduce_impl.reduce(input, output, reduce_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void reduce(T input, T& output, storage_type& storage, BinaryFunction reduce_op)
+    {
+        (void)storage; // disables unused parameter warning
+        this->reduce(input, output, reduce_op);
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void reduce(T input, T& output, unsigned int valid_items, BinaryFunction reduce_op)
+    {
+        dispatch([&](auto warp_reduce_impl)
+                 { warp_reduce_impl.reduce(input, output, valid_items, reduce_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void reduce(T              input,
+                T&             output,
+                unsigned int   valid_items,
+                storage_type&  storage,
+                BinaryFunction reduce_op)
+    {
+        (void)storage; // disables unused parameter warning
+        this->reduce(input, output, valid_items, reduce_op);
+    }
+
+    template<class Flag, class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void head_segmented_reduce(T input, T& output, Flag flag, BinaryFunction reduce_op)
+    {
+        dispatch([&](auto warp_reduce_impl)
+                 { warp_reduce_impl.head_segmented_reduce(input, output, flag, reduce_op); });
+    }
+
+    template<class Flag, class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void head_segmented_reduce(
+        T input, T& output, Flag flag, storage_type& storage, BinaryFunction reduce_op)
+    {
+        dispatch(
+            [&](auto warp_reduce_impl)
+            { warp_reduce_impl.head_segmented_reduce(input, output, flag, storage, reduce_op); });
+    }
+
+    template<class Flag, class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void tail_segmented_reduce(T input, T& output, Flag flag, BinaryFunction reduce_op)
+    {
+        dispatch([&](auto warp_reduce_impl)
+                 { warp_reduce_impl.tail_segmented_reduce(input, output, flag, reduce_op); });
+    }
+
+    template<class Flag, class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void tail_segmented_reduce(
+        T input, T& output, Flag flag, storage_type& storage, BinaryFunction reduce_op)
+    {
+        dispatch(
+            [&](auto warp_reduce_impl)
+            { warp_reduce_impl.tail_segmented_reduce(input, output, flag, storage, reduce_op); });
+    }
+};
 
 } // end namespace detail
 

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_crosslane.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_crosslane.hpp
@@ -44,7 +44,10 @@ private:
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void dispatch(F&& f)
     {
-        if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
+        // We use a dispatch here because when we target SPIR-V, we have to know after
+        // compiling SPIR-V whether DPP is available. Therefore, this check cannot
+        // be done at the C++ constexpr-level.
+        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
         {
             if constexpr(UseDPP)
             {

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -73,27 +73,50 @@ public:
             // registers (asume warp size of at least hardware warp-size)
             output = reduce_op(warp_move_dpp<T, 0x128>(output), output);
         }
-#ifdef ROCPRIM_DETAIL_HAS_DPP_BROADCAST
-        if(VirtualWaveSize > 16)
+
+        if SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
-            // row_bcast:15
-            output = reduce_op(warp_move_dpp<T, 0x142>(output), output);
-        }
-        if(VirtualWaveSize > 32)
-        {
-            // row_bcast:31
-            output = reduce_op(warp_move_dpp<T, 0x143>(output), output);
-        }
-        static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
+            if(VirtualWaveSize > 16)
+            {
+                // row_bcast:15
+                output = reduce_op(warp_swizzle<T, 0x1e0>(output), output);
+            }
+
+#if !ROCPRIM_TARGET_SPIRV
+            static_assert(VirtualWaveSize <= 32,
+                          "VirtualWaveSize > 32 is not supported without DPP broadcasts");
 #else
-        if(VirtualWaveSize > 16)
-        {
-            // row_bcast:15
-            output = reduce_op(warp_swizzle<T, 0x1e0>(output), output);
-        }
-        static_assert(VirtualWaveSize <= 32,
-                      "VirtualWaveSize > 32 is not supported without DPP broadcasts");
+            if constexpr(VirtualWaveSize > 32)
+            {
+                ROCPRIM_PRINT_ERROR_ONCE(
+                    "VirtualWaveSize > 32 is not supported without DPP broadcasts");
+                return;
+            }
 #endif
+        }
+        else
+        {
+            if(VirtualWaveSize > 16)
+            {
+                // row_bcast:15
+                output = reduce_op(warp_move_dpp<T, 0x142>(output), output);
+            }
+            if(VirtualWaveSize > 32)
+            {
+                // row_bcast:31
+                output = reduce_op(warp_move_dpp<T, 0x143>(output), output);
+            }
+
+#if !ROCPRIM_TARGET_SPIRV
+            static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
+#else
+            if constexpr(VirtualWaveSize > 64)
+            {
+                ROCPRIM_PRINT_ERROR_ONCE("VirtualWaveSize > 64 is not supported");
+                return;
+            }
+#endif
+        }
         // Read the result from the last lane of the logical warp
         output = warp_shuffle(output, VirtualWaveSize - 1, VirtualWaveSize);
     }

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -74,7 +74,7 @@ public:
             output = reduce_op(warp_move_dpp<T, 0x128>(output), output);
         }
 
-        if SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
             if(VirtualWaveSize > 16)
             {

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -74,6 +74,8 @@ public:
             output = reduce_op(warp_move_dpp<T, 0x128>(output), output);
         }
 
+        // Check for __builtin_amdgcn_permlane16; if it exists, the DPP equivalent is not available.
+        // Swizzle is kept instead of __builtin_amdgcn_permlanex16, as the latter can be slower in some cases.
         if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
             if(VirtualWaveSize > 16)

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_crosslane.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_crosslane.hpp
@@ -41,7 +41,10 @@ private:
     ROCPRIM_DEVICE ROCPRIM_INLINE
     void dispatch(F&& f)
     {
-        if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
+        // We use a dispatch here because when we target SPIR-V, we have to know after
+        // compiling SPIR-V whether DPP is available. Therefore, this check cannot
+        // be done at the C++ constexpr-level.
+        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
         {
             if constexpr(UseDPP)
             {

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_crosslane.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_crosslane.hpp
@@ -34,9 +34,214 @@ namespace detail
 {
 
 template<class T, unsigned int VirtualWaveSize, bool UseDPP = ROCPRIM_DETAIL_USE_DPP>
-using warp_scan_crosslane = typename std::conditional<UseDPP,
-                                                      warp_scan_dpp<T, VirtualWaveSize>,
-                                                      warp_scan_shuffle<T, VirtualWaveSize>>::type;
+class warp_scan_crosslane
+{
+private:
+    template<class F>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void dispatch(F&& f)
+    {
+        if SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
+        {
+            if constexpr(UseDPP)
+            {
+                f(warp_scan_dpp<T, VirtualWaveSize>{});
+            }
+        }
+        else
+        {
+            f(warp_scan_shuffle<T, VirtualWaveSize>{});
+        }
+    }
+
+public:
+    using storage_type = detail::empty_storage_type;
+
+    // Inclusive scan
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void inclusive_scan(T input, T& output, BinaryFunction scan_op)
+    {
+        dispatch([&](auto impl) { impl.inclusive_scan(input, output, scan_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void inclusive_scan(T input, T& output, storage_type& storage, BinaryFunction scan_op)
+    {
+        (void)storage;
+        inclusive_scan(input, output, scan_op);
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void inclusive_scan(T input, T& output, BinaryFunction scan_op, T init)
+    {
+        dispatch([&](auto impl) { impl.inclusive_scan(input, output, scan_op, init); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void inclusive_scan(T input, T& output, storage_type& storage, BinaryFunction scan_op, T init)
+    {
+        (void)storage;
+        inclusive_scan(input, output, scan_op, init);
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void inclusive_scan(T input, T& output, T& reduction, BinaryFunction scan_op)
+    {
+        dispatch([&](auto impl) { impl.inclusive_scan(input, output, reduction, scan_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void inclusive_scan(
+        T input, T& output, T& reduction, storage_type& storage, BinaryFunction scan_op)
+    {
+        (void)storage;
+        inclusive_scan(input, output, reduction, scan_op);
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void inclusive_scan(T input, T& output, T& reduction, BinaryFunction scan_op, T init)
+    {
+        dispatch([&](auto impl) { impl.inclusive_scan(input, output, reduction, scan_op, init); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void inclusive_scan(
+        T input, T& output, T& reduction, storage_type& storage, BinaryFunction scan_op, T init)
+    {
+        (void)storage;
+        inclusive_scan(input, output, reduction, scan_op, init);
+    }
+
+    // Exclusive scan
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exclusive_scan(T input, T& output, T init, BinaryFunction scan_op)
+    {
+        dispatch([&](auto impl) { impl.exclusive_scan(input, output, init, scan_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exclusive_scan(T input, T& output, T init, storage_type& storage, BinaryFunction scan_op)
+    {
+        (void)storage;
+        exclusive_scan(input, output, init, scan_op);
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exclusive_scan(T input, T& output, storage_type& storage, BinaryFunction scan_op)
+    {
+        (void)storage;
+        dispatch([&](auto impl) { impl.exclusive_scan(input, output, storage, scan_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exclusive_scan(
+        T input, T& output, storage_type& storage, T& reduction, BinaryFunction scan_op)
+    {
+        (void)storage;
+        dispatch([&](auto impl)
+                 { impl.exclusive_scan(input, output, storage, reduction, scan_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exclusive_scan(T input, T& output, T init, T& reduction, BinaryFunction scan_op)
+    {
+        dispatch([&](auto impl) { impl.exclusive_scan(input, output, init, reduction, scan_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void exclusive_scan(
+        T input, T& output, T init, T& reduction, storage_type& storage, BinaryFunction scan_op)
+    {
+        (void)storage;
+        exclusive_scan(input, output, init, reduction, scan_op);
+    }
+
+    // Scan (inclusive + exclusive)
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void scan(T input, T& inclusive_output, T& exclusive_output, T init, BinaryFunction scan_op)
+    {
+        dispatch([&](auto impl)
+                 { impl.scan(input, inclusive_output, exclusive_output, init, scan_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void scan(T              input,
+              T&             inclusive_output,
+              T&             exclusive_output,
+              T              init,
+              storage_type&  storage,
+              BinaryFunction scan_op)
+    {
+        (void)storage;
+        scan(input, inclusive_output, exclusive_output, init, scan_op);
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void scan(T              input,
+              T&             inclusive_output,
+              T&             exclusive_output,
+              storage_type&  storage,
+              BinaryFunction scan_op)
+    {
+        (void)storage;
+        dispatch([&](auto impl)
+                 { impl.scan(input, inclusive_output, exclusive_output, storage, scan_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void scan(T              input,
+              T&             inclusive_output,
+              T&             exclusive_output,
+              T              init,
+              T&             reduction,
+              BinaryFunction scan_op)
+    {
+        dispatch(
+            [&](auto impl)
+            { impl.scan(input, inclusive_output, exclusive_output, init, reduction, scan_op); });
+    }
+
+    template<class BinaryFunction>
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void scan(T              input,
+              T&             inclusive_output,
+              T&             exclusive_output,
+              T              init,
+              T&             reduction,
+              storage_type&  storage,
+              BinaryFunction scan_op)
+    {
+        (void)storage;
+        scan(input, inclusive_output, exclusive_output, init, reduction, scan_op);
+    }
+
+    // Broadcast
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    T broadcast(T input, const unsigned int src_lane, storage_type& storage)
+    {
+        T result{};
+        dispatch([&](auto impl) { result = impl.broadcast(input, src_lane, storage); });
+        return result;
+    }
+};
 
 } // end namespace detail
 

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -75,30 +75,52 @@ public:
             if(row_lane_id >= 8)
                 output = scan_op(t, output);
         }
-#ifdef ROCPRIM_DETAIL_HAS_DPP_BROADCAST
-        if(VirtualWaveSize > 16)
+
+        if SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
-            T t = warp_move_dpp<T, 0x142>(output); // row_bcast:15
-            if(lane_id % 32 >= 16)
-                output = scan_op(t, output);
-        }
-        if(VirtualWaveSize > 32)
-        {
-            T t = warp_move_dpp<T, 0x143>(output); // row_bcast:31
-            if(lane_id >= 32)
-                output = scan_op(t, output);
-        }
-        static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
+            if(VirtualWaveSize > 16)
+            {
+                T t = warp_swizzle<T, 0x1e0>(output); // row_bcast:15
+                if(lane_id % 32 >= 16)
+                    output = scan_op(t, output);
+            }
+
+#if !ROCPRIM_TARGET_SPIRV
+            static_assert(VirtualWaveSize <= 32,
+                          "VirtualWaveSize > 32 is not supported without DPP broadcasts");
 #else
-        if(VirtualWaveSize > 16)
-        {
-            T t = warp_swizzle<T, 0x1e0>(output); // row_bcast:15
-            if(lane_id % 32 >= 16)
-                output = scan_op(t, output);
-        }
-        static_assert(VirtualWaveSize <= 32,
-                      "VirtualWaveSize > 32 is not supported without DPP broadcasts");
+            if constexpr(VirtualWaveSize > 32)
+            {
+                ROCPRIM_PRINT_ERROR_ONCE(
+                    "VirtualWaveSize > 32 is not supported without DPP broadcasts");
+                return;
+            }
 #endif
+        }
+        else
+        {
+            if(VirtualWaveSize > 16)
+            {
+                T t = warp_move_dpp<T, 0x142>(output); // row_bcast:15
+                if(lane_id % 32 >= 16)
+                    output = scan_op(t, output);
+            }
+            if(VirtualWaveSize > 32)
+            {
+                T t = warp_move_dpp<T, 0x143>(output); // row_bcast:31
+                if(lane_id >= 32)
+                    output = scan_op(t, output);
+            }
+#if !ROCPRIM_TARGET_SPIRV
+            static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
+#else
+            if constexpr(VirtualWaveSize > 64)
+            {
+                ROCPRIM_PRINT_ERROR_ONCE("VirtualWaveSize > 64 is not supported");
+                return;
+            }
+#endif
+        }
     }
 
     template<class BinaryFunction>

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -76,6 +76,8 @@ public:
                 output = scan_op(t, output);
         }
 
+        // Check for __builtin_amdgcn_permlane16; if it exists, the DPP equivalent is not available.
+        // Swizzle is kept instead of __builtin_amdgcn_permlanex16, as the latter can be slower in some cases.
         if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
             if(VirtualWaveSize > 16)

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -76,7 +76,7 @@ public:
                 output = scan_op(t, output);
         }
 
-        if SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
             if(VirtualWaveSize > 16)
             {


### PR DESCRIPTION
## Motivation

We temporarily disabled DPP when building with SPIR-V. A new check was necessary, this PR introduces this check.

## Technical Details

DPP will only be enabled when using SPIR-V with a compiler newer then rocm  7.0. The new check should not have any different machine code when building without SPIR-V, it is all done at compile time.

## Test Plan

Build and run warp_reduce and warp_scan tests.

## Test Result

Passed for both SPIR-V and non-spirv.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
