### PR TITLE
Deprecation of cmake functions

### DIFF
--- a/projects/composablekernel/CMakeLists.txt
+++ b/projects/composablekernel/CMakeLists.txt
@@ -146,7 +146,7 @@ execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD OUTPUT_VARIABLE COMMI
 configure_file(include/ck/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/ck/version.h)
 
 set(ROCM_SYMLINK_LIBS OFF)
-find_package(ROCM REQUIRED PATHS /opt/rocm)
+find_package(ROCmCMakeBuildTools REQUIRED PATHS /opt/rocm)
 
 include(ROCMInstallTargets)
 include(ROCMPackageConfigHelpers)

--- a/projects/composablekernel/codegen/CMakeLists.txt
+++ b/projects/composablekernel/codegen/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CK_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 configure_file(${CK_ROOT}/include/ck/config.h.in ${CK_ROOT}/include/ck/config.h)
 
-find_package(ROCM)
+find_package(ROCmCMakeBuildTools)
 include(ROCMInstallTargets)
 include(ROCMTest)
 find_package(hiprtc REQUIRED)

--- a/projects/hipblas-common/cmake/dependencies.cmake
+++ b/projects/hipblas-common/cmake/dependencies.cmake
@@ -26,7 +26,7 @@
 
 include(FetchContent)
 
-find_package(ROCM 0.11.0 CONFIG QUIET PATHS "${ROCM_PATH}") # First version with Sphinx doc gen improvement
+find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET PATHS "${ROCM_PATH}") # First version with Sphinx doc gen improvement
 if(NOT ROCM_FOUND)
   message(STATUS "ROCm CMake not found. Fetching...")
   set(rocm_cmake_tag
@@ -39,9 +39,9 @@ if(NOT ROCM_FOUND)
     SOURCE_SUBDIR "DISABLE ADDING TO BUILD" # We don't really want to consume the build and test targets of ROCm CMake.
   )
   FetchContent_MakeAvailable(rocm-cmake)
-  find_package(ROCM CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
+  find_package(ROCmCMakeBuildTools CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
 else()
-  find_package(ROCM 0.11.0 CONFIG REQUIRED PATHS "${ROCM_PATH}")
+  find_package(ROCmCMakeBuildTools 0.11.0 CONFIG REQUIRED PATHS "${ROCM_PATH}")
 endif()
 
 include(ROCMSetupVersion)

--- a/projects/hipblas/cmake/get-rocm-cmake.cmake
+++ b/projects/hipblas/cmake/get-rocm-cmake.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 
 find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET PATHS "${ROCM_PATH}")
 if(NOT ROCmCMakeBuildTools_FOUND)
-  find_package(ROCM 0.11.0 CONFIG QUIET PATHS "${ROCM_PATH}") # deprecated fallback
+  find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET PATHS "${ROCM_PATH}") # deprecated fallback
   if(NOT ROCM_FOUND)
     message(STATUS "ROCmCMakeBuildTools not found. Fetching...")
     set(rocm_cmake_tag "rocm-6.4.0" CACHE STRING "rocm-cmake tag to download")

--- a/projects/hipcub/cmake/ROCmCMakeBuildToolsDependency.cmake
+++ b/projects/hipcub/cmake/ROCmCMakeBuildToolsDependency.cmake
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
-  find_package(ROCM 0.7.3 CONFIG QUIET PATHS "${ROCM_ROOT}")
+  find_package(ROCmCMakeBuildTools 0.7.3 CONFIG QUIET PATHS "${ROCM_ROOT}")
 endif()
 if(NOT ROCM_FOUND)
   message(STATUS "ROCm CMake not found. Fetching...")
@@ -39,9 +39,9 @@ if(NOT ROCM_FOUND)
     ${SOURCE_SUBDIR_ARG}
   )
   FetchContent_MakeAvailable(rocm-cmake)
