### PR TITLE
[Origami] Remove debug parameter

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
@@ -686,7 +686,6 @@ std::vector<SolutionIndexParameters> chooseSolutionIndexParameters(
         kernelType.scaleABlockRowSize * kernelType.scaleABlockColSize, //Handle A vs B block size.
         0.8,
         false,
-        false,
         WGM);
 
     for(auto const& selected_tile : selected_tiles)

--- a/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
@@ -188,7 +188,6 @@ namespace TensileLite
                 miDataType,
                 0,   // mx_block_size -> MX Data types come from rocroller.
                 0.8, // L2 hit-rate (not used anymore -- should be removed)
-                debug,
                 false,
                 defaultWGM);
             for(const auto& tile : selected_tiles)

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -1253,7 +1253,6 @@ namespace TensileLite
                                                                    wgmList,
                                                                    elementSize,
                                                                    H_L2,
-                                                                   false,
                                                                    false);
                         defaultWGM         = bestWGM.second;
                         if(T_Debug)

--- a/shared/origami/include/origami/gemm.hpp
+++ b/shared/origami/include/origami/gemm.hpp
@@ -34,8 +34,7 @@ namespace origami
                                                   size_t          MT_K,
                                                   size_t          MI_M,
                                                   size_t          MI_N,
-                                                  size_t          MI_K,
-                                                  bool            debug);
+                                                  size_t          MI_K);
 
         // Determine the compute latency per MT_MxMT_NxMT_K Macro Tile (L_MT).
         size_t compute_mt_compute_latency(const hardware_t& hardware,
@@ -52,8 +51,7 @@ namespace origami
                                           size_t          MI_K,
                                           size_t          element_size_A, //In bits
                                           size_t          element_size_B, //In bits,
-                                          data_type_t     mi_datatype,
-                                          bool            debug);
+                                          data_type_t     mi_datatype);
 
         /* ---------------------------------------------------------------------------------------- */
         /* Memory-related functions                                                                 */
@@ -63,18 +61,17 @@ namespace origami
                                 size_t          MT_M,
                                 size_t          MT_N,
                                 size_t          MT_K,
-                                size_t          element_size,
-                                bool            debug);
+                                size_t          element_size_out);
 
         // Compute the amount of data loaded from A to produce a MT_MxMT_NxMT_K tile.
-        size_t compute_A_loads(size_t MT_M, size_t MT_K, bool debug);
+        size_t compute_A_loads(size_t MT_M, size_t MT_K);
 
         // Compute the amount of data loaded from B to produce a MT_MxMT_NxMT_K tile.
-        size_t compute_B_loads(size_t MT_N, size_t MT_K, bool debug);
+        size_t compute_B_loads(size_t MT_N, size_t MT_K);
 
         // Computes total data loads per CU per MT from A and B
         // Reads happen every MT, Writes happen every K-complete tile.
-        size_t compute_cu_loads(size_t MT_M, size_t MT_N, size_t MT_K, bool debug);
+        size_t compute_cu_loads(size_t MT_M, size_t MT_N, size_t MT_K);
 
         // Estimates the l2 hit-rate
         double estimate_l2_hit(const hardware_t& hardware,
@@ -116,8 +113,7 @@ namespace origami
                                       size_t          mx_block_size,
                                       int             WGM,
                                       size_t          numActiveCUs,
-                                      size_t          splittingFactor,
-                                      bool            debug);
+                                      size_t          splittingFactor);
 
         /* ---------------------------------------------------------------------------------------- */
         /* Tile-related functions                                                                   */
@@ -143,8 +139,7 @@ namespace origami
                                     size_t          mx_block_size,
                                     int             WGM,
                                     size_t          numActiveCUs,
-                                    size_t          splittingFactor,
-                                    bool            debug);
+                                    size_t          splittingFactor);
 
         // Computes the latency per K-complete MT wave.
         // A wave is defined as : The time it takes for one CU to complete one K-complete output tile
@@ -168,8 +163,7 @@ namespace origami
                                     size_t          mx_block_size,
                                     int             WGM,
                                     size_t          numActiveCUs,
