### PR TITLE
Initialize CMAKE_Fortran_COMPILER for hipblaslt

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -114,10 +114,15 @@ else()
 endif()
 
 if(HIPBLASLT_ENABLE_CLIENT)
+    if (NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC})
+        set(CMAKE_Fortran_COMPILER  "gfortran")
+    endif()
     enable_language(Fortran)
+
     if(HIPBLASLT_ENABLE_BLIS)
         find_package(BLIS REQUIRED)
     endif()
+
     # There is an implicit find_package(BLAS) when finding lapack
     find_package(LAPACK REQUIRED)
 endif()


### PR DESCRIPTION
## Motivation

Fixes build breaks reported at https://github.com/ROCm/TheRock/pull/1473#discussion_r2353219606 and https://github.com/ROCm/rocm-libraries/pull/1462#discussion_r2349911730:

```
[hipBLASLt configure] -- The Fortran compiler identification is unknown
[hipBLASLt configure] -- Detecting Fortran compiler ABI info
[hipBLASLt configure] CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
[hipBLASLt configure] Missing variable is:
[hipBLASLt configure] CMAKE_Fortran_PREPROCESS_SOURCE
[hipBLASLt configure] CMake Error at C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineCompilerABI.cmake:74 (try_compile):
[hipBLASLt configure]   Failed to generate test project build system.
[hipBLASLt configure] Call Stack (most recent call first):
[hipBLASLt configure]   C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeTestFortranCompiler.cmake:20 (CMAKE_DETERMINE_COMPILER_ABI)
[hipBLASLt configure]   CMakeLists.txt:117 (enable_language)
[hipBLASLt configure] 
[hipBLASLt configure] 
[hipBLASLt configure] -- Configuring incomplete, errors occurred!
```

## Technical Details

This matches how other subprojects initialize this variable, see https://github.com/search?q=repo%3AROCm%2Frocm-libraries+CMAKE_Fortran_COMPILER&type=code. (we may want to use flang instead later). See also https://github.com/ROCm/rocm-libraries/pull/809.

## Test Plan

* Build hipblaslt locally within TheRock
* Until https://github.com/ROCm/rocm-libraries/pull/1462 is in, tested downstream in TheRock at https://github.com/ROCm/TheRock/pull/1496.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
