### PR TITLE
Add 2d and 3d conv wrw wmma group solvers

### DIFF
--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -256,6 +256,7 @@ set( MIOpen_Source
     solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
     solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
     solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+    solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_wmma.cpp
     solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
     solver/conv/conv_hip_implicit_gemm_nonxdlops_common.cpp
     solver/conv/conv_hip_implicit_gemm_wrw_v4r4.cpp

--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -253,6 +253,7 @@ set( MIOpen_Source
     solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
     solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
     solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+    solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
     solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
     solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
     solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp

--- a/projects/miopen/src/include/miopen/conv/solvers.hpp
+++ b/projects/miopen/src/include/miopen/conv/solvers.hpp
@@ -4991,6 +4991,84 @@ private:
     bool CheckCKApplicability(const miopen::conv::ProblemDescription&) const;
 };
 
+struct PerformanceConfigHipImplicitGemm3DGroupWrwWmma
+    : PerfConfigBaseCK<PerformanceConfigHipImplicitGemm3DGroupWrwWmma>
+{
+    int index;
+    int split_k;
+    std::string kernel_id;
+    std::vector<std::string> valid_kernels;
+    PerformanceConfigHipImplicitGemm3DGroupWrwWmma(int idx, std::string kernl_id)
+        : index(idx), kernel_id(kernl_id)
+    {
+    }
+    PerformanceConfigHipImplicitGemm3DGroupWrwWmma()
+        : PerformanceConfigHipImplicitGemm3DGroupWrwWmma(0, "")
+    {
+    }
+    PerformanceConfigHipImplicitGemm3DGroupWrwWmma(bool)
+        : PerformanceConfigHipImplicitGemm3DGroupWrwWmma(0, "")
+    {
+    }
+    MIOPEN_INTERNALS_EXPORT void HeuristicInit(const miopen::conv::ProblemDescription&);
+    MIOPEN_INTERNALS_EXPORT bool SetNextValue(const miopen::conv::ProblemDescription&);
+    MIOPEN_INTERNALS_EXPORT bool IsValidValue() const;
+    bool IsValid(const ExecutionContext&, const miopen::conv::ProblemDescription& problem) const
+    {
+        return IsValid(problem);
+    }
+    MIOPEN_INTERNALS_EXPORT bool IsValid(const miopen::conv::ProblemDescription&) const;
+    MIOPEN_INTERNALS_EXPORT bool
+    operator==(const PerformanceConfigHipImplicitGemm3DGroupWrwWmma& other) const;
+
+private:
+    template <typename DataType>
+    void Init(const miopen::conv::ProblemDescription&);
+    template <typename DataType>
+    bool CheckIsSupportCKArgs(const miopen::conv::ProblemDescription&) const;
+};
+
+struct ConvHipImplicitGemm3DGroupWrwWmma final
+    : ConvTunableSolver<PerformanceConfigHipImplicitGemm3DGroupWrwWmma>
+{
+    const std::string& SolverDbId() const override
+    {
+        return GetSolverDbId<ConvHipImplicitGemm3DGroupWrwWmma>();
+    }
+
+    MIOPEN_INTERNALS_EXPORT PerformanceConfigHipImplicitGemm3DGroupWrwWmma
+    GetDefaultPerformanceConfig(const ExecutionContext&,
+                                const miopen::conv::ProblemDescription&) const override;
+    MIOPEN_INTERNALS_EXPORT bool
+    IsValidPerformanceConfig(const ExecutionContext&,
+                             const miopen::conv::ProblemDescription&,
+                             const PerformanceConfigHipImplicitGemm3DGroupWrwWmma&) const override;
+    MIOPEN_INTERNALS_EXPORT PerformanceConfigHipImplicitGemm3DGroupWrwWmma
+    Search(const ExecutionContext&,
+           const miopen::conv::ProblemDescription&,
+           const AnyInvokeParams& invoke_ctx) const override;
+    MIOPEN_INTERNALS_EXPORT bool
+    IsApplicable(const ExecutionContext&, const miopen::conv::ProblemDescription&) const override;
+    bool IsDynamic() const override { return true; }
+    MIOPEN_INTERNALS_EXPORT ConvSolution
+    GetSolution(const ExecutionContext&,
+                const miopen::conv::ProblemDescription&,
+                const PerformanceConfigHipImplicitGemm3DGroupWrwWmma&) const override;
+    /// \ref igemm_get_wti_magic_number
+    float GetWti(const ExecutionContext&, const miopen::conv::ProblemDescription&) const override
+    {
+        return 0.02f;
+    };
+
+    MIOPEN_INTERNALS_EXPORT size_t GetWorkspaceSize(
+        const ExecutionContext&, const miopen::conv::ProblemDescription&) const override;
+    bool MayNeedWorkspace() const override { return true; }
+
+private:
+    template <typename DataType>
+    bool CheckCKApplicability(const miopen::conv::ProblemDescription&) const;
+};
+
 } // namespace conv
 } // namespace solver
 } // namespace miopen

--- a/projects/miopen/src/include/miopen/conv/solvers.hpp
+++ b/projects/miopen/src/include/miopen/conv/solvers.hpp
@@ -4912,6 +4912,100 @@ private:
     bool CheckCKApplicability(const miopen::conv::ProblemDescription&) const;
 };
 
+struct PerformanceConfigHipImplicitGemmGroupWrwWmma
+    : PerfConfigBaseCK<PerformanceConfigHipImplicitGemmGroupWrwWmma>
+{
+    int index;
+    int split_k;
+    std::string kernel_id;
+    std::vector<std::string> valid_kernels;
+    PerformanceConfigHipImplicitGemmGroupWrwWmma(int idx, std::string kernl_id)
+        : index(idx), kernel_id(kernl_id)
+    {
+    }
+    PerformanceConfigHipImplicitGemmGroupWrwWmma()
+        : PerformanceConfigHipImplicitGemmGroupWrwWmma(0, "")
+    {
+    }
+    PerformanceConfigHipImplicitGemmGroupWrwWmma(bool)
+        : PerformanceConfigHipImplicitGemmGroupWrwWmma(0, "")
+    {
+    }
+    MIOPEN_INTERNALS_EXPORT void HeuristicInit(const ExecutionContext&,
+                                               const miopen::conv::ProblemDescription&);
+    MIOPEN_INTERNALS_EXPORT bool SetNextValue(const miopen::conv::ProblemDescription&);
+    MIOPEN_INTERNALS_EXPORT bool IsValidValue() const;
+    bool IsValid(const ExecutionContext&, const miopen::conv::ProblemDescription& problem) const
+    {
+        return IsValid(problem);
+    }
+    MIOPEN_INTERNALS_EXPORT bool IsValid(const miopen::conv::ProblemDescription&) const;
+    MIOPEN_INTERNALS_EXPORT bool
+    operator==(const PerformanceConfigHipImplicitGemmGroupWrwWmma& other) const;
+    MIOPEN_INTERNALS_EXPORT bool
+    IsModelApplicable(const ExecutionContext& ctx,
+                      const miopen::conv::ProblemDescription& problem) const;
+
+private:
+#if MIOPEN_ENABLE_AI_KERNEL_TUNING
+    std::vector<int> heuristic_indexes;
+    std::unordered_map<int, std::vector<std::string>> heuristic_kernels;
+    template <typename DataType>
+    bool RunParameterPredictionModel(const ExecutionContext& ctx,
+                                     const miopen::conv::ProblemDescription& problem);
+    void InitHeuristicKernelIDs(const std::string& type);
+    bool ModelApplyToken(int idx,
+                         std::string value,
+                         const std::string& arch,
+                         const miopen::conv::ProblemDescription& problem);
+#endif
+    template <typename DataType>
+    void Init(const miopen::conv::ProblemDescription&);
+    template <typename DataType>
+    bool CheckIsSupportCKArgs(const miopen::conv::ProblemDescription&) const;
+};
+
+struct ConvHipImplicitGemmGroupWrwWmma final
+    : ConvTunableSolver<PerformanceConfigHipImplicitGemmGroupWrwWmma>
+{
+    const std::string& SolverDbId() const override
+    {
+        return GetSolverDbId<ConvHipImplicitGemmGroupWrwWmma>();
+    }
+
+    MIOPEN_INTERNALS_EXPORT PerformanceConfigHipImplicitGemmGroupWrwWmma
+    GetDefaultPerformanceConfig(const ExecutionContext&,
+                                const miopen::conv::ProblemDescription&) const override;
+    MIOPEN_INTERNALS_EXPORT bool
+    IsValidPerformanceConfig(const ExecutionContext&,
+                             const miopen::conv::ProblemDescription&,
+                             const PerformanceConfigHipImplicitGemmGroupWrwWmma&) const override;
+    MIOPEN_INTERNALS_EXPORT PerformanceConfigHipImplicitGemmGroupWrwWmma
+    Search(const ExecutionContext&,
+           const miopen::conv::ProblemDescription&,
+           const AnyInvokeParams& invoke_ctx) const override;
+    MIOPEN_INTERNALS_EXPORT bool
+    IsApplicable(const ExecutionContext&, const miopen::conv::ProblemDescription&) const override;
+    bool IsDynamic() const override { return true; }
+    MIOPEN_INTERNALS_EXPORT ConvSolution
+    GetSolution(const ExecutionContext&,
+                const miopen::conv::ProblemDescription&,
+                const PerformanceConfigHipImplicitGemmGroupWrwWmma&) const override;
+    /// \ref igemm_get_wti_magic_number
+    float GetWti(const ExecutionContext&, const miopen::conv::ProblemDescription&) const override
+    {
+        return 0.02f;
+    };
+
+    MIOPEN_INTERNALS_EXPORT size_t GetWorkspaceSize(
+        const ExecutionContext&, const miopen::conv::ProblemDescription&) const override;
+    bool MayNeedWorkspace() const override { return true; }
+
+private:
+    template <typename DataType>
+    bool CheckCKApplicability(const miopen::conv::ProblemDescription&) const;
+};
+
 } // namespace conv
 } // namespace solver
 } // namespace miopen

