### PR TITLE
[rocSPARSE] sync before hipFree.

### DIFF
--- a/projects/rocsparse/library/src/auxiliary/rocsparse_auxiliary.cpp
+++ b/projects/rocsparse/library/src/auxiliary/rocsparse_auxiliary.cpp
@@ -1305,6 +1305,14 @@ try
     ROCSPARSE_ROUTINE_TRACE;
 
     ROCSPARSE_CHECKARG_POINTER(0, hyb);
+
+    // Due to the changes in the hipFree introduced in HIP 7.0
+    // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+    // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+    // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+    // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+    RETURN_IF_HIP_ERROR(hipDeviceSynchronize());
+
     // Clean up ELL part
     if(hyb->ell_col_ind != nullptr)
     {
@@ -4983,6 +4991,13 @@ try
     ROCSPARSE_ROUTINE_TRACE;
 
     ROCSPARSE_CHECKARG_POINTER(0, descr);
+
+    // Due to the changes in the hipFree introduced in HIP 7.0
+    // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+    // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+    // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+    // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+    RETURN_IF_HIP_ERROR(hipDeviceSynchronize());
 
     // Clean up row pointer array
     if(descr->csr_row_ptr_C != nullptr)

--- a/projects/rocsparse/library/src/common/rocsparse_handle.cpp
+++ b/projects/rocsparse/library/src/common/rocsparse_handle.cpp
@@ -152,6 +152,13 @@ _rocsparse_handle::~_rocsparse_handle()
 {
     ROCSPARSE_ROUTINE_TRACE;
 
+    // Due to the changes in the hipFree introduced in HIP 7.0
+    // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+    // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+    // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+    // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+    PRINT_IF_HIP_ERROR(hipDeviceSynchronize());
+
     PRINT_IF_HIP_ERROR(rocsparse_hipFree(buffer));
     PRINT_IF_HIP_ERROR(rocsparse_hipFree(sone));
     PRINT_IF_HIP_ERROR(rocsparse_hipFree(done));

--- a/projects/rocsparse/library/src/common/rocsparse_mat_info.cpp
+++ b/projects/rocsparse/library/src/common/rocsparse_mat_info.cpp
@@ -197,6 +197,13 @@ _rocsparse_mat_info::~_rocsparse_mat_info()
     // Clear csritsv info struct
     WARNING_IF_ROCSPARSE_ERROR(rocsparse::destroy_csritsv_info(this->csritsv_info));
 
+    // Due to the changes in the hipFree introduced in HIP 7.0
+    // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+    // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+    // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+    // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+    WARNING_IF_HIP_ERROR(hipDeviceSynchronize());
+
     // Clear zero pivot
     WARNING_IF_HIP_ERROR(rocsparse_hipFree(this->zero_pivot));
 

--- a/projects/rocsparse/library/src/common/rocsparse_trm_info.cpp
+++ b/projects/rocsparse/library/src/common/rocsparse_trm_info.cpp
@@ -27,6 +27,13 @@
 
 rocsparse::trm_info_t::~trm_info_t()
 {
+    // Due to the changes in the hipFree introduced in HIP 7.0
+    // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+    // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+    // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+    // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+    WARNING_IF_HIP_ERROR(hipDeviceSynchronize());
+
     WARNING_IF_HIP_ERROR(rocsparse_hipFree(this->row_map));
     this->row_map = nullptr;
 

--- a/projects/rocsparse/library/src/conversion/rocsparse_csxsldu_preprocess.cpp
+++ b/projects/rocsparse/library/src/conversion/rocsparse_csxsldu_preprocess.cpp
@@ -57,7 +57,7 @@ namespace rocsparse
 
         if(temp_alloc)
         {
-            RETURN_IF_HIP_ERROR(rocsparse_hipFree(temp_storage_ptr));
+            RETURN_IF_HIP_ERROR(rocsparse_hipFreeAsync(temp_storage_ptr, handle->stream));
         }
 
         return rocsparse_status_success;

--- a/projects/rocsparse/library/src/conversion/rocsparse_extract.hpp
+++ b/projects/rocsparse/library/src/conversion/rocsparse_extract.hpp
@@ -38,6 +38,13 @@ public:
     int64_t* m_device_nnz{};
     virtual ~_rocsparse_extract_descr()
     {
+        // Due to the changes in the hipFree introduced in HIP 7.0
+        // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+        // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+        // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+        // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+        WARNING_IF_HIP_ERROR(hipDeviceSynchronize());
+
         std::ignore = rocsparse_hipFree(this->m_device_nnz);
     }
 

--- a/projects/rocsparse/library/src/conversion/rocsparse_sparse_to_sparse.cpp
+++ b/projects/rocsparse/library/src/conversion/rocsparse_sparse_to_sparse.cpp
@@ -175,6 +175,14 @@ try
                                                         &ind_type,
                                                         &base,
                                                         &val_type));
+
+            // Due to the changes in the hipFree introduced in HIP 7.0
+            // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+            // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+            // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+            // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+            RETURN_IF_HIP_ERROR(hipDeviceSynchronize());
+
             RETURN_IF_HIP_ERROR(rocsparse_hipFree(row));
             RETURN_IF_HIP_ERROR(rocsparse_hipFree(col));
             RETURN_IF_HIP_ERROR(rocsparse_hipFree(val));

--- a/projects/rocsparse/library/src/level2/rocsparse_csritsv_info.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_csritsv_info.cpp
@@ -88,6 +88,13 @@ rocsparse_status rocsparse::destroy_csritsv_info(rocsparse_csritsv_info info)
 
     if(info->ptr_end != nullptr && info->is_submatrix)
     {
+        // Due to the changes in the hipFree introduced in HIP 7.0
+        // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+        // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+        // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+        // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+        RETURN_IF_HIP_ERROR(hipDeviceSynchronize());
+
         RETURN_IF_HIP_ERROR(rocsparse_hipFree(info->ptr_end));
         info->ptr_end = nullptr;
     }

--- a/projects/rocsparse/library/src/level2/rocsparse_csrmv_adaptive_info.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_csrmv_adaptive_info.cpp
@@ -28,6 +28,12 @@
 
 _rocsparse_adaptive_info::~_rocsparse_adaptive_info()
 {
+    // Due to the changes in the hipFree introduced in HIP 7.0
+    // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+    // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+    // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+    // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+    WARNING_IF_HIP_ERROR(hipDeviceSynchronize());
 
     WARNING_IF_HIP_ERROR(rocsparse_hipFree(this->row_blocks));
     WARNING_IF_HIP_ERROR(rocsparse_hipFree(this->wg_flags));
@@ -43,9 +49,17 @@ _rocsparse_adaptive_info::~_rocsparse_adaptive_info()
 
 void _rocsparse_adaptive_info::clear()
 {
+    // Due to the changes in the hipFree introduced in HIP 7.0
+    // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+    // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+    // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+    // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+    WARNING_IF_HIP_ERROR(hipDeviceSynchronize());
+
     THROW_IF_HIP_ERROR(rocsparse_hipFree(this->row_blocks));
     THROW_IF_HIP_ERROR(rocsparse_hipFree(this->wg_flags));
     THROW_IF_HIP_ERROR(rocsparse_hipFree(this->wg_ids));
+
     this->row_blocks = nullptr;
     this->wg_flags   = nullptr;
     this->wg_ids     = nullptr;

--- a/projects/rocsparse/library/src/level2/rocsparse_csrmv_lrb_info.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_csrmv_lrb_info.cpp
@@ -28,6 +28,13 @@
 
 _rocsparse_lrb_info::~_rocsparse_lrb_info()
 {
+    // Due to the changes in the hipFree introduced in HIP 7.0
+    // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+    // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+    // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+    // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+    WARNING_IF_HIP_ERROR(hipDeviceSynchronize());
+
     WARNING_IF_HIP_ERROR(rocsparse_hipFree(this->wg_flags));
     WARNING_IF_HIP_ERROR(rocsparse_hipFree(this->rows_offsets_scratch));
     WARNING_IF_HIP_ERROR(rocsparse_hipFree(this->rows_bins));
@@ -41,6 +48,13 @@ _rocsparse_lrb_info::~_rocsparse_lrb_info()
 
 void _rocsparse_lrb_info::clear()
 {
+    // Due to the changes in the hipFree introduced in HIP 7.0
+    // https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree
+    // we need to introduce a device synchronize here as the below hipFree calls are now asynchronous.
+    // hipFree() previously had an implicit wait for synchronization purpose which is applicable for all memory allocations.
+    // This wait has been disabled in the HIP 7.0 runtime for allocations made with hipMallocAsync and hipMallocFromPoolAsync.
+    THROW_IF_HIP_ERROR(hipDeviceSynchronize());
+
     THROW_IF_HIP_ERROR(rocsparse_hipFree(this->wg_flags));
     THROW_IF_HIP_ERROR(rocsparse_hipFree(this->rows_offsets_scratch));
     THROW_IF_HIP_ERROR(rocsparse_hipFree(this->rows_bins));

--- a/projects/rocsparse/library/src/level2/rocsparse_csrsv_analysis.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_csrsv_analysis.cpp
@@ -500,7 +500,6 @@ rocsparse_status rocsparse::trm_analysis(rocsparse_handle          handle,
         handle, m, startbit, endbit, &rocprim_size)));
     RETURN_IF_ROCSPARSE_ERROR(rocsparse::primitives::radix_sort_pairs(
         handle, keys, vals, m, startbit, endbit, rocprim_size, rocprim_buffer));
-    RETURN_IF_HIP_ERROR(hipStreamSynchronize(stream));
 
     if(vals.current() != row_map)
     {

--- a/projects/rocsparse/library/src/reordering/rocsparse_csrcolor.cpp
+++ b/projects/rocsparse/library/src/reordering/rocsparse_csrcolor.cpp
@@ -317,7 +317,7 @@ namespace rocsparse
                 seq_ptr);
         }
 
-        RETURN_IF_HIP_ERROR(rocsparse_hipFree(seq_ptr));
+        RETURN_IF_HIP_ERROR(rocsparse_hipFreeAsync(seq_ptr, handle->stream));
         return rocsparse_status_success;
     }
 }


### PR DESCRIPTION
Since HIP 7.0 `hipFree` is not implicitly blocking as before (see  https://rocm.docs.amd.com/projects/HIP/en/latest/hip-7-changes.html#update-hipfree ). Specifically if we allocate using `hipMallocAsync` and then try to free using `hipFree`, the `hipFree` will not be blocking. This means that in the cases where we allocate using `hipMallocAsync` and then free using `hipFree` (for example when the stream is not available for the free), we need to do an explicit synchronization.

This PR adds required synchronization points.

This PR also reverts #1609 as it is not required anymore.