### PR TITLE
CODEOWNERS: Adjust recently migrated projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,19 +18,21 @@
 /projects/hipblas-common/                           @ROCm/hipblas-common-reviewers
 /projects/hipblaslt/                                @ROCm/hipblaslt-reviewers
 /projects/hipcub/                                   @ROCm/prims-rands-reviewers
+/projects/hipdnn/                                   @ROCm/hipdnn-reviewers
 /projects/hipfft/                                   @ROCm/fft-reviewers
 /projects/hiprand/                                  @ROCm/prims-rands-reviewers
-/projects/hipsolver/                                @jzuniga-amd @tfalders @cgmb @qjojo @EdDAzevedo @jmachado-amd
-/projects/hipsparse/                                @ntrost57 @YvanMokwinski @jsandham
+/projects/hipsolver/                                @ROCm/solvers-reviewers
+/projects/hipsparse/                                @ROCm/sparses-reviewers
 /projects/hipsparselt/                              @ROCm/hipsparselt-reviewers
 /projects/miopen/                                   @ROCm/miopen-reviewers
 /projects/rocblas/                                  @ROCm/rocblas-reviewers
 /projects/rocfft/                                   @ROCm/fft-reviewers
 /projects/rocprim/                                  @ROCm/prims-rands-reviewers
 /projects/rocrand/                                  @ROCm/prims-rands-reviewers
-/projects/rocsolver/                                @jzuniga-amd @tfalders @cgmb @qjojo @EdDAzevedo @jmachado-amd @AGonzales-amd
-/projects/rocsparse/                                @ntrost57 @YvanMokwinski @jsandham @kliegeois
+/projects/rocsolver/                                @ROCm/solvers-reviewers
+/projects/rocsparse/                                @ROCm/sparses-reviewers
 /projects/rocthrust/                                @ROCm/prims-rands-reviewers
+/shared/origami/                                    @ROCm/origami-reviewers
 /shared/mxdatagenerator/                            @ROCm/rocroller-developers
 /shared/rocroller/                                  @ROCm/rocroller-developers
 /shared/tensile/                                    @ROCm/tensile-reviewers
@@ -42,17 +44,20 @@
 /projects/hipblaslt/**/*.cmake                      @ROCm/rocm-math-lib-build-infra
 /projects/hipblaslt/**/CMakeLists.txt               @ROCm/rocm-math-lib-build-infra
 
-/projects/rocblas/**/*.cmake                        @ROCm/rocm-math-lib-build-infra @ROCm/rocblas-reviewers
-/projects/rocblas/**/CMakeLists.txt                 @ROCm/rocm-math-lib-build-infra @ROCm/rocblas-reviewers
-
 /projects/hipsparselt/**/*.cmake                    @ROCm/rocm-math-lib-build-infra @ROCm/hipsparselt-reviewers
 /projects/hipsparselt/**/CMakeLists.txt             @ROCm/rocm-math-lib-build-infra @ROCm/hipsparselt-reviewers
 
-/shared/rocroller/**/*.cmake                        @ROCm/rocm-math-lib-build-infra
-/shared/rocroller/**/CMakeLists.txt                 @ROCm/rocm-math-lib-build-infra
+/projects/rocblas/**/*.cmake                        @ROCm/rocm-math-lib-build-infra @ROCm/rocblas-reviewers
+/projects/rocblas/**/CMakeLists.txt                 @ROCm/rocm-math-lib-build-infra @ROCm/rocblas-reviewers
 
 /shared/mxdatagenerator/**/*.cmake                  @ROCm/rocm-math-lib-build-infra
 /shared/mxdatagenerator/**/CMakeLists.txt           @ROCm/rocm-math-lib-build-infra
+
+/shared/origami/**/*.cmake                          @ROCm/rocm-math-lib-build-infra
+/shared/origami/**/CMakeLists.txt                   @ROCm/rocm-math-lib-build-infra
+
+/shared/rocroller/**/*.cmake                        @ROCm/rocm-math-lib-build-infra
+/shared/rocroller/**/CMakeLists.txt                 @ROCm/rocm-math-lib-build-infra
 
 /shared/tensile/**/*.cmake                          @ROCm/rocm-math-lib-build-infra
 /shared/tensile/**/CMakeLists.txt                   @ROCm/rocm-math-lib-build-infra
