### PR TITLE
Declare get_sreg_lanemask functions as inline

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/intrinsics/thread.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/intrinsics/thread.hpp
@@ -165,28 +165,28 @@ auto flat_block_id()
            (blockIdx.z * gridDim.y * gridDim.x);
 }
 // Returns the warp lane mask of all lanes less than the calling thread
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+ROCPRIM_DEVICE ROCPRIM_INLINE
 uint64_t get_sreg_lanemask_lt()
 {
     return (uint64_t(1) << ::rocprim::lane_id()) - 1;
 }
 
 // Returns the warp lane mask of all lanes less than or equal to the calling thread
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+ROCPRIM_DEVICE ROCPRIM_INLINE
 uint64_t get_sreg_lanemask_le()
 {
     return ((uint64_t(1) << ::rocprim::lane_id()) << 1) - 1;
 }
 
 // Returns the warp lane mask of all lanes greater than the calling thread
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+ROCPRIM_DEVICE ROCPRIM_INLINE
 uint64_t get_sreg_lanemask_gt()
 {
     return uint64_t(-1) ^ get_sreg_lanemask_le();
 }
 
 // Returns the warp lane mask of all lanes greater than or equal to the calling thread
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE
+ROCPRIM_DEVICE ROCPRIM_INLINE
 uint64_t get_sreg_lanemask_ge()
 {
     return uint64_t(-1) ^ get_sreg_lanemask_lt();


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/rocm-libraries/issues/1733.

## Technical Details

Newly added functions, `get_sreg_lanemask_lt`, `get_sreg_lanemask_le`, `get_sreg_lanemask_gt` and `get_sreg_lanemask_ge` are currently declared with `ROCPRIM_FORCE_INLINE` which does not actually make the function inline. This is causing duplicate symbol errors as highlighted in the above ticket. Changing to `ROCPRIM_INLINE` which expands to `inline` and resolves linking errors.

Similar functions in `thread.hpp` are also marked with `ROCPRIM_INLINE`.

## Test Plan

User tested changes in above ticket.

## Test Result

Duplicate symbol errors were resolved with changes and code built successfully.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
