### PR TITLE
feat(rocprim): output benchmark iteration info

### DIFF
--- a/projects/rocprim/.gitlab/run_benchmarks.py
+++ b/projects/rocprim/.gitlab/run_benchmarks.py
@@ -29,7 +29,7 @@ import stat
 import subprocess
 import sys
 
-BenchmarkContext = namedtuple('BenchmarkContext', ['gpu_architecture', 'benchmark_output_dir', 'benchmark_dir', 'benchmark_filename_regex', 'benchmark_filter_regex', 'size', 'trials', 'seed', 'skip_gathered'])
+BenchmarkContext = namedtuple('BenchmarkContext', ['gpu_architecture', 'benchmark_output_dir', 'benchmark_dir', 'benchmark_filename_regex', 'benchmark_filter_regex', 'size', 'trials', 'seed', 'skip_gathered', 'iteration_times_output_dir'])
 
 def run_benchmarks(benchmark_context):
     def is_benchmark_executable(filename):
@@ -76,6 +76,8 @@ def run_benchmarks(benchmark_context):
             args += ['--trials', benchmark_context.trials]
         if benchmark_context.seed:
             args += ['--seed', benchmark_context.seed]
+        if benchmark_context.iteration_times_output_dir:
+            args += ['--iteration_times_out', os.path.join(benchmark_context.iteration_times_output_dir, results_json_name)]
         try:
             subprocess.check_call(args)
         except subprocess.CalledProcessError as error:
@@ -121,6 +123,9 @@ def main():
         default=False,
         action='store_true',
         required=False)
+    parser.add_argument('--iteration_times_output_dir',
+        help='The directory to write the benchmark iteration times to',
+        required=False)
 
     args = parser.parse_args()
 
@@ -133,7 +138,8 @@ def main():
         args.size,
         args.trials,
         args.seed,
-        args.skip_gathered)
+        args.skip_gathered,
+        args.iteration_times_output_dir)
 
     benchmark_run_successful = run_benchmarks(benchmark_context)
 

--- a/projects/rocprim/.gitlab/run_benchmarks.py
+++ b/projects/rocprim/.gitlab/run_benchmarks.py
@@ -29,7 +29,7 @@ import stat
 import subprocess
 import sys
 
-BenchmarkContext = namedtuple('BenchmarkContext', ['gpu_architecture', 'benchmark_output_dir', 'benchmark_dir', 'benchmark_filename_regex', 'benchmark_filter_regex', 'size', 'trials', 'seed', 'skip_gathered', 'iteration_times_output_dir'])
+BenchmarkContext = namedtuple('BenchmarkContext', ['gpu_architecture', 'benchmark_output_dir', 'benchmark_dir', 'benchmark_filename_regex', 'benchmark_filter_regex', 'size', 'trials', 'seed', 'skip_gathered', 'iteration_info_output_dir', 'benchmark_min_time'])
 
 def run_benchmarks(benchmark_context):
     def is_benchmark_executable(filename):
@@ -76,8 +76,10 @@ def run_benchmarks(benchmark_context):
             args += ['--trials', benchmark_context.trials]
         if benchmark_context.seed:
             args += ['--seed', benchmark_context.seed]
-        if benchmark_context.iteration_times_output_dir:
-            args += ['--iteration_times_out', os.path.join(benchmark_context.iteration_times_output_dir, results_json_name)]
+        if benchmark_context.iteration_info_output_dir:
+            args += ['--iteration_info_out', os.path.join(benchmark_context.iteration_info_output_dir, results_json_name)]
+        if benchmark_context.benchmark_min_time:
+            args += ['--benchmark_min_time', benchmark_context.benchmark_min_time]
         try:
             subprocess.check_call(args)
         except subprocess.CalledProcessError as error:
@@ -123,8 +125,11 @@ def main():
         default=False,
         action='store_true',
         required=False)
-    parser.add_argument('--iteration_times_output_dir',
-        help='The directory to write the benchmark iteration times to',
+    parser.add_argument('--iteration_info_output_dir',
+        help='The directory to write the benchmark iteration info to',
+        required=False)
+    parser.add_argument('--benchmark_min_time', # TODO: Remove this option once the benchmarks don't use Google Benchmark anymore.
+        help='The minimum amount of time for Google Benchmark to run a benchmark for, where the value \'0s\' means no minimum time',
         required=False)
 
     args = parser.parse_args()
@@ -139,7 +144,8 @@ def main():
         args.trials,
         args.seed,
         args.skip_gathered,
-        args.iteration_times_output_dir)
+        args.iteration_info_output_dir,
+        args.benchmark_min_time)
 
     benchmark_run_successful = run_benchmarks(benchmark_context)
 

--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -12,6 +12,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Added a new cmake option, `BUILD_OFFLOAD_COMPRESS`. When rocPRIM is build with this option enabled, the `--offload-compress` switch is passed to the compiler. This causes the compiler to compress the binary that it generates. Compression can be useful in cases where you are compiling for a large number of targets, since this often results in a large binary. Without compression, in some cases, the generated binary may become so large symbols are placed out of range, resulting in linking errors. The new `BUILD_OFFLOAD_COMPRESS` option is set to `ON` by default.
 * Added a new CMake option `-DUSE_SYSTEM_LIB` to allow tests to be built from `ROCm` libraries provided by the system.
 * Added `rocprim::apply` which applies a function to a `rocprim::tuple`.
+* Added a new cmake option, `BENCHMARK_USE_AMDSMI`. It is set to `OFF` by default. When this option is set to `ON`, it lets benchmarks use AMD SMI to output more GPU statistics.
 
 ### Changed
 

--- a/projects/rocprim/README.md
+++ b/projects/rocprim/README.md
@@ -42,12 +42,13 @@ You can build and install rocPRIM on Linux or Windows.
 
   # Configure rocPRIM, setup options for your system.
   # Build options:
-  #   ONLY_INSTALL - OFF by default, If this flag is on, the build ignore the BUILD_* flags
-  #   BUILD_TEST - OFF by default,
-  #   BUILD_EXAMPLE - OFF by default,
+  #   ONLY_INSTALL - OFF by default. If this flag is on, the build ignores the BUILD_* flags.
+  #   BUILD_TEST - OFF by default.
+  #   BUILD_EXAMPLE - OFF by default.
   #   BUILD_BENCHMARK - OFF by default.
   #   BENCHMARK_CONFIG_TUNING - OFF by default. The purpose of this flag to find the best kernel config parameters.
   #     At ON the compilation time can be increased significantly.
+  #   BENCHMARK_USE_AMDSMI - OFF by default. Set to ON to let benchmarks use AMD SMI to output more GPU statistics.
   #   AMDGPU_TARGETS - list of AMD architectures, default: gfx803;gfx900;gfx906;gfx908.
   #     You can make compilation faster if you want to test/benchmark only on one architecture,
   #     for example, add -DAMDGPU_TARGETS=gfx906 to 'cmake' parameters.

--- a/projects/rocprim/benchmark/CMakeLists.txt
+++ b/projects/rocprim/benchmark/CMakeLists.txt
@@ -27,7 +27,6 @@ include(ConfigAutotuneSettings.cmake)
 option(BENCHMARK_TUNE_PARAM_NAMES "Tuning parameter names" "")
 option(BENCHMARK_TUNE_PARAMS "Tuning parameters" "")
 
-# TODO: Document this somewhere
 option(BENCHMARK_USE_AMDSMI "Let benchmarks use AMD SMI to output more GPU statistics" OFF)
 
 if(BENCHMARK_CONFIG_TUNING)

--- a/projects/rocprim/benchmark/CMakeLists.txt
+++ b/projects/rocprim/benchmark/CMakeLists.txt
@@ -27,6 +27,9 @@ include(ConfigAutotuneSettings.cmake)
 option(BENCHMARK_TUNE_PARAM_NAMES "Tuning parameter names" "")
 option(BENCHMARK_TUNE_PARAMS "Tuning parameters" "")
 
+# TODO: Document this somewhere
+option(BENCHMARK_USE_AMDSMI "Let benchmarks use AMD SMI to output more GPU statistics" OFF)
+
 if(BENCHMARK_CONFIG_TUNING)
   add_custom_target("benchmark_config_tuning")
 endif()
@@ -91,6 +94,16 @@ function(add_rocprim_benchmark BENCHMARK_SOURCE)
     target_link_libraries(${BENCHMARK_TARGET}
       PRIVATE
       hip::device)
