### PR TITLE
[hipblaslt] Fix path to MatchTable.yaml

### DIFF
--- a/projects/hipblaslt/utilities/find_exact.py
+++ b/projects/hipblaslt/utilities/find_exact.py
@@ -56,7 +56,7 @@ globalParameters["WorkingDir"] = {}
 globalParameters["WorkingDir"]["Bench"] = "0_Bench"
 globalParameters["WorkingDir"]["LogicYaml"] = "1_LogicYaml"
 globalParameters["WorkingDir"]["GridYaml"] = "2_GridYaml"
-globalParameters["MatchTablePath"] = "/library/src/amd_detail/rocblaslt/src/MatchTable.yaml"
+globalParameters["MatchTablePath"] = "/device-library/MatchTable.yaml"
 
 defaultBenchOptions = {"ProblemType": {
     "TransposeA": 0,


### PR DESCRIPTION
Fix the path to the generated MatchTable.yaml file in find_exact.py.

## Motivation

In order for `find_exact.py` to execute correctly, it must properly reference the MatchTable.yaml file generated during the build process. The path is wrong in the current file

## Test Plan

Execute find_exact.py as described in the documentation

## Test Result

Script executes correctly and desired output is generated.

