### PR TITLE
[TheRock CI] Honoring workflow dispatch arguments

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -96,13 +96,14 @@ def retrieve_projects(args):
     if args.get("is_push"):
         subtrees = list(subtree_to_project_map.keys())
 
-    # If .github/*/therock* were changed, run all subtrees
-    base_ref = args.get("base_ref")
-    modified_paths = get_modified_paths(base_ref)
-    print("modified_paths (max 200):", modified_paths[:200])
-    related_to_therock_ci = check_for_workflow_file_related_to_ci(modified_paths)
-    if related_to_therock_ci:
-        subtrees = list(subtree_to_project_map.keys())
+    # If .github/*/therock* were changed for a push or pull request, run all subtrees
+    if args.get("is_push") or args.get("is_pull_request"):
+        base_ref = args.get("base_ref")
+        modified_paths = get_modified_paths(base_ref)
+        print("modified_paths (max 200):", modified_paths[:200])
+        related_to_therock_ci = check_for_workflow_file_related_to_ci(modified_paths)
+        if related_to_therock_ci:
+            subtrees = list(subtree_to_project_map.keys())
 
     projects = set()
     # collect the associated subtree to project


### PR DESCRIPTION
Currently for pull_request, workflow_dispatch and is_push, it runs all projects if a `.github/workflows/therock-*` or `.github/scripts/therock-*` is changed.

However for workflow_dispatch, we don't want to run all tests (especially when adding a new test for CI) during testing as it takes up a lot of machine utilization.

Works here for workflow_dispatch run: https://github.com/ROCm/rocm-libraries/actions/runs/18020376566