-                                    size_t          splittingFactor,
-                                    bool            debug);
+                                    size_t          splittingFactor);
 
         // Compute the total latency of a gemm based on the latency of one wave multiplied by the number of waves
         // A wave is defined as : The time it takes for one CU to complete one K-complete output tile
@@ -192,8 +186,7 @@ namespace origami
                                      data_type_t     mi_datatype,
                                      size_t          mx_block_size,
                                      int             WGM,
-                                     size_t          split = 0,
-                                     bool            debug = false);
+                                     size_t          split = 0);
 
 
         // Compute the performance from the latency.
@@ -213,6 +206,5 @@ namespace origami
                                    size_t          element_size_A,
                                    size_t          element_size_B,
                                    size_t          element_size_out,
-                                   int             WGM,
-                                   bool            debug);
+                                   int             WGM);
 } // namespace origami

--- a/shared/origami/include/origami/utils.hpp
+++ b/shared/origami/include/origami/utils.hpp
@@ -50,7 +50,6 @@ namespace origami
                                      data_type_t     mi_datatype,
                                      size_t          mx_block_size,
                                      double          H_L2,
-                                     bool            debug,
                                      size_t          WGM,
                                      size_t          biggest_allowable_split = 8);
 
@@ -68,7 +67,6 @@ namespace origami
                                                              data_type_t mi_datatype,
                                                              size_t mx_block_size,
                                                              double H_L2,
-                                                             bool   debug,
                                                              bool   print,
                                                              size_t WGM);
 
@@ -86,7 +84,6 @@ namespace origami
                                                         size_t    step_MT_N    = 32,
                                                         size_t    step_MT_K    = 32,
                                                         double    H_L2         = 0.8,
-                                                        bool      debug        = false,
                                                         const std::vector<tile_tuple>& tiles_to_add
                                                         = {},
                                                         bool print = false);
@@ -106,14 +103,12 @@ namespace origami
             const std::vector<size_t>& WGM_list,
             size_t                     element_size,
             double H_L2, // not needed for L2 hit rate but retained if your code expects it
-            bool   debug,
             bool   print);
 
         double compute_tflops_from_latency(double latency_cycles,
                                            size_t M,
                                            size_t N,
                                            size_t K,
-                                           double clock_GHz,
-                                           bool   debug = false);
+                                           double clock_GHz);
 
 } // namespace origami

--- a/shared/origami/python/origami_test.py
+++ b/shared/origami/python/origami_test.py
@@ -235,7 +235,6 @@ def main():
             origami.string_to_datatype(args.type_compute),
             args.scale_block_size,
             0.8,
-            args.debug,
             args.print,
             args.wgm,
         )

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -50,7 +50,6 @@ namespace origami
                                                             size_t          workspace_size_per_elem_c,
                                                             int             occupancy,
                                                             int             dynamic_grid_version,
-                                                            bool            debug,
                                                             size_t          split)
     {
         // Number of output MTs
@@ -117,7 +116,7 @@ namespace origami
             splitFactor  = safe_ceil_div(numWGs, numMTs);
         }
 
-        if(debug || hardware_t::is_debug_enabled())
+        if(hardware_t::is_debug_enabled())
         {
             hardware.log_debug("numMTs", numMTs);
             hardware.log_debug("numWGs", numWGs);
@@ -139,8 +138,7 @@ namespace origami
                                                 size_t          MT_K,
                                                 size_t          MI_M,
                                                 size_t          MI_N,
-                                                size_t          MI_K,
-                                                bool            debug)
+                                                size_t          MI_K)
     {
         // Compute the number of Matrix Instructions required in each dim
         size_t N_MI_M = safe_ceil_div(MT_M, MI_M);
@@ -172,8 +170,7 @@ namespace origami
                                                 size_t          MI_N,
                                                 size_t          MI_K,
                                                 size_t          element_size_A,
-                                                size_t          element_size_B,
-                                                bool            debug)
+                                                size_t          element_size_B)
     {
         // Wave tile sizes
         // TODO: Use kernel's actual wavetiles.
@@ -249,12 +246,11 @@ namespace origami
                                         size_t          MI_K,
                                         size_t          element_size_A,
                                         size_t          element_size_B,
-                                        data_type_t     mi_datatype,
-                                        bool            debug)
+                                        data_type_t     mi_datatype)
     {
         // Compute the number of matrix instructions
         size_t N_MI = compute_number_matrix_instructions(
-            hardware, MT_M, MT_N, MT_K, MI_M, MI_N, MI_K, debug);
+            hardware, MT_M, MT_N, MT_K, MI_M, MI_N, MI_K);
         // Latency of a single MT_MxMT_NxMT_k tile is the latency of one MI multiplied by
         // number of MI per MT_MxMT_NxMT_k.
         size_t L_MI = hardware.get_mi_latency(MI_M, MI_N, MI_K, mi_datatype);
