### PR TITLE
Remove hiprand dependency for hipfft samples, and fix it up for hipfft test with a cufft back-end.

### DIFF
--- a/projects/hipfft/clients/samples/CMakeLists.txt
+++ b/projects/hipfft/clients/samples/CMakeLists.txt
@@ -89,13 +89,6 @@ foreach( sample ${sample_list} )
       target_compile_options( ${sample} PRIVATE -arch sm_53 -gencode=arch=compute_53,code=sm_53 -Xptxas=-w)
     endif()
     target_link_libraries( ${sample} PRIVATE ${CUDA_LIBRARIES} )
-  else()
-    if( USE_HIPRAND AND NOT hiprand_FOUND )
-      find_package( hiprand REQUIRED )
-    endif()
-    if ( USE_HIPRAND )
-      target_link_libraries( ${sample} PRIVATE hip::hiprand )
-    endif()
   endif()
 
   target_include_directories( ${sample}

--- a/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
@@ -73,7 +73,7 @@ int main()
     }
 
     // Define list of GPUs to use
-    std::array<int, 2> gpus = {0, 1};
+    std::vector<int> gpus = {0, 1};
 
     // Create the multi-gpu plan
     hipLibXtDesc* desc; // input descriptor

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -133,15 +133,32 @@ foreach( target ${TEST_TARGETS} )
     CXX_STANDARD_REQUIRED ON
     )
 
-    if( BUILD_CLIENTS_TESTS_OPENMP )
-      set_target_properties( ${TEST_TARGETS} PROPERTIES
-         BUILD_RPATH "${BUILD_RPATH}"
-      )
-      set_target_properties( ${TEST_TARGETS} PROPERTIES
-        INSTALL_RPATH "${INSTALL_RPATH}"
-      )
-    endif()
+  if( BUILD_CLIENTS_TESTS_OPENMP )
+    set_target_properties( ${TEST_TARGETS} PROPERTIES
+       BUILD_RPATH "${BUILD_RPATH}"
+    )
+    set_target_properties( ${TEST_TARGETS} PROPERTIES
+      INSTALL_RPATH "${INSTALL_RPATH}"
+    )
+  endif()
 
+  if( NOT hiprand_FOUND )
+    find_package( hiprand REQUIRED )
+  endif()
+  if( USE_HIPRAND )
+    if( BUILD_WITH_LIB STREQUAL "CUDA" )
+      # nvcc doesn't know what do with hiprand.so.1.1, but we can try linking it to hiprand.so,
+      # assuming that it's in the same directory.
+      get_target_property( HIPRAND_FILE_PATH hip::hiprand LOCATION )
+      string( REGEX REPLACE ".so(.[0-9]*)*" ".so" HIPRAND_FILE_PATH_NOVER "${HIPRAND_FILE_PATH}" )
+      message( "Renamed hiprand so filename: ${HIPRAND_FILE_PATH_NOVER}" )
+      
+      target_link_libraries( ${target} PRIVATE ${HIPRAND_FILE_PATH_NOVER} )
+    else()
+      target_link_libraries( ${target} PRIVATE hip::hiprand )
+    endif()
+  endif()
+  
   if( BUILD_WITH_LIB STREQUAL "ROCM" )
     target_compile_options( ${target} PRIVATE ${WARNING_FLAGS} )
     target_link_libraries( ${target}
@@ -153,12 +170,6 @@ foreach( target ${TEST_TARGETS} )
       target_compile_options( ${target} PRIVATE --offload-arch=${gpu_target} )
     endforeach()
 
-    if( NOT hiprand_FOUND )
-      find_package( hiprand REQUIRED )
-    endif()
-    if( USE_HIPRAND )
-      target_link_libraries( ${target} PRIVATE hip::hiprand )
-    endif()
   else()
     target_compile_definitions( ${target} PRIVATE __HIP_PLATFORM_NVIDIA__)
     target_include_directories( ${target} PRIVATE ${HIP_INCLUDE_DIRS})
@@ -176,7 +187,6 @@ foreach( target ${TEST_TARGETS} )
     endif()
     target_compile_definitions( ${target} PUBLIC _CUFFT_BACKEND )
   endif()
-
 
   target_include_directories( ${target}
     PRIVATE

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -142,10 +142,11 @@ foreach( target ${TEST_TARGETS} )
     )
   endif()
 
-  if( NOT hiprand_FOUND )
-    find_package( hiprand REQUIRED )
-  endif()
   if( USE_HIPRAND )
+    if( NOT hiprand_FOUND )
+      find_package( hiprand REQUIRED )
+    endif()
+    
     if( BUILD_WITH_LIB STREQUAL "CUDA" )
       # nvcc doesn't know what do with hiprand.so.1.1, but we can try linking it to hiprand.so,
       # assuming that it's in the same directory.


### PR DESCRIPTION
## Motivation

hipFFT samples do not rely on hipRAND, so remove this cmake dependency.
hipFFT tests do need hipRAND, but this wasn't handled correctly for the cuFFT back-end.

## Technical Details

nvcc doesn't know what to do with shared objects that do not end in .so, so we need to use a regex to remove the so version information.

## Test Plan

Manual testing.

## Test Result

Manually works.