+  endif()
+
+  if(BENCHMARK_USE_AMDSMI)
+    find_library(AMDSMI_LIB NAMES amd_smi)
+    if(AMDSMI_LIB)
+      target_link_libraries(${BENCHMARK_TARGET} PRIVATE ${AMDSMI_LIB})
+    else()
+      message(FATAL_ERROR "BENCHMARK_USE_AMDSMI was ON, but AMD SMI is not installed")
+    endif()
+    target_compile_definitions(${BENCHMARK_TARGET} PRIVATE BENCHMARK_USE_AMDSMI)
   endif()
 
   target_compile_options(${BENCHMARK_TARGET}

--- a/projects/rocprim/benchmark/benchmark_device_find_first_of.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_find_first_of.parallel.hpp
@@ -150,7 +150,7 @@ struct device_find_first_of_benchmark : public benchmark_utils::autotune_interfa
         void*  d_temporary_storage     = nullptr;
         size_t temporary_storage_bytes = 0;
 
-        auto run = [&](size_t key_size, const type* d_input)
+        const auto launch = [&](size_t key_size, const type* d_input)
         {
             HIP_CHECK(rocprim::find_first_of<Config>(d_temporary_storage,
                                                      temporary_storage_bytes,
@@ -166,7 +166,7 @@ struct device_find_first_of_benchmark : public benchmark_utils::autotune_interfa
         size_t max_temporary_storage_bytes = 0;
         for(size_t keys_size : keys_sizes)
         {
-            run(keys_size, d_inputs[0]);
+            launch(keys_size, d_inputs[0]);
             max_temporary_storage_bytes
                 = std::max(max_temporary_storage_bytes, temporary_storage_bytes);
         }
@@ -180,7 +180,7 @@ struct device_find_first_of_benchmark : public benchmark_utils::autotune_interfa
                 {
                     for(size_t keys_size : keys_sizes)
                     {
-                        run(keys_size, d_inputs[fi]);
+                        launch(keys_size, d_inputs[fi]);
                     }
                 }
             });

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -1012,23 +1012,18 @@ constexpr size_t GiB = 1024 * MiB;
 class amdsmi
 {
 public:
-    amdsmi(std::string iteration_info_out)
-        : m_iteration_info_out(iteration_info_out), m_is_active(!iteration_info_out.empty())
+    amdsmi()
     {
-        if(!m_is_active)
-            return;
-
         amdsmi_init(AMDSMI_INIT_AMD_GPUS);
 
+        // These can't be turned into a member initializer list,
+        // because the amdsmi_init() above has to be called first.
         m_target  = get_target();
         m_context = get_context(m_target);
     }
 
     ~amdsmi()
     {
-        if(!m_is_active)
-            return;
-
         amdsmi_shut_down();
     }
 
@@ -1042,6 +1037,109 @@ public:
         std::optional<uint64_t> vram_used_bytes;
     };
 
+    std::string serialize_stats(const stats& stats) const
+    {
+        std::ostringstream ss;
+        ss << "{";
+
+        ss << "\"metrics\":" << serialize_metrics(stats.metrics);
+
+        ss << ",\"clocks\":{";
+        bool first = true;
+        for(const auto& kv : stats.clocks)
+        {
+            if(!first)
+                ss << ",";
+            ss << "\"" << kv.first << "\":" << serialize_optional(kv.second);
+            first = false;
+        }
+        ss << "}";
+
+        ss << ",\"vram_used_bytes\":" << serialize_optional(stats.vram_used_bytes);
+
+        ss << "}";
+        return ss.str();
+    }
+
+    std::string serialize_context() const
+    {
+        const auto& ctx = m_context;
+
+        std::ostringstream ss;
+        ss << "{";
+
+        ss << "\"product_name\":" << serialize_optional_string(ctx.product_name);
+        ss << ",\"amdsmi_version\":" << serialize_optional_string(ctx.amdsmi_version);
+
+        ss << ",\"amdsmi_metrics_version\":{";
+        ss << "\"format_revision\":" << std::to_string(ctx.amdsmi_metrics_version.format_revision);
+        ss << ",\"content_revision\":"
+           << std::to_string(ctx.amdsmi_metrics_version.content_revision);
+        ss << "}";
+
+        // Clocks min/max
+        ss << ",\"clocks\":{";
+        bool first = true;
+        for(const auto& kv : ctx.clocks)
+        {
+            if(!first)
+                ss << ",";
+            ss << "\"" << kv.first << "\":";
+            if(kv.second)
+                ss << "{"
+                   << "\"min_clk\":" << kv.second->first << ",\"max_clk\":" << kv.second->second
+                   << "}";
+            else
+                ss << "null";
+            first = false;
+        }
+        ss << "}";
+
+        // Power cap info
+        ss << ",\"power_cap\":" << serialize_optional(ctx.power_cap);
+        ss << ",\"power_cap_default\":" << serialize_optional(ctx.power_cap_default);
+        ss << ",\"power_cap_dpm\":" << serialize_optional(ctx.power_cap_dpm);
+
+        ss << ",\"energy_resolution\":" << serialize_optional(ctx.energy_resolution);
+
+        // VRAM vendor + total
+        ss << ",\"vram_vendor\":" << serialize_optional_string(ctx.vram_vendor);
+        ss << ",\"vram_total_bytes\":" << serialize_optional(ctx.vram_total_bytes);
+
+        // Stats
+        ss << ",\"stats\":" << serialize_stats(ctx.stats);
+
+        ss << "}";
+        return ss.str();
+    }
+
+    stats get_stats() const
+    {
+        stats stats{};
+
+        // Copy all GPU metrics
+        amdsmi_gpu_metrics_t metrics{};
+        if(amdsmi_get_gpu_metrics_info(m_target, &metrics) == AMDSMI_STATUS_SUCCESS)
+            stats.metrics = metrics;
+
+        // Clocks
+        for(auto clk : clk_types)
+        {
+            amdsmi_clk_info_t clk_info{};
+            if(amdsmi_get_clock_info(m_target, clk, &clk_info) == AMDSMI_STATUS_SUCCESS)
+                stats.clocks[clk_type_to_string(clk)] = clk_info.clk;
+        }
+
+        // Memory usage
+        uint64_t vram_used;
+        if(amdsmi_get_gpu_memory_usage(m_target, AMDSMI_MEM_TYPE_VRAM, &vram_used)
+           == AMDSMI_STATUS_SUCCESS)
+            stats.vram_used_bytes = vram_used;
+
+        return stats;
+    }
+
+private:
     struct context
     {
         std::optional<std::string> product_name;
@@ -1069,112 +1167,6 @@ public:
         stats stats;
     };
 
-    stats get_stats() const
-    {
-        if(!m_is_active)
-            return {};
-
-        stats it{};
-
-        // Copy all GPU metrics
-        amdsmi_gpu_metrics_t metrics{};
-        if(amdsmi_get_gpu_metrics_info(m_target, &metrics) == AMDSMI_STATUS_SUCCESS)
-            it.metrics = metrics;
-
-        // Clocks
-        for(auto clk : clk_types)
-        {
-            amdsmi_clk_info_t clk_info{};
-            if(amdsmi_get_clock_info(m_target, clk, &clk_info) == AMDSMI_STATUS_SUCCESS)
-                it.clocks[clk_type_to_string(clk)] = clk_info.clk;
-        }
-
-        // Memory usage
-        uint64_t vram_used;
-        if(amdsmi_get_gpu_memory_usage(m_target, AMDSMI_MEM_TYPE_VRAM, &vram_used)
-           == AMDSMI_STATUS_SUCCESS)
-            it.vram_used_bytes = vram_used;
-
-        return it;
-    }
-
-    void save_batch(const std::vector<double>& batch_times, const stats& stats)
-    {
-        m_batches.emplace_back((struct batch){batch_times, stats});
-    }
-
-    // TODO: This method should be removed once gbench isn't used anymore.
-    size_t get_batches_count() const
-    {
-        return m_batches.size();
-    }
-
-private:
-    struct batch
-    {
-        std::vector<double> batch_times;
-        stats               amdsmi_stats;
-    };
-
-public:
-    void output_iteration_info(const std::string& name) const
-    {
-        if(!m_is_active)
-            return;
-
-        // Try opening file
-        std::fstream outfile(m_iteration_info_out, std::ios::in | std::ios::out | std::ios::ate);
-        bool         new_file = false;
-
-        if(!outfile)
-        {
-            // File doesn’t exist, create it
-            outfile.open(m_iteration_info_out, std::ios::out | std::ios::trunc);
-            new_file = true;
-        }
-        else
-        {
-            // File exists, check size
-            outfile.seekp(0, std::ios::end);
-            auto end_pos = outfile.tellp();
-            if(end_pos == 0)
-            {
-                new_file = true;
-            }
-            else if(end_pos < 2)
-            {
-                std::cerr << "Malformed JSON file.\n";
-                std::exit(EXIT_FAILURE);
-            }
-            else
-            {
-                // Trim trailing "]}" so we can append new benchmarks
-                outfile.seekp(-2, std::ios::end);
-            }
-        }
-
-        if(new_file)
-        {
-            outfile << "{";
-            outfile << "\"context\":{";
-            outfile << "\"amdsmi\":" << serialize_context(m_context);
-            outfile << "},";
-            outfile << "\"benchmarks\":[";
-        }
-        else
-        {
-            outfile << ",";
-        }
-
-        // Append the serialized benchmark
-        outfile << serialize_benchmark(name);
-
-        // Close benchmarks array and JSON
-        outfile << "]}";
-        outfile.close();
-    }
-
-private:
     const std::vector<amdsmi_clk_type_t> clk_types = {
         AMDSMI_CLK_TYPE_SYS,
         AMDSMI_CLK_TYPE_DF,
@@ -1188,9 +1180,72 @@ private:
         AMDSMI_CLK_TYPE_DCLK1,
     };
 
+    amdsmi_processor_handle get_target() const
+    {
+        // Get HIP device
+        hipStream_t stream;
+        HIP_CHECK(hipStreamCreate(&stream));
+        int hip_dev;
+        HIP_CHECK(hipStreamGetDevice(stream, &hip_dev));
+        char hip_bus_id[64];
+        HIP_CHECK(hipDeviceGetPCIBusId(hip_bus_id, sizeof(hip_bus_id), hip_dev));
+
+        // Get all AMD SMI sockets
+        uint32_t socket_count;
+        amdsmi_get_socket_handles(&socket_count, nullptr);
+        std::vector<amdsmi_socket_handle> sockets(socket_count);
+        amdsmi_get_socket_handles(&socket_count, sockets.data());
+
+        // Get AMD SMI GPU device handle of the HIP device
+        amdsmi_processor_handle target = nullptr;
+        for(auto s : sockets)
+        {
+            uint32_t dev_count = 0;
+            amdsmi_get_processor_handles(s, &dev_count, nullptr);
+            std::vector<amdsmi_processor_handle> devs(dev_count);
+            amdsmi_get_processor_handles(s, &dev_count, devs.data());
+            for(auto h : devs)
+            {
+                processor_type_t type;
+                amdsmi_get_processor_type(h, &type);
+                if(type != AMDSMI_PROCESSOR_TYPE_AMD_GPU)
+                    continue;
+                if(get_amdsmi_pci_bus_id(h) == hip_bus_id)
+                {
+                    target = h;
+                    break;
+                }
+            }
+            if(target)
+                break;
+        }
+
+        if(!target)
+        {
+            std::cerr << "No matching GPU found for HIP device " << hip_dev << "\n";
+            exit(1);
+        }
+
+        return target;
+    }
+
+    std::string get_amdsmi_pci_bus_id(amdsmi_processor_handle h) const
+    {
+        uint64_t bdfid;
+        amdsmi_get_gpu_bdf_id(h, &bdfid);
+        uint32_t           domain   = (bdfid >> 32) & 0xffff;
+        uint32_t           bus      = (bdfid >> 8) & 0xff;
+        uint32_t           device   = (bdfid >> 3) & 0x1f;
+        uint32_t           function = bdfid & 0x7;
+        std::ostringstream oss;
+        oss << std::setfill('0') << std::hex << std::setw(4) << domain << ":" << std::setw(2) << bus
+            << ":" << std::setw(2) << device << "." << function;
+        return oss.str();
+    }
+
     context get_context(amdsmi_processor_handle target) const
     {
-        struct context ctx;
+        context ctx;
 
         amdsmi_board_info_t board_info;
         if(amdsmi_get_gpu_board_info(target, &board_info) == AMDSMI_STATUS_SUCCESS)
@@ -1261,140 +1316,6 @@ private:
         exit(1);
     }
 
-    std::string get_amdsmi_pci_bus_id(amdsmi_processor_handle h) const
-    {
-        uint64_t bdfid;
-        amdsmi_get_gpu_bdf_id(h, &bdfid);
-        uint32_t           domain   = (bdfid >> 32) & 0xffff;
-        uint32_t           bus      = (bdfid >> 8) & 0xff;
-        uint32_t           device   = (bdfid >> 3) & 0x1f;
-        uint32_t           function = bdfid & 0x7;
-        std::ostringstream oss;
-        oss << std::setfill('0') << std::hex << std::setw(4) << domain << ":" << std::setw(2) << bus
-            << ":" << std::setw(2) << device << "." << function;
-        return oss.str();
-    }
-
-    amdsmi_processor_handle get_target() const
-    {
-        // Get HIP device
-        hipStream_t stream;
-        HIP_CHECK(hipStreamCreate(&stream));
-        int hip_dev;
-        HIP_CHECK(hipStreamGetDevice(stream, &hip_dev));
-        char hip_bus_id[64];
-        HIP_CHECK(hipDeviceGetPCIBusId(hip_bus_id, sizeof(hip_bus_id), hip_dev));
-
-        // Get all AMD SMI sockets
-        uint32_t socket_count;
-        amdsmi_get_socket_handles(&socket_count, nullptr);
-        std::vector<amdsmi_socket_handle> sockets(socket_count);
-        amdsmi_get_socket_handles(&socket_count, sockets.data());
-
-        // Get AMD SMI GPU device handle of the HIP device
-        amdsmi_processor_handle target = nullptr;
-        for(auto s : sockets)
-        {
-            uint32_t dev_count = 0;
-            amdsmi_get_processor_handles(s, &dev_count, nullptr);
-            std::vector<amdsmi_processor_handle> devs(dev_count);
-            amdsmi_get_processor_handles(s, &dev_count, devs.data());
-            for(auto h : devs)
-            {
-                processor_type_t type;
-                amdsmi_get_processor_type(h, &type);
-                if(type != AMDSMI_PROCESSOR_TYPE_AMD_GPU)
-                    continue;
-                if(get_amdsmi_pci_bus_id(h) == hip_bus_id)
-                {
-                    target = h;
-                    break;
-                }
-            }
-            if(target)
-                break;
-        }
-
-        if(!target)
-        {
-            std::cerr << "No matching GPU found for HIP device " << hip_dev << "\n";
-            exit(1);
-        }
-
-        return target;
-    }
-
-    std::string serialize_benchmark(const std::string& name) const
-    {
-        std::ostringstream ss;
-        ss << "{";
-        ss << "\"name\":\"" << name << "\",";
-        ss << "\"batches\":[";
-        for(size_t i = 0; i < m_batches.size(); i++)
-        {
-            if(i != 0)
-                ss << ",";
-            ss << "{";
-            ss << "\"iterations_ms\":" << serialize_batch_times(m_batches[i].batch_times) << ",";
-            ss << "\"amdsmi_stats_after_iterations\":"
-               << serialize_stats(m_batches[i].amdsmi_stats);
-            ss << "}";
-        }
-        ss << "]";
-        ss << "}";
-        return ss.str();
-    }
-
-    std::string serialize_context(const context& ctx) const
-    {
-        std::ostringstream ss;
-        ss << "{";
-
-        ss << "\"product_name\":" << serialize_optional_string(ctx.product_name);
-        ss << ",\"amdsmi_version\":" << serialize_optional_string(ctx.amdsmi_version);
-
-        ss << ",\"amdsmi_metrics_version\":{";
-        ss << "\"format_revision\":" << std::to_string(ctx.amdsmi_metrics_version.format_revision);
-        ss << ",\"content_revision\":"
-           << std::to_string(ctx.amdsmi_metrics_version.content_revision);
-        ss << "}";
-
-        // Clocks min/max
-        ss << ",\"clocks\":{";
-        bool first = true;
-        for(const auto& kv : ctx.clocks)
-        {
-            if(!first)
-                ss << ",";
-            ss << "\"" << kv.first << "\":";
-            if(kv.second)
-                ss << "{"
-                   << "\"min_clk\":" << kv.second->first << ",\"max_clk\":" << kv.second->second
-                   << "}";
-            else
-                ss << "null";
-            first = false;
-        }
-        ss << "}";
-
-        // Power cap info
-        ss << ",\"power_cap\":" << serialize_optional(ctx.power_cap);
-        ss << ",\"power_cap_default\":" << serialize_optional(ctx.power_cap_default);
-        ss << ",\"power_cap_dpm\":" << serialize_optional(ctx.power_cap_dpm);
-
-        ss << ",\"energy_resolution\":" << serialize_optional(ctx.energy_resolution);
-
-        // VRAM vendor + total
-        ss << ",\"vram_vendor\":" << serialize_optional_string(ctx.vram_vendor);
-        ss << ",\"vram_total_bytes\":" << serialize_optional(ctx.vram_total_bytes);
-
-        // Stats
-        ss << ",\"stats\":" << serialize_stats(ctx.stats);
-
-        ss << "}";
-        return ss.str();
-    }
-
     std::string serialize_optional_string(const std::optional<std::string>& opt) const
     {
         return opt ? ("\"" + *opt + "\"") : "null";
@@ -1406,45 +1327,7 @@ private:
         return opt ? std::to_string(*opt) : "null";
     }
 
-    std::string serialize_batch_times(const std::vector<double>& batch_times) const
-    {
-        std::ostringstream ss;
-        ss << "[";
-        for(size_t i = 0; i < batch_times.size(); i++)
-        {
-            if(i != 0)
-                ss << ",";
-            ss << batch_times[i];
-        }
-        ss << "]";
-        return ss.str();
-    }
-
-    std::string serialize_stats(const stats& stats) const
-    {
-        std::ostringstream ss;
-        ss << "{";
-
-        ss << "\"metrics\":" << serialize_amdsmi_metrics(stats.metrics);
-
-        ss << ",\"clocks\":{";
-        bool first = true;
-        for(const auto& kv : stats.clocks)
-        {
-            if(!first)
-                ss << ",";
-            ss << "\"" << kv.first << "\":" << serialize_optional(kv.second);
-            first = false;
-        }
-        ss << "}";
-
-        ss << ",\"vram_used_bytes\":" << serialize_optional(stats.vram_used_bytes);
-
-        ss << "}";
-        return ss.str();
-    }
-
-    std::string serialize_amdsmi_metrics(const amdsmi_gpu_metrics_t& metrics) const
+    std::string serialize_metrics(const amdsmi_gpu_metrics_t& metrics) const
     {
         std::ostringstream ss;
         ss << "{";
@@ -1480,13 +1363,13 @@ private:
     #define ADD(field) add_field(#field, metrics.field)
     #define ADD_ARRAY(field) add_array(#field, metrics.field)
 
-        struct RevisionBlock
+        struct revision_block
         {
             int                   min_content_revision;
             std::function<void()> serialize;
         };
 
-        std::vector<RevisionBlock> blocks = {
+        std::vector<revision_block> blocks = {
             {0,
              [&]
              {
@@ -1605,14 +1488,168 @@ private:
         return ss.str();
     }
 
+    amdsmi_processor_handle m_target;
+    context                 m_context;
+};
+#endif
+
+class logger
+{
+public:
+    logger(std::string iteration_info_out)
+        : m_iteration_info_out(iteration_info_out), m_is_active(!iteration_info_out.empty())
+    {}
+
+#ifdef BENCHMARK_USE_AMDSMI
+    void record_amdsmi_stats()
+    {
+        if(!m_is_active)
+            return;
+
+        m_amdsmi_stats = m_amdsmi.get_stats();
+    }
+#endif
+
+    void save_batch_times(const std::vector<double> batch_times)
+    {
+        if(!m_is_active)
+            return;
+
+        struct batch batch = {};
+
+        batch.batch_times = batch_times;
+
+#ifdef BENCHMARK_USE_AMDSMI
+        batch.amdsmi_stats = m_amdsmi_stats;
+#endif
+
+        m_batches.emplace_back(batch);
+    }
+
+    // This function doesn't use a JSON library,
+    // since it just appends text onto the end of a JSON file.
+    // Seeking and writing to the end of a huge file is very fast.
+    void output_specialization_info(const std::string& name) const
+    {
+        if(!m_is_active)
+            return;
+
+        // Try opening file
+        std::fstream outfile(m_iteration_info_out, std::ios::in | std::ios::out | std::ios::ate);
+        bool         new_file = false;
+
+        if(!outfile)
+        {
+            // File doesn’t exist, create it
+            outfile.open(m_iteration_info_out, std::ios::out | std::ios::trunc);
+            new_file = true;
+        }
+        else
+        {
+            // File exists, check size
+            outfile.seekp(0, std::ios::end);
+            auto end_pos = outfile.tellp();
+            if(end_pos == 0)
+            {
+                new_file = true;
+            }
+            else if(end_pos < 2)
+            {
+                std::cerr << "Malformed JSON file.\n";
+                std::exit(EXIT_FAILURE);
+            }
+            else
+            {
+                // Trim trailing "]}" so we can append new benchmarks
+                outfile.seekp(-2, std::ios::end);
+            }
+        }
+
+        if(new_file)
+        {
+            outfile << "{";
+            outfile << "\"context\":{";
+
+#ifdef BENCHMARK_USE_AMDSMI
+            outfile << "\"amdsmi\":" << m_amdsmi.serialize_context();
+#endif
+
+            outfile << "},";
+            outfile << "\"benchmarks\":[";
+        }
+        else
+        {
+            outfile << ",";
+        }
+
+        // Append the serialized benchmark
+        outfile << serialize_benchmark(name);
+
+        // Close benchmarks array and JSON
+        outfile << "]}";
+        outfile.close();
+    }
+
+private:
+    struct batch
+    {
+        std::vector<double> batch_times;
+
+#ifdef BENCHMARK_USE_AMDSMI
+        amdsmi::stats amdsmi_stats;
+#endif
+    };
+
+    std::string serialize_benchmark(const std::string& name) const
+    {
+        std::ostringstream ss;
+        ss << "{";
+        ss << "\"name\":\"" << name << "\",";
+        ss << "\"batches\":[";
+        for(size_t i = 0; i < m_batches.size(); i++)
+        {
+            if(i != 0)
+                ss << ",";
+
+            ss << "{";
+            ss << "\"iterations_ms\":" << serialize_batch_times(m_batches[i].batch_times);
+
+#ifdef BENCHMARK_USE_AMDSMI
+            ss << ",\"amdsmi_stats_after_iterations\":"
+               << m_amdsmi.serialize_stats(m_batches[i].amdsmi_stats);
+#endif
+
+            ss << "}";
+        }
+        ss << "]";
+        ss << "}";
+        return ss.str();
+    }
+
+    std::string serialize_batch_times(const std::vector<double>& batch_times) const
+    {
+        std::ostringstream ss;
+        ss << "[";
+        for(size_t i = 0; i < batch_times.size(); i++)
+        {
+            if(i != 0)
+                ss << ",";
+            ss << batch_times[i];
+        }
+        ss << "]";
+        return ss.str();
+    }
+
     std::string m_iteration_info_out;
     bool        m_is_active;
 
-    amdsmi_processor_handle m_target = nullptr;
-    context                 m_context;
-    std::vector<batch>      m_batches;
+    std::vector<batch> m_batches;
+
+#ifdef BENCHMARK_USE_AMDSMI
+    amdsmi        m_amdsmi;
+    amdsmi::stats m_amdsmi_stats;
+#endif
 };
-#endif // class amdsmi
 
 class state
 {
@@ -1624,8 +1661,7 @@ public:
           benchmark::State&   gbench_state,
           size_t              warmup_iterations,
           bool                cold,
-          std::string         iteration_info_out,
-          int                 trials) // TODO: Remove this trials parameter once gbench is removed
+          std::string         iteration_info_out)
         : stream(stream)
         , bytes(bytes)
         , seed(seed)
@@ -1633,12 +1669,22 @@ public:
         , gbench_state(gbench_state)
         , m_warmup_iterations(warmup_iterations)
         , m_cold(cold)
-        , m_trials(trials)
         , m_events(batch_iterations * 2)
-#ifdef BENCHMARK_USE_AMDSMI
-        , m_amdsmi(iteration_info_out)
-#endif
-    {}
+        , m_logger(iteration_info_out)
+    {
+        for(auto& event : m_events)
+        {
+            HIP_CHECK(hipEventCreate(&event));
+        }
+    }
+
+    ~state()
+    {
+        for(const auto& event : m_events)
+        {
+            HIP_CHECK(hipEventDestroy(event));
+        }
+    }
 
     // Used to reset the input array of algorithms like device_merge_inplace.
     void run_before_every_iteration(std::function<void()> lambda)
@@ -1654,11 +1700,6 @@ public:
 
     void run(std::function<void()> kernel)
     {
-        for(auto& event : m_events)
-        {
-            HIP_CHECK(hipEventCreate(&event));
-        }
-
         // Warm-up
         for(size_t i = 0; i < m_warmup_iterations; ++i)
         {
@@ -1701,9 +1742,12 @@ public:
             HIP_CHECK(hipEventSynchronize(m_events[batch_iterations * 2 - 1]));
 
 #ifdef BENCHMARK_USE_AMDSMI
-            amdsmi::stats       stats = m_amdsmi.get_stats();
-            std::vector<double> batch_times;
+            // This is a *really* slow call, but you can increase batch_iterations
+            // if this ever dominates the benchmarking runtime.
+            m_logger.record_amdsmi_stats();
 #endif
+
+            std::vector<double> batch_times;
 
             // Accumulate the total elapsed time.
             double elapsed_ms = 0.0;
@@ -1712,33 +1756,21 @@ public:
                 float iteration_ms;
                 HIP_CHECK(hipEventElapsedTime(&iteration_ms, m_events[i * 2], m_events[i * 2 + 1]));
                 m_times.emplace_back(iteration_ms);
-                elapsed_ms += iteration_ms;
-
-#ifdef BENCHMARK_USE_AMDSMI
                 batch_times.emplace_back(iteration_ms);
-#endif
+                elapsed_ms += iteration_ms;
             }
 
             gbench_state.SetIterationTime(elapsed_ms / 1000);
 
-#ifdef BENCHMARK_USE_AMDSMI
-            m_amdsmi.save_batch(batch_times, stats);
+            m_logger.save_batch_times(batch_times);
 
             // TODO: When gbench is removed in the future, replace the gbench_state loop
             // with an infinite while-loop, and use this instead:
             // now = time.now()
             // elapsed = now - start
             // if elapsed > min_time {
-            //     std::string escaped_name = get_escaped_name(gbench_state.name());
-            //     amdsmi.output_iteration_info(escaped_name)
             //     break
             // }
-            if(m_amdsmi.get_batches_count() >= m_trials)
-            {
-                std::string escaped_name = get_escaped_name(gbench_state.name());
-                m_amdsmi.output_iteration_info(escaped_name);
-            }
-#endif
         }
 
         if(m_reset_total_gbench_iterations_every_run)
@@ -1746,11 +1778,6 @@ public:
             m_total_gbench_iterations = 0;
         }
         m_total_gbench_iterations += gbench_state.iterations();
-
-        for(const auto& event : m_events)
-        {
-            HIP_CHECK(hipEventDestroy(event));
-        }
     }
 
     void set_throughput(size_t actual_size, size_t type_size)
@@ -1768,6 +1795,9 @@ public:
         gbench_state.SetItemsProcessed(m_total_gbench_iterations * batch_iterations * actual_size);
 
         output_statistics();
+
+        std::string name = get_escaped_name(gbench_state.name());
+        m_logger.output_specialization_info(name);
     }
 
     // These are directly read by benchmarks.
@@ -1864,18 +1894,14 @@ private:
 
     size_t m_warmup_iterations;
     bool   m_cold;
-    int    m_trials;
 
     std::vector<hipEvent_t> m_events;
+    logger                  m_logger;
     std::function<void()>   m_run_before_every_iteration_lambda       = nullptr;
     size_t                  m_total_gbench_iterations                 = 0;
     bool                    m_reset_total_gbench_iterations_every_run = true;
     std::vector<double>     m_times;
     bool                    m_has_set_throughput = false;
-
-#ifdef BENCHMARK_USE_AMDSMI
-    class amdsmi m_amdsmi;
-#endif
 };
 
 struct autotune_interface
