### PR TITLE
SPIR-V support for thread_load and thread_store load_cg/ store_cg modifier

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -146,13 +146,15 @@
 #endif
 
 #if __has_builtin(__builtin_amdgcn_processor_is)
-    // There will be error: value of type 'void' is not contextually convertible to 'bool' when including the following archs
-
-    // CDNA3: gfx9-4-generic
-    // RDNA4: gfx1250
-    // RDNA4: gfx12-generic
-    #define IS_CDNA3() \
-        __builtin_amdgcn_processor_is("gfx942") || __builtin_amdgcn_processor_is("gfx950")
+    #if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS)
+        #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
+    #endif
+    #if !defined(ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS)
+        #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
+    #endif
+    #define IS_CDNA3()                                                                     \
+        __builtin_amdgcn_processor_is("gfx942") || __builtin_amdgcn_processor_is("gfx950") \
+            || __builtin_amdgcn_processor_is("gfx9-4-generic")
     #define IS_CDNA2() __builtin_amdgcn_processor_is("gfx90a")
     #define IS_CDNA1() __builtin_amdgcn_processor_is("gfx908")
     #define IS_GCN5()                                                                             \
@@ -160,8 +162,10 @@
             || __builtin_amdgcn_processor_is("gfx904") || __builtin_amdgcn_processor_is("gfx906") \
             || __builtin_amdgcn_processor_is("gfx90c")                                            \
             || __builtin_amdgcn_processor_is("gfx9-generic")
-    #define IS_RDNA4() \
-        __builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201")
+    #define IS_RDNA4()                                                                       \
+        __builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201") \
+            || __builtin_amdgcn_processor_is("gfx1250")                                      \
+            || __builtin_amdgcn_processor_is("gfx12-generic")
     #define IS_RDNA3()                                                                       \
         __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \
             || __builtin_amdgcn_processor_is("gfx1102")                                      \
@@ -185,21 +189,65 @@
             || __builtin_amdgcn_processor_is("gfx803") || __builtin_amdgcn_processor_is("gfx805") \
             || __builtin_amdgcn_processor_is("gfx810")
 #else
-    #define IS_CDNA3() ROCPRIM_TARGET_CDNA3
-    #define IS_CDNA2() ROCPRIM_TARGET_CDNA2
-    #define IS_CDNA1() ROCPRIM_TARGET_CDNA1
-    #define IS_GCN5() ROCPRIM_TARGET_GCN5
-    #define IS_RDNA4() ROCPRIM_TARGET_RDNA4
-    #define IS_RDNA3() ROCPRIM_TARGET_RDNA3
-    #define IS_RDNA2() ROCPRIM_TARGET_RDNA2
-    #define IS_RDNA1() ROCPRIM_TARGET_RDNA1
-    #define IS_GCN3() ROCPRIM_TARGET_GCN3
-    #if defined(ROCPRIM_TARGET_SPIRV)
-        #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 0
-        #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 0
+    #if defined(ROCPRIM_TARGET_CDNA3)
+        #define IS_CDNA3() 1
     #else
-        #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
-        #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
+        #define IS_CDNA3() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_CDNA2)
+        #define IS_CDNA2() 1
+    #else
+        #define IS_CDNA2() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_CDNA1)
+        #define IS_CDNA1() 1
+    #else
+        #define IS_CDNA1() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_GCN5)
+        #define IS_GCN5() 1
+    #else
+        #define IS_GCN5() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_RDNA4)
+        #define IS_RDNA4() 1
+    #else
+        #define IS_RDNA4() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_RDNA3)
+        #define IS_RDNA3() 1
+    #else
+        #define IS_RDNA3() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_RDNA2)
+        #define IS_RDNA2() 1
+    #else
+        #define IS_RDNA2() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_RDNA1)
+        #define IS_RDNA1() 1
+    #else
+        #define IS_RDNA1() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_GCN3)
+        #define IS_GCN3() 1
+    #else
+        #define IS_GCN3() 0
+    #endif
+
+    #if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS)
+        #if defined(ROCPRIM_TARGET_SPIRV)
+            #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 0
+        #else
+            #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
+        #endif
+    #endif
+    #if !defined(ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS)
+        #if defined(ROCPRIM_TARGET_SPIRV)
+            #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 0
+        #else
+            #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
+        #endif
     #endif
 #endif
 

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -145,41 +145,41 @@
     #define ROCPRIM_CONSTEXPR constexpr
 #endif
 
-#if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS)
-    #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
-#endif
-
-#if !defined(ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS)
-    #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
-#endif
-
 #if __has_builtin(__builtin_amdgcn_processor_is)
+    // There will be error: value of type 'void' is not contextually convertible to 'bool' when including the following archs
+
+    // CDNA3: gfx9-4-generic
+    // RDNA4: gfx1250
+    // RDNA4: gfx12-generic
     #define IS_CDNA3() \
         __builtin_amdgcn_processor_is("gfx942") || __builtin_amdgcn_processor_is("gfx950")
     #define IS_CDNA2() __builtin_amdgcn_processor_is("gfx90a")
     #define IS_CDNA1() __builtin_amdgcn_processor_is("gfx908")
     #define IS_GCN5()                                                                             \
         __builtin_amdgcn_processor_is("gfx900") || __builtin_amdgcn_processor_is("gfx902")        \
-            || __builtin_amdgcn_processor_is("gfx904") || __builtin_amdgcn_processor_is("gfx906") \ \
-            || __builtin_amdgcn_processor_is("gfx90c") \                                            \
+            || __builtin_amdgcn_processor_is("gfx904") || __builtin_amdgcn_processor_is("gfx906") \
+            || __builtin_amdgcn_processor_is("gfx90c")                                            \
             || __builtin_amdgcn_processor_is("gfx9-generic")
     #define IS_RDNA4() \
         __builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201")
     #define IS_RDNA3()                                                                       \
-        __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \ \
+        __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \
             || __builtin_amdgcn_processor_is("gfx1102")                                      \
-            || __builtin_amdgcn_processor_is("gfx1103") \                                      \
+            || __builtin_amdgcn_processor_is("gfx1103")                                      \
             || __builtin_amdgcn_processor_is("gfx11-generic")
     #define IS_RDNA2()                                                                       \
-        __builtin_amdgcn_processor_is("gfx1030") || __builtin_amdgcn_processor_is("gfx1031") \ \
+        __builtin_amdgcn_processor_is("gfx1030") || __builtin_amdgcn_processor_is("gfx1031") \
             || __builtin_amdgcn_processor_is("gfx1032")                                      \
