### PR TITLE
Add missing workspace_size argument for cpp gemm initialize

### DIFF
--- a/projects/hipblaslt/clients/bench/src/client_api_overhead.cpp
+++ b/projects/hipblaslt/clients/bench/src/client_api_overhead.cpp
@@ -502,6 +502,7 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
         }
 
         // Make sure to initialize every time when algo changes
+        gemm.setMaxWorkspaceBytes(max_workspace_size);
         CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
         CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     }
@@ -534,6 +535,7 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
         algoIdx = hipblaslt_ext::getIndexFromAlgo(heuristicResult[0].algo);
 
         // Make sure to initialize every time when algo changes
+        gemm.setMaxWorkspaceBytes(max_workspace_size);
         CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
 
         start_ext_run = std::chrono::steady_clock::now();
@@ -645,6 +647,7 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
         }
 
         // Make sure to initialize every time when algo changes
+        gemm.setMaxWorkspaceBytes(workspace_size);
         CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[validIdx[0]].algo, d_workspace));
         CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     }
@@ -697,6 +700,7 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
         }
 
         // Make sure to initialize every time when algo changes
+        gemm.setMaxWorkspaceBytes(workspace_size);
         CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[validIdx[0]].algo, d_workspace));
 
         start_ext_run = std::chrono::steady_clock::now();
@@ -810,6 +814,7 @@ void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
         }
 
         // Make sure to initialize every time when algo changes
+        gemm.setMaxWorkspaceBytes(max_workspace_size);
         CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
         CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     }
@@ -864,6 +869,7 @@ void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
         }
 
         // Make sure to initialize every time when algo changes
+        gemm.setMaxWorkspaceBytes(max_workspace_size);
         CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
 
         start_ext_run = std::chrono::steady_clock::now();

