### PR TITLE
cmake: move USE_HIPRAND to target-specific definitions

### DIFF
--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -113,10 +113,6 @@ option(ROCFFT_BUILD_OFFLINE_TUNER "Build with offline tuner executable rocfft_of
 # Provide ability to disable hipRAND dependency
 option(USE_HIPRAND "Use hipRAND to provide device-side input generation" ON)
 
-if( USE_HIPRAND )
-  add_compile_definitions(USE_HIPRAND)
-endif( )
-
 # Split up function pool compilation across N files to parallelize its build
 set(ROCFFT_FUNCTION_POOL_N 8 CACHE STRING "Number of files to split function_pool into for compilation")
 

--- a/projects/rocfft/clients/bench/CMakeLists.txt
+++ b/projects/rocfft/clients/bench/CMakeLists.txt
@@ -105,6 +105,7 @@ foreach( bench ${bench_list})
     PRIVATE
     hip::hiprand
     )
+    target_compile_definitions( ${bench} PRIVATE USE_HIPRAND )
   endif()
 
   # We need to include both rocfft.h and rocfft-export.h

--- a/projects/rocfft/clients/samples/mpi/CMakeLists.txt
+++ b/projects/rocfft/clients/samples/mpi/CMakeLists.txt
@@ -97,6 +97,7 @@ foreach( sample ${sample_list} )
     PRIVATE
     hip::hiprand
     )
+    target_compile_definitions( ${sample} PRIVATE USE_HIPRAND )
   endif()
 
   target_compile_options( ${sample} PRIVATE ${WARNING_FLAGS} -Wno-cpp )

--- a/projects/rocfft/clients/samples/multi_gpu/CMakeLists.txt
+++ b/projects/rocfft/clients/samples/multi_gpu/CMakeLists.txt
@@ -79,6 +79,7 @@ foreach( sample ${sample_list} )
       PRIVATE
       hip::hiprand
     )
+    target_compile_definitions( ${sample} PRIVATE USE_HIPRAND )
   endif()
 
   target_compile_options( ${sample} PRIVATE ${WARNING_FLAGS} -Wno-cpp )

--- a/projects/rocfft/clients/samples/rocfft/CMakeLists.txt
+++ b/projects/rocfft/clients/samples/rocfft/CMakeLists.txt
@@ -80,6 +80,7 @@ foreach( sample ${sample_list} )
       PRIVATE
       hip::hiprand
       )
+    target_compile_definitions( ${sample} PRIVATE USE_HIPRAND )
   endif()
 
   target_compile_options( ${sample} PRIVATE ${WARNING_FLAGS} -Wno-cpp )

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -259,6 +259,7 @@ if ( USE_HIPRAND )
   PRIVATE
   hip::hiprand
   )
+  target_compile_definitions( rocfft-test PRIVATE USE_HIPRAND )
 endif()
 
 if( ROCFFT_MPI_ENABLE )


### PR DESCRIPTION
## Motivation

Prevent a build-time dependency of the rocFFT library on hipRAND.  Optional rocFFT client programs can still have this dependency (as that speeds up generation of test/benchmark data), but the rocFFT library itself should not depend on hipRAND.

## Technical Details

USE_HIPRAND is currently a global `add_definitions` in CMake, which means fft_params pulls in hipRAND.  But the core rocFFT library also uses fft_params and should not depend on hipRAND.  Move the definition to be target-specific so that the rocFFT library does not depend on hipRAND.

Introduced by ffde1cc8f958ffbeafceb1fd4a295da1814f773c.

## Test Plan

This issue breaks the build on developer workstations because CMake is not told about rocFFT depending on hipRAND, and can't find the hipRAND header files.  So once the build succeeds, the existing test coverage will ensure things are working.

## Test Result

Developer workstation builds succeed with this change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
