### PR TITLE
[hipblaslt] Avoid installing rocm-cmake if already found

### DIFF
--- a/projects/hipblaslt/cmake/dependencies.cmake
+++ b/projects/hipblaslt/cmake/dependencies.cmake
@@ -32,7 +32,7 @@ list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hip /opt/rocm)
 
 # ROCm cmake package
 find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET) # First version with Sphinx doc gen improvement
-if(NOT ROCM_FOUND)
+if(NOT ROCmCMakeBuildTools_FOUND)
   set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
   set(rocm_cmake_tag "rocm-6.4.1" CACHE STRING "rocm-cmake tag to download")
   file(DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip


### PR DESCRIPTION
## Motivation

It seems that `hipblaslt` always download rocm-cmake, even if it is already available in the system or environment. 

## Technical Details

At first glance, it seems that this was only due to a type, in which `ROCM_FOUND` was accidentally used instead of `ROCmCMakeBuildTools_FOUND`.

## Test Plan

I built the project, and verified that if `rocm-cmake` was already installed, it was not downloaded again.

## Test Result

See test plan.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
