### PR TITLE
Users/cenxuan/thrust test scan by key inclusive cu occasionally fails

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -32,6 +32,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Fixed `device_select`, `device_merge`, and `device_merge_sort` not allocating the correct amount of virtual shared memory on the host.
 * Fixed the `->` operator for the `transform_iterator`, the `texture_cache_iterator` and the `arg_index_iterator`, by now returning a proxy pointer.
   * The `arg_index_iterator` also now only returns the internal iterator for the `->`.
+* Fixed the issue where `rocprim::device_scan_by_key` failed when performing an "in-place" inclusive scan by reusing "keys" as output, by adding a buffer to store the last keys of each block (excluding the last block). This fix only affects the specific case of reusing "keys" as output in an inclusive scan, and does not affect other cases.
 
 ## rocPRIM 4.0.1 for ROCm 7.0.2
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -105,7 +105,7 @@ struct load_values_flagged
 
         const auto flag_segment_boundaries = [&]()
         {
-            if(Exclusive)
+            if constexpr(Exclusive)
             {
                 const key_type tile_successor
                     = global_block_id < number_of_blocks - 1

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -76,17 +76,20 @@ struct load_values_flagged
     //   restart the scan from that value
     template<typename KeyIterator, typename ValueIterator, typename CompareFunction>
     ROCPRIM_DEVICE
-    void load(KeyIterator        keys_input,
-              ValueIterator      values_input,
-              CompareFunction    compare,
-              const result_type  initial_value,
-              const unsigned int flat_block_id,
-              const size_t       starting_block,
-              const size_t       number_of_blocks,
-              const unsigned int flat_thread_id,
-              const size_t       size,
-              rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
-              storage_type& storage)
+    void load(
+        KeyIterator        keys_input,
+        ValueIterator      values_input,
+        CompareFunction    compare,
+        const result_type  initial_value,
+        const unsigned int flat_block_id,
+        const size_t       starting_block,
+        const size_t       number_of_blocks,
+        const unsigned int flat_thread_id,
+        const size_t       size,
+        bool               use_last_keys,
+        const typename std::iterator_traits<KeyIterator>::value_type* const __restrict__ last_keys,
+        rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
+        storage_type& storage)
     {
         constexpr static unsigned int items_per_block = items_per_thread * block_size;
         const unsigned int            block_offset    = flat_block_id * items_per_block;
@@ -98,13 +101,14 @@ struct load_values_flagged
         bool        flags[items_per_thread];
 
         auto not_equal = [compare](const auto& a, const auto& b) mutable { return !compare(a, b); };
+        const auto global_block_id = starting_block + flat_block_id;
 
         const auto flag_segment_boundaries = [&]()
         {
             if(Exclusive)
             {
                 const key_type tile_successor
-                    = starting_block + flat_block_id < number_of_blocks - 1
+                    = global_block_id < number_of_blocks - 1
                           ? static_cast<key_type>(block_keys[items_per_block])
                           : static_cast<key_type>(*block_keys);
                 block_discontinuity{}.flag_tails(flags,
@@ -114,10 +118,12 @@ struct load_values_flagged
                                                  storage.keys.flag);
             }
             else
-            {
-                const key_type tile_predecessor = starting_block + flat_block_id > 0
-                                                      ? static_cast<key_type>(block_keys[-1])
-                                                      : static_cast<key_type>(*block_keys);
+            { // Inclusive
+                const key_type tile_predecessor
+                    = global_block_id > 0
+                          ? (use_last_keys ? static_cast<key_type>(last_keys[global_block_id - 1])
+                                           : static_cast<key_type>(block_keys[-1]))
+                          : static_cast<key_type>(*block_keys);
                 block_discontinuity{}.flag_heads(flags,
                                                  tile_predecessor,
                                                  keys,
@@ -126,7 +132,7 @@ struct load_values_flagged
             }
         };
 
-        if(starting_block + flat_block_id < number_of_blocks - 1)
+        if(global_block_id < number_of_blocks - 1)
         {
             block_load_keys{}.load(block_keys, keys, storage.keys.load);
 
@@ -267,7 +273,9 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                                        const size_t,
                                        const size_t,
                                        const size_t,
-                                       const rocprim::tuple<ResultType, bool>* const)
+                                       const rocprim::tuple<ResultType, bool>* const,
+                                       bool,
+                                       const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__)
             -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
     {
         // No need to build the kernel with sleep on a device that does not require it
@@ -294,7 +302,9 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
         const size_t                                  size,
         const size_t                                  starting_block,
         const size_t                                  number_of_blocks,
-        const rocprim::tuple<ResultType, bool>* const previous_last_value)
+        const rocprim::tuple<ResultType, bool>* const previous_last_value,
+        bool use_last_keys,
+        const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__ last_keys)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
     {
         using result_type = ResultType;
@@ -347,6 +357,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                             number_of_blocks,
                             flat_thread_id,
                             size,
+                            use_last_keys,
+                            last_keys,
                             wrapped_values,
                             storage.load);
 
@@ -362,7 +374,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
             // multi grid launch
             if(previous_last_value != nullptr)
             {
-                if(Exclusive)
+                if constexpr(Exclusive)
                 {
                     rocprim::get<0>(wrapped_initial_value) = rocprim::get<0>(*previous_last_value);
                 }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_common.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_common.hpp
@@ -82,14 +82,12 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void init_lookback_scan_state(LookBackScanState  l
 }
 
 template<typename LookBackScanState>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
-    init_lookback_scan_state_kernel(LookBackScanState              lookback_scan_state,
-                                    const unsigned int             number_of_blocks,
-                                    ordered_block_id<unsigned int> ordered_bid,
-                                    unsigned int                   save_index = 0,
-                                    typename LookBackScanState::value_type* const save_dest
-                                    = nullptr)
+ROCPRIM_FORCE_INLINE ROCPRIM_DEVICE 
+void init_lookback_scan_state_kernel_impl(LookBackScanState              lookback_scan_state,
+                                          const unsigned int             number_of_blocks,
+                                          ordered_block_id<unsigned int> ordered_bid, // ordered block id is passed by value, so no need to call its constructor
+                                          unsigned int                   save_index,
+                                          typename LookBackScanState::value_type* const save_dest)
 {
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();
@@ -111,13 +109,11 @@ ROCPRIM_KERNEL
 }
 
 template<typename LookBackScanState>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
-    init_lookback_scan_state_kernel(LookBackScanState  lookback_scan_state,
+ROCPRIM_FORCE_INLINE ROCPRIM_DEVICE 
+void init_lookback_scan_state_kernel_impl(LookBackScanState  lookback_scan_state,
                                     const unsigned int number_of_blocks,
-                                    unsigned int       save_index = 0,
-                                    typename LookBackScanState::value_type* const save_dest
-                                    = nullptr)
+                                    unsigned int       save_index,
+                                    typename LookBackScanState::value_type* const save_dest)
 {
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();
@@ -136,6 +132,38 @@ ROCPRIM_KERNEL
     }
 
     init_lookback_scan_state(lookback_scan_state, number_of_blocks, flat_thread_id);
+}
+
+template<typename LookBackScanState>
+ROCPRIM_KERNEL
+    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
+    init_lookback_scan_state_kernel(LookBackScanState              lookback_scan_state,
+                                    const unsigned int             number_of_blocks,
+                                    ordered_block_id<unsigned int> ordered_bid,
+                                    unsigned int                   save_index = 0,
+                                    typename LookBackScanState::value_type* const save_dest
+                                    = nullptr)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         ordered_bid,
+                                         save_index,
+                                         save_dest);
+}
+
+template<typename LookBackScanState>
+ROCPRIM_KERNEL
+    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
+    init_lookback_scan_state_kernel(LookBackScanState  lookback_scan_state,
+                                    const unsigned int number_of_blocks,
+                                    unsigned int       save_index = 0,
+                                    typename LookBackScanState::value_type* const save_dest
+                                    = nullptr)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         save_index,
+                                         save_dest);
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -34,7 +34,6 @@
 #include "detail/device_scan_by_key.hpp"
 #include "detail/lookback_scan_state.hpp"
 #include "device_scan_by_key_config.hpp"
-#include "device_transform.hpp"
 
 #include <hip/hip_runtime.h>
 