--- a/projects/miopen/src/include/miopen/conv/solvers.hpp
+++ b/projects/miopen/src/include/miopen/conv/solvers.hpp
@@ -4942,23 +4942,8 @@ struct PerformanceConfigHipImplicitGemmGroupWrwWmma
     MIOPEN_INTERNALS_EXPORT bool IsValid(const miopen::conv::ProblemDescription&) const;
     MIOPEN_INTERNALS_EXPORT bool
     operator==(const PerformanceConfigHipImplicitGemmGroupWrwWmma& other) const;
-    MIOPEN_INTERNALS_EXPORT bool
-    IsModelApplicable(const ExecutionContext& ctx,
-                      const miopen::conv::ProblemDescription& problem) const;
 
 private:
-#if MIOPEN_ENABLE_AI_KERNEL_TUNING
-    std::vector<int> heuristic_indexes;
-    std::unordered_map<int, std::vector<std::string>> heuristic_kernels;
-    template <typename DataType>
-    bool RunParameterPredictionModel(const ExecutionContext& ctx,
-                                     const miopen::conv::ProblemDescription& problem);
-    void InitHeuristicKernelIDs(const std::string& type);
-    bool ModelApplyToken(int idx,
-                         std::string value,
-                         const std::string& arch,
-                         const miopen::conv::ProblemDescription& problem);
-#endif
     template <typename DataType>
     void Init(const miopen::conv::ProblemDescription&);
     template <typename DataType>

--- a/projects/miopen/src/include/miopen/solver/ck_utility_common.hpp
+++ b/projects/miopen/src/include/miopen/solver/ck_utility_common.hpp
@@ -52,7 +52,7 @@ static inline bool is_ck_whitelist(const Handle& handle)
 
 static inline bool is_wmma_capable(const std::string& device_name)
 {
-    return StartsWith(device_name, "gfx110") || StartsWith(device_name, "gfx120");
+    return StartsWith(device_name, "gfx11") || StartsWith(device_name, "gfx12");
 }
 
 static inline bool is_wmma_capable(const Handle& handle)

--- a/projects/miopen/src/include/miopen/solver/ck_utility_common.hpp
+++ b/projects/miopen/src/include/miopen/solver/ck_utility_common.hpp
@@ -50,6 +50,16 @@ static inline bool is_ck_whitelist(const Handle& handle)
     return is_ck_whitelist(handle.GetDeviceName());
 }
 
+static inline bool is_wmma_capable(const std::string& device_name)
+{
+    return StartsWith(device_name, "gfx110") || StartsWith(device_name, "gfx120");
+}
+
+static inline bool is_wmma_capable(const Handle& handle)
+{
+    return is_wmma_capable(handle.GetDeviceName());
+}
+
 } // namespace ck_utility
 } // namespace solver
 } // namespace miopen

--- a/projects/miopen/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/projects/miopen/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -1462,6 +1462,63 @@ MakeSolutionGroupConvImplicitGemmXdlops(const miopen::conv::ProblemDescription& 
 #endif
 }
 
+template <typename InvokerFactoryMakerNCHW, typename InvokerFactoryMakerNHWC>
+ConvSolution
+MakeSolutionGroupConvImplicitGemmWmma(const miopen::conv::ProblemDescription& problem,
+                                      InvokerFactoryMakerNCHW&& invoker_factory_maker_ncdhw,
+                                      InvokerFactoryMakerNHWC&& invoker_factory_maker_ndhwc)
+{
+
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    if(problem.IsLayoutDefault())
+    {
+        switch(problem.GetInDataType())
+        {
+        case miopenHalf: return invoker_factory_maker_ncdhw(ck::half_t{});
+        case miopenFloat: return invoker_factory_maker_ncdhw(float{});
+        case miopenBFloat16: return invoker_factory_maker_ncdhw(ck::bhalf_t{});
+        case miopenInt8:
+        case miopenInt64:
+        case miopenInt32:
+        case miopenDouble:
+        case miopenFloat8_fnuz:
+        case miopenBFloat8_fnuz:
+        default:
+            MIOPEN_THROW(miopenStatusInternalError,
+                         "GroupConvolutionImplicitGemmWmma operation not implemented for this "
+                         "data type");
+        }
+    }
+    else if(problem.IsLayoutNHWC())
+    {
+        switch(problem.GetInDataType())
+        {
+        case miopenHalf: return invoker_factory_maker_ndhwc(ck::half_t{});
+        case miopenFloat: return invoker_factory_maker_ndhwc(float{});
+        case miopenBFloat16: return invoker_factory_maker_ndhwc(ck::bhalf_t{});
+        case miopenInt8:
+        case miopenInt64:
+        case miopenInt32:
+        case miopenDouble:
+        case miopenFloat8_fnuz:
+        case miopenBFloat8_fnuz:
+        default:
+            MIOPEN_THROW(miopenStatusInternalError,
+                         "GroupConvolutionImplicitGemmWmma operation not implemented for this "
+                         "data type");
+        }
+    }
+    else
+    {
+        MIOPEN_THROW(
+            miopenStatusInternalError,
+            "GroupConvolutionImplicitGemmWmma operation not implemented for this data type");
+    }
+#else
+    return {};
+#endif
+}
+
 /// \todo This check is probably no longer needed, as it was likely related to static_ck or
 /// legacy_ck, and was copy-pasted into solvers that use the modern CK.
 static inline bool IsIndexRangeLargeEnough(const miopen::conv::ProblemDescription& problem)

--- a/projects/miopen/src/mlo_dir_conv.cpp
+++ b/projects/miopen/src/mlo_dir_conv.cpp
@@ -158,6 +158,7 @@ static auto GetImplicitGemmWrWSolvers()
         miopen::solver::conv::ConvHipImplicitGemmGroupWrwXdlops,
         miopen::solver::conv::ConvHipImplicitGemm3DGroupWrwXdlops,
         miopen::solver::conv::ConvHipImplicitGemmGroupWrwWmma,
+        miopen::solver::conv::ConvHipImplicitGemm3DGroupWrwWmma,
 #endif // MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
         miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC>{};
 }

--- a/projects/miopen/src/mlo_dir_conv.cpp
+++ b/projects/miopen/src/mlo_dir_conv.cpp
@@ -157,6 +157,7 @@ static auto GetImplicitGemmWrWSolvers()
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
         miopen::solver::conv::ConvHipImplicitGemmGroupWrwXdlops,
         miopen::solver::conv::ConvHipImplicitGemm3DGroupWrwXdlops,
+        miopen::solver::conv::ConvHipImplicitGemmGroupWrwWmma,
 #endif // MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
         miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC>{};
 }

--- a/projects/miopen/src/solver.cpp
+++ b/projects/miopen/src/solver.cpp
@@ -728,6 +728,10 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
     Register(registry, ++id, Primitive::Normalization, layernorm::LayernormBackward().SolverDbId());
     RegisterWithSolver(
         registry, ++id, conv::ConvHipImplicitGemmGroupWrwWmma{}, miopenConvolutionAlgoImplicitGEMM);
+    RegisterWithSolver(registry,
+                       ++id,
+                       conv::ConvHipImplicitGemm3DGroupWrwWmma{},
+                       miopenConvolutionAlgoImplicitGEMM);
     // IMPORTANT: New solvers should be added to the end of the function, and don't leave a white
     // space between this comment and the newly registered solver(s)!
 }

--- a/projects/miopen/src/solver.cpp
+++ b/projects/miopen/src/solver.cpp
@@ -726,6 +726,8 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
              miopenConvolutionAlgoImplicitGEMM);
 
     Register(registry, ++id, Primitive::Normalization, layernorm::LayernormBackward().SolverDbId());
+    RegisterWithSolver(
+        registry, ++id, conv::ConvHipImplicitGemmGroupWrwWmma{}, miopenConvolutionAlgoImplicitGEMM);
     // IMPORTANT: New solvers should be added to the end of the function, and don't leave a white
     // space between this comment and the newly registered solver(s)!
 }

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_wmma.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_wmma.cpp
@@ -251,11 +251,6 @@ struct CKArgs
     bool IsSupportedBy(const ConvPtr& conv_ptr) const
     {
         auto arg_ptr = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, 1);
