### PR TITLE
rocfft: compute sub-comm ranks correctly in MPI global transpose

### DIFF
--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -375,41 +375,36 @@ if( ROCFFT_MPI_ENABLE )
     )
     target_compile_options( ${worker} PRIVATE ${WARNING_FLAGS} )
 
-  if ( ROCFFT_CRAY_MPI_ENABLE )
-    target_link_libraries( ${worker} PRIVATE
-      OpenMP::OpenMP_CXX 
-      hip::hiprand
-      hip::device
-      MPI::MPI_CXX
-      ${FFTW_LIBRARIES}
-      "mpi_gtl_hsa"
-    )
-      get_filename_component( MPI_LIBDIR ${MPI_LIBRARY} DIRECTORY )
-      target_link_directories( ${worker}
-	PRIVATE
-	${MPI_LIBDIR}/../../../../gtl/lib )
+    if ( ROCFFT_CRAY_MPI_ENABLE )
+      target_link_libraries( ${worker} PRIVATE
+        OpenMP::OpenMP_CXX 
+        hip::hiprand
+        hip::device
+        MPI::MPI_CXX
+        ${FFTW_LIBRARIES}
+        "mpi_gtl_hsa"
+      )
+        get_filename_component( MPI_LIBDIR ${MPI_LIBRARY} DIRECTORY )
+        target_link_directories( ${worker}
+  	PRIVATE
+  	${MPI_LIBDIR}/../../../../gtl/lib )
     else()
-    target_link_libraries( ${worker} PRIVATE
-      OpenMP::OpenMP_CXX 
-      hip::hiprand
-      hip::device
-      MPI::MPI_CXX
-      ${FFTW_LIBRARIES}
-    )    
+      target_link_libraries( ${worker} PRIVATE
+        OpenMP::OpenMP_CXX 
+        hip::hiprand
+        hip::device
+        MPI::MPI_CXX
+        ${FFTW_LIBRARIES}
+      )    
     endif()
+
+    target_compile_definitions( ${worker} PRIVATE USE_HIPRAND )
+
     set_target_properties(${worker}
                           PROPERTIES 
                           RUNTIME_OUTPUT_DIRECTORY 
                           ${TESTS_OUT_DIR})
     rocm_install(TARGETS ${worker} COMPONENT tests)
-    
-    if( USE_HIPRAND )
-      target_link_libraries( ${worker}
-      PRIVATE
-      hip::hiprand
-      )
-      target_compile_definitions( ${worker} PRIVATE USE_HIPRAND )
-    endif()
 
   endforeach()
 

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -376,7 +376,7 @@ if( ROCFFT_MPI_ENABLE )
     target_compile_options( ${worker} PRIVATE ${WARNING_FLAGS} )
 
   if ( ROCFFT_CRAY_MPI_ENABLE )
