### PR TITLE
Update documentation to refer to DVC instead of Git LFS

### DIFF
--- a/projects/miopen/README.md
+++ b/projects/miopen/README.md
@@ -309,42 +309,24 @@ To format the code per commit, you can install githooks:
 ./.githooks/install
 ```
 
-## Storing large file using Git Large File Storage
+## Storing large files using Data Versioning System
 
-Git Large File Storage (LFS) replaces large files, such as audio samples, videos, datasets, and graphics
-with text pointers inside Git, while storing the file contents on a remote server. In MIOpen, we use Gi
-LFS to store our large files, such as our kernel database files (*.kdb) that are normally > 0.5 GB.
+[Data Versioning System (DVS)](https://dvc.org/) replaces large files, such as audio samples, videos, datasets, and
+graphics with text pointers inside Git, while storing the file contents on a remote server. In MIOpen, we use DVC to
+store our large files, such as our kernel database files (*.kdb) that are normally > 0.5 GB.
 
-You can install Git LFS using the following code:
+You can install DVC using the [instructions provided for your platform here](https://dvc.org/doc/install).
 
-```shell
-sudo apt install git-lfs
-git lfs install
-```
-
-In the Git repository where you want to use Git LFS, track the file type using the following code (if the
-file type has already been tracked, you can skip this step):
+You can [pull](https://dvc.org/doc/command-reference/pull) all large files or a single large file using:
 
 ```shell
-git lfs track "*.file_type"
-git add .gitattributes
-```
-
-You can pull all or a single large file using:
-
-```shell
-git lfs pull --exclude=
+dvc pull
 or
-git lfs pull --exclude= --include "filename"
+dvc pull "filename"
 ```
 
-Update the large files and push to GitHub using:
-
-```shell
-git add my_large_files
-git commit -m "the message"
-git push
-```
+If you are familiar with using Git LFS, a key difference with DVC is that you must manually run `dvc pull` after you 
+switch branches or merge changes in Git to ensure any large binaries are kept in sync with your checkout.
 
 ## Installing the dependencies manually
 

--- a/projects/miopen/docs/install/build-source.rst
+++ b/projects/miopen/docs/install/build-source.rst
@@ -230,17 +230,13 @@ To format the code per commit, install githooks:
 Storing large file using Git Large File Storage
 =========================================================
 
-`Data Versioning System (DVS) <https://dvc.org/>` replaces large
-files, such as audio samples, videos, datasets, and graphics with text
-pointers inside Git, while storing the file contents on a remote server.
-In MIOpen, we use DVC to store our large files, such as our kernel
-database files (\*.kdb) that are normally > 0.5 GB.
+`Data Versioning System (DVS) <https://dvc.org/>` replaces large files, such as audio samples, videos, datasets, and 
+graphics with text pointers inside Git, while storing the file contents on a remote server. In MIOpen, we use DVC to 
+store our large files, such as our kernel database files (\*.kdb) that are normally > 0.5 GB.
 
-You can install DVC using the `instructions provided for your platform
-here <https://dvc.org/doc/install>`.
+You can install DVC using the `instructions provided for your platform here <https://dvc.org/doc/install>`.
 
-You can `pull <https://dvc.org/doc/command-reference/pull>` all large
-files or a single large file using:
+You can `pull <https://dvc.org/doc/command-reference/pull>` all large files or a single large file using:
 
 .. code:: shell
 

--- a/projects/miopen/docs/install/build-source.rst
+++ b/projects/miopen/docs/install/build-source.rst
@@ -240,7 +240,7 @@ You can `pull <https://dvc.org/doc/command-reference/pull>`_ all large files or 
 
 .. code:: shell
 
-   dvc pull "filename"
+   dvc pull
 
 or
 

--- a/projects/miopen/docs/install/build-source.rst
+++ b/projects/miopen/docs/install/build-source.rst
@@ -230,44 +230,31 @@ To format the code per commit, install githooks:
 Storing large file using Git Large File Storage
 =========================================================
 
-Git Large File Storage (LFS) replaces large files, such as audio samples, videos, datasets, and graphics
-with text pointers inside Git, while storing the file contents on a remote server. MIOpen uses Git
-LFS to store large files, such as kernel database files (``*.kdb``), which are normally > 0.5 GB.
+`Data Versioning System (DVS) <https://dvc.org/>` replaces large
+files, such as audio samples, videos, datasets, and graphics with text
+pointers inside Git, while storing the file contents on a remote server.
+In MIOpen, we use DVC to store our large files, such as our kernel
+database files (\*.kdb) that are normally > 0.5 GB.
 
