### PR TITLE
[rocthrust] Add missing copyrights

### DIFF
--- a/projects/rocthrust/scripts/code-format/check-format.sh
+++ b/projects/rocthrust/scripts/code-format/check-format.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
 
 SOURCE_COMMIT="$1"
 if [ "$#" -gt 0 ]; then

--- a/projects/rocthrust/scripts/copyright-date/check-copyright.sh
+++ b/projects/rocthrust/scripts/copyright-date/check-copyright.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
 
 # Start of configuration
 preamble="Copyright *(\([cC]\)|©)? *"

--- a/projects/rocthrust/scripts/gdb-pretty-printers.py
+++ b/projects/rocthrust/scripts/gdb-pretty-printers.py
@@ -1,3 +1,6 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 import gdb
 import sys
 

--- a/projects/rocthrust/scripts/gdb-pretty-printers.py
+++ b/projects/rocthrust/scripts/gdb-pretty-printers.py
@@ -1,6 +1,3 @@
-# Copyright © Advanced Micro Devices, Inc., or its affiliates.
-# SPDX-License-Identifier: MIT
-
 import gdb
 import sys
 

--- a/projects/rocthrust/test/test_imag_assertions.hpp
+++ b/projects/rocthrust/test/test_imag_assertions.hpp
@@ -1,3 +1,23 @@
+// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 #pragma once
 
 #include <cfloat>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
AMD copyright headers were missing in a few source files in rocthrust. This PR fixes the issue.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add the copyright headers to the identified source files.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Everything else remains the same.

## Test Result

<!-- Briefly summarize test outcomes. -->
N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
