### PR TITLE
[hipDNN] Fix seg fault in json segmentation of empty flatbuffers::Vector

### DIFF
--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/BatchnormAttributes.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/BatchnormAttributes.hpp
@@ -18,7 +18,7 @@ void to_json(nlohmann::json& batchnormJson, BatchnormAttributes const& bn)
     inputs["scale_tensor_uid"] = bn.scale_tensor_uid();
     inputs["bias_tensor_uid"] = bn.bias_tensor_uid();
     inputs["epsilon_tensor_uid"] = bn.epsilon_tensor_uid();
-    inputs["peer_stats_tensor_uid"] = *bn.peer_stats_tensor_uid();
+    inputs["peer_stats_tensor_uid"] = bn.peer_stats_tensor_uid();
     inputs["prev_running_mean_tensor_uid"] = bn.prev_running_mean_tensor_uid();
     inputs["prev_running_variance_tensor_uid"] = bn.prev_running_variance_tensor_uid();
     inputs["momentum_tensor_uid"] = bn.momentum_tensor_uid();

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/BatchnormBackwardAttributes.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/BatchnormBackwardAttributes.hpp
@@ -17,7 +17,7 @@ void to_json(nlohmann::json& batchnormJson, BatchnormBackwardAttributes const& b
     inputs["mean_tensor_uid"] = bn.mean_tensor_uid();
     inputs["inv_variance_tensor_uid"] = bn.inv_variance_tensor_uid();
     inputs["scale_tensor_uid"] = bn.scale_tensor_uid();
-    inputs["peer_stats_tensor_uid"] = *bn.peer_stats_tensor_uid();
+    inputs["peer_stats_tensor_uid"] = bn.peer_stats_tensor_uid();
 
     auto& outputs = batchnormJson["outputs"] = {};
     outputs["dbias_tensor_uid"] = bn.dbias_tensor_uid();

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Common.hpp
@@ -7,27 +7,27 @@
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/json.hpp>
 
-// When implicit conversions are defined, the explicit conversion function is disabled in the nlohmann json library. 
+// When implicit conversions are defined, the explicit conversion function is disabled in the nlohmann json library.
 // This may be unintended behavior
 #ifdef JSON_USE_IMPLICIT_CONVERSIONS
 NLOHMANN_JSON_NAMESPACE_BEGIN
-namespace detail{
-    template<typename BasicJsonType, typename T>
-    void from_json(const BasicJsonType& j, std::optional<T>& opt)
+namespace detail
+{
+template <typename BasicJsonType, typename T>
+void from_json(const BasicJsonType& j, std::optional<T>& opt)
+{
+    if(j.is_null())
     {
-        if (j.is_null())
-        {
-            opt = std::nullopt;
-        }
-        else
-        {
-            opt.emplace(j.template get<T>());
-        }
-    }  
+        opt = std::nullopt;
+    }
+    else
+    {
+        opt.emplace(j.template get<T>());
+    }
 }
-NLOHMANN_JSON_NAMESPACE_END  
+}
+NLOHMANN_JSON_NAMESPACE_END
 #endif
-
 
 namespace flatbuffers
 {
@@ -36,7 +36,8 @@ template <class T>
 void to_json(nlohmann::json& vectorList, const Vector<T>* vec)
 {
     vectorList = nlohmann::json::array();
-    if(vec == nullptr){
+    if(vec == nullptr)
+    {
         return;
     }
 
@@ -51,7 +52,8 @@ template <class T>
 void to_json(nlohmann::json& vectorList, const Vector<Offset<T>>* vec)
 {
     vectorList = nlohmann::json::array();
-    if(vec == nullptr){
+    if(vec == nullptr)
+    {
         return;
     }
     for(auto v : *vec)

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Common.hpp
@@ -7,14 +7,40 @@
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/json.hpp>
 
-namespace std
+// When implicit conversions are defined, the explicit conversion function is disabled in the nlohmann json library. 
+// This may be unintended behavior
+#ifdef JSON_USE_IMPLICIT_CONVERSIONS
+NLOHMANN_JSON_NAMESPACE_BEGIN
+namespace detail{
+    template<typename BasicJsonType, typename T>
+    void from_json(const BasicJsonType& j, std::optional<T>& opt)
+    {
+        if (j.is_null())
+        {
+            opt = std::nullopt;
+        }
+        else
+        {
+            opt.emplace(j.template get<T>());
+        }
+    }  
+}
+NLOHMANN_JSON_NAMESPACE_END  
+#endif
+
+
+namespace flatbuffers
 {
 template <class T>
 // NOLINTNEXTLINE(readability-identifier-naming)
-void to_json(nlohmann::json& vectorList, vector<T> const& vec)
+void to_json(nlohmann::json& vectorList, const Vector<T>* vec)
 {
     vectorList = nlohmann::json::array();
-    for(auto v : vec)
+    if(vec == nullptr){
+        return;
+    }
+
+    for(auto v : *vec)
     {
         vectorList.push_back(v);
     }
@@ -22,36 +48,13 @@ void to_json(nlohmann::json& vectorList, vector<T> const& vec)
 
 template <class T>
 // NOLINTNEXTLINE(readability-identifier-naming)
-void from_json(const nlohmann::json& vecJson, vector<T>& vec)
-{
-    if(!vecJson.is_array())
-    {
-        throw std::runtime_error("from_json: Attempting to deserialize non-array into vector");
-    }
-    vec.reserve(vecJson.size());
-    for(const auto& v : vecJson)
-    {
-        vec.push_back(v.get<T>());
-    }
-}
-
-template <class T>
-// NOLINTNEXTLINE(readability-identifier-naming)
-void from_json(const nlohmann::json& entry, optional<T>& opt)
-{
-    opt = (entry.is_null()) ? std::nullopt : std::optional<T>{entry.get<T>()};
-}
-
-}
-
-namespace flatbuffers
-{
-template <class T>
-// NOLINTNEXTLINE(readability-identifier-naming)
-void to_json(nlohmann::json& vectorList, Vector<Offset<T>> const& vec)
+void to_json(nlohmann::json& vectorList, const Vector<Offset<T>>* vec)
 {
     vectorList = nlohmann::json::array();
-    for(auto v : vec)
+    if(vec == nullptr){
+        return;
+    }
+    for(auto v : *vec)
     {
         vectorList.push_back(*v);
     }
@@ -77,13 +80,6 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType,
 
 namespace hipdnn_sdk::json
 {
-
-template <class T, class Key>
-std::optional<T> optionalValue(nlohmann::json obj, Key&& key)
-{
-    auto it = obj.find(std::forward<Key>(key));
-    return (it != obj.end()) ? std::optional<T>(it->template get<T>()) : std::nullopt;
-}
 
 template <class T>
 auto to(flatbuffers::FlatBufferBuilder& builder, nlohmann::json const& entry);

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Graph.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Graph.hpp
@@ -52,12 +52,12 @@ void to_json(nlohmann::json& nodeJson, data_objects::Node const& node)
 // NOLINTNEXTLINE(readability-identifier-naming)
 void to_json(nlohmann::json& graphJson, data_objects::Graph const& graph)
 {
-    graphJson["nodes"] = *graph.nodes();
+    graphJson["nodes"] = graph.nodes();
     graphJson["compute_type"] = graph.compute_type();
     graphJson["io_type"] = graph.io_type();
     graphJson["intermediate_type"] = graph.intermediate_type();
     graphJson["name"] = graph.name()->c_str();
-    graphJson["tensors"] = *graph.tensors();
+    graphJson["tensors"] = graph.tensors();
 }
 
 }

--- a/projects/hipdnn/sdk/tests/utilities/TestJson.cpp
+++ b/projects/hipdnn/sdk/tests/utilities/TestJson.cpp
@@ -104,7 +104,6 @@ void enumTestSuite(T value, const std::string& stringRep, const std::string& con
     EXPECT_EQ(value, jsonValue.get<T>()) << context;
     EXPECT_EQ(jsonValue.dump(), std::string{jsonStringRep}) << context;
     EXPECT_EQ(nlohmann::json(stringRep).get<T>(), value) << context;
-    std::cout << nlohmann::json{stringRep} << "\n";
 }
 
 TEST(TestJson, Enum)


### PR DESCRIPTION
## Motivation

Fix seg fault in json serialization of empty flatbuffer vectors.

## Technical Details

When a flatbuffers::Vector is created with an empty vector, the accessor function will return a nullptr instead of an empty vector. The json serialization code was assuming it would be non-null, resulting in a segmentation fault in debug builds. To fix this, I'm serializing from the pointer instead, and creating an empty list when that is detected

In addition, I removed the definitions we added to the std namespace in favor of using nlohmann's built in ones (that I didn't know existed). Unfortunately when `JSON_USE_IMPLICIT_CONVERSIONS` is enabled, the nlohmann json library does not define the explicit conversion for std::optional. Since explicit conversions are preferred, I created a definition for it when that define is used. I expect this is unintended behavior and I'm going to log an issue as well 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
