### PR TITLE
[hipfft][tests] Skipping some symptomatic cases with cuFFT backend + clear externally-managed work areas while runtime is initialized

### DIFF
--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -621,6 +621,8 @@ int main(int argc, char* argv[])
     std::cout << "double precision max l-inf epsilon: " << max_linf_eps_double << std::endl;
     std::cout << "double precision max l2 epsilon:     " << max_l2_eps_double << std::endl;
 
+    hipfft_params::externally_managed_workareas.clear();
+
     return retval;
 }
 

--- a/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
+++ b/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
@@ -34,6 +34,7 @@
 #include "../../shared/accuracy_test.h"
 #include "../../shared/fftw_transform.h"
 #include "../../shared/gpubuf.h"
+#include "../../shared/params_gen.h"
 #include "../../shared/rocfft_against_fftw.h"
 #include "../../shared/rocfft_complex.h"
 #include "../../shared/subprocess.h"
@@ -41,6 +42,21 @@
 extern std::string mp_launch;
 
 extern last_cpu_fft_cache last_cpu_fft_data;
+
+// clang-format off
+// tokens of tests found to be symptomatic
+static const std::vector<std::string> symptomatic_tokens = {
+#ifndef _CUFFT_BACKEND
+// cases specific to ROCM backend
+#else
+    // cases specific to CUFFT backend
+    "real_forward_len_16384_half_ip_batch_4_istride_1_R_ostride_1_HI_idist_16386_odist_8193_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_32768_half_ip_batch_4_istride_1_R_ostride_1_HI_idist_32770_odist_16385_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_65536_half_ip_batch_2_istride_1_R_ostride_1_HI_idist_65538_odist_32769_ioffset_0_0_ooffset_0_0",
+#endif
+    // common  to both backends
+};
+// clang-format on
 
 void fft_vs_reference(hipfft_params& params, bool round_trip)
 {
@@ -78,23 +94,19 @@ TEST_P(accuracy_test, vs_fftw)
     {
     case fft_params::fft_mp_lib_none:
     {
-#ifdef _CUFFT_BACKEND
-        // skipping tests that are found symptomatic with CUFFT backend
-        const std::vector<std::string> symptomatic_tokens_with_cufft
-            = {"real_forward_len_16384_half_ip_batch_4_istride_1_R_ostride_1_HI_idist_16386_odist_"
-               "8193_ioffset_0_0_ooffset_0_0",
-               "real_forward_len_32768_half_ip_batch_4_istride_1_R_ostride_1_HI_idist_32770_odist_"
-               "16385_ioffset_0_0_ooffset_0_0",
-               "real_forward_len_65536_half_ip_batch_2_istride_1_R_ostride_1_HI_idist_65538_odist_"
-               "32769_ioffset_0_0_ooffset_0_0"};
-        if(std::find(symptomatic_tokens_with_cufft.begin(),
-                     symptomatic_tokens_with_cufft.end(),
-                     params.token())
-           != symptomatic_tokens_with_cufft.end())
+        // skipping symptomatic case(s), unless forcefully/knowingly executing normally-disabled
+        // test tokens (e.g., by using --gtest_also_run_disabled_tests)
+        const char* test_suite_name
+            = ::testing::UnitTest::GetInstance()->current_test_info()->test_suite_name();
+        if(!symptomatic_tokens.empty() && std::strstr(test_suite_name, "DISABLED") == nullptr
+           && std::find(symptomatic_tokens.begin(), symptomatic_tokens.end(), params.token())
+                  != symptomatic_tokens.end())
         {
-            GTEST_SKIP() << "Test currently disabled with cuFFT backend (force-skipping)";
+            GTEST_SKIP()
+                << "Symptomatic test that's currently disabled by default (force-skipping). Use "
+                   "CLI arguments '--gtest_also_run_disabled_tests' to force the test execution "
+                   "(via another test suite).";
         }
-#endif
         // only do round trip for forward FFTs
         const bool do_round_trip = params.is_forward();
 
@@ -157,6 +169,11 @@ TEST_P(accuracy_test, vs_fftw)
 
     SUCCEED();
 }
+
+INSTANTIATE_TEST_SUITE_P(DISABLED_symptomatic_tokens,
+                         accuracy_test,
+                         ::testing::ValuesIn(param_generator_token(test_prob, symptomatic_tokens)),
+                         accuracy_test::TestName);
 
 #ifdef __HIP__
 

--- a/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
+++ b/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
@@ -78,6 +78,23 @@ TEST_P(accuracy_test, vs_fftw)
     {
     case fft_params::fft_mp_lib_none:
     {
+#ifdef _CUFFT_BACKEND
+        // skipping tests that are found symptomatic with CUFFT backend
+        const std::vector<std::string> symptomatic_tokens_with_cufft
+            = {"real_forward_len_16384_half_ip_batch_4_istride_1_R_ostride_1_HI_idist_16386_odist_"
+               "8193_ioffset_0_0_ooffset_0_0",
+               "real_forward_len_32768_half_ip_batch_4_istride_1_R_ostride_1_HI_idist_32770_odist_"
+               "16385_ioffset_0_0_ooffset_0_0",
+               "real_forward_len_65536_half_ip_batch_2_istride_1_R_ostride_1_HI_idist_65538_odist_"
+               "32769_ioffset_0_0_ooffset_0_0"};
+        if(std::find(symptomatic_tokens_with_cufft.begin(),
+                     symptomatic_tokens_with_cufft.end(),
+                     params.token())
+           != symptomatic_tokens_with_cufft.end())
+        {
+            GTEST_SKIP() << "Test currently disabled with cuFFT backend (force-skipping)";
+        }
+#endif
         // only do round trip for forward FFTs
         const bool do_round_trip = params.is_forward();
 


### PR DESCRIPTION
## Motivation

The test tokens
`real_forward_len_16384_half_ip_batch_4_istride_1_R_ostride_1_HI_idist_16386_odist_8193_ioffset_0_0_ooffset_0_0`,
`real_forward_len_32768_half_ip_batch_4_istride_1_R_ostride_1_HI_idist_32770_odist_16385_ioffset_0_0_ooffset_0_0`,
`real_forward_len_65536_half_ip_batch_2_istride_1_R_ostride_1_HI_idist_65538_odist_32769_ioffset_0_0_ooffset_0_0`
are failing with cuFFT backend.
This PR suggests to skip them explicitly.

## Technical Details

Self-explanatory, see title.

## Test Plan

Tested locally, will be covered in automated tests, too.

## Test Result

Symptomatic tests are skipped instead of triggering (hipfft) test failures.