@@ -339,12 +335,11 @@ namespace origami
                             size_t          MT_M,
                             size_t          MT_N,
                             size_t          MT_K,
-                            size_t          element_size,
-                            bool            debug)
+                            size_t          element_size)
     {
         // A and B size
-        size_t Ld_A_value = compute_A_loads(MT_M, MT_K, debug);
-        size_t Ld_B_value = compute_B_loads(MT_N, MT_K, debug);
+        size_t Ld_A_value = compute_A_loads(MT_M, MT_K);
+        size_t Ld_B_value = compute_B_loads(MT_N, MT_K);
         // Size of those in bytes
         size_t LDS_usage = (Ld_A_value + Ld_B_value) * (element_size / 8);
 
@@ -359,7 +354,7 @@ namespace origami
     }
 
     // Compute the amount of data loaded from A to produce a MT_MxMT_NxMT_K tile.
-    size_t compute_A_loads(size_t MT_M, size_t MT_K, bool debug)
+    size_t compute_A_loads(size_t MT_M, size_t MT_K)
     {
         // Compute the size of loads from A for a single MT_MxMT_NxMT_K tiles
         size_t Ld_A_value = MT_M * MT_K;
@@ -368,7 +363,7 @@ namespace origami
     }
 
     // Compute the amount of data loaded from B to produce a MT_MxMT_NxMT_K tile.
-    size_t compute_B_loads(size_t MT_N, size_t MT_K, bool debug)
+    size_t compute_B_loads(size_t MT_N, size_t MT_K)
     {
         // Compute the size of loads from B for a single MT_MxMT_NxMT_K tiles
         size_t Ld_B_value = MT_N * MT_K;
@@ -553,8 +548,7 @@ namespace origami
                                     size_t          mx_block_size,
                                     int             WGM,
                                     size_t          numActiveCUs,
-                                    size_t          splittingFactor,
-                                    bool            debug)
+                                    size_t          splittingFactor)
     {
         // 1) Estimate L2 hit-rate
         double H_mem1
@@ -565,8 +559,8 @@ namespace origami
             = estimate_mall_hit(hardware, M, N, K, batch, MT_M, MT_N, MT_K, WGM, numActiveCUs, splittingFactor);
 
         // 3) Total loads are loads from A and loads from B
-        size_t Ld_A_value  = compute_A_loads(MT_M, MT_K, debug);
-        size_t Ld_B_value  = compute_B_loads(MT_N, MT_K, debug);
+        size_t Ld_A_value  = compute_A_loads(MT_M, MT_K);
+        size_t Ld_B_value  = compute_B_loads(MT_N, MT_K);
         size_t Ld_CU_bytes = (Ld_A_value * safe_ceil_div(element_size_A, 8)) // A Bytes
                                 + (Ld_B_value * safe_ceil_div(element_size_B, 8)); //B Bytes
 
@@ -672,7 +666,7 @@ namespace origami
             }
         }
 