--- a/projects/hipblaslt/clients/bench/src/client_groupedgemm_fixed_mk.cpp
+++ b/projects/hipblaslt/clients/bench/src/client_groupedgemm_fixed_mk.cpp
@@ -948,6 +948,7 @@ int test_hipblaslt(hipDataType                 in_datatype,
     for(int sol = 0; sol < validIdx.size(); sol++)
     {
         // step3: Initialize
+        groupedGemm.setMaxWorkspaceBytes(max_workspace_size);
         CHECK_HIPBLASLT_ERROR(
             groupedGemm.initialize(heuristicResult[validIdx[sol]].algo, d_workspace));
 

--- a/projects/hipblaslt/clients/bench/src/client_sequence.cpp
+++ b/projects/hipblaslt/clients/bench/src/client_sequence.cpp
@@ -522,8 +522,11 @@ int main(int argc, char** argv)
         for(size_t gemmIdx = 0; gemmIdx < layer.size(); gemmIdx++)
         {
             if(layer[gemmIdx].type == Layer::TYPE::GEMM)
+            {
+                (*layer[gemmIdx].gemms)[b].setMaxWorkspaceBytes(layer[gemmIdx].ws_size);
                 CHECK_HIPBLASLT_ERROR((*layer[gemmIdx].gemms)[b].initialize(
                     heuristicResults[gemmIdx].algo, layer[gemmIdx].ws));
+            }
         }
 
     hipEvent_t event_gpu_time_start, event_gpu_time_end;

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -3481,6 +3481,7 @@ void testing_matmul_with_bias(const Arguments& arg,
             {
                 if(arg.use_ext)
                 {
+                    gemmVec[0].setMaxWorkspaceBytes(workspace_size);
                     CHECK_HIPBLASLT_ERROR(
                         gemmVec[0].initialize(heuristicResult[sol].algo,
                                               tuningVec[heuristicTuningIndex[sol]],
@@ -3514,6 +3515,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                 //grouped gemm
                 if(arg.use_user_args)
                 {
+                    groupedGemmVec[0].setMaxWorkspaceBytes(workspace_size);
                     CHECK_HIPBLASLT_ERROR(
                         groupedGemmVec[0].initialize(heuristicResult[sol].algo,
                                                      tuningVec[heuristicTuningIndex[0]],
@@ -3529,6 +3531,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                 }
                 else
                 {
+                    groupedGemmVec[0].setMaxWorkspaceBytes(workspace_size);
                     CHECK_HIPBLASLT_ERROR(
                         groupedGemmVec[0].initialize(heuristicResult[sol].algo,
                                                      tuningVec[heuristicTuningIndex[0]],
@@ -3658,10 +3661,13 @@ void testing_matmul_with_bias(const Arguments& arg,
                 if(arg.use_ext)
                 {
                     for(int32_t b = 0; b < block_count; b++)
+                    {
+                        gemmVec[b].setMaxWorkspaceBytes(workspace_size);
                         CHECK_HIPBLASLT_ERROR(
                             gemmVec[b].initialize(heuristicResult[sol].algo,
                                                   tuningVec[heuristicTuningIndex[sol]],
                                                   *dWorkspace));
+                    }
                     if(arg.skip_slow_solution_ratio)
                         pre_gpu_time(
                             arg.use_gpu_timer, event_gpu_time_start, gpu_time_used, stream);
@@ -3813,6 +3819,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                     //grouped gemm
                     for(int32_t b = 0; b < block_count; b++)
                     {
+                        groupedGemmVec[b].setMaxWorkspaceBytes(workspace_size);
                         CHECK_HIPBLASLT_ERROR(groupedGemmVec[b].initialize(
                             heuristicResult[sol].algo,
                             tuningVec[heuristicTuningIndex[sol]],
@@ -3874,12 +3881,15 @@ void testing_matmul_with_bias(const Arguments& arg,
                 {
                     //grouped gemm
                     for(int32_t b = 0; b < block_count; b++)
+                    {
+                        groupedGemmVec[b].setMaxWorkspaceBytes(workspace_size);
                         CHECK_HIPBLASLT_ERROR(groupedGemmVec[b].initialize(
                             heuristicResult[sol].algo,
                             tuningVec[heuristicTuningIndex[sol]],
                             ((unsigned char*)(*dWorkspace) + b * workspace_size),
                             false,
                             stream));
+                    }
 
                     if(arg.skip_slow_solution_ratio)
                         pre_gpu_time(

--- a/projects/hipblaslt/clients/samples/01_hipblaslt_gemm_ext/sample_hipblaslt_gemm_ext.cpp
+++ b/projects/hipblaslt/clients/samples/01_hipblaslt_gemm_ext/sample_hipblaslt_gemm_ext.cpp
@@ -125,12 +125,14 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     return;

--- a/projects/hipblaslt/clients/samples/02_hipblaslt_gemm_batched_ext/sample_hipblaslt_gemm_batched_ext.cpp
+++ b/projects/hipblaslt/clients/samples/02_hipblaslt_gemm_batched_ext/sample_hipblaslt_gemm_batched_ext.cpp
@@ -125,12 +125,14 @@ void simplebatchGemmExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     return;

--- a/projects/hipblaslt/clients/samples/03_hipblaslt_gemm_tuning_splitk_ext/sample_hipblaslt_gemm_tuning_splitk_ext.cpp
+++ b/projects/hipblaslt/clients/samples/03_hipblaslt_gemm_tuning_splitk_ext/sample_hipblaslt_gemm_tuning_splitk_ext.cpp
@@ -182,14 +182,17 @@ void simpleGemmTuningSplitKExt(hipblasLtHandle_t  handle,
     }
     else
     {
-        ws_ptr = d_workspace;
+        ws_ptr         = d_workspace;
+        workspace_size = max_workspace_size;
     }
 
+    gemm.setMaxWorkspaceBytes(workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[validIdx[0]].algo, tunings[0], ws_ptr));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 
     // Make sure to initialize every time when algo changes
     // If tuning is given, the API will not return success if the solution cannot accept an user tuning parameter.
+    gemm.setMaxWorkspaceBytes(workspace_size);
     CHECK_HIPBLASLT_ERROR(
         gemm.initialize(heuristicResult[validIdxTuning[0]].algo, tunings[1], ws_ptr));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));

--- a/projects/hipblaslt/clients/samples/04_hipblaslt_gemm_bias_ext/sample_hipblaslt_gemm_bias_ext.cpp
+++ b/projects/hipblaslt/clients/samples/04_hipblaslt_gemm_bias_ext/sample_hipblaslt_gemm_bias_ext.cpp
@@ -134,12 +134,14 @@ void simpleGemmEpilogueBiasVecExt(hipblasLtHandle_t   handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     return;

--- a/projects/hipblaslt/clients/samples/05_hipblaslt_gemm_get_all_algos_ext/sample_hipblaslt_gemm_get_all_algos_ext.cpp
+++ b/projects/hipblaslt/clients/samples/05_hipblaslt_gemm_get_all_algos_ext/sample_hipblaslt_gemm_get_all_algos_ext.cpp
@@ -149,9 +149,11 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[validIdx[0]].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     return;

--- a/projects/hipblaslt/clients/samples/06_hipblaslt_gemm_get_algo_by_index_ext/sample_hipblaslt_gemm_get_algo_by_index_ext.cpp
+++ b/projects/hipblaslt/clients/samples/06_hipblaslt_gemm_get_algo_by_index_ext/sample_hipblaslt_gemm_get_algo_by_index_ext.cpp
@@ -165,9 +165,11 @@ void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     return;

--- a/projects/hipblaslt/clients/samples/07_hipblaslt_gemm_alphavec_ext/sample_hipblaslt_gemm_alphavec_ext.cpp
+++ b/projects/hipblaslt/clients/samples/07_hipblaslt_gemm_alphavec_ext/sample_hipblaslt_gemm_alphavec_ext.cpp
@@ -129,6 +129,7 @@ void simpleGemmAlphaVecExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
@@ -140,6 +141,7 @@ void simpleGemmAlphaVecExt(hipblasLtHandle_t  handle,
     }
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     return;

--- a/projects/hipblaslt/clients/samples/08_hipblaslt_gemm_gelu_aux_bias_ext/sample_hipblaslt_gemm_gelu_aux_bias_ext.cpp
+++ b/projects/hipblaslt/clients/samples/08_hipblaslt_gemm_gelu_aux_bias_ext/sample_hipblaslt_gemm_gelu_aux_bias_ext.cpp
@@ -140,12 +140,14 @@ void simpleGemmGeluAuxBiasExt(hipblasLtHandle_t   handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     CHECK_HIP_ERROR(hipFree(d_aux_buffer));

--- a/projects/hipblaslt/clients/samples/09_hipblaslt_gemm_amax_ext/sample_hipblaslt_gemm_amax_ext.cpp
+++ b/projects/hipblaslt/clients/samples/09_hipblaslt_gemm_amax_ext/sample_hipblaslt_gemm_amax_ext.cpp
@@ -135,12 +135,14 @@ void simpleGemmAmaxExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 

--- a/projects/hipblaslt/clients/samples/10_hipblaslt_gemm_amax_with_scale_ext/sample_hipblaslt_gemm_amax_with_scale_ext.cpp
+++ b/projects/hipblaslt/clients/samples/10_hipblaslt_gemm_amax_with_scale_ext/sample_hipblaslt_gemm_amax_with_scale_ext.cpp
@@ -141,12 +141,14 @@ void simpleGemmAmaxWithScaleExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 

--- a/projects/hipblaslt/clients/samples/11_hipblaslt_gemm_ext_bgradb/sample_hipblaslt_gemm_ext_bgradb.cpp
+++ b/projects/hipblaslt/clients/samples/11_hipblaslt_gemm_ext_bgradb/sample_hipblaslt_gemm_ext_bgradb.cpp
@@ -140,12 +140,14 @@ void simpleGemmEpilogueBiasVecExt(hipblasLtHandle_t   handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     return;

--- a/projects/hipblaslt/clients/samples/12_hipblaslt_gemm_dgelu_bgrad_ext/sample_hipblaslt_gemm_dgelu_bgrad_ext.cpp
+++ b/projects/hipblaslt/clients/samples/12_hipblaslt_gemm_dgelu_bgrad_ext/sample_hipblaslt_gemm_dgelu_bgrad_ext.cpp
@@ -144,12 +144,14 @@ void simpleGemmDgeluBgradExt(hipblasLtHandle_t   handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     CHECK_HIP_ERROR(hipFree(d_aux_buffer));

--- a/projects/hipblaslt/clients/samples/14_hipblaslt_gemm_tuning_wgm_ext/sample_hipblaslt_gemm_tuning_wgm_ext.cpp
+++ b/projects/hipblaslt/clients/samples/14_hipblaslt_gemm_tuning_wgm_ext/sample_hipblaslt_gemm_tuning_wgm_ext.cpp
@@ -181,14 +181,17 @@ void simpleGemmTuningWGMExt(hipblasLtHandle_t  handle,
     }
     else
     {
-        ws_ptr = d_workspace;
+        ws_ptr         = d_workspace;
+        workspace_size = max_workspace_size;
     }
 
+    gemm.setMaxWorkspaceBytes(workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[validIdx[0]].algo, tunings[0], ws_ptr));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 
     // Make sure to initialize every time when algo changes
     // If tuning is given, the API will not return success if the solution cannot accept an user tuning parameter.
+    gemm.setMaxWorkspaceBytes(workspace_size);
     CHECK_HIPBLASLT_ERROR(
         gemm.initialize(heuristicResult[validIdxTuning[0]].algo, tunings[1], ws_ptr));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));

--- a/projects/hipblaslt/clients/samples/15_hipblaslt_gemm_with_scale_a_b_ext/sample_hipblaslt_gemm_with_scale_a_b_ext.cpp
+++ b/projects/hipblaslt/clients/samples/15_hipblaslt_gemm_with_scale_a_b_ext/sample_hipblaslt_gemm_with_scale_a_b_ext.cpp
@@ -147,12 +147,14 @@ void simpleGemmScaleABExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     return;

--- a/projects/hipblaslt/clients/samples/16_hipblaslt_groupedgemm_ext/sample_hipblaslt_groupedgemm_ext.cpp
+++ b/projects/hipblaslt/clients/samples/16_hipblaslt_groupedgemm_ext/sample_hipblaslt_groupedgemm_ext.cpp
@@ -136,6 +136,7 @@ void simpleGroupedGemmExt(hipblasLtHandle_t     handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
@@ -154,6 +155,7 @@ void simpleGroupedGemmExt(hipblasLtHandle_t     handle,
                               hipMemcpyHostToDevice));
 
     // Make sure to initialize every time when algo changes
+    groupedgemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(groupedgemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(groupedgemm.run(d_userArgs, stream));
 

--- a/projects/hipblaslt/clients/samples/17_hipblaslt_groupedgemm_fixed_mk_ext/sample_hipblaslt_groupedgemm_fixed_mk_ext.cpp
+++ b/projects/hipblaslt/clients/samples/17_hipblaslt_groupedgemm_fixed_mk_ext/sample_hipblaslt_groupedgemm_fixed_mk_ext.cpp
@@ -209,6 +209,7 @@ void simpleGroupedGemmFixedMKExt(hipblasLtHandle_t     handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
@@ -217,6 +218,7 @@ void simpleGroupedGemmFixedMKExt(hipblasLtHandle_t     handle,
     for(int i = 0; i < validIdx.size(); i++)
     {
         // Make sure to initialize every time the algo changes
+        groupedgemm.setMaxWorkspaceBytes(max_workspace_size);
         CHECK_HIPBLASLT_ERROR(
             groupedgemm.initialize(heuristicResult[validIdx[i]].algo, d_workspace));
 

--- a/projects/hipblaslt/clients/samples/18_hipblaslt_groupedgemm_get_all_algos_ext/sample_hipblaslt_groupedgemm_get_all_algos_ext.cpp
+++ b/projects/hipblaslt/clients/samples/18_hipblaslt_groupedgemm_get_all_algos_ext/sample_hipblaslt_groupedgemm_get_all_algos_ext.cpp
@@ -154,6 +154,7 @@ void multipleGroupsGroupedGemmExt(hipblasLtHandle_t     handle,
         auto& groupedGemm = groupedGemms.at(i);
         // Make sure to initialize every time when algo changes
         // Run first valid solution in this sample
+        groupedGemm.setMaxWorkspaceBytes(max_workspace_size);
         CHECK_HIPBLASLT_ERROR(groupedGemm.initialize(
             heuristicResult[validIndices.at(i).at(i % NumGroups)].algo, d_workspace));
         CHECK_HIPBLASLT_ERROR(groupedGemm.run(groupedGemmUserArgs.at(i).get(), stream));
@@ -311,6 +312,7 @@ void simpleGroupedGemmExt(hipblasLtHandle_t     handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Get the default values from the grouepdgemm object
@@ -326,6 +328,7 @@ void simpleGroupedGemmExt(hipblasLtHandle_t     handle,
                               hipMemcpyHostToDevice));
 
     // Make sure to initialize every time when algo changes
+    groupedgemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(groupedgemm.initialize(heuristicResult[validIdx[0]].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(groupedgemm.run(d_userArgs, stream));
 

--- a/projects/hipblaslt/clients/samples/19_hipblaslt_gemm_mix_precision_ext/sample_hipblaslt_gemm_mix_precision_ext.cpp
+++ b/projects/hipblaslt/clients/samples/19_hipblaslt_gemm_mix_precision_ext/sample_hipblaslt_gemm_mix_precision_ext.cpp
@@ -204,12 +204,14 @@ void simpleGemmMixPrecisionExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 

--- a/projects/hipblaslt/clients/samples/20_hipblaslt_gemm_mix_precision_with_amax_ext/sample_hipblaslt_gemm_mix_precision_with_amax_ext.cpp
+++ b/projects/hipblaslt/clients/samples/20_hipblaslt_gemm_mix_precision_with_amax_ext/sample_hipblaslt_gemm_mix_precision_with_amax_ext.cpp
@@ -138,12 +138,14 @@ void simpleGemmMixPrecisionExt(hipblasLtHandle_t  handle,
 
     // In this sample, the workspace is already allocated with max_workspace_size
     // If not, calculate the needed workspace_size and allocate d_workspace here
+    // Then initialize gemm with calculated d_workspace and workspace_size
     // uint64_t workspace_size = 0;
     // for(int i = 0; i < returnedAlgoCount; i++)
     //     workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
     // CHECK_HIP_ERRORhipMalloc(&d_workspace, workspace_size));
 
     // Make sure to initialize every time when algo changes
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 

--- a/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_bias_swizzle_a_ext/sample_hipblaslt_gemm_bias_swizzle_a_ext.cpp
+++ b/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_bias_swizzle_a_ext/sample_hipblaslt_gemm_bias_swizzle_a_ext.cpp
@@ -248,6 +248,7 @@ void swizzleGemmEpilogueBiasVecExt(hipblasLtHandle_t  handle,
         return;
     }
 
+    gemm.setMaxWorkspaceBytes(max_workspace_size);
     CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResults[0].algo, d_workspace));
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 

--- a/projects/hipblaslt/library/include/hipblaslt/hipblaslt-ext.hpp
+++ b/projects/hipblaslt/library/include/hipblaslt/hipblaslt-ext.hpp
@@ -436,6 +436,21 @@ namespace hipblaslt_ext
                                         size_t&                workspaceSizeInBytes);
 
         /*! \ingroup library_module
+         *  \brief This function sets the max workspace size.
+         *
+         *  @param[in]
+         *  workspaceBytes  Set the max workspace size in bytes.
+         */
+        HIPBLASLT_EXPORT void setMaxWorkspaceBytes(size_t workspaceBytes);
+
+        /*! \ingroup library_module
+         *  \brief This function returns the set max workspace size.
+         *
+         *  \retval size_t Returns the set max workspace size.
+         */
+        HIPBLASLT_EXPORT const size_t getMaxWorkspaceBytes() const;
+
+        /*! \ingroup library_module
         *  \brief Create kernel arguments from a given hipblaslt_ext::GemmInstance.
         *
         *  \details
@@ -459,7 +474,9 @@ namespace hipblaslt_ext
         * submitted. (May be deprecated in the future)
         *
         *  \retval HIPBLAS_STATUS_SUCCESS           If the operation completed
-        * successfully. \retval HIPBLAS_STATUS_INVALID_VALUE If the gemm_count = 0.
+        * successfully. \retval HIPBLAS_STATUS_INVALID_VALUE If the gemm_count = 0 or
+        * workspace is null but workspaceBytes is greater than zero.
+        * Note that workspaceBytes should be set with setMaxWorkspaceBytes.
         */
         HIPBLASLT_EXPORT
         hipblasStatus_t initialize(const hipblasLtMatmulAlgo_t& algo,
@@ -495,7 +512,9 @@ namespace hipblaslt_ext
         * submitted. (May be deprecated in the future)
         *
         *  \retval HIPBLAS_STATUS_SUCCESS           If the operation completed
-        * successfully. \retval HIPBLAS_STATUS_INVALID_VALUE If the gemm_count = 0.
+        * successfully. \retval HIPBLAS_STATUS_INVALID_VALUE If the gemm_count = 0 or
+        * workspace is null but workspaceBytes is greater than zero.
+        * Note that workspaceBytes should be set with setMaxWorkspaceBytes.
         */
         HIPBLASLT_EXPORT
         hipblasStatus_t initialize(const hipblasLtMatmulAlgo_t& algo,
@@ -541,6 +560,8 @@ namespace hipblaslt_ext
 
         hipblasLtHandle_t     m_handle;
         std::shared_ptr<void> m_data;
+
+        size_t m_workspace_bytes = 0;
     };
 
     /*! \ingroup types_module

--- a/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext.cpp
@@ -798,6 +798,16 @@ namespace hipblaslt_ext
         return exception_to_hipblas_status();
     }
 
+    void GemmInstance::setMaxWorkspaceBytes(size_t workspaceBytes)
+    {
+        m_workspace_bytes = workspaceBytes;
+    }
+
+    const size_t GemmInstance::getMaxWorkspaceBytes() const
+    {
+        return m_workspace_bytes;
+    }
+
     hipblasStatus_t GemmInstance::initialize(const hipblasLtMatmulAlgo_t& algo,
                                              void*                        workspace,
                                              bool                         useUserArgs,
@@ -805,7 +815,7 @@ namespace hipblaslt_ext
     try
     {
         rocblaslt::Debug::Instance().markerStart("hipblasLtInitializeCpp");
-        if(m_gemm_count == 0)
+        if((m_gemm_count == 0) || (workspace == nullptr && m_workspace_bytes > 0))
         {
             rocblaslt::Debug::Instance().markerStop();
             return HIPBLAS_STATUS_INVALID_VALUE;
@@ -819,6 +829,7 @@ namespace hipblaslt_ext
                                                                     *rocalgo,
                                                                     tuning,
                                                                     workspace,
+                                                                    m_workspace_bytes,
                                                                     useUserArgs,
                                                                     stream,
                                                                     m_data));
@@ -838,7 +849,7 @@ namespace hipblaslt_ext
     try
     {
         rocblaslt::Debug::Instance().markerStart("hipblasLtInitializeTuningV2Cpp");
-        if(m_gemm_count == 0)
+        if((m_gemm_count == 0) || (workspace == nullptr && m_workspace_bytes > 0))
         {
             rocblaslt::Debug::Instance().markerStop();
             return HIPBLAS_STATUS_INVALID_VALUE;
@@ -852,6 +863,7 @@ namespace hipblaslt_ext
                                                                     *rocalgo,
                                                                     roctuning,
                                                                     workspace,
+                                                                    m_workspace_bytes,
                                                                     useUserArgs,
                                                                     stream,
                                                                     m_data));

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/include/rocblaslt-functions.h
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/include/rocblaslt-functions.h
@@ -212,6 +212,7 @@ rocblaslt_status rocblaslt_makeArgument_cpp(rocblaslt_handle              handle
                                             const rocblaslt_matmul_algo&  algo,
                                             const rocblaslt::RocTuningV2* tuning,
                                             void*                         workspace,
+                                            size_t                        workspaceSizeInBytes,
                                             bool                          useUserArgs,
                                             hipStream_t                   stream,
                                             std::shared_ptr<void>         gemmData);

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/include/tensile_host.hpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/include/tensile_host.hpp
@@ -91,6 +91,7 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
                               const rocblaslt_matmul_algo& algo,
                               const Tuning*                tuning,
                               void*                        workspace,
+                              size_t                       workspaceSizeInBytes,
                               bool                         useUserArgs,
                               hipStream_t                  stream,
                               std::shared_ptr<void>        gemmData);

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -1495,11 +1495,12 @@ rocblaslt_status rocblaslt_makeArgument_cpp(rocblaslt_handle              handle
                                             const rocblaslt_matmul_algo&  algo,
                                             const rocblaslt::RocTuningV2* tuning,
                                             void*                         workspace,
+                                            size_t                        workspaceSizeInBytes,
                                             bool                          useUserArgs,
                                             hipStream_t                   stream,
                                             std::shared_ptr<void>         gemmData)
 {
-    return makeArgument(handle, gemmType, algo, tuning, workspace, useUserArgs, stream, gemmData);
+    return makeArgument(handle, gemmType, algo, tuning, workspace, workspaceSizeInBytes, useUserArgs, stream, gemmData);
 }
 
 std::string rocblaslt_get_kernel_name_from_data_cpp(rocblaslt_handle             handle,

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -2880,6 +2880,7 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
                               const rocblaslt_matmul_algo& algo,
                               const Tuning*                tuning,
                               void*                        workspace,
+                              size_t                       workspaceSizeInBytes,
                               bool                         useUserArgs,
                               hipStream_t                  stream,
                               std::shared_ptr<void>        gemmData)
@@ -2944,6 +2945,10 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
 
             data->inputs.ws = workspace;
 
+            // set workspace size from argument
+            data->inputs.workspaceSize = workspaceSizeInBytes;
+            data->problem.setWorkspaceSize(workspaceSizeInBytes);
+
             data->kernels = solution->solve(data->problem, data->inputs, *hardware);
         }
         else if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GROUPED_GEMM)
@@ -3004,6 +3009,19 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
                 data->inputs.grouped[i].ws = workspace;
             }
             data->inputs.ws = workspace;
+
+            // set workspace size from argument
+            data->problem.setWorkspaceSizeGroupedGemm(workspaceSizeInBytes);
+            data->problem.setWorkspaceSize(workspaceSizeInBytes);
+            for(int i = 0; i < data->inputs.grouped.size(); i++)
+            {
+                data->inputs.grouped[i].workspaceSize = workspaceSizeInBytes;
+            }
+            for(size_t i = 0; i < data->problem.gemms.size(); i++)
+            {
+                data->problem.gemms[i].setWorkspaceSizeGroupedGemm(workspaceSizeInBytes);
+                data->problem.gemms[i].setWorkspaceSize(workspaceSizeInBytes);
+            }
 
             data->useUserArgs = useUserArgs;
             if(useUserArgs)
@@ -4295,6 +4313,7 @@ std::atomic_bool& rocblaslt_internal_tensile_is_initialized()
                                                    const rocblaslt_matmul_algo& algo,                          \
                                                    const Tuning*                tuning,                        \
                                                    void*                        workspace,                     \
+                                                   size_t                       workspaceSizeInBytes,          \
                                                    bool                         useUserArgs,                   \
                                                    hipStream_t                  stream,                        \
                                                    std::shared_ptr<void>        gemmData);                     \


### PR DESCRIPTION
## Motivation

In gemm cpp initialize, exact workspace_size is not given, so library functions will see that workspace_size is zero. We can fix it by adding setMaxWorkspaceBytes and getMaxWorkspaceBytes to set workspace_size from client.

## Technical Details

Library api is updated along with documentation, bench/sample codes are also modified.

## Test Plan

This is related to api change, current CI should pass with no error.

## Test Result

Passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