-  find_package(ROCM CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
+  find_package(ROCmCMakeBuildTools CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
 else()
-  find_package(ROCM 0.7.3 CONFIG REQUIRED PATHS "${ROCM_ROOT}")
+  find_package(ROCmCMakeBuildTools 0.7.3 CONFIG REQUIRED PATHS "${ROCM_ROOT}")
 endif()
 
 include(ROCMSetupVersion)

--- a/projects/hipcub/cmake/ROCmCMakeBuildToolsDependency.cmake
+++ b/projects/hipcub/cmake/ROCmCMakeBuildToolsDependency.cmake
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
-  find_package(ROCmCMakeBuildTools 0.7.3 CONFIG QUIET PATHS "${ROCM_ROOT}")
+  find_package(ROCM 0.7.3 CONFIG QUIET PATHS "${ROCM_ROOT}")
 endif()
 if(NOT ROCM_FOUND)
   message(STATUS "ROCm CMake not found. Fetching...")
@@ -39,9 +39,9 @@ if(NOT ROCM_FOUND)
     ${SOURCE_SUBDIR_ARG}
   )
   FetchContent_MakeAvailable(rocm-cmake)
-  find_package(ROCmCMakeBuildTools CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
+  find_package(ROCM CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
 else()
-  find_package(ROCmCMakeBuildTools 0.7.3 CONFIG REQUIRED PATHS "${ROCM_ROOT}")
+  find_package(ROCM 0.7.3 CONFIG REQUIRED PATHS "${ROCM_ROOT}")
 endif()
 
 include(ROCMSetupVersion)

--- a/projects/hiprand/cmake/ROCmCMakeBuildToolsDependency.cmake
+++ b/projects/hiprand/cmake/ROCmCMakeBuildToolsDependency.cmake
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 # Find or download/install rocm-cmake project
-find_package(ROCM 0.7.3 QUIET CONFIG PATHS ${ROCM_PATH})
+find_package(ROCmCMakeBuildTools 0.7.3 QUIET CONFIG PATHS ${ROCM_PATH})
 if(NOT ROCM_FOUND)
     set(PROJECT_EXTERN_DIR "${CMAKE_CURRENT_BINARY_DIR}/deps")
     file( TO_NATIVE_PATH "${PROJECT_EXTERN_DIR}" PROJECT_EXTERN_DIR_NATIVE)
@@ -54,7 +54,7 @@ if(NOT ROCM_FOUND)
     if(rocm_cmake_unpack_error_code)
         message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip failed")
     endif()
-    find_package(ROCM 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR})
+    find_package(ROCmCMakeBuildTools 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR})
 endif()
 
 include(ROCMSetupVersion)

--- a/projects/hipsolver/CMakeLists.txt
+++ b/projects/hipsolver/CMakeLists.txt
@@ -49,7 +49,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # This finds the rocm-cmake project, and installs it if not found
 # rocm-cmake contains common cmake code for rocm projects to help setup and install
 set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
-find_package(ROCM 0.7.3 CONFIG QUIET PATHS /opt/rocm)
+find_package(ROCmCMakeBuildTools 0.7.3 CONFIG QUIET PATHS /opt/rocm)
 if(NOT ROCM_FOUND)
   set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
   set(rocm_cmake_url "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip")
@@ -76,7 +76,7 @@ if(NOT ROCM_FOUND)
   execute_process(COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
     WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
 
-  find_package(ROCM 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake)
+  find_package(ROCmCMakeBuildTools 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake)
 endif()
 
 include(ROCMSetupVersion)

--- a/projects/hipsparse/cmake/Dependencies.cmake
+++ b/projects/hipsparse/cmake/Dependencies.cmake
@@ -59,7 +59,7 @@ endif()
 # ROCm cmake package
 find_package(ROCmCMakeBuildTools 0.11.0 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH})
 if(NOT ROCmCMakeBuildTools_FOUND)
-  find_package(ROCM 0.7.3 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH}) # deprecated fallback
+  find_package(ROCmCMakeBuildTools 0.7.3 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH}) # deprecated fallback
   if(NOT ROCM_FOUND)
     message(STATUS "ROCmCMakeBuildTools not found. Fetching...")
     set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)

