### PR TITLE
[hipBLASlt] Add initialization with random numbers uniformly in [0, 1]

### DIFF
--- a/projects/hipblaslt/clients/bench/README.md
+++ b/projects/hipblaslt/clients/bench/README.md
@@ -35,7 +35,7 @@ cd hipBLASLt; cd build/release
 --compute_input_typeA <value>     Options: f32_r, f16_r, bf16_r, f8_r, bf8_r, f8_fnuz_r, bf8_fnuz_r, The default value indicates that the argument has no effect. (Default value is: INVALID)
 --compute_input_typeB <value>     Options: f32_r, f16_r, bf16_r, f8_r, bf8_r, f8_fnuz_r, bf8_fnuz_r, The default value indicates that the argument has no effect. (Default value is: INVALID)
 --scale_type <value>       Precision of scalar. Options: f16_r,bf16_r
---initialization <value>   Initialize matrix data.Options: rand_int, trig_float, hpl(floating), special, zero  (Default value is: hpl)
+--initialization <value>   Initialize matrix data.Options: rand_int, trig_float, hpl(floating), special, zero, norm_dist, uniform_01  (Default value is: hpl)
 --transA <value>           N = no transpose, T = transpose                                                     (Default value is: N)
 --transB <value>           N = no transpose, T = transpose                                                     (Default value is: N)
 --batch_count <value>      Number of matrices. Only applicable to batched and strided_batched routines         (Default value is: 1)

--- a/projects/hipblaslt/clients/bench/src/client.cpp
+++ b/projects/hipblaslt/clients/bench/src/client.cpp
@@ -431,7 +431,7 @@ try
         ("initialization",
          value<std::string>(&initialization)->default_value("hpl"),
          "Initialize matrix data."
-         "Options: rand_int, trig_float, hpl(floating), special, zero, norm_dist")
+         "Options: rand_int, trig_float, hpl(floating), special, zero, norm_dist, uniform_01")
 
         ("transA",
          value<char>(&arg.transA)->default_value('N'),

--- a/projects/hipblaslt/clients/common/include/hipblaslt_datatype2string.hpp
+++ b/projects/hipblaslt/clients/common/include/hipblaslt_datatype2string.hpp
@@ -39,6 +39,7 @@ enum class hipblaslt_initialization
     special    = 444,
     zero       = 555,
     norm_dist  = 666,
+    uniform_01 = 777,
 };
 
 typedef enum class _hipblaslt_activation_type
@@ -126,6 +127,8 @@ constexpr auto hipblaslt_initialization2string(hipblaslt_initialization init)
         return "zero";
     case hipblaslt_initialization::norm_dist:
         return "norm_dist";
+    case hipblaslt_initialization::uniform_01:
+        return "uniform_01";
     }
     return "invalid";
 }
@@ -146,6 +149,7 @@ inline hipblaslt_initialization string2hipblaslt_initialization(const std::strin
         value == "special"    ? hipblaslt_initialization::special    :
         value == "zero"       ? hipblaslt_initialization::zero       :
         value == "norm_dist"  ? hipblaslt_initialization::norm_dist  :
+        value == "uniform_01" ? hipblaslt_initialization::uniform_01 :
         static_cast<hipblaslt_initialization>(0);
 }
 // clang-format on

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -1871,10 +1871,11 @@ void testing_matmul_with_bias(const Arguments& arg,
         if(arg.scaleA == hipblaslt_scaling_format::Block)
         {
             if(arg.initialization != hipblaslt_initialization::hpl
-               && arg.initialization != hipblaslt_initialization::trig_float)
+               && arg.initialization != hipblaslt_initialization::trig_float
+               && arg.initialization != hipblaslt_initialization::uniform_01)
             {
                 hipblaslt_cout
-                    << "Initialization of microscaling data only allows hpl and trig_float not "
+                    << "Initialization of microscaling data only allows hpl, trig_float or uniform_01, not "
                     << hipblaslt_initialization2string(arg.initialization) << std::endl;
                 return;
             }
@@ -1922,10 +1923,11 @@ void testing_matmul_with_bias(const Arguments& arg,
         if(arg.scaleB == hipblaslt_scaling_format::Block)
         {
             if(arg.initialization != hipblaslt_initialization::hpl
-               && arg.initialization != hipblaslt_initialization::trig_float)
+               && arg.initialization != hipblaslt_initialization::trig_float
+               && arg.initialization != hipblaslt_initialization::uniform_01)
             {
                 hipblaslt_cout
-                    << "Initialization of microscaling data only allows hpl and trig_float not "
+                    << "Initialization of microscaling data only allows hpl, trig_float or uniform_01, not "
                     << hipblaslt_initialization2string(arg.initialization) << std::endl;
                 return;
             }

--- a/projects/hipblaslt/clients/common/src/hipblaslt_init_device.cpp
+++ b/projects/hipblaslt/clients/common/src/hipblaslt_init_device.cpp
@@ -60,13 +60,10 @@ __device__ uint32_t pseudo_random_device(size_t idx)
     auto s = idx * 1664525 + 1013904223;
     // Run a few extra iterations to make the generators diverge
     // in case the seeds are still poor (consecutive ints)
-    for(int i = 0; i < 3; i++)
-    {
-        // Marsaglia, G. (2003). "Xorshift RNGs". Journal of Statistical Software. 8 (14). doi:10.18637/jss.v008.i14
-        s ^= s << 13;
-        s ^= s >> 17;
-        s ^= s << 5;
-    }
+    // Marsaglia, G. (2003). "Xorshift RNGs". Journal of Statistical Software. 8 (14). doi:10.18637/jss.v008.i14
+    s ^= (s << 13) ^ ( s >> 17) ^ (s << 5);
+    s ^= (s << 13) ^ ( s >> 17) ^ (s << 5);
+    s ^= (s << 13) ^ ( s >> 17) ^ (s << 5);
     return s;
 }
 
@@ -114,6 +111,24 @@ __device__ int8_t random_hpl(size_t idx)
     auto v = nearbyint(double(r) / double(std::numeric_limits<decltype(r)>::max()) * 2. - 1.);
     return int8_t(v > 127.f ? 127.f : v < -128.f ? -128.f : v);
 }
