### PR TITLE
Shrink trampoline logic

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
@@ -155,22 +155,6 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     block_store_key().store(keys, sample_buffer, size, storage.store);
 }
 
-template<class Config, class KeysIterator, class BinaryFunction>
-inline hipError_t launch_block_sort(detail::target_arch arch,
-                                    KeysIterator        keys,
-                                    const unsigned int  size,
-                                    BinaryFunction      compare_function,
-                                    dim3                grid,
-                                    dim3                block,
-                                    size_t              shmem,
-                                    hipStream_t         stream)
-{
-    auto kernel = [=](auto arch_config)
-    { block_sort_kernel_impl<decltype(arch_config)>(keys, size, compare_function); };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 template<class ArchConfig, class KeysIterator, class BinaryFunction>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void find_splitters_kernel_impl(
                                KeysIterator                                             keys,
@@ -211,31 +195,6 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void find_splitters_kernel_impl(
     }
 
     equality_buckets[idx] = equality_bucket;
-}
-
-template<class Config, class KeysIterator, class BinaryFunction>
-inline hipError_t
-    launch_find_splitters(detail::target_arch                                      arch,
-                          KeysIterator                                             keys,
-                          typename std::iterator_traits<KeysIterator>::value_type* tree,
-                          bool*                                                    equality_buckets,
-                          const unsigned int                                       size,
-                          BinaryFunction                                           compare_function,
-                          dim3                                                     grid,
-                          dim3                                                     block,
-                          size_t                                                   shmem,
-                          hipStream_t                                              stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        find_splitters_kernel_impl<decltype(arch_config)>(keys,
-                                                          tree,
-                                                          equality_buckets,
-                                                          size,
-                                                          compare_function);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class ArchConfig, class KeysIterator, class BinaryFunction>
@@ -342,33 +301,6 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     }
 }
 