-        if(debug || hardware_t::is_debug_enabled())
+        if(hardware_t::is_debug_enabled())
         {
             hardware.log_debug("mem1_perf_ratio", hardware.mem1_perf_ratio);
             hardware.log_debug("mem2_perf_ratio", hardware.mem2_perf_ratio);
@@ -716,8 +710,7 @@ namespace origami
                                 size_t          mx_block_size,
                                 int             WGM,
                                 size_t          numActiveCUs,
-                                size_t          splittingFactor,
-                                bool            debug)
+                                size_t          splittingFactor)
     {            
         // 1) Compute per-tile latencies
         double L_compute = compute_mt_compute_latency(hardware,
@@ -734,8 +727,7 @@ namespace origami
                                                         MI_K,
                                                         element_size_A,
                                                         element_size_B,
-                                                        mi_datatype,
-                                                        debug);
+                                                        mi_datatype);
 
         double L_mem = compute_memory_latency(hardware,
                                                 M,
@@ -752,8 +744,7 @@ namespace origami
                                                 mx_block_size,
                                                 WGM,
                                                 numActiveCUs,
-                                                splittingFactor,
-                                                debug);
+                                                splittingFactor);
 
         // 2) Work-group setup & iteration latencies
         double L_WG_setup = 1; // WG_setup_Latency
@@ -797,8 +788,7 @@ namespace origami
                                             MI_N,
                                             MI_K,
                                             element_size_A,
-                                            element_size_B,
-                                            debug);
+                                            element_size_B);
         }
 
         // 5) Single-tile latency (always additive)
@@ -818,7 +808,7 @@ namespace origami
                                 + L_WG_setup
                                 + (28 * num_iter); // 7 instructions (each with 4 cycles) at the end of the loop
 
-        if(debug || hardware_t::is_debug_enabled())
+        if(hardware_t::is_debug_enabled())
         {
             hardware.log_debug("L_compute", L_compute);
             hardware.log_debug("L_mem", L_mem);
@@ -855,8 +845,7 @@ namespace origami
                                 size_t          mx_block_size,
                                 int             WGM,
                                 size_t          numActiveCUs,
-                                size_t          splittingFactor,
-                                bool            debug)
+                                size_t          splittingFactor)
     {
         // Assume latency of a wave is latency of a single k-complete output tile.
         double L_wave = compute_tile_latency(hardware,
@@ -879,8 +868,7 @@ namespace origami
                                                 mx_block_size,
                                                 WGM,
                                                 numActiveCUs,
-                                                splittingFactor,
-                                                debug);
+                                                splittingFactor);
 
         return L_wave;
     }
@@ -906,10 +894,9 @@ namespace origami
                                     data_type_t     mi_datatype,
                                     size_t          mx_block_size,
                                     int             WGM,
-                                    size_t          split,
-                                    bool            debug)
+                                    size_t          split)
     {
-        if(debug || hardware_t::is_debug_enabled())
+        if(hardware_t::is_debug_enabled())
         {
             hardware.log_debug("Problem_Size",
                                 std::to_string(int(M)) + "x" + std::to_string(int(N)) + "x"
@@ -970,7 +957,6 @@ namespace origami
                                                                                 std::numeric_limits<size_t>::max(), // workspace per c
                                                                                 0, // occupancy
                                                                                 6, // dynamic_grid
-                                                                                debug,
                                                                                 split);
 
         // 2) Compute latency of a wave
@@ -995,8 +981,7 @@ namespace origami
                                                 mx_block_size,
                                                 WGM,
                                                 numActiveCUs,
-                                                splittingFactor,
-                                                debug);
+                                                splittingFactor);
         // Compute latency for all waves and return it as the latency for the MT/problem
         double total_latency = L_wave * numWaves;
 
@@ -1183,8 +1168,7 @@ namespace origami
                                 size_t          element_size_B,
                                 size_t          element_size_out,
                                 data_type_t     mi_datatype,
-                                int             WGM,
-                                bool            debug)
+                                int             WGM)
     {
         // Compute total FLOPs
         double total_FLOPs = 2.0 * M * N * K; // For GEMM, each multiply-add is 2 FLOPs
@@ -1210,8 +1194,7 @@ namespace origami
                                                             element_size_out,
                                                             mi_datatype,
                                                             mx_block_size,
-                                                            WGM,
-                                                            debug);
+                                                            WGM);
         double total_time_seconds = latency_cycles / cycles_per_second;
         // Compute performance in FLOPS
         double FLOPS = total_FLOPs / total_time_seconds;

