### PR TITLE
fix(hipcub): fix incorrect args in cmake

### DIFF
--- a/projects/hipcub/CMakeLists.txt
+++ b/projects/hipcub/CMakeLists.txt
@@ -76,6 +76,9 @@ option(BUILD_COMPUTE_SANITIZER "Build tests with cuda's compute sanitizer enable
 check_language(HIP)
 cmake_dependent_option(USE_HIPCXX "Use CMake HIP language support" OFF CMAKE_HIP_COMPILER OFF)
 
+# Check and test cuda compiler, defines 'CMAKE_CUDA_COMPILER'
+check_language(CUDA)
+
 # Set the ROCM install directory.
 if(WIN32)
   set(ROCM_ROOT "$ENV{HIP_PATH}" CACHE PATH "Root directory of the ROCm installation")
@@ -146,9 +149,13 @@ elseif(NOT (CMAKE_CXX_COMPILER MATCHES ".*nvcc$" OR "${CMAKE_CXX_COMPILER_ID}" S
     endif()
     set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)
   endif()
-elseif(CMAKE_CXX_COMPILER MATCHES ".*nvcc$")
-  message(STATUS "Host compiler set to use NVCC (CMAKE_CXX_COMPILER) which is not well supported. Use a plain host compiler such as GCC or compile through HIPCC.")
-  add_compile_options(--forward-unknown-to-host-compiler)
+elseif(CMAKE_CUDA_COMPILER)
+  # We haven't detected HIP, so surely we must be on a CUDA-compatible compiler.
+  # Contrary to HIP, 'enable_language(CUDA)' is supported from CMake 3.8 and higher.
+  enable_language(CUDA)
+
+  # Hack: let CMake think that our 'hpp' and 'hip' files are actually CUDA files.
+  set(CMAKE_CUDA_SOURCE_FILE_EXTENSIONS hpp;hip;cu;cuh)
 endif()
 
 # Compressed offload binaries are currently not working with the SPIR-V target

--- a/projects/hipcub/CMakeLists.txt
+++ b/projects/hipcub/CMakeLists.txt
@@ -183,7 +183,8 @@ endif()
 include(CheckCXXCompilerFlag)
 
 if(BUILD_OFFLOAD_COMPRESS)
-  check_cxx_compiler_flag("--offload-compress" CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+  # We need to pass '-x hip' since check_cxx_compiler_flag assumes c++ and not HIP. 
+  check_cxx_compiler_flag("--offload-compress -x hip" CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
   if(CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --offload-compress")
   else()

--- a/projects/hipcub/CMakeLists.txt
+++ b/projects/hipcub/CMakeLists.txt
@@ -154,8 +154,8 @@ elseif(CMAKE_CUDA_COMPILER)
   # Contrary to HIP, 'enable_language(CUDA)' is supported from CMake 3.8 and higher.
   enable_language(CUDA)
 
-  # Hack: let CMake think that our 'hpp' and 'hip' files are actually CUDA files.
-  set(CMAKE_CUDA_SOURCE_FILE_EXTENSIONS hpp;hip;cu;cuh)
+  # Hack: let CMake think that our 'hip' files are actually CUDA files.
+  set(CMAKE_CUDA_SOURCE_FILE_EXTENSIONS hip;cu)
 endif()
 
 # Compressed offload binaries are currently not working with the SPIR-V target

--- a/projects/hipcub/CMakeLists.txt
+++ b/projects/hipcub/CMakeLists.txt
@@ -72,8 +72,12 @@ option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 option(BUILD_OFFLOAD_COMPRESS "Build hipCUB with offload compression" ON)
 option(BUILD_COMPUTE_SANITIZER "Build tests with cuda's compute sanitizer enabled" OFF)
 
+# Check and test cuda compiler, defines 'CMAKE_HIP_COMPILER'
 check_language(HIP)
 cmake_dependent_option(USE_HIPCXX "Use CMake HIP language support" OFF CMAKE_HIP_COMPILER OFF)
+
+# Check and test cuda compiler, defines 'CMAKE_CUDA_COMPILER'
+check_language(CUDA)
 
 # Set the ROCM install directory.
 if(WIN32)
@@ -116,33 +120,42 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker searc
 # If hip is included prior to setting that then it defaults to building only for the current architecture
 include(ROCmCMakeBuildToolsDependency)
 
-# Setup GPU targets for rocm platform
+# Detect compiler through use of result from 'check_language(...)'
 if(USE_HIPCXX)
   enable_language(HIP)
-else()
-  # Setup GPU targets for rocm platform
-  if(NOT (CMAKE_CXX_COMPILER MATCHES ".*nvcc$" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
-    if(NOT DEFINED AMDGPU_TARGETS)
-      set(GPU_TARGETS "all" CACHE STRING "GPU architectures to compile for")
-    else()
-      set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for")
-    endif()
-    set_property(CACHE GPU_TARGETS PROPERTY STRINGS "all")
+elseif(NOT (CMAKE_CXX_COMPILER MATCHES ".*nvcc$" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
+  # Detected HIP through archaic match by checking passed CXX compiler. This can
+  # be removed once we bump minimum CMake version to 3.21 or higher.
 
-    if(GPU_TARGETS STREQUAL "all")
-      if(BUILD_ADDRESS_SANITIZER)
-        # ASAN builds require xnack
-        rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-          TARGETS "gfx908:xnack+;gfx90a:xnack+;gfx942:xnack+;gfx950:xnack+"
-        )
-      else()
-        rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-          TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
-        )
-      endif()
-      set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)
-    endif()
+  # Setup GPU targets for rocm platform
+  message(STATUS "CMake could not derive language via 'check_language'. Falling back to legacy compiler checks.")
+  if(NOT DEFINED AMDGPU_TARGETS)
+    set(GPU_TARGETS "all" CACHE STRING "GPU architectures to compile for")
+  else()
+    set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for")
   endif()
+  set_property(CACHE GPU_TARGETS PROPERTY STRINGS "all")
+
+  if(GPU_TARGETS STREQUAL "all")
+    if(BUILD_ADDRESS_SANITIZER)
+      # ASAN builds require xnack
+      rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
+        TARGETS "gfx908:xnack+;gfx90a:xnack+;gfx942:xnack+;gfx950:xnack+"
+      )
+    else()
+      rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
+        TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
+      )
+    endif()
+    set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)
+  endif()
+elseif(CMAKE_CUDA_COMPILER)
+  # We haven't detected HIP, so surely we must be on a CUDA-compatible compiler.
+  # Contrary to HIP, 'enable_language(CUDA)' is supported from CMake 3.8 and higher.
+  enable_language(CUDA)
+
+  # Hack: let CMake think that our 'hpp' and 'hip' files are actually CUDA files.
+  set(CMAKE_CUDA_SOURCE_FILE_EXTENSIONS hpp;hip;cu;cuh)
 endif()
 
 # Compressed offload binaries are currently not working with the SPIR-V target

--- a/projects/hipcub/CMakeLists.txt
+++ b/projects/hipcub/CMakeLists.txt
@@ -76,9 +76,6 @@ option(BUILD_COMPUTE_SANITIZER "Build tests with cuda's compute sanitizer enable
 check_language(HIP)
 cmake_dependent_option(USE_HIPCXX "Use CMake HIP language support" OFF CMAKE_HIP_COMPILER OFF)
 
-# Check and test cuda compiler, defines 'CMAKE_CUDA_COMPILER'
-check_language(CUDA)
-
 # Set the ROCM install directory.
 if(WIN32)
   set(ROCM_ROOT "$ENV{HIP_PATH}" CACHE PATH "Root directory of the ROCm installation")
@@ -149,13 +146,9 @@ elseif(NOT (CMAKE_CXX_COMPILER MATCHES ".*nvcc$" OR "${CMAKE_CXX_COMPILER_ID}" S
     endif()
     set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)
   endif()
-elseif(CMAKE_CUDA_COMPILER)
-  # We haven't detected HIP, so surely we must be on a CUDA-compatible compiler.
-  # Contrary to HIP, 'enable_language(CUDA)' is supported from CMake 3.8 and higher.
-  enable_language(CUDA)
-
-  # Hack: let CMake think that our 'hpp' and 'hip' files are actually CUDA files.
-  set(CMAKE_CUDA_SOURCE_FILE_EXTENSIONS hpp;hip;cu;cuh)
+elseif(CMAKE_CXX_COMPILER MATCHES ".*nvcc$")
+  message(STATUS "Host compiler set to use NVCC (CMAKE_CXX_COMPILER) which is not well supported. Use a plain host compiler such as GCC or compile through HIPCC.")
+  add_compile_options(--forward-unknown-to-host-compiler)
 endif()
 
 # Compressed offload binaries are currently not working with the SPIR-V target


### PR DESCRIPTION
## Motivation

This fixes two issues relating to the build configuration in hipCUB:
1. Offload compression is broken due to `amdclang` no longer globally accepting HIP-related flags.
2. Fixes interaction between non-HIP environments and CMake. This also fixes issues where the host compiler is set to a non-standard CXX compiler (i.e. not GCC nor Clang). In that case we also emit a message as this was in a non-working state before this change as well.

## Technical Details

The first fix is quite simple and is resolved by passing `-xhip` to the check to ensure it is checked as it were a HIP-file.

For the second fix we'll leverage the fact we can use CMake's `enable_language(...)` due to our set minimum CMake version.

## Test Plan

Configure and build pass.

## Test Result

Works on my machine (tm), except for a few cases that are fixed by current open PRs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
