### PR TITLE
fix(rocprim): fix incorrect stream being passed to device merge test

### DIFF
--- a/projects/rocprim/test/rocprim/test_device_merge.cpp
+++ b/projects/rocprim/test/rocprim/test_device_merge.cpp
@@ -557,7 +557,7 @@ void testMergeMismatchedIteratorTypes()
                                      keys_input1.size(),
                                      keys_input1.size(),
                                      rocprim::less<int>{},
-                                     hipStreamDefault,
+                                     stream,
                                      debug_synchronous));
 
     if(UseGraphs)


### PR DESCRIPTION
## Motivation

Resolves the following error in Azure CI.

```
[----------] 2 tests from RocprimDeviceMergeTests
[ RUN      ] RocprimDeviceMergeTests.MergeMismatchedIteratorTypes
[       OK ] RocprimDeviceMergeTests.MergeMismatchedIteratorTypes (0 ms)
[ RUN      ] RocprimDeviceMergeTests.MergeMismatchedIteratorTypesWithGraphs
HIP error: operation would make the legacy stream depend on a capturing blocking stream file: /agent/_work/1/s/test/rocprim/test_device_merge.cpp line: 561
```

From: https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=54638&view=logs&j=23014b5f-cf62-5b7c-8b42-fafeac224ac9&t=58f3d0c6-e656-594b-afc4-c97897f87e11

## Technical Details

Someone did an oopsie (used mixed stream) and this unoopsies it (now is all the same stream).

## Test Plan

CI should no longer be sad.

## Test Result

CI is happy :)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