@@ -2151,8 +2177,7 @@ private:
                      gbench_state,
                      m_warmup_iterations,
                      m_cold,
-                     m_iteration_info_out,
-                     m_trials);
+                     m_iteration_info_out);
     }
 
     void apply_settings(benchmark::internal::Benchmark* b)

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -26,6 +26,10 @@
 #include "../common/utils_data_generation.hpp"
 #include "../common/utils_half.hpp"
 
+#ifdef BENCHMARK_USE_AMDSMI
+#include <amd_smi/amdsmi.h>
+#endif
+
 #include <benchmark/benchmark.h>
 
 // rocPRIM
@@ -47,6 +51,7 @@
 #include <array>
 #include <cstddef>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <iterator>
 #include <limits>
@@ -1003,6 +1008,610 @@ constexpr size_t KiB = 1024;
 constexpr size_t MiB = 1024 * KiB;
 constexpr size_t GiB = 1024 * MiB;
 
+#ifdef BENCHMARK_USE_AMDSMI
+class amdsmi
+{
+public:
+    amdsmi(std::string iteration_info_out)
+        : m_iteration_info_out(iteration_info_out)
+        , m_is_active(!iteration_info_out.empty())
+    {
+        if(!m_is_active) return;
+
+        amdsmi_init(AMDSMI_INIT_AMD_GPUS);
+
+        m_target  = get_target();
+        m_context = get_context(m_target);
+    }
+
+    ~amdsmi()
+    {
+        if(!m_is_active) return;
+
+        amdsmi_shut_down();
+    }
+
+    struct stats
+    {
+        amdsmi_gpu_metrics_t metrics;
+
+        // Clocks (current frequencies in MHz)
+        std::map<std::string, std::optional<uint32_t>> clocks;
+
+        std::optional<uint64_t> vram_used_bytes;
+    };
+
+    struct context
+    {
+        std::optional<std::string> product_name;
+
+        std::string amdsmi_version;
+
+        struct
+        {
+            uint8_t format_revision;
+            uint8_t content_revision;
+        } amdsmi_metrics_version;
+
+        // Clocks (min/max in MHz)
+        std::map<std::string, std::optional<std::pair<uint32_t, uint32_t>>> clocks;
+
+        std::optional<uint64_t> power_cap;
+        std::optional<uint64_t> power_cap_default;
+        std::optional<uint64_t> power_cap_dpm;
+
+        std::optional<float> energy_resolution;
+
+        std::optional<std::string> vram_vendor;
+        std::optional<uint64_t>    vram_total_bytes;
+
+        stats stats;
+    };
+
+    stats get_stats() const
+    {
+        if(!m_is_active) return {};
+
+        stats it{};
+
+        // Copy all GPU metrics
+        amdsmi_gpu_metrics_t metrics{};
+        if(amdsmi_get_gpu_metrics_info(m_target, &metrics) == AMDSMI_STATUS_SUCCESS)
+            it.metrics = metrics;
+
+        // Clocks
+        for(auto clk : clk_types)
+        {
+            amdsmi_clk_info_t clk_info{};
+            if(amdsmi_get_clock_info(m_target, clk, &clk_info) == AMDSMI_STATUS_SUCCESS)
+                it.clocks[clk_type_to_string(clk)] = clk_info.clk;
+        }
+
+        // Memory usage
+        uint64_t vram_used;
+        if(amdsmi_get_gpu_memory_usage(m_target, AMDSMI_MEM_TYPE_VRAM, &vram_used)
+           == AMDSMI_STATUS_SUCCESS)
+            it.vram_used_bytes = vram_used;
+
+        return it;
+    }
+
+    void save_batch(const std::vector<double>& batch_times, const stats& stats)
+    {
+        m_batches.emplace_back((struct batch){batch_times, stats});
+    }
+
+    // TODO: This method should be removed once gbench isn't used anymore.
+    size_t get_batches_count() const
+    {
+        return m_batches.size();
+    }
+
+private:
+    struct batch
+    {
+        std::vector<double> batch_times;
+        stats               amdsmi_stats;
+    };
+
+public:
+    void output_iteration_info(const std::string& name) const
+    {
+        if(!m_is_active) return;
+
+        // Try opening file
+        std::fstream outfile(m_iteration_info_out, std::ios::in | std::ios::out | std::ios::ate);
+        bool         new_file = false;
+
+        if(!outfile)
+        {
+            // File doesn’t exist, create it
+            outfile.open(m_iteration_info_out, std::ios::out | std::ios::trunc);
+            new_file = true;
+        }
+        else
+        {
+            // File exists, check size
+            outfile.seekp(0, std::ios::end);
+            auto end_pos = outfile.tellp();
+            if(end_pos == 0)
+            {
+                new_file = true;
+            }
+            else if(end_pos < 2)
+            {
+                std::cerr << "Malformed JSON file.\n";
+                std::exit(EXIT_FAILURE);
+            }
+            else
+            {
+                // Trim trailing "]}" so we can append new benchmarks
+                outfile.seekp(-2, std::ios::end);
+            }
+        }
+
+        if(new_file)
+        {
+            outfile << "{";
+            outfile << "\"context\":{";
+            outfile << "\"amdsmi\":" << serialize_context(m_context);
+            outfile << "},";
+            outfile << "\"benchmarks\":[";
+        }
+        else
+        {
+            outfile << ",";
+        }
+
+        // Append the serialized benchmark
+        outfile << serialize_benchmark(name);
+
+        // Close benchmarks array and JSON
+        outfile << "]}";
+        outfile.close();
+    }
+
+private:
+    const std::vector<amdsmi_clk_type_t> clk_types = {
+        AMDSMI_CLK_TYPE_SYS,
+        AMDSMI_CLK_TYPE_DF,
+        AMDSMI_CLK_TYPE_DCEF,
+        AMDSMI_CLK_TYPE_SOC,
+        AMDSMI_CLK_TYPE_MEM,
+        AMDSMI_CLK_TYPE_PCIE,
+        AMDSMI_CLK_TYPE_VCLK0,
+        AMDSMI_CLK_TYPE_VCLK1,
+        AMDSMI_CLK_TYPE_DCLK0,
+        AMDSMI_CLK_TYPE_DCLK1,
+    };
+
+    context get_context(amdsmi_processor_handle target) const
+    {
+        struct context ctx;
+
+        amdsmi_board_info_t   board_info;
+        if(amdsmi_get_gpu_board_info(target, &board_info) == AMDSMI_STATUS_SUCCESS)
+            ctx.product_name = board_info.product_name;
+
+        amdsmi_version_t amdsmi_version;
+        if(amdsmi_get_lib_version(&amdsmi_version) == AMDSMI_STATUS_SUCCESS)
+            ctx.amdsmi_version = amdsmi_version.build;
+
+        amdsmi_gpu_metrics_t metrics{};
+        if(amdsmi_get_gpu_metrics_info(target, &metrics) == AMDSMI_STATUS_SUCCESS)
+            ctx.amdsmi_metrics_version.format_revision = metrics.common_header.format_revision;
+        ctx.amdsmi_metrics_version.content_revision = metrics.common_header.content_revision;
+
+        for(auto clk : clk_types)
+        {
+            amdsmi_clk_info_t clk_info{};
+            if(amdsmi_get_clock_info(target, clk, &clk_info) == AMDSMI_STATUS_SUCCESS)
+                ctx.clocks[clk_type_to_string(clk)]
+                    = std::make_pair(clk_info.min_clk, clk_info.max_clk);
+        }
+
+        amdsmi_power_cap_info_t pcap;
+        if(amdsmi_get_power_cap_info(target, 0, &pcap) == AMDSMI_STATUS_SUCCESS)
+        {
+            ctx.power_cap         = pcap.power_cap;
+            ctx.power_cap_default = pcap.default_power_cap;
+            ctx.power_cap_dpm     = pcap.dpm_cap;
+        }
+
+        uint64_t energy_acc, energy_ts;
+        float    energy_res;
+        if(amdsmi_get_energy_count(target, &energy_acc, &energy_res, &energy_ts)
+           == AMDSMI_STATUS_SUCCESS)
+            ctx.energy_resolution = energy_res;
+
+        char vram_vendor_buf[128];
+        if(amdsmi_get_gpu_vram_vendor(target, vram_vendor_buf, sizeof(vram_vendor_buf))
+           == AMDSMI_STATUS_SUCCESS)
+            ctx.vram_vendor = vram_vendor_buf;
+
+        uint64_t vram_total;
+        if(amdsmi_get_gpu_memory_total(target, AMDSMI_MEM_TYPE_VRAM, &vram_total)
+           == AMDSMI_STATUS_SUCCESS)
+            ctx.vram_total_bytes = vram_total;
+
+        ctx.stats = get_stats();
+
+        return ctx;
+    }
+
+    std::string clk_type_to_string(amdsmi_clk_type_t clk) const
+    {
+        switch(clk)
+        {
+            case AMDSMI_CLK_TYPE_SYS: return "sys";
+            case AMDSMI_CLK_TYPE_DF: return "df";
+            case AMDSMI_CLK_TYPE_DCEF: return "dcef";
+            case AMDSMI_CLK_TYPE_SOC: return "soc";
+            case AMDSMI_CLK_TYPE_MEM: return "mem";
+            case AMDSMI_CLK_TYPE_PCIE: return "pcie";
+            case AMDSMI_CLK_TYPE_VCLK0: return "vclk0";
+            case AMDSMI_CLK_TYPE_VCLK1: return "vclk1";
+            case AMDSMI_CLK_TYPE_DCLK0: return "dclk0";
+            case AMDSMI_CLK_TYPE_DCLK1: return "dclk1";
+        }
+        std::cerr << "Failed to match clock type " << clk << " to a string\n";
+        exit(1);
+    }
+
+    std::string get_amdsmi_pci_bus_id(amdsmi_processor_handle h) const
+    {
+        uint64_t bdfid;
+        amdsmi_get_gpu_bdf_id(h, &bdfid);
+        uint32_t           domain   = (bdfid >> 32) & 0xffff;
+        uint32_t           bus      = (bdfid >> 8) & 0xff;
+        uint32_t           device   = (bdfid >> 3) & 0x1f;
+        uint32_t           function = bdfid & 0x7;
+        std::ostringstream oss;
+        oss << std::setfill('0') << std::hex << std::setw(4) << domain << ":" << std::setw(2) << bus
+            << ":" << std::setw(2) << device << "." << function;
+        return oss.str();
+    }
+
+    // TODO: Put all methods in this class in a logical order
+    amdsmi_processor_handle get_target() const
+    {
+        // Get HIP device
+        hipStream_t stream;
+        HIP_CHECK(hipStreamCreate(&stream));
+        int hip_dev;
+        HIP_CHECK(hipStreamGetDevice(stream, &hip_dev));
+        char hip_bus_id[64];
+        HIP_CHECK(hipDeviceGetPCIBusId(hip_bus_id, sizeof(hip_bus_id), hip_dev));
+
+        // Get all AMD SMI sockets
+        uint32_t socket_count;
+        amdsmi_get_socket_handles(&socket_count, nullptr);
+        std::vector<amdsmi_socket_handle> sockets(socket_count);
+        amdsmi_get_socket_handles(&socket_count, sockets.data());
+
+        // Get AMD SMI GPU device handle of the HIP device
+        amdsmi_processor_handle target = nullptr;
+        for(auto s : sockets)
+        {
+            uint32_t dev_count = 0;
+            amdsmi_get_processor_handles(s, &dev_count, nullptr);
+            std::vector<amdsmi_processor_handle> devs(dev_count);
+            amdsmi_get_processor_handles(s, &dev_count, devs.data());
+            for(auto h : devs)
+            {
+                processor_type_t type;
+                amdsmi_get_processor_type(h, &type);
+                if(type != AMDSMI_PROCESSOR_TYPE_AMD_GPU)
+                    continue;
+                if(get_amdsmi_pci_bus_id(h) == hip_bus_id)
+                {
+                    target = h;
+                    break;
+                }
+            }
+            if(target)
+                break;
+        }
+
+        if(!target)
+        {
+            std::cerr << "No matching GPU found for HIP device " << hip_dev << "\n";
+            exit(1);
+        }
+
+        return target;
+    }
+
+    std::string serialize_benchmark(const std::string& name) const
+    {
+        std::ostringstream ss;
+        ss << "{";
+        ss << "\"name\":\"" << name << "\",";
+        ss << "\"batches\":[";
+        for(size_t i = 0; i < m_batches.size(); i++)
+        {
+            if(i != 0)
+                ss << ",";
+            ss << "{";
+            ss << "\"iterations_ms\":" << serialize_batch_times(m_batches[i].batch_times) << ",";
+            ss << "\"amdsmi_stats_after_iterations\":"
+               << serialize_stats(m_batches[i].amdsmi_stats);
+            ss << "}";
+        }
+        ss << "]";
+        ss << "}";
+        return ss.str();
+    }
+
+    std::string serialize_context(const context& ctx) const
+    {
+        std::ostringstream ss;
+        ss << "{";
+
+        ss << "\"product_name\":" << serialize_optional_string(ctx.product_name);
+        ss << ",\"amdsmi_version\":" << serialize_optional_string(ctx.amdsmi_version);
+
+        ss << ",\"amdsmi_metrics_version\":{";
+        ss << "\"format_revision\":" << std::to_string(ctx.amdsmi_metrics_version.format_revision);
+        ss << ",\"content_revision\":"
+           << std::to_string(ctx.amdsmi_metrics_version.content_revision);
+        ss << "}";
+
+        // Clocks min/max
+        ss << ",\"clocks\":{";
+        bool first = true;
+        for(const auto& kv : ctx.clocks)
+        {
+            if(!first)
+                ss << ",";
+            ss << "\"" << kv.first << "\":";
+            if(kv.second)
+                ss << "{"
+                   << "\"min_clk\":" << kv.second->first << ",\"max_clk\":" << kv.second->second
+                   << "}";
+            else
+                ss << "null";
+            first = false;
+        }
+        ss << "}";
+
+        // Power cap info
+        ss << ",\"power_cap\":" << serialize_optional(ctx.power_cap);
+        ss << ",\"power_cap_default\":" << serialize_optional(ctx.power_cap_default);
+        ss << ",\"power_cap_dpm\":" << serialize_optional(ctx.power_cap_dpm);
+
+        ss << ",\"energy_resolution\":" << serialize_optional(ctx.energy_resolution);
+
+        // VRAM vendor + total
+        ss << ",\"vram_vendor\":" << serialize_optional_string(ctx.vram_vendor);
+        ss << ",\"vram_total_bytes\":" << serialize_optional(ctx.vram_total_bytes);
+
+        // Stats
+        ss << ",\"stats\":" << serialize_stats(ctx.stats);
+
+        ss << "}";
+        return ss.str();
+    }
+
+    std::string serialize_optional_string(const std::optional<std::string>& opt) const
+    {
+        return opt ? ("\"" + *opt + "\"") : "null";
+    }
+
+    template<typename T>
+    std::string serialize_optional(const std::optional<T>& opt) const
+    {
+        return opt ? std::to_string(*opt) : "null";
+    }
+
+    std::string serialize_batch_times(const std::vector<double>& batch_times) const
+    {
+        std::ostringstream ss;
+        ss << "[";
+        for(size_t i = 0; i < batch_times.size(); i++)
+        {
+            if(i != 0)
+                ss << ",";
+            ss << batch_times[i];
+        }
+        ss << "]";
+        return ss.str();
+    }
+
+    std::string serialize_stats(const stats& stats) const
+    {
+        std::ostringstream ss;
+        ss << "{";
+
+        ss << "\"metrics\":" << serialize_amdsmi_metrics(stats.metrics);
+
+        ss << ",\"clocks\":{";
+        bool first = true;
+        for(const auto& kv : stats.clocks)
+        {
+            if(!first)
+                ss << ",";
+            ss << "\"" << kv.first << "\":" << serialize_optional(kv.second);
+            first = false;
+        }
+        ss << "}";
+
+        ss << ",\"vram_used_bytes\":" << serialize_optional(stats.vram_used_bytes);
+
+        ss << "}";
+        return ss.str();
+    }
+
+    std::string serialize_amdsmi_metrics(const amdsmi_gpu_metrics_t& metrics) const
+    {
+        std::ostringstream ss;
+        ss << "{";
+
+        bool first     = true;
+        auto add_comma = [&]()
+        {
+            if(!first)
+                ss << ",";
+            first = false;
+        };
+
+        auto add_field = [&](const char* name, auto value)
+        {
+            add_comma();
+            ss << "\"" << name << "\":" << value;
+        };
+
+        auto add_array = [&](const char* name, auto&& arr)
+        {
+            add_comma();
+            ss << "\"" << name << "\":[";
+            for(size_t i = 0; i < (sizeof(arr) / sizeof(*arr)); ++i)
+            {
+                if(i > 0)
+                    ss << ",";
+                ss << arr[i];
+            }
+            ss << "]";
+        };
+
+// Convenience macros to avoid repeating field names
+#define ADD(field) add_field(#field, metrics.field)
+#define ADD_ARRAY(field) add_array(#field, metrics.field)
+
+        struct RevisionBlock
+        {
+            int                   min_content_revision;
+            std::function<void()> serialize;
+        };
+
+        std::vector<RevisionBlock> blocks = {
+            {0,
+             [&]
+             {
+             ADD(temperature_edge);
+             ADD(temperature_hotspot);
+             ADD(temperature_mem);
+             ADD(temperature_vrgfx);
+             ADD(temperature_vrsoc);
+             ADD(temperature_vrmem);
+
+             ADD(average_gfx_activity);
+             ADD(average_umc_activity);
+             ADD(average_mm_activity);
+
+             ADD(average_socket_power);
+             ADD(energy_accumulator);
+             ADD(system_clock_counter);
+
+             ADD(average_gfxclk_frequency);
+             ADD(average_socclk_frequency);
+             ADD(average_uclk_frequency);
+             ADD(average_vclk0_frequency);
+             ADD(average_dclk0_frequency);
+             ADD(average_vclk1_frequency);
+             ADD(average_dclk1_frequency);
+
+             ADD(current_gfxclk);
+             ADD(current_socclk);
+             ADD(current_uclk);
+             ADD(current_vclk0);
+             ADD(current_dclk0);
+             ADD(current_vclk1);
+             ADD(current_dclk1);
+
+             ADD(throttle_status);
+             ADD(current_fan_speed);
+             ADD(pcie_link_width);
+             ADD(pcie_link_speed);
+             }                                  },
+            {1,
+             [&]
+             {
+             ADD(gfx_activity_acc);
+             ADD(mem_activity_acc);
+             ADD_ARRAY(temperature_hbm);
+             }                                  },
+            {2, [&] { ADD(firmware_timestamp); }},
+            {3,
+             [&]
+             {
+             ADD(voltage_soc);
+             ADD(voltage_gfx);
+             ADD(voltage_mem);
+             ADD(indep_throttle_status);
+             }                                  },
+            {4,
+             [&]
+             {
+             ADD(current_socket_power);
+             ADD_ARRAY(vcn_activity);
+             ADD(gfxclk_lock_status);
+             ADD(xgmi_link_width);
+             ADD(xgmi_link_speed);
+             ADD(pcie_bandwidth_acc);
+             ADD(pcie_bandwidth_inst);
+             ADD(pcie_l0_to_recov_count_acc);
+             ADD(pcie_replay_count_acc);
+             ADD(pcie_replay_rover_count_acc);
+             ADD_ARRAY(xgmi_read_data_acc);
+             ADD_ARRAY(xgmi_write_data_acc);
+             ADD_ARRAY(current_gfxclks);
+             ADD_ARRAY(current_socclks);
+             ADD_ARRAY(current_vclk0s);
+             ADD_ARRAY(current_dclk0s);
+             }                                  },
+            {5,
+             [&]
+             {
+             ADD_ARRAY(jpeg_activity);
+             ADD(pcie_nak_sent_count_acc);
+             ADD(pcie_nak_rcvd_count_acc);
+             }                                  },
+            {6,
+             [&]
+             {
+             ADD(accumulation_counter);
+             ADD(prochot_residency_acc);
+             ADD(ppt_residency_acc);
+             ADD(socket_thm_residency_acc);
+             ADD(vr_thm_residency_acc);
+             ADD(hbm_thm_residency_acc);
+             ADD(num_partition);
+             // xcp_stats is too annoying and unimportant to serialize.
+             ADD(pcie_lc_perf_other_end_recovery);
+             }                                  },
+            {7,
+             [&]
+             {
+             ADD(vram_max_bandwidth);
+             ADD_ARRAY(xgmi_link_status);
+             }                                  },
+        };
+
+        int currentRev = m_context.amdsmi_metrics_version.content_revision;
+        for(auto& block : blocks)
+        {
+            if(currentRev < block.min_content_revision)
+                break;
+            block.serialize();
+        }
+
+#undef ADD
+#undef ADD_ARRAY
+
+        ss << "}";
+        return ss.str();
+    }
+
+    std::string m_iteration_info_out;
+    bool        m_is_active;
+
+    amdsmi_processor_handle m_target = nullptr;
+    context                 m_context;
+    std::vector<batch>      m_batches;
+};
+#endif // class amdsmi
+
 class state
 {
 public:
@@ -1013,8 +1622,8 @@ public:
           benchmark::State&   gbench_state,
           size_t              warmup_iterations,
           bool                cold,
-          bool                record_as_whole,
-          std::string         iteration_times_out)
+          std::string         iteration_info_out,
+          int                 trials) // TODO: Remove this trials parameter once gbench is removed
         : stream(stream)
         , size(size)
         , bytes(size)