@@ -93,6 +98,18 @@
 /projects/hiprand/docs/                             @ROCm/prims-rands-reviewers @ROCm/rands-docs-reviewers
 /projects/hiprand/library/include/                  @ROCm/prims-rands-reviewers @ROCm/rands-docs-reviewers
 
+/projects/hipsolver/**/*.md                         @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+/projects/hipsolver/**/*.rst                        @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+/projects/hipsolver/**/.readthedocs.yaml            @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+/projects/hipsolver/docs/                           @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+/projects/hipsolver/library/include/                @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+
+/projects/hipsparse/**/*.md                         @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
+/projects/hipsparse/**/*.rst                        @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
+/projects/hipsparse/**/.readthedocs.yaml            @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
+/projects/hipsparse/docs/                           @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
+/projects/hipsparse/library/include/                @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
+
 /projects/hipsparselt/**/*.md                       @ROCm/hipsparselt-reviewers @ROCm/hipsparselt-docs-reviewers
 /projects/hipsparselt/**/*.rst                      @ROCm/hipsparselt-reviewers @ROCm/hipsparselt-docs-reviewers
 /projects/hipsparselt/**/.readthedocs.yaml          @ROCm/hipsparselt-reviewers @ROCm/hipsparselt-docs-reviewers
@@ -126,6 +143,18 @@
 /projects/rocrand/**/.readthedocs.yaml              @ROCm/prims-rands-reviewers @ROCm/rands-docs-reviewers
 /projects/rocrand/docs/                             @ROCm/prims-rands-reviewers @ROCm/rands-docs-reviewers
 /projects/rocrand/library/include/                  @ROCm/prims-rands-reviewers @ROCm/rands-docs-reviewers
+
+/projects/rocsolver/**/*.md                         @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+/projects/rocsolver/**/*.rst                        @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+/projects/rocsolver/**/.readthedocs.yaml            @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+/projects/rocsolver/docs/                           @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+/projects/rocsolver/library/include/                @ROCm/solvers-reviewers @ROCm/solvers-docs-reviewers
+
+/projects/rocsparse/**/*.md                         @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
+/projects/rocsparse/**/*.rst                        @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
+/projects/rocsparse/**/.readthedocs.yaml            @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
+/projects/rocsparse/docs/                           @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
+/projects/rocsparse/library/include/                @ROCm/sparses-reviewers @ROCm/sparses-docs-reviewers
 
 /projects/rocthrust/**/*.md                         @ROCm/prims-rands-reviewers @ROCm/prims-docs-reviewers
 /projects/rocthrust/**/*.rst                        @ROCm/prims-rands-reviewers @ROCm/prims-docs-reviewers

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,10 @@
 - changed-files:
   - any-glob-to-any-file: 'projects/hipcub/**/*'
 
+"project: hipdnn":
+- changed-files:
+  - any-glob-to-any-file: 'projects/hipdnn/**/*'
+
 "project: hipfft":
 - changed-files:
   - any-glob-to-any-file: 'projects/hipfft/**/*'
@@ -75,14 +79,14 @@
 "project: rocthrust":
 - changed-files:
   - any-glob-to-any-file: 'projects/rocthrust/**/*'
-  
-"project: hipdnn":
-- changed-files:
-  - any-glob-to-any-file: 'projects/hipdnn/**/*'
 
 "shared: mxdatagenerator":
 - changed-files:
   - any-glob-to-any-file: 'shared/mxdatagenerator/**/*'
+
+"shared: origami":
+- changed-files:
+  - any-glob-to-any-file: 'shared/origami/**/*'
 
 "shared: rocroller":
 - changed-files:
@@ -91,10 +95,6 @@
 "shared: tensile":
 - changed-files:
   - any-glob-to-any-file: 'shared/tensile/**/*'
-
-"shared: origami":
-- changed-files:
-  - any-glob-to-any-file: 'shared/origami/**/*'
 
 documentation:
 - changed-files:


### PR DESCRIPTION
- Created GitHub Teams for reviewers of recently-migrated projects.
- origami reviewers team is a placeholder, only added @davidd-amd. David can fill in the rest.
- Re-ordered some project entries alphabetically, including the labeler yml file.
- Note that there are no docs entries in the CODEOWNERS for hipdnn and origami.
- Added some key stakeholders as reviewers for awareness.