### PR TITLE
[hipBLASlt] Add predicate for PredictionLibrary

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Properties.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Properties.py
@@ -94,27 +94,21 @@ class Predicate(Property):
         if self.tag == 'TruePred':
             return False
 
-        # EqualityMatching < RangeMatching < FreeSizeMatching
+        # EqualityMatching < RangeMatching < PredictionMatching
         if self.tag == 'EqualityMatching':
-            if other.tag == 'EqualityMatching':
-                return False
             if other.tag == 'RangeMatching':
                 return True
-            if other.tag == 'FreeSizeMatching':
+            if other.tag == 'PredictionMatching':
                 return True
         if self.tag == 'RangeMatching':
             if other.tag == 'EqualityMatching':
                 return False
-            if other.tag == 'RangeMatching':
-                return False
-            if other.tag == 'FreeSizeMatching':
+            if other.tag == 'PredictionMatching':
                 return True
-        if self.tag == 'FreeSizeMatching':
+        if self.tag == 'PredictionMatching':
             if other.tag == 'EqualityMatching':
                 return False
             if other.tag == 'RangeMatching':
-                return False
-            if other.tag == 'FreeSizeMatching':
                 return False
 
         selfValue = self.value

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionLibrary.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionLibrary.py
@@ -431,7 +431,7 @@ class MasterSolutionLibrary:
                 library = PredicateLibrary(tag="Problem")
                 library.rows.append({"predicate": predicate, "library": freesizeLib})
             elif d["LibraryType"] == "Prediction":
-                predicate = Properties.Predicate(tag="FreeSizeMatching") # TODO Do we need a new predicate here?
+                predicate = Properties.Predicate(tag="PredictionMatching")
 
                 predictionLib = PredictionLibrary.FromOriginalState(d["Library"], solutions)
                 library = PredicateLibrary(tag="Problem")

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1972,6 +1972,37 @@ namespace TensileLite
                 }
             };
 
+            struct PredictionMatching
+                : public Predicate_CRTP<PredictionMatching, ContractionProblemGemm>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = false
+                };
+
+                PredictionMatching() = default;
+
+                static std::string Type()
+                {
+                    return "PredictionMatching";
+                }
+
+                virtual bool operator()(ContractionProblemGemm const& problem) const override
+                {
+                    return true;
+                }
+
+                virtual bool debugEval(ContractionProblemGemm const& problem,
+                                       std::ostream&                 stream) const override
+                {
+                    bool rv = (*this)(problem);
+                    stream << rv << ": " << this->type() << std::endl;
+                    return rv;
+                }
+            };
+
+
             struct UseGradientEqual
                 : public Predicate_CRTP<UseGradientEqual, ContractionProblemGemm>
             {

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/ContractionPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/ContractionPredicates.hpp
@@ -105,6 +105,7 @@ namespace TensileLite
                      Base::template Pair<Predicates::Contraction::EqualityMatching>(),
                      Base::template Pair<Predicates::Contraction::RangeMatching>(),
                      Base::template Pair<Predicates::Contraction::FreeSizeMatching>(),
+                     Base::template Pair<Predicates::Contraction::PredictionMatching>(),
                      Base::template Pair<Predicates::Contraction::UseGradientEqual>(),
                      Base::template Pair<Predicates::Contraction::ActivationCheck>(),
                      Base::template Pair<Predicates::Contraction::ActivationComputeTypeEqual>(),
@@ -415,6 +416,12 @@ namespace TensileLite
         template <typename IO>
         struct MappingTraits<Predicates::Contraction::FreeSizeMatching, IO>
             : public AutoMappingTraits<Predicates::Contraction::FreeSizeMatching, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::PredictionMatching, IO>
+            : public AutoMappingTraits<Predicates::Contraction::PredictionMatching, IO>
         {
         };
 


### PR DESCRIPTION
to avoid conflict with FreeSizeMatching

## Motivation

PredictionLibrary was using the FreeSizeMatching predicate, same as the FreeSize library. 
When adding PredictionLibraries for gfx942, this causes a conflict. 
This conflict wasn't seen before on gfx950 because there are no FreeSize libraries for gfx950.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass locally
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
