### PR TITLE
For hipFFTXt multi-gpu transforms put extra data on earlier-index GPUs for nondivisible case

### DIFF
--- a/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
@@ -44,15 +44,14 @@ int main()
     // Note that when using cuFFTXt with two or more GPUs, its latest version requires
     // a minimum size per dimension greater or equal than 32 and less equal than 4096
     // for single precision, and 2048 for double precision.
-    const int Nx        = 25;
-    const int Ny        = 16;
-    int       direction = HIPFFT_FORWARD; // forward=-1, backward=1
+    const int  Nx             = 25;
+    const int  Ny             = 16;
+    int        direction      = HIPFFT_FORWARD; // forward=-1, backward=1
     hipfftType transform_type = HIPFFT_Z2Z; // std::complex<double> to std::complex<double>
-    size_t ngpus = 2;
-    
+    size_t     ngpus          = 2;
+
     // We only want to print a subset of the data:
     const int printlimit = 4;
-    
 
     int deviceCount;
     if(hipGetDeviceCount(&deviceCount) != hipSuccess)
@@ -64,7 +63,6 @@ int main()
         return 0;
     }
     std::cout << "\n";
-    
 
     // Initialize reference data
     std::vector<std::complex<double>> cinput(Nx * Ny);
@@ -76,13 +74,15 @@ int main()
     std::cout << "Input:\n";
     for(int xidx = 0; xidx < Nx; ++xidx)
     {
-        if(xidx > printlimit) {
+        if(xidx > printlimit)
+        {
             std::cout << "...\n";
             xidx = Nx - 1;
         }
         for(int yidx = 0; yidx < Ny; ++yidx)
         {
-            if(yidx > printlimit) {
+            if(yidx > printlimit)
+            {
                 std::cout << "... ";
                 yidx = Ny - 1;
             }
@@ -111,7 +111,7 @@ int main()
 
     // Assign GPUs to the plan
     std::vector<int> gpus(ngpus);
-    std::iota(gpus.begin(), gpus.end(), 0); 
+    std::iota(gpus.begin(), gpus.end(), 0);
     hipfftResult hipfft_rt = hipfftXtSetGPUs(plan, gpus.size(), gpus.data());
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftXtSetGPUs failed.");
@@ -124,9 +124,9 @@ int main()
         throw std::runtime_error("hipfftMakePlan2d failed.");
 
     // Copy input data to GPUs
-    hipfftXtSubFormat_t format = HIPFFT_XT_FORMAT_INPUT;
-    hipLibXtDesc* inoutdesc = nullptr;
-    hipfft_rt                  = hipfftXtMalloc(plan, &inoutdesc, format);
+    hipfftXtSubFormat_t format    = HIPFFT_XT_FORMAT_INPUT;
+    hipLibXtDesc*       inoutdesc = nullptr;
+    hipfft_rt                     = hipfftXtMalloc(plan, &inoutdesc, format);
     if(hipfft_rt != HIPFFT_SUCCESS)
     {
         std::stringstream ss;
@@ -141,7 +141,6 @@ int main()
             = inoutdesc->descriptor->size[idx] / sizeof(decltype(cinput)::value_type);
         std::cout << "\tbuffer " << idx << ": " << inoutdesc->descriptor->size[idx] << " bytes, "
                   << vsize << " values\n";
-
     }
     std::cout << "\n";
 
@@ -156,24 +155,29 @@ int main()
     for(size_t idx = 0; idx < ngpus; ++idx)
     {
         std::cout << "buffer " << idx << "\n";
-        const size_t vsize = inoutdesc->descriptor->size[idx] / sizeof(decltype(cinput)::value_type);
+        const size_t vsize
+            = inoutdesc->descriptor->size[idx] / sizeof(decltype(cinput)::value_type);
         std::vector<decltype(cinput)::value_type> hbuf(vsize);
-        if(hipMemcpy(hbuf.data(), inoutdesc->descriptor->data[idx],
-                  inoutdesc->descriptor->size[idx],
-                  hipMemcpyDeviceToHost) != hipSuccess)
+        if(hipMemcpy(hbuf.data(),
+                     inoutdesc->descriptor->data[idx],
+                     inoutdesc->descriptor->size[idx],
+                     hipMemcpyDeviceToHost)
+           != hipSuccess)
         {
             throw std::runtime_error("hipMemcpy failed.");
         }
         const int Nxmax = Nx / ngpus + ((idx < Nx % ngpus) ? 1 : 0);
         for(int xidx = 0; xidx < Nxmax; ++xidx)
         {
-            if(xidx > printlimit) {
+            if(xidx > printlimit)
+            {
                 std::cout << "...\n";
                 xidx = Nxmax - 1;
             }
             for(int yidx = 0; yidx < Ny; ++yidx)
             {
-                if(yidx > printlimit) {
+                if(yidx > printlimit)
+                {
                     std::cout << "... ";
                     yidx = Ny - 1;
                 }
@@ -184,7 +188,7 @@ int main()
         }
         std::cout << "\n";
     }
-        
+
     // Execute the plan
     hipfft_rt = hipfftXtExecDescriptor(plan, inoutdesc, inoutdesc, direction);
     if(hipfft_rt != HIPFFT_SUCCESS)
@@ -194,26 +198,31 @@ int main()
     for(size_t idx = 0; idx < ngpus; ++idx)
     {
         std::cout << "buffer " << idx << "\n";
-        const size_t vsize = inoutdesc->descriptor->size[idx] / sizeof(decltype(cinput)::value_type);
+        const size_t vsize
+            = inoutdesc->descriptor->size[idx] / sizeof(decltype(cinput)::value_type);
 
         std::vector<decltype(cinput)::value_type> hbuf(vsize);
-        if(hipMemcpy(hbuf.data(), inoutdesc->descriptor->data[idx],
-                  inoutdesc->descriptor->size[idx],
-                  hipMemcpyDeviceToHost) != hipSuccess)
+        if(hipMemcpy(hbuf.data(),
+                     inoutdesc->descriptor->data[idx],
+                     inoutdesc->descriptor->size[idx],
+                     hipMemcpyDeviceToHost)
+           != hipSuccess)
         {
             throw std::runtime_error("hipMemcpy failed.");
         }
         const int Nxmax = Nx / ngpus + ((idx < Nx % ngpus) ? 1 : 0);
         for(int xidx = 0; xidx < Nxmax; ++xidx)
         {
-            if(xidx > printlimit) {
+            if(xidx > printlimit)
+            {
                 std::cout << "...\n";
                 xidx = Nxmax - 1;
             }
 
             for(int yidx = 0; yidx < Ny; ++yidx)
             {
-                if(yidx > printlimit) {
+                if(yidx > printlimit)
+                {
                     std::cout << "... ";
                     yidx = Ny - 1;
                 }
@@ -236,13 +245,15 @@ int main()
     std::cout << "Collected output:\n";
     for(size_t xidx = 0; xidx < Nx; ++xidx)
     {
-        if(xidx > printlimit) {
+        if(xidx > printlimit)
+        {
             std::cout << "...\n";
             xidx = Nx - 1;
         }
         for(size_t yidx = 0; yidx < Ny; ++yidx)
         {
-            if(yidx > printlimit) {
+            if(yidx > printlimit)
+            {
                 std::cout << "... ";
                 yidx = Ny - 1;
             }
@@ -252,7 +263,7 @@ int main()
         std::cout << "\n";
     }
     std::cout << std::endl;
-    
+
     // Clean up
     if(hipfftXtFree(inoutdesc) != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftXtFree failed.");

--- a/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
@@ -21,6 +21,7 @@
 
 #include <complex>
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <hipfft/hipfft.h>
@@ -34,7 +35,7 @@ DISABLE_WARNING_POP
 
 int main()
 {
-    std::cout << "Multi-gpu hipFFT 2D double-precision complex-to-complex transform\n";
+    std::cout << "Multi-gpu hipFFT in-place 2D double-precision complex-to-complex transform\n";
 
     // 2D FFTs are encountered in diverse applications of image processing,
     // examples range from image denoising to RTM seismic imaging.
@@ -43,32 +44,52 @@ int main()
     // Note that when using cuFFTXt with two or more GPUs, its latest version requires
     // a minimum size per dimension greater or equal than 32 and less equal than 4096
     // for single precision, and 2048 for double precision.
-    const int Nx        = 512;
-    const int Ny        = 512;
+    const int Nx        = 25;
+    const int Ny        = 16;
     int       direction = HIPFFT_FORWARD; // forward=-1, backward=1
+    hipfftType transform_type = HIPFFT_Z2Z; // std::complex<double> to std::complex<double>
+    size_t ngpus = 2;
+    
+    // We only want to print a subset of the data:
+    const int printlimit = 4;
+    
 
-    int verbose = 0;
+    int deviceCount;
+    if(hipGetDeviceCount(&deviceCount) != hipSuccess)
+        throw std::runtime_error("hipGetDeviceCount failed.");
+    std::cout << "Number of available devices: " << deviceCount << std::endl;
+    if(deviceCount < ngpus)
+    {
+        std::cout << "Sample needs at least " << ngpus << "GPUs\n";
+        return 0;
+    }
+    std::cout << "\n";
+    
 
     // Initialize reference data
     std::vector<std::complex<double>> cinput(Nx * Ny);
-    for(size_t i = 0; i < Nx * Ny; i++)
+    for(size_t idx = 0; idx < Nx * Ny; ++idx)
     {
-        cinput[i] = i;
+        cinput[idx] = idx;
     }
 
-    if(verbose)
+    std::cout << "Input:\n";
+    for(int xidx = 0; xidx < Nx; ++xidx)
     {
-        std::cout << "Input:\n";
-        for(int i = 0; i < Nx; i++)
-        {
-            for(int j = 0; j < Ny; j++)
-            {
-                int pos = i * Ny + j;
-                std::cout << cinput[pos] << " ";
-            }
-            std::cout << "\n";
+        if(xidx > printlimit) {
+            std::cout << "...\n";
+            xidx = Nx - 1;
         }
-        std::cout << std::endl;
+        for(int yidx = 0; yidx < Ny; ++yidx)
+        {
+            if(yidx > printlimit) {
+                std::cout << "... ";
+                yidx = Ny - 1;
+            }
+            int pos = xidx * Ny + yidx;
+            std::cout << cinput[pos] << " ";
+        }
+        std::cout << "\n";
     }
 
     // Define list of GPUs to use
@@ -89,60 +110,151 @@ int main()
         throw std::runtime_error("hipfftSetStream failed.");
 
     // Assign GPUs to the plan
+    std::vector<int> gpus(ngpus);
+    std::iota(gpus.begin(), gpus.end(), 0); 
     hipfftResult hipfft_rt = hipfftXtSetGPUs(plan, gpus.size(), gpus.data());
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftXtSetGPUs failed.");
 
     // Make the 2D plan
-    std::vector<size_t> workSize(gpus.size());
-    hipfft_rt = hipfftMakePlan2d(plan, Nx, Ny, HIPFFT_Z2Z, workSize.data());
+
+    std::vector<size_t> workSize(ngpus);
+    hipfft_rt = hipfftMakePlan2d(plan, Nx, Ny, transform_type, workSize.data());
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftMakePlan2d failed.");
 
     // Copy input data to GPUs
-    hipfftXtSubFormat_t format = HIPFFT_XT_FORMAT_INPLACE;
-    hipfft_rt                  = hipfftXtMalloc(plan, &desc, format);
+    hipfftXtSubFormat_t format = HIPFFT_XT_FORMAT_INPUT;
+    hipLibXtDesc* inoutdesc = nullptr;
+    hipfft_rt                  = hipfftXtMalloc(plan, &inoutdesc, format);
     if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("hipfftXtMalloc failed.");
+    {
+        std::stringstream ss;
+        ss << "hipfftXtMalloc failed with error " << hipfft_rt;
+        throw std::runtime_error(ss.str());
+    }
+
+    std::cout << "The descriptor is now allocated:\n";
+    for(size_t idx = 0; idx < ngpus; ++idx)
+    {
+        const size_t vsize
+            = inoutdesc->descriptor->size[idx] / sizeof(decltype(cinput)::value_type);
+        std::cout << "\tbuffer " << idx << ": " << inoutdesc->descriptor->size[idx] << " bytes, "
+                  << vsize << " values\n";
+
+    }
+    std::cout << "\n";
 
     hipfft_rt = hipfftXtMemcpy(plan,
-                               reinterpret_cast<void*>(desc),
+                               reinterpret_cast<void*>(inoutdesc),
                                reinterpret_cast<void*>(cinput.data()),
                                HIPFFT_COPY_HOST_TO_DEVICE);
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftXtMemcpy failed.");
 
-    // Execute the plan
-    hipfft_rt = hipfftXtExecDescriptor(plan, desc, desc, direction);
-    if(hipfft_rt != HIPFFT_SUCCESS)
-        throw std::runtime_error("hipfftXtMemcpy failed.");
-
-    // Print output
-    if(verbose)
+    std::cout << "Distributed input data on the GPUs:\n";
+    for(size_t idx = 0; idx < ngpus; ++idx)
     {
-        // Move result to the host
-        hipfft_rt = hipfftXtMemcpy(plan,
-                                   reinterpret_cast<void*>(cinput.data()),
-                                   reinterpret_cast<void*>(desc),
-                                   HIPFFT_COPY_DEVICE_TO_HOST);
-        if(hipfft_rt != HIPFFT_SUCCESS)
-            throw std::runtime_error("hipfftXtMemcpy D2H failed.");
-
-        std::cout << "Output:\n";
-        for(size_t i = 0; i < Nx; i++)
+        std::cout << "buffer " << idx << "\n";
+        const size_t vsize = inoutdesc->descriptor->size[idx] / sizeof(decltype(cinput)::value_type);
+        std::vector<decltype(cinput)::value_type> hbuf(vsize);
+        if(hipMemcpy(hbuf.data(), inoutdesc->descriptor->data[idx],
+                  inoutdesc->descriptor->size[idx],
+                  hipMemcpyDeviceToHost) != hipSuccess)
         {
-            for(size_t j = 0; j < Ny; j++)
+            throw std::runtime_error("hipMemcpy failed.");
+        }
+        const int Nxmax = Nx / ngpus + ((idx < Nx % ngpus) ? 1 : 0);
+        for(int xidx = 0; xidx < Nxmax; ++xidx)
+        {
+            if(xidx > printlimit) {
+                std::cout << "...\n";
+                xidx = Nxmax - 1;
+            }
+            for(int yidx = 0; yidx < Ny; ++yidx)
             {
-                auto pos = i * Ny + j;
-                std::cout << cinput[pos] << " ";
+                if(yidx > printlimit) {
+                    std::cout << "... ";
+                    yidx = Ny - 1;
+                }
+                int pos = xidx * Ny + yidx;
+                std::cout << hbuf[pos] << " ";
             }
             std::cout << "\n";
         }
-        std::cout << std::endl;
+        std::cout << "\n";
+    }
+        
+    // Execute the plan
+    hipfft_rt = hipfftXtExecDescriptor(plan, inoutdesc, inoutdesc, direction);
+    if(hipfft_rt != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftXtMemcpy failed.");
+
+    std::cout << "Distributed output data on the GPUs:\n";
+    for(size_t idx = 0; idx < ngpus; ++idx)
+    {
+        std::cout << "buffer " << idx << "\n";
+        const size_t vsize = inoutdesc->descriptor->size[idx] / sizeof(decltype(cinput)::value_type);
+
+        std::vector<decltype(cinput)::value_type> hbuf(vsize);
+        if(hipMemcpy(hbuf.data(), inoutdesc->descriptor->data[idx],
+                  inoutdesc->descriptor->size[idx],
+                  hipMemcpyDeviceToHost) != hipSuccess)
+        {
+            throw std::runtime_error("hipMemcpy failed.");
+        }
+        const int Nxmax = Nx / ngpus + ((idx < Nx % ngpus) ? 1 : 0);
+        for(int xidx = 0; xidx < Nxmax; ++xidx)
+        {
+            if(xidx > printlimit) {
+                std::cout << "...\n";
+                xidx = Nxmax - 1;
+            }
+
+            for(int yidx = 0; yidx < Ny; ++yidx)
+            {
+                if(yidx > printlimit) {
+                    std::cout << "... ";
+                    yidx = Ny - 1;
+                }
+                int pos = xidx * Ny + yidx;
+                std::cout << hbuf[pos] << " ";
+            }
+            std::cout << "\n";
+        }
+        std::cout << "\n";
     }
 
+    // Move result to the host
+    hipfft_rt = hipfftXtMemcpy(plan,
+                               reinterpret_cast<void*>(cinput.data()),
+                               reinterpret_cast<void*>(inoutdesc),
+                               HIPFFT_COPY_DEVICE_TO_HOST);
+    if(hipfft_rt != HIPFFT_SUCCESS)
+        throw std::runtime_error("hipfftXtMemcpy D2H failed.");
+
+    std::cout << "Collected output:\n";
+    for(size_t xidx = 0; xidx < Nx; ++xidx)
+    {
+        if(xidx > printlimit) {
+            std::cout << "...\n";
+            xidx = Nx - 1;
+        }
+        for(size_t yidx = 0; yidx < Ny; ++yidx)
+        {
+            if(yidx > printlimit) {
+                std::cout << "... ";
+                yidx = Ny - 1;
+            }
+            auto pos = xidx * Ny + yidx;
+            std::cout << cinput[pos] << " ";
+        }
+        std::cout << "\n";
+    }
+    std::cout << std::endl;
+    
     // Clean up
-    if(hipfftXtFree(desc) != HIPFFT_SUCCESS)
+    if(hipfftXtFree(inoutdesc) != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftXtFree failed.");
 
     if(hipfftDestroy(plan) != HIPFFT_SUCCESS)

--- a/projects/hipfft/library/include/hipfft/hiplibxt.h
+++ b/projects/hipfft/library/include/hipfft/hiplibxt.h
@@ -37,19 +37,19 @@
 typedef struct hipXtDesc_t
 {
     int version;
-    
+
     // Count of GPUs
     int nGPUs;
-    
+
     // Device IDs
     int GPUs[MAX_HIP_DESCRIPTOR_GPUS];
-    
+
     // Data pointers for each GPU
     void* data[MAX_HIP_DESCRIPTOR_GPUS];
-    
+
     // Size of data pointed to, for each GPU
     size_t size[MAX_HIP_DESCRIPTOR_GPUS];
-    
+
     // Internal state
     void* hipXtState;
 } hipXtDesc;

--- a/projects/hipfft/library/include/hipfft/hiplibxt.h
+++ b/projects/hipfft/library/include/hipfft/hiplibxt.h
@@ -37,14 +37,19 @@
 typedef struct hipXtDesc_t
 {
     int version;
+    
     // Count of GPUs
     int nGPUs;
+    
     // Device IDs
     int GPUs[MAX_HIP_DESCRIPTOR_GPUS];
+    
     // Data pointers for each GPU
     void* data[MAX_HIP_DESCRIPTOR_GPUS];
+    
     // Size of data pointed to, for each GPU
     size_t size[MAX_HIP_DESCRIPTOR_GPUS];
+    
     // Internal state
     void* hipXtState;
 } hipXtDesc;

--- a/projects/hipfft/library/src/amd_detail/hipfft.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfft.cpp
@@ -1859,10 +1859,10 @@ try
 
     // but at this point we know devices, so record what the user
     // gave us
-    for(size_t i = 0; i < static_cast<size_t>(count); ++i)
+    for(size_t idx = 0; idx < static_cast<size_t>(count); ++idx)
     {
-        plan->inBricks[i].device  = gpus[i];
-        plan->outBricks[i].device = gpus[i];
+        plan->inBricks[idx].device  = gpus[idx];
+        plan->outBricks[idx].device = gpus[idx];
     }
 
     plan->singleProcMultiDevice = true;
@@ -1945,15 +1945,15 @@ try
 
     xt_desc->nGPUs = static_cast<int>(bricks->size());
 
-    for(size_t i = 0; i < bricks->size(); ++i)
+    for(size_t idx = 0; idx < bricks->size(); ++idx)
     {
-        auto& brick = (*bricks)[i];
+        auto& brick = (*bricks)[idx];
 
         rocfft_scoped_device dev(brick.device);
 
-        xt_desc->GPUs[i] = brick.device;
-        xt_desc->size[i] = brick.min_size * bits_per_element / 8;
-        if(hipMalloc(&(xt_desc->data[i]), xt_desc->size[i]) != hipSuccess)
+        xt_desc->GPUs[idx] = brick.device;
+        xt_desc->size[idx] = brick.min_size * bits_per_element / 8;
+        if(hipMalloc(&(xt_desc->data[idx]), xt_desc->size[idx]) != hipSuccess)
             return HIPFFT_INTERNAL_ERROR;
     }
 

--- a/projects/hipfft/shared/hipfft_brick.h
+++ b/projects/hipfft/shared/hipfft_brick.h
@@ -87,20 +87,28 @@ static void set_bricks(const std::vector<size_t>& length,
 {
     const size_t dim = length.size();
 
-    for(size_t i = 0; i < bricks.size(); ++i)
+    for(size_t idx = 0; idx < bricks.size(); ++idx)
     {
-        auto& brick = bricks[i];
+        auto& brick = bricks[idx];
 
         // lower idx starts at origin, upper is one-past-the-end
         brick.field_lower.resize(dim);
+        brick.field_upper.resize(dim);
+        
         std::fill(brick.field_lower.begin(), brick.field_lower.end(), 0);
-        brick.field_upper = length;
+
+        // All of the remainders get put on the low-index bricks.
+        brick.field_lower[split_dim] = length[split_dim] / bricks.size() * idx
+            + std::min(idx, length[split_dim] % bricks.size());
 
         // length of the brick along the split dimension
-        size_t split_len             = length[split_dim] / bricks.size();
-        brick.field_lower[split_dim] = split_len * i;
-        if(i != bricks.size() - 1)
+        size_t split_len = length[split_dim] / bricks.size()
+            + (idx < length[split_dim] % bricks.size() ? 1 : 0);
+
+        brick.field_upper = length;        
+        if(idx != bricks.size() - 1)
             brick.field_upper[split_dim] = brick.field_lower[split_dim] + split_len;
+        
         brick.set_contiguous_stride();
 
         // work out how big a buffer we need to allocate
@@ -126,12 +134,10 @@ static void set_io_bricks(const std::vector<size_t>& inLength,
     std::vector<size_t> outLengthWithBatch = outLength;
     outLengthWithBatch.push_back(batch);
 
-    // for batched FFT, split input on batch, otherwise split input
+    // For batched FFT, split input on batch, otherwise split input
     // on fastest FFT dim and output on slowest FFT dim
-    const size_t in_split_dim
-        = batch > 1 ? inLengthWithBatch.size() - 1 : inLengthWithBatch.size() - 2;
-    const size_t out_split_dim
-        = batch > 1 ? outLengthWithBatch.size() - 1 : outLengthWithBatch.size() - 2;
+    const size_t in_split_dim   = inLengthWithBatch.size() - (batch > 1 ? 1 : 2);
+    const size_t out_split_dim  = outLengthWithBatch.size() - (batch > 1 ? 1 : 2);
 
     set_bricks(inLengthWithBatch, inBricks, in_split_dim);
     set_bricks(outLengthWithBatch, outBricks, out_split_dim);

--- a/projects/hipfft/shared/hipfft_brick.h
+++ b/projects/hipfft/shared/hipfft_brick.h
@@ -94,21 +94,21 @@ static void set_bricks(const std::vector<size_t>& length,
         // lower idx starts at origin, upper is one-past-the-end
         brick.field_lower.resize(dim);
         brick.field_upper.resize(dim);
-        
+
         std::fill(brick.field_lower.begin(), brick.field_lower.end(), 0);
 
         // All of the remainders get put on the low-index bricks.
         brick.field_lower[split_dim] = length[split_dim] / bricks.size() * idx
-            + std::min(idx, length[split_dim] % bricks.size());
+                                       + std::min(idx, length[split_dim] % bricks.size());
 
         // length of the brick along the split dimension
-        size_t split_len = length[split_dim] / bricks.size()
-            + (idx < length[split_dim] % bricks.size() ? 1 : 0);
+        size_t split_len
+            = length[split_dim] / bricks.size() + (idx < length[split_dim] % bricks.size() ? 1 : 0);
 
-        brick.field_upper = length;        
+        brick.field_upper = length;
         if(idx != bricks.size() - 1)
             brick.field_upper[split_dim] = brick.field_lower[split_dim] + split_len;
-        
+
         brick.set_contiguous_stride();
 
         // work out how big a buffer we need to allocate
@@ -136,8 +136,8 @@ static void set_io_bricks(const std::vector<size_t>& inLength,
 
     // For batched FFT, split input on batch, otherwise split input
     // on fastest FFT dim and output on slowest FFT dim
-    const size_t in_split_dim   = inLengthWithBatch.size() - (batch > 1 ? 1 : 2);
-    const size_t out_split_dim  = outLengthWithBatch.size() - (batch > 1 ? 1 : 2);
+    const size_t in_split_dim  = inLengthWithBatch.size() - (batch > 1 ? 1 : 2);
+    const size_t out_split_dim = outLengthWithBatch.size() - (batch > 1 ? 1 : 2);
 
     set_bricks(inLengthWithBatch, inBricks, in_split_dim);
     set_bricks(outLengthWithBatch, outBricks, out_split_dim);


### PR DESCRIPTION
## Motivation

Fix the data decomposition for multi-GPU single-process hipFFTXt transforms.

## Technical Details

When the decomposed dimension's length isn't divisible by the number of GPUs, we should put the extra data on earlier GPUs rather than later ones.  Also improves the multi-GPU example to show the user how data is distributed.

## Test Plan

Working on it!

## Test Result

It's a draft PR, so we'll get there.