### PR TITLE
Update TheRock CI to use health status script

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -40,39 +40,33 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 80198e080271a2013073fc1d3dd03672a3214779 # 2025-09-22 commit
+          ref: 7afbe45f7eaa4f2e9abcb9cd7f1c4042a2d7b638 # 2025-09-24 commit
 
-      - name: Runner Health Settings
+      - name: Install python deps
+        run: |
+          pip install -r TheRock/requirements.txt
+
+      # safe.directory must be set before Runner health status
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
         run: |
           ./TheRock/build_tools/setup_ccache.py \
             --config-preset "github-oss-presubmit" \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
             --local-path "$CACHE_DIR/ccache"
-          df -h
-          echo "ccache version: $(ccache --version)"
-          echo "ccache config:"
-          echo "---"
-          cat "$CCACHE_CONFIGPATH"
-          echo "---"
-          ccache -z
-          ccache -s -v
-          cmake --version
-          echo "Installed Python versions:"
-          ls -d /opt/python
-          echo "python: $(which python), python3: $(which python3)"
-          echo "Git version: $(git --version)"
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
+
+      - name: Runner health status
+        run: |
+          ./TheRock/build_tools/health_status.py
 
       - name: Fetch sources
         timeout-minutes: 30
         run: |
           ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-libraries --no-include-ml-frameworks
-
-      - name: Install python deps
-        run: |
-          pip install -r TheRock/requirements.txt
-          pip freeze
 
       - name: Patch rocm-libraries
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 80198e080271a2013073fc1d3dd03672a3214779 # 2025-09-22 commit
+          ref: 7afbe45f7eaa4f2e9abcb9cd7f1c4042a2d7b638 # 2025-09-24 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -76,6 +76,11 @@ jobs:
       # After other installs, so MSVC get priority in the PATH.
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Runner health status
+        run: |
+          ccache --zero-stats
+          python ./TheRock/build_tools/health_status.py
 
       - name: Fetch sources
         timeout-minutes: 30


### PR DESCRIPTION
This will update the CI to match TheRocks CI by introducing to use a python script to report on health status. Commands that were in the section that modified the status were moved to separate sections (ccache, git config, ..).

Related PR:
ROCm/TheRock#1516