-            || __builtin_amdgcn_processor_is("gfx1033") \                                      \
+            || __builtin_amdgcn_processor_is("gfx1033")                                      \
             || __builtin_amdgcn_processor_is("gfx1034")                                      \
-            || __builtin_amdgcn_processor_is("gfx1035") \                                      \
-            || __builtin_amdgcn_processor_is("gfx1036") \                                      \
+            || __builtin_amdgcn_processor_is("gfx1035")                                      \
+            || __builtin_amdgcn_processor_is("gfx1036")                                      \
             || __builtin_amdgcn_processor_is("gfx10-3-generic")
-    #define IS_RDNA1() \
-        __builtin_amdgcn_processor_is("gfx1012") || __builtin_amdgcn_processor_is("gfx1013")
+    #define IS_RDNA1()                                                                       \
+        __builtin_amdgcn_processor_is("gfx1010") || __builtin_amdgcn_processor_is("gfx1011") \
+            || __builtin_amdgcn_processor_is("gfx1012")                                      \
+            || __builtin_amdgcn_processor_is("gfx1013")                                      \
+            || __builtin_amdgcn_processor_is("gfx10-1-generic")
     #define IS_GCN3()                                                                             \
         __builtin_amdgcn_processor_is("gfx801") || __builtin_amdgcn_processor_is("gfx802")        \
             || __builtin_amdgcn_processor_is("gfx803") || __builtin_amdgcn_processor_is("gfx805") \
@@ -197,6 +197,9 @@
     #if defined(ROCPRIM_TARGET_SPIRV)
         #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 0
         #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 0
+    #else
+        #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
+        #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
     #endif
 #endif
 
@@ -221,7 +224,7 @@
     #define ROCPRIM_DETAIL_HAS_DPP 1
 #endif
 
-#if (!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) \
+#if(!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) \
     && (defined(ROCPRIM_DETAIL_HAS_DPP) && ROCPRIM_DETAIL_HAS_DPP == 1)
     #define ROCPRIM_DETAIL_USE_DPP 1
 #else
@@ -250,7 +253,7 @@
 /// Quad size (group of 4 threads)
 #define ROCPRIM_QUAD_SIZE 4u
 
-#if (defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
+#if(defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
     #define ROCPRIM_UNROLL
     #define ROCPRIM_NO_UNROLL
 #else

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -145,32 +145,60 @@
     #define ROCPRIM_CONSTEXPR constexpr
 #endif
 
-#define IS_CDNA3()                                                                     \
-    __builtin_amdgcn_processor_is("gfx942") || __builtin_amdgcn_processor_is("gfx950")
-#define IS_CDNA2() __builtin_amdgcn_processor_is("gfx90a")
-#define IS_CDNA1() __builtin_amdgcn_processor_is("gfx908")
-#define IS_GCN5()                                                                             \
-    __builtin_amdgcn_processor_is("gfx900") || __builtin_amdgcn_processor_is("gfx902")        \
-        || __builtin_amdgcn_processor_is("gfx904") || __builtin_amdgcn_processor_is("gfx906") \ \
-        || __builtin_amdgcn_processor_is("gfx90c") \                                            \
-        || __builtin_amdgcn_processor_is("gfx9-generic")
-#define IS_RDNA4() __builtin_amdgcn_processor_is("gfx1201") || __builtin_amdgcn_processor_is("gfx1200")
-#define IS_RDNA3()                                                                              \
-    __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \        \
-        || __builtin_amdgcn_processor_is("gfx1102") || __builtin_amdgcn_processor_is("gfx1103") \ \
-        || __builtin_amdgcn_processor_is("gfx11-generic")
-#define IS_RDNA2()                                                                              \
-    __builtin_amdgcn_processor_is("gfx1030") || __builtin_amdgcn_processor_is("gfx1031") \        \
-        || __builtin_amdgcn_processor_is("gfx1032") || __builtin_amdgcn_processor_is("gfx1033") \ \
-        || __builtin_amdgcn_processor_is("gfx1034") || __builtin_amdgcn_processor_is("gfx1035") \ \
-        || __builtin_amdgcn_processor_is("gfx1036") \                                             \
-        || __builtin_amdgcn_processor_is("gfx10-3-generic")
-#define IS_RDNA1() \
-    __builtin_amdgcn_processor_is("gfx1012") || __builtin_amdgcn_processor_is("gfx1013")
-#define IS_GCN3()                                                                             \
-    __builtin_amdgcn_processor_is("gfx801") || __builtin_amdgcn_processor_is("gfx802")        \
-        || __builtin_amdgcn_processor_is("gfx803") || __builtin_amdgcn_processor_is("gfx805") \
-        || __builtin_amdgcn_processor_is("gfx810")
+#if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS)
+    #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
+#endif
+
+#if !defined(ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS)
+    #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
+#endif
+
+#if __has_builtin(__builtin_amdgcn_processor_is)
+    #define IS_CDNA3() \
+        __builtin_amdgcn_processor_is("gfx942") || __builtin_amdgcn_processor_is("gfx950")
+    #define IS_CDNA2() __builtin_amdgcn_processor_is("gfx90a")
+    #define IS_CDNA1() __builtin_amdgcn_processor_is("gfx908")
+    #define IS_GCN5()                                                                             \
+        __builtin_amdgcn_processor_is("gfx900") || __builtin_amdgcn_processor_is("gfx902")        \
+            || __builtin_amdgcn_processor_is("gfx904") || __builtin_amdgcn_processor_is("gfx906") \ \
+            || __builtin_amdgcn_processor_is("gfx90c") \                                            \
+            || __builtin_amdgcn_processor_is("gfx9-generic")
+    #define IS_RDNA4() \
+        __builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201")
+    #define IS_RDNA3()                                                                       \
+        __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \ \
+            || __builtin_amdgcn_processor_is("gfx1102")                                      \
+            || __builtin_amdgcn_processor_is("gfx1103") \                                      \
+            || __builtin_amdgcn_processor_is("gfx11-generic")
+    #define IS_RDNA2()                                                                       \
+        __builtin_amdgcn_processor_is("gfx1030") || __builtin_amdgcn_processor_is("gfx1031") \ \
+            || __builtin_amdgcn_processor_is("gfx1032")                                      \
+            || __builtin_amdgcn_processor_is("gfx1033") \                                      \
+            || __builtin_amdgcn_processor_is("gfx1034")                                      \
+            || __builtin_amdgcn_processor_is("gfx1035") \                                      \
+            || __builtin_amdgcn_processor_is("gfx1036") \                                      \
+            || __builtin_amdgcn_processor_is("gfx10-3-generic")
+    #define IS_RDNA1() \
+        __builtin_amdgcn_processor_is("gfx1012") || __builtin_amdgcn_processor_is("gfx1013")
+    #define IS_GCN3()                                                                             \
+        __builtin_amdgcn_processor_is("gfx801") || __builtin_amdgcn_processor_is("gfx802")        \
+            || __builtin_amdgcn_processor_is("gfx803") || __builtin_amdgcn_processor_is("gfx805") \
+            || __builtin_amdgcn_processor_is("gfx810")
+#else
+    #define IS_CDNA3() ROCPRIM_TARGET_CDNA3
+    #define IS_CDNA2() ROCPRIM_TARGET_CDNA2
+    #define IS_CDNA1() ROCPRIM_TARGET_CDNA1
+    #define IS_GCN5() ROCPRIM_TARGET_GCN5
+    #define IS_RDNA4() ROCPRIM_TARGET_RDNA4
+    #define IS_RDNA3() ROCPRIM_TARGET_RDNA3
+    #define IS_RDNA2() ROCPRIM_TARGET_RDNA2
+    #define IS_RDNA1() ROCPRIM_TARGET_RDNA1
+    #define IS_GCN3() ROCPRIM_TARGET_GCN3
+    #if defined(ROCPRIM_TARGET_SPIRV)
+        #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 0
+        #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 0
+    #endif
+#endif
 
 // SPIR-V and unknown targets do not support 128-bit atomics.
 #if defined(ROCPRIM_TARGET_UNKNOWN) || defined(ROCPRIM_TARGET_SPIRV)