@@ -203,6 +202,7 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                                    const bool            debug_synchronous)
 {
     using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;
+
     using config = wrapped_scan_by_key_config<Config, key_type, AccType>;
 
     detail::target_arch target_arch;
@@ -229,6 +229,7 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
     const unsigned int limited_size
         = static_cast<unsigned int>(std::min<size_t>(size, aligned_size_limit));
     const bool use_limited_size = limited_size == aligned_size_limit;
+
     // Number of blocks in a single launch (or the only launch if it fits)
     const unsigned int number_of_blocks = ceiling_div(limited_size, items_per_block);
 
@@ -344,25 +345,7 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
         with_scan_state(
             [&](const auto scan_state)
             {
-                // only when in-place scan is needed, we initialize the last_keys_of_each_block
-                if(last_keys_of_each_block_size_byte != 0 && i == 0)
-                {
-                    hipLaunchKernelGGL(init_device_scan_by_key_kernel,
-                                       dim3(init_grid_size),
-                                       dim3(block_size),
-                                       0,
-                                       stream,
-                                       scan_state,
-                                       scan_blocks,
-                                       number_of_blocks - 1,
-                                       i > 0 ? previous_last_value : nullptr,
-                                       keys,
-                                       last_keys_of_each_block,
-                                       last_keys_of_each_block_size_byte
-                                           / sizeof(decltype(*last_keys_of_each_block)),
-                                       items_per_block);
-                }
-                else
+                if constexpr(Exclusive)
                 {
                     hipLaunchKernelGGL(init_device_scan_by_key_kernel,
                                        dim3(init_grid_size),
@@ -373,6 +356,39 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                                        scan_blocks,
                                        number_of_blocks - 1,
                                        i > 0 ? previous_last_value : nullptr);
+                }
+                else
+                {
+                    // only when in-place scan is needed, we initialize the last_keys_of_each_block
+                    if(last_keys_of_each_block_size_byte != 0 && i == 0)
+                    {
+                        hipLaunchKernelGGL(init_device_scan_by_key_kernel,
+                                           dim3(init_grid_size),
+                                           dim3(block_size),
+                                           0,
+                                           stream,
+                                           scan_state,
+                                           scan_blocks,
+                                           number_of_blocks - 1,
+                                           i > 0 ? previous_last_value : nullptr,
+                                           keys,
+                                           last_keys_of_each_block,
+                                           last_keys_of_each_block_size_byte
+                                               / sizeof(decltype(*last_keys_of_each_block)),
+                                           items_per_block);
+                    }
+                    else
+                    {
+                        hipLaunchKernelGGL(init_device_scan_by_key_kernel,
+                                           dim3(init_grid_size),
+                                           dim3(block_size),
+                                           0,
+                                           stream,
+                                           scan_state,
+                                           scan_blocks,
+                                           number_of_blocks - 1,
+                                           i > 0 ? previous_last_value : nullptr);
+                    }
                 }
             });
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_device_scan_by_key_kernel",

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -34,6 +34,7 @@
 #include "detail/device_scan_by_key.hpp"
 #include "detail/lookback_scan_state.hpp"
 #include "device_scan_by_key_config.hpp"
+#include "device_transform.hpp"
 
 #include <hip/hip_runtime.h>
 
@@ -118,6 +119,7 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                                    const bool            debug_synchronous)
 {
     using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;
+    using value_type = typename std::iterator_traits<InputIterator>::value_type;
 
     using config = wrapped_scan_by_key_config<Config, key_type, AccType>;
 
@@ -151,6 +153,8 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
 
     void*         scan_state_storage;
     wrapped_type* previous_last_value;
+    value_type*   temp_output;
+    size_t        temp_output_size_byte = 0;
 
     detail::temp_storage::layout layout{};
     const hipError_t             layout_result
@@ -160,14 +164,37 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
         return layout_result;
     }
 
+    // Detect if the buffer of `keys` is reused as `output`
+    if constexpr(std::is_same<KeysInputIterator, OutputIterator>::value)
+    {
+        if(static_cast<typename std::remove_const<decltype(size)>::type>(
+               std::distance(keys, output))
+           < size)
+        {
+            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
+            temp_output_size_byte = sizeof(value_type) * size;
+        }
+    }
+    else if constexpr(std::is_pointer<KeysInputIterator>::value
+                      && std::is_pointer<OutputIterator>::value)
+    {
+        if(static_cast<typename std::remove_const<decltype(size)>::type>(
+               std::distance(keys, reinterpret_cast<KeysInputIterator>(output)))
+           < size)
+        {
+            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
+            temp_output_size_byte = sizeof(value_type) * size;
+        }
+    }
+
     const hipError_t partition_result = detail::temp_storage::partition(
         temporary_storage,
         storage_size,
         detail::temp_storage::make_linear_partition(
             // This is valid even with offset_scan_state_with_sleep_type
             detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&previous_last_value,
-                                                    use_limited_size ? 1 : 0)));
+            detail::temp_storage::ptr_aligned_array(&previous_last_value, use_limited_size ? 1 : 0),
+            detail::temp_storage::ptr_aligned_array(&temp_output, temp_output_size_byte)));
     if(partition_result != hipSuccess || temporary_storage == nullptr)
     {
         return partition_result;
@@ -228,72 +255,98 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
         std::cout << "----------------------------------\n";
     }
 
-    for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
+    auto launch_scan_by_key = [&](auto phantom_output)
     {
-        // limited_size is of type unsigned int, so current_size also fits in an unsigned int
-        // size_t is necessary as type of std::min because 'size - offset' can exceed the
-        // upper limit of unsigned int and converting it can lead to wrong results
-        const unsigned int current_size
-            = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
-        const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
-        const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
-
-        // Start point for time measurements
-        std::chrono::steady_clock::time_point start;
-        if(debug_synchronous)
+        for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
         {
-            std::cout << "index:            " << i << '\n';
-            std::cout << "current_size:     " << current_size << '\n';
-            std::cout << "number of blocks: " << scan_blocks << '\n';
+            // limited_size is of type unsigned int, so current_size also fits in an unsigned int
+            // size_t is necessary as type of std::min because 'size - offset' can exceed the
+            // upper limit of unsigned int and converting it can lead to wrong results
+            const unsigned int current_size
+                = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
+            const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
+            const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
 
-            start = std::chrono::steady_clock::now();
-        }
-
-        with_scan_state(
-            [&](const auto scan_state)
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+            if(debug_synchronous)
             {
-                hipLaunchKernelGGL(init_lookback_scan_state_kernel,
-                                   dim3(init_grid_size),
-                                   dim3(block_size),
-                                   0,
-                                   stream,
-                                   scan_state,
-                                   scan_blocks,
-                                   number_of_blocks - 1,
-                                   i > 0 ? previous_last_value : nullptr);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                    scan_blocks,
-                                                    start);
+                std::cout << "index:            " << i << '\n';
+                std::cout << "current_size:     " << current_size << '\n';
+                std::cout << "number of blocks: " << scan_blocks << '\n';
 
-        if(debug_synchronous)
-        {
-            start = std::chrono::steady_clock::now();
-        }
-        ROCPRIM_RETURN_ON_ERROR(with_scan_state(
-            [&](auto& scan_state)
+                start = std::chrono::steady_clock::now();
+            }
+
+            with_scan_state(
+                [&](const auto scan_state)
+                {
+                    hipLaunchKernelGGL(init_lookback_scan_state_kernel,
+                                       dim3(init_grid_size),
+                                       dim3(block_size),
+                                       0,
+                                       stream,
+                                       scan_state,
+                                       scan_blocks,
+                                       number_of_blocks - 1,
+                                       i > 0 ? previous_last_value : nullptr);
+                });
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
+                                                        scan_blocks,
+                                                        start);
+
+            if(debug_synchronous)
             {
-                return launch_device_scan_by_key<config, Determinism, Exclusive>(
-                    target_arch,
-                    keys + offset,
-                    input + offset,
-                    output + offset,
-                    initial_value,
-                    compare,
-                    scan_op,
-                    scan_state,
-                    size,
-                    i * number_of_blocks,
-                    total_number_of_blocks,
-                    i > 0 ? as_const_ptr(previous_last_value) : nullptr,
-                    dim3(scan_blocks),
-                    dim3(block_size),
-                    0,
-                    stream);
-            }));
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
-                                                    current_size,
-                                                    start);
+                start = std::chrono::steady_clock::now();
+            }
+            ROCPRIM_RETURN_ON_ERROR(with_scan_state(
+                [&](auto& scan_state)
+                {
+                    return launch_device_scan_by_key<config, Determinism, Exclusive>(
+                        target_arch,
+                        keys + offset,
+                        input + offset,
+                        phantom_output + offset,
+                        initial_value,
+                        compare,
+                        scan_op,
+                        scan_state,
+                        size,
+                        i * number_of_blocks,
+                        total_number_of_blocks,
+                        i > 0 ? as_const_ptr(previous_last_value) : nullptr,
+                        dim3(scan_blocks),
+                        dim3(block_size),
+                        0,
+                        stream);
+                }));
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
+                                                        current_size,
+                                                        start);
+        }
+    };
+
+    if(temp_output_size_byte > 0)
+    {
+        launch_scan_by_key(temp_output);
+        // Store data -- "in-place" scan_by_key will use more global memory and here is an extra step of
+        // storing data back into the output. So it is slower than not reusing the input.
+        ROCPRIM_RETURN_ON_ERROR(
+            ::rocprim::transform(temp_output,
+                                 output,
+                                 size,
+                                 // The temp_output holds value_type data, the ideal situation
+                                 // is that the compiler will throw an error if it's not possible
+                                 // to assign output[i] with a value_type item, which means that
+                                 // value_type is not convertible to key_type, in this case, the
+                                 // "in-place" scan_by_key shouldn't be allowed.
+                                 ::rocprim::identity<value_type>(),
+                                 stream,
+                                 debug_synchronous));
+    }
+    else
+    {
+        launch_scan_by_key(output);
     }
     return hipSuccess;
 }
