### PR TITLE
[hipblaslt] Compute the hipblaslt commit

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -26,6 +26,7 @@ include(hipblaslt_target_configure_sanitizers)
 include(tensilelite_supported_architectures)
 
 set(HIPBLASLT_PROJECT_VERSION "1.1.0" CACHE STRING "Semantic version string.")
+rocm_get_git_commit_tag(hipblaslt_COMMIT)
 
 set(PROJECT_VERSION "${HIPBLASLT_PROJECT_VERSION}")
 string(REPLACE "." ";" VERSION_LIST ${PROJECT_VERSION})
@@ -36,7 +37,7 @@ list(LENGTH VERSION_LIST list_size)
 if(list_size EQUAL 4)
     list(GET VERSION_LIST 3 PROJECT_VERSION_TWEAK)
 else()
-    rocm_get_git_commit_tag(PROJECT_VERSION_TWEAK)
+    set(PROJECT_VERSION_TWEAK "${hipblaslt_COMMIT}")
 endif()
 
 set(hipblaslt_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")

--- a/projects/hipblaslt/library/include/hipblaslt-version.h.in
+++ b/projects/hipblaslt/library/include/hipblaslt-version.h.in
@@ -37,6 +37,7 @@
 #define HIPBLASLT_VERSION_MINOR     @hipblaslt_VERSION_MINOR@
 #define HIPBLASLT_VERSION_PATCH     @hipblaslt_VERSION_PATCH@
 #define HIPBLASLT_VERSION_TWEAK     @hipblaslt_VERSION_TWEAK@
+#define HIPBLASLT_COMMIT            @hipblaslt_COMMIT@
 /* clang-format on */
 
 #endif /* _HIPBLASLT_VERSION_H_ */

--- a/projects/hipblaslt/library/src/amd_detail/hipblaslt.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/hipblaslt.cpp
@@ -688,7 +688,7 @@ try
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
-    static constexpr char v[] = TO_STR(HIPBLASLT_VERSION_TWEAK);
+    static constexpr char v[] = TO_STR(HIPBLASLT_COMMIT);
 
     memcpy(rev, v, sizeof(v));
 

--- a/projects/rocblas/clients/common/client_utility.cpp
+++ b/projects/rocblas/clients/common/client_utility.cpp
@@ -125,7 +125,7 @@ void print_rocblas_client_commit_hashes()
 #ifdef BUILD_WITH_HIPBLASLT
     rocblas_cout << "hipBLASLt version: " << TOSTR(HIPBLASLT_VERSION_MAJOR) << "."
                  << TOSTR(HIPBLASLT_VERSION_MINOR) << "." << TOSTR(HIPBLASLT_VERSION_PATCH)
-                 << " commit-hash: " << TOSTR(HIPBLASLT_VERSION_TWEAK) << std::endl;
+                 << " commit-hash: " << TOSTR(HIPBLASLT_COMMIT) << std::endl;
 #else
     rocblas_cout << "hipBLASLt: N/A, as rocBLAS was built without hipBLASLt" << std::endl;
 #endif


### PR DESCRIPTION
## Motivation

In the past, we assumed that the tweak version would be the TWEAK version. If it is used to specify something other than the commit we lose the commit associated with the build (which a fragile way to track version but something that people have come to rely on).

## Technical Details

- Stores the current commit in hipblaslt_COMMIT.
- Writes the commit to the version header.

## Test Plan

Pipelines testing.