### PR TITLE
[HipDNN][ALMIOPEN-286] - Properly enabled tidy, and fixed errors

### DIFF
--- a/projects/hipdnn/.clang-tidy
+++ b/projects/hipdnn/.clang-tidy
@@ -28,7 +28,7 @@ HeaderFileExtensions: ['h','hpp']
 
 # This regex is a inclusion filter for the files to be checked. Its a Posix regex and
 # does not seem to support negative lookahead.  
-HeaderFilterRegex: '*'
+HeaderFilterRegex: '.'
 ExcludeHeaderFilterRegex: '^(.*data_objects.*)$'
 
 CheckOptions:

--- a/projects/hipdnn/backend/src/descriptors/BackendDescriptor.hpp
+++ b/projects/hipdnn/backend/src/descriptors/BackendDescriptor.hpp
@@ -7,6 +7,8 @@
 #include "hipdnn_backend.h"
 #include <memory>
 
+// NOLINTBEGIN(portability-template-virtual-member-function)
+
 struct IBackendDescriptor
 {
     virtual ~IBackendDescriptor() = default;
@@ -28,11 +30,15 @@ struct IBackendDescriptor
     virtual hipdnnBackendDescriptorType_t getType() const = 0;
 };
 
+// NOLINTEND(portability-template-virtual-member-function)
+
 //NOLINTBEGIN(readability-identifier-naming)
 namespace hipdnn_backend
 {
 
 class MockDescriptorUtility;
+
+// NOLINTBEGIN(portability-template-virtual-member-function)
 
 template <typename T>
 class HipdnnBackendDescriptorImpl : public IBackendDescriptor
@@ -66,6 +72,9 @@ public:
         return T::getStaticType();
     }
 };
+
+// NOLINTEND(portability-template-virtual-member-function)
+
 }
 
 namespace

--- a/projects/hipdnn/backend/src/plugin/PluginCore.hpp
+++ b/projects/hipdnn/backend/src/plugin/PluginCore.hpp
@@ -271,7 +271,7 @@ private:
 
                 actionAfterAdding(*_plugins.back());
             },