@@ -321,6 +374,11 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
 /// if \p temporary_storage in a null pointer.
 /// * Ranges specified by \p keys_input, \p values_input, and \p values_output must have
 /// at least \p size elements.
+///
+/// \note In-place scan_by_key
+/// In-place scan_by_key is supported by using the same buffer for `values_input` and `values_output`.
+/// Reusing `keys_input` as `values_output` is supported only when the sizeof(key_type) is larger than
+/// the sizeof(value_type).
 ///
 /// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `scan_by_key_config`.
 /// \tparam KeysInputIterator random-access iterator type of the input range. It can be
@@ -513,6 +571,11 @@ inline hipError_t deterministic_inclusive_scan_by_key(void* const               
 /// if \p temporary_storage in a null pointer.
 /// * Ranges specified by \p keys_input, \p values_input, and \p values_output must have
 /// at least \p size elements.
+///
+/// \note In-place scan_by_key
+/// In-place scan_by_key is supported by using the same buffer for `values_input` and `values_output`.
+/// Reusing `keys_input` as `values_output` is supported only when the sizeof(key_type) is larger than
+/// the sizeof(value_type).
 ///
 /// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `scan_by_key_config`.
 /// \tparam KeysInputIterator random-access iterator type of the input range. It can be

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -47,6 +47,50 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
+template<typename LookBackScanState>
+ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
+    init_device_scan_by_key_kernel(LookBackScanState  lookback_scan_state,
+                                   const unsigned int number_of_blocks,
+                                   unsigned int       save_index,
+                                   typename LookBackScanState::value_type* const save_dest)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         save_index,
+                                         save_dest);
+}
+
+template<typename LookBackScanState, class KeysInputIterator, class ItemPerBlockType>
+ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void init_device_scan_by_key_kernel(
+    LookBackScanState                             lookback_scan_state,
+    const unsigned int                            number_of_blocks,
+    unsigned int                                  save_index,
+    typename LookBackScanState::value_type* const save_dest,
+    KeysInputIterator                             keys, // keys from the 0 without any offsets
+    typename std::iterator_traits<
+        KeysInputIterator>::value_type* __restrict__ last_keys_of_each_block,
+    size_t                 num_last_keys_of_each_block,
+    const ItemPerBlockType items_per_block)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         save_index,
+                                         save_dest);
+
+    // Initialize the last_keys_of_each_block
+    const auto block_size = ::rocprim::detail::block_size<0>();
+    const auto global_tid
+        = (::rocprim::detail::block_id<0>() * block_size) + ::rocprim::detail::block_thread_id<0>();
+    const auto total_threads = ::rocprim::detail::grid_size<0>() * block_size;
+    using common_size_t      = typename std::common_type<decltype(num_last_keys_of_each_block),
+                                                    decltype(total_threads)>::type;
+    for(common_size_t i = global_tid; i < static_cast<common_size_t>(num_last_keys_of_each_block);
+        i += static_cast<common_size_t>(total_threads))
+    {
+        last_keys_of_each_block[i] = keys[(i * items_per_block) + (items_per_block - 1)];
+    }
+}
+
 template<typename Config,
          lookback_scan_determinism Determinism,
          bool                      Exclusive,
@@ -58,23 +102,25 @@ template<typename Config,
          typename BinaryFunction,
          typename LookbackScanState,
          typename AccType>
-inline hipError_t
-    launch_device_scan_by_key(detail::target_arch                          arch,
-                              const KeyInputIterator                       keys,
-                              const InputIterator                          values,
-                              const OutputIterator                         output,
-                              const InitialValueType                       initial_value,
-                              const CompareFunction                        compare,
-                              const BinaryFunction                         scan_op,
-                              const LookbackScanState                      scan_state,
-                              const size_t                                 size,
-                              const size_t                                 starting_block,
-                              const size_t                                 number_of_blocks,
-                              const ::rocprim::tuple<AccType, bool>* const previous_last_value,
-                              dim3                                         grid,
-                              dim3                                         block,
-                              size_t                                       shmem,
-                              hipStream_t                                  stream)
+inline hipError_t launch_device_scan_by_key(
+    detail::target_arch                          arch,
+    const KeyInputIterator                       keys,
+    const InputIterator                          values,
+    const OutputIterator                         output,
+    const InitialValueType                       initial_value,
+    const CompareFunction                        compare,
+    const BinaryFunction                         scan_op,
+    const LookbackScanState                      scan_state,
+    const size_t                                 size,
+    const size_t                                 starting_block,
+    const size_t                                 number_of_blocks,
+    const ::rocprim::tuple<AccType, bool>* const previous_last_value,
+    bool                                         use_last_keys,
+    const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__ last_keys,
+    dim3        grid,
+    dim3        block,
+    size_t      shmem,
+    hipStream_t stream)
 {
 
     auto kernel = [=](auto arch_config)
@@ -90,10 +136,48 @@ inline hipError_t
             size,
             starting_block,
             number_of_blocks,
-            previous_last_value);
+            previous_last_value,
+            use_last_keys,
+            last_keys);
     };
 
     return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
+}
+
+/// \return 0 if in-place is not detected
+template<bool Exclusive,
+         typename KeysInputIterator,
+         typename OutputIterator,
+         typename SizeType,
+         typename NumBlockType>
+ROCPRIM_FORCE_INLINE ROCPRIM_HOST size_t detect_reusing_keys(
+    KeysInputIterator keys,
+    OutputIterator output,
+    SizeType size,
+    NumBlockType number_of_blocks)
+{
+    using key_type    = typename std::iterator_traits<KeysInputIterator>::value_type;
+    using output_type = typename std::iterator_traits<OutputIterator>::value_type;
+    if constexpr(std::is_same<KeysInputIterator, OutputIterator>::value)
+    {
+        if(static_cast<SizeType>(std::distance(keys, output)) < size)
+        {
+            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
+            return sizeof(key_type) * (number_of_blocks - 1);
+        }
+    }
+    else if constexpr(std::is_pointer<KeysInputIterator>::value
+                      && std::is_pointer<OutputIterator>::value
+                      && std::is_convertible<key_type, output_type>::value)
+    {
+        if(static_cast<SizeType>(std::distance(keys, reinterpret_cast<KeysInputIterator>(output)))
+           < size)
+        {
+            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
+            return sizeof(key_type) * (number_of_blocks - 1);
+        }
+    }
+    return 0;
 }
 
 template<lookback_scan_determinism Determinism,
@@ -119,8 +203,6 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                                    const bool            debug_synchronous)
 {
     using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;
-    using value_type = typename std::iterator_traits<InputIterator>::value_type;
-
     using config = wrapped_scan_by_key_config<Config, key_type, AccType>;
 
     detail::target_arch target_arch;
@@ -147,14 +229,11 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
     const unsigned int limited_size
         = static_cast<unsigned int>(std::min<size_t>(size, aligned_size_limit));
     const bool use_limited_size = limited_size == aligned_size_limit;
-
     // Number of blocks in a single launch (or the only launch if it fits)
     const unsigned int number_of_blocks = ceiling_div(limited_size, items_per_block);
 
     void*         scan_state_storage;
     wrapped_type* previous_last_value;
-    value_type*   temp_output;
-    size_t        temp_output_size_byte = 0;
 
     detail::temp_storage::layout layout{};
     const hipError_t             layout_result
@@ -164,28 +243,13 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
         return layout_result;
     }
 
-    // Detect if the buffer of `keys` is reused as `output`
-    if constexpr(std::is_same<KeysInputIterator, OutputIterator>::value)
-    {
-        if(static_cast<typename std::remove_const<decltype(size)>::type>(
-               std::distance(keys, output))
-           < size)
-        {
-            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
-            temp_output_size_byte = sizeof(value_type) * size;
-        }
-    }
-    else if constexpr(std::is_pointer<KeysInputIterator>::value
-                      && std::is_pointer<OutputIterator>::value)
-    {
-        if(static_cast<typename std::remove_const<decltype(size)>::type>(
-               std::distance(keys, reinterpret_cast<KeysInputIterator>(output)))
-           < size)
-        {
-            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
-            temp_output_size_byte = sizeof(value_type) * size;
-        }
-    }
+    key_type*  last_keys_of_each_block;
+    const auto last_keys_of_each_block_size_byte
+        = items_per_thread ? detect_reusing_keys<Exclusive>(keys,
+                                                            output,
+                                                            size,
+                                                            ceiling_div(size, items_per_block))
+                           : 0;
 
     const hipError_t partition_result = detail::temp_storage::partition(
         temporary_storage,
@@ -194,7 +258,8 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
             // This is valid even with offset_scan_state_with_sleep_type
             detail::temp_storage::make_partition(&scan_state_storage, layout),
             detail::temp_storage::ptr_aligned_array(&previous_last_value, use_limited_size ? 1 : 0),
-            detail::temp_storage::ptr_aligned_array(&temp_output, temp_output_size_byte)));
+            detail::temp_storage::ptr_aligned_array(&last_keys_of_each_block,
+                                                    last_keys_of_each_block_size_byte)));
     if(partition_result != hipSuccess || temporary_storage == nullptr)
     {
         return partition_result;
@@ -255,33 +320,51 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
         std::cout << "----------------------------------\n";
     }
 