-template<class Config, class KeysIterator, class BinaryFunction>
-inline hipError_t
-    launch_count_bucket_sizes(detail::target_arch                                      arch,
-                              KeysIterator                                             keys,
-                              typename std::iterator_traits<KeysIterator>::value_type* tree,
-                              const unsigned int                                       size,
-                              unsigned int*                                            buckets,
-                              bool*          equality_buckets,
-                              BinaryFunction compare_function,
-                              dim3           grid,
-                              dim3           block,
-                              size_t         shmem,
-                              hipStream_t    stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        count_bucket_sizes_kernel_impl<decltype(arch_config)>(keys,
-                                                              tree,
-                                                              size,
-                                                              buckets,
-                                                              equality_buckets,
-                                                              compare_function);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 template<class ArchConfig>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     find_nth_element_bucket_kernel_impl(unsigned int*                      buckets,
@@ -413,29 +345,6 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
         nth_element_data->equality_bucket = equality_buckets[nth_element];
         nth_element_data->bucket_idx      = nth_element;
     }
-}
-
-template<class Config>
-inline hipError_t launch_find_nth_element_bucket(detail::target_arch          arch,
-                                                 unsigned int*                buckets,
-                                                 n_th_element_iteration_data* nth_element_data,
-                                                 bool*                        equality_buckets,
-                                                 const unsigned int           rank,
-                                                 dim3                         grid,
-                                                 dim3                         block,
-                                                 size_t                       shmem,
-                                                 hipStream_t                  stream)
-
-{
-    auto kernel = [=](auto arch_config)
-    {
-        find_nth_element_bucket_kernel_impl<decltype(arch_config)>(buckets,
-                                                                   nth_element_data,
-                                                                   equality_buckets,
-                                                                   rank);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<class ArchConfig, unsigned int NumPartitions, class KeysIterator, class BinaryFunction, class WrappedBlockId>
@@ -637,46 +546,9 @@ template<class Config,
          class KeysIterator,
          class BinaryFunction,
          class WrappedBlockId>
-inline hipError_t
-    launch_copy_buckets(detail::target_arch                                      arch,
-                        KeysIterator                                             keys,
-                        typename std::iterator_traits<KeysIterator>::value_type* tree,
-                        const unsigned int                                       size,
-                        nth_element_onesweep_lookback_state*                     lookback_states,
-                        n_th_element_iteration_data*                             nth_element_data,
-                        typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
-                        bool*                                                    equality_buckets,
-                        BinaryFunction                                           compare_function,
-                        WrappedBlockId                                           ordered_bid,
-                        dim3                                                     grid,
-                        dim3                                                     block,
-                        size_t                                                   shmem,
-                        hipStream_t                                              stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        copy_buckets_kernel_impl<decltype(arch_config), NumPartitions>(keys,
-                                                                       tree,
-                                                                       size,
-                                                                       lookback_states,
-                                                                       nth_element_data,
-                                                                       keys_buffer,
-                                                                       equality_buckets,
-                                                                       compare_function,
-                                                                       ordered_bid);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
-template<class Config,
-         unsigned int NumPartitions,
-         class KeysIterator,
-         class BinaryFunction,
-         class WrappedBlockId>
 ROCPRIM_INLINE
 hipError_t
-    nth_element_keys_impl(detail::target_arch                                      arch,
+    nth_element_keys_impl(detail::target_arch                                      target_arch,
                           KeysIterator                                             keys,
                           typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
                           typename std::iterator_traits<KeysIterator>::value_type* tree,
@@ -740,47 +612,60 @@ hipError_t
         ROCPRIM_RETURN_ON_ERROR(ordered_bid.reset_from_host(stream));
 
         start_timer();
-        ROCPRIM_RETURN_ON_ERROR(launch_find_splitters<Config>(arch,
-                                                              keys,
+        auto find_splitters_kernel = [=](auto arch_config)
+        {
+            find_splitters_kernel_impl<decltype(arch_config)>(keys,
                                                               tree,
                                                               equality_buckets,
                                                               size,
-                                                              compare_function,
-                                                              1,
-                                                              num_splitters,
-                                                              0,
-                                                              stream));
+                                                              compare_function);
+        };
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<Config>(target_arch,
+                                                            find_splitters_kernel,
+                                                            1,
+                                                            num_splitters,
+                                                            0,
+                                                            stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("find_splitters_kernel", size, start);
 
         start_timer();
-        ROCPRIM_RETURN_ON_ERROR(launch_count_bucket_sizes<Config>(arch,
-                                                                  keys,
+        auto count_bucket_sizes_kernel = [=](auto arch_config)
+        {
+            count_bucket_sizes_kernel_impl<decltype(arch_config)>(keys,
                                                                   tree,
                                                                   size,
                                                                   buckets,
                                                                   equality_buckets,
-                                                                  compare_function,
-                                                                  num_blocks,
-                                                                  num_threads_per_block,
-                                                                  0,
-                                                                  stream));
+                                                                  compare_function);
+        };
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<Config>(target_arch,
+                                                            count_bucket_sizes_kernel,
+                                                            num_blocks,
+                                                            num_threads_per_block,
+                                                            0,
+                                                            stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("count_bucket_sizes_kernel", size, start);
 
         start_timer();
-        ROCPRIM_RETURN_ON_ERROR(launch_find_nth_element_bucket<Config>(arch,
-                                                                       buckets,
+        auto find_nth_element_bucket_kernel = [=](auto arch_config)
+        {
+            find_nth_element_bucket_kernel_impl<decltype(arch_config)>(buckets,
                                                                        nth_element_data,
                                                                        equality_buckets,
-                                                                       rank,
-                                                                       1,
-                                                                       num_buckets,
-                                                                       0,
-                                                                       stream));
+                                                                       rank);
+        };
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<Config>(target_arch,
+                                                            find_nth_element_bucket_kernel,
+                                                            1,
+                                                            num_buckets,
+                                                            0,
+                                                            stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("find_nth_element_bucket_kernel", size, start);
 
         start_timer();
-        ROCPRIM_RETURN_ON_ERROR(launch_copy_buckets<Config, num_partitions>(arch,
-                                                                            keys,
+        auto copy_buckets_kernel = [=](auto arch_config)
+        {
+            copy_buckets_kernel_impl<decltype(arch_config), num_partitions>(keys,
                                                                             tree,
                                                                             size,
                                                                             lookback_states,
@@ -788,11 +673,14 @@ hipError_t
                                                                             keys_buffer,
                                                                             equality_buckets,
                                                                             compare_function,
-                                                                            ordered_bid,
-                                                                            num_blocks,
-                                                                            num_threads_per_block,
-                                                                            0,
-                                                                            stream));
+                                                                            ordered_bid);
+        };
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<Config>(target_arch,
+                                                            copy_buckets_kernel,
+                                                            num_blocks,
+                                                            num_threads_per_block,
+                                                            0,
+                                                            stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("copy_buckets_kernel", size, start);
 
         // Copy the results in keys_buffer back to the keys
@@ -829,14 +717,15 @@ hipError_t
     }
 
     start_timer();
-    ROCPRIM_RETURN_ON_ERROR(launch_block_sort<Config>(arch,
-                                                      keys,
-                                                      size,
-                                                      compare_function,
-                                                      1,
-                                                      stop_recursion_size,
-                                                      0,
-                                                      stream));
+    auto block_sort_kernel = [=](auto arch_config)
+    { block_sort_kernel_impl<decltype(arch_config)>(keys, size, compare_function); };
+
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<Config>(target_arch,
+                                                        block_sort_kernel,
+                                                        1,
+                                                        stop_recursion_size,
+                                                        0,
+                                                        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_block_sort", size, start);
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
@@ -131,12 +131,14 @@ void search_kernel_shared_impl(InputIterator1 input,
     const unsigned int flat_id       = rocprim::detail::block_thread_id<0>();
     const unsigned int flat_block_id = rocprim::detail::block_id<0>();
 
-    const size_t block_offset = flat_block_id * items_per_block;
-    const size_t offset       = flat_id * items_per_thread;
-    bool find_pattern = false;
+    const size_t                                     block_offset = flat_block_id * items_per_block;
+    const size_t                                     offset       = flat_id * items_per_thread;
+    bool                                             find_pattern = false;
 
-    ROCPRIM_SHARED_MEMORY uninitialized_array<key_type, max_shared_key> local_keys_;
-    ROCPRIM_SHARED_MEMORY uninitialized_array<value_type, items_per_block> local_input_;
+    ROCPRIM_SHARED_MEMORY
+    uninitialized_array<key_type, max_shared_key>    local_keys_;
+    ROCPRIM_SHARED_MEMORY
+    uninitialized_array<value_type, items_per_block> local_input_;
 
     // Check if a key was already found in a place before this block
     if(block_offset > atomic_load(output))
@@ -250,127 +252,23 @@ void search_kernel_shared_impl(InputIterator1 input,
     }
 }
 
-template<class Config, class InputIterator1, class InputIterator2, class BinaryFunction>
-struct search_impl_kernels
+template<class T>
+static ROCPRIM_KERNEL
+void set_output_kernel(T* output, T value)
 {
-    inline static hipError_t launch_search_shared(detail::target_arch arch,
-                                                  InputIterator1      input,
-                                                  InputIterator2      keys,
-                                                  size_t*             output,
-                                                  size_t              size,
-                                                  size_t              keys_size,
-                                                  BinaryFunction      compare_function,
-                                                  dim3                grid,
-                                                  dim3                block,
-                                                  size_t              shmem,
-                                                  hipStream_t         stream)
+    *output = value;
+}
+
+template<class T>
+static ROCPRIM_KERNEL
+void reverse_index_kernel(T* output, T size, T keys_size)
+{
+    // Return the reverse index as long as the index is lower than the size.
+    if(*output < size)
     {
-        auto kernel = [=](auto arch_config)
-        {
-            search_kernel_shared_impl<decltype(arch_config)>(input,
-                                                             keys,
-                                                             output,
-                                                             size,
-                                                             keys_size,
-                                                             compare_function);
-        };
-
-        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
+        *output = size - keys_size - *output;
     }
-
-    inline static hipError_t launch_search(detail::target_arch arch,
-                                           InputIterator1      input,
-                                           InputIterator2      keys,
-                                           size_t*             output,
-                                           size_t              size,
-                                           size_t              keys_size,
-                                           BinaryFunction      compare_function,
-                                           dim3                grid,
-                                           dim3                block,
-                                           size_t              shmem,
-                                           hipStream_t         stream)
-    {
-        auto kernel = [=](auto arch_config)
-        {
-            search_kernel_impl<decltype(arch_config)>(input,
-                                                      keys,
-                                                      output,
-                                                      size,
-                                                      keys_size,
-                                                      compare_function);
-        };
-
-        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-    }
-
-    inline static hipError_t launch_search_shared(detail::target_arch              arch,
-                                                  reverse_iterator<InputIterator1> input,
-                                                  reverse_iterator<InputIterator2> keys,
-                                                  size_t*                          output,
-                                                  size_t                           size,
-                                                  size_t                           keys_size,
-                                                  BinaryFunction                   compare_function,
-                                                  dim3                             grid,
-                                                  dim3                             block,
-                                                  size_t                           shmem,
-                                                  hipStream_t                      stream)
-    {
-        auto kernel = [=](auto arch_config)
-        {
-            search_kernel_shared_impl<decltype(arch_config)>(input,
-                                                             keys,
-                                                             output,
-                                                             size,
-                                                             keys_size,
-                                                             compare_function);
-        };
-
-        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-    }
-
-    inline static hipError_t launch_search(detail::target_arch              arch,
-                                           reverse_iterator<InputIterator1> input,
-                                           reverse_iterator<InputIterator2> keys,
-                                           size_t*                          output,
-                                           size_t                           size,
-                                           size_t                           keys_size,
-                                           BinaryFunction                   compare_function,
-                                           dim3                             grid,
-                                           dim3                             block,
-                                           size_t                           shmem,
-                                           hipStream_t                      stream)
-    {
-        auto kernel = [=](auto arch_config)
-        {
-            search_kernel_impl<decltype(arch_config)>(input,
-                                                      keys,
-                                                      output,
-                                                      size,
-                                                      keys_size,
-                                                      compare_function);
-        };
-
-        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-    }
-
-    template<class T>
-    static ROCPRIM_KERNEL
-    void set_output_kernel(T* output, T value)
-    {
-        *output = value;
-    }
-
-    template<class T>
-    static ROCPRIM_KERNEL
-    void reverse_index_kernel(T* output, T size, T keys_size)
-    {
-        // Return the reverse index as long as the index is lower than the size.
-        if(*output < size)
-        {
-            *output = size - keys_size - *output;
-        }
-    }
-};
+}
 
 template<class Config,
          bool find_first,
@@ -395,8 +293,6 @@ hipError_t search_impl(void*          temporary_storage,
     using output_type = typename std::iterator_traits<OutputIterator>::value_type;
 
     using config = wrapped_search_config<Config, input_type>;
-    using search_kernels
-        = search_impl_kernels<config, InputIterator1, InputIterator2, BinaryFunction>;
 
     target_arch target_arch;
     ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
@@ -435,8 +331,7 @@ hipError_t search_impl(void*          temporary_storage,
     size_t* tmp_output = reinterpret_cast<size_t*>(temporary_storage);
 
     start_timer();
-    search_kernels::set_output_kernel<<<1, 1, 0, stream>>>(tmp_output,
-                                                           find_first && keys_size <= 0 ? 0 : size);
+    set_output_kernel<<<1, 1, 0, stream>>>(tmp_output, find_first && keys_size <= 0 ? 0 : size);
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("set_output_kernel", 1, start);
 
     if(size > 0 && keys_size > 0)
@@ -447,34 +342,42 @@ hipError_t search_impl(void*          temporary_storage,
             if constexpr(find_first)
             {
                 start_timer();
-                ROCPRIM_RETURN_ON_ERROR(search_kernels::launch_search_shared(target_arch,
-                                                                             input,
-                                                                             keys,
-                                                                             tmp_output,
-                                                                             size,
-                                                                             keys_size,
-                                                                             compare_function,
-                                                                             num_blocks,
-                                                                             block_size,
-                                                                             0,
-                                                                             stream));
+                auto search_shared_kernel = [=](auto arch_config)
+                {
+                    search_kernel_shared_impl<decltype(arch_config)>(input,
+                                                                     keys,
+                                                                     tmp_output,
+                                                                     size,
+                                                                     keys_size,
+                                                                     compare_function);
+                };
+                ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                    search_shared_kernel,
+                                                                    num_blocks,
+                                                                    block_size,
+                                                                    0,
+                                                                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel_shared", size, start);
             }
             else
             {
                 start_timer();
-                ROCPRIM_RETURN_ON_ERROR(search_kernels::launch_search_shared(
-                    target_arch,
-                    rocprim::make_reverse_iterator(input + size),
-                    rocprim::make_reverse_iterator(keys + keys_size),
-                    tmp_output,
-                    size,
-                    keys_size,
-                    compare_function,
-                    num_blocks,
-                    block_size,
-                    0,
-                    stream));
+                auto search_shared_kernel = [=](auto arch_config)
+                {
+                    search_kernel_shared_impl<decltype(arch_config)>(
+                        rocprim::make_reverse_iterator(input + size),
+                        rocprim::make_reverse_iterator(keys + keys_size),
+                        tmp_output,
+                        size,
+                        keys_size,
+                        compare_function);
+                };
+                ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                    search_shared_kernel,
+                                                                    num_blocks,
+                                                                    block_size,
+                                                                    0,
+                                                                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel_shared", size, start);
             }
         }
@@ -483,34 +386,42 @@ hipError_t search_impl(void*          temporary_storage,
             if constexpr(find_first)
             {
                 start_timer();
-                ROCPRIM_RETURN_ON_ERROR(search_kernels::launch_search(target_arch,
-                                                                      input,
-                                                                      keys,
-                                                                      tmp_output,
-                                                                      size,
-                                                                      keys_size,
-                                                                      compare_function,
-                                                                      num_blocks,
-                                                                      block_size,
-                                                                      0,
-                                                                      stream));
+                auto search_kernel = [=](auto arch_config)
+                {
+                    search_kernel_impl<decltype(arch_config)>(input,
+                                                              keys,
+                                                              tmp_output,
+                                                              size,
+                                                              keys_size,
+                                                              compare_function);
+                };
+                ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                    search_kernel,
+                                                                    num_blocks,
+                                                                    block_size,
+                                                                    0,
+                                                                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel", size, start);
             }
             else
             {
                 start_timer();
-                ROCPRIM_RETURN_ON_ERROR(
-                    search_kernels::launch_search(target_arch,
-                                                  rocprim::make_reverse_iterator(input + size),
-                                                  rocprim::make_reverse_iterator(keys + keys_size),
-                                                  tmp_output,
-                                                  size,
-                                                  keys_size,
-                                                  compare_function,
-                                                  num_blocks,
-                                                  block_size,
-                                                  0,
-                                                  stream));
+                auto search_kernel = [=](auto arch_config)
+                {
+                    search_kernel_impl<decltype(arch_config)>(
+                        rocprim::make_reverse_iterator(input + size),
+                        rocprim::make_reverse_iterator(keys + keys_size),
+                        tmp_output,
+                        size,
+                        keys_size,
+                        compare_function);
+                };
+                ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                    search_kernel,
+                                                                    num_blocks,
+                                                                    block_size,
+                                                                    0,
+                                                                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_kernel", size, start);
             }
         }
@@ -518,7 +429,7 @@ hipError_t search_impl(void*          temporary_storage,
         if constexpr(!find_first)
         {
             start_timer();
-            search_kernels::reverse_index_kernel<<<1, 1, 0, stream>>>(tmp_output, size, keys_size);
+            reverse_index_kernel<<<1, 1, 0, stream>>>(tmp_output, size, keys_size);
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reverse_index_kernel", 1, start);
         }
     }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search.hpp
@@ -131,14 +131,12 @@ void search_kernel_shared_impl(InputIterator1 input,
     const unsigned int flat_id       = rocprim::detail::block_thread_id<0>();
     const unsigned int flat_block_id = rocprim::detail::block_id<0>();
 
-    const size_t                                     block_offset = flat_block_id * items_per_block;
-    const size_t                                     offset       = flat_id * items_per_thread;
-    bool                                             find_pattern = false;
+    const size_t block_offset = flat_block_id * items_per_block;
+    const size_t offset       = flat_id * items_per_thread;
+    bool find_pattern = false;
 
-    ROCPRIM_SHARED_MEMORY
-    uninitialized_array<key_type, max_shared_key>    local_keys_;
-    ROCPRIM_SHARED_MEMORY
-    uninitialized_array<value_type, items_per_block> local_input_;
+    ROCPRIM_SHARED_MEMORY uninitialized_array<key_type, max_shared_key> local_keys_;
+    ROCPRIM_SHARED_MEMORY uninitialized_array<value_type, items_per_block> local_input_;
 
     // Check if a key was already found in a place before this block
     if(block_offset > atomic_load(output))

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_search_n.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_search_n.hpp
@@ -34,237 +34,12 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config, class InputIterator, class BinaryPredicate>
-struct search_n_impl_kernels
+template<class SizeType>
+static ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(1) void search_n_init_kernel(SizeType* __restrict__ output,
+                                                   const SizeType target)
 {
-    inline hipError_t launch_search_n_normal(
-        detail::target_arch arch,
-        InputIterator       input,
-        size_t* __restrict__ output,
-        const size_t                                                    size,
-        const size_t                                                    possible_head_exist_size,
-        const size_t                                                    count,
-        const typename std::iterator_traits<InputIterator>::value_type* value,
-        const BinaryPredicate                                           binary_predicate,
-        dim3                                                            grid,
-        dim3                                                            block,
-        size_t                                                          shmem,
-        hipStream_t                                                     stream)
-    {
-        auto kernel = [=](auto arch_config)
-        {
-            static constexpr auto params           = decltype(arch_config)::params;
-            static constexpr auto block_size       = params.kernel_config.block_size;
-            static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
-            static constexpr auto items_per_block  = block_size * items_per_thread;
-
-            const size_t this_thread_start_idx
-                = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
-
-            // Not able to find a sequence equal to or longer than count
-            if(this_thread_start_idx >= possible_head_exist_size)
-            {
-                return;
-            }
-
-            size_t       remaining_count = count;
-            size_t       head            = this_thread_start_idx;
-            const size_t this_thread_end_idx
-                = std::min<size_t>(this_thread_start_idx + items_per_thread, size);
-
-            for(size_t i = this_thread_start_idx;
-                head < this_thread_end_idx && i + remaining_count <= size;
-                ++i)
-            {
-                if(binary_predicate(input[i], *value))
-                {
-                    if(--remaining_count == 0)
-                    {
-                        atomic_min(output, head);
-                        return;
-                    }
-                }
-                else
-                {
-                    remaining_count = count;
-                    head            = i + 1;
-                }
-            }
-        };
-        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-    }
-
-    template<class SizeType>
-    static ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(1) void search_n_init_kernel(SizeType* __restrict__ output,
-                                                       const SizeType target)
-    {
-        *output = target;
-    }
-
-    inline hipError_t launch_search_n_find_heads(
-        detail::target_arch                                             arch,
-        InputIterator                                                   input,
-        const size_t                                                    input_size,
-        const size_t                                                    possible_head_exist_size,
-        const typename std::iterator_traits<InputIterator>::value_type* value,
-        const BinaryPredicate                                           binary_predicate,
-        size_t* __restrict__ unfiltered_heads,
-        const size_t group_size,
-        dim3         grid,
-        dim3         block,
-        size_t       shmem,
-        hipStream_t  stream)
-    {
-        auto kernel = [=](auto arch_config)
-        {
-            static constexpr auto params           = decltype(arch_config)::params;
-            static constexpr auto block_size       = params.kernel_config.block_size;
-            static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
-            static constexpr auto items_per_block  = block_size * items_per_thread;
-
-            const size_t this_thread_start_idx
-                = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
-            const size_t this_thread_end_idx
-                = std::min<size_t>(this_thread_start_idx + items_per_thread,
-                                   possible_head_exist_size);
-            for(size_t i = this_thread_start_idx; i < this_thread_end_idx; i++)
-            {
-                if(binary_predicate(input[i], *value))
-                {
-                    if(i == 0)
-                    {
-                        // This item is the first head
-                        // `input_size - i - 1` is the distance to the end
-                        atomic_min(&(unfiltered_heads[i / group_size]), input_size - i - 1);
-                    }
-                    else if(!binary_predicate(input[i - 1], *value))
-                    {
-                        // This item is head
-                        atomic_min(&(unfiltered_heads[i / group_size]), input_size - i - 1);
-                    }
-                }
-            }
-        };
-        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-    }
-
-    inline hipError_t launch_search_n_heads_filter(detail::target_arch arch,
-                                                   const size_t        input_size,
-                                                   const size_t        count,
-                                                   const size_t* __restrict__ unfiltered_heads,
-                                                   const size_t unfiltered_heads_size,
-                                                   size_t* __restrict__ filtered_heads,
-                                                   size_t* __restrict__ filtered_heads_size,
-                                                   dim3        grid,
-                                                   dim3        block,
-                                                   size_t      shmem,
-                                                   hipStream_t stream)
-    {
-        auto kernel = [=](auto arch_config)
-        {
-            static constexpr auto params           = decltype(arch_config)::params;
-            static constexpr auto block_size       = params.kernel_config.block_size;
-            static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
-            static constexpr auto items_per_block  = block_size * items_per_thread;
-
-            const size_t this_thread_start_idx
-                = (block_id<0>() * items_per_block) + (block_thread_id<0>() * items_per_thread);
-            const size_t this_thread_end_idx
-                = std::min<size_t>(items_per_thread + this_thread_start_idx, unfiltered_heads_size);
-            for(size_t i = this_thread_start_idx; i < this_thread_end_idx; ++i)
-            {
-                const auto cur_val = unfiltered_heads[i];
-                // This is not a valid head
-                if(cur_val == (size_t)-1)
-                {
-                    continue;
-                }
-                const size_t this_head = input_size - cur_val - 1;
-                // Other heads
-                if(i + 1 < unfiltered_heads_size)
-                {
-                    const auto next_val = unfiltered_heads[i + 1];
-                    // Check if this head is valid by calculating the distance between this head and the next head.
-                    if((next_val != (size_t)-1)
-                       && (((input_size - next_val - 1) - this_head - 1) < count))
-                    {
-                        continue;
-                    }
-                }
-                filtered_heads[atomic_add(filtered_heads_size, 1)] = this_head;
-            }
-        };
-        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-    }
-
-    inline hipError_t launch_search_n_discard_heads(
-        detail::target_arch                                             arch,
-        InputIterator                                                   input,
-        const size_t                                                    input_size,
-        const size_t                                                    count,
-        const typename std::iterator_traits<InputIterator>::value_type* value,
-        const BinaryPredicate                                           binary_predicate,
-        size_t* __restrict__ filtered_heads,
-        size_t*     filtered_heads_size,
-        dim3        grid,
-        dim3        block,
-        size_t      shmem,
-        hipStream_t stream)
-    {
-        auto kernel = [=](auto arch_config)
-        {
-            static constexpr auto params           = decltype(arch_config)::params;
-            static constexpr auto block_size       = params.kernel_config.block_size;
-            static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
-            static constexpr auto items_per_block  = block_size * items_per_thread;
-
-            const size_t heads_size = *filtered_heads_size;
-            const auto   block_idx  = block_id<0>();
-            if(heads_size == 0)
-            {
-                return;
-            }
-            const size_t total_check_size  = heads_size * count /*group_size*/;
-            const size_t num_blocks_needed = ceiling_div(total_check_size, items_per_block);
-            if(block_idx >= num_blocks_needed)
-            {
-                return;
-            }
-
-            const size_t this_thread_start_idx
-                = (block_idx * items_per_block) + (block_thread_id<0>() * items_per_thread);
-            const size_t this_thread_end_idx
-                = std::min<size_t>(items_per_thread + this_thread_start_idx, total_check_size);
-            // The `global_idx` is the index of item in the whole `input`
-            for(size_t global_idx = this_thread_start_idx; global_idx < this_thread_end_idx;
-                global_idx++)
-            {
-                // The id of the group who contains the item on global_idx
-                const size_t group_id = global_idx / count /*group_size*/;
-                if(group_id >= heads_size)
-                {
-                    return;
-                }
-                const size_t check_head
-                    = filtered_heads[group_id]
-                      + 1; // The `head` is already checked, so we check the next value here
-                const size_t check_count = count - 1;
-                const size_t idx         = check_head + (global_idx % count);
-
-                if((idx >= input_size) || (idx >= (check_head + check_count)))
-                {
-                    return;
-                }
-                if(!binary_predicate(input[idx], *value))
-                {
-                    filtered_heads[group_id] = input_size;
-                    return;
-                }
-            }
-        };
-        return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-    }
-};
+    *output = target;
+}
 
 inline void search_n_start_timer(std::chrono::steady_clock::time_point& start,
                                  const bool                             debug_synchronous)
@@ -288,10 +63,9 @@ hipError_t search_n_impl(void*          temporary_storage,
                          const hipStream_t     stream,
                          const bool            debug_synchronous)
 {
-    using input_type       = typename std::iterator_traits<InputIterator>::value_type;
-    using output_type      = typename std::iterator_traits<OutputIterator>::value_type;
-    using config           = wrapped_search_n_config<Config, input_type>;
-    using search_n_kernels = search_n_impl_kernels<config, InputIterator, BinaryPredicate>;
+    using input_type  = typename std::iterator_traits<InputIterator>::value_type;
+    using output_type = typename std::iterator_traits<OutputIterator>::value_type;
+    using config      = wrapped_search_n_config<Config, input_type>;
 
     // The `size` must greater than or equal to `count`
     if(count > size)
@@ -327,8 +101,7 @@ hipError_t search_n_impl(void*          temporary_storage,
         // Return end or begin
         search_n_start_timer(start, debug_synchronous);
 
-        search_n_kernels::search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output,
-                                                                    count <= 0 ? 0 : size);
+        search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output, count <= 0 ? 0 : size);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_init_kernel", 1, start);
         ROCPRIM_RETURN_ON_ERROR(
             transform(tmp_output, output, 1, identity<output_type>(), stream, debug_synchronous));
@@ -348,21 +121,55 @@ hipError_t search_n_impl(void*          temporary_storage,
 
         // do `normal_search_n`
         search_n_start_timer(start, debug_synchronous);
-        search_n_kernels::search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output, size);
+        search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output, size);
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_init_kernel", 1, start);
 
-        ROCPRIM_RETURN_ON_ERROR(search_n_kernels{}.launch_search_n_normal(target_arch,
-                                                                          input,
-                                                                          tmp_output,
-                                                                          size,
-                                                                          possible_head_exist_size,
-                                                                          count,
-                                                                          value,
-                                                                          binary_predicate,
-                                                                          num_blocks,
-                                                                          block_size,
-                                                                          0,
-                                                                          stream));
+        auto search_n_normal_kernel = [=](auto arch_config)
+        {
+            static constexpr auto params           = decltype(arch_config)::params;
+            static constexpr auto block_size       = params.kernel_config.block_size;
+            static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+            static constexpr auto items_per_block  = block_size * items_per_thread;
+
+            const size_t this_thread_start_idx
+                = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
+
+            // Not able to find a sequence equal to or longer than count
+            if(this_thread_start_idx >= possible_head_exist_size)
+            {
+                return;
+            }
+
+            size_t       remaining_count = count;
+            size_t       head            = this_thread_start_idx;
+            const size_t this_thread_end_idx
+                = std::min<size_t>(this_thread_start_idx + items_per_thread, size);
+
+            for(size_t i = this_thread_start_idx;
+                head < this_thread_end_idx && i + remaining_count <= size;
+                ++i)
+            {
+                if(binary_predicate(input[i], *value))
+                {
+                    if(--remaining_count == 0)
+                    {
+                        atomic_min(tmp_output, head);
+                        return;
+                    }
+                }
+                else
+                {
+                    remaining_count = count;
+                    head            = i + 1;
+                }
+            }
+        };
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                            search_n_normal_kernel,
+                                                            num_blocks,
+                                                            block_size,
+                                                            0,
+                                                            stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_normal_kernel", size, start);
         ROCPRIM_RETURN_ON_ERROR(
             transform(tmp_output, output, 1, identity<output_type>(), stream, debug_synchronous));
@@ -408,18 +215,41 @@ hipError_t search_n_impl(void*          temporary_storage,
     // This function processes `possible_head_exist_size` items
     const size_t num_blocks_for_find_heads = ceiling_div(possible_head_exist_size, items_per_block);
 
-    ROCPRIM_RETURN_ON_ERROR(search_n_kernels{}.launch_search_n_find_heads(target_arch,
-                                                                          input,
-                                                                          size,
-                                                                          possible_head_exist_size,
-                                                                          value,
-                                                                          binary_predicate,
-                                                                          unfiltered_heads,
-                                                                          count /*group_size*/,
-                                                                          num_blocks_for_find_heads,
-                                                                          block_size,
-                                                                          0,
-                                                                          stream));
+    auto search_n_find_heads_kernel = [=](auto arch_config)
+    {
+        static constexpr auto params           = decltype(arch_config)::params;
+        static constexpr auto block_size       = params.kernel_config.block_size;
+        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+        static constexpr auto items_per_block  = block_size * items_per_thread;
+
+        const size_t this_thread_start_idx
+            = (block_id<0>() * items_per_block) + (items_per_thread * block_thread_id<0>());
+        const size_t this_thread_end_idx
+            = std::min<size_t>(this_thread_start_idx + items_per_thread, possible_head_exist_size);
+        for(size_t i = this_thread_start_idx; i < this_thread_end_idx; i++)
+        {
+            if(binary_predicate(input[i], *value))
+            {
+                if(i == 0)
+                {
+                    // This item is the first head
+                    // `input_size - i - 1` is the distance to the end
+                    atomic_min(&(unfiltered_heads[i / count]), size - i - 1);
+                }
+                else if(!binary_predicate(input[i - 1], *value))
+                {
+                    // This item is head
+                    atomic_min(&(unfiltered_heads[i / count]), size - i - 1);
+                }
+            }
+        }
+    };
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                        search_n_find_heads_kernel,
+                                                        num_blocks_for_find_heads,
+                                                        block_size,
+                                                        0,
+                                                        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_find_heads_kernel",
                                                 possible_head_exist_size,
                                                 start);
@@ -427,18 +257,49 @@ hipError_t search_n_impl(void*          temporary_storage,
     // This function processes `num_groups` items
     const size_t num_blocks_for_heads_filter = ceiling_div(num_groups, items_per_block);
 
-    ROCPRIM_RETURN_ON_ERROR(search_n_kernels{}.launch_search_n_heads_filter(
-        target_arch,
-        size, // It is just a value to decode the heads' index value
-        count, // It is just a value to determine whether a certain head is invalid
-        unfiltered_heads, // Input heads
-        num_groups, // Size of unfiltered_heads
-        filtered_heads, // Output
-        tmp_output, // Used to store the number of items in `filtered_heads`
-        num_blocks_for_heads_filter,
-        block_size,
-        0,
-        stream));
+    auto search_n_heads_filter_kernel = [=](auto arch_config)
+    {
+        static constexpr auto params           = decltype(arch_config)::params;
+        static constexpr auto block_size       = params.kernel_config.block_size;
+        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+        static constexpr auto items_per_block  = block_size * items_per_thread;
+
+        const size_t this_thread_start_idx
+            = (block_id<0>() * items_per_block) + (block_thread_id<0>() * items_per_thread);
+        // num_groups: size of unfiltered_heads
+        const size_t this_thread_end_idx
+            = std::min<size_t>(items_per_thread + this_thread_start_idx, num_groups);
+        for(size_t i = this_thread_start_idx; i < this_thread_end_idx; ++i)
+        {
+            const auto cur_val = unfiltered_heads[i];
+            // This is not a valid head
+            if(cur_val == (size_t)-1)
+            {
+                continue;
+            }
+            // size: a value to decode the heads' index value
+            const size_t this_head = size - cur_val - 1;
+            // Other heads
+            if(i + 1 < num_groups)
+            {
+                const auto next_val = unfiltered_heads[i + 1];
+                // Check if this head is valid by calculating the distance between this head and the next head.
+                if((next_val != (size_t)-1) && (((size - next_val - 1) - this_head - 1) < count))
+                {
+                    // count: a value to determine whether a certain head is invalid
+                    continue;
+                }
+            }
+            // tmp_output: used to store the number of items in `filtered_heads`
+            filtered_heads[atomic_add(tmp_output, 1)] = this_head;
+        }
+    };
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                        search_n_heads_filter_kernel,
+                                                        num_blocks_for_heads_filter,
+                                                        block_size,
+                                                        0,
+                                                        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_heads_filter_kernel", num_groups, start);
 
     size_t h_filtered_heads_size = 0;
@@ -453,7 +314,7 @@ hipError_t search_n_impl(void*          temporary_storage,
         {
             // Return end
             search_n_start_timer(start, debug_synchronous);
-            search_n_kernels::search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output, size);
+            search_n_init_kernel<<<1, 1, 0, stream>>>(tmp_output, size);
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_init_kernel", 1, start);
             ROCPRIM_RETURN_ON_ERROR(transform(tmp_output,
                                               output,
@@ -474,19 +335,64 @@ hipError_t search_n_impl(void*          temporary_storage,
     const size_t num_blocks_for_discard_heads
         = ceiling_div(h_filtered_heads_size * count, items_per_block);
 
-    ROCPRIM_RETURN_ON_ERROR(search_n_kernels{}.launch_search_n_discard_heads(
-        target_arch,
-        input,
-        size,
-        count,
-        value,
-        binary_predicate,
-        filtered_heads,
-        tmp_output, // Currently, `tmp_output` contains the actual size of `filtered_heads`
-        num_blocks_for_discard_heads,
-        block_size,
-        0,
-        stream));
+    auto search_n_discard_heads_kernel = [=](auto arch_config)
+    {
+        static constexpr auto params           = decltype(arch_config)::params;
+        static constexpr auto block_size       = params.kernel_config.block_size;
+        static constexpr auto items_per_thread = params.kernel_config.items_per_thread;
+        static constexpr auto items_per_block  = block_size * items_per_thread;
+
+        // Currently, `tmp_output` contains the actual size of `filtered_heads`
+        const size_t heads_size = *tmp_output;
+        const auto   block_idx  = block_id<0>();
+        if(heads_size == 0)
+        {
+            return;
+        }
+        const size_t total_check_size  = heads_size * count /*group_size*/;
+        const size_t num_blocks_needed = ceiling_div(total_check_size, items_per_block);
+        if(block_idx >= num_blocks_needed)
+        {
+            return;
+        }
+
+        const size_t this_thread_start_idx
+            = (block_idx * items_per_block) + (block_thread_id<0>() * items_per_thread);
+        const size_t this_thread_end_idx
+            = std::min<size_t>(items_per_thread + this_thread_start_idx, total_check_size);
+        // The `global_idx` is the index of item in the whole `input`
+        for(size_t global_idx = this_thread_start_idx; global_idx < this_thread_end_idx;
+            global_idx++)
+        {
+            // The id of the group who contains the item on global_idx
+            const size_t group_id = global_idx / count /*group_size*/;
+            if(group_id >= heads_size)
+            {
+                return;
+            }
+            const size_t check_head
+                = filtered_heads[group_id]
+                  + 1; // The `head` is already checked, so we check the next value here
+            const size_t check_count = count - 1;
+            const size_t idx         = check_head + (global_idx % count);
+
+            if((idx >= size) || (idx >= (check_head + check_count)))
+            {
+                return;
+            }
+            if(!binary_predicate(input[idx], *value))
+            {
+                filtered_heads[group_id] = size;
+                return;
+            }
+        }
+    };
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                        search_n_discard_heads_kernel,
+                                                        num_blocks_for_discard_heads,
+                                                        block_size,
+                                                        0,
+                                                        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("search_n_discard_heads_kernel ",
                                                 h_filtered_heads_size,
                                                 start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_difference.hpp
@@ -57,38 +57,6 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config,
-         bool InPlace,
-         bool Right,
-         typename InputIt,
-         typename OutputIt,
-         typename BinaryFunction>
-inline hipError_t launch_adjacent_difference(
-    detail::target_arch                                       arch,
-    const InputIt                                             input,
-    const OutputIt                                            output,
-    const std::size_t                                         size,
-    const BinaryFunction                                      op,
-    const typename std::iterator_traits<InputIt>::value_type* previous_values,
-    const std::size_t                                         starting_block,
-    dim3                                                      grid,
-    dim3                                                      block,
-    size_t                                                    shmem,
-    hipStream_t                                               stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        adjacent_difference_kernel_impl<decltype(arch_config), InPlace, Right>(input,
-                                                                               output,
-                                                                               size,
-                                                                               op,
-                                                                               previous_values,
-                                                                               starting_block);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 template<typename Config,
          bool InPlace,
          bool Right,
@@ -204,18 +172,24 @@ hipError_t adjacent_difference_impl(void* const          temporary_storage,
             start = std::chrono::steady_clock::now();
         }
 
-        ROCPRIM_RETURN_ON_ERROR(
-            launch_adjacent_difference<config, InPlace, Right>(target_arch,
-                                                               input + offset,
-                                                               output + offset,
-                                                               size,
-                                                               op,
-                                                               previous_values + starting_block,
-                                                               starting_block,
-                                                               current_blocks,
-                                                               block_size,
-                                                               0,
-                                                               stream));
+        auto adjacent_difference_kernel = [=](auto arch_config)
+        {
+            adjacent_difference_kernel_impl<decltype(arch_config), InPlace, Right>(
+                input + offset,
+                output + offset,
+                size,
+                op,
+                previous_values + starting_block,
+                starting_block);
+        };
+
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                            adjacent_difference_kernel,
+                                                            current_blocks,
+                                                            block_size,
+                                                            0,
+                                                            stream));
+
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("adjacent_difference_kernel",
                                                     current_size,
                                                     start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -43,29 +43,6 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config, unsigned int ActiveChannels, class Counter>
-inline hipError_t launch_init_histogram(detail::target_arch                       arch,
-                                        fixed_array<Counter*, ActiveChannels>     histogram,
-                                        const fixed_array<size_t, ActiveChannels> bins,
-                                        dim3                                      grid,
-                                        dim3                                      block,
-                                        size_t                                    shmem,
-                                        hipStream_t                               stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        static constexpr histogram_config_params params = decltype(arch_config)::params;
-        init_histogram<params.histogram_config.block_size, ActiveChannels>(histogram, bins);
-    };
-
-    return execute_launch_plan<Config, decltype(kernel), histogram_config_selector>(arch,
-                                                                                    kernel,
-                                                                                    grid,
-                                                                                    block,
-                                                                                    shmem,
-                                                                                    stream);
-}
-
 template<class ArchConfig,
          unsigned int Channels,
          unsigned int ActiveChannels,
@@ -202,100 +179,6 @@ auto make_histogram_launch_plan(rocprim::detail::target_arch arch, Kernel kernel
         plan.max_grid_size          = params.max_grid_size;
     }
     return plan;
-}
-
-template<class Config,
-         unsigned int Channels,
-         unsigned int ActiveChannels,
-         class SampleIterator,
-         class Counter,
-         class SampleToBinOp>
-inline hipError_t
-    launch_histogram_global(detail::target_arch                              arch,
-                            SampleIterator                                   samples,
-                            unsigned int                                     columns,
-                            unsigned int                                     row_stride,
-                            fixed_array<Counter*, ActiveChannels>            histogram,
-                            const fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                            const fixed_array<size_t, ActiveChannels>        bins_bits,
-                            dim3                                             grid,
-                            dim3                                             block,
-                            size_t                                           shmem,
-                            hipStream_t                                      stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        static constexpr histogram_config_params params = decltype(arch_config)::params;
-
-        histogram_global<params.histogram_config.block_size,
-                         params.histogram_config.items_per_thread,
-                         Channels,
-                         ActiveChannels>(samples,
-                                         columns,
-                                         row_stride,
-                                         histogram,
-                                         sample_to_bin_op,
-                                         bins_bits);
-    };
-
-    return execute_launch_plan<Config, decltype(kernel), histogram_config_selector>(arch,
-                                                                                    kernel,
-                                                                                    grid,
-                                                                                    block,
-                                                                                    shmem,
-                                                                                    stream);
-}
-
-template<class Config,
-         unsigned int Channels,
-         unsigned int ActiveChannels,
-         class SampleIterator,
-         class Counter,
-         class SampleToBinOp>
-inline hipError_t
-    launch_histogram_private_global(detail::target_arch                        arch,
-                                    SampleIterator                             samples,
-                                    unsigned int                               columns,
-                                    unsigned int                               rows,
-                                    unsigned int                               row_stride,
-                                    fixed_array<Counter*, ActiveChannels>      histogram,
-                                    fixed_array<SampleToBinOp, ActiveChannels> sample_to_bin_op,
-                                    fixed_array<size_t, ActiveChannels>        bins_bits,
-                                    fixed_array<size_t, ActiveChannels>        bins,
-                                    Counter*                                   private_histograms,
-                                    unsigned int                               virtual_max_blocks,
-                                    unsigned int*                              block_id_count,
-                                    dim3                                       grid,
-                                    dim3                                       block,
-                                    size_t                                     shmem,
-                                    hipStream_t                                stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        static constexpr histogram_config_params params = decltype(arch_config)::params;
-
-        histogram_private_global<params.histogram_global_config.block_size,
-                                 params.histogram_global_config.items_per_thread,
-                                 Channels,
-                                 ActiveChannels>(samples,
-                                                 columns,
-                                                 rows,
-                                                 row_stride,
-                                                 histogram,
-                                                 sample_to_bin_op,
-                                                 bins_bits,
-                                                 bins,
-                                                 private_histograms,
-                                                 virtual_max_blocks,
-                                                 block_id_count);
-    };
-
-    return execute_launch_plan<Config, decltype(kernel), histogram_global_config_selector>(arch,
-                                                                                           kernel,
-                                                                                           grid,
-                                                                                           block,
-                                                                                           shmem,
-                                                                                           stream);
 }
 
 template<unsigned int Channels,
@@ -441,16 +324,25 @@ inline hipError_t histogram_impl(void*          temporary_storage,
     {
         start = std::chrono::steady_clock::now();
     }
-    ROCPRIM_RETURN_ON_ERROR(launch_init_histogram<config, ActiveChannels>(
-        target_arch,
-        fixed_array<Counter*, ActiveChannels>(histogram),
-        fixed_array<size_t, ActiveChannels>(bins),
-        dim3(::rocprim::detail::ceiling_div(max_bins, block_size)),
-        dim3(block_size),
-        0,
-        stream));
 
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_histogram", max_bins, start);
+    auto init_histogram_kernel
+        = [hist       = fixed_array<Counter*, ActiveChannels>(histogram),
+           bin_counts = fixed_array<size_t, ActiveChannels>(bins)](auto arch_config)
+    {
+        static constexpr histogram_config_params params = decltype(arch_config)::params;
+        init_histogram<params.histogram_config.block_size, ActiveChannels>(hist, bin_counts);
+    };
+
+    ROCPRIM_RETURN_ON_ERROR(
+        execute_launch_plan<config, decltype(init_histogram_kernel), histogram_config_selector>(
+            target_arch,
+            init_histogram_kernel,
+            ::rocprim::detail::ceiling_div(max_bins, block_size),
+            block_size,
+            0,
+            stream));
+
+    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_histogram_kernel", max_bins, start);
 
     if(columns == 0 || rows == 0)
     {
@@ -523,7 +415,6 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         plan.device_callback.shared_histograms = chosen_shared_histograms;
         plan.device_callback.rows_per_block    = rows_per_block;
 
-        // 4) 发射（无需再做任何按架构分发）
         plan.launch(grid_size,
                     dim3(block_size, 1),
                     chosen_shared_histograms * block_histogram_bytes,
@@ -543,25 +434,49 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             {
                 start = std::chrono::steady_clock::now();
             }
-            ROCPRIM_RETURN_ON_ERROR(
-                launch_histogram_private_global<config, Channels, ActiveChannels>(
-                    target_arch,
-                    samples,
-                    columns,
-                    rows,
-                    row_stride,
-                    fixed_array<Counter*, ActiveChannels>(histogram),
-                    fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                    fixed_array<size_t, ActiveChannels>(bins_bits),
-                    fixed_array<size_t, ActiveChannels>(bins),
-                    private_histograms,
-                    virtual_max_blocks,
-                    block_id_count,
-                    dim3(global_histogram_grid_size),
-                    dim3(params.histogram_global_config.block_size),
-                    0,
-                    stream));
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_private_global",
+
+            auto histogram_private_global_kernel
+                = [samples,
+                   columns,
+                   rows,
+                   row_stride,
+                   hist     = fixed_array<Counter*, ActiveChannels>(histogram),
+                   ops      = fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
+                   bits     = fixed_array<size_t, ActiveChannels>(bins_bits),
+                   bins_fix = fixed_array<size_t, ActiveChannels>(bins),
+                   private_histograms,
+                   virtual_max_blocks,
+                   block_id_count](auto arch_config)
+            {
+                static constexpr histogram_config_params params = decltype(arch_config)::params;
+
+                histogram_private_global<params.histogram_global_config.block_size,
+                                         params.histogram_global_config.items_per_thread,
+                                         Channels,
+                                         ActiveChannels>(samples,
+                                                         columns,
+                                                         rows,
+                                                         row_stride,
+                                                         hist,
+                                                         ops,
+                                                         bits,
+                                                         bins_fix,
+                                                         private_histograms,
+                                                         virtual_max_blocks,
+                                                         block_id_count);
+            };
+
+            ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config,
+                                                        decltype(histogram_private_global_kernel),
+                                                        histogram_global_config_selector>(
+                target_arch,
+                histogram_private_global_kernel,
+                dim3(global_histogram_grid_size),
+                dim3(params.histogram_global_config.block_size),
+                0,
+                stream));
+
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_private_global_kernel",
                                                         blocks_x * block_size * rows,
                                                         start);
         }
@@ -571,19 +486,31 @@ inline hipError_t histogram_impl(void*          temporary_storage,
             {
                 start = std::chrono::steady_clock::now();
             }
-            ROCPRIM_RETURN_ON_ERROR(launch_histogram_global<config, Channels, ActiveChannels>(
-                target_arch,
-                samples,
-                columns,
-                row_stride,
-                fixed_array<Counter*, ActiveChannels>(histogram),
-                fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
-                fixed_array<size_t, ActiveChannels>(bins_bits),
-                dim3(blocks_x, rows),
-                dim3(block_size, 1),
-                0,
-                stream));
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global",
+            auto histogram_global_kernel
+                = [samples,
+                   columns,
+                   row_stride,
+                   hist = fixed_array<Counter*, ActiveChannels>(histogram),
+                   ops  = fixed_array<SampleToBinOp, ActiveChannels>(sample_to_bin_op),
+                   bits = fixed_array<size_t, ActiveChannels>(bins_bits)](auto arch_config)
+            {
+                static constexpr histogram_config_params params = decltype(arch_config)::params;
+                histogram_global<params.histogram_config.block_size,
+                                 params.histogram_config.items_per_thread,
+                                 Channels,
+                                 ActiveChannels>(samples, columns, row_stride, hist, ops, bits);
+            };
+
+            ROCPRIM_RETURN_ON_ERROR(
+                execute_launch_plan<config,
+                                    decltype(histogram_global_kernel),
+                                    histogram_config_selector>(target_arch,
+                                                               histogram_global_kernel,
+                                                               dim3(blocks_x, rows),
+                                                               dim3(block_size, 1),
+                                                               0,
+                                                               stream));
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("histogram_global_kernel",
                                                         blocks_x * block_size * rows,
                                                         start);
         }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
@@ -42,96 +42,6 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config,
-         class IndexIterator,
-         class KeysInputIterator1,
-         class KeysInputIterator2,
-         class BinaryFunction>
-inline hipError_t launch_partition(detail::target_arch arch,
-                                   IndexIterator       index,
-                                   KeysInputIterator1  keys_input1,
-                                   KeysInputIterator2  keys_input2,
-                                   const size_t        input1_size,
-                                   const size_t        input2_size,
-                                   const unsigned int  spacing,
-                                   BinaryFunction      compare_function,
-                                   dim3                grid,
-                                   dim3                block,
-                                   size_t              shmem,
-                                   hipStream_t         stream)
-{
-    auto kernel = [=](auto)
-    {
-        partition_kernel_impl<IndexIterator,
-                              KeysInputIterator1,
-                              KeysInputIterator2,
-                              BinaryFunction>(index,
-                                              keys_input1,
-                                              keys_input2,
-                                              input1_size,
-                                              input2_size,
-                                              spacing,
-                                              compare_function);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
-template<class Config,
-         class IndexIterator,
-         class KeysInputIterator1,
-         class KeysInputIterator2,
-         class KeysOutputIterator,
-         class ValuesInputIterator1,
-         class ValuesInputIterator2,
-         class ValuesOutputIterator,
-         class BinaryFunction>
-inline hipError_t launch_merge(detail::target_arch  arch,
-                               IndexIterator        index,
-                               KeysInputIterator1   keys_input1,
-                               KeysInputIterator2   keys_input2,
-                               KeysOutputIterator   keys_output,
-                               ValuesInputIterator1 values_input1,
-                               ValuesInputIterator2 values_input2,
-                               ValuesOutputIterator values_output,
-                               const size_t         input1_size,
-                               const size_t         input2_size,
-                               BinaryFunction       compare_function,
-                               detail::vsmem_t      vsmem,
-                               dim3                 grid,
-                               dim3                 block,
-                               size_t               shmem,
-                               hipStream_t          stream)
-{
-    auto kernel = [=](auto arch_config) mutable
-    {
-        using key_type   = typename std::iterator_traits<KeysInputIterator1>::value_type;
-        using value_type = typename std::iterator_traits<ValuesInputIterator1>::value_type;
-
-        using merge_kernel_impl_t = merge_kernel_impl_<decltype(arch_config), key_type, value_type>;
-
-        using VSmemHelperT = detail::vsmem_helper_impl<merge_kernel_impl_t>;
-        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
-        // Get temporary storage
-        typename merge_kernel_impl_t::storage_type& storage
-            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
-
-        merge_kernel_impl_t().merge(index,
-                                    keys_input1,
-                                    keys_input2,
-                                    keys_output,
-                                    values_input1,
-                                    values_input2,
-                                    values_output,
-                                    input1_size,
-                                    input2_size,
-                                    compare_function,
-                                    storage);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 template<typename Config, typename Key, typename Value>
 inline size_t get_merge_vsmem_size_per_block(detail::target_arch arch)
 {
@@ -244,41 +154,72 @@ inline hipError_t merge_impl(void*                temporary_storage,
     const unsigned int partition_blocks = ((number_of_blocks + 1) + half_block - 1) / half_block;
 
     if(debug_synchronous)
+    {
         start = std::chrono::steady_clock::now();
+    }
 
-    ROCPRIM_RETURN_ON_ERROR(launch_partition<config>(target_arch,
-                                                     index,
-                                                     keys_input1,
-                                                     keys_input2,
-                                                     input1_size,
-                                                     input2_size,
-                                                     items_per_block,
-                                                     compare_function,
-                                                     partition_blocks,
-                                                     half_block,
-                                                     0,
-                                                     stream));
+    auto partition_kernel = [=](auto)
+    {
+        partition_kernel_impl<unsigned int*,
+                              KeysInputIterator1,
+                              KeysInputIterator2,
+                              BinaryFunction>(index,
+                                              keys_input1,
+                                              keys_input2,
+                                              input1_size,
+                                              input2_size,
+                                              items_per_block,
+                                              compare_function);
+    };
+
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                        partition_kernel,
+                                                        partition_blocks,
+                                                        half_block,
+                                                        0,
+                                                        stream));
+
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", input1_size, start);
 
     if(debug_synchronous)
+    {
         start = std::chrono::steady_clock::now();
+    }
 
-    ROCPRIM_RETURN_ON_ERROR(launch_merge<config>(target_arch,
-                                                 index,
-                                                 keys_input1,
-                                                 keys_input2,
-                                                 keys_output,
-                                                 values_input1,
-                                                 values_input2,
-                                                 values_output,
-                                                 input1_size,
-                                                 input2_size,
-                                                 compare_function,
-                                                 detail::vsmem_t{vsmem},
-                                                 dim3(number_of_blocks),
-                                                 dim3(block_size),
-                                                 0,
-                                                 stream));
+    auto merge_kernel = [=, vsm = detail::vsmem_t{vsmem}](auto arch_config) mutable
+    {
+        using key_type   = typename std::iterator_traits<KeysInputIterator1>::value_type;
+        using value_type = typename std::iterator_traits<ValuesInputIterator1>::value_type;
+
+        using merge_kernel_impl_t = merge_kernel_impl_<decltype(arch_config), key_type, value_type>;
+
+        using VSmemHelperT = detail::vsmem_helper_impl<merge_kernel_impl_t>;
+        ROCPRIM_SHARED_MEMORY
+        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        // Get temporary storage
+        typename merge_kernel_impl_t::storage_type& storage
+            = VSmemHelperT::get_temp_storage(static_temp_storage, vsm);
+
+        merge_kernel_impl_t().merge(index,
+                                    keys_input1,
+                                    keys_input2,
+                                    keys_output,
+                                    values_input1,
+                                    values_input2,
+                                    values_output,
+                                    input1_size,
+                                    input2_size,
+                                    compare_function,
+                                    storage);
+    };
+
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                        merge_kernel,
+                                                        dim3(number_of_blocks),
+                                                        dim3(block_size),
+                                                        0,
+                                                        stream));
+
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("merge_kernel", input1_size, start);
 
     return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge.hpp
@@ -194,8 +194,7 @@ inline hipError_t merge_impl(void*                temporary_storage,
         using merge_kernel_impl_t = merge_kernel_impl_<decltype(arch_config), key_type, value_type>;
 
         using VSmemHelperT = detail::vsmem_helper_impl<merge_kernel_impl_t>;
-        ROCPRIM_SHARED_MEMORY
-        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
         // Get temporary storage
         typename merge_kernel_impl_t::storage_type& storage
             = VSmemHelperT::get_temp_storage(static_temp_storage, vsm);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
@@ -190,8 +190,7 @@ inline hipError_t merge_sort_block_merge_impl(
                         = static_cast<OffsetT>(tilegroup_start_id) * items_per_tile;
 
                     const OffsetT keys1_beg = rocprim::min(size, tilegroup_start);
-                    const OffsetT keys1_end
-                        = rocprim::min(size, tilegroup_start + block);
+                    const OffsetT keys1_end = rocprim::min(size, tilegroup_start + block);
                     const OffsetT keys2_beg = keys1_end;
                     const OffsetT keys2_end = rocprim::min(size, keys2_beg + block);
 
@@ -525,14 +524,13 @@ inline hipError_t merge_sort_block_sort(KeysInputIterator    keys_input,
         const unsigned int valid_in_last_block = size - block_offset;
         const bool         is_incomplete_block = flat_block_id == (size / items_per_block);
 
-        using sort_impl    = block_sort_impl<key_type,
-                                             value_type,
-                                             params.kernel_config.block_size,
-                                             params.kernel_config.items_per_thread>;
+        using sort_impl = block_sort_impl<key_type,
+                                          value_type,
+                                          params.kernel_config.block_size,
+                                          params.kernel_config.items_per_thread>;
         using VSmemHelperT = detail::vsmem_helper_impl<sort_impl>;
 
-        ROCPRIM_SHARED_MEMORY
-        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
 
         typename sort_impl::storage_type& storage
             = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_merge_sort.hpp
@@ -46,248 +46,6 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config,
-         class KeysInputIterator,
-         class KeysOutputIterator,
-         class ValuesInputIterator,
-         class ValuesOutputIterator,
-         class OffsetT,
-         class BinaryFunction>
-inline hipError_t launch_block_sort(detail::target_arch  arch,
-                                    KeysInputIterator    keys_input,
-                                    KeysOutputIterator   keys_output,
-                                    ValuesInputIterator  values_input,
-                                    ValuesOutputIterator values_output,
-                                    const OffsetT        size,
-                                    const unsigned int   num_blocks,
-                                    BinaryFunction       compare_function,
-                                    detail::vsmem_t      vsmem,
-                                    dim3                 grid,
-                                    dim3                 block,
-                                    size_t               shmem,
-                                    hipStream_t          stream)
-{
-    auto kernel = [=](auto arch_config) mutable
-    {
-        constexpr auto params = decltype(arch_config)::params;
-
-        constexpr unsigned int items_per_block
-            = params.kernel_config.block_size * params.kernel_config.items_per_thread;
-
-        const unsigned int flat_block_id = ::rocprim::flat_block_id();
-        if(flat_block_id >= num_blocks)
-        {
-            return;
-        }
-
-        const OffsetT      block_offset = static_cast<OffsetT>(flat_block_id) * items_per_block;
-        const unsigned int valid_in_last_block = size - block_offset;
-        const bool         is_incomplete_block = flat_block_id == (size / items_per_block);
-
-        // Shared memory or global memory pointer (vsmem)
-        using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
-        using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
-
-        using sort_impl = block_sort_impl<key_type,
-                                          value_type,
-                                          params.kernel_config.block_size,
-                                          params.kernel_config.items_per_thread>;
-        using VSmemHelperT = detail::vsmem_helper_impl<sort_impl>;
-
-        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
-
-        typename sort_impl::storage_type& storage
-            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
-
-        // Core part of the block sort kernel
-        sort_impl().sort(valid_in_last_block,
-                         is_incomplete_block,
-                         keys_input + block_offset,
-                         keys_output + block_offset,
-                         values_input + block_offset,
-                         values_output + block_offset,
-                         compare_function,
-                         storage);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
-template<class Config,
-         class KeysInputIterator,
-         class KeysOutputIterator,
-         class ValuesInputIterator,
-         class ValuesOutputIterator,
-         class OffsetT,
-         class BinaryFunction>
-inline hipError_t launch_device_block_merge_oddeven(detail::target_arch  arch,
-                                                    KeysInputIterator    keys_input,
-                                                    KeysOutputIterator   keys_output,
-                                                    ValuesInputIterator  values_input,
-                                                    ValuesOutputIterator values_output,
-                                                    const OffsetT        input_size,
-                                                    const OffsetT        sorted_block_size,
-                                                    BinaryFunction       compare_function,
-                                                    dim3                 grid,
-                                                    dim3                 block,
-                                                    size_t               shmem,
-                                                    hipStream_t          stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        static constexpr merge_sort_block_merge_config_params params
-            = decltype(arch_config)::params;
-        block_merge_oddeven_kernel<params.merge_oddeven_config.block_size,
-                                   params.merge_oddeven_config.items_per_thread>(keys_input,
-                                                                                 keys_output,
-                                                                                 values_input,
-                                                                                 values_output,
-                                                                                 input_size,
-                                                                                 sorted_block_size,
-                                                                                 compare_function);
-    };
-
-    return execute_launch_plan<Config, decltype(kernel), merge_oddeven_config_selector>(arch,
-                                                                                        kernel,
-                                                                                        grid,
-                                                                                        block,
-                                                                                        shmem,
-                                                                                        stream);
-}
-
-template<class Config,
-         class KeysInputIterator,
-         class KeysOutputIterator,
-         class ValuesInputIterator,
-         class ValuesOutputIterator,
-         class OffsetT,
-         class BinaryFunction>
-inline hipError_t launch_device_block_merge_mergepath(detail::target_arch  arch,
-                                                      KeysInputIterator    keys_input,
-                                                      KeysOutputIterator   keys_output,
-                                                      ValuesInputIterator  values_input,
-                                                      ValuesOutputIterator values_output,
-                                                      const OffsetT        input_size,
-                                                      const OffsetT        sorted_block_size,
-                                                      const unsigned int   num_blocks,
-                                                      BinaryFunction       compare_function,
-                                                      const OffsetT*       merge_partitions,
-                                                      detail::vsmem_t      vsmem,
-                                                      dim3                 grid,
-                                                      dim3                 block,
-                                                      size_t               shmem,
-                                                      hipStream_t          stream)
-{
-    auto kernel = [=](auto arch_config) mutable
-    {
-        static constexpr merge_sort_block_merge_config_params params
-            = decltype(arch_config)::params;
-
-        // Shared memory or global memory pointer (vsmem)
-        using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
-        using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
-
-        using merge_impl = block_merge_impl<key_type,
-                                            value_type,
-                                            params.merge_mergepath_config.block_size,
-                                            params.merge_mergepath_config.items_per_thread>;
-
-        using VSmemHelperT = detail::vsmem_helper_impl<merge_impl>;
-        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
-
-        typename merge_impl::storage_type& storage
-            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
-
-        // Core part of block mergepath kernel
-        merge_impl().process_tile(keys_input,
-                                  keys_output,
-                                  values_input,
-                                  values_output,
-                                  input_size,
-                                  sorted_block_size,
-                                  num_blocks,
-                                  compare_function,
-                                  merge_partitions,
-                                  storage);
-    };
-
-    return execute_launch_plan<Config, decltype(kernel), merge_mergepath_config_selector>(arch,
-                                                                                          kernel,
-                                                                                          grid,
-                                                                                          block,
-                                                                                          shmem,
-                                                                                          stream);
-}
-
-template<typename Config, typename KeysInputIterator, typename OffsetT, typename CompareOpT>
-inline hipError_t launch_device_block_merge_mergepath_partition(detail::target_arch arch,
-                                                                KeysInputIterator   keys,
-                                                                const OffsetT       input_size,
-                                                                const unsigned int  num_partitions,
-                                                                OffsetT*         merge_partitions,
-                                                                const CompareOpT compare_op,
-                                                                const OffsetT    sorted_block_size,
-                                                                dim3             grid,
-                                                                dim3             block,
-                                                                size_t           shmem,
-                                                                hipStream_t      stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        static constexpr merge_sort_block_merge_config_params params
-            = decltype(arch_config)::params;
-        static constexpr unsigned int items_per_tile
-            = params.merge_mergepath_config.block_size
-              * params.merge_mergepath_config.items_per_thread;
-
-        const unsigned int partition_id
-            = blockIdx.x * params.merge_mergepath_partition_config.block_size + threadIdx.x;
-
-        if(partition_id >= num_partitions)
-        {
-            return;
-        }
-
-        const unsigned int merged_tiles        = sorted_block_size / items_per_tile;
-        const unsigned int target_merged_tiles = merged_tiles * 2;
-        const unsigned int mask                = target_merged_tiles - 1;
-
-        // id of the first tile in the current tile-group
-        const unsigned int tilegroup_start_id = ~mask & partition_id;
-        // id of the current tile in the current tile-group
-        const unsigned int local_tile_id = mask & partition_id;
-
-        // index of the first item in the current tile-group
-        const OffsetT tilegroup_start = static_cast<OffsetT>(tilegroup_start_id) * items_per_tile;
-
-        const OffsetT keys1_beg = rocprim::min(input_size, tilegroup_start);
-        const OffsetT keys1_end = rocprim::min(input_size, tilegroup_start + sorted_block_size);
-        const OffsetT keys2_beg = keys1_end;
-        const OffsetT keys2_end = rocprim::min(input_size, keys2_beg + sorted_block_size);
-
-        const OffsetT partition_at
-            = rocprim::min(keys2_end - keys1_beg,
-                           static_cast<OffsetT>(local_tile_id) * items_per_tile);
-
-        const OffsetT partition_diag = ::rocprim::detail::merge_path(keys + keys1_beg,
-                                                                     keys + keys2_beg,
-                                                                     keys1_end - keys1_beg,
-                                                                     keys2_end - keys2_beg,
-                                                                     partition_at,
-                                                                     compare_op);
-
-        merge_partitions[partition_id] = keys1_beg + partition_diag;
-    };
-
-    return execute_launch_plan<Config, decltype(kernel), merge_mergepath_partition_config_selector>(
-        arch,
-        kernel,
-        grid,
-        block,
-        shmem,
-        stream);
-}
-
 // it assumes the temporary storage has been already partitioned
 // it is used by merge_sort where partition is done externally for
 // both block_sort and block_merge
@@ -397,44 +155,122 @@ inline hipError_t merge_sort_block_merge_impl(
             if(use_mergepath && block >= merge_mergepath_items_per_block)
             {
                 if(debug_synchronous)
+                {
                     start = std::chrono::steady_clock::now();
+                }
+
+                auto device_block_merge_mergepath_partition_kernel = [=](auto arch_config)
+                {
+                    static constexpr merge_sort_block_merge_config_params params
+                        = decltype(arch_config)::params;
+                    static constexpr unsigned int items_per_tile
+                        = params.merge_mergepath_config.block_size
+                          * params.merge_mergepath_config.items_per_thread;
+
+                    const unsigned int partition_id
+                        = blockIdx.x * params.merge_mergepath_partition_config.block_size
+                          + threadIdx.x;
+
+                    if(partition_id >= merge_num_partitions)
+                    {
+                        return;
+                    }
+
+                    const unsigned int merged_tiles        = block / items_per_tile;
+                    const unsigned int target_merged_tiles = merged_tiles * 2;
+                    const unsigned int mask                = target_merged_tiles - 1;
+
+                    // id of the first tile in the current tile-group
+                    const unsigned int tilegroup_start_id = ~mask & partition_id;
+                    // id of the current tile in the current tile-group
+                    const unsigned int local_tile_id = mask & partition_id;
+
+                    // index of the first item in the current tile-group
+                    const OffsetT tilegroup_start
+                        = static_cast<OffsetT>(tilegroup_start_id) * items_per_tile;
+
+                    const OffsetT keys1_beg = rocprim::min(size, tilegroup_start);
+                    const OffsetT keys1_end
+                        = rocprim::min(size, tilegroup_start + block);
+                    const OffsetT keys2_beg = keys1_end;
+                    const OffsetT keys2_end = rocprim::min(size, keys2_beg + block);
+
+                    const OffsetT partition_at
+                        = rocprim::min(keys2_end - keys1_beg,
+                                       static_cast<OffsetT>(local_tile_id) * items_per_tile);
+
+                    const OffsetT partition_diag
+                        = ::rocprim::detail::merge_path(keys_input_ + keys1_beg,
+                                                        keys_input_ + keys2_beg,
+                                                        keys1_end - keys1_beg,
+                                                        keys2_end - keys2_beg,
+                                                        partition_at,
+                                                        compare_function);
+
+                    d_merge_partitions[partition_id] = keys1_beg + partition_diag;
+                };
+
                 // Note: shared memory is not used in this kernel so there is no need to pass vsmem
-                ROCPRIM_RETURN_ON_ERROR(launch_device_block_merge_mergepath_partition<config>(
-                    target_arch,
-                    keys_input_,
-                    size,
-                    merge_num_partitions,
-                    d_merge_partitions,
-                    compare_function,
-                    block,
-                    dim3(merge_partition_number_of_blocks),
-                    dim3(merge_partition_block_size),
-                    0,
-                    stream));
+                ROCPRIM_RETURN_ON_ERROR(
+                    execute_launch_plan<config,
+                                        decltype(device_block_merge_mergepath_partition_kernel),
+                                        merge_mergepath_partition_config_selector>(
+                        target_arch,
+                        device_block_merge_mergepath_partition_kernel,
+                        dim3(merge_partition_number_of_blocks),
+                        dim3(merge_partition_block_size),
+                        0,
+                        stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR(
                     "device_block_merge_mergepath_partition_kernel",
                     merge_num_partitions,
                     start);
 
                 if(debug_synchronous)
+                {
                     start = std::chrono::steady_clock::now();
-                ROCPRIM_RETURN_ON_ERROR(launch_device_block_merge_mergepath<config>(
-                    target_arch,
-                    keys_input_,
-                    keys_output_,
-                    values_input_,
-                    values_output_,
-                    size,
-                    block,
-                    merge_mergepath_number_of_blocks,
-                    compare_function,
-                    d_merge_partitions,
-                    vsmem,
-                    calculate_grid_dim(merge_mergepath_number_of_blocks,
-                                       merge_mergepath_block_size),
-                    dim3(merge_mergepath_block_size),
-                    0,
-                    stream));
+                }
+                auto device_block_merge_mergepath_kernel = [=](auto arch_config) mutable
+                {
+                    static constexpr merge_sort_block_merge_config_params params
+                        = decltype(arch_config)::params;
+
+                    using merge_impl
+                        = block_merge_impl<key_type,
+                                           value_type,
+                                           params.merge_mergepath_config.block_size,
+                                           params.merge_mergepath_config.items_per_thread>;
+
+                    using VSmemHelperT = detail::vsmem_helper_impl<merge_impl>;
+                    ROCPRIM_SHARED_MEMORY
+                    typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+
+                    typename merge_impl::storage_type& storage
+                        = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
+
+                    // Core part of block mergepath kernel
+                    merge_impl().process_tile(keys_input_,
+                                              keys_output_,
+                                              values_input_,
+                                              values_output_,
+                                              size,
+                                              block,
+                                              merge_mergepath_number_of_blocks,
+                                              compare_function,
+                                              d_merge_partitions,
+                                              storage);
+                };
+                ROCPRIM_RETURN_ON_ERROR(
+                    execute_launch_plan<config,
+                                        decltype(device_block_merge_mergepath_kernel),
+                                        merge_mergepath_config_selector>(
+                        target_arch,
+                        device_block_merge_mergepath_kernel,
+                        calculate_grid_dim(merge_mergepath_number_of_blocks,
+                                           merge_mergepath_block_size),
+                        dim3(merge_mergepath_block_size),
+                        0,
+                        stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_block_merge_mergepath_kernel",
                                                             size,
                                                             start);
@@ -442,23 +278,38 @@ inline hipError_t merge_sort_block_merge_impl(
             else
             {
                 if(debug_synchronous)
+                {
                     start = std::chrono::steady_clock::now();
+                }
                 // As this kernel is only called with small sizes, it is safe to use 32-bit integers
                 // for size and block.
                 // Note: shared memory is not used in this kernel so there is no need to pass vsmem
+
+                auto device_block_merge_oddeven_kernel = [=](auto arch_config)
+                {
+                    static constexpr merge_sort_block_merge_config_params params
+                        = decltype(arch_config)::params;
+                    block_merge_oddeven_kernel<params.merge_oddeven_config.block_size,
+                                               params.merge_oddeven_config.items_per_thread>(
+                        keys_input_,
+                        keys_output_,
+                        values_input_,
+                        values_output_,
+                        static_cast<unsigned int>(size),
+                        static_cast<unsigned int>(block),
+                        compare_function);
+                };
                 ROCPRIM_RETURN_ON_ERROR(
-                    launch_device_block_merge_oddeven<config>(target_arch,
-                                                              keys_input_,
-                                                              keys_output_,
-                                                              values_input_,
-                                                              values_output_,
-                                                              static_cast<unsigned int>(size),
-                                                              static_cast<unsigned int>(block),
-                                                              compare_function,
-                                                              dim3(merge_oddeven_number_of_blocks),
-                                                              dim3(merge_oddeven_block_size),
-                                                              0,
-                                                              stream));
+                    execute_launch_plan<config,
+                                        decltype(device_block_merge_oddeven_kernel),
+                                        merge_oddeven_config_selector>(
+                        target_arch,
+                        device_block_merge_oddeven_kernel,
+                        dim3(merge_oddeven_number_of_blocks),
+                        dim3(merge_oddeven_block_size),
+                        0,
+                        stream));
+
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_block_merge_oddeven_kernel",
                                                             size,
                                                             start);
@@ -653,22 +504,58 @@ inline hipError_t merge_sort_block_sort(KeysInputIterator    keys_input,
     // Start point for time measurements
     std::chrono::steady_clock::time_point start;
     if(debug_synchronous)
+    {
         start = std::chrono::steady_clock::now();
+    }
 
-    ROCPRIM_RETURN_ON_ERROR(launch_block_sort<config>(
+    auto block_sort_kernel = [=](auto arch_config) mutable
+    {
+        constexpr auto params = decltype(arch_config)::params;
+
+        constexpr unsigned int items_per_block
+            = params.kernel_config.block_size * params.kernel_config.items_per_thread;
+
+        const unsigned int flat_block_id = ::rocprim::flat_block_id();
+        if(flat_block_id >= sort_number_of_blocks)
+        {
+            return;
+        }
+
+        const size_t       block_offset = static_cast<size_t>(flat_block_id) * items_per_block;
+        const unsigned int valid_in_last_block = size - block_offset;
+        const bool         is_incomplete_block = flat_block_id == (size / items_per_block);
+
+        using sort_impl    = block_sort_impl<key_type,
+                                             value_type,
+                                             params.kernel_config.block_size,
+                                             params.kernel_config.items_per_thread>;
+        using VSmemHelperT = detail::vsmem_helper_impl<sort_impl>;
+
+        ROCPRIM_SHARED_MEMORY
+        typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+
+        typename sort_impl::storage_type& storage
+            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
+
+        // Core part of the block sort kernel
+        sort_impl().sort(valid_in_last_block,
+                         is_incomplete_block,
+                         keys_input + block_offset,
+                         keys_output + block_offset,
+                         values_input + block_offset,
+                         values_output + block_offset,
+                         compare_function,
+                         storage);
+    };
+
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(
         target_arch,
-        keys_input,
-        keys_output,
-        values_input,
-        values_output,
-        size,
-        sort_number_of_blocks,
-        compare_function,
-        vsmem,
+        block_sort_kernel,
         calculate_grid_dim(sort_number_of_blocks, params.kernel_config.block_size),
-        dim3(params.kernel_config.block_size),
+        params.kernel_config.block_size,
         0,
         stream));
+
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_sort_kernel", size, start);
 
     return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
@@ -54,84 +54,6 @@ namespace detail
 template<class Config,
          select_method SelectMethod,
          bool          OnlySelected,
-         class KeyIterator,
-         class ValueIterator,
-         class FlagIterator,
-         class OutputKeyIterator,
-         class OutputValueIterator,
-         class InequalityOp,
-         class OffsetLookbackScanState,
-         class BlockIdWrapper,
-         class... UnaryPredicates>
-inline hipError_t launch_partition(detail::target_arch     arch,
-                                   KeyIterator             keys_input,
-                                   ValueIterator           values_input,
-                                   FlagIterator            flags,
-                                   OutputKeyIterator       keys_output,
-                                   OutputValueIterator     values_output,
-                                   size_t*                 selected_count,
-                                   size_t*                 prev_selected_count,
-                                   size_t                  prev_processed,
-                                   const size_t            total_size,
-                                   InequalityOp            inequality_op,
-                                   OffsetLookbackScanState offset_scan_state,
-                                   const unsigned int      number_of_blocks,
-                                   detail::vsmem_t         vsmem,
-                                   BlockIdWrapper          block_id,
-                                   dim3                    grid,
-                                   dim3                    block,
-                                   size_t                  shmem,
-                                   hipStream_t             stream,
-                                   UnaryPredicates... predicates)
-{
-    auto kernel = [=](auto arch_config) mutable
-    {
-        using offset_type = typename OffsetLookbackScanState::value_type;
-        using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
-        using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
-        using flag_type =
-            typename std::conditional<SelectMethod == select_method::predicated_flag,
-                                      typename std::iterator_traits<FlagIterator>::value_type,
-                                      bool>::type;
-
-        using partition_kernel_impl_t = partition_kernel_impl_<decltype(arch_config),
-                                                               SelectMethod,
-                                                               OnlySelected,
-                                                               key_type,
-                                                               value_type,
-                                                               flag_type,
-                                                               offset_type,
-                                                               BlockIdWrapper>;
-
-        using VSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
-        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
-        // Get temporary storage
-        typename partition_kernel_impl_t::storage_type& storage
-            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
-
-        partition_kernel_impl_t().partition(keys_input,
-                                            values_input,
-                                            flags,
-                                            keys_output,
-                                            values_output,
-                                            selected_count,
-                                            prev_selected_count,
-                                            prev_processed,
-                                            total_size,
-                                            inequality_op,
-                                            offset_scan_state,
-                                            number_of_blocks,
-                                            block_id,
-                                            storage,
-                                            predicates...);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
-template<class Config,
-         select_method SelectMethod,
-         bool          OnlySelected,
          class Key,
          class Value,
          class FlagType,
@@ -390,27 +312,46 @@ inline hipError_t partition_impl(void*                       temporary_storage,
                     start = std::chrono::steady_clock::now();
                 }
 
-                ROCPRIM_RETURN_ON_ERROR(launch_partition<config, method, write_only_selected>(
-                    target_arch,
-                    keys_input + prev_processed,
-                    values_input + prev_processed,
-                    flags + prev_processed,
-                    keys_output,
-                    values_output,
-                    selected_count,
-                    prev_selected_count,
-                    prev_processed,
-                    size,
-                    inequality_op,
-                    scan_state,
-                    current_number_of_blocks,
-                    detail::vsmem_t{vsmem},
-                    block_id,
-                    dim3(current_number_of_blocks),
-                    dim3(block_size),
-                    0,
-                    stream,
-                    predicates...));
+                auto partition_kernel = [=, vsm = detail::vsmem_t{vsmem}](auto arch_config) mutable
+                {
+                    using partition_kernel_impl_t = partition_kernel_impl_<decltype(arch_config),
+                                                                           method,
+                                                                           write_only_selected,
+                                                                           key_type,
+                                                                           value_type,
+                                                                           flag_type,
+                                                                           offset_type,
+                                                                           decltype(block_id)>;
+
+                    using VSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
+                    ROCPRIM_SHARED_MEMORY
+                    typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+                    // Get temporary storage
+                    typename partition_kernel_impl_t::storage_type& storage
+                        = VSmemHelperT::get_temp_storage(static_temp_storage, vsm);
+
+                    partition_kernel_impl_t().partition(keys_input + prev_processed,
+                                                        values_input + prev_processed,
+                                                        flags + prev_processed,
+                                                        keys_output,
+                                                        values_output,
+                                                        selected_count,
+                                                        prev_selected_count,
+                                                        prev_processed,
+                                                        size,
+                                                        inequality_op,
+                                                        scan_state,
+                                                        current_number_of_blocks,
+                                                        block_id,
+                                                        storage,
+                                                        predicates...);
+                };
+                ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                    partition_kernel,
+                                                                    dim3(current_number_of_blocks),
+                                                                    dim3(block_size),
+                                                                    0,
+                                                                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", size, start);
 
                 std::swap(selected_count, prev_selected_count);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -78,70 +78,6 @@ struct decomposer_max_bits
 template<class Size>
 using offset_type_t = std::conditional_t<sizeof(Size) <= 4, unsigned int, size_t>;
 
-template<class Config, bool Descending, class KeysInputIterator, class Offset, class Decomposer>
-inline hipError_t launch_onesweep_histograms(detail::target_arch arch,
-                                             KeysInputIterator   keys_input,
-                                             Offset*             global_digit_counts,
-                                             const Offset        size,
-                                             const Offset        full_blocks,
-                                             Decomposer          decomposer,
-                                             const unsigned int  begin_bit,
-                                             const unsigned int  end_bit,
-                                             dim3                grid,
-                                             dim3                block,
-                                             size_t              shmem,
-                                             hipStream_t         stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        static constexpr radix_sort_onesweep_config_params params = decltype(arch_config)::params;
-        onesweep_histograms<params.histogram.block_size,
-                            params.histogram.items_per_thread,
-                            params.radix_bits_per_place,
-                            Descending>(keys_input,
-                                        global_digit_counts,
-                                        size,
-                                        full_blocks,
-                                        decomposer,
-                                        begin_bit,
-                                        end_bit);
-    };
-
-    return execute_launch_plan<Config,
-                               decltype(kernel),
-                               radix_sort_onesweep_histogram_config_selector>(arch,
-                                                                              kernel,
-                                                                              grid,
-                                                                              block,
-                                                                              shmem,
-                                                                              stream);
-}
-
-template<class Config, class Offset>
-inline hipError_t launch_onesweep_scan_histograms(detail::target_arch arch,
-                                                  Offset*             global_digit_offsets,
-                                                  dim3                grid,
-                                                  dim3                block,
-                                                  size_t              shmem,
-                                                  hipStream_t         stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        static constexpr radix_sort_onesweep_config_params params = decltype(arch_config)::params;
-        onesweep_scan_histograms<params.histogram.block_size, params.radix_bits_per_place>(
-            global_digit_offsets);
-    };
-
-    return execute_launch_plan<Config,
-                               decltype(kernel),
-                               radix_sort_onesweep_histogram_config_selector>(arch,
-                                                                              kernel,
-                                                                              grid,
-                                                                              block,
-                                                                              shmem,
-                                                                              stream);
-}
-
 template<class Config,
          bool Descending,
          class KeysInputIterator,
@@ -197,19 +133,29 @@ hipError_t radix_sort_onesweep_global_offsets(KeysInputIterator keys_input,
     }
 
     // Compute a histogram for each digit.
-    ROCPRIM_RETURN_ON_ERROR(
-        launch_onesweep_histograms<config, Descending>(target_arch,
-                                                       keys_input,
-                                                       global_digit_offsets,
-                                                       size,
-                                                       full_blocks,
-                                                       decomposer,
-                                                       begin_bit,
-                                                       end_bit,
-                                                       dim3(blocks),
-                                                       dim3(params.histogram.block_size),
-                                                       0,
-                                                       stream));
+    auto onesweep_histograms_kernel = [=](auto arch_config)
+    {
+        static constexpr radix_sort_onesweep_config_params params = decltype(arch_config)::params;
+        onesweep_histograms<params.histogram.block_size,
+                            params.histogram.items_per_thread,
+                            params.radix_bits_per_place,
+                            Descending>(keys_input,
+                                        global_digit_offsets,
+                                        size,
+                                        full_blocks,
+                                        decomposer,
+                                        begin_bit,
+                                        end_bit);
+    };
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config,
+                                                decltype(onesweep_histograms_kernel),
+                                                radix_sort_onesweep_histogram_config_selector>(
+        target_arch,
+        onesweep_histograms_kernel,
+        dim3(blocks),
+        dim3(params.histogram.block_size),
+        0,
+        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("compute_global_digit_histograms", size, start);
 
     // Scan each histogram separately to get the final offsets.
@@ -218,75 +164,23 @@ hipError_t radix_sort_onesweep_global_offsets(KeysInputIterator keys_input,
         start = std::chrono::steady_clock::now();
     }
 
-    ROCPRIM_RETURN_ON_ERROR(launch_onesweep_scan_histograms<config>(
+    auto onesweep_scan_histograms_kernel = [=](auto arch_config)
+    {
+        static constexpr radix_sort_onesweep_config_params params = decltype(arch_config)::params;
+        onesweep_scan_histograms<params.histogram.block_size, params.radix_bits_per_place>(
+            global_digit_offsets);
+    };
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config,
+                                                decltype(onesweep_scan_histograms_kernel),
+                                                radix_sort_onesweep_histogram_config_selector>(
         target_arch,
-        global_digit_offsets,
+        onesweep_scan_histograms_kernel,
         dim3(digit_places), // One block for every digit place.
         dim3(params.histogram.block_size),
         0,
         stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("scan_global_digit_histograms", bins, start);
     return hipSuccess;
-}
-
-template<class Config,
-         bool Descending,
-         class KeysInputIterator,
-         class KeysOutputIterator,
-         class ValuesInputIterator,
-         class ValuesOutputIterator,
-         class Offset,
-         class Decomposer,
-         class BlockIdWrapper>
-inline hipError_t launch_onesweep_iteration(detail::target_arch      arch,
-                                            KeysInputIterator        keys_input,
-                                            KeysOutputIterator       keys_output,
-                                            ValuesInputIterator      values_input,
-                                            ValuesOutputIterator     values_output,
-                                            const unsigned int       size,
-                                            Offset*                  global_digit_offsets_in,
-                                            Offset*                  global_digit_offsets_out,
-                                            onesweep_lookback_state* lookback_states,
-                                            Decomposer               decomposer,
-                                            const unsigned int       bit,
-                                            const unsigned int       current_radix_bits,
-                                            const unsigned int       full_blocks,
-                                            BlockIdWrapper           ordered_bid,
-                                            dim3                     grid,
-                                            dim3                     block,
-                                            size_t                   shmem,
-                                            hipStream_t              stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        static constexpr auto params = decltype(arch_config)::params;
-
-        onesweep_iteration<params.sort.block_size,
-                           params.sort.items_per_thread,
-                           params.radix_bits_per_place,
-                           Descending,
-                           params.radix_rank_algorithm>(keys_input,
-                                                        keys_output,
-                                                        values_input,
-                                                        values_output,
-                                                        size,
-                                                        global_digit_offsets_in,
-                                                        global_digit_offsets_out,
-                                                        lookback_states,
-                                                        decomposer,
-                                                        bit,
-                                                        current_radix_bits,
-                                                        full_blocks,
-                                                        ordered_bid);
-    };
-
-    return execute_launch_plan<Config, decltype(kernel), radix_sort_onesweep_sort_config_selector>(
-        arch,
-        kernel,
-        grid,
-        block,
-        shmem,
-        stream);
 }
 
 template<class Config,
@@ -379,93 +273,68 @@ hipError_t radix_sort_onesweep_iteration(
 
         ROCPRIM_RETURN_ON_ERROR(ordered_bid.reset_from_host(stream));
 
+        auto launch_onesweep_iteration
+            = [&](auto keys_in, auto keys_out, auto values_in, auto values_out)
+        {
+            auto onesweep_iteration_kernel = [=](auto arch_config)
+            {
+                static constexpr auto params = decltype(arch_config)::params;
+
+                onesweep_iteration<params.sort.block_size,
+                                   params.sort.items_per_thread,
+                                   params.radix_bits_per_place,
+                                   Descending,
+                                   params.radix_rank_algorithm>(keys_in,
+                                                                keys_out,
+                                                                values_in,
+                                                                values_out,
+                                                                current_batch_size,
+                                                                global_digit_offsets_in,
+                                                                global_digit_offsets_out,
+                                                                lookback_states,
+                                                                decomposer,
+                                                                bit,
+                                                                current_radix_bits,
+                                                                full_blocks,
+                                                                ordered_bid);
+            };
+            return execute_launch_plan<config,
+                                       decltype(onesweep_iteration_kernel),
+                                       radix_sort_onesweep_sort_config_selector>(
+                target_arch,
+                onesweep_iteration_kernel,
+                dim3(blocks),
+                dim3(params.sort.block_size),
+                0,
+                stream);
+        };
         if(from_input && to_output)
         {
-            ROCPRIM_RETURN_ON_ERROR(
-                launch_onesweep_iteration<config, Descending>(target_arch,
-                                                              keys_input + offset,
+            ROCPRIM_RETURN_ON_ERROR(launch_onesweep_iteration(keys_input + offset,
                                                               keys_output,
                                                               values_input + offset,
-                                                              values_output,
-                                                              current_batch_size,
-                                                              global_digit_offsets_in,
-                                                              global_digit_offsets_out,
-                                                              lookback_states,
-                                                              decomposer,
-                                                              bit,
-                                                              current_radix_bits,
-                                                              full_blocks,
-                                                              ordered_bid,
-                                                              dim3(blocks),
-                                                              dim3(params.sort.block_size),
-                                                              0,
-                                                              stream));
+                                                              values_output));
         }
         else if(from_input)
         {
-            ROCPRIM_RETURN_ON_ERROR(
-                launch_onesweep_iteration<config, Descending>(target_arch,
-                                                              keys_input + offset,
+            ROCPRIM_RETURN_ON_ERROR(launch_onesweep_iteration(keys_input + offset,
                                                               keys_tmp,
                                                               values_input + offset,
-                                                              values_tmp,
-                                                              current_batch_size,
-                                                              global_digit_offsets_in,
-                                                              global_digit_offsets_out,
-                                                              lookback_states,
-                                                              decomposer,
-                                                              bit,
-                                                              current_radix_bits,
-                                                              full_blocks,
-                                                              ordered_bid,
-                                                              dim3(blocks),
-                                                              dim3(params.sort.block_size),
-                                                              0,
-                                                              stream));
+                                                              values_tmp));
         }
         else if(to_output)
         {
-            ROCPRIM_RETURN_ON_ERROR(
-                launch_onesweep_iteration<config, Descending>(target_arch,
-                                                              keys_tmp + offset,
+            ROCPRIM_RETURN_ON_ERROR(launch_onesweep_iteration(keys_tmp + offset,
                                                               keys_output,
                                                               values_tmp + offset,
-                                                              values_output,
-                                                              current_batch_size,
-                                                              global_digit_offsets_in,
-                                                              global_digit_offsets_out,
-                                                              lookback_states,
-                                                              decomposer,
-                                                              bit,
-                                                              current_radix_bits,
-                                                              full_blocks,
-                                                              ordered_bid,
-                                                              dim3(blocks),
-                                                              dim3(params.sort.block_size),
-                                                              0,
-                                                              stream));
+                                                              values_output));
         }
         else
         {
-            ROCPRIM_RETURN_ON_ERROR(
-                launch_onesweep_iteration<config, Descending>(target_arch,
-                                                              keys_output + offset,
+            ROCPRIM_RETURN_ON_ERROR(launch_onesweep_iteration(keys_output + offset,
                                                               keys_tmp,
                                                               values_output + offset,
-                                                              values_tmp,
-                                                              current_batch_size,
-                                                              global_digit_offsets_in,
-                                                              global_digit_offsets_out,
-                                                              lookback_states,
-                                                              decomposer,
-                                                              bit,
-                                                              current_radix_bits,
-                                                              full_blocks,
-                                                              ordered_bid,
-                                                              dim3(blocks),
-                                                              dim3(params.sort.block_size),
-                                                              0,
-                                                              stream));
+                                                              values_tmp));
         }
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("onesweep_iteration", size, start);
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -45,38 +45,6 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config,
-         bool         WithInitialValue,
-         bool         FitLarger,
-         unsigned int FitItems,
-         class ResultType,
-         class InputIterator,
-         class OutputIterator,
-         class InitValueType,
-         class BinaryFunction>
-inline hipError_t launch_block_reduce(detail::target_arch arch,
-                                      InputIterator       input,
-                                      const size_t        size,
-                                      OutputIterator      output,
-                                      InitValueType       initial_value,
-                                      BinaryFunction      reduce_op,
-                                      dim3                grid,
-                                      dim3                block,
-                                      size_t              shmem,
-                                      hipStream_t         stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        block_reduce_kernel_impl<decltype(arch_config),
-                                 WithInitialValue,
-                                 FitLarger,
-                                 FitItems,
-                                 ResultType>(input, size, output, initial_value, reduce_op);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 #define ROCPRIM_DETAIL_HIP_SYNC(name, size, start)                                           \
     if(debug_synchronous)                                                                    \
     {                                                                                        \
@@ -89,34 +57,37 @@ inline hipError_t launch_block_reduce(detail::target_arch arch,
         std::cout << " " << _d.count() * 1000 << " ms" << '\n';                              \
     }
 
-#define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                            \
-    do                                                                                         \
-    {                                                                                          \
-        detail::target_arch target_arch;                                                       \
-        hipError_t          result = detail::host_target_arch(stream, target_arch);            \
-        if(result != hipSuccess)                                                               \
-        {                                                                                      \
-            return result;                                                                     \
-        }                                                                                      \
-        if(debug_synchronous)                                                                  \
-        {                                                                                      \
-            start = std::chrono::steady_clock::now();                                          \
-        }                                                                                      \
-                                                                                               \
-        ROCPRIM_RETURN_ON_ERROR(                                                               \
-            launch_block_reduce<config, WithInitialValue, fit_larger, fit_items, result_type>( \
-                target_arch,                                                                   \
-                input,                                                                         \
-                size,                                                                          \
-                output,                                                                        \
-                initial_value,                                                                 \
-                reduce_op,                                                                     \
-                dim3(1),                                                                       \
-                dim3(block_size),                                                              \
-                0,                                                                             \
-                stream));                                                                      \
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);       \
-    }                                                                                          \
+#define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                               \
+    do                                                                                            \
+    {                                                                                             \
+        detail::target_arch target_arch;                                                          \
+        hipError_t          result = detail::host_target_arch(stream, target_arch);               \
+        if(result != hipSuccess)                                                                  \
+        {                                                                                         \
+            return result;                                                                        \
+        }                                                                                         \
+        if(debug_synchronous)                                                                     \
+        {                                                                                         \
+            start = std::chrono::steady_clock::now();                                             \
+        }                                                                                         \
+                                                                                                  \
+        auto block_reduce_kernel = [=](auto arch_config) mutable                                  \
+        {                                                                                         \
+            block_reduce_kernel_impl<decltype(arch_config),                                       \
+                                     WithInitialValue,                                            \
+                                     fit_larger,                                                  \
+                                     fit_items,                                                   \
+                                     result_type>(input, size, output, initial_value, reduce_op); \
+        };                                                                                        \
+                                                                                                  \
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,                          \
+                                                            block_reduce_kernel,                  \
+                                                            dim3(1),                              \
+                                                            dim3(block_size),                     \
+                                                            0,                                    \
+                                                            stream));                             \
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);          \
+    }                                                                                             \
     while(0)
 
 template<bool WithInitialValue, // true when inital_value should be used in reduction
@@ -216,22 +187,22 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             {
                 start = std::chrono::steady_clock::now();
             }
-            const hipError_t error = launch_block_reduce<config, false, true, 1, result_type>(
-                target_arch,
-                input + offset,
-                current_size,
-                block_prefixes + i * number_of_blocks_limit,
-                initial_value,
-                reduce_op,
-                dim3(current_blocks),
-                dim3(block_size),
-                0,
-                stream);
-
-            if(error != hipSuccess)
+            auto block_reduce_kernel = [=](auto arch_config)
             {
-                return error;
-            }
+                block_reduce_kernel_impl<decltype(arch_config), false, true, 1, result_type>(
+                    input + offset,
+                    current_size,
+                    block_prefixes + i * number_of_blocks_limit,
+                    initial_value,
+                    reduce_op);
+            };
+            ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                block_reduce_kernel,
+                                                                dim3(current_blocks),
+                                                                dim3(block_size),
+                                                                0,
+                                                                stream));
+
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", current_size, start);
         }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -96,59 +96,6 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
     init_lookback_scan_state(lookback_scan_state, number_of_blocks, ordered_bid, flat_thread_id);
 }
 
-template<typename Config,
-         lookback_scan_determinism Determinism,
-         typename AccumulatorType,
-         typename KeyIterator,
-         typename ValueIterator,
-         typename UniqueIterator,
-         typename ReductionIterator,
-         typename UniqueCountIterator,
-         typename CompareFunction,
-         typename BinaryOp,
-         typename LookbackScanState,
-         typename BlockIdWrapper>
-inline hipError_t launch_reduce_by_key(detail::target_arch          arch,
-                                       const KeyIterator            keys_input,
-                                       const ValueIterator          values_input,
-                                       const UniqueIterator         unique_keys,
-                                       const ReductionIterator      reductions,
-                                       const UniqueCountIterator    unique_count,
-                                       const BinaryOp               reduce_op,
-                                       const CompareFunction        compare,
-                                       const LookbackScanState      scan_state,
-                                       const std::size_t            starting_block,
-                                       const std::size_t            total_number_of_blocks,
-                                       const std::size_t            size,
-                                       const std::size_t* const     global_head_count,
-                                       const AccumulatorType* const previous_accumulated,
-                                       BlockIdWrapper               ordered_bid,
-                                       dim3                         grid,
-                                       dim3                         block,
-                                       size_t                       shmem,
-                                       hipStream_t                  stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        reduce_by_key::kernel_impl<decltype(arch_config), Determinism>(keys_input,
-                                                                       values_input,
-                                                                       unique_keys,
-                                                                       reductions,
-                                                                       unique_count,
-                                                                       reduce_op,
-                                                                       compare,
-                                                                       scan_state,
-                                                                       starting_block,
-                                                                       total_number_of_blocks,
-                                                                       size,
-                                                                       global_head_count,
-                                                                       previous_accumulated,
-                                                                       ordered_bid);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 template<lookback_scan_determinism Determinism,
          typename config,
          typename KeysInputIterator,
@@ -303,27 +250,30 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_init_kernel",
                                                             number_of_blocks_launch,
                                                             start);
-
-                ROCPRIM_RETURN_ON_ERROR(launch_reduce_by_key<config, Determinism>(
-                    target_arch,
-                    keys_input + offset,
-                    values_input + offset,
-                    unique_output,
-                    aggregates_output,
-                    unique_count_output,
-                    reduce_op,
-                    key_compare_op,
-                    scan_state,
-                    i * number_of_blocks,
-                    total_number_of_blocks,
-                    size,
-                    i > 0 ? d_global_head_count : nullptr,
-                    i > 0 ? d_previous_accumulated : nullptr,
-                    ordered_bid,
-                    dim3(number_of_blocks_launch),
-                    dim3(block_size),
-                    0,
-                    stream));
+                auto kernel = [=](auto arch_config)
+                {
+                    reduce_by_key::kernel_impl<decltype(arch_config), Determinism>(
+                        keys_input + offset,
+                        values_input + offset,
+                        unique_output,
+                        aggregates_output,
+                        unique_count_output,
+                        reduce_op,
+                        key_compare_op,
+                        scan_state,
+                        i * number_of_blocks,
+                        total_number_of_blocks,
+                        size,
+                        i > 0 ? d_global_head_count : nullptr,
+                        i > 0 ? d_previous_accumulated : nullptr,
+                        ordered_bid);
+                };
+                ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                    kernel,
+                                                                    dim3(number_of_blocks_launch),
+                                                                    dim3(block_size),
+                                                                    0,
+                                                                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_kernel",
                                                             current_size,
                                                             start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
@@ -96,44 +96,6 @@ hipError_t run_length_encode_impl(void*                     temporary_storage,
 }
 
 template<typename Config,
-         typename OffsetCountPairType,
-         typename InputIterator,
-         typename OffsetsOutputIterator,
-         typename CountsOutputIterator,
-         typename RunsCountOutputIterator,
-         typename LookbackScanState,
-         typename BlockIdWrapper>
-inline hipError_t launch_non_trivial(detail::target_arch           arch,
-                                     const InputIterator           input,
-                                     const OffsetsOutputIterator   offsets_output,
-                                     const CountsOutputIterator    counts_output,
-                                     const RunsCountOutputIterator runs_count_output,
-                                     const LookbackScanState       scan_state,
-                                     const std::size_t             grid_size,
-                                     const std::size_t             size,
-                                     BlockIdWrapper                ordered_bid,
-                                     dim3                          grid,
-                                     dim3                          block,
-                                     size_t                        shmem,
-                                     hipStream_t                   stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        run_length_encode::non_trivial_kernel_impl<decltype(arch_config), OffsetCountPairType>(
-            input,
-            offsets_output,
-            counts_output,
-            runs_count_output,
-            scan_state,
-            grid_size,
-            size,
-            ordered_bid);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
-template<typename Config,
          typename InputIterator,
          typename OffsetsOutputIterator,
          typename CountsOutputIterator,
@@ -245,21 +207,26 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
                                                         grid_size,
                                                         start);
 
-            ROCPRIM_RETURN_ON_ERROR(
-                run_length_encode::launch_non_trivial<config, offset_count_pair_type>(
-                    target_arch,
-                    input + 0,
+            auto non_trivial_kernel = [=](auto arch_config)
+            {
+                run_length_encode::non_trivial_kernel_impl<decltype(arch_config),
+                                                           offset_count_pair_type>(
+                    input,
                     offsets_output,
                     counts_output,
                     runs_count_output,
                     scan_state,
                     grid_size,
                     size,
-                    ordered_bid,
-                    dim3(grid_size),
-                    dim3(block_size),
-                    0,
-                    stream));
+                    ordered_bid);
+            };
+
+            ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                non_trivial_kernel,
+                                                                dim3(grid_size),
+                                                                dim3(block_size),
+                                                                0,
+                                                                stream));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("run_length_encode::non_trivial_kernel",
                                                         size,
                                                         start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
@@ -48,136 +48,6 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-// Single kernel scan (performs scan on one thread block only)
-template<class ArchConfig,
-         bool Exclusive,
-         bool UseInitialValue,
-         class InputIterator,
-         class OutputIterator,
-         class BinaryFunction,
-         class AccType>
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void single_scan_kernel_impl(InputIterator  input,
-                                                                 const size_t   input_size,
-                                                                 AccType        initial_value,
-                                                                 OutputIterator output,
-                                                                 BinaryFunction scan_op)
-{
-    static constexpr scan_config_params params = ArchConfig::params;
-
-    constexpr unsigned int block_size       = params.kernel_config.block_size;
-    constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
-
-    using block_load_type
-        = ::rocprim::block_load<AccType, block_size, items_per_thread, params.block_load_method>;
-    using block_store_type
-        = ::rocprim::block_store<AccType, block_size, items_per_thread, params.block_store_method>;
-    using block_scan_type = ::rocprim::block_scan<AccType, block_size, params.block_scan_method>;
-
-    ROCPRIM_SHARED_MEMORY union
-    {
-        typename block_load_type::storage_type  load;
-        typename block_store_type::storage_type store;
-        typename block_scan_type::storage_type  scan;
-    } storage;
-
-    AccType values[items_per_thread];
-    // load input values into values
-    block_load_type().load(input, values, input_size, *(input), storage.load);
-    ::rocprim::syncthreads(); // sync threads to reuse shared memory
-
-    single_scan_block_scan<Exclusive, UseInitialValue, block_scan_type>(values, // input
-                                                                        values, // output
-                                                                        initial_value,
-                                                                        storage.scan,
-                                                                        scan_op);
-    ::rocprim::syncthreads(); // sync threads to reuse shared memory
-
-    // Save values into output array
-    block_store_type().store(output, values, input_size, storage.store);
-}
-
-template<class Config,
-         bool Exclusive,
-         bool UseInitialValue,
-         class InputIterator,
-         class OutputIterator,
-         class BinaryFunction,
-         class InitValueType,
-         class AccType>
-inline hipError_t launch_single_scan(detail::target_arch arch,
-                                     InputIterator       input,
-                                     const size_t        size,
-                                     const InitValueType initial_value,
-                                     OutputIterator      output,
-                                     BinaryFunction      scan_op,
-                                     dim3                grid,
-                                     dim3                block,
-                                     size_t              shmem,
-                                     hipStream_t         stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        single_scan_kernel_impl<decltype(arch_config), Exclusive, UseInitialValue>(
-            input,
-            size,
-            static_cast<AccType>(get_input_value(initial_value)),
-            output,
-            scan_op);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
-// Single pass (look-back kernels)
-template<class Config,
-         lookback_scan_determinism Determinism,
-         bool                      Exclusive,
-         bool                      UseInitialValue,
-         class InputIterator,
-         class OutputIterator,
-         class BinaryFunction,
-         class InitValueType,
-         class AccType,
-         class LookBackScanState,
-         class BlockIdWrapper>
-inline hipError_t launch_lookback_scan(detail::target_arch arch,
-                                       InputIterator       input,
-                                       OutputIterator      output,
-                                       const size_t        size,
-                                       InitValueType       initial_value,
-                                       BinaryFunction      scan_op,
-                                       LookBackScanState   lookback_scan_state,
-                                       const unsigned int  number_of_blocks,
-                                       dim3                grid,
-                                       dim3                block,
-                                       size_t              shmem,
-                                       hipStream_t         stream,
-                                       AccType*            previous_last_element,
-                                       AccType*            new_last_element,
-                                       bool                override_first_value,
-                                       bool                save_last_value,
-                                       BlockIdWrapper      ordered_bid)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        lookback_scan_kernel_impl<decltype(arch_config), Determinism, Exclusive, UseInitialValue>(
-            input,
-            output,
-            size,
-            static_cast<AccType>(get_input_value(initial_value)),
-            scan_op,
-            lookback_scan_state,
-            number_of_blocks,
-            previous_last_element,
-            new_last_element,
-            override_first_value,
-            save_last_value,
-            ordered_bid);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 template<lookback_scan_determinism Determinism,
          bool                      Exclusive,
          bool                      UseInitialValue,
@@ -324,31 +194,31 @@ inline auto scan_impl(void*               temporary_storage,
                         std::cout << "items_per_block " << items_per_block << '\n';
                     }
 
-                    ROCPRIM_RETURN_ON_ERROR(launch_lookback_scan<config,
-                                                                 Determinism,
-                                                                 Exclusive,
-                                                                 UseInitialValue,
-                                                                 InputIterator,
-                                                                 OutputIterator,
-                                                                 BinaryFunction,
-                                                                 InitValueType,
-                                                                 AccType>(target_arch,
-                                                                          input + offset,
-                                                                          output + offset,
-                                                                          current_size,
-                                                                          initial_value,
-                                                                          scan_op,
-                                                                          scan_state,
-                                                                          number_of_blocks,
-                                                                          dim3(grid_size),
-                                                                          dim3(block_size),
-                                                                          0,
-                                                                          stream,
-                                                                          previous_last_element,
-                                                                          new_last_element,
-                                                                          i != size_t(0),
-                                                                          number_of_launch > 1,
-                                                                          block_id));
+                    auto lookback_scan_kernel = [=](auto arch_config)
+                    {
+                        lookback_scan_kernel_impl<decltype(arch_config),
+                                                  Determinism,
+                                                  Exclusive,
+                                                  UseInitialValue>(
+                            input + offset,
+                            output + offset,
+                            current_size,
+                            static_cast<AccType>(get_input_value(initial_value)),
+                            scan_op,
+                            scan_state,
+                            number_of_blocks,
+                            previous_last_element,
+                            new_last_element,
+                            (i != size_t(0)),
+                            (number_of_launch > 1),
+                            block_id);
+                    };
+                    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                        lookback_scan_kernel,
+                                                                        dim3(grid_size),
+                                                                        dim3(block_size),
+                                                                        0,
+                                                                        stream));
                     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("lookback_scan_kernel",
                                                                 current_size,
                                                                 start);
@@ -376,24 +246,51 @@ inline auto scan_impl(void*               temporary_storage,
                     start = std::chrono::steady_clock::now();
                 }
 
-                ROCPRIM_RETURN_ON_ERROR(
-                    launch_single_scan<config,
-                                       Exclusive, // flag for exclusive scan operation
-                                       UseInitialValue,
-                                       InputIterator,
-                                       OutputIterator,
-                                       BinaryFunction,
-                                       InitValueType,
-                                       AccType>(target_arch,
-                                                input,
-                                                size,
-                                                initial_value,
-                                                output,
-                                                scan_op,
-                                                dim3(1),
-                                                dim3(block_size),
-                                                0,
-                                                stream));
+                auto single_scan_kernel = [=](auto arch_config) mutable
+                {
+                    static constexpr scan_config_params params = decltype(arch_config)::params;
+
+                    constexpr unsigned int block_size       = params.kernel_config.block_size;
+                    constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
+
+                    using block_load_type = ::rocprim::
+                        block_load<AccType, block_size, items_per_thread, params.block_load_method>;
+                    using block_store_type = ::rocprim::block_store<AccType,
+                                                                    block_size,
+                                                                    items_per_thread,
+                                                                    params.block_store_method>;
+                    using block_scan_type
+                        = ::rocprim::block_scan<AccType, block_size, params.block_scan_method>;
+
+                    ROCPRIM_SHARED_MEMORY union
+                    {
+                        typename block_load_type::storage_type  load;
+                        typename block_store_type::storage_type store;
+                        typename block_scan_type::storage_type  scan;
+                    } storage;
+
+                    AccType values[items_per_thread];
+                    // load input values into values
+                    block_load_type().load(input, values, size, *(input), storage.load);
+                    ::rocprim::syncthreads(); // sync threads to reuse shared memory
+
+                    single_scan_block_scan<Exclusive, UseInitialValue, block_scan_type>(
+                        values, // input
+                        values, // output
+                        static_cast<AccType>(get_input_value(initial_value)),
+                        storage.scan,
+                        scan_op);
+                    ::rocprim::syncthreads(); // sync threads to reuse shared memory
+
+                    // Save values into output array
+                    block_store_type().store(output, values, size, storage.store);
+                };
+                ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                    single_scan_kernel,
+                                                                    dim3(1),
+                                                                    dim3(block_size),
+                                                                    0,
+                                                                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("single_scan_kernel", size, start);
             }
             return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -97,62 +97,6 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void init_d
     }
 }
 
-template<typename Config,
-         lookback_scan_determinism Determinism,
-         bool                      Exclusive,
-         typename KeyInputIterator,
-         typename InputIterator,
-         typename OutputIterator,
-         typename InitialValueType,
-         typename CompareFunction,
-         typename BinaryFunction,
-         typename LookbackScanState,
-         typename AccType,
-         typename WrappedBlockId>
-inline hipError_t launch_device_scan_by_key(
-    detail::target_arch                          arch,
-    const KeyInputIterator                       keys,
-    const InputIterator                          values,
-    const OutputIterator                         output,
-    const InitialValueType                       initial_value,
-    const CompareFunction                        compare,
-    const BinaryFunction                         scan_op,
-    const LookbackScanState                      scan_state,
-    const size_t                                 size,
-    const size_t                                 starting_block,
-    const size_t                                 number_of_blocks,
-    const ::rocprim::tuple<AccType, bool>* const previous_last_value,
-    bool                                         use_last_keys,
-    const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__ last_keys,
-    WrappedBlockId ordered_bid,
-    dim3                           grid,
-    dim3                           block,
-    size_t                         shmem,
-    hipStream_t                    stream)
-{
-
-    auto kernel = [=](auto arch_config)
-    {
-        device_scan_by_key_kernel_impl<decltype(arch_config), Determinism, Exclusive>(
-            keys,
-            values,
-            output,
-            static_cast<AccType>(get_input_value(initial_value)),
-            compare,
-            scan_op,
-            scan_state,
-            size,
-            starting_block,
-            number_of_blocks,
-            previous_last_value,
-            use_last_keys,
-            last_keys,
-            ordered_bid);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 /// \return 0 if in-place is not detected
 template<bool Exclusive,
          typename KeysInputIterator,
@@ -374,26 +318,30 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                 {
                     start = std::chrono::steady_clock::now();
                 }
-                ROCPRIM_RETURN_ON_ERROR(launch_device_scan_by_key<config, Determinism, Exclusive>(
-                    target_arch,
-                    keys + offset,
-                    input + offset,
-                    output + offset,
-                    initial_value,
-                    compare,
-                    scan_op,
-                    scan_state,
-                    size,
-                    i * number_of_blocks,
-                    total_number_of_blocks,
-                    i > 0 ? as_const_ptr(previous_last_value) : nullptr,
-                    last_keys_of_each_block_size_byte != 0,
-                    last_keys_of_each_block,
-                    ordered_bid,
-                    dim3(scan_blocks),
-                    dim3(block_size),
-                    0,
-                    stream));
+                auto device_scan_by_key_kernel = [=](auto arch_config)
+                {
+                    device_scan_by_key_kernel_impl<decltype(arch_config), Determinism, Exclusive>(
+                        keys + offset,
+                        input + offset,
+                        output + offset,
+                        static_cast<AccType>(get_input_value(initial_value)),
+                        compare,
+                        scan_op,
+                        scan_state,
+                        size,
+                        i * number_of_blocks,
+                        total_number_of_blocks,
+                        i > 0 ? as_const_ptr(previous_last_value) : nullptr,
+                        last_keys_of_each_block_size_byte != 0,
+                        last_keys_of_each_block,
+                        ordered_bid);
+                };
+                ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                                    device_scan_by_key_kernel,
+                                                                    dim3(scan_blocks),
+                                                                    dim3(block_size),
+                                                                    0,
+                                                                    stream));
                 ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
                                                             current_size,
                                                             start);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_radix_sort.hpp
@@ -51,209 +51,6 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config,
-         bool Descending,
-         class KeysInputIterator,
-         class KeysOutputIterator,
-         class ValuesInputIterator,
-         class ValuesOutputIterator,
-         class OffsetIterator>
-inline hipError_t launch_segmented_sort(
-    detail::target_arch                                             arch,
-    KeysInputIterator                                               keys_input,
-    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
-    KeysOutputIterator                                              keys_output,
-    ValuesInputIterator                                             values_input,
-    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
-    ValuesOutputIterator                                            values_output,
-    bool                                                            to_output,
-    OffsetIterator                                                  begin_offsets,
-    OffsetIterator                                                  end_offsets,
-    unsigned int                                                    iterations,
-    unsigned int                                                    begin_bit,
-    unsigned int                                                    end_bit,
-    dim3                                                            grid,
-    dim3                                                            block,
-    size_t                                                          shmem,
-    hipStream_t                                                     stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        segmented_sort<decltype(arch_config), Descending>(keys_input,
-                                                          keys_tmp,
-                                                          keys_output,
-                                                          values_input,
-                                                          values_tmp,
-                                                          values_output,
-                                                          to_output,
-                                                          begin_offsets,
-                                                          end_offsets,
-                                                          iterations,
-                                                          begin_bit,
-                                                          end_bit);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
-template<class Config,
-         bool Descending,
-         class KeysInputIterator,
-         class KeysOutputIterator,
-         class ValuesInputIterator,
-         class ValuesOutputIterator,
-         class SegmentIndexIterator,
-         class OffsetIterator>
-inline hipError_t launch_segmented_sort_large(
-    detail::target_arch                                             arch,
-    KeysInputIterator                                               keys_input,
-    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
-    KeysOutputIterator                                              keys_output,
-    ValuesInputIterator                                             values_input,
-    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
-    ValuesOutputIterator                                            values_output,
-    bool                                                            to_output,
-    SegmentIndexIterator                                            segment_indices,
-    OffsetIterator                                                  begin_offsets,
-    OffsetIterator                                                  end_offsets,
-    unsigned int                                                    iterations,
-    unsigned int                                                    begin_bit,
-    unsigned int                                                    end_bit,
-    dim3                                                            grid,
-    dim3                                                            block,
-    size_t                                                          shmem,
-    hipStream_t                                                     stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        segmented_sort_large<decltype(arch_config), Descending>(keys_input,
-                                                                keys_tmp,
-                                                                keys_output,
-                                                                values_input,
-                                                                values_tmp,
-                                                                values_output,
-                                                                to_output,
-                                                                segment_indices,
-                                                                begin_offsets,
-                                                                end_offsets,
-                                                                iterations,
-                                                                begin_bit,
-                                                                end_bit);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
-template<class Config,
-         bool Descending,
-         class KeysInputIterator,
-         class KeysOutputIterator,
-         class ValuesInputIterator,
-         class ValuesOutputIterator,
-         class SegmentIndexIterator,
-         class OffsetIterator>
-inline hipError_t launch_segmented_sort_small(
-    detail::target_arch                                             arch,
-    KeysInputIterator                                               keys_input,
-    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
-    KeysOutputIterator                                              keys_output,
-    ValuesInputIterator                                             values_input,
-    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
-    ValuesOutputIterator                                            values_output,
-    bool                                                            to_output,
-    unsigned int                                                    num_segments,
-    SegmentIndexIterator                                            segment_indices,
-    OffsetIterator                                                  begin_offsets,
-    OffsetIterator                                                  end_offsets,
-    unsigned int                                                    begin_bit,
-    unsigned int                                                    end_bit,
-    dim3                                                            grid,
-    dim3                                                            block,
-    size_t                                                          shmem,
-    hipStream_t                                                     stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        segmented_sort_small<decltype(arch_config), Descending>(keys_input,
-                                                                keys_tmp,
-                                                                keys_output,
-                                                                values_input,
-                                                                values_tmp,
-                                                                values_output,
-                                                                to_output,
-                                                                num_segments,
-                                                                segment_indices,
-                                                                begin_offsets,
-                                                                end_offsets,
-                                                                begin_bit,
-                                                                end_bit);
-    };
-
-    return execute_launch_plan<Config,
-                               decltype(kernel),
-                               segmented_radix_sort_warp_sort_small_config_selector>(arch,
-                                                                                     kernel,
-                                                                                     grid,
-                                                                                     block,
-                                                                                     shmem,
-                                                                                     stream);
-}
-
-template<class Config,
-         bool Descending,
-         class KeysInputIterator,
-         class KeysOutputIterator,
-         class ValuesInputIterator,
-         class ValuesOutputIterator,
-         class SegmentIndexIterator,
-         class OffsetIterator>
-inline hipError_t launch_segmented_sort_medium(
-    detail::target_arch                                             arch,
-    KeysInputIterator                                               keys_input,
-    typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
-    KeysOutputIterator                                              keys_output,
-    ValuesInputIterator                                             values_input,
-    typename std::iterator_traits<ValuesInputIterator>::value_type* values_tmp,
-    ValuesOutputIterator                                            values_output,
-    bool                                                            to_output,
-    unsigned int                                                    num_segments,
-    SegmentIndexIterator                                            segment_indices,
-    OffsetIterator                                                  begin_offsets,
-    OffsetIterator                                                  end_offsets,
-    unsigned int                                                    begin_bit,
-    unsigned int                                                    end_bit,
-    dim3                                                            grid,
-    dim3                                                            block,
-    size_t                                                          shmem,
-    hipStream_t                                                     stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        segmented_sort_medium<decltype(arch_config), Descending>(keys_input,
-                                                                 keys_tmp,
-                                                                 keys_output,
-                                                                 values_input,
-                                                                 values_tmp,
-                                                                 values_output,
-                                                                 to_output,
-                                                                 num_segments,
-                                                                 segment_indices,
-                                                                 begin_offsets,
-                                                                 end_offsets,
-                                                                 begin_bit,
-                                                                 end_bit);
-    };
-
-    return execute_launch_plan<Config,
-                               decltype(kernel),
-                               segmented_radix_sort_warp_sort_meduim_config_selector>(arch,
-                                                                                      kernel,
-                                                                                      grid,
-                                                                                      block,
-                                                                                      shmem,
-                                                                                      stream);
-}
-
 struct Partitioner
 {
     bool three_way_partitioning;
@@ -534,26 +331,34 @@ inline hipError_t segmented_radix_sort_impl(
         {
             std::chrono::steady_clock::time_point start;
             if(debug_synchronous)
+            {
                 start = std::chrono::steady_clock::now();
-            ROCPRIM_RETURN_ON_ERROR(launch_segmented_sort_large<config, Descending>(
-                target_arch,
-                keys_input,
-                keys_tmp,
-                keys_output,
-                values_input,
-                values_tmp,
-                values_output,
-                to_output,
-                large_segment_indices_output,
-                begin_offsets,
-                end_offsets,
-                iterations,
-                begin_bit,
-                end_bit,
-                dim3(large_segment_count),
-                dim3(params.kernel_config.block_size),
-                0,
-                stream));
+            }
+            auto segmented_sort_large_kernel = [=](auto arch_config)
+            {
+                segmented_sort_large<decltype(arch_config), Descending>(
+                    keys_input,
+                    keys_tmp,
+                    keys_output,
+                    values_input,
+                    values_tmp,
+                    values_output,
+                    to_output,
+                    large_segment_indices_output,
+                    begin_offsets,
+                    end_offsets,
+                    iterations,
+                    begin_bit,
+                    end_bit);
+            };
+
+            ROCPRIM_RETURN_ON_ERROR(
+                execute_launch_plan<config>(target_arch,
+                                            segmented_sort_large_kernel,
+                                            dim3(large_segment_count),
+                                            dim3(params.kernel_config.block_size),
+                                            0,
+                                            stream));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort:large_segments",
                                                         large_segment_count,
                                                         start);
@@ -564,26 +369,37 @@ inline hipError_t segmented_radix_sort_impl(
                 = ::rocprim::detail::ceiling_div(medium_segment_count, medium_segments_per_block);
             std::chrono::steady_clock::time_point start;
             if(debug_synchronous)
+            {
                 start = std::chrono::steady_clock::now();
-            ROCPRIM_RETURN_ON_ERROR(launch_segmented_sort_medium<config, Descending>(
-                target_arch,
-                keys_input,
-                keys_tmp,
-                keys_output,
-                values_input,
-                values_tmp,
-                values_output,
-                is_result_in_output,
-                medium_segment_count,
-                medium_segment_indices_output,
-                begin_offsets,
-                end_offsets,
-                begin_bit,
-                end_bit,
-                dim3(medium_segment_grid_size),
-                dim3(params.warp_sort_config.block_size_medium),
-                0,
-                stream));
+            }
+            auto segmented_sort_medium_kernel = [=](auto arch_config)
+            {
+                segmented_sort_medium<decltype(arch_config), Descending>(
+                    keys_input,
+                    keys_tmp,
+                    keys_output,
+                    values_input,
+                    values_tmp,
+                    values_output,
+                    is_result_in_output,
+                    medium_segment_count,
+                    medium_segment_indices_output,
+                    begin_offsets,
+                    end_offsets,
+                    begin_bit,
+                    end_bit);
+            };
+
+            ROCPRIM_RETURN_ON_ERROR(
+                execute_launch_plan<config,
+                                    decltype(segmented_sort_medium_kernel),
+                                    segmented_radix_sort_warp_sort_meduim_config_selector>(
+                    target_arch,
+                    segmented_sort_medium_kernel,
+                    dim3(medium_segment_grid_size),
+                    dim3(params.warp_sort_config.block_size_medium),
+                    0,
+                    stream));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort:medium_segments",
                                                         medium_segment_count,
                                                         start);
@@ -594,26 +410,37 @@ inline hipError_t segmented_radix_sort_impl(
                 = ::rocprim::detail::ceiling_div(small_segment_count, small_segments_per_block);
             std::chrono::steady_clock::time_point start;
             if(debug_synchronous)
+            {
                 start = std::chrono::steady_clock::now();
-            ROCPRIM_RETURN_ON_ERROR(launch_segmented_sort_small<config, Descending>(
-                target_arch,
-                keys_input,
-                keys_tmp,
-                keys_output,
-                values_input,
-                values_tmp,
-                values_output,
-                is_result_in_output,
-                small_segment_count,
-                small_segment_indices_output,
-                begin_offsets,
-                end_offsets,
-                begin_bit,
-                end_bit,
-                dim3(small_segment_grid_size),
-                dim3(params.warp_sort_config.block_size_small),
-                0,
-                stream));
+            }
+            auto segmented_sort_small_kernel = [=](auto arch_config)
+            {
+                segmented_sort_small<decltype(arch_config), Descending>(
+                    keys_input,
+                    keys_tmp,
+                    keys_output,
+                    values_input,
+                    values_tmp,
+                    values_output,
+                    is_result_in_output,
+                    small_segment_count,
+                    small_segment_indices_output,
+                    begin_offsets,
+                    end_offsets,
+                    begin_bit,
+                    end_bit);
+            };
+
+            ROCPRIM_RETURN_ON_ERROR(
+                execute_launch_plan<config,
+                                    decltype(segmented_sort_small_kernel),
+                                    segmented_radix_sort_warp_sort_small_config_selector>(
+                    target_arch,
+                    segmented_sort_small_kernel,
+                    dim3(small_segment_grid_size),
+                    dim3(params.warp_sort_config.block_size_small),
+                    0,
+                    stream));
             ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort:small_segments",
                                                         small_segment_count,
                                                         start);
@@ -623,25 +450,31 @@ inline hipError_t segmented_radix_sort_impl(
     {
         std::chrono::steady_clock::time_point start;
         if(debug_synchronous)
+        {
             start = std::chrono::steady_clock::now();
-        ROCPRIM_RETURN_ON_ERROR(
-            launch_segmented_sort<config, Descending>(target_arch,
-                                                      keys_input,
-                                                      keys_tmp,
-                                                      keys_output,
-                                                      values_input,
-                                                      values_tmp,
-                                                      values_output,
-                                                      to_output,
-                                                      begin_offsets,
-                                                      end_offsets,
-                                                      iterations,
-                                                      begin_bit,
-                                                      end_bit,
-                                                      dim3(segments),
-                                                      dim3(params.kernel_config.block_size),
-                                                      0,
-                                                      stream));
+        }
+        auto segmented_sort_kernel = [=](auto arch_config)
+        {
+            segmented_sort<decltype(arch_config), Descending>(keys_input,
+                                                              keys_tmp,
+                                                              keys_output,
+                                                              values_input,
+                                                              values_tmp,
+                                                              values_output,
+                                                              to_output,
+                                                              begin_offsets,
+                                                              end_offsets,
+                                                              iterations,
+                                                              begin_bit,
+                                                              end_bit);
+        };
+
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                            segmented_sort_kernel,
+                                                            dim3(segments),
+                                                            dim3(params.kernel_config.block_size),
+                                                            0,
+                                                            stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_sort", segments, start);
     }
     return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_reduce.hpp
@@ -46,37 +46,6 @@ template<class Config,
          class InputIterator,
          class OutputIterator,
          class OffsetIterator,
-         class ResultType,
-         class BinaryFunction>
-inline hipError_t launch_segmented_reduce(detail::target_arch arch,
-                                          InputIterator       input,
-                                          OutputIterator      output,
-                                          OffsetIterator      begin_offsets,
-                                          OffsetIterator      end_offsets,
-                                          BinaryFunction      reduce_op,
-                                          ResultType          initial_value,
-                                          dim3                grid,
-                                          dim3                block,
-                                          size_t              shmem,
-                                          hipStream_t         stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        segmented_reduce<decltype(arch_config)>(input,
-                                                output,
-                                                begin_offsets,
-                                                end_offsets,
-                                                reduce_op,
-                                                initial_value);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
-template<class Config,
-         class InputIterator,
-         class OutputIterator,
-         class OffsetIterator,
          class InitValueType,
          class BinaryFunction>
 inline hipError_t segmented_reduce_impl(void*          temporary_storage,
@@ -120,18 +89,25 @@ inline hipError_t segmented_reduce_impl(void*          temporary_storage,
     std::chrono::steady_clock::time_point start;
 
     if(debug_synchronous)
+    {
         start = std::chrono::steady_clock::now();
-    ROCPRIM_RETURN_ON_ERROR(launch_segmented_reduce<config>(target_arch,
-                                                            input,
-                                                            output,
-                                                            begin_offsets,
-                                                            end_offsets,
-                                                            reduce_op,
-                                                            static_cast<result_type>(initial_value),
-                                                            dim3(segments),
-                                                            dim3(block_size),
-                                                            0,
-                                                            stream));
+    }
+    auto segmented_reduce_kernel = [=](auto arch_config)
+    {
+        segmented_reduce<decltype(arch_config)>(input,
+                                                output,
+                                                begin_offsets,
+                                                end_offsets,
+                                                reduce_op,
+                                                static_cast<result_type>(initial_value));
+    };
+
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                        segmented_reduce_kernel,
+                                                        dim3(segments),
+                                                        dim3(block_size),
+                                                        0,
+                                                        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_reduce", segments, start);
 
     return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_segmented_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_segmented_scan.hpp
@@ -72,40 +72,6 @@ struct transform_op_t
     }
 };
 
-template<class Config,
-         bool Exclusive,
-         class ResultType,
-         class InputIterator,
-         class OutputIterator,
-         class OffsetIterator,
-         class InitValueType,
-         class BinaryFunction>
-inline hipError_t launch_segmented_scan(detail::target_arch arch,
-                                        InputIterator       input,
-                                        OutputIterator      output,
-                                        OffsetIterator      begin_offsets,
-                                        OffsetIterator      end_offsets,
-                                        InitValueType       initial_value,
-                                        BinaryFunction      scan_op,
-                                        dim3                grid,
-                                        dim3                block,
-                                        size_t              shmem,
-                                        hipStream_t         stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        segmented_scan<decltype(arch_config), Exclusive, ResultType>(
-            input,
-            output,
-            begin_offsets,
-            end_offsets,
-            static_cast<ResultType>(initial_value),
-            scan_op);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 template<bool Exclusive,
          class Config,
          class InputIterator,
@@ -153,18 +119,26 @@ inline hipError_t segmented_scan_impl(void*               temporary_storage,
 
     std::chrono::steady_clock::time_point start;
     if(debug_synchronous)
+    {
         start = std::chrono::steady_clock::now();
-    ROCPRIM_RETURN_ON_ERROR(launch_segmented_scan<config, Exclusive, result_type>(target_arch,
-                                                                                  input,
-                                                                                  output,
-                                                                                  begin_offsets,
-                                                                                  end_offsets,
-                                                                                  initial_value,
-                                                                                  scan_op,
-                                                                                  dim3(segments),
-                                                                                  dim3(block_size),
-                                                                                  0,
-                                                                                  stream));
+    }
+    auto segmented_scan_kernel = [=](auto arch_config)
+    {
+        segmented_scan<decltype(arch_config), Exclusive, result_type>(
+            input,
+            output,
+            begin_offsets,
+            end_offsets,
+            static_cast<result_type>(initial_value),
+            scan_op);
+    };
+
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                        segmented_scan_kernel,
+                                                        dim3(segments),
+                                                        dim3(block_size),
+                                                        0,
+                                                        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("segmented_scan", segments, start);
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_transform.hpp
@@ -46,36 +46,6 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<class Config,
-         bool IsPointer,
-         class ResultType,
-         class InputIt,
-         class OutputIt,
-         class UnaryOp>
-inline hipError_t launch_transform(detail::target_arch arch,
-                                   InputIt             in,
-                                   OutputIt            out,
-                                   size_t              n,
-                                   UnaryOp             op,
-                                   dim3                grid,
-                                   dim3                block,
-                                   size_t              shmem,
-                                   hipStream_t         stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        constexpr auto params = decltype(arch_config)::params;
-
-        detail::transform_kernel_impl<IsPointer,
-                                      params.kernel_config.block_size,
-                                      params.kernel_config.items_per_thread,
-                                      params.load_type,
-                                      ResultType>(in, n, out, op);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 template<bool IsPointer,
          class Config,
          class InputIterator,
@@ -139,16 +109,26 @@ inline hipError_t transform_impl(InputIterator     input,
         {
             start = std::chrono::steady_clock::now();
         }
+        auto transform_kernel = [=](auto arch_config)
+        {
+            constexpr auto params = decltype(arch_config)::params;
 
-        ROCPRIM_RETURN_ON_ERROR(launch_transform<config, IsPointer, result_type>(target_arch,
-                                                                                 input + offset,
-                                                                                 output + offset,
-                                                                                 current_size,
-                                                                                 transform_op,
-                                                                                 current_blocks,
-                                                                                 block_size,
-                                                                                 0,
-                                                                                 stream));
+            detail::transform_kernel_impl<IsPointer,
+                                          params.kernel_config.block_size,
+                                          params.kernel_config.items_per_thread,
+                                          params.load_type,
+                                          result_type>(input + offset,
+                                                       current_size,
+                                                       output + offset,
+                                                       transform_op);
+        };
+
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                            transform_kernel,
+                                                            current_blocks,
+                                                            block_size,
+                                                            0,
+                                                            stream));
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("transform_kernel", current_size, start);
     }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/specialization/device_radix_block_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/specialization/device_radix_block_sort.hpp
@@ -37,49 +37,6 @@ template<class Config,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Decomposer>
-inline hipError_t launch_radix_sort_block_sort(detail::target_arch  arch,
-                                               KeysInputIterator    keys_input,
-                                               KeysOutputIterator   keys_output,
-                                               ValuesInputIterator  values_input,
-                                               ValuesOutputIterator values_output,
-                                               unsigned int         size,
-                                               Decomposer           decomposer,
-                                               unsigned int         bit,
-                                               unsigned int         current_radix_bits,
-                                               dim3                 grid,
-                                               dim3                 block,
-                                               size_t               shmem,
-                                               hipStream_t          stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        static constexpr auto params = decltype(arch_config)::params;
-
-        sort_single<params.block_size, params.items_per_thread, Descending>(keys_input,
-                                                                            keys_output,
-                                                                            values_input,
-                                                                            values_output,
-                                                                            size,
-                                                                            decomposer,
-                                                                            bit,
-                                                                            current_radix_bits);
-    };
-
-    return execute_launch_plan<Config, decltype(kernel), radix_sort_config_selector>(arch,
-                                                                                     kernel,
-                                                                                     grid,
-                                                                                     block,
-                                                                                     shmem,
-                                                                                     stream);
-}
-
-template<class Config,
-         bool Descending,
-         class KeysInputIterator,
-         class KeysOutputIterator,
-         class ValuesInputIterator,
-         class ValuesOutputIterator,
-         class Decomposer>
 inline hipError_t radix_sort_block_sort(KeysInputIterator    keys_input,
                                         KeysOutputIterator   keys_output,
                                         ValuesInputIterator  values_input,
@@ -127,20 +84,29 @@ inline hipError_t radix_sort_block_sort(KeysInputIterator    keys_input,
         start = std::chrono::steady_clock::now();
     }
 
+    auto radix_sort_block_sort_kernel = [=](auto arch_config)
+    {
+        static constexpr auto params = decltype(arch_config)::params;
+
+        sort_single<params.block_size, params.items_per_thread, Descending>(keys_input,
+                                                                            keys_output,
+                                                                            values_input,
+                                                                            values_output,
+                                                                            size,
+                                                                            decomposer,
+                                                                            bit,
+                                                                            current_radix_bits);
+    };
+
     ROCPRIM_RETURN_ON_ERROR(
-        launch_radix_sort_block_sort<config, Descending>(target_arch,
-                                                         keys_input,
-                                                         keys_output,
-                                                         values_input,
-                                                         values_output,
-                                                         size,
-                                                         decomposer,
-                                                         bit,
-                                                         current_radix_bits,
-                                                         dim3(sort_number_of_blocks),
-                                                         dim3(params.block_size),
-                                                         0,
-                                                         stream));
+        execute_launch_plan<config,
+                            decltype(radix_sort_block_sort_kernel),
+                            radix_sort_config_selector>(target_arch,
+                                                        radix_sort_block_sort_kernel,
+                                                        dim3(sort_number_of_blocks),
+                                                        dim3(params.block_size),
+                                                        0,
+                                                        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("radix_sort_block_sort_kernel", size, start);
     return hipSuccess;
 }

--- a/projects/rocprim/test/rocprim/test_device_scan.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan.cpp
@@ -476,29 +476,33 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
             const auto launch_err = with_scan_state(
                 [&](const auto scan_state)
                 {
-                    return rocprim::detail::launch_lookback_scan < config,
-                           deterministic
-                               ? rocprim::detail::lookback_scan_determinism::deterministic
-                               : rocprim::detail::lookback_scan_determinism::nondeterministic,
-                           Exclusive, use_initial_value, decltype(input_iterator), U*, scan_op_type,
-                           acc_type,
-                           acc_type > (target_arch,
-                                       input_iterator,
-                                       d_output.get(),
-                                       size,
-                                       initial_value,
-                                       scan_op,
-                                       scan_state,
-                                       number_of_blocks,
-                                       dim3(grid_size),
-                                       dim3(block_size),
-                                       0,
-                                       stream,
-                                       previous_last_element,
-                                       new_last_element,
-                                       false,
-                                       false,
-                                       ordered_bid);
+                    auto lookback_scan_kernel = [=, out_ptr = d_output.get()](auto arch_config)
+                    {
+                        rocprim::detail::lookback_scan_kernel_impl<
+                            decltype(arch_config),
+                            deterministic
+                                ? rocprim::detail::lookback_scan_determinism::deterministic
+                                : rocprim::detail::lookback_scan_determinism::nondeterministic,
+                            Exclusive,
+                            use_initial_value>(input_iterator,
+                                               out_ptr,
+                                               size,
+                                               initial_value,
+                                               scan_op,
+                                               scan_state,
+                                               number_of_blocks,
+                                               previous_last_element,
+                                               new_last_element,
+                                               false,
+                                               false,
+                                               ordered_bid);
+                    };
+                    return rocprim::detail::execute_launch_plan<config>(target_arch,
+                                                                        lookback_scan_kernel,
+                                                                        dim3(grid_size),
+                                                                        dim3(block_size),
+                                                                        0,
+                                                                        stream);
                 });
 
             ASSERT_EQ(hipSuccess, launch_err);
@@ -710,28 +714,33 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
         const auto launch_err = with_scan_state(
             [&](const auto scan_state)
             {
-                return rocprim::detail::launch_lookback_scan < config,
-                       deterministic ? rocprim::detail::lookback_scan_determinism::deterministic
-                                     : rocprim::detail::lookback_scan_determinism::nondeterministic,
-                       Exclusive, use_initial_value, decltype(input_iterator), U*, scan_op_type,
-                       acc_type,
-                       acc_type > (target_arch,
-                                   input_iterator,
-                                   d_output.get(),
-                                   size,
-                                   initial_value,
-                                   scan_op,
-                                   scan_state,
-                                   number_of_blocks,
-                                   dim3(grid_size),
-                                   dim3(block_size),
-                                   0,
-                                   stream,
-                                   previous_last_element,
-                                   new_last_element,
-                                   false,
-                                   false,
-                                   ordered_bid);
+                auto lookback_scan_kernel = [=, out_ptr = d_output.get()](auto arch_config)
+                {
+                    rocprim::detail::lookback_scan_kernel_impl<
+                        decltype(arch_config),
+                        deterministic
+                            ? rocprim::detail::lookback_scan_determinism::deterministic
+                            : rocprim::detail::lookback_scan_determinism::nondeterministic,
+                        Exclusive,
+                        use_initial_value>(input_iterator,
+                                           out_ptr,
+                                           size,
+                                           initial_value,
+                                           scan_op,
+                                           scan_state,
+                                           number_of_blocks,
+                                           previous_last_element,
+                                           new_last_element,
+                                           false,
+                                           false,
+                                           ordered_bid);
+                };
+                return rocprim::detail::execute_launch_plan<config>(target_arch,
+                                                                    lookback_scan_kernel,
+                                                                    dim3(grid_size),
+                                                                    dim3(block_size),
+                                                                    0,
+                                                                    stream);
             });
 
         ASSERT_EQ(hipSuccess, launch_err);

--- a/projects/rocprim/test/rocprim/test_linking_new_scan.hpp
+++ b/projects/rocprim/test/rocprim/test_linking_new_scan.hpp
@@ -78,37 +78,6 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void single_scan_kernel_impl(InputIterator  
     block_store_direct_striped<block_size>(flat_block_thread_id(), output, values, input_size);
 }
 
-template<class Config,
-         bool Exclusive,
-         class InputIterator,
-         class OutputIterator,
-         class BinaryFunction,
-         class InitValueType,
-         class AccType>
-inline hipError_t launch_single_scan(detail::target_arch arch,
-                                     InputIterator       input,
-                                     const size_t        size,
-                                     const InitValueType initial_value,
-                                     OutputIterator      output,
-                                     BinaryFunction      scan_op,
-                                     dim3                grid,
-                                     dim3                block,
-                                     size_t              shmem,
-                                     hipStream_t         stream)
-{
-    auto kernel = [=](auto arch_config)
-    {
-        single_scan_kernel_impl<decltype(arch_config), Exclusive>(
-            input,
-            size,
-            static_cast<AccType>(get_input_value(initial_value)),
-            output,
-            scan_op);
-    };
-
-    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
-}
-
 template<lookback_scan_determinism Determinism,
          bool                      Exclusive,
          class Config,
@@ -155,18 +124,17 @@ inline auto scan_impl(void*               temporary_storage,
         return hipErrorInvalidValue;
     }
 
-    ROCPRIM_RETURN_ON_ERROR(launch_single_scan<config,
-                                               Exclusive,
-                                               InputIterator,
-                                               OutputIterator,
-                                               BinaryFunction,
-                                               InitValueType,
-                                               AccType>(target_arch,
-                                                        input,
-                                                        size,
-                                                        initial_value,
-                                                        output,
-                                                        scan_op,
+    auto single_scan_kernel = [=](auto arch_config)
+    {
+        single_scan_kernel_impl<decltype(arch_config), Exclusive>(
+            input,
+            size,
+            static_cast<AccType>(get_input_value(initial_value)),
+            output,
+            scan_op);
+    };
+    ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
+                                                        single_scan_kernel,
                                                         dim3(1),
                                                         dim3(block_size),
                                                         0,


### PR DESCRIPTION
This PR unifies the structure of SPIR-V related functions/ structures reference pattern.

For example, for `device_adjacent_difference`, the old version was:

```cpp
template<......>
inline hipError_t launch_adjacent_difference(....)
{
    auto kernel = [=](auto arch_config)
    {
        adjacent_difference_kernel_impl<.....>(....);
    };

    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
}

template<.....>
hipError_t adjacent_difference_impl(....)
{
        ROCPRIM_RETURN_ON_ERROR(
            launch_adjacent_difference<.....>(.....));
}
```

The `launch_adjacent_difference` function is called only once, and is just a wrapper of a lambda function calling the kernel implementation, so it can just be fit into the host function as following:

```cpp
template<.....>
hipError_t adjacent_difference_impl(....)
{
       auto adjacent_difference_kernel = [=](auto arch_config)
        {
            adjacent_difference_kernel_impl<....>(.....);
        };

        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<config>(target_arch,
                                                            adjacent_difference_kernel,
                                                            current_blocks,
                                                            block_size,
                                                            0,
                                                            stream));
}
```

In this way the structure of the internal functions would be less complex.