@@ -193,7 +221,7 @@
     #define ROCPRIM_DETAIL_HAS_DPP 1
 #endif
 
-#if(!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) \
+#if (!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) \
     && (defined(ROCPRIM_DETAIL_HAS_DPP) && ROCPRIM_DETAIL_HAS_DPP == 1)
     #define ROCPRIM_DETAIL_USE_DPP 1
 #else
@@ -222,7 +250,7 @@
 /// Quad size (group of 4 threads)
 #define ROCPRIM_QUAD_SIZE 4u
 
-#if(defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
+#if (defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
     #define ROCPRIM_UNROLL
     #define ROCPRIM_NO_UNROLL
 #else

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -154,7 +154,7 @@
         || __builtin_amdgcn_processor_is("gfx904") || __builtin_amdgcn_processor_is("gfx906") \ \
         || __builtin_amdgcn_processor_is("gfx90c") \                                            \
         || __builtin_amdgcn_processor_is("gfx9-generic")
-#define IS_RDNA4() __builtin_amdgcn_processor_is("gfx1201")
+#define IS_RDNA4() __builtin_amdgcn_processor_is("gfx1201") || __builtin_amdgcn_processor_is("gfx1200")
 #define IS_RDNA3()                                                                              \
     __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \        \
         || __builtin_amdgcn_processor_is("gfx1102") || __builtin_amdgcn_processor_is("gfx1103") \ \
@@ -200,12 +200,8 @@
     #define ROCPRIM_DETAIL_USE_DPP 0
 #endif
 
-#if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS) && !defined(ROCPRIM_TARGET_SPIRV)
+#if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS)
     #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
-#endif
-
-#if !defined(ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS) && !defined(ROCPRIM_TARGET_SPIRV)
-    #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
 #endif
 
 #ifndef ROCPRIM_NAVI

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -164,8 +164,9 @@
             || __builtin_amdgcn_processor_is("gfx9-generic")
     #define IS_RDNA4()                                                                       \
         __builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201") \
-            || __builtin_amdgcn_processor_is("gfx1250")                                      \
-            || __builtin_amdgcn_processor_is("gfx12-generic")
+        // TODO: enable when these structures are supported
+            /*|| __builtin_amdgcn_processor_is("gfx1250")                                      \
+            || __builtin_amdgcn_processor_is("gfx12-generic")*/
     #define IS_RDNA3()                                                                       \
         __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \
             || __builtin_amdgcn_processor_is("gfx1102")                                      \

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -140,9 +140,9 @@
 #endif
 
 #ifdef ROCPRIM_TARGET_SPIRV
-    #define ROCPRIM_CONSTEXPR
+    #define ROCPRIM_AMDGCN_CONSTEXPR
 #else
-    #define ROCPRIM_CONSTEXPR constexpr
+    #define ROCPRIM_AMDGCN_CONSTEXPR constexpr
 #endif
 
 #if __has_builtin(__builtin_amdgcn_processor_is)
@@ -272,15 +272,11 @@
     #define ROCPRIM_DETAIL_HAS_DPP 1
 #endif
 
-#if(!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) \
+#if (!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) \
     && (defined(ROCPRIM_DETAIL_HAS_DPP) && ROCPRIM_DETAIL_HAS_DPP == 1)
     #define ROCPRIM_DETAIL_USE_DPP 1
 #else
     #define ROCPRIM_DETAIL_USE_DPP 0
-#endif
-
-#if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS)
-    #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
 #endif
 
 #ifndef ROCPRIM_NAVI
@@ -301,7 +297,7 @@
 /// Quad size (group of 4 threads)
 #define ROCPRIM_QUAD_SIZE 4u
 
-#if(defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
+#if (defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
     #define ROCPRIM_UNROLL
     #define ROCPRIM_NO_UNROLL
 #else

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -139,6 +139,39 @@
     #define ROCPRIM_TARGET_UNKNOWN 1
 #endif
 