-    auto launch_scan_by_key = [&](auto phantom_output)
+    for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
     {
-        for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
+        // limited_size is of type unsigned int, so current_size also fits in an unsigned int
+        // size_t is necessary as type of std::min because 'size - offset' can exceed the
+        // upper limit of unsigned int and converting it can lead to wrong results
+        const unsigned int current_size
+            = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
+        const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
+        const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
+
+        // Start point for time measurements
+        std::chrono::steady_clock::time_point start;
+        if(debug_synchronous)
         {
-            // limited_size is of type unsigned int, so current_size also fits in an unsigned int
-            // size_t is necessary as type of std::min because 'size - offset' can exceed the
-            // upper limit of unsigned int and converting it can lead to wrong results
-            const unsigned int current_size
-                = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
-            const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
-            const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
+            std::cout << "index:            " << i << '\n';
+            std::cout << "current_size:     " << current_size << '\n';
+            std::cout << "number of blocks: " << scan_blocks << '\n';
 
-            // Start point for time measurements
-            std::chrono::steady_clock::time_point start;
-            if(debug_synchronous)
+            start = std::chrono::steady_clock::now();
+        }
+
+        with_scan_state(
+            [&](const auto scan_state)
             {
-                std::cout << "index:            " << i << '\n';
-                std::cout << "current_size:     " << current_size << '\n';
-                std::cout << "number of blocks: " << scan_blocks << '\n';
-
-                start = std::chrono::steady_clock::now();
-            }
-
-            with_scan_state(
-                [&](const auto scan_state)
+                // only when in-place scan is needed, we initialize the last_keys_of_each_block
+                if(last_keys_of_each_block_size_byte != 0 && i == 0)
                 {
-                    hipLaunchKernelGGL(init_lookback_scan_state_kernel,
+                    hipLaunchKernelGGL(init_device_scan_by_key_kernel,
+                                       dim3(init_grid_size),
+                                       dim3(block_size),
+                                       0,
+                                       stream,
+                                       scan_state,
+                                       scan_blocks,
+                                       number_of_blocks - 1,
+                                       i > 0 ? previous_last_value : nullptr,
+                                       keys,
+                                       last_keys_of_each_block,
+                                       last_keys_of_each_block_size_byte
+                                           / sizeof(decltype(*last_keys_of_each_block)),
+                                       items_per_block);
+                }
+                else
+                {
+                    hipLaunchKernelGGL(init_device_scan_by_key_kernel,
                                        dim3(init_grid_size),
                                        dim3(block_size),
                                        0,
@@ -290,64 +373,44 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                                        scan_blocks,
                                        number_of_blocks - 1,
                                        i > 0 ? previous_last_value : nullptr);
-                });
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                        scan_blocks,
-                                                        start);
+                }
+            });
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_device_scan_by_key_kernel",
+                                                    scan_blocks,
+                                                    start);
 
-            if(debug_synchronous)
-            {
-                start = std::chrono::steady_clock::now();
-            }
-            ROCPRIM_RETURN_ON_ERROR(with_scan_state(
-                [&](auto& scan_state)
-                {
-                    return launch_device_scan_by_key<config, Determinism, Exclusive>(
-                        target_arch,
-                        keys + offset,
-                        input + offset,
-                        phantom_output + offset,
-                        initial_value,
-                        compare,
-                        scan_op,
-                        scan_state,
-                        size,
-                        i * number_of_blocks,
-                        total_number_of_blocks,
-                        i > 0 ? as_const_ptr(previous_last_value) : nullptr,
-                        dim3(scan_blocks),
-                        dim3(block_size),
-                        0,
-                        stream);
-                }));
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
-                                                        current_size,
-                                                        start);
+        if(debug_synchronous)
+        {
+            start = std::chrono::steady_clock::now();
         }
-    };
+        ROCPRIM_RETURN_ON_ERROR(with_scan_state(
+            [&](auto& scan_state)
+            {
+                return launch_device_scan_by_key<config, Determinism, Exclusive>(
+                    target_arch,
+                    keys + offset,
+                    input + offset,
+                    output + offset,
+                    initial_value,
+                    compare,
+                    scan_op,
+                    scan_state,
+                    size,
+                    i * number_of_blocks,
+                    total_number_of_blocks,
+                    i > 0 ? as_const_ptr(previous_last_value) : nullptr,
+                    last_keys_of_each_block_size_byte != 0,
+                    last_keys_of_each_block,
+                    dim3(scan_blocks),
+                    dim3(block_size),
+                    0,
+                    stream);
+            }));
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
+                                                    current_size,
+                                                    start);
+    }
 
-    if(temp_output_size_byte > 0)
-    {
-        launch_scan_by_key(temp_output);
-        // Store data -- "in-place" scan_by_key will use more global memory and here is an extra step of
-        // storing data back into the output. So it is slower than not reusing the input.
-        ROCPRIM_RETURN_ON_ERROR(
-            ::rocprim::transform(temp_output,
-                                 output,
-                                 size,
-                                 // The temp_output holds value_type data, the ideal situation
-                                 // is that the compiler will throw an error if it's not possible
-                                 // to assign output[i] with a value_type item, which means that
-                                 // value_type is not convertible to key_type, in this case, the
-                                 // "in-place" scan_by_key shouldn't be allowed.
-                                 ::rocprim::identity<value_type>(),
-                                 stream,
-                                 debug_synchronous));
-    }
-    else
-    {
-        launch_scan_by_key(output);
-    }
     return hipSuccess;
 }
 
@@ -375,10 +438,12 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
 /// * Ranges specified by \p keys_input, \p values_input, and \p values_output must have
 /// at least \p size elements.
 ///
-/// \note In-place scan_by_key
-/// In-place scan_by_key is supported by using the same buffer for `values_input` and `values_output`.
-/// Reusing `keys_input` as `values_output` is supported only when the sizeof(key_type) is larger than
-/// the sizeof(value_type).
+/// \note In-place inclusive_scan_by_key
+/// In these situations, in-place inclusive_scan_by_key is supported:
+/// - The buffers in `keys_input` and `values_output` are overlaped to each other, and `KeysInputIterator` and `ValuesOutputIterator` are the same.
+/// - The buffers in `keys_input` and `values_output` are overlaped to each other, `KeysInputIterator` and `ValuesOutputIterator` are the different,
+///   but they are both pointer types, and their "std::iterator_traits<KeysInputIterator>::value_type" is convertible to
+///   "std::iterator_traits<ValuesOutputIterator>::value_type"
 ///
 /// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `scan_by_key_config`.
 /// \tparam KeysInputIterator random-access iterator type of the input range. It can be
@@ -572,10 +637,8 @@ inline hipError_t deterministic_inclusive_scan_by_key(void* const               
 /// * Ranges specified by \p keys_input, \p values_input, and \p values_output must have
 /// at least \p size elements.
 ///
-/// \note In-place scan_by_key
-/// In-place scan_by_key is supported by using the same buffer for `values_input` and `values_output`.
-/// Reusing `keys_input` as `values_output` is supported only when the sizeof(key_type) is larger than
-/// the sizeof(value_type).
+/// \note In-place exclusive_scan_by_key
+/// In-place exclusive_scan_by_key is supported.
 ///
 /// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `scan_by_key_config`.
 /// \tparam KeysInputIterator random-access iterator type of the input range. It can be

--- a/projects/rocprim/test/rocprim/test_device_scan_by_key.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan_by_key.cpp
@@ -358,51 +358,134 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
                 keys = test_utils::get_random_data<K>(size, 0, 3, seed_value);
             }
 
-            common::device_ptr<T> d_input(input);
-            common::device_ptr<K> d_keys(keys);
-            common::device_ptr<U> d_output(input.size());
-
             // Scan function
             scan_op_type scan_op;
             // Key compare function
             rocprim::equal_to<K> keys_compare_op;
 
-            // Calculate expected results on host
-            std::vector<U> expected(input.size());
-            test_utils::host_inclusive_scan_by_key(input.begin(),
-                                                   input.end(),
-                                                   keys.begin(),
-                                                   expected.begin(),
-                                                   scan_op,
-                                                   keys_compare_op);
+            // Normal test
+            {
+                common::device_ptr<T> d_input(input);
+                common::device_ptr<K> d_keys(keys);
+                common::device_ptr<U> d_output(input.size());
+                std::vector<U>        expected(input.size());
+                test_utils::host_inclusive_scan_by_key(input.begin(),
+                                                       input.end(),
+                                                       keys.begin(),
+                                                       expected.begin(),
+                                                       scan_op,
+                                                       keys_compare_op);
+                auto input_iterator = rocprim::make_transform_iterator(
+                    d_input.get(),
+                    [](T in) { return static_cast<acc_type>(in); });
 
-            auto input_iterator
-                = rocprim::make_transform_iterator(d_input.get(),
-                                                   [](T in) { return static_cast<acc_type>(in); });
+                test_utils::test_kernel_wrapper(
+                    [&](void* temp_storage, size_t& storage_bytes)
+                    {
+                        return invoke_inclusive_scan_by_key<deterministic, Config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_keys.get(),
+                            input_iterator,
+                            d_output.get(),
+                            input.size(),
+                            scan_op,
+                            keys_compare_op,
+                            stream,
+                            debug_synchronous);
+                    },
+                    stream,
+                    TestFixture::use_graphs);
 
