### PR TITLE
Fix rocThrust 2.8.5 NVCC job failures

### DIFF
--- a/projects/rocthrust/thrust/system/hip/detail/future.inl
+++ b/projects/rocthrust/thrust/system/hip/detail/future.inl
@@ -43,7 +43,7 @@
 #  include _THRUST_STD_INCLUDE(__memory/unique_ptr.h)
 // clang-format on
 #else
-#  include <memory>
+#  include <thrust/detail/memory_wrapper.h>
 #endif
 
 #  include <type_traits>


### PR DESCRIPTION
This PR contains fixes for libcudacxx/libhipcxx compatibility for the rocThrust version aligned with Thrust v2.8.5.