-    target_link_libraries( ${worker}
+    target_link_libraries( ${worker} PRIVATE
       OpenMP::OpenMP_CXX 
       hip::hiprand
       hip::device
@@ -389,7 +389,7 @@ if( ROCFFT_MPI_ENABLE )
 	PRIVATE
 	${MPI_LIBDIR}/../../../../gtl/lib )
     else()
-    target_link_libraries( ${worker}
+    target_link_libraries( ${worker} PRIVATE
       OpenMP::OpenMP_CXX 
       hip::hiprand
       hip::device
@@ -403,16 +403,24 @@ if( ROCFFT_MPI_ENABLE )
                           ${TESTS_OUT_DIR})
     rocm_install(TARGETS ${worker} COMPONENT tests)
     
+    if( USE_HIPRAND )
+      target_link_libraries( ${worker}
+      PRIVATE
+      hip::hiprand
+      )
+      target_compile_definitions( ${worker} PRIVATE USE_HIPRAND )
+    endif()
+
   endforeach()
 
   # link normal MPI worker against rocFFT
-  target_link_libraries( rocfft_mpi_worker
+  target_link_libraries( rocfft_mpi_worker PRIVATE
     roc::rocfft
   )
 
   # dyna worker only needs to dynamically load libraries
   target_compile_definitions( dyna_rocfft_mpi_worker PRIVATE ROCFFT_DYNA_MPI_WORKER )
-  target_link_libraries( dyna_rocfft_mpi_worker
+  target_link_libraries( dyna_rocfft_mpi_worker PRIVATE
     ${CMAKE_DL_LIBS}
   )
 

--- a/projects/rocfft/library/src/include/plan.h
+++ b/projects/rocfft/library/src/include/plan.h
@@ -149,7 +149,9 @@ struct rocfft_plan_description_t
     // Multi-process communicator info:
     rocfft_comm_type comm_type = rocfft_comm_none;
 #ifdef ROCFFT_MPI_ENABLE
-    MPI_Comm_wrapper_t mpi_comm;
+    // this is the communicator that was directly provided by the user
+    // - we don't own it so it doesn't need to be wrapped or freed
+    MPI_Comm user_mpi_comm = MPI_COMM_NULL;
 #endif
 
     LoadOps  loadOps;
@@ -195,6 +197,9 @@ struct rocfft_plan_description_t
 
 struct rocfft_plan_t
 {
+#ifdef ROCFFT_MPI_ENABLE
+    MPI_Comm_wrapper_t mpi_comm;
+#endif
     size_t rank = 0;
     // input lengths
     std::vector<size_t> lengths;

--- a/projects/rocfft/library/src/include/plan.h
+++ b/projects/rocfft/library/src/include/plan.h
@@ -344,8 +344,7 @@ private:
                          std::vector<BufferPtr>&    output,
                          const std::vector<size_t>& inputAntecedents,
                          std::vector<size_t>&       outputItems,
-                         size_t                     transposeNumber,
-                         MPI_Comm_wrapper_t&&       subcomm = MPI_Comm_wrapper_t{});
+                         size_t                     transposeNumber);
 
     // default global all-to-all transpose
     void GlobalTransposeA2A(size_t                     elem_size,
@@ -356,17 +355,6 @@ private:
                             const std::vector<size_t>& inputAntecedents,
                             std::vector<size_t>&       outputItems,
                             const std::string&         itemGroup);
-
-    // global transpose implemented as an all-to-all communication with sub-communicator optimization.
-    void GlobalTransposeA2ASubcomm(size_t                     elem_size,
-                                   const rocfft_field_t&      inField,
-                                   const rocfft_field_t&      outField,
-                                   std::vector<BufferPtr>&    input,
-                                   std::vector<BufferPtr>&    output,
-                                   const std::vector<size_t>& inputAntecedents,
-                                   std::vector<size_t>&       outputItems,
-                                   const std::string&         itemGroup,
-                                   MPI_Comm_wrapper_t&&       subcomm = MPI_Comm_wrapper_t{});
 
     // fallback case for global transpose that uses point-to-point
     // communications, for when all-to-all isn't possible.

--- a/projects/rocfft/library/src/include/rocfft_mpi.h
+++ b/projects/rocfft/library/src/include/rocfft_mpi.h
@@ -301,11 +301,12 @@ inline MPI_Comm_wrapper_t make_subcommunicator(MPI_Comm parent_comm, const std::
 
 #else
 
+typedef int MPI_Comm;
 class MPI_Comm_wrapper_t
 {
 public:
     MPI_Comm_wrapper_t() {}
-    static MPI_Comm_wrapper_t from_raw(int)
+    static MPI_Comm_wrapper_t from_raw(MPI_Comm)
     {
         return MPI_Comm_wrapper_t{};
     }

--- a/projects/rocfft/library/src/include/rocfft_mpi.h
+++ b/projects/rocfft/library/src/include/rocfft_mpi.h
@@ -48,16 +48,8 @@ public:
         return mpi_comm;
     }
 
-    // copy, duplicating the communicator
-    MPI_Comm_wrapper_t(const MPI_Comm_wrapper_t& other)
-    {
-        duplicate(other.mpi_comm);
-    }
-    MPI_Comm_wrapper_t& operator=(const MPI_Comm_wrapper_t& other)
-    {
-        duplicate(other.mpi_comm);
-        return *this;
-    }
+    MPI_Comm_wrapper_t(const MPI_Comm_wrapper_t&) = delete;
+    MPI_Comm_wrapper_t& operator=(const MPI_Comm_wrapper_t&) = delete;
 
     // move communicator
     MPI_Comm_wrapper_t(MPI_Comm_wrapper_t&& other)

--- a/projects/rocfft/library/src/include/tree_node.h
+++ b/projects/rocfft/library/src/include/tree_node.h
@@ -1400,6 +1400,13 @@ struct CommAllToAll : public MultiPlanItem
         , recvCounts(_recvCounts)
         , sendBuf(_sendBuf)
         , recvBuf(_recvBuf)
+        // check if uniform exchange to use MPI_Alltoall
+        , uniform_counts(std::all_of(sendCounts.begin(),
+                                     sendCounts.end(),
+                                     [&](size_t c) { return c == sendCounts[0]; })
+                         && std::all_of(recvCounts.begin(), recvCounts.end(), [&](size_t c) {
+                                return c == recvCounts[0];
+                            }))
     {
         subcomm = std::move(_subcomm);
 
@@ -1416,14 +1423,6 @@ struct CommAllToAll : public MultiPlanItem
         checkArray(sendCounts);
         checkArray(recvOffsets);
         checkArray(recvCounts);
-
-        // check if uniform exchange to use MPI_Alltoall
-        uniform_counts = std::all_of(sendCounts.begin(),
-                                     sendCounts.end(),
-                                     [&](size_t c) { return c == sendCounts[0]; })
-                         && std::all_of(recvCounts.begin(), recvCounts.end(), [&](size_t c) {
-                                return c == recvCounts[0];
-                            });
     }
 
     // enum for error handling for different multi-process communication
@@ -1474,7 +1473,7 @@ private:
     const BufferPtr recvBuf;
 
     // check uniform counts for using AlltoAll instead of AlltoAllv
-    bool uniform_counts = false;
+    const bool uniform_counts = false;
 };
 
 // Tree-structured FFT plan.  This is specific to a single device on

--- a/projects/rocfft/library/src/include/tree_node.h
+++ b/projects/rocfft/library/src/include/tree_node.h
@@ -1094,7 +1094,7 @@ struct MultiPlanItem
     // This process's rank relative to the plan communicator.
     int local_comm_rank;
 
-    // Sub-communicator for this operation, which is only set if the
+    // Sub-communicator for this operation, which is only set if
     // we know we're only talking to a subset of the ranks
     std::optional<MPI_Comm_wrapper_t> subcomm;
     // Helper to get the sub-communicator if it's set, or the plan's

--- a/projects/rocfft/library/src/include/tree_node.h
+++ b/projects/rocfft/library/src/include/tree_node.h
@@ -1384,7 +1384,6 @@ struct CommAllToAll : public MultiPlanItem
                  const std::vector<size_t>& _recvCounts,
                  BufferPtr                  _sendBuf,
                  BufferPtr                  _recvBuf,
-                 bool                       uniformCounts,
                  MPI_Comm_wrapper_t         subcomm = {})
         : precision(_precision)
         , arrayType(_arrayType)
@@ -1394,7 +1393,6 @@ struct CommAllToAll : public MultiPlanItem
         , recvCounts(_recvCounts)
         , sendBuf(_sendBuf)
         , recvBuf(_recvBuf)
-        , uniform_counts(uniformCounts)
         , subcomm(std::move(subcomm))
     {
         // Currently MPI interface uses 32-bit signed ints, so assert
@@ -1410,6 +1408,14 @@ struct CommAllToAll : public MultiPlanItem
         checkArray(sendCounts);
         checkArray(recvOffsets);
         checkArray(recvCounts);
+
+        // check if uniform exchange to use MPI_Alltoall
+        uniform_counts = std::all_of(sendCounts.begin(),
+                                     sendCounts.end(),
+                                     [&](size_t c) { return c == sendCounts[0]; })
+                         && std::all_of(recvCounts.begin(), recvCounts.end(), [&](size_t c) {
+                                return c == recvCounts[0];
+                            });
     }
 
     // enum for error handling for different multi-process communication
@@ -1444,16 +1450,6 @@ struct CommAllToAll : public MultiPlanItem
         return true;
     }
 
-    void set_uniform_count_inside_subcomm(size_t val)
-    {
-        uniform_count_inside_subcomm = val;
-    }
-
-    void set_uniform_count(bool val)
-    {
-        uniform_counts = val;
-    }
-
 private:
     const rocfft_precision  precision;
     const rocfft_array_type arrayType;
@@ -1464,9 +1460,6 @@ private:
     const std::vector<size_t> sendCounts;
     const std::vector<size_t> recvOffsets;
     const std::vector<size_t> recvCounts;
-
-    // counts for MPIAlltoall inside a subcommunicator
-    size_t uniform_count_inside_subcomm;
 
     // send/receive buffers
     const BufferPtr sendBuf;

--- a/projects/rocfft/library/src/include/tree_node.h
+++ b/projects/rocfft/library/src/include/tree_node.h
@@ -1093,6 +1093,10 @@ struct MultiPlanItem
 
     // This process's rank relative to the plan communicator.
     int local_comm_rank;
+
+    // Sub-communicator for this operation, which is only set if the
+    // we know we're only talking to a subset of the ranks
+    std::optional<MPI_Comm_wrapper_t> subcomm;
 };
 
 // Communication operations