-            test_utils::test_kernel_wrapper(
-                [&](void* temp_storage, size_t& storage_bytes)
-                {
-                    return invoke_inclusive_scan_by_key<deterministic, Config>(temp_storage,
-                                                                               storage_bytes,
-                                                                               d_keys.get(),
-                                                                               input_iterator,
-                                                                               d_output.get(),
-                                                                               input.size(),
-                                                                               scan_op,
-                                                                               keys_compare_op,
-                                                                               stream,
-                                                                               debug_synchronous);
-                },
-                stream,
-                TestFixture::use_graphs);
+                // Copy output to host
+                const auto output = d_output.load();
 
-            // Copy output to host
-            const auto output = d_output.load();
+                // Check if output values are as expected
+                ASSERT_NO_FATAL_FAILURE(
+                    test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+            }
+            // In-place by storing results in keys, K will not be able to be assigned with custom types
+            if constexpr(std::is_arithmetic<T>::value)
+            {
+                common::device_ptr<T> d_input(input);
+                common::device_ptr<K> d_keys(keys);
+                std::vector<K>        expected(input.size());
+                test_utils::host_inclusive_scan_by_key(input.begin(),
+                                                       input.end(),
+                                                       keys.begin(),
+                                                       expected.begin(),
+                                                       scan_op,
+                                                       keys_compare_op);
+                auto input_iterator = rocprim::make_transform_iterator(
+                    d_input.get(),
+                    [](T in) { return static_cast<acc_type>(in); });
 
-            // Check if output values are as expected
-            ASSERT_NO_FATAL_FAILURE(
-                test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+                test_utils::test_kernel_wrapper(
+                    [&](void* temp_storage, size_t& storage_bytes)
+                    {
+                        return invoke_inclusive_scan_by_key<deterministic, Config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_keys.get(),
+                            input_iterator,
+                            d_keys.get(),
+                            input.size(),
+                            scan_op,
+                            keys_compare_op,
+                            stream,
+                            debug_synchronous);
+                    },
+                    stream,
+                    TestFixture::use_graphs);
+
+                // Copy output to host
+                const auto output = d_keys.load();
+
+                // Check if output values are as expected
+                ASSERT_NO_FATAL_FAILURE(
+                    test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+            }
+            // In-place by storing results in input
+            if constexpr(std::is_arithmetic<T>::value)
+            {
+                common::device_ptr<T> d_input(input);
+                common::device_ptr<K> d_keys(keys);
+                std::vector<T>        expected(input.size());
+                test_utils::host_inclusive_scan_by_key(input.begin(),
+                                                       input.end(),
+                                                       keys.begin(),
+                                                       expected.begin(),
+                                                       scan_op,
+                                                       keys_compare_op);
+                auto input_iterator = rocprim::make_transform_iterator(
+                    d_input.get(),
+                    [](T in) { return static_cast<acc_type>(in); });
+
+                test_utils::test_kernel_wrapper(
+                    [&](void* temp_storage, size_t& storage_bytes)
+                    {
+                        return invoke_inclusive_scan_by_key<deterministic, Config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_keys.get(),
+                            input_iterator,
+                            d_input.get(),
+                            input.size(),
+                            scan_op,
+                            keys_compare_op,
+                            stream,
+                            debug_synchronous);
+                    },
+                    stream,
+                    TestFixture::use_graphs);
+
+                // Copy output to host
+                const auto output = d_input.load();
+
+                // Check if output values are as expected
+                ASSERT_NO_FATAL_FAILURE(
+                    test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+            }
         }
     }
 
@@ -479,55 +562,141 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
             {
                 keys = test_utils::get_random_data<K>(size, 0, 3, seed_value);
             }
-
-            common::device_ptr<T> d_input(input);
-            common::device_ptr<K> d_keys(keys);
-            common::device_ptr<U> d_output(input.size());
-
             // Scan function
             scan_op_type scan_op;
 
             // Key compare function
             rocprim::equal_to<K> keys_compare_op;
 
-            // Calculate expected results on host
-            std::vector<U> expected(input.size());
-            test_utils::host_exclusive_scan_by_key(input.begin(),
-                                                   input.end(),
-                                                   keys.begin(),
-                                                   initial_value,
-                                                   expected.begin(),
-                                                   scan_op,
-                                                   keys_compare_op);
+            // Noremal test
+            {
+                common::device_ptr<T> d_input(input);
+                common::device_ptr<K> d_keys(keys);
+                common::device_ptr<U> d_output(input.size());
+                std::vector<U>        expected(input.size());
+                test_utils::host_exclusive_scan_by_key(input.begin(),
+                                                       input.end(),
+                                                       keys.begin(),
+                                                       initial_value,
+                                                       expected.begin(),
+                                                       scan_op,
+                                                       keys_compare_op);
+                auto input_iterator = rocprim::make_transform_iterator(
+                    d_input.get(),
+                    [](T in) { return static_cast<acc_type>(in); });
 
-            auto input_iterator
-                = rocprim::make_transform_iterator(d_input.get(),
-                                                   [](T in) { return static_cast<acc_type>(in); });
+                test_utils::test_kernel_wrapper(
+                    [&](void* temp_storage, size_t& storage_bytes)
+                    {
+                        return invoke_exclusive_scan_by_key<deterministic, Config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_keys.get(),
+                            input_iterator,
+                            d_output.get(),
+                            initial_value,
+                            input.size(),
+                            scan_op,
+                            keys_compare_op,
+                            stream,
+                            debug_synchronous);
+                    },
+                    stream,
+                    TestFixture::use_graphs);
 
-            test_utils::test_kernel_wrapper(
-                [&](void* temp_storage, size_t& storage_bytes)
-                {
-                    return invoke_exclusive_scan_by_key<deterministic, Config>(temp_storage,
-                                                                               storage_bytes,
-                                                                               d_keys.get(),
-                                                                               input_iterator,
-                                                                               d_output.get(),
-                                                                               initial_value,
-                                                                               input.size(),
-                                                                               scan_op,
-                                                                               keys_compare_op,
-                                                                               stream,
-                                                                               debug_synchronous);
-                },
-                stream,
-                TestFixture::use_graphs);
+                // Copy output to host
+                const auto output = d_output.load();
 
-            // Copy output to host
-            const auto output = d_output.load();
+                // Check if output values are as expected
+                ASSERT_NO_FATAL_FAILURE(
+                    test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+            }
+            // In-place by storing results in keys
+            if constexpr(std::is_arithmetic<T>::value)
+            {
+                common::device_ptr<T> d_input(input);
+                common::device_ptr<K> d_keys(keys);
+                std::vector<K>        expected(input.size());
+                test_utils::host_exclusive_scan_by_key(input.begin(),
+                                                       input.end(),
+                                                       keys.begin(),
+                                                       initial_value,
+                                                       expected.begin(),
+                                                       scan_op,
+                                                       keys_compare_op);
+                auto input_iterator = rocprim::make_transform_iterator(
+                    d_input.get(),
+                    [](T in) { return static_cast<acc_type>(in); });
 
-            // Check if output values are as expected
-            ASSERT_NO_FATAL_FAILURE(
-                test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+                test_utils::test_kernel_wrapper(
+                    [&](void* temp_storage, size_t& storage_bytes)
+                    {
+                        return invoke_exclusive_scan_by_key<deterministic, Config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_keys.get(),
+                            input_iterator,
+                            d_keys.get(),
+                            initial_value,
+                            input.size(),
+                            scan_op,
+                            keys_compare_op,
+                            stream,
+                            debug_synchronous);
+                    },
+                    stream,
+                    TestFixture::use_graphs);
+
+                // Copy output to host
+                const auto output = d_keys.load();
+
+                // Check if output values are as expected
+                ASSERT_NO_FATAL_FAILURE(
+                    test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+            }
+            // In-place by storing results in input
+            if constexpr(std::is_arithmetic<T>::value)
+            {
+                common::device_ptr<T> d_input(input);
+                common::device_ptr<K> d_keys(keys);
+                std::vector<T>        expected(input.size());
+                test_utils::host_exclusive_scan_by_key(input.begin(),
+                                                       input.end(),
+                                                       keys.begin(),
+                                                       initial_value,
+                                                       expected.begin(),
+                                                       scan_op,
+                                                       keys_compare_op);
+                auto input_iterator = rocprim::make_transform_iterator(
+                    d_input.get(),
+                    [](T in) { return static_cast<acc_type>(in); });
+
+                test_utils::test_kernel_wrapper(
+                    [&](void* temp_storage, size_t& storage_bytes)
+                    {
+                        return invoke_exclusive_scan_by_key<deterministic, Config>(
+                            temp_storage,
+                            storage_bytes,
+                            d_keys.get(),
+                            input_iterator,
+                            d_input.get(),
+                            initial_value,
+                            input.size(),
+                            scan_op,
+                            keys_compare_op,
+                            stream,
+                            debug_synchronous);
+                    },
+                    stream,
+                    TestFixture::use_graphs);
+
+                // Copy output to host
+                const auto output = d_input.load();
+
+                // Check if output values are as expected
+                ASSERT_NO_FATAL_FAILURE(
+                    test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
+            }
         }
     }
 