-            fmt::format("Error loading plugin from [{}]: ", filePath.string()).c_str());
+            fmt::format("Error loading plugin from [{}]: ", filePath.string()));
     }
 
     std::vector<std::shared_ptr<Plugin>> _plugins;

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -315,7 +315,7 @@ constexpr size_t toBitPosition(PointwiseMode mode)
 
 inline const PointwiseModeBitset& getUnaryModesBitset()
 {
-    static const PointwiseModeBitset unaryModes = []() {
+    static const PointwiseModeBitset s_unaryModes = []() {
         PointwiseModeBitset bitset;
         bitset.set(toBitPosition(PointwiseMode::ABS));
         bitset.set(toBitPosition(PointwiseMode::CEIL));
@@ -342,12 +342,12 @@ inline const PointwiseModeBitset& getUnaryModesBitset()
         bitset.set(toBitPosition(PointwiseMode::TANH_FWD));
         return bitset;
     }();
-    return unaryModes;
+    return s_unaryModes;
 }
 
 inline const PointwiseModeBitset& getBinaryModesBitset()
 {
-    static const PointwiseModeBitset binaryModes = []() {
+    static const PointwiseModeBitset s_binaryModes = []() {
         PointwiseModeBitset bitset;
         bitset.set(toBitPosition(PointwiseMode::ADD));
         bitset.set(toBitPosition(PointwiseMode::ADD_SQUARE));
@@ -374,17 +374,17 @@ inline const PointwiseModeBitset& getBinaryModesBitset()
         bitset.set(toBitPosition(PointwiseMode::TANH_BWD));
         return bitset;
     }();
-    return binaryModes;
+    return s_binaryModes;
 }
 
 inline const PointwiseModeBitset& getTernaryModesBitset()
 {
-    static const PointwiseModeBitset ternaryModes = []() {
+    static const PointwiseModeBitset s_ternaryModes = []() {
         PointwiseModeBitset bitset;
         bitset.set(toBitPosition(PointwiseMode::BINARY_SELECT));
         return bitset;
     }();
-    return ternaryModes;
+    return s_ternaryModes;
 }
 
 inline bool isUnaryPointwiseMode(PointwiseMode mode)

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Utilities.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Utilities.hpp
@@ -84,10 +84,10 @@ inline int32_t initializeFrontendLogging(hipdnnCallback_t fn = hipdnnLoggingCall
         return -1;
     }
 
-    static bool loggingInitialized = false;
-    static bool loggingEnabled = hipdnn_sdk::logging::isLoggingEnabled();
+    static bool s_loggingInitialized = false;
+    static bool s_loggingEnabled = hipdnn_sdk::logging::isLoggingEnabled();
 
-    if(loggingInitialized || !loggingEnabled)
+    if(s_loggingInitialized || !s_loggingEnabled)
     {
         return 0;
     }
@@ -98,7 +98,7 @@ inline int32_t initializeFrontendLogging(hipdnnCallback_t fn = hipdnnLoggingCall
     return -1;
 #endif
 
-    loggingInitialized = true;
+    s_loggingInitialized = true;
     HIPDNN_LOG_INFO("Frontend logging initialized via callback.");
 
     return 0;

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/GraphAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/GraphAttributes.hpp
@@ -63,13 +63,25 @@ public:
     GraphAttributes& fill_missing_properties(const GraphAttributes& other)
     {
         if(_computeType == DataType::NOT_SET)
+        {
             _computeType = other._computeType;
+        }
+
         if(_intermediateType == DataType::NOT_SET)
+        {
             _intermediateType = other._intermediateType;
+        }
+
         if(_ioType == DataType::NOT_SET)
+        {
             _ioType = other._ioType;
+        }
+
         if(_name.empty())
+        {
             _name = other._name;
+        }
+
         return *this;
     }
 

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/ConvolutionCommon.hpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/ConvolutionCommon.hpp
@@ -77,7 +77,7 @@ struct ConvTestCase
         for(size_t i = 0; i < spatialDims; ++i)
         {
             auto paddedInputSize = _xDims[2 + i] + _convPrePadding[i] + _convPostPadding[i];
-            auto effectiveKernelSize = _convDilation[i] * (_wDims[2 + i] - 1) + 1;
+            auto effectiveKernelSize = (_convDilation[i] * (_wDims[2 + i] - 1)) + 1;
             auto dimOut = ((paddedInputSize - effectiveKernelSize) / _convStride[i]) + 1;
             outputDims.push_back(dimOut);
         }

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceBatchnorm.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceBatchnorm.hpp
@@ -26,14 +26,8 @@ public:
         using namespace hipdnn_sdk::data_objects;
 
         // Support both BatchNorm inference and backward
-        if(node.attributes_type() != NodeAttributes::BatchnormInferenceAttributes
-           && node.attributes_type() != NodeAttributes::BatchnormBackwardAttributes)
-        {
-            return false;
-        }
-
-        // Default to supporting the node
-        return true;
+        return (node.attributes_type() == NodeAttributes::BatchnormInferenceAttributes
+                || node.attributes_type() != NodeAttributes::BatchnormBackwardAttributes);
     }
 
     static void batchnormFwdInference(const TensorBase<InputDataType>& input,
@@ -155,7 +149,7 @@ public:
             if(prevRunningMean != nullptr && prevRunningVariance != nullptr
                && nextRunningMean != nullptr && nextRunningVariance != nullptr)
             {
-                constexpr MeanVarianceDataType one = static_cast<MeanVarianceDataType>(1.0f);
+                auto one = static_cast<MeanVarianceDataType>(1.0f);
                 auto currentMean = prevRunningMean->getHostValue(0, cidx);
                 auto newMean = (one - momentum) * currentMean + momentum * channelMean;
                 nextRunningMean->setHostValue(newMean, 0, cidx);
@@ -294,9 +288,9 @@ private:
     static void iterateChannelElements(const TensorBase<InputDataType>& tensor,
                                        int64_t channelIdx,
                                        int64_t elementsPerChannel,
-                                       std::function<void(const std::vector<int64_t>&)> func)
+                                       const std::function<void(const std::vector<int64_t>&)>& func)
     {
-        auto dims = tensor.dims();
+        const auto& dims = tensor.dims();
 
         if(dims.size() < 2)
         {
@@ -316,10 +310,12 @@ private:
             {
                 // Skip channel dimension
                 if(dim == 1)
+                {
                     continue;
+                }
 
                 // Cast to size_t to avoid warnings.
-                size_t index = static_cast<size_t>(dim);
+                auto index = static_cast<size_t>(dim);
                 indices[index]++;
 
                 // No carry needed

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceConvolution.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceConvolution.hpp
@@ -26,12 +26,7 @@ public:
     {
         using namespace hipdnn_sdk::data_objects;
 
-        if(node.attributes_type() != NodeAttributes::ConvolutionFwdAttributes)
-        {
-            return false;
-        }
-
-        return true;
+        return (node.attributes_type() != NodeAttributes::ConvolutionFwdAttributes);
     }
 
     static void convFwdInference(const TensorBase<InputDataType>& input,
@@ -113,13 +108,13 @@ public:
         int64_t padW = padding[1];
 
         auto convolutionFunc = [&](auto g, auto n, auto k, auto ho, auto wo) {
-            AccumulatorType accumulator = static_cast<AccumulatorType>(0);
+            auto accumulator = static_cast<AccumulatorType>(0);
 
-            int64_t gIdx = static_cast<int64_t>(g);
-            int64_t nIdx = static_cast<int64_t>(n);
-            int64_t kIdx = static_cast<int64_t>(k);
-            int64_t hoIdx = static_cast<int64_t>(ho);
-            int64_t woIdx = static_cast<int64_t>(wo);
+            auto gIdx = static_cast<int64_t>(g);
+            auto nIdx = static_cast<int64_t>(n);
+            auto kIdx = static_cast<int64_t>(k);
+            auto hoIdx = static_cast<int64_t>(ho);
+            auto woIdx = static_cast<int64_t>(wo);
 
             int64_t baseInputChannel = gIdx * channelsPerGroup;
 
@@ -129,17 +124,17 @@ public:
 
                 for(int64_t y = 0; y < kernelHeight; ++y)
                 {
-                    int64_t hi = hoIdx * strideH + y * dilationH - padH;
+                    int64_t hi = (hoIdx * strideH) + (y * dilationH) - padH;
 
                     for(int64_t x = 0; x < kernelWidth; ++x)
                     {
-                        int64_t wi = woIdx * strideW + x * dilationW - padW;
+                        int64_t wi = (woIdx * strideW) + (x * dilationW) - padW;
 
                         if(hi >= 0 && hi < inputHeight && wi >= 0 && wi < inputWidth)
                         {
                             InputDataType inputVal = input.getHostValue(nIdx, inputChannel, hi, wi);
 
-                            int64_t weightIdx = gIdx * outputChannelsPerGroup + kIdx;
+                            int64_t weightIdx = (gIdx * outputChannelsPerGroup) + kIdx;
                             InputDataType weightVal = weight.getHostValue(weightIdx, c, y, x);
 
                             accumulator += static_cast<AccumulatorType>(inputVal)
@@ -149,7 +144,7 @@ public:
                 }
             }
 
-            int64_t outputChannel = gIdx * outputChannelsPerGroup + kIdx;
+            int64_t outputChannel = (gIdx * outputChannelsPerGroup) + kIdx;
             output.setHostValue(
                 static_cast<InputDataType>(accumulator), nIdx, outputChannel, hoIdx, woIdx);
         };

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceUtilities.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/CpuFpReferenceUtilities.hpp
@@ -31,12 +31,15 @@ struct JoinableThread : std::thread
     ~JoinableThread()
     {
         if(this->joinable())
+        {
             this->join();
+        }
     }
 };
 
 template <typename F, typename T, std::size_t... Is>
-static auto callFuncUnpackArgsImpl(F f, T args, std::index_sequence<Is...>)
+static auto
+    callFuncUnpackArgsImpl(F f, T args, [[maybe_unused]] std::index_sequence<Is...> sequence)
 {
     return f(std::get<Is>(args)...);
 }

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/FlatbufferGraphTestUtils.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/FlatbufferGraphTestUtils.hpp
@@ -33,8 +33,8 @@ inline flatbuffers::FlatBufferBuilder createEmptyValidGraph()
 }
 
 inline flatbuffers::FlatBufferBuilder
-    createValidBatchnormInferenceGraph(std::vector<int64_t> strides = {1, 3, 224, 224},
-                                       std::vector<int64_t> dims = {1, 3, 224, 224},
+    createValidBatchnormInferenceGraph(const std::vector<int64_t>& strides = {1, 3, 224, 224},
+                                       const std::vector<int64_t>& dims = {1, 3, 224, 224},
                                        hipdnn_sdk::data_objects::DataType inputDataType
                                        = DataType::FLOAT)
 {
@@ -112,8 +112,8 @@ inline flatbuffers::FlatBufferBuilder
 }
 
 inline flatbuffers::FlatBufferBuilder
-    createValidBatchnormBwdGraph(std::vector<int64_t> strides = {1, 3, 224, 224},
-                                 std::vector<int64_t> dims = {1, 3, 224, 224},
+    createValidBatchnormBwdGraph(const std::vector<int64_t>& strides = {1, 3, 224, 224},
+                                 const std::vector<int64_t>& dims = {1, 3, 224, 224},
                                  bool hasOptionalAttributes = true,
                                  hipdnn_sdk::data_objects::DataType inputDataType = DataType::FLOAT)
 {
@@ -259,16 +259,16 @@ inline flatbuffers::FlatBufferBuilder createBatchnormGraph()
 }
 
 inline flatbuffers::FlatBufferBuilder
-    createValidConvFwdGraph(std::vector<int64_t> xDims = {4, 4, 4, 4},
-                            std::vector<int64_t> xStrides = {64, 16, 4, 1},
-                            std::vector<int64_t> wDims = {4, 4, 1, 1},
-                            std::vector<int64_t> wStrides = {4, 1, 1, 1},
-                            std::vector<int64_t> yDims = {4, 4, 4, 4},
-                            std::vector<int64_t> yStrides = {64, 16, 4, 1},
-                            std::vector<int64_t> convPrePadding = {0, 0},
-                            std::vector<int64_t> convPostPadding = {0, 0},
-                            std::vector<int64_t> convStrides = {1, 1},
-                            std::vector<int64_t> convDilation = {1, 1},
+    createValidConvFwdGraph(const std::vector<int64_t>& xDims = {4, 4, 4, 4},
+                            const std::vector<int64_t>& xStrides = {64, 16, 4, 1},
+                            const std::vector<int64_t>& wDims = {4, 4, 1, 1},
+                            const std::vector<int64_t>& wStrides = {4, 1, 1, 1},
+                            const std::vector<int64_t>& yDims = {4, 4, 4, 4},
+                            const std::vector<int64_t>& yStrides = {64, 16, 4, 1},
+                            const std::vector<int64_t>& convPrePadding = {0, 0},
+                            const std::vector<int64_t>& convPostPadding = {0, 0},
+                            const std::vector<int64_t>& convStrides = {1, 1},
+                            const std::vector<int64_t>& convDilation = {1, 1},
                             DataType dataType = DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/cpu_graph_executor/BatchnormRegistry.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/cpu_graph_executor/BatchnormRegistry.hpp
@@ -30,8 +30,8 @@ inline std::unordered_map<BatchnormSignatureRegistryKey,
     static std::unordered_map<BatchnormSignatureRegistryKey,
                               std::unique_ptr<IGenericBatchnormExecutor>,
                               BatchnormSignatureRegistryKeyHash>
-        registry;
-    return registry; //
+        s_registry;
+    return s_registry; //
 }
 
 /**
@@ -49,7 +49,7 @@ inline std::unordered_map<BatchnormSignatureRegistryKey,
  *       the registration for each index in the sequence
  */
 template <std::size_t... Is>
-void registerBatchnormExecutors(std::index_sequence<Is...>)
+void registerBatchnormExecutors([[maybe_unused]] std::index_sequence<Is...> sequence)
 {
     ((batchnormRegistry()[ALL_BATCHNORM_SIGNATURES[Is]]
       = std::make_unique<BatchnormExecutor<ALL_BATCHNORM_SIGNATURES[Is].inputDataType,
@@ -71,7 +71,7 @@ struct BatchnormRegistryInitializer
     }
 };
 
-inline BatchnormRegistryInitializer _batchnormRegistryInitializer;
+inline BatchnormRegistryInitializer batchnormRegistryInitializer;
 
 }
 }

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/ShallowHostOnlyMigratableMemory.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/ShallowHostOnlyMigratableMemory.hpp
@@ -76,7 +76,7 @@ public:
         return MemoryLocation::HOST;
     }
 
-    void resize(size_t) override
+    void resize([[maybe_unused]] size_t size) override
     {
         throwNotSupported();
     }

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/Tensor.hpp
@@ -72,7 +72,7 @@ public:
     template <typename IndexType>
     int64_t getIndex(const std::vector<IndexType>& indices) const
     {
-        static_assert(std::is_integral<IndexType>::value, "Index type must be integral!");
+        static_assert(std::is_integral_v<IndexType>, "Index type must be integral!");
 
         if(indices.size() > strides().size())
         {

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/UtilsBfp16.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/UtilsBfp16.hpp
@@ -37,18 +37,24 @@ inline __HOST_DEVICE__ hip_bfloat16 habs(const hip_bfloat16 a)
 inline __HOST_DEVICE__ bool hisnan(const hip_bfloat16 a)
 {
     hip_bfloat16 hr = a;
-    return !(~hr.data & 0x7f80) && +(hr.data & 0x7f);
+    return !static_cast<bool>(~hr.data & 0x7f80) && static_cast<bool>(+(hr.data & 0x7f));
 }
 
 inline __HOST_DEVICE__ hip_bfloat16 hmax(const hip_bfloat16 a, const hip_bfloat16 b)
 {
-    auto a_nan = hisnan(a), b_nan = hisnan(b);
-    if(a_nan || b_nan)
+    auto aNan = hisnan(a);
+    auto bNan = hisnan(b);
+
+    if(aNan || bNan)
     {
-        if(a_nan && b_nan)
+        if(aNan && bNan)
+        {
             return HIPDNN_NAN_BF16; // return canonical NaN
-        return a_nan ? b : a;
+        }
+
+        return aNan ? b : a;
     }
+
     return a.data > b.data ? a : b;
 }
 

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/UtilsFp16.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/UtilsFp16.hpp
@@ -40,13 +40,21 @@ inline __HOST_DEVICE__ bool hisnan(__half x)
 inline __HOST_DEVICE__ half hmax(const half a, const half b)
 {
     if(hisnan(a) && !hisnan(b))
+    {
         return b;
+    }
     if(!hisnan(a) && hisnan(b))
+    {
         return a;
+    }
     if(hisnan(a) && hisnan(b))
+    {
         return HIPDNN_NAN_FP16;
+    }
     if(static_cast<__half_raw>(a).x > static_cast<__half_raw>(b).x)
+    {
         return __half_raw{static_cast<__half_raw>(a).x};
+    }
     return __half_raw{static_cast<__half_raw>(b).x};
 }
 

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/Workspace.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/Workspace.hpp
@@ -31,8 +31,10 @@ public:
 
     ~Workspace()
     {
-        if(_ptr)
+        if(_ptr != nullptr)
+        {
             _allocator.deallocate(static_cast<char*>(_ptr), _size);
+        }
     }
 
     Workspace(Workspace&& other) noexcept
@@ -47,8 +49,10 @@ public:
     {
         if(this != &other)
         {
-            if(_ptr)
+            if(_ptr != nullptr)
+            {
                 _allocator.deallocate(static_cast<char*>(_ptr), _size);
+            }
 
             _ptr = other._ptr;
             _size = other._size;

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Common.hpp
@@ -7,6 +7,8 @@
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/json.hpp>
 
+// NOLINTBEGIN(readability-identifier-naming)
+
 // When implicit conversions are defined, the explicit conversion function is disabled in the nlohmann json library.
 // This may be unintended behavior
 #ifdef JSON_USE_IMPLICIT_CONVERSIONS
@@ -63,6 +65,8 @@ void to_json(nlohmann::json& vectorList, const Vector<Offset<T>>* vec)
 }
 
 }
+
+// NOLINTEND(readability-identifier-naming)
 
 namespace hipdnn_sdk::data_objects
 {


### PR DESCRIPTION
## Motivation

clang-tidy was misconfigured and a lot of header files were getting missed.  Properly enabled the clang-tidy filter, and then fixed the subsequently found errors.

## Technical Details

## Test Plan

- [x] - All unit tests run
- [x] - All integration tests run
- [x] - ASAN run 

## Test Result

All tests completed successfully.  There is an unrelated ASAN error in the JSON stuff.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Code formatted 
