### PR TITLE
[hipblastlt] PTS script: added --targetArch and auto-detection to run different suites according to the arch. 

### DIFF
--- a/projects/hipblaslt/clients/scripts/performance/generator.py
+++ b/projects/hipblaslt/clients/scripts/performance/generator.py
@@ -69,7 +69,7 @@ class SuiteProblemGenerator:
                                    None]] = field(default_factory=dict)
 
     # default arch is gfx942 when no argument is set and query is failed
-    target_arch_static: str = str("gfx942")
+    target_arch_static: str = "gfx942"
 
     @staticmethod
     def detectISA():
@@ -79,11 +79,10 @@ class SuiteProblemGenerator:
         process = run([enumerator], stdout=PIPE)
         for line in process.stdout.decode().split("\n"):
             archStr = line.strip()
-            if archStr is not None:
-                if "gfx" in archStr:
-                    print(f"Info: Auto Detected GPU with ISA: {archStr}")
-                    SuiteProblemGenerator.target_arch_static = archStr
-                    break
+            if "gfx" in archStr:
+                print(f"Info: Auto Detected GPU with ISA: {archStr}")
+                SuiteProblemGenerator.target_arch_static = archStr
+                break
         if process.returncode:
             print(f"{enumerator} exited with code {process.returncode}, using default arch gfx942")
 

--- a/projects/hipblaslt/clients/scripts/performance/generator.py
+++ b/projects/hipblaslt/clients/scripts/performance/generator.py
@@ -21,6 +21,7 @@
 import logging
 
 from dataclasses import dataclass, field
+from subprocess import run, PIPE
 from pathlib import Path as path
 from typing import Dict, List, Mapping, Generator
 
@@ -66,6 +67,25 @@ class SuiteProblemGenerator:
     suite_names: List[str]
     suites: Mapping[str, Generator[ProblemSet, None,
                                    None]] = field(default_factory=dict)
+
+    # default arch is gfx942 when no argument is set and query is failed
+    target_arch_static: str = str("gfx942")
+
+    @staticmethod
+    def detectISA():
+        # TODO- currently this is for PTS only. If we'd like to make it generic,
+        # we need to select correct exec from "rocm_agent_enumerator", "amdgpu-arch", "hipinfo"
+        enumerator = "/opt/rocm/bin/rocm_agent_enumerator"
+        process = run([enumerator], stdout=PIPE)
+        for line in process.stdout.decode().split("\n"):
+            archStr = line.strip()
+            if archStr is not None:
+                if "gfx" in archStr:
+                    print(f"Info: Auto Detected GPU with ISA: {archStr}")
+                    SuiteProblemGenerator.target_arch_static = archStr
+                    break
+        if process.returncode:
+            print(f"{enumerator} exited with code {process.returncode}, using default arch gfx942")
 
     def __post_init__(self):
         for name in self.suite_names:

--- a/projects/hipblaslt/clients/scripts/performance/hipblaslt-perf
+++ b/projects/hipblaslt/clients/scripts/performance/hipblaslt-perf
@@ -309,6 +309,11 @@ def main():
                         type=str,
                         action='append')
 
+    parser.add_argument('--targetArch',
+                        type=str,
+                        help='specify the target arch, mainly used when --suite all for PTS. If None, will use rocm_agent_enumerator to query',
+                        default=None)
+
     parser.add_argument('--tag',
                         type=str,
                         help='subfolder under workspace, (optional, useful for comparing two commits)',
@@ -330,6 +335,8 @@ def main():
                         default=False)
 
     arguments = parser.parse_args()
+
+    SuiteProblemGenerator.target_arch_static = arguments.targetArch
 
     if arguments.run_sh is not None:
         run_sh_bench(arguments)

--- a/projects/hipblaslt/clients/scripts/performance/suites.py
+++ b/projects/hipblaslt/clients/scripts/performance/suites.py
@@ -19,7 +19,7 @@
 # THE SOFTWARE.
 
 from copy import deepcopy
-from generator import Problem, ProblemSet
+from generator import Problem, ProblemSet, SuiteProblemGenerator
 
 amax_def_args = {'--type'  : 'H',
                  '--dtype' : 'S',
@@ -101,7 +101,23 @@ def matmul_set_2():
 def all():
     """all routine benchmarks"""
 
+    target_arch = SuiteProblemGenerator.target_arch_static
+    # if --targetArch is not set, we have to query it with rocm_agent_enumerator
+    if target_arch is None:
+        print(f'Info: targetArch is not set, auto-detecting...')
+        SuiteProblemGenerator.detectISA()
+        target_arch = SuiteProblemGenerator.target_arch_static
+
+    print(f'Info: bench with --suite all with --targetArch {target_arch}')
+
+    # general suites for all arches
     yield from api_overhead()
     yield from amax_set_1()
-    yield from matmul_set_1()
-    yield from matmul_set_2()
+
+    if "942" in target_arch:
+        yield from matmul_set_1() # this problemset is an initial test example for gfx942
+        yield from matmul_set_2()
+        # Can put any other interested set for gfx942
+    elif "950" in target_arch:
+        yield from matmul_set_2()
+        # Can put any other interested set for gfx950


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Performance CI Job runs "**`--suite all`**" by default. But in current scenario, different architectures have their own focused default problem sizes (but we'd still like to use --suite all). It is possible that "No Solution Found" error will happen in different architectures since the problem-sizes in the bench-yaml are not supported. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Added an argument **`--targetArch`** to **`./hipblaslt-perf`**. 
When running the Perf CI Job, rockJenkins can still use `--suite all`, but with this PR, we can add an additional "**`--targetArch gfxXXX`**" option in the groovy. So the Perf Job can run the specific problem sizes according to the GPU of the running nodes. 

When --targetArch is not specified (this modification needs to be done in rocJenkins), this PR provides a simple auto-detection way to detect the ISA of the current architecture. 

But for PTS, the most ideal case is to pass "**`--targetArch gfxXXX`**" in the performance CI job; the auto-detection functionality currently works as a workaround when the groovy file is not updated.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Tested by common CI routine. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