@@ -1376,15 +1380,15 @@ private:
 struct CommAllToAll : public MultiPlanItem
 {
 
-    CommAllToAll(rocfft_precision           _precision,
-                 rocfft_array_type          _arrayType,
-                 const std::vector<size_t>& _sendOffsets,
-                 const std::vector<size_t>& _sendCounts,
-                 const std::vector<size_t>& _recvOffsets,
-                 const std::vector<size_t>& _recvCounts,
-                 BufferPtr                  _sendBuf,
-                 BufferPtr                  _recvBuf,
-                 MPI_Comm_wrapper_t         subcomm = {})
+    CommAllToAll(rocfft_precision                    _precision,
+                 rocfft_array_type                   _arrayType,
+                 const std::vector<size_t>&          _sendOffsets,
+                 const std::vector<size_t>&          _sendCounts,
+                 const std::vector<size_t>&          _recvOffsets,
+                 const std::vector<size_t>&          _recvCounts,
+                 BufferPtr                           _sendBuf,
+                 BufferPtr                           _recvBuf,
+                 std::optional<MPI_Comm_wrapper_t>&& _subcomm = {})
         : precision(_precision)
         , arrayType(_arrayType)
         , sendOffsets(_sendOffsets)
@@ -1393,8 +1397,9 @@ struct CommAllToAll : public MultiPlanItem
         , recvCounts(_recvCounts)
         , sendBuf(_sendBuf)
         , recvBuf(_recvBuf)
-        , subcomm(std::move(subcomm))
     {
+        subcomm = std::move(_subcomm);
+
         // Currently MPI interface uses 32-bit signed ints, so assert
         // that our counts/offsets don't overflow that type
         auto checkArray = [](const std::vector<size_t>& arr) {
@@ -1467,9 +1472,6 @@ private:
 
     // check uniform counts for using AlltoAll instead of AlltoAllv
     bool uniform_counts = false;
-
-    // subcomm for optimizations whenever possible
-    MPI_Comm_wrapper_t subcomm;
 };
 
 // Tree-structured FFT plan.  This is specific to a single device on

--- a/projects/rocfft/library/src/include/tree_node.h
+++ b/projects/rocfft/library/src/include/tree_node.h
@@ -1097,6 +1097,9 @@ struct MultiPlanItem
     // Sub-communicator for this operation, which is only set if the
     // we know we're only talking to a subset of the ranks
     std::optional<MPI_Comm_wrapper_t> subcomm;
+    // Helper to get the sub-communicator if it's set, or the plan's
+    // communicator.
+    MPI_Comm ActiveMPIComm(const rocfft_plan plan) const;
 };
 
 // Communication operations
@@ -1388,7 +1391,7 @@ struct CommAllToAll : public MultiPlanItem
                  const std::vector<size_t>&          _recvCounts,
                  BufferPtr                           _sendBuf,
                  BufferPtr                           _recvBuf,
-                 std::optional<MPI_Comm_wrapper_t>&& _subcomm = {})
+                 std::optional<MPI_Comm_wrapper_t>&& _subcomm)
         : precision(_precision)
         , arrayType(_arrayType)
         , sendOffsets(_sendOffsets)

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -2257,7 +2257,7 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
             if(intersection.empty())
                 continue;
 
-            conn.add_connection(inBrick.location.comm_rank, outBrick.location.comm_rank);
+            conn.add_connection(inRank, outRank);
 
             const auto elems = intersection.count_elems();
 

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -2172,6 +2172,62 @@ void rocfft_plan_t::GlobalTransposeP2P(size_t                     elem_size,
     }
 }
 
+// Helper to compute disjoint sets of ranks that need to collectively
+// communicate (e.g. during an all-to-all operation).  This
+// information can be used to partition the global communicator into
+// sub-communicators.
+struct ConnectedRanks
+{
+    // Initialize parent array - each rank begins as its own parent
+    ConnectedRanks(int comm_size)
+        : parent(comm_size)
+    {
+        std::iota(parent.begin(), parent.end(), 0);
+    }
+    std::vector<int> parent;
+
+    // Get the root parent of a rank
+    int get_root(int rank)
+    {
+        // If rank is its own parent, that's the root
+        if(parent[rank] == rank)
+            return rank;
+        // Otherwise, follow the links until we get to the root
+        return parent[rank] = get_root(parent[rank]);
+    }
+
+    // Add a connection between rankA and rankB
+    void add_connection(int rankA, int rankB)
+    {
+        // A and B are now part of the same set, so give them the same
+        // root
+        auto rootA = get_root(rankA);
+        auto rootB = get_root(rankB);
+        if(rootA != rootB)
+            parent[rootA] = parent[rootB];
+    }
+
+    // Get the set of ranks that's connected to a specified rank
+    std::set<int> get_connected(int rank)
+    {
+        // Compress the paths in the parent array so that each rank
+        // points to its root parent
+        for(int i = 0; i < static_cast<int>(parent.size()); ++i)
+        {
+            parent[i] = get_root(i);
+        }
+
+        // Return ranks that have the same parent
+        std::set<int> ret;
+        for(int i = 0; i < static_cast<int>(parent.size()); ++i)
+        {
+            if(parent[i] == parent[rank])
+                ret.insert(i);
+        }
+        return ret;
+    }
+};
+
 // global transpose using MPI sub-communicators
 // subcomm is guaranteed to be a valid communicator (not MPI_COMM_NULL) before this call
 void rocfft_plan_t::GlobalTransposeA2ASubcomm(size_t                     elem_size,

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -380,17 +380,14 @@ try
     case rocfft_comm_none:
     {
 #ifdef ROCFFT_MPI_ENABLE
-        description->mpi_comm.free();
+        description->user_mpi_comm = nullptr;
 #endif
         break;
     }
 #ifdef ROCFFT_MPI_ENABLE
     case rocfft_comm_mpi:
     {
-        description->mpi_comm.duplicate(*static_cast<MPI_Comm*>(comm_handle));
-        auto mpiret = MPI_Comm_set_errhandler(description->mpi_comm, MPI_ERRORS_RETURN);
-        if(mpiret != MPI_SUCCESS)
-            return rocfft_status_failure;
+        description->user_mpi_comm = *static_cast<MPI_Comm*>(comm_handle);
         break;
     }
 #endif
@@ -2947,7 +2944,7 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
                               global_brick_count.data(),
                               1,
                               type_to_mpi_type<typeof(decltype(global_brick_count)::value_type)>(),
-                              plan->desc.mpi_comm);
+                              plan->mpi_comm);
         if(rcmpi != MPI_SUCCESS)
         {
             throw std::runtime_error("MPI_Allgather failed: " + std::to_string(rcmpi));
@@ -3026,7 +3023,7 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
                            recvcount.data(),
                            displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_lowers)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           plan->mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3043,7 +3040,7 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
                            recvcount.data(),
                            displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_uppers)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           plan->mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3060,7 +3057,7 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
                            recvcount.data(),
                            displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_strides)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           plan->mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3077,7 +3074,7 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
                            global_brick_count.data(),
                            scalar_displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_devices)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           plan->mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3094,7 +3091,7 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
                            global_brick_count.data(),
                            scalar_displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_comm_ranks)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           plan->mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3156,7 +3153,7 @@ rocfft_status allgather_brick_params_mpi(rocfft_plan& plan)
 #if !defined ROCFFT_MPI_ENABLE
     return rocfft_status_failure;
 #else