--- a/projects/hipsparselt/cmake/Dependencies.cmake
+++ b/projects/hipsparselt/cmake/Dependencies.cmake
@@ -31,7 +31,7 @@ find_package(Git REQUIRED)
 list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hip /opt/rocm)
 
 # ROCm cmake package
-find_package(ROCM 0.6 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH})
+find_package(ROCmCMakeBuildTools 0.6 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH})
 if(NOT ROCM_FOUND)
   set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
   set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")

--- a/projects/miopen/CMakeLists.txt
+++ b/projects/miopen/CMakeLists.txt
@@ -80,7 +80,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(CTest)
 
 find_package(Threads REQUIRED)
-find_package(ROCM 0.7.3 REQUIRED PATHS /opt/rocm)
+find_package(ROCmCMakeBuildTools 0.7.3 REQUIRED PATHS /opt/rocm)
 
 include(ROCMInstallTargets)
 include(ROCMPackageConfigHelpers)

--- a/projects/rocblas/cmake/get-rocm-cmake.cmake
+++ b/projects/rocblas/cmake/get-rocm-cmake.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 
 find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET PATHS "${ROCM_PATH}")
 if(NOT ROCmCMakeBuildTools_FOUND)
-  find_package(ROCM 0.7.3 CONFIG QUIET PATHS "${ROCM_PATH}") # deprecated fallback
+  find_package(ROCmCMakeBuildTools 0.7.3 CONFIG QUIET PATHS "${ROCM_PATH}") # deprecated fallback
   if(NOT ROCM_FOUND)
     message(STATUS "ROCmCMakeBuildTools not found. Fetching...")
     set(rocm_cmake_tag "rocm-6.4.0" CACHE STRING "rocm-cmake tag to download")

--- a/projects/rocblas/next-cmake/cmake/FetchROCmCMake.cmake
+++ b/projects/rocblas/next-cmake/cmake/FetchROCmCMake.cmake
@@ -17,7 +17,7 @@ if(NOT ROCmCMakeBuildTools_FOUND)
 
   FetchContent_GetProperties(rocm-cmake)
   if(NOT rocm-cmake_POPULATED)
-    FetchContent_Populate(rocm-cmake)
+    FetchContent_MakeAvailable(rocm-cmake)
     add_subdirectory(${rocm-cmake_SOURCE_DIR} ${rocm-cmake_BINARY_DIR} EXCLUDE_FROM_ALL)
     list(APPEND CMAKE_MODULE_PATH ${rocm-cmake_SOURCE_DIR}/modules)
   endif()

--- a/projects/rocprim/cmake/Dependencies.cmake
+++ b/projects/rocprim/cmake/Dependencies.cmake
@@ -144,7 +144,7 @@ if(BUILD_BENCHMARK)
 endif(BUILD_BENCHMARK)
 
 if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
-  find_package(ROCM 0.11.0 CONFIG QUIET PATHS "${ROCM_ROOT}") # rocm-cmake
+  find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET PATHS "${ROCM_ROOT}") # rocm-cmake
 endif()
 if(NOT ROCM_FOUND)
   message(STATUS "ROCm CMake not found. Fetching...")
@@ -165,7 +165,7 @@ if(NOT ROCM_FOUND)
   FetchContent_GetProperties(rocm-cmake)
   if(NOT rocm-cmake_POPULATED)
     # rocm-cmake 0.12.0 and higher needs to built from source
-    FetchContent_Populate(rocm-cmake)
+    FetchContent_MakeAvailable(rocm-cmake)
     message("Populated: ${rocm-cmake_SOURCE_DIR}")
     execute_process(
       WORKING_DIRECTORY ${rocm-cmake_SOURCE_DIR}
@@ -177,9 +177,9 @@ if(NOT ROCM_FOUND)
     )
   endif()
   FetchContent_MakeAvailable(rocm-cmake)