@@ -1023,10 +1632,13 @@ public:
         , gbench_state(gbench_state)
         , warmup_iterations(warmup_iterations)
         , cold(cold)
-        , record_as_whole(record_as_whole)
-        , iteration_times_out(iteration_times_out)
-        , events(record_as_whole ? 2 : batch_iterations * 2)
-    {}
+        , trials(trials)
+        , events(batch_iterations * 2)
+#ifdef BENCHMARK_USE_AMDSMI
+        , amdsmi(iteration_info_out)
+#endif
+    {
+    }
 
     // Used to reset the input array of algorithms like device_merge_inplace.
     void run_before_every_iteration(std::function<void()> lambda)
@@ -1061,75 +1673,72 @@ public:
         }
         HIP_CHECK(hipDeviceSynchronize());
 
-        if(run_before_every_iteration_lambda && batch_iterations > 1 && record_as_whole)
-        {
-            std::cerr << "Error: This benchmark calls run_before_every_iteration() and has a "
-                         "batch_iterations count that is higher than 1, which means it does not "
-                         "support using --record_as_whole.\n";
-            exit(EXIT_FAILURE);
-        }
-
         // Run
         for(auto _ : gbench_state)
         {
-            if(record_as_whole)
+            for(size_t i = 0; i < batch_iterations; ++i)
             {
                 if(run_before_every_iteration_lambda)
                 {
                     run_before_every_iteration_lambda();
                 }
 
-                HIP_CHECK(hipEventRecord(events[0], stream));
-                for(size_t i = 0; i < batch_iterations; ++i)
+                if(cold)
                 {
-                    kernel();
+                    clear_gpu_cache(stream);
                 }
-                HIP_CHECK(hipEventRecord(events[1], stream));
-                HIP_CHECK(hipEventSynchronize(events[1]));
 
-                float elapsed_mseconds;
-                HIP_CHECK(hipEventElapsedTime(&elapsed_mseconds, events[0], events[1]));
-                times.emplace_back(elapsed_mseconds);
-                gbench_state.SetIterationTime(elapsed_mseconds / 1000);
+                // Even events record the start time.
+                HIP_CHECK(hipEventRecord(events[i * 2], stream));
+
+                kernel();
+
+                // Odd events record the stop time.
+                HIP_CHECK(hipEventRecord(events[i * 2 + 1], stream));
             }
-            else
+
+            // Wait until the last record event has completed.
+            HIP_CHECK(hipEventSynchronize(events[batch_iterations * 2 - 1]));
+
+#ifdef BENCHMARK_USE_AMDSMI
+            amdsmi::stats stats = amdsmi.get_stats();
+            std::vector<double> batch_times;
+#endif
+
+            // Accumulate the total elapsed time.
+            double elapsed_ms = 0.0;
+            for(size_t i = 0; i < batch_iterations; i++)
             {
-                for(size_t i = 0; i < batch_iterations; ++i)
-                {
-                    if(run_before_every_iteration_lambda)
-                    {
-                        run_before_every_iteration_lambda();
-                    }
+                float iteration_ms;
+                HIP_CHECK(hipEventElapsedTime(&iteration_ms, events[i * 2], events[i * 2 + 1]));
+                times.emplace_back(iteration_ms);
+                elapsed_ms += iteration_ms;
 
-                    if(cold)
-                    {
-                        clear_gpu_cache(stream);
-                    }
-
-                    // Even events record the start time.
-                    HIP_CHECK(hipEventRecord(events[i * 2], stream));
-
-                    kernel();
-
-                    // Odd events record the stop time.
-                    HIP_CHECK(hipEventRecord(events[i * 2 + 1], stream));
-                }
-
-                // Wait until the last record event has completed.
-                HIP_CHECK(hipEventSynchronize(events[batch_iterations * 2 - 1]));
-
-                // Accumulate the total elapsed time.
-                double elapsed_mseconds = 0.0;
-                for(size_t i = 0; i < batch_iterations; i++)
-                {
-                    float iteration_mseconds;
-                    HIP_CHECK(
-                        hipEventElapsedTime(&iteration_mseconds, events[i * 2], events[i * 2 + 1]));
-                    times.emplace_back(iteration_mseconds);
-                    elapsed_mseconds += iteration_mseconds;
-                }
-                gbench_state.SetIterationTime(elapsed_mseconds / 1000);
+#ifdef BENCHMARK_USE_AMDSMI
+                batch_times.emplace_back(iteration_ms);
+#endif
             }
+
+            gbench_state.SetIterationTime(elapsed_ms / 1000);
+
+#ifdef BENCHMARK_USE_AMDSMI
+            amdsmi.save_batch(batch_times, stats);
+
+            // TODO: When gbench is removed in the future, replace the gbench_state loop
+            // with an infinite while-loop, and use this instead:
+            // now = time.now()
+            // elapsed = now - start
+            // if elapsed > min_time {
+            //     std::string escaped_name = get_escaped_name(gbench_state.name());
+            //     amdsmi.output_iteration_info(escaped_name)
+            //     break
+            // }
+            if(amdsmi.get_batches_count() >= trials)
+            {
+                std::string escaped_name = get_escaped_name(gbench_state.name());
+                amdsmi.output_iteration_info(escaped_name);
+            }
+#endif
         }
 
         if(reset_total_gbench_iterations_every_run)