+#ifdef ROCPRIM_TARGET_SPIRV
+    #define ROCPRIM_CONSTEXPR
+#else
+    #define ROCPRIM_CONSTEXPR constexpr
+#endif
+
+#define IS_CDNA3()                                                                     \
+    __builtin_amdgcn_processor_is("gfx942") || __builtin_amdgcn_processor_is("gfx950")
+#define IS_CDNA2() __builtin_amdgcn_processor_is("gfx90a")
+#define IS_CDNA1() __builtin_amdgcn_processor_is("gfx908")
+#define IS_GCN5()                                                                             \
+    __builtin_amdgcn_processor_is("gfx900") || __builtin_amdgcn_processor_is("gfx902")        \
+        || __builtin_amdgcn_processor_is("gfx904") || __builtin_amdgcn_processor_is("gfx906") \ \
+        || __builtin_amdgcn_processor_is("gfx90c") \                                            \
+        || __builtin_amdgcn_processor_is("gfx9-generic")
+#define IS_RDNA4() __builtin_amdgcn_processor_is("gfx1201")
+#define IS_RDNA3()                                                                              \
+    __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \        \
+        || __builtin_amdgcn_processor_is("gfx1102") || __builtin_amdgcn_processor_is("gfx1103") \ \
+        || __builtin_amdgcn_processor_is("gfx11-generic")
+#define IS_RDNA2()                                                                              \
+    __builtin_amdgcn_processor_is("gfx1030") || __builtin_amdgcn_processor_is("gfx1031") \        \
+        || __builtin_amdgcn_processor_is("gfx1032") || __builtin_amdgcn_processor_is("gfx1033") \ \
+        || __builtin_amdgcn_processor_is("gfx1034") || __builtin_amdgcn_processor_is("gfx1035") \ \
+        || __builtin_amdgcn_processor_is("gfx1036") \                                             \
+        || __builtin_amdgcn_processor_is("gfx10-3-generic")
+#define IS_RDNA1() \
+    __builtin_amdgcn_processor_is("gfx1012") || __builtin_amdgcn_processor_is("gfx1013")
+#define IS_GCN3()                                                                             \
+    __builtin_amdgcn_processor_is("gfx801") || __builtin_amdgcn_processor_is("gfx802")        \
+        || __builtin_amdgcn_processor_is("gfx803") || __builtin_amdgcn_processor_is("gfx805") \
+        || __builtin_amdgcn_processor_is("gfx810")
+
 // SPIR-V and unknown targets do not support 128-bit atomics.
 #if defined(ROCPRIM_TARGET_UNKNOWN) || defined(ROCPRIM_TARGET_SPIRV)
     #define ROCPRIM_MAX_ATOMIC_SIZE 8

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -139,7 +139,7 @@
     #define ROCPRIM_TARGET_UNKNOWN 1
 #endif
 
-#ifdef ROCPRIM_TARGET_SPIRV
+#if defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1
     #define ROCPRIM_AMDGCN_CONSTEXPR
 #else
     #define ROCPRIM_AMDGCN_CONSTEXPR constexpr
@@ -256,12 +256,6 @@
     #define ROCPRIM_MAX_ATOMIC_SIZE 8
 #else
     #define ROCPRIM_MAX_ATOMIC_SIZE 16
