### PR TITLE
Fix rocThrust 3.0.0 base NVCC job failures

### DIFF
--- a/projects/rocthrust/CMakeLists.txt
+++ b/projects/rocthrust/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2019-2025 Advanced Micro Devices, Inc.
 # ########################################################################
 
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 # --------------------------------------
 # Update these variables at release time

--- a/projects/rocthrust/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/projects/rocthrust/cmake/DownloadProject.CMakeLists.cmake.in
@@ -1,7 +1,7 @@
 # Distributed under the OSI-approved MIT License.  See accompanying
 # file LICENSE or https://github.com/Crascit/DownloadProject for details.
 
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 project(${DL_ARGS_PROJ}-download NONE)
 

--- a/projects/rocthrust/extra/CMakeLists.txt
+++ b/projects/rocthrust/extra/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2019-2025 Advanced Micro Devices, Inc.
 # ########################################################################
 
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 # This project includes tests that should be run after
 # rocThrust is installed from package or using `make install`

--- a/projects/rocthrust/testing/cmake/check_namespace.cmake
+++ b/projects/rocthrust/testing/cmake/check_namespace.cmake
@@ -5,7 +5,7 @@
 # manually with:
 # cmake -D "Thrust_SOURCE_DIR=<thrust project root>" -P check_namespace.cmake
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.16)
 
 set(exclusions
   # This defines the macros and must have bare namespace declarations:

--- a/projects/rocthrust/thrust/detail/alignment.h
+++ b/projects/rocthrust/thrust/detail/alignment.h
@@ -33,14 +33,8 @@
 #include _THRUST_STD_INCLUDE(type_traits) // For `std::alignment_of`.
 
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
-#  if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-#    include <cuda/cmath>
-#  else
-#    include <hip/cmath>
-#  endif
-#endif
-
-#if !_THRUST_HAS_DEVICE_SYSTEM_STD
+#  include _THRUST_LIBCXX_INCLUDE(cmath)
+#else
 #  include <rocprim/detail/various.hpp>
 #endif
 
@@ -87,11 +81,7 @@ THRUST_HOST_DEVICE T aligned_reinterpret_cast(U u)
 THRUST_HOST_DEVICE inline _THRUST_STD::size_t aligned_storage_size(_THRUST_STD::size_t n, _THRUST_STD::size_t align)
 {
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
-#  if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-  return ::cuda::ceil_div(n, align) * align;
-#  else
-  return ::hip::ceil_div(n, align) * align;
-#  endif
+  return _THRUST_LIBCXX::ceil_div(n, align) * align;
 #else
   return ::rocprim::detail::ceiling_div(n, align) * align;
 #endif

--- a/projects/rocthrust/thrust/detail/attributes.h
+++ b/projects/rocthrust/thrust/detail/attributes.h
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DETAIL_ATTRIBUTES_H
+#define DETAIL_ATTRIBUTES_H
+
+#include <thrust/detail/config.h>
+#if _THRUST_HAS_DEVICE_SYSTEM_STD
+
+// clang-format off
+#  include _THRUST_STD_INCLUDE(__cccl/attributes.h)
+// clang-format on
+
+#  define THRUST_DECLSPEC_EMPTY_BASES _CCCL_DECLSPEC_EMPTY_BASES
+
+#else // !_THRUST_HAS_DEVICE_SYSTEM_STD
+
+#  ifdef __has_declspec_attribute
+#    define THRUST_HAS_DECLSPEC_ATTRIBUTE(__x) __has_declspec_attribute(__x)
+#  else // ^^^ __has_declspec_attribute ^^^ / vvv !__has_declspec_attribute vvv
+#    define THRUST_HAS_DECLSPEC_ATTRIBUTE(__x) 0
+#  endif // !__has_declspec_attribute
+
+// MSVC needs extra help with empty base classes
+#  if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || THRUST_HAS_DECLSPEC_ATTRIBUTE(empty_bases)
+#    define THRUST_DECLSPEC_EMPTY_BASES __declspec(empty_bases)
+#  else // !THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
+#    define THRUST_DECLSPEC_EMPTY_BASES
+#  endif // THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
+
+#endif // _THRUST_HAS_DEVICE_SYSTEM_STD
+
+#endif // DETAIL_ATTRIBUTES_H

--- a/projects/rocthrust/thrust/detail/config/compiler.h
+++ b/projects/rocthrust/thrust/detail/config/compiler.h
@@ -21,22 +21,15 @@
 
 #pragma once
 
-#if defined(__HIP__)
-// Macro enables Device Malloc
-#  ifndef __HIP_ENABLE_DEVICE_MALLOC__
-#    define __HIP_ENABLE_DEVICE_MALLOC__ 1
-#  endif
-#  include <hip/hip_runtime.h>
-#endif
+// Internal config header that is only included through thrust/detail/config/config.h
 
-// For _CCCL_IMPLICIT_SYSTEM_HEADER
-#if defined(__CUDACC__)
-#  include <cuda/__cccl_config>
-#elif defined(__has_include)
-#  if __has_include(<cuda/__cccl_config>)
-#    include <cuda/__cccl_config>
-#  endif
-#endif
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
 
 // enumerate host compilers we know about
 //! deprecated [Since 2.7]

--- a/projects/rocthrust/thrust/detail/config/config.h
+++ b/projects/rocthrust/thrust/detail/config/config.h
@@ -20,10 +20,20 @@
 
 #pragma once
 
-#if defined(__CUDACC__)
+#include <thrust/detail/config/libcxx.h> // IWYU pragma: export
+
 // For _CCCL_IMPLICIT_SYSTEM_HEADER
-#  include <cuda/__cccl_config> // IWYU pragma: export
+#if _THRUST_HAS_DEVICE_SYSTEM_STD
+#  include _THRUST_LIBCXX_INCLUDE(__cccl_config) // IWYU pragma: export
 #endif
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
 
 // NOTE: The order of these #includes matters.
 
@@ -39,7 +49,6 @@
 #include <thrust/detail/config/diagnostic.h> // IWYU pragma: export
 #include <thrust/detail/config/execution_space.h> // IWYU pragma: export
 #include <thrust/detail/config/global_workarounds.h> // IWYU pragma: export
-#include <thrust/detail/config/libcxx.h> // IWYU pragma: export
 #include <thrust/detail/config/namespace.h> // IWYU pragma: export
 #include <thrust/detail/config/rtti.h> // IWYU pragma: export
 #include <thrust/detail/config/visibility.h> // IWYU pragma: export

--- a/projects/rocthrust/thrust/detail/config/cpp_compatibility.h
+++ b/projects/rocthrust/thrust/detail/config/cpp_compatibility.h
@@ -78,7 +78,7 @@
 #    define THRUST_INCLUDE_DEVICE_CODE 0
 #    define THRUST_INCLUDE_HOST_CODE   1
 #  endif
-#elif THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+#else
 // These definitions were intended for internal use only and are now obsolete.
 // If you relied on them, consider porting your code to use the functionality
 // in libcu++'s <nv/target> header.

--- a/projects/rocthrust/thrust/detail/config/libcxx.h
+++ b/projects/rocthrust/thrust/detail/config/libcxx.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <thrust/detail/config/config.h>
+#include <thrust/detail/config/preprocessor.h>
 
 // This is a utility file that helps managing which
 // 'std' implementation we're using. The provided
@@ -33,33 +33,36 @@
 //     #include _THRUST_STD_INCLUDE(optional)
 //     using optional_int = _THRUST_STD::optional<int>;
 
-// When targeting CUDA, we want to use 'libcudacxx'. This
-// should always be available, since we are also dependent
-// on CCCL/thrust, which is a sibling of CCCL/libcudacxx.
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+// If 'libcudacxx' is available
+// clang-format off
+#if THRUST_HAS_INCLUDE(<cuda/std/cassert>)
+// clang-format on
+#  define _THRUST_LIBCXX_INCLUDE(LIB)   <cuda/LIB>
 #  define _THRUST_STD_INCLUDE(LIB)      <cuda/std/LIB>
+#  define _THRUST_LIBCXX                ::cuda
 #  define _THRUST_STD                   _CUDA_VSTD
 #  define _THRUST_HAS_DEVICE_SYSTEM_STD 1
 #  define _THRUST_STD_NAMESPACE_BEGIN   _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #  define _THRUST_STD_NAMESPACE_END     _LIBCUDACXX_END_NAMESPACE_STD
 
-// When targeting HIP, we want to use 'libhipcxx' if
-// available. We can do this by checking the existance
-// of a known include.
-#elif THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_HIP
-#  if defined(__has_include) && __has_include(<hip/std/cassert>)
-#    define _THRUST_STD_INCLUDE(LIB)      <hip/std/LIB>
-#    define _THRUST_STD                   ::hip::std
-#    define _THRUST_HAS_DEVICE_SYSTEM_STD 1
-#    define _THRUST_STD_NAMESPACE_BEGIN   _LIBCUDACXX_BEGIN_NAMESPACE_STD
-#    define _THRUST_STD_NAMESPACE_END     _LIBCUDACXX_END_NAMESPACE_STD
-#  endif
+// If 'libhipcxx' is available
+// clang-format off
+#elif THRUST_HAS_INCLUDE(<hip/std/cassert>)
+// clang-format on
+#  define _THRUST_LIBCXX_INCLUDE(LIB)   <hip/LIB>
+#  define _THRUST_STD_INCLUDE(LIB)      <hip/std/LIB>
+#  define _THRUST_LIBCXX                ::hip
+#  define _THRUST_STD                   ::hip::std
+#  define _THRUST_HAS_DEVICE_SYSTEM_STD 1
+#  define _THRUST_STD_NAMESPACE_BEGIN   _LIBCUDACXX_BEGIN_NAMESPACE_STD
+#  define _THRUST_STD_NAMESPACE_END     _LIBCUDACXX_END_NAMESPACE_STD
 #endif
 
-// If not using GPU backend or GPU vendor's STD is not
-// found, use fallback.
+// If 'libcudacxx' or 'libhipcxx' is not found, use fallback.
 #ifndef _THRUST_HAS_DEVICE_SYSTEM_STD
-#  define _THRUST_STD_INCLUDE(LIB)      <LIB>
+#  define _THRUST_LIBCXX_INCLUDE(LIB)
+#  define _THRUST_STD_INCLUDE(LIB) <LIB>
+#  define _THRUST_LIBCXX
 #  define _THRUST_STD                   ::std
 #  define _THRUST_HAS_DEVICE_SYSTEM_STD 0
 #  define _THRUST_STD_NAMESPACE_BEGIN \

--- a/projects/rocthrust/thrust/detail/config/memory_resource.h
+++ b/projects/rocthrust/thrust/detail/config/memory_resource.h
@@ -28,7 +28,6 @@
 
 #include <thrust/detail/alignment.h>
 #include <thrust/detail/config/cpp_compatibility.h>
-#include <thrust/detail/preprocessor.h>
 
 #include <cstddef>
 
@@ -37,7 +36,9 @@
 #if THRUST_HAS_INCLUDE(<memory_resource>)
 #  define THRUST_MR_STD_MR_HEADER <memory_resource>
 #  define THRUST_MR_STD_MR_NS     std::pmr
-#elif THRUST_HAS_INCLUDE(<experimental / memory_resource>)
+// clang-format off
+#elif THRUST_HAS_INCLUDE(<experimental/memory_resource>)
+// clang-format on
 #  define THRUST_MR_STD_MR_HEADER <experimental/memory_resource>
 #  define THRUST_MR_STD_MR_NS     std::experimental::pmr
 #endif

--- a/projects/rocthrust/thrust/detail/config/preprocessor.h
+++ b/projects/rocthrust/thrust/detail/config/preprocessor.h
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CONFIG_PREPROCESSOR_H
+#define CONFIG_PREPROCESSOR_H
+
+#ifdef __has_include
+#  define THRUST_HAS_INCLUDE(_X) __has_include(_X)
+#else
+#  define THRUST_HAS_INCLUDE(_X) 0
+#endif
+
+#endif // CONFIG_PREPROCESSOR_H

--- a/projects/rocthrust/thrust/detail/functional/actor.h
+++ b/projects/rocthrust/thrust/detail/functional/actor.h
@@ -75,11 +75,11 @@ struct actor : Eval
 };
 
 template <typename T>
-struct is_actor : ::thrust::detail::false_type
+struct is_actor : _THRUST_STD::false_type
 {};
 
 template <typename T>
-struct is_actor<actor<T>> : ::thrust::detail::true_type
+struct is_actor<actor<T>> : _THRUST_STD::true_type
 {};
 
 // a node selecting and returning one of the arguments to the entire expression template

--- a/projects/rocthrust/thrust/detail/functional/address_stability.h
+++ b/projects/rocthrust/thrust/detail/functional/address_stability.h
@@ -23,7 +23,7 @@
 
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
 // clang-format off
-#  include _THRUST_STD_INCLUDE(__functional/address_stability.h)
+#  include _THRUST_LIBCXX_INCLUDE(__functional/address_stability.h)
 // clang-format on
 #else
 #  include <functional>
@@ -38,21 +38,17 @@ namespace detail
 
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
 
-#  if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-using ::cuda::proclaim_copyable_arguments;
-using ::cuda::proclaims_copyable_arguments;
-#  else
-using ::hip::proclaim_copyable_arguments;
-using ::hip::proclaims_copyable_arguments;
-#  endif
+using _THRUST_LIBCXX::__has_builtin_operators;
+using _THRUST_LIBCXX::proclaim_copyable_arguments;
+using _THRUST_LIBCXX::proclaims_copyable_arguments;
 #  define THRUST_MARK_CAN_COPY_ARGUMENTS(functor)                                              \
     /*we know what plus<T> etc. does if T is not a type that could have a weird operatorX() */ \
     template <typename T>                                                                      \
-    struct proclaims_copyable_arguments<functor<T>> : has_builtin_operators<T>                 \
+    struct proclaims_copyable_arguments<functor<T>> : __has_builtin_operators<T>               \
     {};                                                                                        \
     /*we do not know what plus<void> etc. does, which depends on the types it is invoked on */ \
     template <>                                                                                \
-    struct proclaims_copyable_arguments<functor<void>> : ::std::false_type                     \
+    struct proclaims_copyable_arguments<functor<void>> : _THRUST_STD::false_type               \
     {};
 
 #else

--- a/projects/rocthrust/thrust/detail/preprocessor.h
+++ b/projects/rocthrust/thrust/detail/preprocessor.h
@@ -19,10 +19,10 @@
 #  pragma system_header
 #endif // no system header
 
-#ifdef __has_include
-#  define THRUST_HAS_INCLUDE(_X) __has_include(_X)
-#else
-#  define THRUST_HAS_INCLUDE(_X) 0
+#if _THRUST_HAS_DEVICE_SYSTEM_STD
+// clang-format off
+#  include _THRUST_STD_INCLUDE(__cccl/preprocessor.h)
+// clang-format on
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/projects/rocthrust/thrust/detail/type_traits.h
+++ b/projects/rocthrust/thrust/detail/type_traits.h
@@ -232,7 +232,7 @@ namespace internal
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
 
 template <typename... Tp>
-using promoted_numerical_type = _THRUST_STD::common_type_t<Tp...>;
+using promoted_numerical_type = _THRUST_STD::common_type<Tp...>;
 
 #else // !_THRUST_HAS_DEVICE_SYSTEM_STD
 

--- a/projects/rocthrust/thrust/detail/vector_base.h
+++ b/projects/rocthrust/thrust/detail/vector_base.h
@@ -194,8 +194,7 @@ public:
    *  \param first The beginning of the range.
    *  \param last The end of the range.
    */
-  template <typename InputIterator,
-            _THRUST_STD::enable_if_t<::thrust::detail::is_cpp17_input_iterator<InputIterator>::value, int> = 0>
+  template <typename InputIterator, _THRUST_STD::enable_if_t<is_cpp17_input_iterator<InputIterator>::value, int> = 0>
   vector_base(InputIterator first, InputIterator last);
 
   /*! This constructor builds a vector_base from a range.
@@ -203,8 +202,7 @@ public:
    *  \param last The end of the range.
    *  \param alloc The allocator to use by this vector_base.
    */
-  template <typename InputIterator,
-            _THRUST_STD::enable_if_t<::thrust::detail::is_cpp17_input_iterator<InputIterator>::value, int> = 0>
+  template <typename InputIterator, _THRUST_STD::enable_if_t<is_cpp17_input_iterator<InputIterator>::value, int> = 0>
   vector_base(InputIterator first, InputIterator last, const Alloc& alloc);
 
   /*! The destructor erases the elements.

--- a/projects/rocthrust/thrust/detail/vector_base.inl
+++ b/projects/rocthrust/thrust/detail/vector_base.inl
@@ -274,8 +274,7 @@ void vector_base<T, Alloc>::range_init(ForwardIterator first, ForwardIterator la
 } // end vector_base::range_init()
 
 template <typename T, typename Alloc>
-template <typename InputIterator,
-          _THRUST_STD::enable_if_t<::thrust::detail::is_cpp17_input_iterator<InputIterator>::value, int>>
+template <typename InputIterator, _THRUST_STD::enable_if_t<is_cpp17_input_iterator<InputIterator>::value, int>>
 vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last)
     : m_storage()
     , m_size(0)
@@ -288,8 +287,7 @@ vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last)
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
-template <typename InputIterator,
-          _THRUST_STD::enable_if_t<::thrust::detail::is_cpp17_input_iterator<InputIterator>::value, int>>
+template <typename InputIterator, _THRUST_STD::enable_if_t<is_cpp17_input_iterator<InputIterator>::value, int>>
 vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last, const Alloc& alloc)
     : m_storage(alloc)
     , m_size(0)

--- a/projects/rocthrust/thrust/functional.h
+++ b/projects/rocthrust/thrust/functional.h
@@ -37,11 +37,7 @@
 #include _THRUST_STD_INCLUDE(functional)
 
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
-#  if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-#    include <cuda/functional>
-#  else
-#    include <hip/functional>
-#  endif
+#  include _THRUST_LIBCXX_INCLUDE(functional)
 #else
 #  include <utility>
 #endif
@@ -52,13 +48,8 @@ namespace internal
 {
 
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
-#  if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-using ::cuda::maximum;
-using ::cuda::minimum;
-#  else
-using ::hip::maximum;
-using ::hip::minimum;
-#  endif
+using _THRUST_LIBCXX::maximum;
+using _THRUST_LIBCXX::minimum;
 using identity = _THRUST_STD::__identity;
 #else
 // cuda::maximum or hip::maximum

--- a/projects/rocthrust/thrust/iterator/counting_iterator.h
+++ b/projects/rocthrust/thrust/iterator/counting_iterator.h
@@ -40,6 +40,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <thrust/detail/attributes.h>
 #include <thrust/iterator/iterator_adaptor.h>
 #include <thrust/iterator/iterator_categories.h>
 #include <thrust/iterator/iterator_facade.h>
@@ -136,13 +137,7 @@ template <typename Incrementable,
           typename System     = use_default,
           typename Traversal  = use_default,
           typename Difference = use_default>
-#if !defined(THRUST_DOXYGEN_INVOKED)                    \
-  && (THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC \
-      || (defined(__has_declspec_attribute) && __has_declspec_attribute(empty_bases)))
-class __declspec(empty_bases) counting_iterator
-#else
-class counting_iterator
-#endif
+class THRUST_DECLSPEC_EMPTY_BASES counting_iterator
     : public detail::counting_iterator_base<Incrementable, System, Traversal, Difference>::type
 {
   /*! \cond

--- a/projects/rocthrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/projects/rocthrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -157,8 +157,7 @@ _THRUST_STD_NAMESPACE_BEGIN
 THRUST_NAMESPACE_BEGIN
 #endif
 
-// 'libhipcxx' implementation is incomplete so we ignore this for now
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+#if _THRUST_HAS_DEVICE_SYSTEM_STD
 template <class... Ts>
 struct __is_tuple_of_iterator_references<THRUST_NS_QUALIFIER::detail::tuple_of_iterator_references<Ts...>> : true_type
 {};

--- a/projects/rocthrust/thrust/iterator/iterator_adaptor.h
+++ b/projects/rocthrust/thrust/iterator/iterator_adaptor.h
@@ -40,6 +40,7 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+#include <thrust/detail/attributes.h>
 #include <thrust/detail/use_default.h>
 #include <thrust/iterator/detail/iterator_adaptor_base.h>
 #include <thrust/iterator/iterator_facade.h>
@@ -126,13 +127,7 @@ template <typename Derived,
           typename Traversal  = use_default,
           typename Reference  = use_default,
           typename Difference = use_default>
-#if !defined(THRUST_DOXYGEN_INVOKED)                    \
-  && (THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC \
-      || (defined(__has_declspec_attribute) && __has_declspec_attribute(empty_bases)))
-class __declspec(empty_bases) iterator_adaptor
-#else
-class iterator_adaptor
-#endif
+class THRUST_DECLSPEC_EMPTY_BASES iterator_adaptor
     : public detail::iterator_adaptor_base<Derived, Base, Value, System, Traversal, Reference, Difference>::type
 {
   /*! \cond

--- a/projects/rocthrust/thrust/iterator/permutation_iterator.h
+++ b/projects/rocthrust/thrust/iterator/permutation_iterator.h
@@ -40,6 +40,7 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+#include <thrust/detail/attributes.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/iterator/detail/permutation_iterator_base.h>
 #include <thrust/iterator/iterator_facade.h>
@@ -122,13 +123,7 @@ THRUST_NAMESPACE_BEGIN
  *  \see make_permutation_iterator
  */
 template <typename ElementIterator, typename IndexIterator>
-#if !defined(THRUST_DOXYGEN_INVOKED)                    \
-  && (THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC \
-      || (defined(__has_declspec_attribute) && __has_declspec_attribute(empty_bases)))
-class __declspec(empty_bases) permutation_iterator
-#else
-class permutation_iterator
-#endif
+class THRUST_DECLSPEC_EMPTY_BASES permutation_iterator
     : public thrust::detail::permutation_iterator_base<ElementIterator, IndexIterator>::type
 {
   /*! \cond

--- a/projects/rocthrust/thrust/iterator/zip_iterator.h
+++ b/projects/rocthrust/thrust/iterator/zip_iterator.h
@@ -39,6 +39,7 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+#include <thrust/detail/attributes.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/iterator/detail/zip_iterator_base.h>
 #include <thrust/iterator/iterator_facade.h>
@@ -131,13 +132,7 @@ THRUST_NAMESPACE_BEGIN
  *  \see get
  */
 template <typename IteratorTuple>
-#if !defined(THRUST_DOXYGEN_INVOKED)                    \
-  && (THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC \
-      || (defined(__has_declspec_attribute) && __has_declspec_attribute(empty_bases)))
-class __declspec(empty_bases) zip_iterator : public detail::zip_iterator_base<IteratorTuple>::type
-#else
-class zip_iterator : public detail::zip_iterator_base<IteratorTuple>::type
-#endif
+class THRUST_DECLSPEC_EMPTY_BASES zip_iterator : public detail::zip_iterator_base<IteratorTuple>::type
 {
 public:
   /*! The underlying iterator tuple type. Alias to zip_iterator's first template argument.

--- a/projects/rocthrust/thrust/version.h
+++ b/projects/rocthrust/thrust/version.h
@@ -39,11 +39,7 @@
 #endif // no system header
 
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
-#  if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
-#    include <cuda/version> // IWYU pragma: export
-#  else
-#    include <hip/version> // IWYU pragma: export
-#  endif
+#  include _THRUST_LIBCXX_INCLUDE(version) // IWYU pragma: export
 #endif
 
 //  This is the only Thrust header that is guaranteed to
@@ -94,7 +90,7 @@
  */
 #define THRUST_PATCH_NUMBER 0
 
-#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+#if _THRUST_HAS_DEVICE_SYSTEM_STD
 static_assert(THRUST_MAJOR_VERSION == CCCL_MAJOR_VERSION, "");
 static_assert(THRUST_MINOR_VERSION == CCCL_MINOR_VERSION, "");
 static_assert(THRUST_SUBMINOR_VERSION == CCCL_PATCH_VERSION, "");


### PR DESCRIPTION
This PR contains fixes for libcudacxx/libhipcxx compatibility in rocThrust, forming part of the base for aligning rocThrust with Thrust v3.0.0.

It also bumps rocThrust CMake version to 3.16, which is actually needed for the build.