-    if(!plan->desc.mpi_comm)
+    if(!plan->mpi_comm)
     {
         // If the comm type is MPI, but the comm pointer is null, then return an error.
         return rocfft_status_failure;
@@ -3220,7 +3217,7 @@ rocfft_status allgather_brick_params_mpi(rocfft_plan& plan)
                               all_brick_lengths.data(),
                               1,
                               type_to_mpi_type<typeof(decltype(all_brick_lengths)::value_type)>(),
-                              plan->desc.mpi_comm);
+                              plan->mpi_comm);
         if(rcmpi != MPI_SUCCESS)
         {
             throw std::runtime_error("MPI_Allgather failed: " + std::to_string(rcmpi));
@@ -3247,9 +3244,9 @@ rocfft_status allgather_brick_params_mpi(rocfft_plan& plan)
     // Verify that all ranks have the same number of input and output fields.
     try
     {
-        if(!all_mpi_ranks_same_scalar(plan->desc.inFields.size(), plan->desc.mpi_comm))
+        if(!all_mpi_ranks_same_scalar(plan->desc.inFields.size(), plan->mpi_comm))
             return rocfft_status_failure;
-        if(!all_mpi_ranks_same_scalar(plan->desc.outFields.size(), plan->desc.mpi_comm))
+        if(!all_mpi_ranks_same_scalar(plan->desc.outFields.size(), plan->mpi_comm))
             return rocfft_status_failure;
     }
     catch(std::exception& e)
@@ -3356,11 +3353,11 @@ void rocfft_plan_t::ValidateFields() const
 int rocfft_plan_t::get_local_comm_rank() const
 {
 #ifdef ROCFFT_MPI_ENABLE
-    if(desc.comm_type == rocfft_comm_none || !desc.mpi_comm)
+    if(desc.comm_type == rocfft_comm_none || !mpi_comm)
         return 0;
 
     int  mpi_rank = 0;
-    auto rcmpi    = MPI_Comm_rank(desc.mpi_comm, &mpi_rank);
+    auto rcmpi    = MPI_Comm_rank(mpi_comm, &mpi_rank);
     if(rcmpi != MPI_SUCCESS)
         throw std::runtime_error("MPI_Comm_rank failed: " + std::to_string(rcmpi));
     return mpi_rank;
@@ -3372,11 +3369,11 @@ int rocfft_plan_t::get_local_comm_rank() const
 int rocfft_plan_t::get_local_comm_size() const
 {
 #ifdef ROCFFT_MPI_ENABLE
-    if(desc.comm_type == rocfft_comm_none || !desc.mpi_comm)
+    if(desc.comm_type == rocfft_comm_none || !mpi_comm)
         return 1;
 
     int  mpi_size = 0;
-    auto rcmpi    = MPI_Comm_size(desc.mpi_comm, &mpi_size);
+    auto rcmpi    = MPI_Comm_size(mpi_comm, &mpi_size);
     if(rcmpi != MPI_SUCCESS)
         throw std::runtime_error("MPI_Comm_rank failed: " + std::to_string(rcmpi));
     return mpi_size;
@@ -3424,14 +3421,26 @@ rocfft_status rocfft_plan_create_internal(rocfft_plan                   plan,
 
         auto rcfft = rocfft_status_success;
 
+#ifdef ROCFFT_MPI_ENABLE
         if(plan->desc.comm_type == rocfft_comm_mpi)
         {
+            // duplicate the user-provided MPI communicator and set
+            // our own error policy on it
+            if(plan->desc.user_mpi_comm)
+            {
+                plan->mpi_comm.duplicate(plan->desc.user_mpi_comm);
+                auto mpiret = MPI_Comm_set_errhandler(plan->mpi_comm, MPI_ERRORS_RETURN);
+                if(mpiret != MPI_SUCCESS)
+                    return rocfft_status_failure;
+            }
+
             // Each rank needs to know the global data distribution for plan generation, so we
             // gather all the brick information here.
             rcfft = allgather_brick_params_mpi(plan);
             if(rcfft != rocfft_status_success)
                 throw std::runtime_error("gather brick params failed");
         }
+#endif
 
         // Sort the parameters to be row major, in case they're not
         plan->sort();

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -2243,6 +2243,8 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
     // unpack operations after the all-to-all communication
     std::vector<size_t> unpack_ops;
 
+    ConnectedRanks conn(local_comm_size);
+
     // loop over each input brick, finding the intersection of it with
     // every output brick
     for(size_t inBrickIdx = 0; inBrickIdx < inField.bricks.size(); ++inBrickIdx)
@@ -2257,6 +2259,8 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
             auto intersection = inBrick.intersect(outBrick);
             if(intersection.empty())
                 continue;
+
+            conn.add_connection(inBrick.location.comm_rank, outBrick.location.comm_rank);
 
             const auto elems = intersection.count_elems();
 
@@ -2375,6 +2379,34 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
         }
     }
 
+    // get the set of ranks that this rank needs to communicate with
+    std::set<int> comm_ranks = conn.get_connected(local_comm_rank);
+
+    // if the set of ranks we need to communicate with is a subset,
+    // narrow the AllToAll to just that set
+    std::optional<MPI_Comm_wrapper_t> subcomm;
+#ifdef ROCFFT_MPI_ENABLE
+    if(comm_ranks.size() < static_cast<size_t>(local_comm_size))
+    {
+        // go backwards through the ranks
+        for(int i = local_comm_size - 1; i >= 0; --i)
+        {
+            if(comm_ranks.find(i) == comm_ranks.end())
+            {
+                send_counts.erase(send_counts.begin() + i);
+                send_offsets.erase(send_offsets.begin() + i);
+                recv_counts.erase(recv_counts.begin() + i);
+                recv_offsets.erase(recv_offsets.begin() + i);
+            }
+        }
+
+        // create a subcommunicator with this subset
+        std::vector<int> comm_ranks_vec;
+        std::copy(comm_ranks.begin(), comm_ranks.end(), std::back_inserter(comm_ranks_vec));
+        subcomm = make_subcommunicator(mpi_comm, comm_ranks_vec);
+    }
+#endif
+
     // add the all-to-all op itself, which depends on pack ops
     auto alltoall_ptr = std::make_unique<CommAllToAll>(precision,
                                                        desc.inArrayType,
@@ -2383,7 +2415,8 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
                                                        recv_offsets,
                                                        recv_counts,
                                                        BufferPtr::temp(send_buf.data()),
-                                                       BufferPtr::temp(recv_buf.data()));
+                                                       BufferPtr::temp(recv_buf.data()),
+                                                       std::move(subcomm));
 
     auto alltoall_op                    = AddMultiPlanItem(std::move(alltoall_ptr), pack_ops);
     multiPlan[alltoall_op]->group       = itemGroup;
@@ -2753,25 +2786,6 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
             else
                 nextField = MakeFieldWithPencilSplit(
                     currentField, lengthsWithBatch, split_axes, split_sizes);
-
-            // determine overlapping ranks (subcommunicator members)
-            std::set<int> pencil_neighbors;
-            for(const auto& out_brick : nextField.bricks)
-            {
-                if(out_brick.location.comm_rank == local_comm_rank)
-                {
-                    for(const auto& in_brick : currentField.bricks)
-                        if(!in_brick.intersect(out_brick).empty())
-                            pencil_neighbors.insert(in_brick.location.comm_rank);
-                }
-            }
-
-            // create subcommunicator using helper (RAII)
-            std::vector<int> pencil_neighbors_vec(pencil_neighbors.begin(), pencil_neighbors.end());
-            MPI_Comm_wrapper_t pencil_comm
-                = make_subcommunicator(desc.mpi_comm, pencil_neighbors_vec);
-            if(!pencil_comm)
-                throw std::runtime_error("Failed to create a valid Pencil sub-communicator");
 
             // allocate temp buffers for nextField, though we only
             // need to do this if we're in the middle of the

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -2028,8 +2028,7 @@ void rocfft_plan_t::GlobalTranspose(size_t                     elem_size,
                                     std::vector<BufferPtr>&    output,
                                     const std::vector<size_t>& inputAntecedents,
                                     std::vector<size_t>&       outputItems,
-                                    size_t                     transposeNumber,
-                                    MPI_Comm_wrapper_t&&       subcomm)
+                                    size_t                     transposeNumber)
 {
     // All-to-all transpose is preferred as it's faster. This requires
     // that each rank have a single base pointer to send/receive with
@@ -2051,25 +2050,8 @@ void rocfft_plan_t::GlobalTranspose(size_t                     elem_size,
     {
         // GlobalTransposeA2A will use MPI_Ialltoall when possible,
         // falling back to MPI_Ialltoallv otherwise
-        if(subcomm)
-            GlobalTransposeA2ASubcomm(elem_size,
-                                      inField,
-                                      outField,
-                                      input,
-                                      output,
-                                      inputAntecedents,
-                                      outputItems,
-                                      itemGroup,
-                                      std::move(subcomm));
-        else
-            GlobalTransposeA2A(elem_size,
-                               inField,
-                               outField,
-                               input,
-                               output,
-                               inputAntecedents,
-                               outputItems,
-                               itemGroup);
+        GlobalTransposeA2A(
+            elem_size, inField, outField, input, output, inputAntecedents, outputItems, itemGroup);
     }
 }
 
@@ -2227,218 +2209,6 @@ struct ConnectedRanks
         return ret;
     }
 };
