### PR TITLE
[rocSPARSE] remove ROCSPARSE_CLIENTS_RUN_BENCHMARK

### DIFF
--- a/projects/rocsparse/clients/include/utility.hpp
+++ b/projects/rocsparse/clients/include/utility.hpp
@@ -1004,47 +1004,4 @@ namespace rocsparse_clients
 
 }
 
-#define ROCSPARSE_CLIENTS_RUN_BENCHMARK(handle, arguments_, gpu_time_used_, func_)                 \
-    if(arguments_.iters_inner == 0)                                                                \
-    {                                                                                              \
-        std::cerr << "error " << __FUNCTION__ << ": arguments_.iters_inner is zero." << std::endl; \
-        CHECK_ROCSPARSE_ERROR(rocsparse_status_invalid_value);                                     \
-    }                                                                                              \
-                                                                                                   \
-    if(arguments_.iters == 0)                                                                      \
-    {                                                                                              \
-        std::cerr << "error " << __FUNCTION__ << ": arguments_.iters is zero." << std::endl;       \
-        CHECK_ROCSPARSE_ERROR(rocsparse_status_invalid_value);                                     \
-    }                                                                                              \
-                                                                                                   \
-    const int32_t n_cold_calls = 2;                                                                \
-    const int32_t n_sub_calls  = arguments_.iters_inner;                                           \
-    const int32_t n_calls      = arguments_.iters;                                                 \
-                                                                                                   \
-    hipStream_t stream;                                                                            \
-    rocsparse_get_stream(handle, &stream);                                                         \
-                                                                                                   \
-    for(int32_t iter = 0; iter < n_cold_calls; ++iter)                                             \
-    {                                                                                              \
-        CHECK_ROCSPARSE_ERROR(func_);                                                              \
-    }                                                                                              \
-                                                                                                   \
-    std::vector<double> gpu_time(n_calls);                                                         \
-                                                                                                   \
-    rocsparse_clients::timer t(stream);                                                            \
-    for(int32_t iter = 0; iter < n_calls; ++iter)                                                  \
-    {                                                                                              \
-        t.start();                                                                                 \
-        for(int32_t iter2 = 0; iter2 < n_sub_calls; ++iter2)                                       \
-        {                                                                                          \
-            std::ignore = func_;                                                                   \
-        }                                                                                          \
-        const double t_microseconds = (t.stop() * 1000);                                           \
-        gpu_time[iter]              = t_microseconds / n_sub_calls;                                \
-    }                                                                                              \
-                                                                                                   \
-    std::sort(gpu_time.begin(), gpu_time.end());                                                   \
-    const int32_t mid = n_calls / 2;                                                               \
-    gpu_time_used_ = (n_calls % 2 == 0) ? (gpu_time[mid] + gpu_time[mid - 1]) / 2 : gpu_time[mid];
-
 #endif // UTILITY_HPP

--- a/projects/rocsparse/clients/testings/testing_bsrxmv.cpp
+++ b/projects/rocsparse/clients/testings/testing_bsrxmv.cpp
@@ -316,9 +316,8 @@ void testing_bsrxmv(const Arguments& arg)
     {
 
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
-        double gpu_time_used;
-        ROCSPARSE_CLIENTS_RUN_BENCHMARK(
-            handle, arg, gpu_time_used, rocsparse_bsrxmv<T>(PARAMS(h_alpha, dA, dx, h_beta, dy)));
+        const double gpu_time_used = rocsparse_clients::run_benchmark(
+            arg, rocsparse_bsrxmv<T>, handle, h_alpha, dA, dx, h_beta, dy);
 
         //
         // Re-use bsrmv gflop and gbyte counts but with different parameters

--- a/projects/rocsparse/clients/testings/testing_bsrxmv.cpp
+++ b/projects/rocsparse/clients/testings/testing_bsrxmv.cpp
@@ -317,7 +317,7 @@ void testing_bsrxmv(const Arguments& arg)
 
         CHECK_ROCSPARSE_ERROR(rocsparse_set_pointer_mode(handle, rocsparse_pointer_mode_host));
         const double gpu_time_used = rocsparse_clients::run_benchmark(
-            arg, rocsparse_bsrxmv<T>, handle, h_alpha, dA, dx, h_beta, dy);
+            arg, rocsparse_bsrxmv<T>, PARAMS(h_alpha, dA, dx, h_beta, dy));
 
         //
         // Re-use bsrmv gflop and gbyte counts but with different parameters


### PR DESCRIPTION
This PR removes the `ROCSPARSE_CLIENTS_RUN_BENCHMARK` macro.