-#endif
-
-#if defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1
-    #define ROCPRIM_SPIRV_CONSTEXPR
-#else
-    #define ROCPRIM_SPIRV_CONSTEXPR constexpr
 #endif
 
 // DPP is supported only after Volcanic Islands (GFX8+)

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -129,13 +129,13 @@ T lookback_reduce_forward_init(F scan_op, T block_prefix, unsigned int valid_ite
     for(unsigned int i = 0; i < valid_items; ++i)
     {
         // If ROCPRIM_HAS_PERMLANE() is true, DPP_WF_RL1 is not available.
-        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
             prefix = warp_shuffle_down(prefix, 1, ::rocprim::arch::wavefront::size());
         }
         else
         {
-            if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
+            if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP())
             {
                 prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
             }
@@ -156,9 +156,9 @@ ROCPRIM_DEVICE ROCPRIM_INLINE
 T lookback_reduce_forward(F scan_op, T prefix, T block_prefix)
 {
     // If ROCPRIM_HAS_PERMLANE() is true, DPP_WF_RL1 is not available.
-    if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+    if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
     {
-        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP())
         {
             // If we can't rotate or shift the entire wavefront in one instruction,
             // iterate over rows of 16 lanes and use warp_readlane to communicate across rows.
@@ -191,7 +191,7 @@ T lookback_reduce_forward(F scan_op, T prefix, T block_prefix)
     }
     else
     {
-        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP())
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP())
         {
             for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
             {

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_load.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_load.hpp
@@ -80,11 +80,7 @@ T asm_thread_load(void* ptr)
 
     // Important for syncing. Check section 9.2.2 or 7.3 in the following document
     // http://developer.amd.com/wordpress/media/2013/12/AMD_GCN3_Instruction_Set_Architecture_rev1.1.pdf
-    #define ROCPRIM_ASM_THREAD_LOAD(cache_modifier,                                         \
-                                    type,                                                   \
-                                    interim_type,                                           \
-                                    asm_operator,                                           \
-                                    output_modifier)                                        \
+    #define ROCPRIM_ASM_THREAD_LOAD(cache_modifier, type, interim_type, asm_operator)       \
         template<>                                                                          \
         ROCPRIM_DEVICE ROCPRIM_INLINE type asm_thread_load<cache_modifier, type>(void* ptr) \
         {                                                                                   \
@@ -93,21 +89,21 @@ T asm_thread_load(void* ptr)
             {                                                                               \
                 asm volatile(#asm_operator " %0, %1 th:TH_DEFAULT scope:SCOPE_DEV\n\t"      \
                                            "s_wait_loadcnt_dscnt(%2)"                       \
-                             : "=" #output_modifier(retval)                                 \
+                             : "=&v"(retval)                                                \
                              : "v"(ptr), "I"(0x00));                                        \
             }                                                                               \
             else if ROCPRIM_CONSTEXPR(IS_CDNA3())                                           \
             {                                                                               \
                 asm volatile(#asm_operator " %0, %1 sc0 nt\n\t"                             \
                                            "s_waitcnt(%2)"                                  \
-                             : "=" #output_modifier(retval)                                 \
+                             : "=&v"(retval)                                                \
                              : "v"(ptr), "I"(0x00));                                        \
             }                                                                               \
             else                                                                            \
             {                                                                               \
                 asm volatile(#asm_operator " %0, %1 glc slc\n\t"                            \
                                            "s_waitcnt(%2)"                                  \
-                             : "=" #output_modifier(retval)                                 \
+                             : "=v"(retval)                                                 \
                              : "v"(ptr), "I"(0x00));                                        \
             }                                                                               \
             return *bit_cast<type*>(&retval);                                               \
@@ -115,15 +111,15 @@ T asm_thread_load(void* ptr)
 
     // TODO Add specialization for custom larger data types
     // clang-format off
-#define ROCPRIM_ASM_THREAD_LOAD_GROUP(cache_modifier)                                  \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, int8_t,   int32_t,  flat_load_sbyte,   v); \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, int16_t,  int32_t,  flat_load_sshort,  v); \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint8_t,  uint32_t, flat_load_ubyte,   v); \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint16_t, uint32_t, flat_load_ushort,  v); \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint32_t, uint32_t, flat_load_dword,   v); \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, float,    uint32_t, flat_load_dword,   v); \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint64_t, uint64_t, flat_load_dwordx2, v); \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, double,   uint64_t, flat_load_dwordx2, v)
+#define ROCPRIM_ASM_THREAD_LOAD_GROUP(cache_modifier)                                   \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, int8_t,   int32_t,  flat_load_sbyte);       \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, int16_t,  int32_t,  flat_load_sshort);      \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint8_t,  uint32_t, flat_load_ubyte);       \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint16_t, uint32_t, flat_load_ushort);      \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint32_t, uint32_t, flat_load_dword);       \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, float,    uint32_t, flat_load_dword);       \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint64_t, uint64_t, flat_load_dwordx2);     \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, double,   uint64_t, flat_load_dwordx2)
 // clang-format on
 
 ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cg);

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_load.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_load.hpp
@@ -76,51 +76,51 @@ T asm_thread_load(void* ptr)
     return retval;
 }
 
-#if ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS == 1
+// Important for syncing. Check section 9.2.2 or 7.3 in the following document
+// http://developer.amd.com/wordpress/media/2013/12/AMD_GCN3_Instruction_Set_Architecture_rev1.1.pdf
+#define ROCPRIM_ASM_THREAD_LOAD(cache_modifier, type, interim_type, asm_operator, output_modifier) \
+    template<>                                                                                     \
+    ROCPRIM_DEVICE ROCPRIM_INLINE type asm_thread_load<cache_modifier, type>(void* ptr)            \
+    {                                                                                              \
+        interim_type retval;                                                                       \
+        if ROCPRIM_CONSTEXPR(IS_RDNA4())                                                           \
+        {                                                                                          \
+            asm volatile(#asm_operator " %0, %1 th:TH_DEFAULT scope:SCOPE_DEV\n\t"                 \
+                                       "s_wait_loadcnt_dscnt(%2)"                                  \
+                         : "=" #output_modifier(retval)                                            \
+                         : "v"(ptr), "I"(0x00));                                                   \
+        }                                                                                          \
+        else if ROCPRIM_CONSTEXPR(IS_CDNA3())                                                      \
+        {                                                                                          \
+            asm volatile(#asm_operator " %0, %1 sc0 nt\n\t"                                        \
+                                       "s_waitcnt(%2)"                                             \
+                         : "=" #output_modifier(retval)                                            \
+                         : "v"(ptr), "I"(0x00));                                                   \
+        }                                                                                          \
+        else                                                                                       \
+        {                                                                                          \
+            asm volatile(#asm_operator " %0, %1 glc slc\n\t"                                       \
+                                       "s_waitcnt(%2)"                                             \
+                         : "=" #output_modifier(retval)                                            \
+                         : "v"(ptr), "I"(0x00));                                                   \
+        }                                                                                          \
+        return *bit_cast<type*>(&retval);                                                          \
+    }
 
-    // Important for syncing. Check section 9.2.2 or 7.3 in the following document
-    // http://developer.amd.com/wordpress/media/2013/12/AMD_GCN3_Instruction_Set_Architecture_rev1.1.pdf
-    #define ROCPRIM_ASM_THREAD_LOAD(cache_modifier,                                             \
-                                    llvm_cache_modifier,                                        \
-                                    type,                                                       \
-                                    interim_type,                                               \
-                                    asm_operator,                                               \
-                                    output_modifier,                                            \
-                                    wait_inst,                                                  \
-                                    wait_cmd)                                                   \
-        template<>                                                                              \
-        ROCPRIM_DEVICE ROCPRIM_INLINE type asm_thread_load<cache_modifier, type>(void* ptr)     \
-        {                                                                                       \
-            interim_type retval;                                                                \
-            asm volatile(#asm_operator " %0, %1 " llvm_cache_modifier "\n\t" wait_inst wait_cmd \
-                                       "(%2)"                                                   \
-                         : "=" #output_modifier(retval)                                         \
-                         : "v"(ptr), "I"(0x00));                                                \
-            return *bit_cast<type*>(&retval);                                                   \
-        }
+// TODO Add specialization for custom larger data types
+// clang-format off
+#define ROCPRIM_ASM_THREAD_LOAD_GROUP(cache_modifier)                                  \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, int8_t,   int32_t,  flat_load_sbyte,   v); \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, int16_t,  int32_t,  flat_load_sshort,  v); \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint8_t,  uint32_t, flat_load_ubyte,   v); \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint16_t, uint32_t, flat_load_ushort,  v); \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint32_t, uint32_t, flat_load_dword,   v); \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, float,    uint32_t, flat_load_dword,   v); \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, uint64_t, uint64_t, flat_load_dwordx2, v); \
+    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, double,   uint64_t, flat_load_dwordx2, v)
+// clang-format on
 
