### PR TITLE
[hipblaslt] Correct rocroller_host.hpp file direct

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/include/rocblaslt/rocroller_host.hpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/include/rocblaslt/rocroller_host.hpp
@@ -1,1 +1,1 @@
-../rocroller_host.hpp
+../../rocroller/include/rocroller_host.hpp


### PR DESCRIPTION
started getting errors such as:

```
CMake Error at cmake/therock_subproject.cmake:965 (target_sources):
  Cannot find source file:

    /__w/rocm-libraries/rocm-libraries/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/include/rocblaslt/rocroller_host.hpp
Call Stack (most recent call first):
  math-libs/BLAS/CMakeLists.txt:146 (therock_cmake_subproject_glob_c_sources)
```
in TheRock.

Noticed that [rocroller_host.hpp](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/include/rocblaslt/rocroller_host.hpp) points to the incorrect location, after this [PR#1555](https://github.com/ROCm/rocm-libraries/commit/a8d451507808c2c36f9a4b4d7c84abf95d872b6e#diff-3ceecabed4401fa84e4935f2a7ac32b410e32f0f041767b50d42a7dbbb56791f). This PR fixes the path

Progress on #1462
