### PR TITLE
[hipfft] add code to export llvm-cov format to lcov format

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -42,6 +42,9 @@ coverage:
       hipFFT:
         flags: [hipFFT]
         target: 80%
+      rocFFT:
+        flags: [rocFFT]
+        target: 80%
       Tensile:
         flags: [Tensile]
         target: 80%

--- a/codecov.yml
+++ b/codecov.yml
@@ -36,9 +36,6 @@ coverage:
       rocThrust:
         flags: [rocThrust]
         target: 80%
-      rocFFT:
-        flags: [rocFFT]
-        target: 80%
       hipFFT:
         flags: [hipFFT]
         target: 80%

--- a/codecov.yml
+++ b/codecov.yml
@@ -39,6 +39,9 @@ coverage:
       rocFFT:
         flags: [rocFFT]
         target: 80%
+      hipFFT:
+        flags: [hipFFT]
+        target: 80%
       Tensile:
         flags: [Tensile]
         target: 80%

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -312,4 +312,11 @@ if (BUILD_CODE_COVERAGE)
     COMMAND ${LLVM_COV} show -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
+
+  add_custom_target(
+    export_coverage_report
+    COMMAND ${LLVM_COV} export -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata --format=lcov > ./coverage-report/coverage.info
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
 endif()

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -310,7 +310,7 @@ if (BUILD_CODE_COVERAGE)
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
     COMMAND ${LLVM_COV} report -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
     COMMAND ${LLVM_COV} show -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
-    COMMAND ${LLVM_COV} export -object ./library/libhipfftw.so -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata --format=lcov > ./coverage-report/coverage.info
+    COMMAND ${LLVM_COV} export -object ./library/libhipfftw.so -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=lcov > ./coverage-report/coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -310,12 +310,7 @@ if (BUILD_CODE_COVERAGE)
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
     COMMAND ${LLVM_COV} report -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
     COMMAND ${LLVM_COV} show -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
-
-  add_custom_target(
-    export_coverage_report
-    COMMAND ${LLVM_COV} export -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata --format=lcov > ./coverage-report/coverage.info
+    COMMAND ${LLVM_COV} export -object ./library/libhipfftw.so -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata --format=lcov > ./coverage-report/coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 

--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -310,7 +310,7 @@ if (BUILD_CODE_COVERAGE)
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/hipfft-coverage_*.profraw -o ./coverage-report/hipfft.profdata
     COMMAND ${LLVM_COV} report -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata
     COMMAND ${LLVM_COV} show -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=html -output-dir=coverage-report
-    COMMAND ${LLVM_COV} export -object ./library/libhipfftw.so -object ./library/src/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=lcov > ./coverage-report/coverage.info
+    COMMAND ${LLVM_COV} export -object ./library/libhipfftw.so -object ./library/libhipfft.so -instr-profile=./coverage-report/hipfft.profdata -format=lcov > ./coverage-report/coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 


### PR DESCRIPTION
## Motivation

We want to upload code coverage reports to codecov.io and the reports must be in lcov format before doing so.  This PR  introduces an extra line in the `coverage` target that exports the profdata file to a coverage.info file, which can then be uploaded to codecov.io by CI.


## Test Plan

Testing with a custom CI branch

## Test Result

CI run: https://math-ci.amd.com/job/rocm-libraries/job/codecov/job/hipfft/view/change-requests/job/PR-1826/9/

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