-
-        // // Creat dummy workspace to pass the ck IsSupportedArgument check.
-        // int dummy_var = 1;
-        // conv_ptr->SetWorkSpacePointer(arg_ptr.get(), &dummy_var);
-
         return conv_ptr->IsSupportedArgument(arg_ptr.get());
     }
 

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_wmma.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_wmma.cpp
@@ -251,6 +251,11 @@ struct CKArgs
     bool IsSupportedBy(const ConvPtr& conv_ptr) const
     {
         auto arg_ptr = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, 1);
+        // Creat dummy workspace to pass the ck IsSupportedArgument check.
+
+        int dummy_var = 1;
+        conv_ptr->SetWorkSpacePointer(arg_ptr.get(), &dummy_var);
+
         return conv_ptr->IsSupportedArgument(arg_ptr.get());
     }
 

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_wmma.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_wmma.cpp
@@ -359,10 +359,6 @@ bool ConvHipImplicitGemm3DGroupWrwWmma::CheckCKApplicability(
 void PerformanceConfigHipImplicitGemm3DGroupWrwWmma::HeuristicInit(
     [[maybe_unused]] const ProblemDescription& problem)
 {
-    index     = 0;
-    split_k   = 1;
-    kernel_id = "";
-
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     switch(problem.GetInDataType())
     {

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_wmma.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_wmma.cpp
@@ -1,0 +1,588 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <vector>
+#include <cstdint>
+
+#include <miopen/conv/solvers.hpp>
+#include <miopen/env.hpp>
+#include <miopen/generic_search.hpp>
+#include <miopen/conv/wrw_invoke_params.hpp>
+#include <miopen/solver/problem_description_interpreter.hpp>
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+#include <miopen/solver/ck_utility_common.hpp>
+#endif
+#include <miopen/solver/implicitgemm_ck_util.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_WRW_WMMA)
+
+namespace miopen {
+namespace solver {
+namespace conv {
+
+using ProblemDescription = miopen::conv::ProblemDescription;
+
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+
+namespace {
+
+template <typename DataType>
+struct CKArgs
+{
+    CKArgs(const ProblemDescription& problem)
+    {
+        G               = ProblemInterpreter::GetGroupCountG(problem);
+        N               = ProblemInterpreter::GetBatchN(problem);
+        K1              = ProblemInterpreter::GetOutputChannelK(problem);
+        C1              = ProblemInterpreter::GetInputChannelC(problem);
+        C               = C1 / G; // Number of input Channel per group
+        K               = K1 / G; // Number of output Channel per group
+        Hi              = ProblemInterpreter::GetInputHeightHi(problem);
+        Wi              = ProblemInterpreter::GetInputWidthWi(problem);
+        Di              = ProblemInterpreter::GetInputDepthDi(problem);
+        Ho              = ProblemInterpreter::GetOutputHeightHo(problem);
+        Wo              = ProblemInterpreter::GetOutputWidthWo(problem);
+        Do              = ProblemInterpreter::GetOutputDepthDo(problem);
+        Y               = ProblemInterpreter::GetFilterHeightY(problem);
+        X               = ProblemInterpreter::GetFilterWidthX(problem);
+        Z               = ProblemInterpreter::GetFilterDepthZ(problem);
+        data_type       = ProblemInterpreter::GetOutputDataType(problem);
+        alpha_beta_case = ProblemInterpreter::GetAlphaBetaCase(problem);
+
+        in_lengths  = {G, N, C, Di, Hi, Wi};
+        out_lengths = {G, N, K, Do, Ho, Wo};
+        wei_lengths = {G, K, C, Z, Y, X};
+
+        // CK strides are in GNCDHW order
+        if(problem.IsLayoutNHWC())
+        {
+            // first entry reserved for G's stride
+            auto copy_strides = [](const auto& src, auto& dst) {
+                assert(dst.size() == (src.size() + 1));
+                std::copy(src.begin(), src.end(), dst.begin() + 1);
+            };
+            copy_strides(problem.GetIn().GetStrides(), in_strides);
+            copy_strides(problem.GetOut().GetStrides(), out_strides);
+            copy_strides(problem.GetWeights().GetStrides(), wei_strides);
+
+            // On a backward pass, problem.GetIn() means y(or out),
+            // and problem.GetOut means x(or in)
+            /// \todo remove this when we stop swapping in and out tensors/descriptors
+            std::swap(in_strides, out_strides);
+
+            // Now compute G's stride
+            in_strides[0]  = C;
+            out_strides[0] = K;
+            wei_strides[0] = K * wei_strides[1];
+        }
+        else
+        {
+            assert(problem.IsLayoutDefault()); // already checked in IsApplicable
+            // for default layout, we produce packed strides for NHWC layout
+            // because we transpose to NHWC layout before calling CK kernel
+            in_strides  = {C, Di * Hi * Wi * G * C, 1, Hi * Wi * G * C, Wi * G * C, G * C};
+            out_strides = {K, Do * Ho * Wo * G * K, 1, Ho * Wo * G * K, Wo * G * K, G * K};
+            wei_strides = {K * Z * Y * X * C, Z * Y * X * C, 1, Y * X * C, X * C, C};
+        }
+
+        filter_strides   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
+                          ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                          ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+        filter_dilations = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
+                            ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
+                            ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+        lPadding         = {ProblemInterpreter::GetInputLeftPadD(problem),
+                    ProblemInterpreter::GetInputLeftPadH(problem),
+                    ProblemInterpreter::GetInputLeftPadW(problem)};
+        rPadding         = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
+                    ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+    }
+    CKArgs(const CKArgs&) = default;
+    CKArgs(CKArgs&&)      = default;
+    CKArgs& operator=(const CKArgs&) = default;
+
+    template <typename ConvPtr>
+    auto MakeArgPtr(const ConvPtr& conv_ptr,
+                    ConstData_t x,
+                    Data_t dw,
+                    ConstData_t dy,
+                    float alpha,
+                    float beta,
+                    int split_k) const
+    {
+        using DeviceP = std::remove_pointer_t<decltype(conv_ptr.get())>;
+        if constexpr(std::is_same_v<DeviceP, DeviceOpGBwdWeightBilinear<DataType>>)
+        {
+            return MakeBilinearArgPtr(conv_ptr, x, dw, dy, alpha, beta, split_k);
+        }
+        else if constexpr(std::is_same_v<DeviceP, DeviceOpGBwdWeightScale<DataType>>)
+        {
+            (void)beta;
+            return MakeScaleArgPtr(conv_ptr, x, dw, dy, alpha, split_k);
+        }
+        else
+        {
+            (void)alpha;
+            (void)beta;
+            static_assert(std::is_same_v<DeviceP, DeviceOpGBwdWeightDefault<DataType>>,
+                          "Default should be wrw pass through");
+            return MakeDefaultArgPtr(conv_ptr, x, dw, dy, split_k);
+        }
+    }
+    template <typename ConvPtr>
+    auto MakeBilinearArgPtr(const ConvPtr& conv_ptr,
+                            ConstData_t x,
+                            Data_t dw,
+                            ConstData_t dy,
+                            float alpha,
+                            float beta,
+                            int split_k) const
+    {
+        return conv_ptr->MakeArgumentPointer(x,
+                                             dw,
+                                             dy,
+                                             {dw},
+                                             in_lengths,
+                                             in_strides,
+                                             wei_lengths,
+                                             wei_strides,
+                                             out_lengths,
+                                             out_strides,
+                                             {wei_lengths},
+                                             {wei_strides},
+                                             filter_strides,
+                                             filter_dilations,
+                                             lPadding,
+                                             rPadding,
+                                             PassThrough{},
+                                             Bilinear{alpha, beta},
+                                             PassThrough{},
+                                             split_k);
+    }
+
+    template <typename ConvPtr>
+    auto MakeScaleArgPtr(const ConvPtr& conv_ptr,
+                         ConstData_t x,
+                         Data_t dw,
+                         ConstData_t dy,
+                         float alpha,
+                         int split_k) const
+    {
+        return conv_ptr->MakeArgumentPointer(x,
+                                             dw,
+                                             dy,
+                                             {},
+                                             in_lengths,
+                                             in_strides,
+                                             wei_lengths,
+                                             wei_strides,
+                                             out_lengths,
+                                             out_strides,
+                                             {},
+                                             {},
+                                             filter_strides,
+                                             filter_dilations,
+                                             lPadding,
+                                             rPadding,
+                                             PassThrough{},
+                                             Scale{alpha},
+                                             PassThrough{},
+                                             split_k);
+    }
+
+    template <typename ConvPtr>
+    auto MakeDefaultArgPtr(
+        const ConvPtr& conv_ptr, ConstData_t x, Data_t dw, ConstData_t dy, int split_k) const
+    {
+        return conv_ptr->MakeArgumentPointer(x,
+                                             dw,
+                                             dy,
+                                             in_lengths,
+                                             in_strides,
+                                             wei_lengths,
+                                             wei_strides,
+                                             out_lengths,
+                                             out_strides,
+                                             filter_strides,
+                                             filter_dilations,
+                                             lPadding,
+                                             rPadding,
+                                             PassThrough{},
+                                             PassThrough{},
+                                             PassThrough{},
+                                             split_k);
+    }
+
+    template <typename ConvPtr>
+    auto MakeArgPtr(const ConvPtr& conv_ptr,
+                    const ConvWrwTensors& tensors,
+                    float alpha,
+                    float beta,
+                    int split_k) const
+    {
+        return MakeArgPtr(conv_ptr, tensors.x, tensors.dw, tensors.dy, alpha, beta, split_k);
+    }
+
+    template <typename ConvPtr>
+    bool IsSupportedBy(const ConvPtr& conv_ptr) const
+    {
+        auto arg_ptr = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, 1);
+
+        // // Creat dummy workspace to pass the ck IsSupportedArgument check.
+        // int dummy_var = 1;
+        // conv_ptr->SetWorkSpacePointer(arg_ptr.get(), &dummy_var);
+
+        return conv_ptr->IsSupportedArgument(arg_ptr.get());
+    }
+
+    template <typename ConvPtr>
+    bool IsSupportedBySplitK(const ConvPtr& conv_ptr, int split_k) const
+    {
+        auto arg_ptr = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, split_k);
+
+        if(CKWrwRequireWorkspace(G, C1, K1, data_type, alpha_beta_case))
+        {
+            // Creat dummy workspace to pass the ck IsSupportedArgument check.
+            int dummy_var = 1;
+            conv_ptr->SetWorkSpacePointer(arg_ptr.get(), &dummy_var);
+        }
+        return conv_ptr->IsSupportedArgument(arg_ptr.get());
+    }
+
+    int G;
+    int N;
+    int K;
+    int C;
+    int C1;
+    int K1;
+    int Hi;
+    int Wi;
+    int Di;
+    int Ho;
+    int Wo;
+    int Do;
+    int Y;
+    int X;
+    int Z;
+    miopenAlphaBetaCase_t alpha_beta_case;
+    miopenDataType_t data_type;
+    std::array<ck::index_t, 6> in_lengths;
+    std::array<ck::index_t, 6> in_strides;
+    std::array<ck::index_t, 6> out_lengths;
+    std::array<ck::index_t, 6> out_strides;
+    std::array<ck::index_t, 6> wei_lengths;
+    std::array<ck::index_t, 6> wei_strides;
+    std::array<ck::index_t, 3> filter_strides;
+    std::array<ck::index_t, 3> filter_dilations;
+    std::array<ck::index_t, 3> lPadding;
+    std::array<ck::index_t, 3> rPadding;
+};
+} // namespace
+
+template <typename DataType>
+void PerformanceConfigHipImplicitGemm3DGroupWrwWmma::Init(const ProblemDescription& problem)
+{
+    switch(problem.GetAlphaBetaCase())
+    {
+    case BILINEAR:
+        valid_kernels =
+            FillValidKernelsIDs<DeviceOpGBwdWeightBilinearPtrs<DataType>, CKArgs<DataType>>(
+                problem);
+        break;
+    case SCALE:
+        valid_kernels =
+            FillValidKernelsIDs<DeviceOpGBwdWeightScalePtrs<DataType>, CKArgs<DataType>>(problem);
+        break;
+    default:
+        valid_kernels =
+            FillValidKernelsIDs<DeviceOpGBwdWeightDefaultPtrs<DataType>, CKArgs<DataType>>(problem);
+        break;
+    }
+    index     = 0;
+    split_k   = 1;
+    kernel_id = valid_kernels[index] + "+" + std::to_string(split_k);
+}
+
+template <typename DataType>
+bool PerformanceConfigHipImplicitGemm3DGroupWrwWmma::CheckIsSupportCKArgs(
+    const ProblemDescription& problem) const
+{
+    switch(problem.GetAlphaBetaCase())
+    {
+    case BILINEAR:
+        return IsCKArgsSupported<DeviceOpGBwdWeightBilinearPtrs<DataType>, CKArgs<DataType>>(
+            problem, kernel_id);
+    case SCALE:
+        return IsCKArgsSupported<DeviceOpGBwdWeightScalePtrs<DataType>, CKArgs<DataType>>(
+            problem, kernel_id);
+    default:
+        return IsCKArgsSupported<DeviceOpGBwdWeightDefaultPtrs<DataType>, CKArgs<DataType>>(
+            problem, kernel_id);
+    }
+}
+
+template <typename DataType>
+bool ConvHipImplicitGemm3DGroupWrwWmma::CheckCKApplicability(
+    const ProblemDescription& problem) const
+{
+    switch(problem.GetAlphaBetaCase())
+    {
+    case BILINEAR:
+        return IsCKApplicable<DeviceOpGBwdWeightBilinearPtrs<DataType>, CKArgs<DataType>>(problem);
+    case SCALE:
+        return IsCKApplicable<DeviceOpGBwdWeightScalePtrs<DataType>, CKArgs<DataType>>(problem);
+    default:
+        return IsCKApplicable<DeviceOpGBwdWeightDefaultPtrs<DataType>, CKArgs<DataType>>(problem);
+    }
+}
+#endif
+
+void PerformanceConfigHipImplicitGemm3DGroupWrwWmma::HeuristicInit(
+    [[maybe_unused]] const ProblemDescription& problem)
+{
+    index     = 0;
+    split_k   = 1;
+    kernel_id = "";
+
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    switch(problem.GetInDataType())
+    {
+    case miopenHalf: Init<ck::half_t>(problem); break;
+    case miopenFloat: Init<float>(problem); break;
+    case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+    case miopenInt8:
+    case miopenInt64:
+    case miopenInt32:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenDouble: break;
+    }
+#endif
+}
+
+bool PerformanceConfigHipImplicitGemm3DGroupWrwWmma::SetNextValue(const ProblemDescription& problem)
+{
+#if MIOPEN_USE_COMPOSABLEKERNEL
+    if(valid_kernels.empty())
+    {
+        HeuristicInit(problem);
+        if(valid_kernels.empty())
+        {
+            return false;
+        }
+    }
+    do
+    {
+        bool flag = NextTwoPower<1, 128>(split_k);
+        if(!flag)
+        {
+            kernel_id = valid_kernels[index] + "+" + std::to_string(split_k);
+            break;
+        }
+
+        if(!NextLinear(0, valid_kernels.size() - 1, index))
+        {
+            kernel_id = valid_kernels[index] + "+" + std::to_string(split_k);
+            break;
+        }
+        // All split_k and index values were iterated
+        return false;
+    } while(false);
+#endif
+    return true;
+}
+
+bool PerformanceConfigHipImplicitGemm3DGroupWrwWmma::IsValidValue() const
+{
+    return index < valid_kernels.size();
+}
+
+bool PerformanceConfigHipImplicitGemm3DGroupWrwWmma::IsValid(
+    [[maybe_unused]] const ProblemDescription& problem) const
+{
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    switch(problem.GetInDataType())
+    {
+    case miopenHalf: return CheckIsSupportCKArgs<ck::half_t>(problem);
+    case miopenFloat: return CheckIsSupportCKArgs<float>(problem);
+    case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(problem);
+    case miopenInt8:
+    case miopenInt64:
+    case miopenInt32:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenDouble: break;
+    }
+#endif
+    return false;
+}
+
+bool PerformanceConfigHipImplicitGemm3DGroupWrwWmma::operator==(
+    const PerformanceConfigHipImplicitGemm3DGroupWrwWmma& other) const
+{
+    return kernel_id == other.kernel_id;
+}
+
+PerformanceConfigHipImplicitGemm3DGroupWrwWmma
+ConvHipImplicitGemm3DGroupWrwWmma::GetDefaultPerformanceConfig(
+    const ExecutionContext&, const ProblemDescription& problem) const
+{
+    PerformanceConfigHipImplicitGemm3DGroupWrwWmma pp;
+    pp.HeuristicInit(problem);
+    return pp;
+}
+
+bool ConvHipImplicitGemm3DGroupWrwWmma::IsValidPerformanceConfig(
+    const ExecutionContext&,
+    const ProblemDescription& problem,
+    const PerformanceConfigHipImplicitGemm3DGroupWrwWmma& config) const
+{
+    return config.IsValid(problem);
+}
+
+size_t ConvHipImplicitGemm3DGroupWrwWmma::GetWorkspaceSize(const ExecutionContext&,
+                                                           const ProblemDescription& problem) const
+{
+    return GetWorkspaceSizeLayoutTransformConv(problem);
+}
+
+PerformanceConfigHipImplicitGemm3DGroupWrwWmma
+ConvHipImplicitGemm3DGroupWrwWmma::Search(const ExecutionContext& ctx,
+                                          const ProblemDescription& problem,
+                                          const AnyInvokeParams& invoke_ctx) const
+{
+    return GenericSearch(*this, ctx, problem, invoke_ctx);
+}
+
+bool ConvHipImplicitGemm3DGroupWrwWmma::IsApplicable(
+    [[maybe_unused]] const ExecutionContext& ctx,
+    [[maybe_unused]] const ProblemDescription& problem) const
+{
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    if(env::disabled(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_WRW_WMMA))
+        return false;
+    if(problem.GetConv().attribute.deterministic)
+        return false;
+    if(!problem.AllTensorsDimsFitIntoInt())
+        return false;
+    if(problem.HasMixedDataTypes())
+        return false;
+    if(!problem.IsDirectionBackwardWrW())
+        return false;
+    if(!problem.Is3d())
+        return false;
+    if(!(problem.IsLayoutNHWC() || problem.IsLayoutDefault()))
+        return false;
+    // needed because layout transpose kernel does not support non-packed tensors
+    if(problem.IsLayoutDefault() && problem.HasNonPackedTensors())
+        return false;
+    if(!ck_utility::is_wmma_capable(ctx.GetStream().GetDeviceName()))
+        return false;
+    switch(problem.GetInDataType())
+    {
+    case miopenHalf: return CheckCKApplicability<ck::half_t>(problem);
+    case miopenFloat: return CheckCKApplicability<float>(problem);
+    case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenInt8:
+    case miopenInt64:
+    case miopenInt32:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenDouble: break;
+    }
+#endif
+    return false;
+}
+
+ConvSolution ConvHipImplicitGemm3DGroupWrwWmma::GetSolution(
+    [[maybe_unused]] const ExecutionContext& ctx,
+    [[maybe_unused]] const ProblemDescription& problem,
+    [[maybe_unused]] const PerformanceConfigHipImplicitGemm3DGroupWrwWmma& config) const
+{
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    return MakeSolutionGroupConvImplicitGemmWmma(
+        problem,
+        [&](auto data_type_val) {
+            using T = decltype(data_type_val);
+            switch(problem.GetAlphaBetaCase())
+            {
+            case BILINEAR:
+                return InitInvokerFactoryWrwNCHW<3,
+                                                 false,
+                                                 DeviceOpGBwdWeightBilinearPtrs<T>,
+                                                 CKArgs<T>,
+                                                 miopen::conv::WrWInvokeParams>(
+                    ctx, problem, config.kernel_id);
+            case SCALE:
+                return InitInvokerFactoryWrwNCHW<3,
+                                                 false,
+                                                 DeviceOpGBwdWeightScalePtrs<T>,
+                                                 CKArgs<T>,
+                                                 miopen::conv::WrWInvokeParams>(
+                    ctx, problem, config.kernel_id);
+            default:
+                return InitInvokerFactoryWrwNCHW<3,
+                                                 false,
+                                                 DeviceOpGBwdWeightDefaultPtrs<T>,
+                                                 CKArgs<T>,
+                                                 miopen::conv::WrWInvokeParams>(
+                    ctx, problem, config.kernel_id);
+            }
+        },
+        [&](auto data_type_val) {
+            using T = decltype(data_type_val);
+            switch(problem.GetAlphaBetaCase())
+            {
+            case BILINEAR:
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGBwdWeightBilinearPtrs<T>,
+                                              CKArgs<T>,
+                                              miopen::conv::WrWInvokeParams>(
+                    ctx, problem, config.kernel_id);
+            case SCALE:
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGBwdWeightScalePtrs<T>,
+                                              CKArgs<T>,
+                                              miopen::conv::WrWInvokeParams>(
+                    ctx, problem, config.kernel_id);
+            default:
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGBwdWeightDefaultPtrs<T>,
+                                              CKArgs<T>,
+                                              miopen::conv::WrWInvokeParams>(
+                    ctx, problem, config.kernel_id);
+            }
+        });
+
+#else
+    return {};
+#endif
+}
+
+} // namespace conv
+} // namespace solver
+} // namespace miopen

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
@@ -254,8 +254,6 @@ static std::vector<std::string> GetKernelAsTokens(const std::string& kernel)
  */
 void PerformanceConfigHipImplicitGemmGroupWrwWmma::InitHeuristicKernelIDs(const std::string& type)
 {
-    // TODO check if specific arch has different tokens
-
     for(int i = 0; i < valid_kernels.size(); i++)
     {
         if(valid_kernels[i].find(type) != std::string::npos)
@@ -266,12 +264,17 @@ void PerformanceConfigHipImplicitGemmGroupWrwWmma::InitHeuristicKernelIDs(const 
     }
 }
 
+bool PerformanceConfigHipImplicitGemmGroupWrwWmma::ModelApplyToken(
+    int idx, std::string value, const std::string& arch, const ProblemDescription& problem)
+{
+    // TODO once the AI model is trained/available
+    return false;
+}
+
 static std::vector<float> GetFeatures(const ProblemDescription& problem, const std::string& arch)
 {
     // TODO - Extract convolution problem characteristics and format them as numerical features for
     // the AI model
-    (void)problem;
-    (void)arch;
     std::size_t n = 0;
     std::vector<float> features(n * n, 0.0f);
     return features;
@@ -281,9 +284,7 @@ template <typename DataType>
 bool PerformanceConfigHipImplicitGemmGroupWrwWmma::RunParameterPredictionModel(
     const ExecutionContext& ctx, const ProblemDescription& problem)
 {
-    // TODO - Execute the complete AI pipeline to predict the best kernel for this problem
-    (void)ctx;
-    (void)problem;
+    // TODO once the AI model is trained/available
     return false;
 }
 #endif // MIOPEN_ENABLE_AI_KERNEL_TUNING
@@ -292,10 +293,7 @@ bool PerformanceConfigHipImplicitGemmGroupWrwWmma::RunParameterPredictionModel(
 bool PerformanceConfigHipImplicitGemmGroupWrwWmma::IsModelApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
-    // TODO - Decide if the AI model is trained/available for this specific combination of
-    // architecture, data types, and problem constraints
-    (void)ctx;
-    (void)problem;
+    // TODO once the AI model is trained/available
     return false;
 }
 
@@ -307,7 +305,7 @@ void PerformanceConfigHipImplicitGemmGroupWrwWmma::HeuristicInit(
 #if MIOPEN_ENABLE_AI_KERNEL_TUNING
     if(IsModelApplicable(ctx, problem))
     {
-        // TODO - when models are defined and trained
+        // TODO once the AI model is trained/available
     }
 #endif
     switch(problem.GetInDataType())

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
@@ -162,6 +162,11 @@ struct CKArgs
     bool IsSupportedBy(const ConvPtr& conv_ptr) const
     {
         auto arg_ptr = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, 1);
+        // Creat dummy workspace to pass the ck IsSupportedArgument check.
+
+        int dummy_var = 1;
+        conv_ptr->SetWorkSpacePointer(arg_ptr.get(), &dummy_var);
+
         return conv_ptr->IsSupportedArgument(arg_ptr.get());
     }
 

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
@@ -162,11 +162,6 @@ struct CKArgs
     bool IsSupportedBy(const ConvPtr& conv_ptr) const
     {
         auto arg_ptr = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, 1);
-
-        // // Creat dummy workspace to pass the ck IsSupportedArgument check.
-        // int dummy_var = 1;
-        // conv_ptr->SetWorkSpacePointer(arg_ptr.get(), &dummy_var);
-
         return conv_ptr->IsSupportedArgument(arg_ptr.get());
     }
 
@@ -378,7 +373,6 @@ bool ConvHipImplicitGemmGroupWrwWmma::IsApplicable(
     if(!(problem.IsLayoutNHWC() || problem.IsLayoutDefault()))
         return false;
     // needed because layout transpose kernel does not support non-packed tensors
-    // TODO - check if this is also the case for WMMA impl (this was copied from xdl solver)
     if(problem.IsLayoutDefault() && problem.HasNonPackedTensors())
         return false;
     if(!ck_utility::is_wmma_capable(ctx.GetStream().GetDeviceName()))

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
@@ -232,82 +232,13 @@ bool ConvHipImplicitGemmGroupWrwWmma::CheckCKApplicability(const ProblemDescript
 {
     return IsCKApplicable<DeviceOpGWrwPtrs<DataType>, CKArgs>(problem);
 }
-
-#if MIOPEN_ENABLE_AI_KERNEL_TUNING
-static std::vector<std::string> GetKernelAsTokens(const std::string& kernel)
-{
-    std::vector<std::string> tokens;
-    std::string token;
-    std::istringstream tokenStream(
-        kernel.substr(kernel.find('<') + 1, kernel.find('>') - kernel.find('<') - 1));
-    while(std::getline(tokenStream, token, ','))
-    {
-        token.erase(remove_if(token.begin(), token.end(), isspace),
-                    token.end()); // strip whitespace
-        tokens.push_back(token);
-    }
-    return tokens;
-}
-
-/**
- * @param type is the kernel type predicted by the parameter prediction model
- */
-void PerformanceConfigHipImplicitGemmGroupWrwWmma::InitHeuristicKernelIDs(const std::string& type)
-{
-    for(int i = 0; i < valid_kernels.size(); i++)
-    {
-        if(valid_kernels[i].find(type) != std::string::npos)
-        {
-            heuristic_indexes.push_back(i);
-            heuristic_kernels[i] = GetKernelAsTokens(valid_kernels[i]);
-        }
-    }
-}
-
-bool PerformanceConfigHipImplicitGemmGroupWrwWmma::ModelApplyToken(
-    int idx, std::string value, const std::string& arch, const ProblemDescription& problem)
-{
-    // TODO once the AI model is trained/available
-    return false;
-}
-
-static std::vector<float> GetFeatures(const ProblemDescription& problem, const std::string& arch)
-{
-    // TODO - Extract convolution problem characteristics and format them as numerical features for
-    // the AI model
-    std::size_t n = 0;
-    std::vector<float> features(n * n, 0.0f);
-    return features;
-}
-
-template <typename DataType>
-bool PerformanceConfigHipImplicitGemmGroupWrwWmma::RunParameterPredictionModel(
-    const ExecutionContext& ctx, const ProblemDescription& problem)
-{
-    // TODO once the AI model is trained/available
-    return false;
-}
-#endif // MIOPEN_ENABLE_AI_KERNEL_TUNING
-#endif // MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-
-bool PerformanceConfigHipImplicitGemmGroupWrwWmma::IsModelApplicable(
-    const ExecutionContext& ctx, const ProblemDescription& problem) const
-{
-    // TODO once the AI model is trained/available
-    return false;
-}
+#endif
 
 void PerformanceConfigHipImplicitGemmGroupWrwWmma::HeuristicInit(
     [[maybe_unused]] const ExecutionContext& ctx,
     [[maybe_unused]] const ProblemDescription& problem)
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-#if MIOPEN_ENABLE_AI_KERNEL_TUNING
-    if(IsModelApplicable(ctx, problem))
-    {
-        // TODO once the AI model is trained/available
-    }
-#endif
     switch(problem.GetInDataType())
     {
     case miopenHalf: Init<ck::half_t>(problem); break;

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_wmma.cpp
@@ -1,0 +1,506 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <vector>
+#include <cstdint>
+
+#include <miopen/conv/solvers.hpp>
+#include <miopen/env.hpp>
+#include <miopen/generic_search.hpp>
+#include <miopen/conv/wrw_invoke_params.hpp>
+#include <miopen/solver/problem_description_interpreter.hpp>
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+#include <miopen/solver/ck_utility_common.hpp>
+#include <miopen/conv/heuristics/ai_heuristics.hpp>
+#endif
+#include <miopen/solver/implicitgemm_ck_util.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_WRW_WMMA)
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_WRW_WMMA_AI_HEUR)
+
+namespace miopen {
+namespace solver {
+namespace conv {
+
+using ProblemDescription = miopen::conv::ProblemDescription;
+
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+
+namespace {
+
+struct CKArgs
+{
+    CKArgs(const ProblemDescription& problem)
+    {
+        G               = ProblemInterpreter::GetGroupCountG(problem);
+        N               = ProblemInterpreter::GetBatchN(problem);
+        K1              = ProblemInterpreter::GetOutputChannelK(problem);
+        C1              = ProblemInterpreter::GetInputChannelC(problem);
+        C               = C1 / G; // Number of input Channel per group
+        K               = K1 / G; // Number of output Channel per group
+        Hi              = ProblemInterpreter::GetInputHeightHi(problem);
+        Wi              = ProblemInterpreter::GetInputWidthWi(problem);
+        Ho              = ProblemInterpreter::GetOutputHeightHo(problem);
+        Wo              = ProblemInterpreter::GetOutputWidthWo(problem);
+        Y               = ProblemInterpreter::GetFilterHeightY(problem);
+        X               = ProblemInterpreter::GetFilterWidthX(problem);
+        data_type       = ProblemInterpreter::GetOutputDataType(problem);
+        alpha_beta_case = ProblemInterpreter::GetAlphaBetaCase(problem);
+        input           = {G, N, C, Hi, Wi};
+        output          = {G, N, K, Ho, Wo};
+        weight          = {G, K, C, Y, X};
+
+        // CK strides are in GNCDHW order
+        if(problem.IsLayoutNHWC())
+        {
+            // first entry reserved for G's stride
+            auto copy_strides = [](const auto& src, auto& dst) {
+                assert(dst.size() == (src.size() + 1));
+                std::copy(src.begin(), src.end(), dst.begin() + 1);
+            };
+            copy_strides(problem.GetIn().GetStrides(), in_strides);
+            copy_strides(problem.GetOut().GetStrides(), out_strides);
+            copy_strides(problem.GetWeights().GetStrides(), wei_strides);
+
+            // On a backward pass, problem.GetIn() means y(or out),
+            // and problem.GetOut means x(or in)
+            /// \todo remove this when we stop swapping in and out tensors/descriptors
+            std::swap(in_strides, out_strides);
+
+            // Now compute G's stride
+            in_strides[0]  = C;
+            out_strides[0] = K;
+            wei_strides[0] = K * wei_strides[1];
+        }
+        else
+        {
+            assert(problem.IsLayoutDefault()); // already checked in IsApplicable
+            // for default layout, we produce packed strides for NHWC layout
+            // because we transpose to NHWC layout before calling CK kernel
+            in_strides  = {C, Hi * Wi * G * C, 1, Wi * G * C, G * C};
+            out_strides = {K, Ho * Wo * G * K, 1, Wo * G * K, G * K};
+            wei_strides = {K * Y * X * C, Y * X * C, 1, X * C, C};
+        }
+
+        strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+        dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
+                    ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+        lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
+                    ProblemInterpreter::GetInputLeftPadW(problem)};
+        rPadding = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+    }
+    CKArgs(const CKArgs&) = default;
+    CKArgs(CKArgs&&)      = default;
+    CKArgs& operator=(const CKArgs&) = default;
+
+    template <typename ConvPtr>
+    auto MakeArgPtr(const ConvPtr& conv_ptr,
+                    ConstData_t x,
+                    Data_t dw,
+                    ConstData_t dy,
+                    float alpha,
+                    float beta,
+                    int split_k) const
+    {
+        (void)alpha;
+        (void)beta;
+        return conv_ptr->MakeArgumentPointer(x,
+                                             dw,
+                                             dy,
+                                             input,
+                                             in_strides,
+                                             weight,
+                                             wei_strides,
+                                             output,
+                                             out_strides,
+                                             strides,
+                                             dilation,
+                                             lPadding,
+                                             rPadding,
+                                             {},
+                                             {},
+                                             {},
+                                             split_k);
+    }
+
+    template <typename ConvPtr>
+    auto MakeArgPtr(const ConvPtr& conv_ptr,
+                    const ConvWrwTensors& tensors,
+                    float alpha,
+                    float beta,
+                    int split_k) const
+    {
+        return MakeArgPtr(conv_ptr, tensors.x, tensors.dw, tensors.dy, alpha, beta, split_k);
+    }
+
+    template <typename ConvPtr>
+    bool IsSupportedBy(const ConvPtr& conv_ptr) const
+    {
+        auto arg_ptr = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, 1);
+
+        // // Creat dummy workspace to pass the ck IsSupportedArgument check.
+        // int dummy_var = 1;
+        // conv_ptr->SetWorkSpacePointer(arg_ptr.get(), &dummy_var);
+
+        return conv_ptr->IsSupportedArgument(arg_ptr.get());
+    }
+
+    template <typename ConvPtr>
+    bool IsSupportedBySplitK(const ConvPtr& conv_ptr, int split_k) const
+    {
+        auto arg_ptr = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, split_k);
+
+        if(CKWrwRequireWorkspace(G, C1, K1, data_type, alpha_beta_case))
+        {
+            // Creat dummy workspace to pass the ck IsSupportedArgument check.
+            int dummy_var = 1;
+            conv_ptr->SetWorkSpacePointer(arg_ptr.get(), &dummy_var);
+        }
+        return conv_ptr->IsSupportedArgument(arg_ptr.get());
+    }
+
+    int G;
+    int N;
+    int K;
+    int C;
+    int C1;
+    int K1;
+    int Hi;
+    int Wi;
+    int Ho;
+    int Wo;
+    int Y;
+    int X;
+    miopenDataType_t data_type;
+    miopenAlphaBetaCase_t alpha_beta_case;
+    std::array<ck::index_t, 5> input;
+    std::array<ck::index_t, 5> in_strides;
+    std::array<ck::index_t, 5> output;
+    std::array<ck::index_t, 5> out_strides;
+    std::array<ck::index_t, 5> weight;
+    std::array<ck::index_t, 5> wei_strides;
+    std::array<ck::index_t, 2> strides;
+    std::array<ck::index_t, 2> dilation;
+    std::array<ck::index_t, 2> lPadding;
+    std::array<ck::index_t, 2> rPadding;
+};
+} // namespace
+
+template <typename DataType>
+void PerformanceConfigHipImplicitGemmGroupWrwWmma::Init(const ProblemDescription& problem)
+{
+    valid_kernels = FillValidKernelsIDs<DeviceOpGWrwPtrs<DataType>, CKArgs>(problem);
+    index         = 0;
+    split_k       = 1;
+    kernel_id     = valid_kernels[index] + "+" + std::to_string(split_k);
+}
+
+template <typename DataType>
+bool PerformanceConfigHipImplicitGemmGroupWrwWmma::CheckIsSupportCKArgs(
+    const ProblemDescription& problem) const
+{
+    return IsCKArgsSupported<DeviceOpGWrwPtrs<DataType>, CKArgs>(problem, kernel_id);
+}
+
+template <typename DataType>
+bool ConvHipImplicitGemmGroupWrwWmma::CheckCKApplicability(const ProblemDescription& problem) const
+{
+    return IsCKApplicable<DeviceOpGWrwPtrs<DataType>, CKArgs>(problem);
+}
+
+#if MIOPEN_ENABLE_AI_KERNEL_TUNING
+static std::vector<std::string> GetKernelAsTokens(const std::string& kernel)
+{
+    std::vector<std::string> tokens;
+    std::string token;
+    std::istringstream tokenStream(
+        kernel.substr(kernel.find('<') + 1, kernel.find('>') - kernel.find('<') - 1));
+    while(std::getline(tokenStream, token, ','))
+    {
+        token.erase(remove_if(token.begin(), token.end(), isspace),
+                    token.end()); // strip whitespace
+        tokens.push_back(token);
+    }
+    return tokens;
+}
+
+/**
+ * @param type is the kernel type predicted by the parameter prediction model
+ */
+void PerformanceConfigHipImplicitGemmGroupWrwWmma::InitHeuristicKernelIDs(const std::string& type)
+{
+    // TODO check if specific arch has different tokens
+
+    for(int i = 0; i < valid_kernels.size(); i++)
+    {
+        if(valid_kernels[i].find(type) != std::string::npos)
+        {
+            heuristic_indexes.push_back(i);
+            heuristic_kernels[i] = GetKernelAsTokens(valid_kernels[i]);
+        }
+    }
+}
+
+static std::vector<float> GetFeatures(const ProblemDescription& problem, const std::string& arch)
+{
+    // TODO - Extract convolution problem characteristics and format them as numerical features for
+    // the AI model
+    (void)problem;
+    (void)arch;
+    std::size_t n = 0;
+    std::vector<float> features(n * n, 0.0f);
+    return features;
+}
+
+template <typename DataType>
+bool PerformanceConfigHipImplicitGemmGroupWrwWmma::RunParameterPredictionModel(
+    const ExecutionContext& ctx, const ProblemDescription& problem)
+{
+    // TODO - Execute the complete AI pipeline to predict the best kernel for this problem
+    (void)ctx;
+    (void)problem;
+    return false;
+}
+#endif // MIOPEN_ENABLE_AI_KERNEL_TUNING
+#endif // MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+
+bool PerformanceConfigHipImplicitGemmGroupWrwWmma::IsModelApplicable(
+    const ExecutionContext& ctx, const ProblemDescription& problem) const
+{
+    // TODO - Decide if the AI model is trained/available for this specific combination of
+    // architecture, data types, and problem constraints
+    (void)ctx;
+    (void)problem;
+    return false;
+}
+
+void PerformanceConfigHipImplicitGemmGroupWrwWmma::HeuristicInit(
+    [[maybe_unused]] const ExecutionContext& ctx,
+    [[maybe_unused]] const ProblemDescription& problem)
+{
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+#if MIOPEN_ENABLE_AI_KERNEL_TUNING
+    if(IsModelApplicable(ctx, problem))
+    {
+        // TODO - when models are defined and trained
+    }
+#endif
+    switch(problem.GetInDataType())
+    {
+    case miopenHalf: Init<ck::half_t>(problem); break;
+    case miopenFloat: Init<float>(problem); break;
+    case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+    case miopenInt8:
+    case miopenInt64:
+    case miopenInt32:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenDouble: break;
+    }
+#endif
+}
+
+bool PerformanceConfigHipImplicitGemmGroupWrwWmma::SetNextValue(const ProblemDescription& problem)
+{
+#if MIOPEN_USE_COMPOSABLEKERNEL
+    if(valid_kernels.empty())
+    {
+        switch(problem.GetInDataType())
+        {
+        case miopenHalf: Init<ck::half_t>(problem); break;
+        case miopenFloat: Init<float>(problem); break;
+        case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+        case miopenInt8:
+        case miopenInt64:
+        case miopenInt32:
+        case miopenFloat8_fnuz:
+        case miopenBFloat8_fnuz:
+        case miopenDouble: break;
+        }
+        assert(!valid_kernels.empty());
+        return true;
+    }
+    do
+    {
+        bool flag = NextTwoPower<1, 128>(split_k);
+        if(!flag)
+        {
+            kernel_id = valid_kernels[index] + "+" + std::to_string(split_k);
+            break;
+        }
+
+        if(!NextLinear(0, valid_kernels.size() - 1, index))
+        {
+            kernel_id = valid_kernels[index] + "+" + std::to_string(split_k);
+            break;
+        }
+        // All split_k and index values were iterated
+        return false;
+    } while(false);
+
+#endif
+    return true;
+}
+
+bool PerformanceConfigHipImplicitGemmGroupWrwWmma::IsValidValue() const
+{
+    return index < valid_kernels.size();
+}
+
+bool PerformanceConfigHipImplicitGemmGroupWrwWmma::IsValid(
+    [[maybe_unused]] const ProblemDescription& problem) const
+{
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    switch(problem.GetInDataType())
+    {
+    case miopenHalf: return CheckIsSupportCKArgs<ck::half_t>(problem);
+    case miopenFloat: return CheckIsSupportCKArgs<float>(problem);
+    case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(problem);
+    case miopenInt8:
+    case miopenInt64:
+    case miopenInt32:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenDouble: break;
+    }
+#endif
+    return false;
+}
+
+bool PerformanceConfigHipImplicitGemmGroupWrwWmma::operator==(
+    const PerformanceConfigHipImplicitGemmGroupWrwWmma& other) const
+{
+    return kernel_id == other.kernel_id;
+}
+
+PerformanceConfigHipImplicitGemmGroupWrwWmma
+ConvHipImplicitGemmGroupWrwWmma::GetDefaultPerformanceConfig(
+    const ExecutionContext& ctx, const ProblemDescription& problem) const
+{
+    PerformanceConfigHipImplicitGemmGroupWrwWmma pp;
+    pp.HeuristicInit(ctx, problem);
+    return pp;
+}
+
+bool ConvHipImplicitGemmGroupWrwWmma::IsValidPerformanceConfig(
+    const ExecutionContext&,
+    const ProblemDescription& problem,
+    const PerformanceConfigHipImplicitGemmGroupWrwWmma& config) const
+{
+    return config.IsValid(problem);
+}
+
+size_t ConvHipImplicitGemmGroupWrwWmma::GetWorkspaceSize(const ExecutionContext&,
+                                                         const ProblemDescription& problem) const
+{
+    return GetWorkspaceSizeLayoutTransformConv(problem);
+}
+
+PerformanceConfigHipImplicitGemmGroupWrwWmma
+ConvHipImplicitGemmGroupWrwWmma::Search(const ExecutionContext& ctx,
+                                        const ProblemDescription& problem,
+                                        const AnyInvokeParams& invoke_ctx) const
+{
+    return GenericSearch(*this, ctx, problem, invoke_ctx);
+}
+
+bool ConvHipImplicitGemmGroupWrwWmma::IsApplicable(
+    [[maybe_unused]] const ExecutionContext& ctx,
+    [[maybe_unused]] const ProblemDescription& problem) const
+{
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    if(env::disabled(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_WRW_WMMA))
+        return false;
+    if(problem.GetConv().attribute.deterministic)
+        return false;
+    if(problem.HasMixedDataTypes())
+        return false;
+    if(!problem.AllTensorsDimsFitIntoInt())
+        return false;
+    if(!problem.IsDirectionBackwardWrW())
+        return false;
+    if(!problem.Is2d())
+        return false;
+    if(!(problem.IsLayoutNHWC() || problem.IsLayoutDefault()))
+        return false;
+    // needed because layout transpose kernel does not support non-packed tensors
+    // TODO - check if this is also the case for WMMA impl (this was copied from xdl solver)
+    if(problem.IsLayoutDefault() && problem.HasNonPackedTensors())
+        return false;
+    if(!ck_utility::is_wmma_capable(ctx.GetStream().GetDeviceName()))
+        return false;
+    switch(problem.GetInDataType())
+    {
+    case miopenHalf: return CheckCKApplicability<ck::half_t>(problem);
+    case miopenFloat: return CheckCKApplicability<float>(problem);
+    case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenInt8:
+    case miopenInt64:
+    case miopenInt32:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenDouble: break;
+    }
+#endif
+    return false;
+}
+
+ConvSolution ConvHipImplicitGemmGroupWrwWmma::GetSolution(
+    [[maybe_unused]] const ExecutionContext& ctx,
+    [[maybe_unused]] const ProblemDescription& problem,
+    [[maybe_unused]] const PerformanceConfigHipImplicitGemmGroupWrwWmma& config) const
+{
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    return MakeSolutionGroupConvImplicitGemmWmma(
+        problem,
+        [&](auto data_type_val) {
+            using T = decltype(data_type_val);
+            return InitInvokerFactoryWrwNCHW<2,
+                                             false,
+                                             DeviceOpGWrwPtrs<T>,
+                                             CKArgs,
+                                             miopen::conv::WrWInvokeParams>(
+                ctx, problem, config.kernel_id);
+        },
+        [&](auto data_type_val) {
+            using T = decltype(data_type_val);
+            return InitInvokerFactoryNHWC<false,
+                                          DeviceOpGWrwPtrs<T>,
+                                          CKArgs,
+                                          miopen::conv::WrWInvokeParams>(
+                ctx, problem, config.kernel_id);
+        });
+
+#else
+    return {};
+#endif
+}
+
+} // namespace conv
+} // namespace solver
+} // namespace miopen

--- a/projects/miopen/test/gtest/group_conv.hpp
+++ b/projects/miopen/test/gtest/group_conv.hpp
@@ -452,6 +452,22 @@ public:
         }
     }
 
