### PR TITLE
[rocSPARSE] add sync to rocsparse_*csr2hyb to fix hipSPARSE tests

### DIFF
--- a/projects/rocsparse/library/src/conversion/rocsparse_csr2hyb.cpp
+++ b/projects/rocsparse/library/src/conversion/rocsparse_csr2hyb.cpp
@@ -390,6 +390,7 @@ try
                                                           hyb,
                                                           user_ell_width,
                                                           partition_type));
+    RETURN_IF_HIP_ERROR(hipStreamSynchronize(handle->stream));
     return rocsparse_status_success;
     // LCOV_EXCL_START
 }
@@ -423,6 +424,7 @@ try
                                                           hyb,
                                                           user_ell_width,
                                                           partition_type));
+    RETURN_IF_HIP_ERROR(hipStreamSynchronize(handle->stream));
     return rocsparse_status_success;
     // LCOV_EXCL_START
 }
@@ -456,6 +458,7 @@ try
                                                           hyb,
                                                           user_ell_width,
                                                           partition_type));
+    RETURN_IF_HIP_ERROR(hipStreamSynchronize(handle->stream));
     return rocsparse_status_success;
     // LCOV_EXCL_START
 }
@@ -489,6 +492,7 @@ try
                                                           hyb,
                                                           user_ell_width,
                                                           partition_type));
+    RETURN_IF_HIP_ERROR(hipStreamSynchronize(handle->stream));
     return rocsparse_status_success;
     // LCOV_EXCL_START
 }


### PR DESCRIPTION
This PR fixes hipSPARSE failures on Windows for the tests: hyb2csr_bin/parameterized_hyb2csr_bin.hyb2csr_bin_double/*
The observed failure was similar to the one fixed by https://github.com/ROCm/rocm-libraries/pull/1609 .