@@ -1159,14 +1768,9 @@ public:
         gbench_state.SetItemsProcessed(total_gbench_iterations * batch_iterations * actual_size);
 
         output_statistics();
-
-        // Write iteration times to JSON file if requested
-        if(!iteration_times_out.empty())
-        {
-            output_iteration_times();
-        }
     }
 
+    // TODO: Consider prefixing these with m_
     hipStream_t       stream;
     size_t            size;
     size_t            bytes;
@@ -1178,7 +1782,7 @@ private:
     // Zeros a 256 MiB buffer, used to clear the cache before each kernel call.
     // 256 MiB is the size of the largest cache on any AMD GPU.
     // It is currently not possible to fetch the L3 cache size from the runtime.
-    inline void clear_gpu_cache(hipStream_t stream) const
+    void clear_gpu_cache(hipStream_t stream) const
     {
         constexpr size_t buf_size = 256 * MiB;
         static void*     buf      = nullptr;
@@ -1187,6 +1791,19 @@ private:
             HIP_CHECK(hipMalloc(&buf, buf_size));
         }
         HIP_CHECK(hipMemsetAsync(buf, 0, buf_size, stream));
+    }
+
+    std::string get_escaped_name(const std::string& name) const
+    {
+        std::string escaped_name;
+        for(char c : name)
+        {
+            if(c == '"' || c == '\\')
+                escaped_name += '\\';
+            escaped_name += c;
+        }
+        escaped_name += "/manual_time";
+        return escaped_name;
     }
 
     void output_statistics() const