-
-// global transpose using MPI sub-communicators
-// subcomm is guaranteed to be a valid communicator (not MPI_COMM_NULL) before this call
-void rocfft_plan_t::GlobalTransposeA2ASubcomm(size_t                     elem_size,
-                                              const rocfft_field_t&      inField,
-                                              const rocfft_field_t&      outField,
-                                              std::vector<BufferPtr>&    input,
-                                              std::vector<BufferPtr>&    output,
-                                              const std::vector<size_t>& inputAntecedents,
-                                              std::vector<size_t>&       outputItems,
-                                              const std::string&         itemGroup,
-                                              MPI_Comm_wrapper_t&&       subcomm)
-{
-#ifdef ROCFFT_MPI_ENABLE
-    int  subcomm_size = -1;
-    auto rcmpi        = MPI_Comm_size(subcomm, &subcomm_size);
-    if(rcmpi != MPI_SUCCESS || subcomm_size < 2)
-        throw std::runtime_error(
-            "MPI_Comm_size error: subcommunicator is invalid or contains fewer than two ranks "
-            "(error code: "
-            + std::to_string(rcmpi) + ", size: " + std::to_string(subcomm_size) + ")");
-
-    // map subcomm-local rank <-> global rank for this pencil
-    // for all ranks, set up a vector:
-    //   global_rank_of_subcomm_rank[local_subcomm_rank] = global rank
-    //   subcomm_rank_of_global_rank[global_rank] = subcomm-local rank, or -1 if not present
-    std::vector<int> global_rank_of_subcomm_rank(subcomm_size, -1);
-    std::vector<int> subcomm_rank_of_global_rank(get_local_comm_size(), -1);
-
-    // build mapping by MPI_Allgather (gathering global rank from all subcomm ranks)
-    int my_global_rank = get_local_comm_rank();
-    rcmpi              = MPI_Allgather(
-        &my_global_rank, 1, MPI_INT, global_rank_of_subcomm_rank.data(), 1, MPI_INT, subcomm);
-    if(rcmpi != MPI_SUCCESS)
-    {
-        throw std::runtime_error("MPI_Allgather failed: " + std::to_string(rcmpi));
-    }
-
-    for(int i = 0; i < subcomm_size; ++i)
-        subcomm_rank_of_global_rank[global_rank_of_subcomm_rank[i]] = i;
-
-    // only communicate with the ranks in this subcomm
-    std::optional<int> local_send_device;
-    std::optional<int> local_recv_device;
-
-    size_t              cumulative_send_elems = 0;
-    size_t              cumulative_recv_elems = 0;
-    std::vector<size_t> send_offsets(subcomm_size, 0);
-    std::vector<size_t> send_counts(subcomm_size, 0);
-    std::vector<size_t> recv_offsets(subcomm_size, 0);
-    std::vector<size_t> recv_counts(subcomm_size, 0);
-
-    std::vector<size_t> pack_ops;
-    std::vector<size_t> unpack_ops;
-
-    // packing/unpacking only within subcomm
-    for(size_t inBrickIdx = 0; inBrickIdx < inField.bricks.size(); ++inBrickIdx)
-    {
-        const auto& inBrick       = inField.bricks[inBrickIdx];
-        const int   inRank        = inBrick.location.comm_rank;
-        const int   inSubcommRank = subcomm_rank_of_global_rank[inRank];
-        if(inSubcommRank == -1)
-            continue; // skip input bricks not in this subcomm
-
-        for(size_t outBrickIdx = 0; outBrickIdx < outField.bricks.size(); ++outBrickIdx)
-        {
-            const auto& outBrick       = outField.bricks[outBrickIdx];
-            const int   outRank        = outBrick.location.comm_rank;
-            const int   outSubcommRank = subcomm_rank_of_global_rank[outRank];
-            if(outSubcommRank == -1)
-                continue; // skip output bricks not in this subcomm
-
-            auto intersection = inBrick.intersect(outBrick);
-            if(intersection.empty())
-                continue;
-
-            const auto elems = intersection.count_elems();
-
-            if(inRank == my_global_rank)
-            {
-                if(local_send_device && *local_send_device != inBrick.location.device)
-                    throw std::runtime_error("multiple devices for send during AlltoAll(subcomm)");
-                local_send_device            = inBrick.location.device;
-                send_offsets[outSubcommRank] = cumulative_send_elems;
-                send_counts[outSubcommRank]  = elems;
-                cumulative_send_elems += elems;
-            }
-            if(outRank == my_global_rank)
-            {
-                if(local_recv_device && *local_recv_device != outBrick.location.device)
-                    throw std::runtime_error("multiple devices for recv during AlltoAll(subcomm)");
-                local_recv_device           = outBrick.location.device;
-                recv_offsets[inSubcommRank] = cumulative_recv_elems;
-                recv_counts[inSubcommRank]  = elems;
-                cumulative_recv_elems += elems;
-            }
-        }
-    }
-
-    if(!local_send_device)
-        throw std::runtime_error("no local send device for all-to-all(subcomm) communication");
-    if(!local_recv_device)
-        throw std::runtime_error("no local recv device for all-to-all(subcomm) communication");
-
-    TempBufferLease send_buf(tempBuffers,
-                             my_global_rank,
-                             {my_global_rank, *local_send_device},
-                             cumulative_send_elems,
-                             elem_size);
-    TempBufferLease recv_buf(tempBuffers,
-                             my_global_rank,
-                             {my_global_rank, *local_recv_device},
-                             cumulative_recv_elems,
-                             elem_size);
-
-    // repeat: pack/unpack only for subcomm, using local indices
-    for(size_t inBrickIdx = 0; inBrickIdx < inField.bricks.size(); ++inBrickIdx)
-    {
-        const auto& inBrick       = inField.bricks[inBrickIdx];
-        int         inRank        = inBrick.location.comm_rank;
-        int         inSubcommRank = subcomm_rank_of_global_rank[inRank];
-        if(inSubcommRank == -1)
-            continue;
-
-        for(size_t outBrickIdx = 0; outBrickIdx < outField.bricks.size(); ++outBrickIdx)
-        {
-            const auto& outBrick       = outField.bricks[outBrickIdx];
-            int         outRank        = outBrick.location.comm_rank;
-            int         outSubcommRank = subcomm_rank_of_global_rank[outRank];
-            if(outSubcommRank == -1)
-                continue;
-
-            auto intersection = inBrick.intersect(outBrick);
-            if(intersection.empty())
-                continue;
-            intersection.stride = intersection.contiguous_strides();
-
-            // pack if this rank owns input brick
-            if(inRank == my_global_rank)
-            {
-                auto pack_op = AddMultiPlanItem(
-                    transpose_brick(my_global_rank,
-                                    inBrick.location,
-                                    intersection.length(),
-                                    precision,
-                                    desc.inArrayType,
-                                    input[inBrickIdx],
-                                    intersection.offset_in_field(inBrick.stride)
-                                        - inBrick.offset_in_field(inBrick.stride),
-                                    inBrick.stride,
-                                    BufferPtr::temp(send_buf.data()),
-                                    send_offsets[outSubcommRank],
-                                    intersection.stride,
-                                    "pack brick for subcomm transpose"),
-                    inputAntecedents);
-                multiPlan[pack_op]->group = itemGroup;
-                multiPlan[pack_op]->description
-                    = "pack " + std::to_string(inBrickIdx) + " + " + std::to_string(outBrickIdx);
-                pack_ops.push_back(pack_op);
-            }
-
-            // unpack if this rank owns output brick
-            if(outRank == my_global_rank)
-            {
-                auto unpack_op = AddMultiPlanItem(
-                    transpose_brick(my_global_rank,
-                                    outBrick.location,
-                                    intersection.length(),
-                                    precision,
-                                    desc.inArrayType,
-                                    BufferPtr::temp(recv_buf.data()),
-                                    recv_offsets[inSubcommRank],
-                                    intersection.stride,
-                                    output[outBrickIdx],
-                                    intersection.offset_in_field(outBrick.stride)
-                                        - outBrick.offset_in_field(outBrick.stride),
-                                    outBrick.stride,
-                                    "unpack brick for subcomm transpose"),
-                    {});
-                multiPlan[unpack_op]->group = itemGroup;
-                multiPlan[unpack_op]->description
-                    = "unpack " + std::to_string(inBrickIdx) + " + " + std::to_string(outBrickIdx);
-                unpack_ops.push_back(unpack_op);
-            }
-        }
-    }
-
-    // add the all-to-all op itself, which depends on pack ops
-    auto alltoall_ptr = std::make_unique<CommAllToAll>(precision,
-                                                       desc.inArrayType,
-                                                       send_offsets,
-                                                       send_counts,
-                                                       recv_offsets,
-                                                       recv_counts,
-                                                       BufferPtr::temp(send_buf.data()),
-                                                       BufferPtr::temp(recv_buf.data()),
-                                                       std::move(subcomm));
-
-    auto alltoall_op                    = AddMultiPlanItem(std::move(alltoall_ptr), pack_ops);
-    multiPlan[alltoall_op]->group       = itemGroup;
-    multiPlan[alltoall_op]->description = "all-to-all communication (subcomm)";
-
-    // update the unpack ops to depend on the all-to-all
-    for(auto op : unpack_ops)
-    {
-        AddAntecedent(op, alltoall_op);
-    }
-
-    // subsequent operations can depend on the unpack ops
-    outputItems = unpack_ops;
-#endif
-}
 
 void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
                                        const rocfft_field_t&      inField,
