### PR TITLE
[hipblaslt] Use find_program for llvm-strip

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -305,7 +305,15 @@ endif()
 
 if(HIPBLASLT_ENABLE_HOST)
     # work around code object stripping failure if using /usr/bin/strip
-    set(CPACK_RPM_SPEC_MORE_DEFINE "%define __strip /opt/rocm/llvm/bin/llvm-strip") # need to generalize this
+    find_program(LLVM_STRIP 
+        NAMES llvm-strip
+        PATH_SUFFIXES lib/llvm/bin llvm/bin bin
+    )
+    if(LLVM_STRIP)
+        set(CPACK_RPM_SPEC_MORE_DEFINE "%define __strip ${LLVM_STRIP}")
+    else()
+        message(WARNING "llvm-strip not found, using default strip tool. This may cause stripping to fail during packaging.")
+    endif()
     get_target_property(hipblaslt_public_headers roc::hipblaslt INTERFACE_SOURCES)
 
     install(

--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -194,6 +194,11 @@ if(HIPBLASLT_ENABLE_ROCROLLER AND NOT ROCM_LIBS_SUPERBUILD)
             set(BUILD_CLIENTS OFF)
             set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--exclude-libs,ALL")
             set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+            # Ensure rocroller uses the same compiler as the parent project
+            # NOTE: This is only required for the pinned commit and isn't present
+            # in the latest rocroller, therefor this should be removed once we bump
+            # the rocroller commit
+            set(ROCROLLER_ASSEMBLER_PATH ${CMAKE_CXX_COMPILER})
             include(FetchContent)
             FetchContent_Declare(
                 rocRoller
@@ -314,6 +319,7 @@ if(HIPBLASLT_ENABLE_HOST)
     else()
         message(WARNING "llvm-strip not found, using default strip tool. This may cause stripping to fail during packaging.")
     endif()
+
     get_target_property(hipblaslt_public_headers roc::hipblaslt INTERFACE_SOURCES)
 
     install(


### PR DESCRIPTION
## Motivation

llvm-strip is hard-coded to `/opt/rocm` but should be findable pending CMAKE_PREFIX_PATH is set to a working ROCm installation.

## Technical Details

Use `find_program` instead of relying on the existence of the file in `/opt/rocm`

## Test Plan

CI tests and local evaluation.

## Test Result

In progress...

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
