### PR TITLE
Revert "remove options --no-enumerate (#966)"

### DIFF
--- a/shared/tensile/Tensile/cmake/TensileConfig.cmake
+++ b/shared/tensile/Tensile/cmake/TensileConfig.cmake
@@ -215,6 +215,9 @@ function(TensileCreateLibraryFiles
     set(Options ${Options} "--architecture=${archString}")
   endif()
 
+  # We do not need to do device enumeration at library build time.
+  set(Options ${Options} "--no-enumerate")
+
   set(CommandLine ${Script} ${Options} ${Tensile_LOGIC_PATH} ${Tensile_OUTPUT_PATH} HIP)
   if (WIN32 OR (VIRTUALENV_BIN_DIR AND VIRTUALENV_PYTHON_EXENAME))
     set(CommandLine ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} ${CommandLine})


### PR DESCRIPTION
This reverts commit 68a380c7dd5498a744d5d63892d7431a5aa31367.

https://github.com/ROCm/rocm-libraries/pull/966#issuecomment-3282990383
> The root cause makes no sense and the lack of any reproduction information makes it just lore that we will carry forward indefinitely (and if true, could be hiding a serious problem).