@@ -1213,10 +1830,13 @@ private:
         std::sort(tmp.begin(), tmp.end());
 
         size_t n = tmp.size();
-        if (n % 2 == 1) {
+        if(n % 2 == 1)
+        {
             // Middle element.
             return tmp[n / 2];
-        } else {
+        }
+        else
+        {
             // Average of two middle elements.
             return (tmp[n / 2 - 1] + tmp[n / 2]) / 2.0;
         }
@@ -1243,159 +1863,22 @@ private:
         return times.size() >= 2 ? stddev / mean : 0.0;
     }
 
-    void output_iteration_times() const
-    {
-        // Compose the key: benchmark name + "/manual_time"
-        std::string key = gbench_state.name();
-        // Escape double quotes and backslashes for JSON
-        std::string escaped_key;
-        for(char c : key)
-        {
-            if(c == '"' || c == '\\')
-                escaped_key += '\\';
-            escaped_key += c;
-        }
-        escaped_key += "/manual_time";
-
-        // Compose the value: array of times
-        std::ostringstream value_stream;
-        value_stream << "[";
-        for(size_t i = 0; i < times.size(); ++i)
-        {
-            if(i != 0)
-                value_stream << ",";
-            value_stream << times[i];
-        }
-        value_stream << "]";
-
-        // Try to append or create the JSON file
-        bool file_exists = false;
-        {
-            std::ifstream infile(iteration_times_out);
-            file_exists = infile.good();
-        }
-
-        std::string content;
-        if(file_exists)
-        {
-            content = update_iteration_times(escaped_key, value_stream);
-        }
-        else
-        {
-            // Create new file
-            content = "{\"" + escaped_key + "\":" + value_stream.str() + "}";
-        }
-
-        std::ofstream outfile(iteration_times_out, std::ios::trunc);
-        if(!outfile)
-        {
-            std::cerr << "Error: Failed to open file for writing: " << iteration_times_out
-                      << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        outfile << content;
-        if(!outfile)
-        {
-            std::cerr << "Error: Failed to write to file: " << iteration_times_out << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        outfile.close();
-    }
-
-    std::string update_iteration_times(const std::string&        escaped_key,
-                                       const std::ostringstream& value_stream) const
-    {
-        std::string content;
-
-        // Read the existing file (assume valid JSON object)
-        std::ifstream infile(iteration_times_out);
-        if(!infile)
-        {
-            std::cerr << "Error: Failed to open file for reading: " << iteration_times_out
-                      << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        content.assign((std::istreambuf_iterator<char>(infile)), std::istreambuf_iterator<char>());
-        if(infile.bad())
-        {
-            std::cerr << "Error: Failed to read from file: " << iteration_times_out << std::endl;
-            std::exit(EXIT_FAILURE);
-        }
-        infile.close();
-
-        // Remove trailing '}' and add comma if needed
-        if(!content.empty() && content.back() == '}')
-        {
-            content.pop_back();
-        }
-        else
-        {
-            // Malformed file, start fresh
-            content = "{";
-        }
-
-        // Find the key in the content
-        std::string key_str = "\"" + escaped_key + "\":[";
-        size_t      key_pos = content.find(key_str);
-        if(key_pos != std::string::npos)
-        {
-            // Find the end of the array for this key (the first ']' after key_pos)
-            size_t array_start = key_pos + key_str.size();
-            size_t array_end   = content.find(']', array_start);
-            if(array_end != std::string::npos)
-            {
-                // Replace the array with the new array
-                content.replace(array_start,
-                                array_end - array_start,
-                                value_stream.str().substr(1, value_stream.str().size() - 2));
-                // Remove everything after the replaced array (including the old ']')
-                content.erase(array_start + value_stream.str().size() - 2);
-                // Add closing bracket for the array
-                content += "]";
-            }
-            else
-            {
-                // Malformed, just replace from key_pos to next comma or end
-                size_t next_comma = content.find(',', key_pos);
-                if(next_comma != std::string::npos)
-                {
-                    content.replace(key_pos,
-                                    next_comma - key_pos,
-                                    "\"" + escaped_key + "\":" + value_stream.str());
-                }
-                else
-                {
-                    content.replace(key_pos,
-                                    std::string::npos,
-                                    "\"" + escaped_key + "\":" + value_stream.str());
-                }
-            }
-        }
-        else
-        {
-            // Key not found, add as new key
-            if(content.size() > 1)
-                content += ",";
-            content += "\"" + escaped_key + "\":" + value_stream.str();
-        }
-
-        // Add closing brace
-        content += "}";
-
-        return content;
-    }
-
+    // TODO: Consider prefixing these with m_
     size_t      warmup_iterations;
     bool        cold;
-    bool        record_as_whole;
-    std::string iteration_times_out;
+    int         trials;
 
+    // TODO: Consider prefixing these with m_
     std::vector<hipEvent_t> events;
     std::function<void()>   run_before_every_iteration_lambda       = nullptr;
     size_t                  total_gbench_iterations                 = 0;
     bool                    reset_total_gbench_iterations_every_run = true;
     std::vector<double>     times;
     bool                    has_set_throughput = false;
+
+#ifdef BENCHMARK_USE_AMDSMI
+    class amdsmi            amdsmi;
+#endif
 };
 
 struct autotune_interface
@@ -1502,12 +1985,6 @@ private:
                                   "hot",
                                   !default_cold,
                                   "don't clear the gpu cache on every batch iteration");
-        parser.set_optional<bool>(
-            "record_as_whole",
-            "record_as_whole",
-            false,
-            "record the batch iterations as a whole, at the very start and end, which necessitates "
-            "that gpu cache clearing between iterations can't be done");
 
         parser.set_optional<std::string>("seed", "seed", "random", get_seed_message());
         parser.set_optional<int>("trials", "trials", default_trials, "number of iterations");
@@ -1527,10 +2004,10 @@ private:
                                  "total parallel instances");
 
         parser.set_optional<std::string>(
-            "iteration_times_out",
-            "iteration_times_out",
+            "iteration_info_out",
+            "iteration_info_out",
             "",
-            "optional output path for a JSON file containing iteration times");
+            "optional output path for a JSON file containing iteration info");
     }
 
     void parse(cli::Parser& parser)
@@ -1544,10 +2021,9 @@ private:
         batch_iterations  = parser.get<size_t>("batch_iterations");
         warmup_iterations = parser.get<size_t>("warmup_iterations");
 
-        cold            = !parser.get<bool>("hot");
-        record_as_whole = parser.get<bool>("record_as_whole");
+        cold = !parser.get<bool>("hot");
 
-        iteration_times_out = parser.get<std::string>("iteration_times_out");
+        iteration_info_out = parser.get<std::string>("iteration_info_out");
 
         trials             = parser.get<int>("trials");
         parallel_instance  = parser.get<int>("parallel_instance");
@@ -1679,8 +2155,8 @@ private:
                      gbench_state,
                      warmup_iterations,
                      cold,
-                     record_as_whole,
-                     iteration_times_out);
+                     iteration_info_out,
+                     trials);
     }
 
     void apply_settings(benchmark::internal::Benchmark* b)
@@ -1727,8 +2203,7 @@ private:
     size_t       batch_iterations;
     size_t       warmup_iterations;
     bool         cold;
-    bool         record_as_whole;
-    std::string  iteration_times_out;
+    std::string  iteration_info_out;
 
     int trials;
     int parallel_instance;

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -46,6 +46,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <fstream>
 #include <iostream>
 #include <iterator>
 #include <limits>
@@ -1012,7 +1013,8 @@ public:
           benchmark::State&   gbench_state,
           size_t              warmup_iterations,
           bool                cold,
-          bool                record_as_whole)
+          bool                record_as_whole,
+          std::string         iteration_times_out)
         : stream(stream)
         , size(size)
         , bytes(size)
@@ -1022,6 +1024,7 @@ public:
         , warmup_iterations(warmup_iterations)
         , cold(cold)
         , record_as_whole(record_as_whole)
+        , iteration_times_out(iteration_times_out)
         , events(record_as_whole ? 2 : batch_iterations * 2)
     {}
 
@@ -1156,6 +1159,12 @@ public:
         gbench_state.SetItemsProcessed(total_gbench_iterations * batch_iterations * actual_size);
 
         output_statistics();
+
+        // Write iteration times to JSON file if requested
+        if(!iteration_times_out.empty())
+        {
+            output_iteration_times();
+        }
     }
 
     hipStream_t       stream;
@@ -1229,9 +1238,152 @@ private:
         return times.size() >= 2 ? stddev / mean : 0.0;
     }
 
-    size_t warmup_iterations;
-    bool   cold;
-    bool   record_as_whole;
+    void output_iteration_times()
+    {
+        // Compose the key: benchmark name + "/manual_time"
+        std::string key = gbench_state.name();
+        // Escape double quotes and backslashes for JSON
+        std::string escaped_key;
+        for(char c : key)
+        {
+            if(c == '"' || c == '\\')
+                escaped_key += '\\';
+            escaped_key += c;
+        }
+        escaped_key += "/manual_time";
+
+        // Compose the value: array of times
+        std::ostringstream value_stream;
+        value_stream << "[";
+        for(size_t i = 0; i < times.size(); ++i)
+        {
+            if(i != 0)
+                value_stream << ",";
+            value_stream << times[i];
+        }
+        value_stream << "]";
+
+        // Try to append or create the JSON file
+        bool file_exists = false;
+        {
+            std::ifstream infile(iteration_times_out);
+            file_exists = infile.good();
+        }
+
+        std::string content;
+        if(file_exists)
+        {
+            content = update_iteration_times(escaped_key, value_stream);
+        }
+        else
+        {
+            // Create new file
+            content = "{\"" + escaped_key + "\":" + value_stream.str() + "}";
+        }
+
+        std::ofstream outfile(iteration_times_out, std::ios::trunc);
+        if(!outfile)
+        {
+            std::cerr << "Error: Failed to open file for writing: " << iteration_times_out
+                      << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        outfile << content;
+        if(!outfile)
+        {
+            std::cerr << "Error: Failed to write to file: " << iteration_times_out << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        outfile.close();
+    }
+
+    std::string update_iteration_times(const std::string&        escaped_key,
+                                       const std::ostringstream& value_stream)
+    {
+        std::string content;
+
+        // Read the existing file (assume valid JSON object)
+        std::ifstream infile(iteration_times_out);
+        if(!infile)
+        {
+            std::cerr << "Error: Failed to open file for reading: " << iteration_times_out
+                      << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        content.assign((std::istreambuf_iterator<char>(infile)), std::istreambuf_iterator<char>());
+        if(infile.bad())
+        {
+            std::cerr << "Error: Failed to read from file: " << iteration_times_out << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        infile.close();
+
+        // Remove trailing '}' and add comma if needed
+        if(!content.empty() && content.back() == '}')
+        {
+            content.pop_back();
+        }
+        else
+        {
+            // Malformed file, start fresh
+            content = "{";
+        }
+
+        // Find the key in the content
+        std::string key_str = "\"" + escaped_key + "\":[";
+        size_t      key_pos = content.find(key_str);
+        if(key_pos != std::string::npos)
+        {
+            // Find the end of the array for this key (the first ']' after key_pos)
+            size_t array_start = key_pos + key_str.size();
+            size_t array_end   = content.find(']', array_start);
+            if(array_end != std::string::npos)
+            {
+                // Replace the array with the new array
+                content.replace(array_start,
+                                array_end - array_start,
+                                value_stream.str().substr(1, value_stream.str().size() - 2));
+                // Remove everything after the replaced array (including the old ']')
+                content.erase(array_start + value_stream.str().size() - 2);
+                // Add closing bracket for the array
+                content += "]";
+            }
+            else
+            {
+                // Malformed, just replace from key_pos to next comma or end
+                size_t next_comma = content.find(',', key_pos);
+                if(next_comma != std::string::npos)
+                {
+                    content.replace(key_pos,
+                                    next_comma - key_pos,
+                                    "\"" + escaped_key + "\":" + value_stream.str());
+                }
+                else
+                {
+                    content.replace(key_pos,
+                                    std::string::npos,
+                                    "\"" + escaped_key + "\":" + value_stream.str());
+                }
+            }
+        }
+        else
+        {
+            // Key not found, add as new key
+            if(content.size() > 1)
+                content += ",";
+            content += "\"" + escaped_key + "\":" + value_stream.str();
+        }
+
+        // Add closing brace
+        content += "}";
+
+        return content;
+    }
+
+    size_t      warmup_iterations;
+    bool        cold;
+    bool        record_as_whole;
+    std::string iteration_times_out;
 
     std::vector<hipEvent_t> events;
     std::function<void()>   run_before_every_iteration_lambda       = nullptr;
@@ -1368,6 +1520,12 @@ private:
                                  "parallel_instances",
                                  1,
                                  "total parallel instances");
+
+        parser.set_optional<std::string>(
+            "iteration_times_out",
+            "iteration_times_out",
+            "",
+            "optional output path for a JSON file containing iteration times");
     }
 
     void parse(cli::Parser& parser)
@@ -1383,6 +1541,8 @@ private:
 
         cold            = !parser.get<bool>("hot");
         record_as_whole = parser.get<bool>("record_as_whole");
+
+        iteration_times_out = parser.get<std::string>("iteration_times_out");
 
         trials             = parser.get<int>("trials");
         parallel_instance  = parser.get<int>("parallel_instance");
@@ -1514,7 +1674,8 @@ private:
                      gbench_state,
                      warmup_iterations,
                      cold,
-                     record_as_whole);
+                     record_as_whole,
+                     iteration_times_out);
     }
 
     void apply_settings(benchmark::internal::Benchmark* b)