-  find_package(ROCM CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
+  find_package(ROCmCMakeBuildTools CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
 else()
-  find_package(ROCM 0.11.0 CONFIG REQUIRED PATHS "${ROCM_ROOT}")
+  find_package(ROCmCMakeBuildTools 0.11.0 CONFIG REQUIRED PATHS "${ROCM_ROOT}")
 endif()
 
 

--- a/projects/rocrand/cmake/Dependencies.cmake
+++ b/projects/rocrand/cmake/Dependencies.cmake
@@ -67,7 +67,7 @@ endif()
 set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
 
 # Find or download/install rocm-cmake project
-find_package(ROCM 0.7.3 QUIET CONFIG PATHS $ENV{ROCM_PATH})
+find_package(ROCmCMakeBuildTools 0.7.3 QUIET CONFIG PATHS $ENV{ROCM_PATH})
 if(NOT ROCM_FOUND)
   set(PROJECT_EXTERN_DIR "${CMAKE_CURRENT_BINARY_DIR}/deps")
   file( TO_NATIVE_PATH "${PROJECT_EXTERN_DIR}" PROJECT_EXTERN_DIR_NATIVE)
@@ -100,7 +100,7 @@ if(NOT ROCM_FOUND)
   if(rocm_cmake_unpack_error_code)
       message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip failed")
   endif()
-  find_package(ROCM 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR} NO_DEFAULT_PATH)
+  find_package(ROCmCMakeBuildTools 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR} NO_DEFAULT_PATH)
 endif()
 
 include(ROCMSetupVersion)

--- a/projects/rocsolver/cmake/get-rocm-cmake.cmake
+++ b/projects/rocsolver/cmake/get-rocm-cmake.cmake
@@ -10,7 +10,7 @@ endif()
 
 find_package(ROCmCMakeBuildTools QUIET PATHS ${ROCM_PATH})
 if(NOT ROCmCMakeBuildTools_FOUND)
-  find_package(ROCM 0.7.3 CONFIG QUIET PATHS ${ROCM_PATH})
+  find_package(ROCmCMakeBuildTools 0.7.3 CONFIG QUIET PATHS ${ROCM_PATH})
   if(NOT ROCM_FOUND)
     set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
     set(rocm_cmake_url "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip")

--- a/projects/rocsparse/cmake/Dependencies.cmake
+++ b/projects/rocsparse/cmake/Dependencies.cmake
@@ -32,7 +32,7 @@ list(APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/hip)
 # ROCm cmake package
 find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET PATHS "${ROCM_PATH}")
 if(NOT ROCmCMakeBuildTools_FOUND)
-  find_package(ROCM 0.7.3 CONFIG QUIET PATHS "${ROCM_PATH}") # deprecated fallback
+  find_package(ROCmCMakeBuildTools 0.7.3 CONFIG QUIET PATHS "${ROCM_PATH}") # deprecated fallback
   if(NOT ROCM_FOUND)
     message(STATUS "ROCmCMakeBuildTools not found. Fetching...")
     set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)

--- a/projects/rocthrust/cmake/FindROCMCmake.cmake
+++ b/projects/rocthrust/cmake/FindROCMCmake.cmake
@@ -17,7 +17,7 @@ if(NOT ROCM_PATH)
   set(ROCM_PATH /opt/rocm)
 endif()
 
-find_package(ROCM 0.7.3 CONFIG QUIET PATHS ${ROCM_PATH} /opt/rocm)
+find_package(ROCmCMakeBuildTools 0.7.3 CONFIG QUIET PATHS ${ROCM_PATH} /opt/rocm)
 if(NOT ROCM_FOUND)
   set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
   set(rocm_cmake_url "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip")


### PR DESCRIPTION
## Motivation

Use of find_package(ROCM) is deprecated as of ROCm 6.4, find_package(ROCmCMakeBuildTools) should be used instead

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