+
+/*! \brief  generate a random number in [0.,1.0]  */
+template <typename T>
+__device__ T uniform_01(size_t idx)
+{
+    auto r = pseudo_random_device(idx);
+    return T(double(r) / double(std::numeric_limits<decltype(r)>::max()));
+}
+
+/*! \brief  generate a random number in [0.,1.0]  */
+template <>
+__device__ int8_t uniform_01(size_t idx)
+{
+    auto r = pseudo_random_device(idx);
+    auto v = nearbyint(double(r) / double(std::numeric_limits<decltype(r)>::max()));
+    return int8_t(v > 127.f ? 127.f : v < -128.f ? -128.f : v);
+}
+
 
 template <typename T>
 void hipblaslt_init_device(ABC_dims                 abc,
@@ -239,6 +254,11 @@ void hipblaslt_init_device(ABC_dims                 abc,
                 });
                 break;
             }
+        case hipblaslt_initialization::uniform_01:
+            fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
+                return uniform_01<T>(idx);
+            });
+            break;
         default:
             hipblaslt_cerr << "Error type in hipblaslt_init_device" << std::endl;
             break;

--- a/projects/hipblaslt/clients/common/src/mxDataGen.cpp
+++ b/projects/hipblaslt/clients/common/src/mxDataGen.cpp
@@ -302,10 +302,10 @@ std::vector<float> generateMXInput(hipDataType            dataType,
     using namespace DGen;
 
     DataGeneratorOptions opt;
-    opt.min          = min_val;
-    opt.max          = max_val;
+    opt.min          = initMethod == "uniform_01" ? 0. : (initMethod == "hpl" ? -.5 : min_val);
+    opt.max          = initMethod == "uniform_01" ? 1. : (initMethod == "hpl" ?  .5 : max_val);
     opt.blockScaling = scaleBlockRowSize * scaleBlockColSize;
-    opt.pattern      = initMethod == "Bounded" ? Bounded : Trigonometric;
+    opt.pattern      = initMethod == "trig_float" ? Trigonometric : Bounded;
 
     const uint32_t seed = 1713573849;
 

--- a/projects/hipblaslt/clients/common/src/mxDataGen.cpp
+++ b/projects/hipblaslt/clients/common/src/mxDataGen.cpp
@@ -305,7 +305,8 @@ std::vector<float> generateMXInput(hipDataType            dataType,
     opt.min          = initMethod == "uniform_01" ? 0. : (initMethod == "hpl" ? -.5 : min_val);
     opt.max          = initMethod == "uniform_01" ? 1. : (initMethod == "hpl" ?  .5 : max_val);
     opt.blockScaling = scaleBlockRowSize * scaleBlockColSize;
-    opt.pattern      = initMethod == "trig_float" ? Trigonometric : Bounded;
+    // TODO initMethod == "hpl" should also be Bounded, but fails some tests
+    opt.pattern      = (initMethod == "Bounded" || initMethod == "uniform_01") ? Bounded : Trigonometric;
 
     const uint32_t seed = 1713573849;
 

--- a/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
+++ b/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
@@ -42,6 +42,8 @@ Datatypes:
         hpl: 333
         special: 444
         zero: 555
+        norm_dist: 666
+        uniform_01: 777
   - hipblaslt_activation_type:
       bases: [ c_int ]
       attr:

--- a/projects/hipblaslt/docs/conceptual/hipblaslt-clients.rst
+++ b/projects/hipblaslt/docs/conceptual/hipblaslt-clients.rst
@@ -87,7 +87,7 @@ For more information, run the command with the ``--help`` option. The output of 
    --compute_input_typeA <value>      Precision of computation input A. Options: f32_r, f16_r, bf16_r, f8_r, bf8_r, f8_fnuz_r, bf8_fnuz_r, The default value indicates that the compute_input_typeA has no effect.
    --compute_input_typeB <value>      Precision of computation input B. Options: f32_r, f16_r, bf16_r, f8_r, bf8_r, f8_fnuz_r, bf8_fnuz_r, The default value indicates that the compute_input_typeA has no effect.
    --scale_type <value>               Precision of scalar. Options: f16_r,bf16_r
-   --initialization <value>           Initialize matrix data.Options: rand_int, trig_float, hpl(floating), special, zero  (Default value is: hpl)
+   --initialization <value>           Initialize matrix data.Options: rand_int, trig_float, hpl(floating), special, zero, norm_dist, uniform_01  (Default value is: hpl)
    --transA <value>                   N = no transpose, T = transpose                                                     (Default value is: N)
    --transB <value>                   N = no transpose, T = transpose                                                     (Default value is: N)
    --swizzleA                         Enable tensor swizzling for A


### PR DESCRIPTION
## Motivation

Add matrix initialization with random numbers uniformly distributed on [0, 1].
See [SWDEV-556978](https://ontrack-internal.amd.com/browse/SWDEV-556978)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Also unroll loop in pseudo random number generator for better performance.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