--- a/shared/origami/src/origami/streamk.cpp
+++ b/shared/origami/src/origami/streamk.cpp
@@ -392,7 +392,6 @@ namespace origami
                             mi_datatype,
                             0,
                             0.0,
-                            false,
                             workgroup_mapping,
                             10);
             }

--- a/shared/origami/src/origami/utils.cpp
+++ b/shared/origami/src/origami/utils.cpp
@@ -135,7 +135,6 @@ namespace origami
                                      data_type_t     mi_datatype,
                                      size_t          mx_block_size,
                                      double          H_L2,
-                                     bool            debug,
                                      size_t          WGM,
                                      size_t          biggest_allowable_split)
         {
@@ -171,8 +170,7 @@ namespace origami
                                                        mi_datatype,
                                                        mx_block_size,
                                                        WGM,
-                                                       split,
-                                                       debug);
+                                                       split);
 
                 if(latency < best_latency)
                 {
@@ -201,7 +199,6 @@ namespace origami
                                                              data_type_t mi_datatype,
                                                              size_t   mx_block_size,
                                                              double   H_L2,
-                                                             bool     debug,
                                                              bool     print,
                                                              size_t   defaultWGM)
         {
@@ -222,14 +219,14 @@ namespace origami
                 size_t occupancy = std::get<6>(mt);
                 size_t WGM       = std::get<7>(mt);
 
-                if(debug)
+                if(hardware_t::is_debug_enabled())
                 {
                     std::cout << "Evaluating MT_M=" << MT_M << ", MT_N=" << MT_N
                               << ", MT_K=" << MT_K << ", MI_M=" << MI_M << ", MI_N=" << MI_N
                               << ", MI_K=" << MI_K << "\n";
                 }
 
-                if(check_lds_capacity(hardware, MT_M, MT_N, MT_K, element_size_A, debug))
+                if(check_lds_capacity(hardware, MT_M, MT_N, MT_K, element_size_A))
                 {
                     double Total_latency = compute_total_latency(hardware,
                                                                  M,
@@ -250,13 +247,12 @@ namespace origami
                                                                  mi_datatype,
                                                                  mx_block_size,
                                                                  WGM,
-                                                                 0, // split will be picked automatically
-                                                                 debug);
+                                                                 0); // split will be picked automatically
 
                     valid_results.emplace_back(
                         Total_latency, MT_M, MT_N, MT_K, MI_M, MI_N, MI_K, occupancy, WGM);
                 }