+    void RunWmmaSolver()
+    {
+        // For now, only 2D WRW has WMMA implementation
+        if constexpr(NDIM == 2u && CONV_DIR == Direction::BackwardWeights)
+        {
+            DispatchSolver<miopen::solver::conv::ConvHipImplicitGemmGroupFwdXdlops, // Placeholder
+                           miopen::solver::conv::ConvHipImplicitGemmGroupBwdXdlops, // Placeholder
+                           miopen::solver::conv::ConvHipImplicitGemmGroupWrwWmma>();
+        }
+        else
+        {
+            test_skipped = true;
+            GTEST_SKIP() << "WMMA solver only supports 2D BackwardWeights";
+        }
+    }
+
 protected:
     void SetUp() override
     {
@@ -630,3 +646,27 @@ std::vector<float> GetBetaValues()
     DEFINE_GROUP_CONV_TEST(2, type, naming_type, dir)
 #define DEFINE_GROUP_CONV3D_TEST(type, naming_type, dir) \
     DEFINE_GROUP_CONV_TEST(3, type, naming_type, dir)
+
+#define DEFINE_GROUP_CONV_WMMA_TEST(ndim, type, naming_type, dir)                       \
+    struct GPU_GroupConvWmma##ndim##D_##dir##_##naming_type                             \
+        : GroupConvTestFix<ndim, type, Direction::dir>                                  \
+    {                                                                                   \
+    };                                                                                  \
+    TEST_P(GPU_GroupConvWmma##ndim##D_##dir##_##naming_type,                            \
+           GroupConvWmma##ndim##D_##dir##_##type##_Test)                                \
+    {                                                                                   \
+        RunWmmaSolver();                                                                \
+    }                                                                                   \
+    INSTANTIATE_TEST_SUITE_P(                                                           \
+        Full,                                                                           \
+        GPU_GroupConvWmma##ndim##D_##dir##_##naming_type,                               \
+        testing::Combine(                                                               \
+            testing::ValuesIn(GroupConvTestConfig<ndim>::GetConfigs<Direction::dir>()), \
+            testing::ValuesIn(GetAlphaValues<ndim>()),                                  \
+            testing::ValuesIn(GetBetaValues<ndim>()),                                   \
+            testing::ValuesIn(GetLayoutValues<ndim>())));
+
+#define DEFINE_GROUP_CONV2D_WMMA_TEST(type, naming_type, dir) \
+    DEFINE_GROUP_CONV_WMMA_TEST(2, type, naming_type, dir)
+#define DEFINE_GROUP_CONV3D_WMMA_TEST(type, naming_type, dir) \
+    DEFINE_GROUP_CONV_WMMA_TEST(3, type, naming_type, dir)

--- a/projects/miopen/test/gtest/group_conv.hpp
+++ b/projects/miopen/test/gtest/group_conv.hpp
@@ -454,17 +454,28 @@ public:
 
     void RunWmmaSolver()
     {
-        // For now, only 2D WRW has WMMA implementation
-        if constexpr(NDIM == 2u && CONV_DIR == Direction::BackwardWeights)
+        // For now, only WRW has WMMA implementation
+        if constexpr(CONV_DIR == Direction::BackwardWeights)
         {
-            DispatchSolver<miopen::solver::conv::ConvHipImplicitGemmGroupFwdXdlops, // Placeholder
-                           miopen::solver::conv::ConvHipImplicitGemmGroupBwdXdlops, // Placeholder
-                           miopen::solver::conv::ConvHipImplicitGemmGroupWrwWmma>();
+            if constexpr(NDIM == 2u)
+            {
+                DispatchSolver<
+                    miopen::solver::conv::ConvHipImplicitGemmGroupFwdXdlops, // Placeholder
+                    miopen::solver::conv::ConvHipImplicitGemmGroupBwdXdlops, // Placeholder
+                    miopen::solver::conv::ConvHipImplicitGemmGroupWrwWmma>();
+            }
+            else
+            {
+                DispatchSolver<
+                    miopen::solver::conv::ConvHipImplicitGemm3DGroupFwdXdlops, // Placeholder
+                    miopen::solver::conv::ConvHipImplicitGemm3DGroupBwdXdlops, // Placeholder
+                    miopen::solver::conv::ConvHipImplicitGemm3DGroupWrwWmma>();
+            }
         }
         else
         {
             test_skipped = true;
-            GTEST_SKIP() << "WMMA solver only supports 2D BackwardWeights";
+            GTEST_SKIP() << "WMMA solver only supports BackwardWeights";
         }
     }
 
@@ -473,7 +484,8 @@ protected:
     {
         if constexpr(CONV_DIR == Direction::BackwardWeights)
         {
-            if(!IsTestSupportedByDevice(Gpu::gfx94X) && std::is_same<T, bfloat16>::value)
+            if(!IsTestSupportedByDevice(Gpu::gfx94X) && !IsTestSupportedByDevice(Gpu::gfx110X) &&
+               !IsTestSupportedByDevice(Gpu::gfx120X) && std::is_same<T, bfloat16>::value)
             {
                 test_skipped = true;
                 GTEST_SKIP() << "bf16 tests skipped on this hardware.";

--- a/projects/miopen/test/gtest/group_conv2d_wrw.cpp
+++ b/projects/miopen/test/gtest/group_conv2d_wrw.cpp
@@ -36,3 +36,7 @@ DEFINE_GROUP_CONV2D_TEST(float, FP32, BackwardWeights);
 /// \todo int8_t tests don't work. Need debugging
 // DEFINE_GROUP_CONV2D_TEST(int8_t, BackwardWeights);
 DEFINE_GROUP_CONV2D_TEST(bfloat16, BFP16, BackwardWeights);
+
+DEFINE_GROUP_CONV2D_WMMA_TEST(float, FP32, BackwardWeights);
+DEFINE_GROUP_CONV2D_WMMA_TEST(half, FP16, BackwardWeights);
+DEFINE_GROUP_CONV2D_WMMA_TEST(bfloat16, BFP16, BackwardWeights);

--- a/projects/miopen/test/gtest/group_conv3d_wrw.cpp
+++ b/projects/miopen/test/gtest/group_conv3d_wrw.cpp
@@ -34,3 +34,7 @@ DEFINE_GROUP_CONV3D_TEST(half, FP16, BackwardWeights);
 // /// \todo int8_t tests don't work. Need debugging
 // // DEFINE_GROUP_CONV3D_TEST(int8_t, BackwardWeights);
 DEFINE_GROUP_CONV3D_TEST(bfloat16, BFP16, BackwardWeights);
+
+DEFINE_GROUP_CONV3D_WMMA_TEST(float, FP32, BackwardWeights);
+DEFINE_GROUP_CONV3D_WMMA_TEST(half, FP16, BackwardWeights);
+DEFINE_GROUP_CONV3D_WMMA_TEST(bfloat16, BFP16, BackwardWeights);


### PR DESCRIPTION
## Motivation

Added WMMA solvers for conv bwd weights 2D and 3D to integrate future work on new RDNA4 WMMA CK Kernels. This PR targets a feature branch that will be tested and merged once the CK work will be merged.

## Technical Details

This PR implements two new solvers:
- `ConvHipImplicitGemmGroupWrwWmma` - 2D group convolution backward weight solver using WMMA
- `ConvHipImplicitGemm3DGroupWrwWmma` - 3D group convolution backward weight solver using WMMA

Both solvers leverage Composable Kernel (CK) WMMA kernels.

Each solver follows the approach of its xdl equivalent, but no heuristics and AI models are implemented yet.

## Test Plan

- Tests integration is added for 2D and 3D group convolution backward weight.
- Compared 20 shapes between Tuned MIOpendriver and ckProfiler.

## Test Result

- Tests pass when using relevant CK branch.
- No regrassions between MIOpenDriver and ckProfiler

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