--- a/projects/rocthrust/CHANGELOG.md
+++ b/projects/rocthrust/CHANGELOG.md
@@ -11,7 +11,12 @@ Documentation for rocThrust available at
 * Introduced `libhipcxx` as a soft depedency. When `liphipcxx` can be included, rocthrust, may use structs and methods defined in `libhipcxx`. This allows for a more complete behaviour parity with CCCL and mirrors CCCL's thrust own depedency on `libcudacxx`.
 * Added a new CMake option `-DUSE_SYSTEM_LIB` to allow tests to be built from `ROCm` libraries provided by the system.
 
+### Resolved issues
+
+* Fixed an issue where the test `test_scan_by_key.inclusive.hip` failed when performing an "in-place" inclusive scan by reusing "keys" as output, by adding a buffer to store the last keys of each block (excluding the last block). Changes were made in rocprim. This fix only affects the specific case of reusing "keys" as output in an inclusive scan, and does not affect other cases.
+
 ### Known Issues
+
 * `event` test is failing on CI and local runs on MI300, MI250 and MI210.
 
 * rocThrust, as well as its dependencies rocPRIM and rocRAND have been moved into the new rocm-libraries "monorepo" repository (https://github.com/ROCm/rocm-libraries). This repository contains a number of ROCm libraries that are frequently used together.
@@ -27,7 +32,8 @@ Documentation for rocThrust available at
 * The previously hidden cmake build option `FORCE_DEPENDENCIES_DOWNLOAD` has been unhidden and renamed `EXTERNAL_DEPS_FORCE_DOWNLOAD` to differentiate it from the new rocPRIM and rocRAND dependency options described above. It's behaviour remains the same - it forces non-ROCm dependencies (Google Benchmark, Google Test, and SQLite) to be downloaded instead of searching for existing installed packages. This option defaults to `OFF`.
 
 ### Removed
-  * The previous dependency-related build options `DOWNLOAD_ROCPRIM` and `DOWNLOAD_ROCRAND` have been removed. Please use `ROCPRIM_FETCH_METHOD=DOWNLOAD` and `ROCRAND_FETCH_METHOD=DOWNLOAD` instead.
+
+* The previous dependency-related build options `DOWNLOAD_ROCPRIM` and `DOWNLOAD_ROCRAND` have been removed. Please use `ROCPRIM_FETCH_METHOD=DOWNLOAD` and `ROCRAND_FETCH_METHOD=DOWNLOAD` instead.
 
 ## rocThrust 4.0.0 for ROCm 7.0
 

--- a/projects/rocthrust/test/test_scan_by_key.inclusive.cpp
+++ b/projects/rocthrust/test/test_scan_by_key.inclusive.cpp
@@ -211,57 +211,57 @@ TYPED_TEST(ScanByKeyInclusiveVariablesTests, TestInclusiveScanByKey)
   }
 }
 
-// TYPED_TEST(ScanByKeyInclusiveVariablesTests, TestInclusiveScanByKeyInPlace)
-// {
-//   using T = typename TestFixture::input_type;
+TYPED_TEST(ScanByKeyInclusiveVariablesTests, TestInclusiveScanByKeyInPlace)
+{
+  using T = typename TestFixture::input_type;
 
-//   SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+  SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-//   for (auto size : get_sizes())
-//   {
-//     SCOPED_TRACE(testing::Message() << "with size= " << size);
+  for (auto size : get_sizes())
+  {
+    SCOPED_TRACE(testing::Message() << "with size= " << size);
 
-//     thrust::host_vector<int> h_keys(size);
-//     thrust::default_random_engine rng;
-//     for (size_t i = 0, k = 0; i < size; i++)
-//     {
-//       h_keys[i] = static_cast<int>(k);
-//       if (rng() % 10 == 0)
-//       {
-//         k++;
-//       }
-//     }
-//     thrust::device_vector<int> d_keys = h_keys;
+    thrust::host_vector<int> h_keys(size);
+    thrust::default_random_engine rng;
+    for (size_t i = 0, k = 0; i < size; i++)
+    {
+      h_keys[i] = static_cast<int>(k);
+      if (rng() % 10 == 0)
+      {
+        k++;
+      }
+    }
+    thrust::device_vector<int> d_keys = h_keys;
 
-//     for (auto seed : get_seeds())
-//     {
-//       SCOPED_TRACE(testing::Message() << "with seed= " << seed);
+    for (auto seed : get_seeds())
+    {
+      SCOPED_TRACE(testing::Message() << "with seed= " << seed);
 
-//       thrust::host_vector<T> h_vals =
-//         get_random_data<int>(size, get_default_limits<int>::min(), get_default_limits<int>::max(), seed);
-//       for (size_t i = 0; i < size; i++)
-//       {
-//         h_vals[i] = static_cast<int>(i % 10);
-//       }
-//       thrust::device_vector<T> d_vals = h_vals;
+      thrust::host_vector<T> h_vals =
+        get_random_data<int>(size, get_default_limits<int>::min(), get_default_limits<int>::max(), seed);
+      for (size_t i = 0; i < size; i++)
+      {
+        h_vals[i] = static_cast<int>(i % 10);
+      }
+      thrust::device_vector<T> d_vals = h_vals;
 
-//       thrust::host_vector<T> h_output(size);
-//       thrust::device_vector<T> d_output(size);
+      thrust::host_vector<T> h_output(size);
+      thrust::device_vector<T> d_output(size);
 
-//       // in-place scans: in/out values aliasing
-//       h_output = h_vals;
-//       d_output = d_vals;
-//       thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_output.begin(), h_output.begin());
-//       thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.end(), d_output.begin(), d_output.begin());
-//       ASSERT_EQ(d_output, h_output);
+      // in-place scans: in/out values aliasing
+      h_output = h_vals;
+      d_output = d_vals;
+      thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_output.begin(), h_output.begin());
+      thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.end(), d_output.begin(), d_output.begin());
+      ASSERT_EQ(d_output, h_output);
 
-//       // in-place scans: in/out keys aliasing
-//       thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys.begin());
-//       thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.end(), d_vals.begin(), d_keys.begin());
-//       ASSERT_EQ(d_keys, h_keys);
-//     }
-//   }
-// }
+      // in-place scans: in/out keys aliasing
+      thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys.begin());
+      thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.end(), d_vals.begin(), d_keys.begin());
+      ASSERT_EQ(d_keys, h_keys);
+    }
+  }
+}
 
 TEST(ScanByKeyInclusiveTests, TestScanByKeyMixedTypes)
 {

--- a/projects/rocthrust/test/test_scan_by_key.inclusive.cpp
+++ b/projects/rocthrust/test/test_scan_by_key.inclusive.cpp
@@ -15,6 +15,8 @@
  *  limitations under the License.
  */
 
+#define TCX_DEBUG
+
 #include <thrust/functional.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/retag.h>
@@ -382,127 +384,23 @@ TEST(ScanByKeyInclusiveTests, TestScanByKeyLargeInput)
       }
       thrust::device_vector<unsigned int> d_keys = h_keys;
 
-      thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.begin() + n, h_vals.begin(), h_output.begin());
-      thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.begin() + n, d_vals.begin(), d_output.begin());
-      ASSERT_EQ(d_output, h_output);
-    }
-  }
-}
+  thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys.begin());
+  thrust::device_vector<T> d_h_keys = h_keys;
 