-                else if(debug)
+                else if(hardware_t::is_debug_enabled())
                 {
                     std::cout << "Skipping MT_M=" << MT_M << ", MT_N=" << MT_N << ", MT_K=" << MT_K
                               << " due to LDS capacity\n";
@@ -331,7 +327,6 @@ namespace origami
          * \param[in] element_size
          * \param[in] H_L2       - some hardware-related constant or factor (no longer used here,
          *                         but kept if your signature or other usage requires it)
-         * \param[in] debug      - whether to print debug messages
          * \param[in] print      - whether to print the final best result
          *
          * \return A pair: (best_l2_hit_rate, best_WGM).
@@ -351,7 +346,6 @@ namespace origami
             const std::vector<size_t>& WGM_list,
             size_t                     element_size,
             double H_L2, // not needed for L2 hit rate but retained if your code expects it
-            bool   debug,
             bool   print)
         {
             using WGMResult = std::pair<double, size_t>; // (l2_hit_rate, WGM)
@@ -362,7 +356,7 @@ namespace origami
             // Iterate over all candidate WGM values
             for(const auto& candidate_wgm : WGM_list)
             {
-                if(debug)
+                if(hardware_t::is_debug_enabled())
                 {
                     std::cout << "Evaluating WGM=" << candidate_wgm << "\n";
                 }
@@ -370,9 +364,9 @@ namespace origami
                 // Optionally ensure we do not exceed LDS capacity
                 // (If you want to factor in WGM, add it to your check_lds_capacity signature.)
                 // For now, let's just check the tile itself:
-                if(!check_lds_capacity(hardware, MT_M, MT_N, MT_K, element_size, debug))
+                if(!check_lds_capacity(hardware, MT_M, MT_N, MT_K, element_size))
                 {
-                    if(debug)
+                    if(hardware_t::is_debug_enabled())
                     {
                         std::cout << "Skipping WGM=" << candidate_wgm << " due to LDS capacity.\n";
                     }
@@ -425,8 +419,7 @@ namespace origami
             size_t                                                         K,
             hardware_t&                                                    hardware,
             std::function<double(size_t, size_t, size_t, size_t, size_t, size_t, hardware_t&)>
-                 tie_breaker_fn,
-            bool debug)
+                 tie_breaker_fn)
         {
             std::vector<std::tuple<double, size_t, size_t, size_t>> tie_breaker_results;
 
@@ -460,7 +453,6 @@ namespace origami
                 size_t                        element_size,
                 data_type_t                   mi_datatype,
                 double                        H_L2,
-                bool                          debug,
                 bool                          print,
                 size_t                        WGM,
                 std::function<double(size_t, size_t, size_t, size_t, size_t, size_t, hardware_t&)>
@@ -479,14 +471,14 @@ namespace origami
                 size_t MI_N = std::get<4>(MT_list[i]);
                 size_t MI_K = std::get<5>(MT_list[i]);
 
-                if(debug)
+                if(hardware_t::is_debug_enabled())
                 {
                     std::cout << "Evaluating MT_M=" << MT_M << ", MT_N=" << MT_N
                               << ", MT_K=" << MT_K << ", MI_M=" << MI_M << ", MI_N=" << MI_N
                               << ", MI_K=" << MI_K << "\n";
                 }
 
-                if(check_lds_capacity(hardware, MT_M, MT_N, MT_K, element_size, debug))
+                if(check_lds_capacity(hardware, MT_M, MT_N, MT_K, element_size))
                 {
                     size_t split         = 1;
                     size_t mx_block_size = 0;
@@ -510,13 +502,12 @@ namespace origami
                                                 mi_datatype,
                                                 mx_block_size,
                                                 WGM,
-                                                split,
-                                                debug);
+                                                split);
 
                     results.push_back(
                         std::make_tuple(Total_latency, MT_M, MT_N, MT_K, MI_M, MI_N, MI_K));
                 }
-                else if(debug)
+                else if(hardware_t::is_debug_enabled())
                 {
                     std::cout << "Skipping MT_M=" << MT_M << ", MT_N=" << MT_N << ", MT_K=" << MT_K
                               << " due to LDS capacity\n";
@@ -544,7 +535,7 @@ namespace origami
 
                 if(top_results.size() > 1)
                 {
-                    if(debug)
+                    if(hardware_t::is_debug_enabled())
                     {
                         std::cout << "Tie detected among top-ranked tile sizes. Applying "
                                      "tie-breaker...\n";
@@ -619,7 +610,7 @@ namespace origami
         }
 
         double compute_tflops_from_latency(
-            double latency_cycles, size_t M, size_t N, size_t K, double clock_GHz, bool debug)
+            double latency_cycles, size_t M, size_t N, size_t K, double clock_GHz)
         {
             // Compute total FLOPs
             double total_FLOPs = 2.0 * M * N * K; // For GEMM, each multiply-add is 2 FLOPs
@@ -631,7 +622,7 @@ namespace origami
             // Convert to TFLOPS
             double TFLOPS = FLOPS / 1e12; // 1 TFLOP = 1e12 FLOPs
 
-            if(debug)
+            if(hardware_t::is_debug_enabled())
             {
                 std::cout << "Total FLOPs: " << total_FLOPs << "\n";
                 std::cout << "Total Time: " << total_time_seconds << " seconds\n";


### PR DESCRIPTION
## Motivation

Remove debug parameter and instead use the environment variable ANALYTICAL_GEMM_DEBUG which is already added

## Test Plan

local Origami build passed
