### PR TITLE
[rocsparse] Fix compilation error caused by no std::fma for _Float16 type

### DIFF
--- a/projects/rocsparse/clients/common/rocsparse_host.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_host.cpp
@@ -5333,9 +5333,9 @@ void rocsparse_host<T, I, J, A, B, C>::csrddmm(rocsparse_operation  transA,
             T sum = static_cast<T>(0);
             for(J k = 0; k < K; ++k)
             {
-                sum = std::fma(x[incx * k], y[incy * k], sum);
+                sum += x[incx * k] * y[incy * k];
             }
-            csr_val_C[at] = std::fma(b, csr_val_C[at], a * sum);
+            csr_val_C[at] = b * csr_val_C[at] + a * sum;
         }
     }
 }


### PR DESCRIPTION
## Motivation

Fix Windows compilation failures introduced in the PR https://github.com/ROCm/rocm-libraries/pull/1424 related to using `std::fma` with `_Float16` type.

## Technical Details

In the host reference solution for csrddmm, we were getting compilation failures related to the fact that no `std::fma` for `_Float16` type was found. This `std::fma` was introduced as part of this PR: https://github.com/ROCm/rocm-libraries/pull/1424. The solution here is to revert this change in the host solution and get building on Windows working again.

## Test Plan

Ensure compilation succeeds and all tests pass.