-To install Git LFS, use these commands:
+You can install DVC using the `instructions provided for your platform
+here <https://dvc.org/doc/install>`.
 
-.. code:: shell
-
-   sudo apt install git-lfs
-   git lfs install
-
-In the Git repository where you want to use Git LFS, track the file type using the following code. If the
-file type is already being tracked, you can skip this step:
+You can `pull <https://dvc.org/doc/command-reference/pull>` all large
+files or a single large file using:
 
 .. code:: shell
 
-   git lfs track "*.file_type"
-   git add .gitattributes
-
-To pull all files or a single large file, use:
-
-.. code:: shell
-
-   git lfs pull --exclude=
+   dvc pull "filename"
 
 or
 
 .. code:: shell
 
-   git lfs pull --exclude= --include "filename"
+   dvc pull "filename"
 
-Update the large files and push to GitHub using the following sequence of commands:
 
-.. code:: shell
-
-   git add my_large_files
-   git commit -m "the message"
-   git push
+If you are familiar with using Git LFS, a key difference with DVC is that you must manually run `dvc pull` after you 
+switch branches or merge changes in Git to ensure any large binaries are kept in sync with your checkout.
 
 Installing the dependencies manually
 ===============================================================

--- a/projects/miopen/docs/install/build-source.rst
+++ b/projects/miopen/docs/install/build-source.rst
@@ -230,13 +230,13 @@ To format the code per commit, install githooks:
 Storing large file using Git Large File Storage
 =========================================================
 
-`Data Versioning System (DVS) <https://dvc.org/>` replaces large files, such as audio samples, videos, datasets, and 
+`Data Versioning System (DVS) <https://dvc.org/>`_ replaces large files, such as audio samples, videos, datasets, and 
 graphics with text pointers inside Git, while storing the file contents on a remote server. MIOpen uses DVC to 
 store large files, such as kernel database files (``*.kdb``), which are normally > 0.5 GB.
 
-To install DVC, use the `instructions provided for your platform here <https://dvc.org/doc/install>`.
+To install DVC, use the `instructions provided for your platform here <https://dvc.org/doc/install>`_.
 
-You can `pull <https://dvc.org/doc/command-reference/pull>` all large files or a single large file using:
+You can `pull <https://dvc.org/doc/command-reference/pull>`_ all large files or a single large file using:
 
 .. code:: shell
 
@@ -249,7 +249,7 @@ or
    dvc pull "filename"
 
 
-If you are familiar with using Git LFS, a key difference with DVC is that you must manually run `dvc pull` after you 
+If you are familiar with using Git LFS, a key difference with DVC is that you must manually run ``dvc pull`` after you 
 switch branches or merge changes in Git to ensure any large binaries are kept in sync with your checkout.
 
 Installing the dependencies manually

--- a/projects/miopen/docs/install/build-source.rst
+++ b/projects/miopen/docs/install/build-source.rst
@@ -231,10 +231,10 @@ Storing large file using Git Large File Storage
 =========================================================
 
 `Data Versioning System (DVS) <https://dvc.org/>` replaces large files, such as audio samples, videos, datasets, and 
-graphics with text pointers inside Git, while storing the file contents on a remote server. In MIOpen, we use DVC to 
-store our large files, such as our kernel database files (\*.kdb) that are normally > 0.5 GB.
+graphics with text pointers inside Git, while storing the file contents on a remote server. MIOpen uses DVC to 
+store large files, such as kernel database files (``*.kdb``), which are normally > 0.5 GB.
 
-You can install DVC using the `instructions provided for your platform here <https://dvc.org/doc/install>`.
+To install DVC, use the `instructions provided for your platform here <https://dvc.org/doc/install>`.
 
 You can `pull <https://dvc.org/doc/command-reference/pull>` all large files or a single large file using:
 


### PR DESCRIPTION
## Motivation

MIOpen recently switched from Git LFS to DVC for its .kdb.bz2 files and the plan going forward is to use DVC for large binary files that would otherwise go in LFS. The documentation (README and .rst source) needs instructions changed from Git LFS to DVC.

## Technical Details

No code changes, those were already part of #1617.

One missing piece that is still TBD is pushing new files or versions of files into DVC. This is currently internal only but the plan is to enable external contributions at a later date.

## Test Plan

* No code changes
* Documentation team will review

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