@@ -3040,8 +2810,7 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
                             writeToUserOutput ? outputBufs : tempBufs,
                             currentAntecedents,
                             transposeItems,
-                            transposeNumber++,
-                            std::move(pencil_comm));
+                            transposeNumber++);
 
             currentField       = nextField;
             currentBufs        = tempBufs;

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -380,7 +380,7 @@ try
     case rocfft_comm_none:
     {
 #ifdef ROCFFT_MPI_ENABLE
-        description->user_mpi_comm = nullptr;
+        description->user_mpi_comm = MPI_COMM_NULL;
 #endif
         break;
     }

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -2358,20 +2358,6 @@ void rocfft_plan_t::GlobalTransposeA2ASubcomm(size_t                     elem_si
         }
     }
 
-    // check uniformity for alltoall within the subcomm
-    const bool uniform_counts
-        = std::all_of(
-              send_counts.begin(), send_counts.end(), [&](size_t c) { return c == send_counts[0]; })
-          && std::all_of(recv_counts.begin(), recv_counts.end(), [&](size_t c) {
-                 return c == recv_counts[0];
-             });
-
-    size_t uniform_count_inside_subcomm = 0;
-    if(uniform_counts)
-        uniform_count_inside_subcomm = send_counts[0];
-    else
-        throw std::runtime_error("Non-uniform send_counts in pencil subcomm!");
-
     // add the all-to-all op itself, which depends on pack ops
     auto alltoall_ptr = std::make_unique<CommAllToAll>(precision,
                                                        desc.inArrayType,
@@ -2381,10 +2367,7 @@ void rocfft_plan_t::GlobalTransposeA2ASubcomm(size_t                     elem_si
                                                        recv_counts,
                                                        BufferPtr::temp(send_buf.data()),
                                                        BufferPtr::temp(recv_buf.data()),
-                                                       uniform_counts,
                                                        std::move(subcomm));
-
-    alltoall_ptr->set_uniform_count_inside_subcomm(uniform_count_inside_subcomm);
 
     auto alltoall_op                    = AddMultiPlanItem(std::move(alltoall_ptr), pack_ops);
     multiPlan[alltoall_op]->group       = itemGroup;
@@ -2566,14 +2549,6 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
         }
     }
 
-    // check if uniform exchange to use MPI_Alltoall
-    const bool uniform_counts
-        = std::all_of(
-              send_counts.begin(), send_counts.end(), [&](size_t c) { return c == send_counts[0]; })
-          && std::all_of(recv_counts.begin(), recv_counts.end(), [&](size_t c) {
-                 return c == recv_counts[0];
-             });
-
     // add the all-to-all op itself, which depends on pack ops
     auto alltoall_ptr = std::make_unique<CommAllToAll>(precision,
                                                        desc.inArrayType,
@@ -2582,8 +2557,7 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
                                                        recv_offsets,
                                                        recv_counts,
                                                        BufferPtr::temp(send_buf.data()),
-                                                       BufferPtr::temp(recv_buf.data()),
-                                                       uniform_counts);
+                                                       BufferPtr::temp(recv_buf.data()));
 
     auto alltoall_op                    = AddMultiPlanItem(std::move(alltoall_ptr), pack_ops);
     multiPlan[alltoall_op]->group       = itemGroup;

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -2844,6 +2844,9 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
         inputFFTBufs.emplace_back(BufferPtr::temp(inputTemp.back().data()));
     }
 