-template <typename T, unsigned int N>
-void _TestScanByKeyWithLargeTypes()
-{
-  size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
-
-  thrust::host_vector<unsigned int> h_keys(n);
-  thrust::host_vector<FixedVector<T, N>> h_vals(n);
-  thrust::host_vector<FixedVector<T, N>> h_output(n);
-
-  thrust::default_random_engine rng;
-  for (size_t i = 0, k = 0; i < h_vals.size(); i++)
+  int i = 0;
+  while (true)
   {
-    h_keys[i] = static_cast<unsigned int>(k);
-    h_vals[i] = FixedVector<T, N>(static_cast<T>(i));
-    if (rng() % 5 == 0)
+    d_keys = d_keys_save; // refresh the d_keys
+    thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.end(), d_vals.begin(), d_keys.begin());
+    if (d_keys == d_h_keys)
     {
-      k++;
+      ++i;
     }
-  }
-
-  thrust::device_vector<unsigned int> d_keys      = h_keys;
-  thrust::device_vector<FixedVector<T, N>> d_vals = h_vals;
-  thrust::device_vector<FixedVector<T, N>> d_output(n);
-
-  thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_output.begin());
-  thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.end(), d_vals.begin(), d_output.begin());
-
-  ASSERT_EQ_QUIET(h_output, d_output);
-}
-
-TEST(ScanByKeyInclusiveTests, TestScanByKeyWithLargeTypes)
-{
-  SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
-
-  _TestScanByKeyWithLargeTypes<int, 1>();
-  _TestScanByKeyWithLargeTypes<int, 2>();
-  _TestScanByKeyWithLargeTypes<int, 4>();
-  _TestScanByKeyWithLargeTypes<int, 8>();
-
-  // too many resources requested for launch:
-  //_TestScanByKeyWithLargeTypes<int,   16>();
-  //_TestScanByKeyWithLargeTypes<int,   32>();
-
-  // too large to pass as argument
-  //_TestScanByKeyWithLargeTypes<int,   64>();
-  //_TestScanByKeyWithLargeTypes<int,  128>();
-  //_TestScanByKeyWithLargeTypes<int,  256>();
-  //_TestScanByKeyWithLargeTypes<int,  512>();
-  //_TestScanByKeyWithLargeTypes<int, 1024>();
-}
-
-__global__ THRUST_HIP_LAUNCH_BOUNDS_DEFAULT void
-InclusiveScanByKeyKernel(int const N, int* in_array, int* keys_array, int* out_array)
-{
-  if (threadIdx.x == 0)
-  {
-    thrust::device_ptr<int> in_begin(in_array);
-    thrust::device_ptr<int> in_end(in_array + N);
-    thrust::device_ptr<int> keys_begin(keys_array);
-    thrust::device_ptr<int> keys_end(keys_array + N);
-    thrust::device_ptr<int> out_begin(out_array);
-
-    thrust::inclusive_scan_by_key(thrust::hip::par, keys_begin, keys_end, in_begin, out_begin);
-  }
-}
-
-TEST(ScanByKeyInclusiveTests, TestInclusiveScanByKeyDevice)
-{
-  SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
-  for (auto size : get_sizes())
-  {
-    SCOPED_TRACE(testing::Message() << "with size= " << size);
-
-    thrust::host_vector<int> h_keys(size);
-    thrust::default_random_engine rng;
-    for (size_t i = 0, k = 0; i < size; i++)
+    else
     {
-      h_keys[i] = k;
-      if (rng() % 10 == 0)
-      {
-        k++;
-      }
+      std::cout << "wrong value after " << i << " runs";
+      exit(-1);
     }
-    thrust::device_vector<int> d_keys = h_keys;
-
-    for (auto seed : get_seeds())
-    {
-      SCOPED_TRACE(testing::Message() << "with seed= " << seed);
-
-      thrust::host_vector<int> h_vals =
-        get_random_data<int>(size, get_default_limits<int>::min(), get_default_limits<int>::max(), seed);
-      for (size_t i = 0; i < size; i++)
-      {
-        h_vals[i] = i % 10;
-      }
-      thrust::device_vector<int> d_vals = h_vals;
-
-      thrust::host_vector<int> h_output(size);
-      thrust::device_vector<int> d_output(size);
-
-      thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_output.begin());
-
-      hipLaunchKernelGGL(
-        InclusiveScanByKeyKernel,
-        dim3(1, 1, 1),
-        dim3(128, 1, 1),
-        0,
-        0,
-        size,
-        thrust::raw_pointer_cast(&d_vals[0]),
-        thrust::raw_pointer_cast(&d_keys[0]),
-        thrust::raw_pointer_cast(&d_output[0]));
-
-      ASSERT_EQ(d_output, h_output);
-    }
+    // the code will hang here
   }
 }

--- a/projects/rocthrust/test/test_scan_by_key.inclusive.cpp
+++ b/projects/rocthrust/test/test_scan_by_key.inclusive.cpp
@@ -15,18 +15,12 @@
  *  limitations under the License.
  */
 
-// #define TCX_DEBUG
-// #define TCX_DUMP_DATA
-
 #include <thrust/functional.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/retag.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/random.h>
 #include <thrust/scan.h>
-
-#include <filesystem>
-#include <fstream>
 
 #include "test_param_fixtures.hpp"
 #include "test_real_assertions.hpp"
@@ -388,28 +382,127 @@ TEST(ScanByKeyInclusiveTests, TestScanByKeyLargeInput)
       }
       thrust::device_vector<unsigned int> d_keys = h_keys;
 
-  thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys.begin());
-  thrust::device_vector<int> d_h_keys = h_keys;
+      thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.begin() + n, h_vals.begin(), h_output.begin());
+      thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.begin() + n, d_vals.begin(), d_output.begin());
+      ASSERT_EQ(d_output, h_output);
+    }
+  }
+}
 
-#ifdef TCX_DUMP_DATA
-  thrust::host_vector<int> output = d_h_keys;
-  dump_binary(output.data(), size * sizeof(int), std::filesystem::current_path().append("./__cache__/output_dump.dat"));
-#endif
+template <typename T, unsigned int N>
+void _TestScanByKeyWithLargeTypes()
+{
+  size_t n = (64 * 1024) / sizeof(FixedVector<T, N>);
 
-  int i = 0;
-  while (true)
+  thrust::host_vector<unsigned int> h_keys(n);
+  thrust::host_vector<FixedVector<T, N>> h_vals(n);
+  thrust::host_vector<FixedVector<T, N>> h_output(n);
+
+  thrust::default_random_engine rng;
+  for (size_t i = 0, k = 0; i < h_vals.size(); i++)
   {
-    d_keys = d_keys_save; // refresh the d_keys
-    thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.end(), d_vals.begin(), d_keys.begin());
-    if (d_keys == d_h_keys)
+    h_keys[i] = static_cast<unsigned int>(k);
+    h_vals[i] = FixedVector<T, N>(static_cast<T>(i));
+    if (rng() % 5 == 0)
     {
-      std::cout << "\rrun " << ++i;
+      k++;
     }
-    else
+  }
+
+  thrust::device_vector<unsigned int> d_keys      = h_keys;
+  thrust::device_vector<FixedVector<T, N>> d_vals = h_vals;
+  thrust::device_vector<FixedVector<T, N>> d_output(n);
+
+  thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_output.begin());
+  thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.end(), d_vals.begin(), d_output.begin());
+
+  ASSERT_EQ_QUIET(h_output, d_output);
+}
+
+TEST(ScanByKeyInclusiveTests, TestScanByKeyWithLargeTypes)
+{
+  SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+
+  _TestScanByKeyWithLargeTypes<int, 1>();
+  _TestScanByKeyWithLargeTypes<int, 2>();
+  _TestScanByKeyWithLargeTypes<int, 4>();
+  _TestScanByKeyWithLargeTypes<int, 8>();
+
+  // too many resources requested for launch:
+  //_TestScanByKeyWithLargeTypes<int,   16>();
+  //_TestScanByKeyWithLargeTypes<int,   32>();
+
+  // too large to pass as argument
+  //_TestScanByKeyWithLargeTypes<int,   64>();
+  //_TestScanByKeyWithLargeTypes<int,  128>();
+  //_TestScanByKeyWithLargeTypes<int,  256>();
+  //_TestScanByKeyWithLargeTypes<int,  512>();
+  //_TestScanByKeyWithLargeTypes<int, 1024>();
+}
+
+__global__ THRUST_HIP_LAUNCH_BOUNDS_DEFAULT void
+InclusiveScanByKeyKernel(int const N, int* in_array, int* keys_array, int* out_array)
+{
+  if (threadIdx.x == 0)
+  {
+    thrust::device_ptr<int> in_begin(in_array);
+    thrust::device_ptr<int> in_end(in_array + N);
+    thrust::device_ptr<int> keys_begin(keys_array);
+    thrust::device_ptr<int> keys_end(keys_array + N);
+    thrust::device_ptr<int> out_begin(out_array);
+
+    thrust::inclusive_scan_by_key(thrust::hip::par, keys_begin, keys_end, in_begin, out_begin);
+  }
+}
+
+TEST(ScanByKeyInclusiveTests, TestInclusiveScanByKeyDevice)
+{
+  SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
+  for (auto size : get_sizes())
+  {
+    SCOPED_TRACE(testing::Message() << "with size= " << size);
+
+    thrust::host_vector<int> h_keys(size);
+    thrust::default_random_engine rng;
+    for (size_t i = 0, k = 0; i < size; i++)
     {
-      std::cout << "\rwrong value after " << i << " runs";
-      exit(-1);
+      h_keys[i] = k;
+      if (rng() % 10 == 0)
+      {
+        k++;
+      }
     }
-    // the code will hang here
+    thrust::device_vector<int> d_keys = h_keys;
+
+    for (auto seed : get_seeds())
+    {
+      SCOPED_TRACE(testing::Message() << "with seed= " << seed);
+
+      thrust::host_vector<int> h_vals =
+        get_random_data<int>(size, get_default_limits<int>::min(), get_default_limits<int>::max(), seed);
+      for (size_t i = 0; i < size; i++)
+      {
+        h_vals[i] = i % 10;
+      }
+      thrust::device_vector<int> d_vals = h_vals;
+
+      thrust::host_vector<int> h_output(size);
+      thrust::device_vector<int> d_output(size);
+
+      thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_output.begin());
+
+      hipLaunchKernelGGL(
+        InclusiveScanByKeyKernel,
+        dim3(1, 1, 1),
+        dim3(128, 1, 1),
+        0,
+        0,
+        size,
+        thrust::raw_pointer_cast(&d_vals[0]),
+        thrust::raw_pointer_cast(&d_keys[0]),
+        thrust::raw_pointer_cast(&d_output[0]));
+
+      ASSERT_EQ(d_output, h_output);
+    }
   }
 }