-    // TODO Add specialization for custom larger data types
-    // clang-format off
-#define ROCPRIM_ASM_THREAD_LOAD_GROUP(cache_modifier, llvm_cache_modifier, wait_inst, wait_cmd)                                  \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, llvm_cache_modifier, int8_t, int32_t, flat_load_sbyte, v, wait_inst, wait_cmd);      \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, llvm_cache_modifier, int16_t, int32_t, flat_load_sshort, v, wait_inst, wait_cmd);    \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, llvm_cache_modifier, uint8_t, uint32_t, flat_load_ubyte, v, wait_inst, wait_cmd);    \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, llvm_cache_modifier, uint16_t, uint32_t, flat_load_ushort, v, wait_inst, wait_cmd);  \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, llvm_cache_modifier, uint32_t, uint32_t, flat_load_dword, v, wait_inst, wait_cmd);   \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, llvm_cache_modifier, float, uint32_t, flat_load_dword, v, wait_inst, wait_cmd);      \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, llvm_cache_modifier, uint64_t, uint64_t, flat_load_dwordx2, v, wait_inst, wait_cmd); \
-    ROCPRIM_ASM_THREAD_LOAD(cache_modifier, llvm_cache_modifier, double, uint64_t, flat_load_dwordx2, v, wait_inst, wait_cmd);
-    // clang-format on
-
-    #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx9_4_generic__)
-ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cg, "sc0 nt", "s_waitcnt", "");
-    #elif defined(__GFX12__)
-ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cg, "th:TH_DEFAULT scope:SCOPE_DEV", "s_wait_loadcnt_dscnt", "");
-    #else
-ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cg, "glc slc", "s_waitcnt", "");
-    #endif
-
-#endif
+ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cg);
 
 } // namespace detail
 

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_load.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_load.hpp
@@ -85,14 +85,14 @@ T asm_thread_load(void* ptr)
         ROCPRIM_DEVICE ROCPRIM_INLINE type asm_thread_load<cache_modifier, type>(void* ptr) \
         {                                                                                   \
             interim_type retval;                                                            \
-            if ROCPRIM_CONSTEXPR(IS_RDNA4())                                                \
+            if ROCPRIM_AMDGCN_CONSTEXPR(IS_RDNA4())                                         \
             {                                                                               \
                 asm volatile(#asm_operator " %0, %1 th:TH_DEFAULT scope:SCOPE_DEV\n\t"      \
                                            "s_wait_loadcnt_dscnt(%2)"                       \
                              : "=&v"(retval)                                                \
                              : "v"(ptr), "I"(0x00));                                        \
             }                                                                               \
-            else if ROCPRIM_CONSTEXPR(IS_CDNA3())                                           \
+            else if ROCPRIM_AMDGCN_CONSTEXPR(IS_CDNA3())                                    \
             {                                                                               \
                 asm volatile(#asm_operator " %0, %1 sc0 nt\n\t"                             \
                                            "s_waitcnt(%2)"                                  \

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_load.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_load.hpp
@@ -76,39 +76,45 @@ T asm_thread_load(void* ptr)
     return retval;
 }
 
-// Important for syncing. Check section 9.2.2 or 7.3 in the following document
-// http://developer.amd.com/wordpress/media/2013/12/AMD_GCN3_Instruction_Set_Architecture_rev1.1.pdf
-#define ROCPRIM_ASM_THREAD_LOAD(cache_modifier, type, interim_type, asm_operator, output_modifier) \
-    template<>                                                                                     \
-    ROCPRIM_DEVICE ROCPRIM_INLINE type asm_thread_load<cache_modifier, type>(void* ptr)            \
-    {                                                                                              \
-        interim_type retval;                                                                       \
-        if ROCPRIM_CONSTEXPR(IS_RDNA4())                                                           \
-        {                                                                                          \
-            asm volatile(#asm_operator " %0, %1 th:TH_DEFAULT scope:SCOPE_DEV\n\t"                 \
-                                       "s_wait_loadcnt_dscnt(%2)"                                  \
-                         : "=" #output_modifier(retval)                                            \
-                         : "v"(ptr), "I"(0x00));                                                   \
-        }                                                                                          \
-        else if ROCPRIM_CONSTEXPR(IS_CDNA3())                                                      \
-        {                                                                                          \
-            asm volatile(#asm_operator " %0, %1 sc0 nt\n\t"                                        \
-                                       "s_waitcnt(%2)"                                             \
-                         : "=" #output_modifier(retval)                                            \
-                         : "v"(ptr), "I"(0x00));                                                   \
-        }                                                                                          \
-        else                                                                                       \
-        {                                                                                          \
-            asm volatile(#asm_operator " %0, %1 glc slc\n\t"                                       \
-                                       "s_waitcnt(%2)"                                             \
-                         : "=" #output_modifier(retval)                                            \
-                         : "v"(ptr), "I"(0x00));                                                   \
-        }                                                                                          \
-        return *bit_cast<type*>(&retval);                                                          \
-    }
+#if ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS == 1
 
-// TODO Add specialization for custom larger data types
-// clang-format off
+    // Important for syncing. Check section 9.2.2 or 7.3 in the following document
+    // http://developer.amd.com/wordpress/media/2013/12/AMD_GCN3_Instruction_Set_Architecture_rev1.1.pdf
+    #define ROCPRIM_ASM_THREAD_LOAD(cache_modifier,                                         \
+                                    type,                                                   \
+                                    interim_type,                                           \
+                                    asm_operator,                                           \
+                                    output_modifier)                                        \
+        template<>                                                                          \
+        ROCPRIM_DEVICE ROCPRIM_INLINE type asm_thread_load<cache_modifier, type>(void* ptr) \
+        {                                                                                   \
+            interim_type retval;                                                            \
+            if ROCPRIM_CONSTEXPR(IS_RDNA4())                                                \
+            {                                                                               \
+                asm volatile(#asm_operator " %0, %1 th:TH_DEFAULT scope:SCOPE_DEV\n\t"      \
+                                           "s_wait_loadcnt_dscnt(%2)"                       \
+                             : "=" #output_modifier(retval)                                 \
+                             : "v"(ptr), "I"(0x00));                                        \
+            }                                                                               \
+            else if ROCPRIM_CONSTEXPR(IS_CDNA3())                                           \
+            {                                                                               \
+                asm volatile(#asm_operator " %0, %1 sc0 nt\n\t"                             \
+                                           "s_waitcnt(%2)"                                  \
+                             : "=" #output_modifier(retval)                                 \
+                             : "v"(ptr), "I"(0x00));                                        \
+            }                                                                               \
+            else                                                                            \
+            {                                                                               \
+                asm volatile(#asm_operator " %0, %1 glc slc\n\t"                            \
+                                           "s_waitcnt(%2)"                                  \
+                             : "=" #output_modifier(retval)                                 \
+                             : "v"(ptr), "I"(0x00));                                        \
+            }                                                                               \
+            return *bit_cast<type*>(&retval);                                               \
+        }
+
+    // TODO Add specialization for custom larger data types
+    // clang-format off
 #define ROCPRIM_ASM_THREAD_LOAD_GROUP(cache_modifier)                                  \
     ROCPRIM_ASM_THREAD_LOAD(cache_modifier, int8_t,   int32_t,  flat_load_sbyte,   v); \
     ROCPRIM_ASM_THREAD_LOAD(cache_modifier, int16_t,  int32_t,  flat_load_sshort,  v); \
@@ -121,6 +127,8 @@ T asm_thread_load(void* ptr)
 // clang-format on
 
 ROCPRIM_ASM_THREAD_LOAD_GROUP(load_cg);
+
+#endif
 
 } // namespace detail
 

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_store.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_store.hpp
@@ -83,14 +83,14 @@ void asm_thread_store(void* ptr, T val)
                                                                                    type  val) \
         {                                                                                     \
             interim_type temp_val = *bit_cast<interim_type*>(&val);                           \
-            if ROCPRIM_CONSTEXPR(IS_RDNA4())                                                  \
+            if ROCPRIM_AMDGCN_CONSTEXPR(IS_RDNA4())                                           \
             {                                                                                 \
                 asm volatile(#asm_operator " %0, %1 th:TH_DEFAULT scope:SCOPE_DEV\n\t"        \
                                            "s_wait_storecnt_dscnt(%2)"                        \
                              :                                                                \
                              : "v"(ptr), "v"(temp_val), "I"(0x00));                           \
             }                                                                                 \
-            else if ROCPRIM_CONSTEXPR(IS_CDNA3())                                             \
+            else if ROCPRIM_AMDGCN_CONSTEXPR(IS_CDNA3())                                      \
             {                                                                                 \
                 asm volatile(#asm_operator " %0, %1 sc0 nt\n\t"                               \
                                            "s_waitcnt(%2)"                                    \

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_store.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_store.hpp
@@ -77,50 +77,54 @@ void asm_thread_store(void* ptr, T val)
 
     // Important for syncing. Check section 9.2.2 or 7.3 in the following document
     // http://developer.amd.com/wordpress/media/2013/12/AMD_GCN3_Instruction_Set_Architecture_rev1.1.pdf
-    #define ROCPRIM_ASM_THREAD_STORE(cache_modifier,                                            \
-                                     llvm_cache_modifier,                                       \
-                                     type,                                                      \
-                                     interim_type,                                              \
-                                     asm_operator,                                              \
-                                     output_modifier,                                           \
-                                     wait_inst,                                                 \
-                                     wait_cmd)                                                  \
-        template<>                                                                              \
-        ROCPRIM_DEVICE __forceinline__ void asm_thread_store<cache_modifier, type>(void* ptr,   \
-                                                                                   type  val)   \
-        {                                                                                       \
-            interim_type temp_val = *bit_cast<interim_type*>(&val);                             \
-            asm volatile(#asm_operator " %0, %1 " llvm_cache_modifier "\n\t" wait_inst wait_cmd \
-                                       "(%2)"                                                   \
-                         :                                                                      \
-                         : "v"(ptr), #output_modifier(temp_val), "I"(0x00));                    \
+    #define ROCPRIM_ASM_THREAD_STORE(cache_modifier,                                          \
+                                     type,                                                    \
+                                     interim_type,                                            \
+                                     asm_operator,                                            \
+                                     input_modifier)                                          \
+        template<>                                                                            \
+        ROCPRIM_DEVICE __forceinline__ void asm_thread_store<cache_modifier, type>(void* ptr, \
+                                                                                   type  val) \
+        {                                                                                     \
+            interim_type temp_val = *bit_cast<interim_type*>(&val);                           \
+            if ROCPRIM_CONSTEXPR(IS_RDNA4())                                                  \
+            {                                                                                 \
+                asm volatile(#asm_operator " %0, %1 th:TH_DEFAULT scope:SCOPE_DEV\n\t"        \
+                                           "s_wait_storecnt_dscnt(%2)"                        \
+                             :                                                                \
+                             : "v"(ptr), #input_modifier(temp_val), "I"(0x00));               \
+            }                                                                                 \
+            else if ROCPRIM_CONSTEXPR(IS_CDNA3())                                             \
+            {                                                                                 \
+                asm volatile(#asm_operator " %0, %1 sc0 nt\n\t"                               \
+                                           "s_waitcnt(%2)"                                    \
+                             :                                                                \
+                             : "v"(ptr), #input_modifier(temp_val), "I"(0x00));               \
+            }                                                                                 \
+            else                                                                              \
+            {                                                                                 \
+                asm volatile(#asm_operator " %0, %1 glc slc\n\t"                              \
+                                           "s_waitcnt(%2)"                                    \
+                             :                                                                \
+                             : "v"(ptr), #input_modifier(temp_val), "I"(0x00));               \
+            }                                                                                 \
         }
 
     // TODO fix flat_store_ubyte and flat_store_sbyte issues
     // TODO Add specialization for custom larger data types
     // clang-format off
-#define ROCPRIM_ASM_THREAD_STORE_GROUP(cache_modifier, llvm_cache_modifier, wait_inst, wait_cmd)                                   \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, llvm_cache_modifier, int8_t, int16_t, flat_store_byte, v, wait_inst, wait_cmd);       \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, llvm_cache_modifier, int16_t, int16_t, flat_store_short, v, wait_inst, wait_cmd);     \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, llvm_cache_modifier, uint8_t, uint16_t, flat_store_byte, v, wait_inst, wait_cmd);     \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, llvm_cache_modifier, uint16_t, uint16_t, flat_store_short, v, wait_inst, wait_cmd);   \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, llvm_cache_modifier, uint32_t, uint32_t, flat_store_dword, v, wait_inst, wait_cmd);   \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, llvm_cache_modifier, float, uint32_t, flat_store_dword, v, wait_inst, wait_cmd);      \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, llvm_cache_modifier, uint64_t, uint64_t, flat_store_dwordx2, v, wait_inst, wait_cmd); \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, llvm_cache_modifier, double, uint64_t, flat_store_dwordx2, v, wait_inst, wait_cmd);
-    // clang-format on
+#define ROCPRIM_ASM_THREAD_STORE_GROUP(cache_modifier)                                   \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, int8_t,   int16_t,  flat_store_byte,   v);  \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, int16_t,  int16_t,  flat_store_short,  v);  \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint8_t,  uint16_t, flat_store_byte,   v);  \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint16_t, uint16_t, flat_store_short,  v);  \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint32_t, uint32_t, flat_store_dword,  v);  \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, float,    uint32_t, flat_store_dword,  v);  \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint64_t, uint64_t, flat_store_dwordx2, v); \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, double,   uint64_t, flat_store_dwordx2, v)
+// clang-format on
 
-    #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx9_4_generic__)
-ROCPRIM_ASM_THREAD_STORE_GROUP(store_cg, "sc0 nt", "s_waitcnt", "");
-    #elif defined(__GFX12__)
-ROCPRIM_ASM_THREAD_STORE_GROUP(store_cg,
-                               "th:TH_DEFAULT scope:SCOPE_DEV",
-                               "s_wait_storecnt_dscnt",
-                               "");
-    #else
-ROCPRIM_ASM_THREAD_STORE_GROUP(store_cg, "glc slc", "s_waitcnt", "");
-    #endif
-
+ROCPRIM_ASM_THREAD_STORE_GROUP(store_cg);
 #endif
 
 } // namespace detail

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_store.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_store.hpp
@@ -77,11 +77,7 @@ void asm_thread_store(void* ptr, T val)
 
     // Important for syncing. Check section 9.2.2 or 7.3 in the following document
     // http://developer.amd.com/wordpress/media/2013/12/AMD_GCN3_Instruction_Set_Architecture_rev1.1.pdf
-    #define ROCPRIM_ASM_THREAD_STORE(cache_modifier,                                          \
-                                     type,                                                    \
-                                     interim_type,                                            \
-                                     asm_operator,                                            \
-                                     input_modifier)                                          \
+    #define ROCPRIM_ASM_THREAD_STORE(cache_modifier, type, interim_type, asm_operator)        \
         template<>                                                                            \
         ROCPRIM_DEVICE __forceinline__ void asm_thread_store<cache_modifier, type>(void* ptr, \
                                                                                    type  val) \
@@ -92,36 +88,36 @@ void asm_thread_store(void* ptr, T val)
                 asm volatile(#asm_operator " %0, %1 th:TH_DEFAULT scope:SCOPE_DEV\n\t"        \
                                            "s_wait_storecnt_dscnt(%2)"                        \
                              :                                                                \
-                             : "v"(ptr), #input_modifier(temp_val), "I"(0x00));               \
+                             : "v"(ptr), "v"(temp_val), "I"(0x00));                           \
             }                                                                                 \
             else if ROCPRIM_CONSTEXPR(IS_CDNA3())                                             \
             {                                                                                 \
                 asm volatile(#asm_operator " %0, %1 sc0 nt\n\t"                               \
                                            "s_waitcnt(%2)"                                    \
                              :                                                                \
-                             : "v"(ptr), #input_modifier(temp_val), "I"(0x00));               \
+                             : "v"(ptr), "v"(temp_val), "I"(0x00));                           \
             }                                                                                 \
             else                                                                              \
             {                                                                                 \
                 asm volatile(#asm_operator " %0, %1 glc slc\n\t"                              \
                                            "s_waitcnt(%2)"                                    \
                              :                                                                \
-                             : "v"(ptr), #input_modifier(temp_val), "I"(0x00));               \
+                             : "v"(ptr), "v"(temp_val), "I"(0x00));                           \
             }                                                                                 \
         }
 
     // TODO fix flat_store_ubyte and flat_store_sbyte issues
     // TODO Add specialization for custom larger data types
     // clang-format off
-#define ROCPRIM_ASM_THREAD_STORE_GROUP(cache_modifier)                                   \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, int8_t,   int16_t,  flat_store_byte,   v);  \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, int16_t,  int16_t,  flat_store_short,  v);  \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint8_t,  uint16_t, flat_store_byte,   v);  \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint16_t, uint16_t, flat_store_short,  v);  \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint32_t, uint32_t, flat_store_dword,  v);  \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, float,    uint32_t, flat_store_dword,  v);  \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint64_t, uint64_t, flat_store_dwordx2, v); \
-    ROCPRIM_ASM_THREAD_STORE(cache_modifier, double,   uint64_t, flat_store_dwordx2, v)
+#define ROCPRIM_ASM_THREAD_STORE_GROUP(cache_modifier)                                      \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, int8_t,   int16_t,  flat_store_byte);          \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, int16_t,  int16_t,  flat_store_short);         \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint8_t,  uint16_t, flat_store_byte);          \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint16_t, uint16_t, flat_store_short);         \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint32_t, uint32_t, flat_store_dword);         \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, float,    uint32_t, flat_store_dword);         \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, uint64_t, uint64_t, flat_store_dwordx2);       \
+    ROCPRIM_ASM_THREAD_STORE(cache_modifier, double,   uint64_t, flat_store_dwordx2)
 // clang-format on
 
 ROCPRIM_ASM_THREAD_STORE_GROUP(store_cg);

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_crosslane.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_crosslane.hpp
@@ -47,7 +47,7 @@ private:
         // We use a dispatch here because when we target SPIR-V, we have to know after
         // compiling SPIR-V whether DPP is available. Therefore, this check cannot
         // be done at the C++ constexpr-level.
-        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
         {
             if constexpr(UseDPP)
             {

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -76,7 +76,7 @@ public:
 
         // Check for __builtin_amdgcn_permlane16; if it exists, the DPP equivalent is not available.
         // Swizzle is kept instead of __builtin_amdgcn_permlanex16, as the latter can be slower in some cases.
-        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
             if(VirtualWaveSize > 16)
             {

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_crosslane.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_crosslane.hpp
@@ -44,7 +44,7 @@ private:
         // We use a dispatch here because when we target SPIR-V, we have to know after
         // compiling SPIR-V whether DPP is available. Therefore, this check cannot
         // be done at the C++ constexpr-level.
-        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
         {
             if constexpr(UseDPP)
             {

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -78,7 +78,7 @@ public:
 
         // Check for __builtin_amdgcn_permlane16; if it exists, the DPP equivalent is not available.
         // Swizzle is kept instead of __builtin_amdgcn_permlanex16, as the latter can be slower in some cases.
-        if ROCPRIM_SPIRV_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
             if(VirtualWaveSize > 16)
             {

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
@@ -391,7 +391,7 @@ private:
 
         // Note: we cannot use a while loop here because all threads need to be active during the
         // shuffle.
-#ifndef __SPIRV__
+#ifndef ROCPRIM_TARGET_SPIRV
         ROCPRIM_UNROLL
 #endif
         for(auto i = 1u; i <= m; i <<= 1u)

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_sort_stable.hpp
@@ -391,7 +391,9 @@ private:
 
         // Note: we cannot use a while loop here because all threads need to be active during the
         // shuffle.
+#ifndef __SPIRV__
         ROCPRIM_UNROLL
+#endif
         for(auto i = 1u; i <= m; i <<= 1u)
         {
             const auto mid = (begin + end) / 2;


### PR DESCRIPTION
Currently we load_cg and store_cg disabled. This should be enabled to have SPIR-V as a first class target.