### PR TITLE
[hipblaslt] Reduce test cases for DTL/CMS gfx950 tests

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
@@ -73,8 +73,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Exact: [4096, 4096, 1, 8192]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Exact: [8192, 4096, 1, 2048]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -108,8 +108,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Exact: [4096, 4096, 1, 8192]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -190,8 +189,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Exact: [4096, 4096, 1, 8192]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -224,8 +222,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Exact: [4096, 4096, 1, 8192]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
 
   ########################################
   # BBS TT - standard
@@ -279,10 +276,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Range: [[613], [612], [1], [1, 1, 192]]
-          - Exact: [4096, 4096, 1, 8192]
-          - Exact: [8192, 8192, 1, 16384]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[613], [612], [1], [1, 1, 64]]
+          - Exact: [8192, 4096, 1, 2048]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -330,10 +326,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Range: [[613], [612], [1], [1, 1, 192]]
-          - Exact: [4096, 4096, 1, 8192]
-          - Exact: [8192, 8192, 1, 16384]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
 
   ########################################
   # BBS TN - standard
@@ -388,10 +381,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Range: [[613], [612], [1], [1, 1, 192]]
-          - Exact: [4096, 4096, 1, 8192]
-          - Exact: [8192, 8192, 1, 16384]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[613], [612], [1], [1, 1, 64]]
+          - Exact: [8192, 4096, 1, 2048]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -439,10 +431,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Range: [[613], [612], [1], [1, 1, 192]]
-          - Exact: [4096, 4096, 1, 8192]
-          - Exact: [8192, 8192, 1, 16384]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
 
   ########################################
   # F8BS TN - standard
@@ -498,9 +487,39 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [[17, 235, 750], [2, 127, 400], [1], [4, 4, 400]]
-          - Range: [[613], [612], [1], [1, 1, 192]]
-          - Exact: [4096, 4096, 1, 8192]
-          - Exact: [8192, 8192, 1, 16384]
+          - Range: [[613], [612], [1], [1, 1, 128]]
+        #- BiasTypeArgs: ['b']
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+           - [16, 16,128, 1,  1, 8, 8,  2,2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [128]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - LocalReadVectorWidth: [16]
+        - GlobalReadVectorWidthA: [16]
+        - GlobalReadVectorWidthB: [16]
+        - DirectToLds: [1]
+        - StreamK: [3]
+        - LdsPadA: [32] #[-1]
+        - LdsPadB: [32] #[-1]
+        - StaggerU: [0]
+        - WorkGroupMapping: [16]
+        - WorkGroupMappingXCC: [2]
+        - 1LDSBuffer: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [8192, 4096, 1, 2048]
         #- BiasTypeArgs: ['b']
 
   ########################################
@@ -555,10 +574,40 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Range: [[613], [612], [1], [1, 1, 192]]
-          - Exact: [4096, 4096, 1, 8192]
-          - Exact: [8192, 8192, 1, 16384]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[613], [612], [1], [1, 1, 128]]
+        - BiasTypeArgs: ['b']
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+           - [16, 16,32, 1,  1, 8, 8,  2,2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - StreamK: [3]
+        - LdsPadA: [8] #[-1]
+        - LdsPadB: [8] #[-1]
+        - StaggerU: [0]
+        - WorkGroupMapping: [16]
+        - WorkGroupMappingXCC: [2]
+        - 1LDSBuffer: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [8192, 4096, 1, 2048]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -605,7 +654,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [1, 13, 200]]
-          - Range: [[613], [612], [1], [1, 1, 192]]
-          - Exact: [4096, 4096, 1, 8192]
-          - Exact: [8192, 8192, 1, 16384]
+          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -5,7 +5,6 @@ GlobalParameters:
   NumElementsToValidate: -1
   MinimumRequiredVersion: 5.0.0
   PrintLevel: 1
-  #PrintSolutionRejectionReason: True
   Device: 0
   CMakeBuildType: Release
   MergeFiles: False
@@ -16,11 +15,9 @@ GlobalParameters:
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 1
   BoundsCheck: 2
-  #MaxFileName: 256
   KeepBuildTmp: True
   DeviceLDS: 163840
   MaxLDS: 163840
-  #GenerateSourcesAndExit: True
 
 BenchmarkProblems:
   ########################################
@@ -62,7 +59,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[1,67,517], [1,93,709], [1], [1,76,865]]
+          - Range: [[1,67,300], [1,93,300], [1], [1,76,192]]
     - # Check DTL+nonDTL tuning
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -129,7 +126,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[1,67,517], [1,93,709], [1], [1,76,865]]
+          - Range: [[1,67,300], [1,93,300], [1], [1,76,192]]
 
   ########################################
   # F8HS TN DTL
@@ -195,7 +192,7 @@ BenchmarkProblems:
           - Range: [[19], [19], [1], [1,3,12]]
           - Range: [[31], [31], [1], [1,7,72]]
           - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13], [17], [1], [258, 3, 512]]
+          - Range: [[13], [17], [1], [258, 3, 384]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -264,7 +261,7 @@ BenchmarkProblems:
           - Range: [[19], [19], [1], [1,3,12]]
           - Range: [[31], [31], [1], [1,7,72]]
           - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13], [17], [1], [258, 3, 512]]