--- a/projects/rocthrust/test/test_scan_by_key.inclusive.cpp
+++ b/projects/rocthrust/test/test_scan_by_key.inclusive.cpp
@@ -15,7 +15,8 @@
  *  limitations under the License.
  */
 
-#define TCX_DEBUG
+// #define TCX_DEBUG
+// #define TCX_DUMP_DATA
 
 #include <thrust/functional.h>
 #include <thrust/iterator/discard_iterator.h>
@@ -23,6 +24,9 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/random.h>
 #include <thrust/scan.h>
+
+#include <filesystem>
+#include <fstream>
 
 #include "test_param_fixtures.hpp"
 #include "test_real_assertions.hpp"
@@ -385,7 +389,12 @@ TEST(ScanByKeyInclusiveTests, TestScanByKeyLargeInput)
       thrust::device_vector<unsigned int> d_keys = h_keys;
 
   thrust::inclusive_scan_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys.begin());
-  thrust::device_vector<T> d_h_keys = h_keys;
+  thrust::device_vector<int> d_h_keys = h_keys;
+
+#ifdef TCX_DUMP_DATA
+  thrust::host_vector<int> output = d_h_keys;
+  dump_binary(output.data(), size * sizeof(int), std::filesystem::current_path().append("./__cache__/output_dump.dat"));
+#endif
 
   int i = 0;
   while (true)
@@ -394,11 +403,11 @@ TEST(ScanByKeyInclusiveTests, TestScanByKeyLargeInput)
     thrust::inclusive_scan_by_key(d_keys.begin(), d_keys.end(), d_vals.begin(), d_keys.begin());
     if (d_keys == d_h_keys)
     {
-      ++i;
+      std::cout << "\rrun " << ++i;
     }
     else
     {
-      std::cout << "wrong value after " << i << " runs";
+      std::cout << "\rwrong value after " << i << " runs";
       exit(-1);
     }
     // the code will hang here

--- a/projects/rocthrust/thrust/system/hip/detail/scan_by_key.h
+++ b/projects/rocthrust/thrust/system/hip/detail/scan_by_key.h
@@ -75,7 +75,7 @@ THRUST_HOST_DEVICE auto invoke_inclusive_scan_by_key(
   const BinaryFunction scan_op,
   const KeyCompareFunction key_compare_op,
   const hipStream_t stream,
-  bool debug_sync) -> std::enable_if_t<decltype(nondeterministic(policy))::value, hipError_t>
+  [[maybe_unused]] bool debug_sync) -> std::enable_if_t<decltype(nondeterministic(policy))::value, hipError_t>
 {
   return rocprim::inclusive_scan_by_key(
     temporary_storage,
@@ -87,7 +87,12 @@ THRUST_HOST_DEVICE auto invoke_inclusive_scan_by_key(
     scan_op,
     key_compare_op,
     stream,
-    debug_sync);
+#  ifdef TCX_DEBUG
+    true
+#  else
+    debug_sync
+#  endif
+  );
 }
 
 template <typename Derived,
@@ -107,7 +112,7 @@ THRUST_HOST_DEVICE auto invoke_inclusive_scan_by_key(
   const BinaryFunction scan_op,
   const KeyCompareFunction key_compare_op,
   const hipStream_t stream,
-  bool debug_sync) -> std::enable_if_t<!decltype(nondeterministic(policy))::value, hipError_t>
+  [[maybe_unused]] bool debug_sync) -> std::enable_if_t<!decltype(nondeterministic(policy))::value, hipError_t>
 {
   return rocprim::deterministic_inclusive_scan_by_key(
     temporary_storage,
@@ -119,7 +124,12 @@ THRUST_HOST_DEVICE auto invoke_inclusive_scan_by_key(
     scan_op,
     key_compare_op,
     stream,
-    debug_sync);
+#  ifdef TCX_DEBUG
+    true
+#  else
+    debug_sync
+#  endif
+  );
 }
 
 THRUST_EXEC_CHECK_DISABLE

--- a/projects/rocthrust/thrust/system/hip/detail/scan_by_key.h
+++ b/projects/rocthrust/thrust/system/hip/detail/scan_by_key.h
@@ -75,7 +75,7 @@ THRUST_HOST_DEVICE auto invoke_inclusive_scan_by_key(
   const BinaryFunction scan_op,
   const KeyCompareFunction key_compare_op,
   const hipStream_t stream,
-  [[maybe_unused]] bool debug_sync) -> std::enable_if_t<decltype(nondeterministic(policy))::value, hipError_t>
+  bool debug_sync) -> std::enable_if_t<decltype(nondeterministic(policy))::value, hipError_t>
 {
   return rocprim::inclusive_scan_by_key(
     temporary_storage,
@@ -87,12 +87,7 @@ THRUST_HOST_DEVICE auto invoke_inclusive_scan_by_key(
     scan_op,
     key_compare_op,
     stream,
-#  ifdef TCX_DEBUG
-    true
-#  else
-    debug_sync
-#  endif
-  );
+    debug_sync);
 }
 
 template <typename Derived,
@@ -112,7 +107,7 @@ THRUST_HOST_DEVICE auto invoke_inclusive_scan_by_key(
   const BinaryFunction scan_op,
   const KeyCompareFunction key_compare_op,
   const hipStream_t stream,
-  [[maybe_unused]] bool debug_sync) -> std::enable_if_t<!decltype(nondeterministic(policy))::value, hipError_t>
+  bool debug_sync) -> std::enable_if_t<!decltype(nondeterministic(policy))::value, hipError_t>
 {
   return rocprim::deterministic_inclusive_scan_by_key(
     temporary_storage,
@@ -124,12 +119,7 @@ THRUST_HOST_DEVICE auto invoke_inclusive_scan_by_key(
     scan_op,
     key_compare_op,
     stream,
-#  ifdef TCX_DEBUG
-    true
-#  else
-    debug_sync
-#  endif
-  );
+    debug_sync);
 }
 
 THRUST_EXEC_CHECK_DISABLE


### PR DESCRIPTION
## Motivation

The rocthust test scan_by_key.inclusive.hip occasionally fails in the CI, and could be reproduced locally.

### Observation
- This failure can also be reproduced in rocprim.
- This failure only happens when performing inclusive scan_by_key "in-place" by reusing `input_keys` also as `output`
- This failure will not reproduce if performing inclusive scan_by_key "in-place" by reusing `input_vals` also as `output`

### The cause of this failure
The logic of scan_by_key can be simply explained like this:
- We do block scan in multiple kernel launch then calculate the final results.
- The subsequent blocks will need the results calculated by the previous blocks. These results are stored in global temporary memory.
- In the kernel, there are few main steps:
  - Load keys, previous result, and values (inclusive scan will load the last key from previous block to determine if that item needs to be included)
  - Do block level lookback_scan (prefix_scan). In this step following blocks need to wait until the block ahead to mark it's lookback_scan state to "__complete__", then it can be started. So this is sort of global level synchronization.
  - Store the results into the designated output buffer.

This logic always works for any type of exclusive scan and any type of non-in-place scan, because there will be no data races. How ever when it comes "__in-place__" "__inclusive__" scan, the situation is different. Inclusive scan needs to read the last key from one block ahead, which is different comparing to exclusive scan -- which ignores the first value.  

Let's just assume we only have 2 blocks. When it comes "__in-place__" "__inclusive__" scan The block B will read from the output of block A. But this operation is not synchronized, which means, when block B is very slow, if will start reading after Block A has done writing, then it will get the wrong key.  

<img width="745" height="277" alt="image" src="https://github.com/user-attachments/assets/428744a4-566e-4152-b416-447d205c6f84" />

### About this fix
I made a fix for this failure:
- Detect if the input_keys buffer is reused by output
- Enlarge the global memory if overlay or input and output buffer is detect
- Create a temporary buffer to store the "last keys" of each block except the last block.
- In every block except the first block, load the first key from this temporary buffer if overlap is detected 
This fix is only applied for "__in-place__" "__inclusive__". For exclusive scan, code related to this fix will not be compiled, since they are filtered by "if constexpr". For inclusive scan, this fix will always be compiled into the kernel but only triggers if "reusing keys" is detected. The "reusing keys detector" will cover major cases. Cases which are not covered by the "reusing keys detector" are documented.

## Test Plan

I also added "in-place" tests in rocprim

## Test Result

The fix is tested locally and it works.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
