### PR TITLE
[rocroller] Some private headers now include boost multi_index.

### DIFF
--- a/shared/rocroller/test/common/CMakeLists.txt
+++ b/shared/rocroller/test/common/CMakeLists.txt
@@ -10,6 +10,11 @@ target_link_libraries(common-test-utilities
         roc::mxDataGenerator
         hip::host
         OpenMP::OpenMP_CXX
+        # Some of the internal rocroller headers use boost templates. Since we
+        # do not wish to advertise a public boost dep from the rocroller library
+        # itself, we add the boost dep only to the tests that depend on these
+        # private headers.
+        Boost::headers
         ${CBLAS_LIBRARIES}
 )
 


### PR DESCRIPTION
Since we do not advertise the Boost::headers dep as PUBLIC and we do not wish to for non-interface headers, add it to the common test utils target.

Without this, some C++ tests include a private header with boost includes but fail to find boost if it is not installed as a system library.
