### PR TITLE
Initial dvc setup

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,6 @@
+[core]
+    remote = storage
+    autostage = true
+['remote "storage"']
+    url = s3://therock-dvc/rocm-libraries
+    allow_anonymous_login = true

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore


### PR DESCRIPTION
- Add base config files for `dvc` to repo
- Do not convert any `git lfs` files yet to `dvc`. That will happen in a subsequent PR.
- This can help verify CI/CD workspaces are setup with `dvc` and can run `dvc config list` command in their workspace.