+          - Range: [[13], [17], [1], [258, 3, 384]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -334,7 +331,6 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - MatrixInstruction:
-          #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
           - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
           - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
@@ -359,7 +355,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[63], [127], [1], [1,63,512]]
+          - Range: [[63], [127], [1], [1,63,384]]
 
   ########################################
   # F8B8HS TN DTL
@@ -422,7 +418,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,9,34],   [16,9,34], [1], [1,3,12]]
+          - Range: [[16,9,34], [16,9,34], [1], [1,3,12]]
           - Exact: [256, 256, 1, 320]
 
   ########################################
@@ -487,7 +483,7 @@ BenchmarkProblems:
           - Range: [[19], [19], [1], [1,3,12]]
           - Range: [[31], [31], [1], [1,7,72]]
           - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13],   [17], [1], [258, 3, 512]]
+          - Range: [[13],   [17], [1], [258, 3, 384]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -516,7 +512,6 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - MatrixInstruction:
-          #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
           - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
           - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
@@ -541,7 +536,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[63], [127], [1], [1,31,512]]
+          - Range: [[63], [127], [1], [1,31,384]]
 
   ########################################
   # F8F8S TT DTL
@@ -586,10 +581,8 @@ BenchmarkProblems:
         - LocalWritePerMfma: [-1]
         - StaggerU: [4]
         - StaggerUStride: [256]
-        #- StaggerUMapping: [2]
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
-        #- ExpandPointerSwap: [0,1]
         - StorePriorityOpt: [0]
         - VectorStore: [-1]
         - StoreSyncOpt: [0]
@@ -597,7 +590,6 @@ BenchmarkProblems:
         - LdsPadB: [-1, 0, 8]
         - 1LDSBuffer: [0]
         - GlobalSplitU: [1,2]
-        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
         - DirectToLds: [1]
@@ -608,7 +600,7 @@ BenchmarkProblems:
           - Range: [[19], [19], [1], [1,3,12]]
           - Range: [[31], [31], [1], [1,7,72]]
           - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13],   [17], [1], [258, 3, 512]]
+          - Range: [[13],   [17], [1], [258, 3, 384]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -665,7 +657,34 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[65], [123], [1], [1,123,512]]
+          - Range: [[65], [123], [1], [1,71,192]]
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
+          - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
+        - PrefetchGlobalRead: [1, 2]
+        - PrefetchLocalRead: [1, 2]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1]
+        - LdsPadA: [8]
+        - LdsPadB: [8]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
           - Exact: [4096, 8192, 1, 128]
 
   ########################################
@@ -691,7 +710,6 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - MatrixInstruction:
-          #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
           - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
           - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
@@ -720,8 +738,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[47], [97], [1], [1,31,512]]
-          - Exact: [4096, 8192, 1, 128]
+          - Range: [[47], [97], [1], [1,31,192]]
     - # ASEM/AFEM check
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -749,6 +766,34 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [[16,2,32],[16,2,32],[1],[1,1,32]]
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
+          - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
+        - PrefetchGlobalRead: [1, 2]
+        - PrefetchLocalRead: [1, 2]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1]
+        - LdsPadA: [8]
+        - LdsPadB: [8]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [4096, 8192, 1, 128]
 
   ########################################
   # HHS TT DTL
@@ -773,7 +818,6 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - MatrixInstruction:
-          #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
           - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
           - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
@@ -800,9 +844,8 @@ BenchmarkProblems:
         - ProblemSizes:
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
-          - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[18], [99], [1], [1,31,512]]
+          - Range: [[18], [99], [1], [1,31,192]]
 
   ########################################
   # HHS TT DTL
@@ -850,8 +893,33 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[4096], [8192], [1], [64,64,384]]
-
+          - Range: [[256], [512], [1], [64,64,192]]
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
+          - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
+        - PrefetchGlobalRead: [1, 2]
+        - PrefetchLocalRead: [1, 2]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - LdsPadA: [8]
+        - LdsPadB: [8]
+        - 1LDSBuffer: [-1]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[4096], [8192], [1], [64,64,192]]
 
   ########################################
   # HHS NT DTL
@@ -904,8 +972,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[65], [123], [1], [1,123,512]]
-          #- Exact: [4096, 8192, 1, 128]
+          - Range: [[65], [123], [1], [1,123,192]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -919,7 +986,6 @@ BenchmarkProblems:
         - DepthU: [64]
         - ScheduleIterAlg: [3]
         - ExpandPointerSwap: [0]
-        #- TransposeLDS: [1] #0,1
         - LocalReadVectorWidth: [8]
         - GlobalReadVectorWidthA: [8]
         - GlobalReadVectorWidthB: [8]
@@ -933,8 +999,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[65], [123], [1], [1,123,512]]
-          - Range: [[4096], [8192], [1], [64,64,384]]
+          - Range: [[65], [123], [1], [1,123,192]]
     - # Check DTL for load width less than 32bits
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -958,4 +1023,31 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[65], [123], [1], [1,123,512]]
+          - Range: [[65], [123], [1], [1,63,192]]
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
+          - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
+        - PrefetchGlobalRead: [1, 2]
+        - PrefetchLocalRead: [1, 2]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[4096], [8192], [1], [64,64,192]]


### PR DESCRIPTION
## Motivation

Reduce test time for gfx950 tox tests. 

## Technical Details

Reduce test cases for DTL/CMS tox tests. Reduce the range and some of the large size tests since they were already covered multiple times. Large sizes are tested with only larger MT, previously we were testing small MT on very large sizes.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