+    std::vector<BufferPtr> outputBufs
+        = GatherUserBuffers(BufferPtr::user_output, desc.outFields.front().bricks);
+
     // plan FFTs along already contiguous dimensions
     std::vector<size_t> inputFFTItems;
     C2CField(
@@ -2918,7 +2921,8 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
 
             // create the next field by splitting using a heuristic approach
             rocfft_field_t nextField;
-            if(i == transpose_sequence.size() - 1)
+            bool           writeToUserOutput = i == transpose_sequence.size() - 1;
+            if(writeToUserOutput)
                 nextField = desc.outFields.front();
             else
                 nextField = MakeFieldWithPencilSplit(
@@ -2943,25 +2947,31 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
             if(!pencil_comm)
                 throw std::runtime_error("Failed to create a valid Pencil sub-communicator");
 
-            // allocate temp buffers for nextField,
-            // loop over the pencil_neighbors_vec (these are the global ranks in this subcomm)
+            // allocate temp buffers for nextField, though we only
+            // need to do this if we're in the middle of the
+            // transpose sequence (last one will write to output, not
+            // temp)
             std::vector<TempBufferLease> tempLeases;
             std::vector<BufferPtr>       tempBufs(nextField.bricks.size());
-            for(size_t b = 0; b < nextField.bricks.size(); ++b)
+
+            if(!writeToUserOutput)
             {
-                // Allocate a buffer only if this global rank owns the brick.
-                if(nextField.bricks[b].location.comm_rank == local_comm_rank)
+                for(size_t b = 0; b < nextField.bricks.size(); ++b)
                 {
-                    tempLeases.emplace_back(tempBuffers,
-                                            local_comm_rank,
-                                            nextField.bricks[b].location,
-                                            nextField.bricks[b].count_elems(),
-                                            elem_size);
-                    tempBufs[b] = BufferPtr::temp(tempLeases.back().data());
-                }
-                else
-                {
-                    tempBufs[b] = BufferPtr();
+                    // Allocate a buffer only if this global rank owns the brick.
+                    if(nextField.bricks[b].location.comm_rank == local_comm_rank)
+                    {
+                        tempLeases.emplace_back(tempBuffers,
+                                                local_comm_rank,
+                                                nextField.bricks[b].location,
+                                                nextField.bricks[b].count_elems(),
+                                                elem_size);
+                        tempBufs[b] = BufferPtr::temp(tempLeases.back().data());
+                    }
+                    else
+                    {
+                        tempBufs[b] = BufferPtr();
+                    }
                 }
             }
 
@@ -2971,7 +2981,7 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
                             currentField,
                             nextField,
                             currentBufs,
-                            tempBufs,
+                            writeToUserOutput ? outputBufs : tempBufs,
                             currentAntecedents,
                             transposeItems,
                             transposeNumber++,
@@ -2987,8 +2997,8 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
                 std::vector<size_t> fftItems;
                 C2CField(currentField,
                          {static_cast<size_t>(pencil_axis)},
-                         currentBufs,
-                         currentBufs,
+                         writeToUserOutput ? outputBufs : currentBufs,
+                         writeToUserOutput ? outputBufs : currentBufs,
                          currentAntecedents,
                          fftItems);
                 fft_done[pencil_axis] = 1;
@@ -3053,8 +3063,6 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
         }
 
         // transpose data to output layout and transform along remaining dimensions
-        std::vector<BufferPtr> outputBufs
-            = GatherUserBuffers(BufferPtr::user_output, desc.outFields.front().bricks);
         std::vector<size_t> finalTransposeItems;
         std::vector<size_t> finalFFTItems;
         GlobalTranspose(elem_size,

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -2186,7 +2186,10 @@ struct ConnectedRanks
             parent[rootA] = parent[rootB];
     }
 
-    // Get the set of ranks that's connected to a specified rank
+    // Get the set of ranks that's connected to a specified rank.
+    // MPI requires that the ranks in a sub-communicator be listed in
+    // the same order on all ranks in that sub-communicator, so a
+    // std::set helps ensure this ordering.
     std::set<int> get_connected(int rank)
     {
         // Compress the paths in the parent array so that each rank
@@ -2397,7 +2400,9 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
             }
         }
 
-        // create a subcommunicator with this subset
+        // create a subcommunicator with this subset - preserve order
+        // enforced by the std::set so that all ranks see the same
+        // ordering
         std::vector<int> comm_ranks_vec;
         std::copy(comm_ranks.begin(), comm_ranks.end(), std::back_inserter(comm_ranks_vec));
         subcomm = make_subcommunicator(mpi_comm, comm_ranks_vec);

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -2168,11 +2168,11 @@ struct ConnectedRanks
     // Get the root parent of a rank
     int get_root(int rank)
     {
-        // If rank is its own parent, that's the root
-        if(parent[rank] == rank)
-            return rank;
+        // If rank is its own parent, that's the root.
         // Otherwise, follow the links until we get to the root
-        return parent[rank] = get_root(parent[rank]);
+        if(parent[rank] != rank)
+            parent[rank] = get_root(parent[rank]);
+        return parent[rank];
     }
 
     // Add a connection between rankA and rankB

