### PR TITLE
[rocfft] allow exporting llvm-cov format to lcov format

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -36,6 +36,9 @@ coverage:
       rocThrust:
         flags: [rocThrust]
         target: 80%
+      rocFFT:
+        flags: [rocFFT]
+        target: 80%
       Tensile:
         flags: [Tensile]
         target: 80%

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -461,4 +461,10 @@ if(BUILD_CODE_COVERAGE)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 
+  add_custom_target(
+    export_coverage_report
+    COMMAND ${LLVM_COV} export -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata --format=lcov > ./coverage-report/coverage.info
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
 endif()

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -458,11 +458,6 @@ if(BUILD_CODE_COVERAGE)
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/rocfft-coverage_*.profraw -o ./coverage-report/rocfft.profdata
     COMMAND ${LLVM_COV} report -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata
     COMMAND ${LLVM_COV} show -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata -format=html -output-dir=coverage-report
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
-
-  add_custom_target(
-    export_coverage_report
     COMMAND ${LLVM_COV} export -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata --format=lcov > ./coverage-report/coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -458,7 +458,7 @@ if(BUILD_CODE_COVERAGE)
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/rocfft-coverage_*.profraw -o ./coverage-report/rocfft.profdata
     COMMAND ${LLVM_COV} report -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata
     COMMAND ${LLVM_COV} show -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata -format=html -output-dir=coverage-report
-    COMMAND ${LLVM_COV} export -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata --format=lcov > ./coverage-report/coverage.info
+    COMMAND ${LLVM_COV} export -object ./library/src/librocfft.so -instr-profile=./coverage-report/rocfft.profdata -format=lcov > ./coverage-report/coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 


### PR DESCRIPTION
## Motivation

We want to upload code coverage reports to codecov.io and the reports must be in lcov format before doing so.  This PR  introduces adds a command to the coverage target that that exports the profdata file to a coverage.info file, which can then be uploaded to codecov.io by CI.


## Test Plan

Testing with a custom CI branch

## Test Result

Code cov report gets uploaded to codecov.io.  Please see https://app.codecov.io/github/ROCm/rocm-libraries/commit/d9fe97a708ec9a377805e9b0455fd34b5189ac31 for the uploaded codecov report for rocFFT.  Please note that it will not show on the rocm-libraries main page, or [here](https://app.codecov.io/gh/ROCm/rocm-libraries/flags), until this is merged and runs on the develop branch.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
