### PR TITLE
stop tracking kdb.bz2 files with git lfs

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,6 @@
+[core]
+    remote = storage
+    autostage = true
+['remote "storage"']
+    url = s3://therock-dvc/rocm-libraries
+    allow_anonymous_login = true

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/projects/miopen/src/kernels/.gitignore
+++ b/projects/miopen/src/kernels/.gitignore
@@ -1,0 +1,6 @@
+/gfx1030.kdb.bz2
+/gfx900.kdb.bz2
+/gfx906.kdb.bz2
+/gfx908.kdb.bz2
+/gfx90a.kdb.bz2
+/gfx942.kdb.bz2

--- a/projects/miopen/src/kernels/gfx1030.kdb.bz2
+++ b/projects/miopen/src/kernels/gfx1030.kdb.bz2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c4484c69eec165ee8b0233b1dd54ca73384d1d53bf79ddedb2ce078748681f2
-size 400027325

--- a/projects/miopen/src/kernels/gfx1030.kdb.bz2.dvc
+++ b/projects/miopen/src/kernels/gfx1030.kdb.bz2.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 22c4bd38cc34d3906add061ee57b099b
+  size: 400027325
+  hash: md5
+  path: gfx1030.kdb.bz2

--- a/projects/miopen/src/kernels/gfx900.kdb.bz2
+++ b/projects/miopen/src/kernels/gfx900.kdb.bz2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:945141e464054e3527c77243c7cd7ac87fbde8e191b7d5ef0737cb1451ed52b1
-size 283195931

--- a/projects/miopen/src/kernels/gfx900.kdb.bz2.dvc
+++ b/projects/miopen/src/kernels/gfx900.kdb.bz2.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: cf9c12dafe25b15ea1e93088b7b061af
+  size: 283195931
+  hash: md5
+  path: gfx900.kdb.bz2

--- a/projects/miopen/src/kernels/gfx906.kdb.bz2
+++ b/projects/miopen/src/kernels/gfx906.kdb.bz2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:727d4e0cb714422fbf40952559b10bba43148f8f9bd6f8e3461853b1e2fdb5d3
-size 333916279

--- a/projects/miopen/src/kernels/gfx906.kdb.bz2.dvc
+++ b/projects/miopen/src/kernels/gfx906.kdb.bz2.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 04b3be6a15c700ff382e0a5e136010e1
+  size: 333916279
+  hash: md5
+  path: gfx906.kdb.bz2

--- a/projects/miopen/src/kernels/gfx908.kdb.bz2
+++ b/projects/miopen/src/kernels/gfx908.kdb.bz2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a48df4ce964bdce10fdda78b755a4cd349c7793c83e4af970c7e3b8345b603e3
-size 109795654

--- a/projects/miopen/src/kernels/gfx908.kdb.bz2.dvc
+++ b/projects/miopen/src/kernels/gfx908.kdb.bz2.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 35b9082b72e661dc5e37f14de1d9d4ed
+  size: 109795654
+  hash: md5
+  path: gfx908.kdb.bz2

--- a/projects/miopen/src/kernels/gfx90a.kdb.bz2
+++ b/projects/miopen/src/kernels/gfx90a.kdb.bz2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e4cd2818dd5fd7b396177ebebd4eb2fc263a83af5319320781790fdeda41231
-size 154425106

--- a/projects/miopen/src/kernels/gfx90a.kdb.bz2.dvc
+++ b/projects/miopen/src/kernels/gfx90a.kdb.bz2.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: a11615323e06c5774fe19cf34c51baef
+  size: 154425106
+  hash: md5
+  path: gfx90a.kdb.bz2

--- a/projects/miopen/src/kernels/gfx942.kdb.bz2
+++ b/projects/miopen/src/kernels/gfx942.kdb.bz2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a31c07a94e538124aed84908e85e813046fb6418abe73f393ba9955423323a58
-size 3335357

--- a/projects/miopen/src/kernels/gfx942.kdb.bz2.dvc
+++ b/projects/miopen/src/kernels/gfx942.kdb.bz2.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 5330c69cfc79e05ab01e34aa7878cc60
+  size: 3335357
+  hash: md5
+  path: gfx942.kdb.bz2


### PR DESCRIPTION
- Requires #1587.
- Requires CI/CD systems to have `dvc` installed.
- Will add documentation updates.