--- a/projects/rocfft/library/src/tree_node.cpp
+++ b/projects/rocfft/library/src/tree_node.cpp
@@ -597,7 +597,7 @@ void CommPointToPoint::ExecuteAsync(const rocfft_plan     plan,
                                           rocfft_type_to_mpi_type(precision, arrayType),
                                           destLocation.comm_rank,
                                           multiPlanIdx,
-                                          plan->desc.mpi_comm,
+                                          plan->mpi_comm,
                                           &request);
             if(mpiret != MPI_SUCCESS)
             {
@@ -614,7 +614,7 @@ void CommPointToPoint::ExecuteAsync(const rocfft_plan     plan,
                                           rocfft_type_to_mpi_type(precision, arrayType),
                                           srcLocation.comm_rank,
                                           multiPlanIdx,
-                                          plan->desc.mpi_comm,
+                                          plan->mpi_comm,
                                           &request);
             if(mpiret != MPI_SUCCESS)
             {
@@ -711,7 +711,7 @@ void CommScatter::ExecuteAsync(const rocfft_plan     plan,
                                               rocfft_type_to_mpi_type(precision, arrayType),
                                               op.destLocation.comm_rank,
                                               GetOperationCommTag(multiPlanIdx, opIdx),
-                                              plan->desc.mpi_comm,
+                                              plan->mpi_comm,
                                               &request);
                 if(mpiret != MPI_SUCCESS)
                 {
@@ -728,7 +728,7 @@ void CommScatter::ExecuteAsync(const rocfft_plan     plan,
                                               rocfft_type_to_mpi_type(precision, arrayType),
                                               srcLocation.comm_rank,
                                               GetOperationCommTag(multiPlanIdx, opIdx),
-                                              plan->desc.mpi_comm,
+                                              plan->mpi_comm,
                                               &request);
                 if(mpiret != MPI_SUCCESS)
                 {
@@ -848,7 +848,7 @@ void CommGather::ExecuteAsync(const rocfft_plan     plan,
                                        rocfft_type_to_mpi_type(precision, arrayType),
                                        destLocation.comm_rank,
                                        GetOperationCommTag(multiPlanIdx, opIdx),
-                                       plan->desc.mpi_comm,
+                                       plan->mpi_comm,
                                        &request);
                 if(rcmpi != MPI_SUCCESS)
                     throw std::runtime_error("MPI_Isend failed: " + std::to_string(rcmpi));
@@ -862,7 +862,7 @@ void CommGather::ExecuteAsync(const rocfft_plan     plan,
                                        rocfft_type_to_mpi_type(precision, arrayType),
                                        op.srcLocation.comm_rank,
                                        GetOperationCommTag(multiPlanIdx, opIdx),
-                                       plan->desc.mpi_comm,
+                                       plan->mpi_comm,
                                        &request);
                 if(rcmpi != MPI_SUCCESS)
                     throw std::runtime_error("MPI_Irecv failed: " + std::to_string(rcmpi));
@@ -945,7 +945,7 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
                                           recvBuf.get(in_buffer, out_buffer, local_comm_rank),
                                           send_count_bytes,
                                           MPI_CHAR,
-                                          plan->desc.mpi_comm,
+                                          mpi_comm,
                                           &request);
 
         if(mpiret != MPI_SUCCESS)
@@ -991,7 +991,7 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
                                            intRecvCounts.data(),
                                            intRecvOffsets.data(),
                                            rocfft_type_to_mpi_type(precision, arrayType),
-                                           plan->desc.mpi_comm,
+                                           mpi_comm,
                                            &request);
 
         if(mpiret != MPI_SUCCESS)

--- a/projects/rocfft/library/src/tree_node.cpp
+++ b/projects/rocfft/library/src/tree_node.cpp
@@ -924,11 +924,11 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
     if(subcomm)
     {
         int tmp_num_ranks = 0;
-        MPI_Comm_size(subcomm, &tmp_num_ranks);
+        MPI_Comm_size(*subcomm, &tmp_num_ranks);
         if(tmp_num_ranks < 0)
             throw std::runtime_error("Sub-communicator size is not positive");
         num_ranks = static_cast<size_t>(tmp_num_ranks);
-        MPI_Comm_rank(subcomm, &subcomm_rank);
+        MPI_Comm_rank(*subcomm, &subcomm_rank);
     }
     else
     {
@@ -974,7 +974,7 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
                                 recvBuf.get(in_buffer, out_buffer, local_comm_rank),
                                 send_count_bytes,
                                 MPI_CHAR,
-                                subcomm,
+                                *subcomm,
                                 &request);
 
         if(ret != MPI_SUCCESS)

--- a/projects/rocfft/library/src/tree_node.cpp
+++ b/projects/rocfft/library/src/tree_node.cpp
@@ -529,6 +529,16 @@ void MultiPlanItem::WaitCommRequests()
 #endif
 }
 
+#ifdef ROCFFT_MPI_ENABLE
+MPI_Comm MultiPlanItem::ActiveMPIComm(rocfft_plan plan) const
+{
+    if(subcomm)
+        return *subcomm;
+    else
+        return plan->mpi_comm;
+}
+#endif
+
 void CommPointToPoint::ExecuteAsync(const rocfft_plan     plan,
                                     void*                 in_buffer[],
                                     void*                 out_buffer[],
@@ -916,79 +926,13 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
     }
 
 #ifdef ROCFFT_MPI_ENABLE
-
-    // check that we have as many elems in our count/offset buffers as
-    // we have ranks
-    size_t num_ranks;
-    int    subcomm_rank;
-    if(subcomm)
-    {
-        int tmp_num_ranks = 0;
-        MPI_Comm_size(*subcomm, &tmp_num_ranks);
-        if(tmp_num_ranks < 0)
-            throw std::runtime_error("Sub-communicator size is not positive");
-        num_ranks = static_cast<size_t>(tmp_num_ranks);
-        MPI_Comm_rank(*subcomm, &subcomm_rank);
-    }
-    else
-    {
-        num_ranks = plan->get_local_comm_size();
-    }
-
-    if(sendOffsets.size() != num_ranks || sendCounts.size() != num_ranks
-       || recvOffsets.size() != num_ranks || recvCounts.size() != num_ranks)
-    {
-        throw std::runtime_error(
-            "CommAllToAll: number of counts/offsets does not match number of ranks");
-    }
-
-    int global_rank = local_comm_rank;
+    auto mpi_comm = ActiveMPIComm(plan);
 
     const auto  elem_size = element_size(precision, arrayType);
     MPI_Request request;
+    const int   local_comm_rank = plan->get_local_comm_rank();
 
-    if(subcomm)
-    {
-        if(LOG_PLAN_ENABLED())
-            log_plan("Using MPI_Ialltoall with sub-communicators\n");
-
-        // optimization with pencil sub-communicators
-        if(!uniform_counts)
-            throw std::runtime_error(
-                "CommAllToAll::ExecuteAsync: non-uniform counts in pencil subcomm!");
-
-        void* send_ptr = sendBuf.get(in_buffer, out_buffer, local_comm_rank);
-        void* recv_ptr = recvBuf.get(in_buffer, out_buffer, local_comm_rank);
-
-        if(!send_ptr || !recv_ptr)
-        {
-            throw std::runtime_error("Buffer pointer(s) are null!");
-        }
-
-        // in subcomm: sendCounts, recvCounts, etc are sized for num_ranks, indexed by subcomm_rank
-        const int send_count_bytes = static_cast<int>(sendCounts.front() * elem_size);
-
-        int ret = MPI_Ialltoall(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
-                                send_count_bytes,
-                                MPI_CHAR,
-                                recvBuf.get(in_buffer, out_buffer, local_comm_rank),
-                                send_count_bytes,
-                                MPI_CHAR,
-                                *subcomm,
-                                &request);
-
-        if(ret != MPI_SUCCESS)
-        {
-            char errmsg[MPI_MAX_ERROR_STRING];
-            int  errlen = 0;
-            MPI_Error_string(ret, errmsg, &errlen);
-            comm_status   = COMM_MPI_ERROR;
-            error_message = "MPI_Ialltoall (subcomm) failed on global rank "
-                            + std::to_string(global_rank) + ": " + std::string(errmsg);
-            return;
-        }
-    }
-    else if(uniform_counts)
+    if(uniform_counts)
     {
         if(LOG_PLAN_ENABLED())
             log_plan("Using MPI_Ialltoall\n");
@@ -1023,7 +967,6 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
             log_plan("Using MPI_Ialltoallv\n");
 
         // non-uniform exchange case (default)
-        const int local_comm_rank = plan->get_local_comm_rank();
 
         // MPI takes ints for everything, convert our size_t elements to int bytes
         auto convertToInt = [](const std::vector<size_t>& src, std::vector<int>& dest) {

--- a/projects/rocfft/library/src/tree_node.cpp
+++ b/projects/rocfft/library/src/tree_node.cpp
@@ -966,7 +966,7 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
         }
 
         // in subcomm: sendCounts, recvCounts, etc are sized for num_ranks, indexed by subcomm_rank
-        const int send_count_bytes = static_cast<int>(uniform_count_inside_subcomm * elem_size);
+        const int send_count_bytes = static_cast<int>(sendCounts.front() * elem_size);
 
         int ret = MPI_Ialltoall(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
                                 send_count_bytes,
@@ -1096,11 +1096,6 @@ void CommAllToAll::Print(rocfft_ostream& os, const int indent) const
             os << val << " ";
         os << "\n";
     };
-
-    // determine whether counts are uniform
-    auto count_matches_first = [&](size_t count) { return count == sendCounts[0]; };
-    bool uniform_counts = std::all_of(sendCounts.begin(), sendCounts.end(), count_matches_first)
-                          && std::all_of(recvCounts.begin(), recvCounts.end(), count_matches_first);
 
     os << indentStr << "CommAllToAll " << precision_name(precision) << " "
        << PrintArrayType(arrayType) << (uniform_counts ? " (MPI_Ialltoall)" : " (MPI_Ialltoallv)")

--- a/projects/rocfft/shared/mpi_worker.h
+++ b/projects/rocfft/shared/mpi_worker.h
@@ -231,6 +231,9 @@ static void gather_field_p2p(MPI_Comm                                  mpi_comm,
         const auto& brick       = bricks[i];
         size_t      brick_elems = compute_ptrdiff(brick.length(), brick.stride, 0, 0);
 
+        if(brick.rank != mpi_rank)
+            continue;
+
         void* brick_ptr   = nullptr;
         auto  local_brick = local_bricks.find(brick.device);
         if(local_brick != local_bricks.end())


### PR DESCRIPTION
## Motivation

Fixes potential issues with sub-communicators in MPI transforms.

## Technical Details

When an MPI rank creates a sub-communicator, the rank must be included in that sub-communicator.  Changed the planner to properly compute the disjoint sets of ranks that need to communicate.

Also generalized the use of sub-communicators, by allowing all global transpose operations to consider them.

Ensured that pencil-to-pencil MPI plans correctly set their final outputs to go into the user-defined buffers.

## Test Plan

Locally ran MPI and single-process multi-GPU test cases.  CI also runs multi-GPU tests.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