@@ -1562,6 +1723,7 @@ private:
     size_t       warmup_iterations;
     bool         cold;
     bool         record_as_whole;
+    std::string  iteration_times_out;
 
     int trials;
     int parallel_instance;

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -27,7 +27,7 @@
 #include "../common/utils_half.hpp"
 
 #ifdef BENCHMARK_USE_AMDSMI
-#include <amd_smi/amdsmi.h>
+    #include <amd_smi/amdsmi.h>
 #endif
 
 #include <benchmark/benchmark.h>
@@ -1013,10 +1013,10 @@ class amdsmi
 {
 public:
     amdsmi(std::string iteration_info_out)
-        : m_iteration_info_out(iteration_info_out)
-        , m_is_active(!iteration_info_out.empty())
+        : m_iteration_info_out(iteration_info_out), m_is_active(!iteration_info_out.empty())
     {
-        if(!m_is_active) return;
+        if(!m_is_active)
+            return;
 
         amdsmi_init(AMDSMI_INIT_AMD_GPUS);
 
@@ -1026,7 +1026,8 @@ public:
 
     ~amdsmi()
     {
-        if(!m_is_active) return;
+        if(!m_is_active)
+            return;
 
         amdsmi_shut_down();
     }
@@ -1070,7 +1071,8 @@ public:
 
     stats get_stats() const
     {
-        if(!m_is_active) return {};
+        if(!m_is_active)
+            return {};
 
         stats it{};
 
@@ -1117,7 +1119,8 @@ private:
 public:
     void output_iteration_info(const std::string& name) const
     {
-        if(!m_is_active) return;
+        if(!m_is_active)
+            return;
 
         // Try opening file
         std::fstream outfile(m_iteration_info_out, std::ios::in | std::ios::out | std::ios::ate);
@@ -1189,7 +1192,7 @@ private:
     {
         struct context ctx;
 
-        amdsmi_board_info_t   board_info;
+        amdsmi_board_info_t board_info;
         if(amdsmi_get_gpu_board_info(target, &board_info) == AMDSMI_STATUS_SUCCESS)
             ctx.product_name = board_info.product_name;
 
@@ -1272,7 +1275,6 @@ private:
         return oss.str();
     }
 
-    // TODO: Put all methods in this class in a logical order
     amdsmi_processor_handle get_target() const
     {
         // Get HIP device
@@ -1474,9 +1476,9 @@ private:
             ss << "]";
         };
 
-// Convenience macros to avoid repeating field names
-#define ADD(field) add_field(#field, metrics.field)
-#define ADD_ARRAY(field) add_array(#field, metrics.field)
+    // Convenience macros to avoid repeating field names
+    #define ADD(field) add_field(#field, metrics.field)
+    #define ADD_ARRAY(field) add_array(#field, metrics.field)
 
         struct RevisionBlock
         {
@@ -1596,8 +1598,8 @@ private:
             block.serialize();
         }
 
-#undef ADD
-#undef ADD_ARRAY
+    #undef ADD
+    #undef ADD_ARRAY
 
         ss << "}";
         return ss.str();
@@ -1616,7 +1618,7 @@ class state
 {
 public:
     state(hipStream_t         stream,
-          size_t              size,
+          size_t              bytes,
           const managed_seed& seed,
           size_t              batch_iterations,
           benchmark::State&   gbench_state,
@@ -1625,48 +1627,46 @@ public:
           std::string         iteration_info_out,
           int                 trials) // TODO: Remove this trials parameter once gbench is removed
         : stream(stream)
-        , size(size)
-        , bytes(size)
+        , bytes(bytes)
         , seed(seed)
         , batch_iterations(batch_iterations)
         , gbench_state(gbench_state)
-        , warmup_iterations(warmup_iterations)
-        , cold(cold)
-        , trials(trials)
-        , events(batch_iterations * 2)
+        , m_warmup_iterations(warmup_iterations)
+        , m_cold(cold)
+        , m_trials(trials)
+        , m_events(batch_iterations * 2)
 #ifdef BENCHMARK_USE_AMDSMI
-        , amdsmi(iteration_info_out)
+        , m_amdsmi(iteration_info_out)
 #endif
-    {
-    }
+    {}
 
     // Used to reset the input array of algorithms like device_merge_inplace.
     void run_before_every_iteration(std::function<void()> lambda)
     {
-        run_before_every_iteration_lambda = lambda;
+        m_run_before_every_iteration_lambda = lambda;
     }
 
     // Used to accumulate the results of state.run() calls.
     void accumulate_total_gbench_iterations_every_run()
     {
-        reset_total_gbench_iterations_every_run = false;
+        m_reset_total_gbench_iterations_every_run = false;
     }
 
     void run(std::function<void()> kernel)
     {
-        for(auto& event : events)
+        for(auto& event : m_events)
         {
             HIP_CHECK(hipEventCreate(&event));
         }
 
         // Warm-up
-        for(size_t i = 0; i < warmup_iterations; ++i)
+        for(size_t i = 0; i < m_warmup_iterations; ++i)
         {
             // Benchmarks may expect their kernel input to be prepared by this lambda,
             // so to prevent any potential crashes, we call the lambda during warm-up.
-            if(run_before_every_iteration_lambda)
+            if(m_run_before_every_iteration_lambda)
             {
-                run_before_every_iteration_lambda();
+                m_run_before_every_iteration_lambda();
             }
 
             kernel();
@@ -1678,30 +1678,30 @@ public:
         {
             for(size_t i = 0; i < batch_iterations; ++i)
             {
-                if(run_before_every_iteration_lambda)
+                if(m_run_before_every_iteration_lambda)
                 {
-                    run_before_every_iteration_lambda();
+                    m_run_before_every_iteration_lambda();
                 }
 
-                if(cold)
+                if(m_cold)
                 {
                     clear_gpu_cache(stream);
                 }
 
-                // Even events record the start time.
-                HIP_CHECK(hipEventRecord(events[i * 2], stream));
+                // Even m_events record the start time.
+                HIP_CHECK(hipEventRecord(m_events[i * 2], stream));
 
                 kernel();
 
-                // Odd events record the stop time.
-                HIP_CHECK(hipEventRecord(events[i * 2 + 1], stream));
+                // Odd m_events record the stop time.
+                HIP_CHECK(hipEventRecord(m_events[i * 2 + 1], stream));
             }
 
             // Wait until the last record event has completed.
-            HIP_CHECK(hipEventSynchronize(events[batch_iterations * 2 - 1]));
+            HIP_CHECK(hipEventSynchronize(m_events[batch_iterations * 2 - 1]));
 
 #ifdef BENCHMARK_USE_AMDSMI
-            amdsmi::stats stats = amdsmi.get_stats();
+            amdsmi::stats       stats = m_amdsmi.get_stats();
             std::vector<double> batch_times;
 #endif
 
@@ -1710,8 +1710,8 @@ public:
             for(size_t i = 0; i < batch_iterations; i++)
             {
                 float iteration_ms;
-                HIP_CHECK(hipEventElapsedTime(&iteration_ms, events[i * 2], events[i * 2 + 1]));
-                times.emplace_back(iteration_ms);
+                HIP_CHECK(hipEventElapsedTime(&iteration_ms, m_events[i * 2], m_events[i * 2 + 1]));
+                m_times.emplace_back(iteration_ms);
                 elapsed_ms += iteration_ms;
 
 #ifdef BENCHMARK_USE_AMDSMI
@@ -1722,7 +1722,7 @@ public:
             gbench_state.SetIterationTime(elapsed_ms / 1000);
 
 #ifdef BENCHMARK_USE_AMDSMI
-            amdsmi.save_batch(batch_times, stats);
+            m_amdsmi.save_batch(batch_times, stats);
 
             // TODO: When gbench is removed in the future, replace the gbench_state loop
             // with an infinite while-loop, and use this instead:
@@ -1733,21 +1733,21 @@ public:
             //     amdsmi.output_iteration_info(escaped_name)
             //     break
             // }
-            if(amdsmi.get_batches_count() >= trials)
+            if(m_amdsmi.get_batches_count() >= m_trials)
             {
                 std::string escaped_name = get_escaped_name(gbench_state.name());
-                amdsmi.output_iteration_info(escaped_name);
+                m_amdsmi.output_iteration_info(escaped_name);
             }
 #endif
         }
 
-        if(reset_total_gbench_iterations_every_run)
+        if(m_reset_total_gbench_iterations_every_run)
         {
-            total_gbench_iterations = 0;
+            m_total_gbench_iterations = 0;
         }
-        total_gbench_iterations += gbench_state.iterations();
+        m_total_gbench_iterations += gbench_state.iterations();
 
-        for(const auto& event : events)
+        for(const auto& event : m_events)
         {
             HIP_CHECK(hipEventDestroy(event));
         }
@@ -1755,24 +1755,23 @@ public:
 
     void set_throughput(size_t actual_size, size_t type_size)
     {
-        if(has_set_throughput)
+        if(m_has_set_throughput)
         {
             std::cerr << "Error: Benchmarks should only ever call set_throughput() once, at the "
                          "very end.\n";
             exit(EXIT_FAILURE);
         }
-        has_set_throughput = true;
+        m_has_set_throughput = true;
 
-        gbench_state.SetBytesProcessed(total_gbench_iterations * batch_iterations * actual_size
+        gbench_state.SetBytesProcessed(m_total_gbench_iterations * batch_iterations * actual_size
                                        * type_size);
-        gbench_state.SetItemsProcessed(total_gbench_iterations * batch_iterations * actual_size);
+        gbench_state.SetItemsProcessed(m_total_gbench_iterations * batch_iterations * actual_size);
 
         output_statistics();
     }
 
-    // TODO: Consider prefixing these with m_
+    // These are directly read by benchmarks.
     hipStream_t       stream;
-    size_t            size;
     size_t            bytes;
     managed_seed      seed;
     size_t            batch_iterations;
@@ -1821,12 +1820,12 @@ private:
 
     double get_mean() const
     {
-        return std::reduce(times.begin(), times.end()) / times.size();
+        return std::reduce(m_times.begin(), m_times.end()) / m_times.size();
     }
 
     double get_median() const
     {
-        auto tmp = times; // Copy, so we don’t mutate *this.
+        auto tmp = m_times; // Copy, so we don’t mutate *this.
         std::sort(tmp.begin(), tmp.end());
 
         size_t n = tmp.size();
@@ -1850,34 +1849,32 @@ private:
         auto Sqrt = [](double dat) { return dat < 0.0 ? 0.0 : std::sqrt(dat); };
 
         double stddev = 0.0;
-        if(times.size() > 1)
+        if(m_times.size() > 1)
         {
-            double avg_squares = SumSquares(times) * (1.0 / times.size());
-            stddev = Sqrt(times.size() / (times.size() - 1.0) * (avg_squares - Sqr(mean)));
+            double avg_squares = SumSquares(m_times) * (1.0 / m_times.size());
+            stddev = Sqrt(m_times.size() / (m_times.size() - 1.0) * (avg_squares - Sqr(mean)));
         }
         return stddev;
     }
 
     double get_cv(double stddev, double mean) const
     {
-        return times.size() >= 2 ? stddev / mean : 0.0;
+        return m_times.size() >= 2 ? stddev / mean : 0.0;
     }
 
-    // TODO: Consider prefixing these with m_
-    size_t      warmup_iterations;
-    bool        cold;
-    int         trials;
+    size_t m_warmup_iterations;
+    bool   m_cold;
+    int    m_trials;
 
-    // TODO: Consider prefixing these with m_
-    std::vector<hipEvent_t> events;
-    std::function<void()>   run_before_every_iteration_lambda       = nullptr;
-    size_t                  total_gbench_iterations                 = 0;
-    bool                    reset_total_gbench_iterations_every_run = true;
-    std::vector<double>     times;
-    bool                    has_set_throughput = false;
+    std::vector<hipEvent_t> m_events;
+    std::function<void()>   m_run_before_every_iteration_lambda       = nullptr;
+    size_t                  m_total_gbench_iterations                 = 0;
+    bool                    m_reset_total_gbench_iterations_every_run = true;
+    std::vector<double>     m_times;
+    bool                    m_has_set_throughput = false;
 
 #ifdef BENCHMARK_USE_AMDSMI
-    class amdsmi            amdsmi;
+    class amdsmi m_amdsmi;
 #endif
 };
 
@@ -1959,7 +1956,7 @@ public:
 
     void run()
     {
-        register_sorted_subset(parallel_instance, parallel_instances);
+        register_sorted_subset(m_parallel_instance, m_parallel_instances);
         benchmark::ConsoleReporter cr;
         benchmark::RunSpecifiedBenchmarks(&cr);
     }
@@ -2012,33 +2009,32 @@ private:
 
     void parse(cli::Parser& parser)
     {
-        size = parser.get<size_t>("size");
+        m_bytes = parser.get<size_t>("size");
 
-        seed_type = parser.get<std::string>("seed");
+        m_seed_type = parser.get<std::string>("seed");
+        m_seed      = managed_seed(m_seed_type);
 
-        seed = managed_seed(seed_type);
+        m_batch_iterations  = parser.get<size_t>("batch_iterations");
+        m_warmup_iterations = parser.get<size_t>("warmup_iterations");
 
-        batch_iterations  = parser.get<size_t>("batch_iterations");
-        warmup_iterations = parser.get<size_t>("warmup_iterations");
+        m_cold = !parser.get<bool>("hot");
 
-        cold = !parser.get<bool>("hot");
+        m_iteration_info_out = parser.get<std::string>("iteration_info_out");
 
-        iteration_info_out = parser.get<std::string>("iteration_info_out");
-
-        trials             = parser.get<int>("trials");
-        parallel_instance  = parser.get<int>("parallel_instance");
-        parallel_instances = parser.get<int>("parallel_instances");
+        m_trials             = parser.get<int>("trials");
+        m_parallel_instance  = parser.get<int>("parallel_instance");
+        m_parallel_instances = parser.get<int>("parallel_instances");
 
         bench_naming::set_format(parser.get<std::string>("name_format"));
     }
 
     void add_context()
     {
-        benchmark::AddCustomContext("size", std::to_string(size));
-        benchmark::AddCustomContext("seed", seed_type);
+        benchmark::AddCustomContext("size", std::to_string(m_bytes));
+        benchmark::AddCustomContext("seed", m_seed_type);
 
-        benchmark::AddCustomContext("batch_iterations", std::to_string(batch_iterations));
-        benchmark::AddCustomContext("warmup_iterations", std::to_string(warmup_iterations));
+        benchmark::AddCustomContext("batch_iterations", std::to_string(m_batch_iterations));
+        benchmark::AddCustomContext("warmup_iterations", std::to_string(m_warmup_iterations));
 
         hipDeviceProp_t devProp;
         int             device_id = 0;
@@ -2148,15 +2144,15 @@ private:
 
     state new_state(benchmark::State& gbench_state)
     {
-        return state(stream,
-                     size,
-                     seed,
-                     batch_iterations,
+        return state(m_stream,
+                     m_bytes,
+                     m_seed,
+                     m_batch_iterations,
                      gbench_state,
-                     warmup_iterations,
-                     cold,
-                     iteration_info_out,
-                     trials);
+                     m_warmup_iterations,
+                     m_cold,
+                     m_iteration_info_out,
+                     m_trials);
     }
 
     void apply_settings(benchmark::internal::Benchmark* b)
@@ -2165,9 +2161,9 @@ private:
         b->Unit(benchmark::kMillisecond);
 
         // trials is -1 by default.
-        if(trials > 0)
+        if(m_trials > 0)
         {
-            b->Iterations(trials);
+            b->Iterations(m_trials);
         }
     }
 
@@ -2196,18 +2192,18 @@ private:
         }
     }
 
-    hipStream_t  stream = hipStreamDefault;
-    size_t       size;
-    std::string  seed_type;
-    managed_seed seed;
-    size_t       batch_iterations;
-    size_t       warmup_iterations;
-    bool         cold;
-    std::string  iteration_info_out;
+    hipStream_t  m_stream = hipStreamDefault;
+    size_t       m_bytes;
+    std::string  m_seed_type;
+    managed_seed m_seed;
+    size_t       m_batch_iterations;
+    size_t       m_warmup_iterations;
+    bool         m_cold;
+    std::string  m_iteration_info_out;
 
-    int trials;
-    int parallel_instance;
-    int parallel_instances;
+    int m_trials;
+    int m_parallel_instance;
+    int m_parallel_instances;
 };
 
 } // namespace benchmark_utils

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -1178,7 +1178,7 @@ private:
     // Zeros a 256 MiB buffer, used to clear the cache before each kernel call.
     // 256 MiB is the size of the largest cache on any AMD GPU.
     // It is currently not possible to fetch the L3 cache size from the runtime.
-    inline void clear_gpu_cache(hipStream_t stream)
+    inline void clear_gpu_cache(hipStream_t stream) const
     {
         constexpr size_t buf_size = 256 * MiB;
         static void*     buf      = nullptr;
@@ -1189,7 +1189,7 @@ private:
         HIP_CHECK(hipMemsetAsync(buf, 0, buf_size, stream));
     }
 
-    void output_statistics()
+    void output_statistics() const
     {
         double mean   = get_mean();
         double median = get_median();
@@ -1202,22 +1202,27 @@ private:
         gbench_state.counters["cv"]     = cv;
     }
 
-    double get_mean()
+    double get_mean() const
     {
         return std::reduce(times.begin(), times.end()) / times.size();
     }
 
-    // Technically when times.size() is even, the median is the arithmetic mean
-    // of the elements k=N/2 and k=N/2+1. This would be overkill here,
-    // as times.size() is large enough, and recorded times are similar enough.
-    double get_median()
+    double get_median() const
     {
-        size_t center_index = times.size() / 2;
-        std::nth_element(times.begin(), times.begin() + center_index, times.end());
-        return times[center_index];
+        auto tmp = times; // Copy, so we don’t mutate *this.
+        std::sort(tmp.begin(), tmp.end());
+
+        size_t n = tmp.size();
+        if (n % 2 == 1) {
+            // Middle element.
+            return tmp[n / 2];
+        } else {
+            // Average of two middle elements.
+            return (tmp[n / 2 - 1] + tmp[n / 2]) / 2.0;
+        }
     }
 
-    double get_stddev(double mean)
+    double get_stddev(double mean) const
     {
         auto SumSquares = [](const std::vector<double>& v)
         { return std::transform_reduce(v.begin(), v.end(), v.begin(), 0.0); };
@@ -1233,12 +1238,12 @@ private:
         return stddev;
     }
 
-    double get_cv(double stddev, double mean)
+    double get_cv(double stddev, double mean) const
     {
         return times.size() >= 2 ? stddev / mean : 0.0;
     }
 
-    void output_iteration_times()
+    void output_iteration_times() const
     {
         // Compose the key: benchmark name + "/manual_time"
         std::string key = gbench_state.name();
@@ -1298,7 +1303,7 @@ private:
     }
 
     std::string update_iteration_times(const std::string&        escaped_key,
-                                       const std::ostringstream& value_stream)
+                                       const std::ostringstream& value_stream) const
     {
         std::string content;
 

--- a/projects/rocprim/docs/install/rocPRIM-build-install-linux.rst
+++ b/projects/rocprim/docs/install/rocPRIM-build-install-linux.rst
@@ -35,6 +35,7 @@ Use the appropriate CMake directive:
 * ``BUILD_DOCS``: Set to ``ON`` to build a local copy of the rocPRIM documentation. ``OFF`` by default.
 * ``BUILD_BENCHMARK``: Set to ``ON`` to build benchmarking tests. ``OFF`` by default.
 * ``BENCHMARK_CONFIG_TUNING``: Set to ``ON`` to find the best kernel configuration parameters for benchmarking. Turning this on might increase compilation time significantly. ``OFF`` by default. 
+* ``BENCHMARK_USE_AMDSMI``: Set to ``ON`` to let benchmarks use AMD SMI to output more GPU statistics. ``OFF`` by default.
 * ``AMDGPU_TARGETS``: Set this to build the library, examples, tests, examples, and benchmarks for specific architecture targets. When not set, the examples, tests, and benchmarks are built for gfx803, gfx900:xnack-, gfx906:xnack-, gfx908:xnack-, gfx90a:xnack-, gfx90a:xnack+, gfx942;gfx950, gfx1030, gfx1100, gfx1101, gfx1102, gfx1151, gfx1200, and gfx1201 architectures. The list of targets must be separated by a semicolon (``;``).
 * ``AMDGPU_TEST_TARGETS``: Set this to build tests for a subset of the architectures specified by ``AMDGPU_TARGETS``. When set, copies of the same test will be generated for each of the architectures listed. These tests can be run using ``ctest -R "TARGET_ARCHITECTURE"``. The list of targets must be separated by a semicolon (``;``).
 * ``USE_SYSTEM_LIB``: Set to ``ON`` to use the installed ``ROCm`` libraries when building the tests. Off by default. For this option to take effect, ``BUILD_TEST`` must be ``ON``.


### PR DESCRIPTION
## Motivation

This PR adds an optional benchmark flag, which specifies the JSON path to output individual benchmark iteration times to:

```json
{
    "{\"lvl\":\"device\",\"algo\":\"find_first_of\",\"keys_size\":1,\"first_occurrence\":\"0.100000\",\"value_type\":\"int8_t\",\"cfg\":\"default_config\"}/manual_time": [
        0.09152,
        0.09184,
        0.092001
    ],
    "{\"lvl\":\"device\",\"algo\":\"find_first_of\",\"keys_size\":1,\"first_occurrence\":\"0.500000\",\"value_type\":\"int8_t\",\"cfg\":\"default_config\"}/manual_time": [
        0.388802,
        0.389442,
        0.389442
    ]
}
```

## Technical Details

This JSON data has already been used by StreamHPC's internal `plot_iteration_times.py` script to generate graphs like these:
<img width="1252" height="693" alt="image" src="https://github.com/user-attachments/assets/0b8d775a-f23f-40f2-a691-aadd3e2a7065" />

Visualizing the benchmark iteration times has helped diagnose why some benchmarks are very noisy.

I also added the commit `refactor(rocprim): stop shadowing the method name`, which just fixes an oversight of mine when I updated this benchmark a few months ago.

The reason the `output_iteration_times()` and `update_iteration_times()` functions this pull request adds are so complex, is because I didn't want to introduce a new dependency on a JSON library.

In a future PR called `Trim outlier iteration times` that is currently under internal review, I noticed that I forgot to add a description above `output_iteration_times()`, so that PR adds this missing description:
```c
// This function overwrites any specialization's previously output JSON array.
// This allows gbench to call this fn several times per specialization.
void output_iteration_times() const
{
```

## Test Plan

This pull request has been reviewed and used internally at StreamHPC.

### Setup
1. Clone rocm-libraries.
2. Checkout this PR.
3. Run `gfx="$(rocminfo | grep -o 'gfx[0-9|a-f]\+' | head -n1)"`.
4. Run `mkdir build && cd build && CXX=hipcc cmake -GNinja -DBUILD_BENCHMARK=ON -DBENCHMARK_CONFIG_TUNING=OFF -DBENCHMARK_AUTOTUNED_TYPES_ONLY=ON -DGPU_TARGETS="$gfx" ..`

### Running benchmark_device_find_first_of
There are two options:
1. Generate `times.json` by running `ninja benchmark_device_find_first_of && time benchmark/benchmark_device_find_first_of --seed 42 --benchmark_out=foo.json --iteration_times_out times.json`.
2. Generate `iteration_times/benchmark_device_find_first_of_gfx90a.json` by running `python3 .gitlab/run_benchmarks.py --benchmark_dir build_benchmark/benchmark --benchmark_gpu_architecture "$gfx" --benchmark_output_dir benchmark_results --benchmark_filename_regex '^benchmark_device_find_first_of' --seed 42 --iteration_times_output_dir iteration_times`.

## Test Result

This JSON data has been successfully used to generate graphs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
