### PR TITLE
Add guards for __HIP_NO_HALF_OPERATORS__ macro

### DIFF
--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
@@ -317,7 +317,8 @@ struct [[deprecated(
         return HIPCUB_MIN(t, u);
     }
 };
-/*
+
+#if !defined(__HIP_NO_HALF_OPERATORS__)
 template<>
 struct [[deprecated(
     "SIMD intrinsics are currently not supported on HIP, use Min instead.")]] SimdMin<__half>
@@ -332,7 +333,8 @@ struct [[deprecated(
         return HIPCUB_MIN(t, u);
     }
 };
-*/
+#endif // !defined(__HIP_NO_HALF_OPERATORS__)
+
 template<>
 struct [[deprecated("SIMD intrinsics are currently not supported on HIP, use Min "
                     "instead.")]] SimdMin<__hip_bfloat16>
@@ -383,7 +385,7 @@ struct [[deprecated(
     }
 };
 
-/*
+#if !defined(__HIP_NO_HALF_OPERATORS__)
 template<>
 struct [[deprecated(
     "SIMD intrinsics are currently not supported on HIP, use Max instead.")]] SimdMax<__half>
@@ -397,7 +399,7 @@ struct [[deprecated(
         return HIPCUB_MAX(t, u);
     }
 };
-*/
+#endif // !defined(__HIP_NO_HALF_OPERATORS__)
 
 template<>
 struct [[deprecated("SIMD intrinsics are currently not supported on HIP, use Max "
@@ -447,7 +449,7 @@ struct [[deprecated(
         return t + u;
     }
 };
-/*
+#if !defined(__HIP_NO_HALF_OPERATORS__)
 template<>
 struct [[deprecated(
     "SIMD intrinsics are currently not supported on HIP, use Sum instead.")]] SimdSum<__half>
@@ -461,7 +463,7 @@ struct [[deprecated(
         return t + u;
     }
 };
-*/
+#endif // !defined(__HIP_NO_HALF_OPERATORS__)
 
 template<>
 struct [[deprecated("SIMD intrinsics are currently not supported on HIP, use Sum "
@@ -514,7 +516,7 @@ struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP
     }
 };
 
-/*
+#if !defined(__HIP_NO_HALF_OPERATORS__)
 template<>
 struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP, so "
                     "this operator will multiply 2 input values directly")]] SimdMul<__half>
@@ -528,7 +530,7 @@ struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP
         return t * u;
     }
 };
-*/
+#endif // !defined(__HIP_NO_HALF_OPERATORS__)
 
 template<>
 struct [[deprecated("Warning: SIMD intrinsics are currently not supported on HIP, so "

--- a/projects/hipcub/test/hipcub/CMakeLists.txt
+++ b/projects/hipcub/test/hipcub/CMakeLists.txt
@@ -207,6 +207,9 @@ endfunction()
 # HIP basic test, which also checks if there are no linkage problems when there are multiple sources
 add_hipcub_test("hipcub.BasicTest" "test_hipcub_basic.cpp;detail/get_hipcub_version.cpp")
 
+# This test checks if hipCUB can compile with the __HIP_NO_HALF_CONVERSIONS__ and __HIP_NO_HALF_OPERATORS__ flags.
+add_hipcub_test("hipcub.NoHalfOperators" test_hipcub_no_half_operators.cpp)
+
 add_hipcub_test("hipcub.CachingDeviceAllocator" test_hipcub_caching_device_allocator.cpp)
 add_hipcub_test("hipcub.BlockAdjacentDifference" test_hipcub_block_adjacent_difference.cpp)
 add_hipcub_test("hipcub.BlockDiscontinuity" test_hipcub_block_discontinuity.cpp)

--- a/projects/hipcub/test/hipcub/test_hipcub_no_half_operators.cpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_no_half_operators.cpp
@@ -1,0 +1,33 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// hipCUB should have at least minimal support for this configuration,
+// because projects already depend on it, so regression should be avoided.
+// Some algorithms won't work with `half` in this setting e.g. histogram,
+// but it should at least compile.
+
+#define __HIP_NO_HALF_CONVERSIONS__ 1
+#define __HIP_NO_HALF_OPERATORS__ 1
+
+#include <hipcub/hipcub.hpp>
+
+int main() {}


### PR DESCRIPTION
## Motivation

hipCUB currently did not compile with the __HIP_NO_HALF_OPERATORS__ flag. Some macro guards were added and a test to confirm was added.

## Technical Details

Just the guards for __HIP_NO_HALF_OPERATORS__, were enough to fix the compile issue.

## Test Plan

Test was added to hipCUB.

## Test Result

Test passes.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
