### PR TITLE
Make config dispatch optional with flag rocRAND

### DIFF
--- a/projects/rocrand/CHANGELOG.md
+++ b/projects/rocrand/CHANGELOG.md
@@ -10,6 +10,10 @@ Documentation for rocRAND is available at
 * Updated error handling for several rocRAND unit tests to accomodate the new hipGetLastError behaviour that was introduced in ROCm 7.0.
 As of ROCm 7.0, the internal error state is cleared on each call to `hipGetLastError` rather than on every HIP API call.
 
+### Changed
+
+* Changed the `USE_DEVICE_DISPATCH` flag so it can turn device dispatch off by setting it to zero. Device dispatch should be turned off when building for SPIRV.
+
 ## rocRAND 4.0.0 for ROCm 7.0
 
 ### Added

--- a/projects/rocrand/README.md
+++ b/projects/rocrand/README.md
@@ -96,6 +96,11 @@ ctest --output-on-failure
 [sudo] make install
 ```
 
+### SPIR-V
+
+rocRAND supports the `amdgcnspirv` target, but it should be built with `USE_DEVICE_DISPATCH`
+turned off like `-DUSE_DEVICE_DISPATCH=0`.
+
 ### HIP on Windows
 
 We've added initial support for HIP on Windows, which you can install using the `rmake.py` python

--- a/projects/rocrand/library/src/rng/common.hpp
+++ b/projects/rocrand/library/src/rng/common.hpp
@@ -26,8 +26,12 @@
     #define ROCRAND_DETAIL_BM_NOT_IN_STATE
 #endif
 
-#if !defined(USE_DEVICE_DISPATCH) && !defined(_WIN32) && defined(__HIP_PLATFORM_AMD__)
-    #define USE_DEVICE_DISPATCH
+#if !defined(USE_DEVICE_DISPATCH)
+    #if !defined(_WIN32) && defined(__HIP_PLATFORM_AMD__)
+        #define USE_DEVICE_DISPATCH 1
+    #else
+        #define USE_DEVICE_DISPATCH 0
+    #endif
 #endif
 
 #include <rocrand/rocrand_common.h>

--- a/projects/rocrand/library/src/rng/config_types.hpp
+++ b/projects/rocrand/library/src/rng/config_types.hpp
@@ -60,7 +60,7 @@ enum class target_arch : unsigned int
 /// @brief Returns the detected processor architecture of the device that is currently compiled against.
 __host__ __device__ constexpr target_arch get_device_arch()
 {
-#if !defined(USE_DEVICE_DISPATCH)
+#if !USE_DEVICE_DISPATCH
     return target_arch::unknown;
 #elif defined(__gfx900__)
     return target_arch::gfx900;
@@ -147,7 +147,7 @@ inline target_arch parse_gcn_arch(const std::string& arch_name)
 /// @return \ref hipSuccess if the querying was successful, a different error code otherwise.
 inline hipError_t get_device_arch([[maybe_unused]] int device_id, target_arch& arch)
 {
-#ifdef USE_DEVICE_DISPATCH
+#if USE_DEVICE_DISPATCH
     constexpr unsigned int          device_arch_cache_size             = 512;
     static std::atomic<target_arch> arch_cache[device_arch_cache_size] = {};
 
@@ -180,7 +180,7 @@ inline hipError_t get_device_arch([[maybe_unused]] int device_id, target_arch& a
     return hipSuccess;
 }
 
-#ifdef USE_DEVICE_DISPATCH
+#if USE_DEVICE_DISPATCH
 /// @brief Queries a device corresponding to a stream using the HIP API.
 /// @param stream The stream in question.
 /// @param device_id Out parameter. The result of the device query is written here.
@@ -212,7 +212,7 @@ inline hipError_t get_device_from_stream(const hipStream_t stream, int& device_i
 /// @return \ref hipSuccess if the querying was successful, a different error code otherwise.
 inline hipError_t get_device_arch(const hipStream_t stream, target_arch& arch)
 {
-#ifdef USE_DEVICE_DISPATCH
+#if USE_DEVICE_DISPATCH
     int              device_id;
     const hipError_t result = get_device_from_stream(stream, device_id);
     if(result != hipSuccess)

--- a/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
@@ -147,7 +147,7 @@ TEST(rocrand_config_dispatch_tests, get_config_on_host_and_device)
     ASSERT_EQ(grid_size, config.blocks);
 }
 
-#ifdef USE_DEVICE_DISPATCH
+#if USE_DEVICE_DISPATCH
 TEST(rocrand_config_dispatch_tests, device_id_from_stream)
 {
     using rocrand_impl::host::get_device_from_stream;


### PR DESCRIPTION
## Motivation

Made the USE_DEVICE_DISPATCH flag a set able flag. Setting it USE_DEVICE_DISPATCH=0 will not use custom configs. This is necessary currently when running it on SPIR-V.

## Technical Details

Changed how the USE_DEVICE_DISPATCH flag is used and set.

## Test Plan

Ran the tests with spirv with and without the flag set to zero.

## Test Result

With the flag set with zero all tests passed using spirv. Without did not.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
