### PR TITLE
Increase max tile for parallel reduction

### DIFF
--- a/shared/origami/src/origami/streamk.cpp
+++ b/shared/origami/src/origami/streamk.cpp
@@ -282,7 +282,7 @@ namespace origami
                     // For problems with large k and low number of tiles, use parallel reduction
                     // TODO Benchmark to check if limits are correct
                     constexpr int MinItersForParallel = 64;
-                    constexpr int MaxTilesForParallel = 16;
+                    constexpr int MaxTilesForParallel = 64;
                     if (iters_per_tile >= MinItersForParallel && tiles <= MaxTilesForParallel)
                         reductionStrat = reduction_type::Parallel;
                 }


### PR DESCRIPTION
## Motivation
Improve performance for some medium M,N and large K sizes.

## Technical Details
Increase max tiles threshold for using parallel reduction.

## Test Plan
Testing was done with different threshold levels.

## Submission Checklist

- [/] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
