### PR TITLE
Cat CPU solver upgrade

### DIFF
--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -41,100 +41,24 @@
 #include <vector>
 #include <../test/tensor_holder.hpp>
 #include <../test/verify.hpp>
-
-#include <fstream>
-#include <iostream>
 #include <miopen/ford.hpp>
 
 #ifndef MLO_CATHOST_H_
 #define MLO_CATHOST_H_
 
 template <typename Tgpu, typename Tcheck>
-int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
-                             std::vector<Tgpu*> inputs,
+int32_t mloCatForwardRunHost(const std::vector<miopenTensorDescriptor_t>& inputDescs,
+                             const std::vector<Tgpu*>& inputs,
                              miopenTensorDescriptor_t outputDesc,
                              Tcheck* outputhost,
-                             uint32_t dim)
+                             uint32_t dim,
+                             bool multi_threaded)
 {
-    // std::vector<size_t> copySizes(inputs.size());
-    const auto t0          = std::chrono::high_resolution_clock::now();
-    auto shape             = miopen::deref(outputDesc).GetLengths();
-    size_t outer_size      = 1;
-    size_t inner_size      = 1;
-    size_t output_dim_size = shape[dim];
-    for(size_t i = 0; i < dim; i++)
-    {
-        outer_size *= shape[i];
-    }
-
-    for(size_t i = dim + 1; i < shape.size(); i++)
-    {
-        inner_size *= shape[i];
-    }
-
-    // std::cout << "Shape: ";
-    // for (const auto& i : shape)
-    // {
-    //     std::cout << i << " ";
-    // }
-    // std::cout << "\nouter_size: " << outer_size << ", inner_size: " << inner_size << std::endl;
-
-    int32_t ret                = 0;
-    size_t output_start_offset = 0;
-
-    for(size_t i = 0; i < inputs.size(); i++)
-    {
-        auto input       = inputs[i];
-        size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
-        size_t copy_size = inner_size * dim_size;
-        // copySizes[i] = copy_size;
-        // std::cout << "\ncopy_size: " << copy_size << ", dim_size: " << dim_size << std::endl;
-        for(size_t o = 0; o < outer_size; o++)
-        {
-            size_t output_offset = output_start_offset + (o * inner_size * output_dim_size);
-            for(size_t j = 0; j < copy_size; j++)
-            {
-                outputhost[output_offset + j] = input[copy_size * o + j];
-            }
-        }
-        output_start_offset += copy_size;
-    }
-
-    const auto t1 = std::chrono::high_resolution_clock::now();
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-
-    std::cout << "Original CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0)
-              << " sec)" << std::endl;
-
-    std::fstream of("/data/Dev/mloCatForwardRunHost.txt", std::ofstream::app);
-    // of << ns << ";";
-
-    // of << outer_size << ";";
-    // for (const auto& s : copySizes)
-    // {
-    //     of << s << ";";
-    // }
-    // of << std::endl;
-
-    of << ns << std::endl;
-
-    return ret;
-}
-
-template <typename Tgpu, typename Tcheck>
-int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& inputDescs,
-                                 const std::vector<Tgpu*>& inputs,
-                                 miopenTensorDescriptor_t outputDesc,
-                                 Tcheck* outputhost,
-                                 uint32_t dim)
-{
-    // std::vector<size_t> copySizes(inputs.size());
-    size_t total_data_size{0};
-    const auto t0                = std::chrono::high_resolution_clock::now();
     const auto& shape            = miopen::deref(outputDesc).GetLengths();
     size_t outer_size            = 1;
     size_t inner_size            = 1;
     const size_t output_dim_size = shape[dim];
+
     for(size_t i = 0; i < dim; ++i)
     {
         outer_size *= shape[i];
@@ -148,20 +72,20 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
     int32_t ret                                = 0;
     size_t output_start_offset                 = 0;
     const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
+    const size_t n                             = inputs.size();
+    const size_t min_grain                     = multi_threaded ? 8 : n;
 
-    for(size_t i = 0; i < inputs.size(); ++i)
-    {
+    miopen::par_for(n, min_grain, [&](size_t i) {
         const auto input                = inputs[i];
         const size_t dim_size           = miopen::deref(inputDescs[i]).GetLengths()[dim];
         const size_t copy_size          = inner_size * dim_size;
         const size_t copy_size_in_bytes = copy_size * sizeof(*outputhost);
-        // copySizes[i] = copy_size;
+
         for(size_t o = 0; o < outer_size; ++o)
         {
             const size_t input_offset  = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            total_data_size += copy_size_in_bytes;
-            // std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
+
             if constexpr(std::is_same_v<Tgpu, Tcheck> && std::is_trivially_copyable_v<Tgpu>)
             {
                 memcpy(&outputhost[output_offset], &input[input_offset], copy_size_in_bytes);
@@ -174,331 +98,9 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
                 }
             }
         }
-        output_start_offset += copy_size;
-    }
 
-    const auto t1 = std::chrono::high_resolution_clock::now();
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-
-    std::cout << "Updated CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0)
-              << " sec)" << std::endl;
-
-    std::fstream of("/data/Dev/mloCatForwardRunHost_upd.txt", std::ofstream::app);
-    of << ns << ";" << total_data_size << ";" << std::endl;
-    // of << ns << ";";// << outer_size << ";";
-    // for (const auto& s : copySizes)
-    // {
-    //     of << s << ";";
-    // }
-    // of << std::endl;
-
-    return ret;
-}
-
-template <typename Tgpu, typename Tcheck>
-int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>& inputDescs,
-                                    const std::vector<Tgpu*>& inputs,
-                                    miopenTensorDescriptor_t outputDesc,
-                                    Tcheck* outputhost,
-                                    uint32_t dim)
-{
-    // std::vector<size_t> copySizes(inputs.size());
-    const auto t0                = std::chrono::high_resolution_clock::now();
-    const auto& shape            = miopen::deref(outputDesc).GetLengths();
-    size_t outer_size            = 1;
-    size_t inner_size            = 1;
-    const size_t output_dim_size = shape[dim];
-    for(size_t i = 0; i < dim; ++i)
-    {
-        outer_size *= shape[i];
-    }
-
-    for(size_t i = dim + 1; i < shape.size(); ++i)
-    {
-        inner_size *= shape[i];
-    }
-
-    int32_t ret                                = 0;
-    size_t output_start_offset                 = 0;
-    const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
-
-    miopen::par_ford(inputs.size())([&](size_t i) {
-        const auto input       = inputs[i];
-        const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
-        const size_t copy_size = inner_size * dim_size;
-        // copySizes[i] = copy_size;
-        miopen::par_ford(outer_size)([&](size_t o) {
-            const size_t input_offset  = copy_size * o;
-            const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            // std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
-            for(size_t j = 0; j < copy_size; j++)
-            {
-                outputhost[output_offset + j] = input[input_offset + j];
-            }
-        });
         output_start_offset += copy_size;
     });
-
-    const auto t1 = std::chrono::high_resolution_clock::now();
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-
-    std::cout << "Updated multi-threaded CPU CAT solver: " << ns << "ns ("
-              << (double(ns) / 1000000000.0) << " sec)" << std::endl;
-
-    std::fstream of("/data/Dev/mloCatForwardRunHost_upd_mt.txt", std::ofstream::app);
-    of << ns; // << ";";// << outer_size << ";";
-    // for (const auto& s : copySizes)
-    // {
-    //     of << s << ";";
-    // }
-    of << std::endl;
-
-    return ret;
-}
-
-template <typename Tgpu, typename Tcheck>
-int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t>& inputDescs,
-                                      const std::vector<Tgpu*>& inputs,
-                                      miopenTensorDescriptor_t outputDesc,
-                                      Tcheck* outputhost,
-                                      uint32_t dim)
-{
-    // std::vector<size_t> copySizes(inputs.size());
-    const auto t0                = std::chrono::high_resolution_clock::now();
-    const auto& shape            = miopen::deref(outputDesc).GetLengths();
-    size_t outer_size            = 1;
-    size_t inner_size            = 1;
-    const size_t output_dim_size = shape[dim];
-    for(size_t i = 0; i < dim; ++i)
-    {
-        outer_size *= shape[i];
-    }
-
-    for(size_t i = dim + 1; i < shape.size(); ++i)
-    {
-        inner_size *= shape[i];
-    }
-
-    int32_t ret                                = 0;
-    size_t output_start_offset                 = 0;
-    const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
-
-    miopen::par_ford(inputs.size())([&](size_t i) {
-        const auto input       = inputs[i];
-        const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
-        const size_t copy_size = inner_size * dim_size;
-        // copySizes[i] = copy_size;
-        for(size_t o = 0; o < outer_size; ++o)
-        {
-            const size_t input_offset  = copy_size * o;
-            const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            // std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
-            for(size_t j = 0; j < copy_size; j++)
-            {
-                outputhost[output_offset + j] = input[input_offset + j];
-            }
-        }
-        output_start_offset += copy_size;
-    });
-
-    const auto t1 = std::chrono::high_resolution_clock::now();
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-
-    std::cout << "Updated multi-threaded CPU CAT solver [2]: " << ns << "ns ("
-              << (double(ns) / 1000000000.0) << " sec)" << std::endl;
-
-    std::fstream of("/data/Dev/mloCatForwardRunHost_upd_mt_2.txt", std::ofstream::app);
-    of << ns; // << ";";// << outer_size << ";";
-    // for (const auto& s : copySizes)
-    // {
-    //     of << s << ";";
-    // }
-    of << std::endl;
-
-    return ret;
-}
-
-template <typename Tgpu, typename Tcheck>
-int32_t mloCatForwardRunHost_upd_2(std::vector<miopenTensorDescriptor_t> inputDescs,
-                                   std::vector<Tgpu*> inputs,
-                                   miopenTensorDescriptor_t outputDesc,
-                                   Tcheck* outputhost,
-                                   uint32_t dim)
-{
-    // std::vector<size_t> copySizes(inputs.size());
-    const auto t0 = std::chrono::high_resolution_clock::now();
-    // Estrai shape e calcola outer/inner come nell'originale
-    auto shape             = miopen::deref(outputDesc).GetLengths();
-    size_t outer_size      = 1;
-    size_t inner_size      = 1;
-    size_t output_dim_size = shape[dim];
-    for(size_t i = 0; i < dim; i++)
-    {
-        outer_size *= shape[i];
-    }
-
-    for(size_t i = dim + 1; i < shape.size(); i++)
-    {
-        inner_size *= shape[i];
-    }
-
-    int32_t ret                = 0;
-    size_t output_start_offset = 0;
-
-    // Per ogni input, copiamo blocchi contigui:
-    // - se Tgpu == Tcheck possiamo memcpyare whole-blocks (più veloce)
-    // - altrimenti facciamo una copia elemento-per-elemento (possibile parallelizzazione)
-    for(size_t i = 0; i < inputs.size(); i++)
-    {
-        const Tgpu* input = inputs[i];
-        size_t dim_size   = miopen::deref(inputDescs[i]).GetLengths()[dim];
-        size_t copy_elems = inner_size * dim_size; // elementi da copiare per ogni 'outer' slice
-        size_t copy_bytes = copy_elems * sizeof(Tgpu);
-        // copySizes[i] = copy_elems;
-
-        // stride (in elementi) nell'output per la dimensione dim totale
-        size_t output_stride_elems = inner_size * output_dim_size;
-
-        // Caso ottimizzato: same type -> memcpy per blocco
-        if(std::is_same<Tgpu, Tcheck>::value)
-        {
-            for(size_t o = 0; o < outer_size; ++o)
-            {
-                size_t out_offset = output_start_offset + (o * output_stride_elems);
-                const void* src   = static_cast<const void*>(input + (o * copy_elems));
-                void* dst         = static_cast<void*>(outputhost + out_offset);
-                // copia contigua di copy_bytes
-                std::memcpy(dst, src, copy_bytes);
-            }
-        }
-        else
-        {
-            // I tipi sono diversi: dobbiamo convertire elemento-per-elemento.
-            for(size_t o = 0; o < outer_size; ++o)
-            {
-                size_t out_offset = output_start_offset + (o * output_stride_elems);
-                const Tgpu* src   = input + (o * copy_elems);
-                Tcheck* dst       = outputhost + out_offset;
-                // conversione elemento-per-elemento
-                for(size_t j = 0; j < copy_elems; ++j)
-                {
-                    dst[j] = static_cast<Tcheck>(src[j]);
-                }
-            }
-        }
-
-        output_start_offset += copy_elems;
-    }
-
-    const auto t1 = std::chrono::high_resolution_clock::now();
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-
-    std::cout << "Updated CPU CAT solver [2]: " << ns << "ns (" << (double(ns) / 1000000000.0)
-              << " sec)" << std::endl;
-
-    std::fstream of("/data/Dev/mloCatForwardRunHost_upd_2.txt", std::ofstream::app);
-    of << ns; // << ";";// << outer_size << ";";
-    // for (const auto& s : copySizes)
-    // {
-    //     of << s << ";";
-    // }
-    of << std::endl;
-
-    return ret;
-}
-
-template <typename Tgpu, typename Tcheck>
-int32_t mloCatForwardRunHost_upd_3(std::vector<miopenTensorDescriptor_t> inputDescs,
-                                   std::vector<Tgpu*> inputs,
-                                   miopenTensorDescriptor_t outputDesc,
-                                   Tcheck* __restrict outputhost,
-                                   uint32_t dim)
-{
-    // std::vector<size_t> copySizes(inputs.size());
-    const auto t0 = std::chrono::high_resolution_clock::now();
-
-    const auto& shape = miopen::deref(outputDesc).GetLengths();
-
-    // Calcola outer e inner size una sola volta
-    size_t outer_size = 1;
-    size_t inner_size = 1;
-    const size_t rank = shape.size();
-    for(size_t i = 0; i < dim; ++i)
-        outer_size *= shape[i];
-    for(size_t i = dim + 1; i < rank; ++i)
-        inner_size *= shape[i];
-
-    const size_t output_dim_size = shape[dim];
-    const size_t output_stride   = inner_size * output_dim_size;
-
-    size_t output_start_offset = 0;
-    int32_t ret                = 0;
-
-    // Scorri tutti gli input concatenati
-    for(size_t i = 0; i < inputs.size(); ++i)
-    {
-        const Tgpu* __restrict input = inputs[i];
-        const auto& in_shape         = miopen::deref(inputDescs[i]).GetLengths();
-        const size_t dim_size        = in_shape[dim];
-        const size_t copy_elems      = inner_size * dim_size;
-        const size_t copy_bytes      = copy_elems * sizeof(Tgpu);
-        // copySizes[i] = copy_elems;
-
-        // Percorso veloce: stesso tipo → blocchi contigui, memcpy
-        if constexpr(std::is_same<Tgpu, Tcheck>::value)
-        {
-            for(size_t o = 0; o < outer_size; ++o)
-            {
-                const Tgpu* src = input + o * copy_elems;
-                Tcheck* dst     = outputhost + output_start_offset + o * output_stride;
-                std::memcpy(dst, src, copy_bytes);
-            }
-        }
-        else
-        {
-            // Percorso conversione: blocchi manuali per locality e prefetch
-            constexpr size_t BLOCK = 16; // tuning: 8–32 va bene per cache L1/L2
-            for(size_t o = 0; o < outer_size; ++o)
-            {
-                const Tgpu* src = input + o * copy_elems;
-                Tcheck* dst     = outputhost + output_start_offset + o * output_stride;
-
-                size_t j           = 0;
-                const size_t limit = copy_elems - (copy_elems % BLOCK);
-
-                // copia a blocchi
-                for(; j < limit; j += BLOCK)
-                {
-                    // Prefetch futura cache line (aiuta per grandi buffer)
-                    __builtin_prefetch(src + j + 64, 0, 0);
-
-// copia blocco manuale
-#pragma unroll
-                    for(size_t k = 0; k < BLOCK; ++k)
-                        dst[j + k] = static_cast<Tcheck>(src[j + k]);
-                }
-                // copia rimanente
-                for(; j < copy_elems; ++j)
-                    dst[j] = static_cast<Tcheck>(src[j]);
-            }
-        }
-
-        output_start_offset += copy_elems;
-    }
-
-    const auto t1 = std::chrono::high_resolution_clock::now();
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-
-    std::cout << "Updated CPU CAT solver [3]: " << ns << "ns (" << (double(ns) / 1000000000.0)
-              << " sec)" << std::endl;
-
-    std::fstream of("/data/Dev/mloCatForwardRunHost_upd_3.txt", std::ofstream::app);
-    of << ns; // << ";";// << outer_size << ";";
-    // for (const auto& s : copySizes)
-    // {
-    //     of << s << ";";
-    // }
-    of << std::endl;
 
     return ret;
 }
@@ -555,12 +157,6 @@ private:
     std::vector<Tgpu> out;
     std::vector<Tref> outhost;
 
-    std::vector<Tref> outhost_upd;
-    std::vector<Tref> outhost_upd_2;
-    std::vector<Tref> outhost_upd_3;
-    std::vector<Tref> outhost_upd_mt;
-    std::vector<Tref> outhost_upd_mt_2;
-
     std::vector<void*> in_devs_ptr;
     std::vector<Tgpu*> ins_ptr;
 
@@ -588,41 +184,16 @@ int CatDriver<Tgpu, Tref>::GetandSetData()
     dim                    = inflags.GetValueInt("dim");
     use_multithread        = (inflags.GetValueInt("mt") != 0);
 
-    // int64_t t = 0;
-
     for(auto in_len : in_lens)
     {
         miopenCreateTensorDescriptor(&inputDesc);
         SetTensorNd(inputDesc, in_len, data_type);
         inputDescs.push_back(inputDesc);
         output_dim_size += in_len[dim];
-
-        // int64_t s = 1;
-
-        // std::cout << "in_len: ";
-
-        // for (const auto i : in_len)
-        // {
-        //     s *= int64_t(i);
-        //     std::cout << i << " ";
-        // }
-
-        // t += s;
-
-        // std::cout << "-> " << s << std::endl;
     }
-    // std::cout << "Tot: " << t << std::endl;
+
     auto out_len = in_lens[0];
     out_len[dim] = output_dim_size;
-
-    // std::cout << "out_len: ";
-
-    // for (const auto i : out_len)
-    // {
-    //     std::cout << i << " ";
-    // }
-
-    // std::cout << std::endl;
 
     SetTensorNd(outputDesc, out_len, data_type);
 
@@ -697,12 +268,6 @@ int CatDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     out     = std::vector<Tgpu>(out_sz, static_cast<Tgpu>(0));
     outhost = std::vector<Tref>(out_sz, static_cast<Tref>(0));
 
-    outhost_upd      = std::vector<Tref>(out_sz, static_cast<Tref>(0));
-    outhost_upd_2    = std::vector<Tref>(out_sz, static_cast<Tref>(0));
-    outhost_upd_3    = std::vector<Tref>(out_sz, static_cast<Tref>(0));
-    outhost_upd_mt   = std::vector<Tref>(out_sz, static_cast<Tref>(0));
-    outhost_upd_mt_2 = std::vector<Tref>(out_sz, static_cast<Tref>(0));
-
     if(out_dev->ToGPU(GetStream(), out.data()) != 0)
         std::cerr << "Error copying (out) to GPU, size: " << out_dev->GetSize() << std::endl;
 
@@ -756,72 +321,8 @@ int CatDriver<Tgpu, Tref>::RunForwardGPU()
 template <typename Tgpu, typename Tref>
 int CatDriver<Tgpu, Tref>::RunForwardCPU()
 {
-    // if constexpr (std::is_same_v<Tgpu, Tref> && std::is_trivially_copyable_v<Tgpu>)
-    // {
-    //     for (size_t i : {10, 100, 1000, 5000, 10000, 50000, 100000, 1000000, 471954865})
-    //     {
-    //         std::vector<Tgpu> vSrc(i);
-    //         std::vector<Tref> vDst(i);
-    //         const size_t byteSize = i * sizeof(vDst[0]);
-    //         const auto* pSrc = vSrc.data();
-    //         auto* pDst = vDst.data();
-
-    //         const auto t0 = std::chrono::high_resolution_clock::now();
-
-    //         for (size_t a = 0; a < ins_ptr.size(); ++a)
-    //         {
-    //             memcpy(pDst, pSrc, byteSize);
-    //         }
-
-    //         const auto t1 = std::chrono::high_resolution_clock::now();
-
-    //         vSrc = std::vector<Tgpu>(i);
-    //         vDst = std::vector<Tref>(i);
-    //         pSrc = vSrc.data();
-    //         pDst = vDst.data();
-
-    //         const auto t2 = std::chrono::high_resolution_clock::now();
-
-    //         for (size_t a = 0; a < ins_ptr.size(); ++a)
-    //         {
-    //             for (auto j = 0; j < i; ++j)
-    //             {
-    //                 pDst[j] = pSrc[j];
-    //             }
-    //         }
-
-    //         const auto t3 = std::chrono::high_resolution_clock::now();
-
-    //         const auto nsMemcpy = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 -
-    //         t0).count(); const auto nsFor =
-    //         std::chrono::duration_cast<std::chrono::nanoseconds>(t3 - t2).count();
-
-    //         std::cout
-    //             << "Copia di " << i << " elementi:\n"
-    //             << "    memcpy: " << nsMemcpy << "ns (" << (double(nsMemcpy) / 1000000000.0) <<
-    //             "s)\n"
-    //             << "    for: " << nsFor << "ns (" << (double(nsFor) / 1000000000.0) << "s)\n"
-    //             << std::endl
-    //             ;
-    //     }
-    // }
-
-    mloCatForwardRunHost<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost.data(), dim);
-
-    mloCatForwardRunHost_upd<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd.data(), dim);
-
-    mloCatForwardRunHost_upd_2<Tgpu, Tref>(
-        inputDescs, ins_ptr, outputDesc, outhost_upd_2.data(), dim);
-
-    mloCatForwardRunHost_upd_3<Tgpu, Tref>(
-        inputDescs, ins_ptr, outputDesc, outhost_upd_3.data(), dim);
-
-    mloCatForwardRunHost_upd_mt<Tgpu, Tref>(
-        inputDescs, ins_ptr, outputDesc, outhost_upd_mt.data(), dim);
-
-    mloCatForwardRunHost_upd_mt_2<Tgpu, Tref>(
-        inputDescs, ins_ptr, outputDesc, outhost_upd_mt_2.data(), dim);
-
+    mloCatForwardRunHost<Tgpu, Tref>(
+        inputDescs, ins_ptr, outputDesc, outhost.data(), dim, use_multithread);
     return miopenStatusSuccess;
 }
 
@@ -835,78 +336,18 @@ template <typename Tgpu, typename Tref>
 int CatDriver<Tgpu, Tref>::VerifyForward()
 {
     RunForwardCPU();
-    const auto error          = miopen::rms_range(outhost, out);
-    const auto error_upd      = miopen::rms_range(outhost_upd, out);
-    const auto error_upd_2    = miopen::rms_range(outhost_upd_2, out);
-    const auto error_upd_3    = miopen::rms_range(outhost_upd_3, out);
-    const auto error_upd_mt   = miopen::rms_range(outhost_upd_mt, out);
-    const auto error_upd_mt_2 = miopen::rms_range(outhost_upd_mt_2, out);
+    const auto error     = miopen::rms_range(outhost, out);
+    const char* pRefType = use_multithread ? "multi-threaded" : "single-threaded";
 
     if(!std::isfinite(error) || error != 0)
     {
-        std::cout << "Forward Cat FAILED against original CPU reference: " << error << " > 0"
-                  << std::endl;
-        return EC_VerifyFwd;
-    }
-    else
-    {
-        std::cout << "Forward Cat Verifies OK on CPU reference" << std::endl;
-    }
-
-    if(!std::isfinite(error_upd) || error_upd != 0)
-    {
-        std::cout << "Forward Cat FAILED against updated CPU reference: " << error_upd << " > 0"
-                  << std::endl;
-        return EC_VerifyFwd;
-    }
-    else
-    {
-        std::cout << "Forward Cat Verifies OK on updated CPU reference" << std::endl;
-    }
-
-    if(!std::isfinite(error_upd_2) || error_upd_2 != 0)
-    {
-        std::cout << "Forward Cat FAILED against updated CPU reference [2]: " << error_upd_2
+        std::cout << "Forward Cat FAILED against " << pRefType << " CPU reference: " << error
                   << " > 0" << std::endl;
         return EC_VerifyFwd;
     }
     else
     {
-        std::cout << "Forward Cat Verifies OK on updated CPU reference [2]" << std::endl;
-    }
-
-    if(!std::isfinite(error_upd_3) || error_upd_3 != 0)
-    {
-        std::cout << "Forward Cat FAILED against updated CPU reference [3]: " << error_upd_2
-                  << " > 0" << std::endl;
-        return EC_VerifyFwd;
-    }
-    else
-    {
-        std::cout << "Forward Cat Verifies OK on updated CPU reference [3]" << std::endl;
-    }
-
-    if(!std::isfinite(error_upd_mt) || error_upd_mt != 0)
-    {
-        std::cout << "Forward Cat FAILED against updated multi-threaded CPU reference: "
-                  << error_upd_mt << " > 0" << std::endl;
-        return EC_VerifyFwd;
-    }
-    else
-    {
-        std::cout << "Forward Cat Verifies OK on updated multi-threaded CPU reference" << std::endl;
-    }
-
-    if(!std::isfinite(error_upd_mt_2) || error_upd_mt_2 != 0)
-    {
-        std::cout << "Forward Cat FAILED against updated multi-threaded CPU reference [2]: "
-                  << error_upd_mt_2 << " > 0" << std::endl;
-        return EC_VerifyFwd;
-    }
-    else
-    {
-        std::cout << "Forward Cat Verifies OK on updated multi-threaded CPU reference [2]"
-                  << std::endl;
+        std::cout << "Forward Cat Verifies OK on " << pRefType << " CPU reference" << std::endl;
     }
 
     return miopenStatusSuccess;

--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -102,8 +102,8 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
 }
 
 template <typename Tgpu, typename Tcheck>
-int32_t mloCatForwardRunHost_upd(std::vector<miopenTensorDescriptor_t> inputDescs,
-                             std::vector<Tgpu*> inputs,
+int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& inputDescs,
+                             const std::vector<Tgpu*>& inputs,
                              miopenTensorDescriptor_t outputDesc,
                              Tcheck* outputhost,
                              uint32_t dim)
@@ -127,7 +127,7 @@ int32_t mloCatForwardRunHost_upd(std::vector<miopenTensorDescriptor_t> inputDesc
     size_t output_start_offset = 0;
     const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
 
-    for(size_t i = 0; i < inputs.size(); i++)
+    for(size_t i = 0; i < inputs.size(); ++i)
     {
         const auto input       = inputs[i];
         const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
@@ -136,10 +136,7 @@ int32_t mloCatForwardRunHost_upd(std::vector<miopenTensorDescriptor_t> inputDesc
         {
             const size_t copy_size_by_o = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            for(size_t j = 0; j < copy_size; j++)
-            {
-                outputhost[output_offset + j] = input[copy_size_by_o + j];
-            }
+            std::copy_n(&input[copy_size_by_o], copy_size, &outputhost[output_offset]);
         }
         output_start_offset += copy_size;
     }
@@ -156,8 +153,8 @@ int32_t mloCatForwardRunHost_upd(std::vector<miopenTensorDescriptor_t> inputDesc
 }
 
 template <typename Tgpu, typename Tcheck>
-int32_t mloCatForwardRunHost_upd_mt(std::vector<miopenTensorDescriptor_t> inputDescs,
-                             std::vector<Tgpu*> inputs,
+int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>& inputDescs,
+                             const std::vector<Tgpu*>& inputs,
                              miopenTensorDescriptor_t outputDesc,
                              Tcheck* outputhost,
                              uint32_t dim)
@@ -188,10 +185,7 @@ int32_t mloCatForwardRunHost_upd_mt(std::vector<miopenTensorDescriptor_t> inputD
         par_ford(outer_size)([&](size_t o){
             const size_t copy_size_by_o = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            for(size_t j = 0; j < copy_size; j++)
-            {
-                outputhost[output_offset + j] = input[copy_size_by_o + j];
-            }            
+            std::copy_n(&input[copy_size_by_o], copy_size, &outputhost[output_offset]);
         });
         output_start_offset += copy_size;
     });
@@ -202,6 +196,56 @@ int32_t mloCatForwardRunHost_upd_mt(std::vector<miopenTensorDescriptor_t> inputD
     std::cout << "Updated multi-threaded CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost_upd_mt.txt", std::ofstream::app);
+    of << ns << std::endl;
+
+    return ret;
+}
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t>& inputDescs,
+                             const std::vector<Tgpu*>& inputs,
+                             miopenTensorDescriptor_t outputDesc,
+                             Tcheck* outputhost,
+                             uint32_t dim)
+{
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    const auto& shape               = miopen::deref(outputDesc).GetLengths();
+    size_t outer_size               = 1;
+    size_t inner_size               = 1;
+    const size_t output_dim_size    = shape[dim];
+    for(size_t i = 0; i < dim; i++)
+    {
+        outer_size *= shape[i];
+    }
+
+    for(size_t i = dim + 1; i < shape.size(); i++)
+    {
+        inner_size *= shape[i];
+    }
+
+    int32_t ret                = 0;
+    size_t output_start_offset = 0;
+    const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
+
+    par_ford(inputs.size())([&](size_t i){
+        const auto input       = inputs[i];
+        const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
+        const size_t copy_size = inner_size * dim_size;
+        for (size_t o = 0; o < outer_size; ++o)
+        {
+            const size_t copy_size_by_o = copy_size * o;
+            const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
+            std::copy_n(&input[copy_size_by_o], copy_size, &outputhost[output_offset]);
+        }
+        output_start_offset += copy_size;
+    });
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+    std::cout << "Updated multi-threaded CPU CAT solver [2]: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+
+    std::fstream of("/data/Dev/mloCatForwardRunHost_upd_mt_2.txt", std::ofstream::app);
     of << ns << std::endl;
 
     return ret;
@@ -261,6 +305,7 @@ private:
 
     std::vector<Tref> outhost_upd;
     std::vector<Tref> outhost_upd_mt;
+    std::vector<Tref> outhost_upd_mt_2;
 
     std::vector<void*> in_devs_ptr;
     std::vector<Tgpu*> ins_ptr;
@@ -369,6 +414,7 @@ int CatDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 
     outhost_upd = std::vector<Tref>(out_sz, static_cast<Tref>(0));
     outhost_upd_mt = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+    outhost_upd_mt_2 = std::vector<Tref>(out_sz, static_cast<Tref>(0));
 
     if(out_dev->ToGPU(GetStream(), out.data()) != 0)
         std::cerr << "Error copying (out) to GPU, size: " << out_dev->GetSize() << std::endl;
@@ -429,6 +475,8 @@ int CatDriver<Tgpu, Tref>::RunForwardCPU()
 
     mloCatForwardRunHost_upd_mt<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_mt.data(), dim);
 
+    mloCatForwardRunHost_upd_mt_2<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_mt_2.data(), dim);
+
     return miopenStatusSuccess;
 }
 
@@ -442,9 +490,10 @@ template <typename Tgpu, typename Tref>
 int CatDriver<Tgpu, Tref>::VerifyForward()
 {
     RunForwardCPU();
-    auto error = miopen::rms_range(outhost, out);
-    auto error_upd = miopen::rms_range(outhost_upd, out);
-    auto error_upd_mt = miopen::rms_range(outhost_upd_mt, out);
+    const auto error = miopen::rms_range(outhost, out);
+    const auto error_upd = miopen::rms_range(outhost_upd, out);
+    const auto error_upd_mt = miopen::rms_range(outhost_upd_mt, out);
+    const auto error_upd_mt_2 = miopen::rms_range(outhost_upd_mt_2, out);
 
     if(!std::isfinite(error) || error != 0)
     {
@@ -474,6 +523,16 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
     else
     {
         std::cout << "Forward Cat Verifies OK on updated multi-threaded CPU reference" << std::endl;
+    }
+
+    if(!std::isfinite(error_upd_mt_2) || error_upd_mt_2 != 0)
+    {
+        std::cout << "Forward Cat FAILED against updated multi-threaded CPU reference [2]: " << error_upd_mt_2 << " > 0" << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        std::cout << "Forward Cat Verifies OK on updated multi-threaded CPU reference [2]" << std::endl;
     }
 
     return miopenStatusSuccess;

--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -56,6 +56,7 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
                              Tcheck* outputhost,
                              uint32_t dim)
 {
+    // std::vector<size_t> copySizes(inputs.size());
     const auto t0 = std::chrono::high_resolution_clock::now();
     auto shape             = miopen::deref(outputDesc).GetLengths();
     size_t outer_size      = 1;
@@ -71,6 +72,13 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
         inner_size *= shape[i];
     }
 
+    // std::cout << "Shape: ";
+    // for (const auto& i : shape)
+    // {
+    //     std::cout << i << " ";
+    // }
+    // std::cout << "\nouter_size: " << outer_size << ", inner_size: " << inner_size << std::endl;
+
     int32_t ret                = 0;
     size_t output_start_offset = 0;
 
@@ -79,6 +87,8 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
         auto input       = inputs[i];
         size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
         size_t copy_size = inner_size * dim_size;
+        // copySizes[i] = copy_size;
+        // std::cout << "\ncopy_size: " << copy_size << ", dim_size: " << dim_size << std::endl;
         for(size_t o = 0; o < outer_size; o++)
         {
             size_t output_offset = output_start_offset + (o * inner_size * output_dim_size);
@@ -96,6 +106,15 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
     std::cout << "Original CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost.txt", std::ofstream::app);
+    // of << ns << ";";
+
+    // of << outer_size << ";";
+    // for (const auto& s : copySizes)
+    // {
+    //     of << s << ";";
+    // }
+    // of << std::endl;
+
     of << ns << std::endl;
 
     return ret;
@@ -108,6 +127,8 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
                              Tcheck* outputhost,
                              uint32_t dim)
 {
+    // std::vector<size_t> copySizes(inputs.size());
+    size_t total_data_size {0};
     const auto t0 = std::chrono::high_resolution_clock::now();
     const auto& shape               = miopen::deref(outputDesc).GetLengths();
     size_t outer_size               = 1;
@@ -127,16 +148,30 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
     size_t output_start_offset = 0;
     const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
 
-    for(size_t i = 0; i < inputs.size(); ++i)
+    for (size_t i = 0; i < inputs.size(); ++i)
     {
         const auto input       = inputs[i];
         const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
         const size_t copy_size = inner_size * dim_size;
-        for(size_t o = 0; o < outer_size; o++)
+        const size_t copy_size_in_bytes = copy_size * sizeof(*outputhost);
+        // copySizes[i] = copy_size;
+        for(size_t o = 0; o < outer_size; ++o)
         {
             const size_t input_offset = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
+            total_data_size += copy_size_in_bytes;
+            // std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
+            if constexpr (std::is_same_v<Tgpu, Tcheck> && std::is_trivially_copyable_v<Tgpu>)
+            {
+                memcpy(&outputhost[output_offset], &input[input_offset], copy_size_in_bytes);
+            }
+            else
+            {
+                for (size_t j = 0; j < copy_size; ++j)
+                {
+                    outputhost[output_offset + j] = input[input_offset + j];
+                }
+            }
         }
         output_start_offset += copy_size;
     }
@@ -147,7 +182,13 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
     std::cout << "Updated CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost_upd.txt", std::ofstream::app);
-    of << ns << std::endl;
+    of << ns << ";" << total_data_size << ";" << std::endl;
+    // of << ns << ";";// << outer_size << ";";
+    // for (const auto& s : copySizes)
+    // {
+    //     of << s << ";";
+    // }
+    // of << std::endl;
 
     return ret;
 }
@@ -159,6 +200,7 @@ int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>&
                              Tcheck* outputhost,
                              uint32_t dim)
 {
+    // std::vector<size_t> copySizes(inputs.size());
     const auto t0 = std::chrono::high_resolution_clock::now();
     const auto& shape               = miopen::deref(outputDesc).GetLengths();
     size_t outer_size               = 1;
@@ -182,10 +224,15 @@ int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>&
         const auto input       = inputs[i];
         const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
         const size_t copy_size = inner_size * dim_size;
+        // copySizes[i] = copy_size;
         par_ford(outer_size)([&](size_t o){
             const size_t input_offset = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
+            // std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
+            for (size_t j = 0; j < copy_size; j++)
+            {
+                outputhost[output_offset + j] = input[input_offset + j];
+            }
         });
         output_start_offset += copy_size;
     });
@@ -196,7 +243,12 @@ int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>&
     std::cout << "Updated multi-threaded CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost_upd_mt.txt", std::ofstream::app);
-    of << ns << std::endl;
+    of << ns; // << ";";// << outer_size << ";";
+    // for (const auto& s : copySizes)
+    // {
+    //     of << s << ";";
+    // }
+    of << std::endl;
 
     return ret;
 }
@@ -208,6 +260,7 @@ int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t
                              Tcheck* outputhost,
                              uint32_t dim)
 {
+    // std::vector<size_t> copySizes(inputs.size());
     const auto t0 = std::chrono::high_resolution_clock::now();
     const auto& shape               = miopen::deref(outputDesc).GetLengths();
     size_t outer_size               = 1;
@@ -231,11 +284,16 @@ int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t
         const auto input       = inputs[i];
         const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
         const size_t copy_size = inner_size * dim_size;
+        // copySizes[i] = copy_size;
         for (size_t o = 0; o < outer_size; ++o)
         {
             const size_t input_offset = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
+            // std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
+            for (size_t j = 0; j < copy_size; j++)
+            {
+                outputhost[output_offset + j] = input[input_offset + j];
+            }
         }
         output_start_offset += copy_size;
     });
@@ -246,7 +304,195 @@ int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t
     std::cout << "Updated multi-threaded CPU CAT solver [2]: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost_upd_mt_2.txt", std::ofstream::app);
-    of << ns << std::endl;
+    of << ns; // << ";";// << outer_size << ";";
+    // for (const auto& s : copySizes)
+    // {
+    //     of << s << ";";
+    // }
+    of << std::endl;
+
+    return ret;
+}
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloCatForwardRunHost_upd_2(std::vector<miopenTensorDescriptor_t> inputDescs,
+                             std::vector<Tgpu*> inputs,
+                             miopenTensorDescriptor_t outputDesc,
+                             Tcheck* outputhost,
+                             uint32_t dim)
+{
+    // std::vector<size_t> copySizes(inputs.size());
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    // Estrai shape e calcola outer/inner come nell'originale
+    auto shape             = miopen::deref(outputDesc).GetLengths();
+    size_t outer_size      = 1;
+    size_t inner_size      = 1;
+    size_t output_dim_size = shape[dim];
+    for(size_t i = 0; i < dim; i++)
+    {
+        outer_size *= shape[i];
+    }
+
+    for(size_t i = dim + 1; i < shape.size(); i++)
+    {
+        inner_size *= shape[i];
+    }
+
+    int32_t ret                = 0;
+    size_t output_start_offset = 0;
+
+    // Per ogni input, copiamo blocchi contigui:
+    // - se Tgpu == Tcheck possiamo memcpyare whole-blocks (più veloce)
+    // - altrimenti facciamo una copia elemento-per-elemento (possibile parallelizzazione)
+    for(size_t i = 0; i < inputs.size(); i++)
+    {
+        const Tgpu* input = inputs[i];
+        size_t dim_size   = miopen::deref(inputDescs[i]).GetLengths()[dim];
+        size_t copy_elems = inner_size * dim_size; // elementi da copiare per ogni 'outer' slice
+        size_t copy_bytes = copy_elems * sizeof(Tgpu);
+        // copySizes[i] = copy_elems;
+
+        // stride (in elementi) nell'output per la dimensione dim totale
+        size_t output_stride_elems = inner_size * output_dim_size;
+
+        // Caso ottimizzato: same type -> memcpy per blocco
+        if(std::is_same<Tgpu, Tcheck>::value)
+        {
+            for(size_t o = 0; o < outer_size; ++o)
+            {
+                size_t out_offset = output_start_offset + (o * output_stride_elems);
+                const void* src   = static_cast<const void*>(input + (o * copy_elems));
+                void* dst         = static_cast<void*>(outputhost + out_offset);
+                // copia contigua di copy_bytes
+                std::memcpy(dst, src, copy_bytes);
+            }
+        }
+        else
+        {
+            // I tipi sono diversi: dobbiamo convertire elemento-per-elemento.
+            for(size_t o = 0; o < outer_size; ++o)
+            {
+                size_t out_offset = output_start_offset + (o * output_stride_elems);
+                const Tgpu* src   = input + (o * copy_elems);
+                Tcheck* dst       = outputhost + out_offset;
+                // conversione elemento-per-elemento
+                for(size_t j = 0; j < copy_elems; ++j)
+                {
+                    dst[j] = static_cast<Tcheck>(src[j]);
+                }
+            }
+        }
+
+        output_start_offset += copy_elems;
+    }
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+    std::cout << "Updated CPU CAT solver [2]: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+
+    std::fstream of("/data/Dev/mloCatForwardRunHost_upd_2.txt", std::ofstream::app);
+    of << ns; // << ";";// << outer_size << ";";
+    // for (const auto& s : copySizes)
+    // {
+    //     of << s << ";";
+    // }
+    of << std::endl;
+
+    return ret;
+}
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloCatForwardRunHost_upd_3(std::vector<miopenTensorDescriptor_t> inputDescs,
+                             std::vector<Tgpu*> inputs,
+                             miopenTensorDescriptor_t outputDesc,
+                             Tcheck* __restrict outputhost,
+                             uint32_t dim)
+{
+    // std::vector<size_t> copySizes(inputs.size());
+    const auto t0 = std::chrono::high_resolution_clock::now();
+
+    const auto& shape = miopen::deref(outputDesc).GetLengths();
+
+    // Calcola outer e inner size una sola volta
+    size_t outer_size = 1;
+    size_t inner_size = 1;
+    const size_t rank = shape.size();
+    for(size_t i = 0; i < dim; ++i)
+        outer_size *= shape[i];
+    for(size_t i = dim + 1; i < rank; ++i)
+        inner_size *= shape[i];
+
+    const size_t output_dim_size = shape[dim];
+    const size_t output_stride   = inner_size * output_dim_size;
+
+    size_t output_start_offset = 0;
+    int32_t ret = 0;
+
+    // Scorri tutti gli input concatenati
+    for(size_t i = 0; i < inputs.size(); ++i)
+    {
+        const Tgpu* __restrict input = inputs[i];
+        const auto& in_shape = miopen::deref(inputDescs[i]).GetLengths();
+        const size_t dim_size = in_shape[dim];
+        const size_t copy_elems = inner_size * dim_size;
+        const size_t copy_bytes = copy_elems * sizeof(Tgpu);
+        // copySizes[i] = copy_elems;
+
+        // Percorso veloce: stesso tipo → blocchi contigui, memcpy
+        if constexpr (std::is_same<Tgpu, Tcheck>::value)
+        {
+            for(size_t o = 0; o < outer_size; ++o)
+            {
+                const Tgpu* src = input + o * copy_elems;
+                Tcheck* dst     = outputhost + output_start_offset + o * output_stride;
+                std::memcpy(dst, src, copy_bytes);
+            }
+        }
+        else
+        {
+            // Percorso conversione: blocchi manuali per locality e prefetch
+            constexpr size_t BLOCK = 16; // tuning: 8–32 va bene per cache L1/L2
+            for(size_t o = 0; o < outer_size; ++o)
+            {
+                const Tgpu* src = input + o * copy_elems;
+                Tcheck* dst     = outputhost + output_start_offset + o * output_stride;
+
+                size_t j = 0;
+                const size_t limit = copy_elems - (copy_elems % BLOCK);
+
+                // copia a blocchi
+                for(; j < limit; j += BLOCK)
+                {
+                    // Prefetch futura cache line (aiuta per grandi buffer)
+                    __builtin_prefetch(src + j + 64, 0, 0);
+
+                    // copia blocco manuale
+                    #pragma unroll
+                    for(size_t k = 0; k < BLOCK; ++k)
+                        dst[j + k] = static_cast<Tcheck>(src[j + k]);
+                }
+                // copia rimanente
+                for(; j < copy_elems; ++j)
+                    dst[j] = static_cast<Tcheck>(src[j]);
+            }
+        }
+
+        output_start_offset += copy_elems;
+    }
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+    std::cout << "Updated CPU CAT solver [3]: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+
+    std::fstream of("/data/Dev/mloCatForwardRunHost_upd_3.txt", std::ofstream::app);
+    of << ns; // << ";";// << outer_size << ";";
+    // for (const auto& s : copySizes)
+    // {
+    //     of << s << ";";
+    // }
+    of << std::endl;
 
     return ret;
 }
@@ -304,6 +550,8 @@ private:
     std::vector<Tref> outhost;
 
     std::vector<Tref> outhost_upd;
+    std::vector<Tref> outhost_upd_2;
+    std::vector<Tref> outhost_upd_3;
     std::vector<Tref> outhost_upd_mt;
     std::vector<Tref> outhost_upd_mt_2;
 
@@ -331,7 +579,7 @@ int CatDriver<Tgpu, Tref>::GetandSetData()
     auto in_lens           = GetInputTensorLengthsFromCmdLine();
     dim                    = inflags.GetValueInt("dim");
 
-    int64_t t = 0;
+    // int64_t t = 0;
 
     for(auto in_len : in_lens)
     {
@@ -340,21 +588,32 @@ int CatDriver<Tgpu, Tref>::GetandSetData()
         inputDescs.push_back(inputDesc);
         output_dim_size += in_len[dim];
 
-        int64_t s = 1;
+        // int64_t s = 1;
 
-        for (const auto i : in_len)
-        {
-            s *= int64_t(i);
-            std::cout << i << " ";
-        }
+        // std::cout << "in_len: ";
 
-        t += s;
+        // for (const auto i : in_len)
+        // {
+        //     s *= int64_t(i);
+        //     std::cout << i << " ";
+        // }
 
-        std::cout << "-> " << s << std::endl;
+        // t += s;
+
+        // std::cout << "-> " << s << std::endl;
     }
-    std::cout << "Tot: " << t << std::endl;
+    // std::cout << "Tot: " << t << std::endl;
     auto out_len = in_lens[0];
     out_len[dim] = output_dim_size;
+
+    // std::cout << "out_len: ";
+
+    // for (const auto i : out_len)
+    // {
+    //     std::cout << i << " ";
+    // }
+
+    // std::cout << std::endl;
 
     SetTensorNd(outputDesc, out_len, data_type);
 
@@ -428,6 +687,8 @@ int CatDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     outhost = std::vector<Tref>(out_sz, static_cast<Tref>(0));
 
     outhost_upd = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+    outhost_upd_2 = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+    outhost_upd_3 = std::vector<Tref>(out_sz, static_cast<Tref>(0));
     outhost_upd_mt = std::vector<Tref>(out_sz, static_cast<Tref>(0));
     outhost_upd_mt_2 = std::vector<Tref>(out_sz, static_cast<Tref>(0));
 
@@ -484,9 +745,61 @@ int CatDriver<Tgpu, Tref>::RunForwardGPU()
 template <typename Tgpu, typename Tref>
 int CatDriver<Tgpu, Tref>::RunForwardCPU()
 {
+    // if constexpr (std::is_same_v<Tgpu, Tref> && std::is_trivially_copyable_v<Tgpu>)
+    // {
+    //     for (size_t i : {10, 100, 1000, 5000, 10000, 50000, 100000, 1000000, 471954865})
+    //     {
+    //         std::vector<Tgpu> vSrc(i);
+    //         std::vector<Tref> vDst(i);
+    //         const size_t byteSize = i * sizeof(vDst[0]);
+    //         const auto* pSrc = vSrc.data();
+    //         auto* pDst = vDst.data();
+
+    //         const auto t0 = std::chrono::high_resolution_clock::now();
+
+    //         for (size_t a = 0; a < ins_ptr.size(); ++a)
+    //         {
+    //             memcpy(pDst, pSrc, byteSize);
+    //         }
+
+    //         const auto t1 = std::chrono::high_resolution_clock::now();
+
+    //         vSrc = std::vector<Tgpu>(i);
+    //         vDst = std::vector<Tref>(i);
+    //         pSrc = vSrc.data();
+    //         pDst = vDst.data();
+
+    //         const auto t2 = std::chrono::high_resolution_clock::now();
+
+    //         for (size_t a = 0; a < ins_ptr.size(); ++a)
+    //         {
+    //             for (auto j = 0; j < i; ++j)
+    //             {
+    //                 pDst[j] = pSrc[j];
+    //             }
+    //         }
+
+    //         const auto t3 = std::chrono::high_resolution_clock::now();
+
+    //         const auto nsMemcpy = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+    //         const auto nsFor = std::chrono::duration_cast<std::chrono::nanoseconds>(t3 - t2).count();
+
+    //         std::cout
+    //             << "Copia di " << i << " elementi:\n"
+    //             << "    memcpy: " << nsMemcpy << "ns (" << (double(nsMemcpy) / 1000000000.0) << "s)\n"
+    //             << "    for: " << nsFor << "ns (" << (double(nsFor) / 1000000000.0) << "s)\n"
+    //             << std::endl
+    //             ;
+    //     }
+    // }
+
     mloCatForwardRunHost<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost.data(), dim);
 
     mloCatForwardRunHost_upd<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd.data(), dim);
+
+    mloCatForwardRunHost_upd_2<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_2.data(), dim);
+
+    mloCatForwardRunHost_upd_3<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_3.data(), dim);
 
     mloCatForwardRunHost_upd_mt<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_mt.data(), dim);
 
@@ -507,6 +820,8 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
     RunForwardCPU();
     const auto error = miopen::rms_range(outhost, out);
     const auto error_upd = miopen::rms_range(outhost_upd, out);
+    const auto error_upd_2 = miopen::rms_range(outhost_upd_2, out);
+    const auto error_upd_3 = miopen::rms_range(outhost_upd_3, out);
     const auto error_upd_mt = miopen::rms_range(outhost_upd_mt, out);
     const auto error_upd_mt_2 = miopen::rms_range(outhost_upd_mt_2, out);
 
@@ -528,6 +843,26 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
     else
     {
         std::cout << "Forward Cat Verifies OK on updated CPU reference" << std::endl;
+    }
+
+    if(!std::isfinite(error_upd_2) || error_upd_2 != 0)
+    {
+        std::cout << "Forward Cat FAILED against updated CPU reference [2]: " << error_upd_2 << " > 0" << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        std::cout << "Forward Cat Verifies OK on updated CPU reference [2]" << std::endl;
+    }
+
+    if(!std::isfinite(error_upd_3) || error_upd_3 != 0)
+    {
+        std::cout << "Forward Cat FAILED against updated CPU reference [3]: " << error_upd_2 << " > 0" << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        std::cout << "Forward Cat Verifies OK on updated CPU reference [3]" << std::endl;
     }
 
     if(!std::isfinite(error_upd_mt) || error_upd_mt != 0)

--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -113,12 +113,12 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
     size_t outer_size               = 1;
     size_t inner_size               = 1;
     const size_t output_dim_size    = shape[dim];
-    for(size_t i = 0; i < dim; i++)
+    for(size_t i = 0; i < dim; ++i)
     {
         outer_size *= shape[i];
     }
 
-    for(size_t i = dim + 1; i < shape.size(); i++)
+    for(size_t i = dim + 1; i < shape.size(); ++i)
     {
         inner_size *= shape[i];
     }
@@ -134,9 +134,9 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
         const size_t copy_size = inner_size * dim_size;
         for(size_t o = 0; o < outer_size; o++)
         {
-            const size_t copy_size_by_o = copy_size * o;
+            const size_t input_offset = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            std::copy_n(&input[copy_size_by_o], copy_size, &outputhost[output_offset]);
+            std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
         }
         output_start_offset += copy_size;
     }
@@ -164,12 +164,12 @@ int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>&
     size_t outer_size               = 1;
     size_t inner_size               = 1;
     const size_t output_dim_size    = shape[dim];
-    for(size_t i = 0; i < dim; i++)
+    for(size_t i = 0; i < dim; ++i)
     {
         outer_size *= shape[i];
     }
 
-    for(size_t i = dim + 1; i < shape.size(); i++)
+    for(size_t i = dim + 1; i < shape.size(); ++i)
     {
         inner_size *= shape[i];
     }
@@ -183,9 +183,9 @@ int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>&
         const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
         const size_t copy_size = inner_size * dim_size;
         par_ford(outer_size)([&](size_t o){
-            const size_t copy_size_by_o = copy_size * o;
+            const size_t input_offset = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            std::copy_n(&input[copy_size_by_o], copy_size, &outputhost[output_offset]);
+            std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
         });
         output_start_offset += copy_size;
     });
@@ -213,12 +213,12 @@ int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t
     size_t outer_size               = 1;
     size_t inner_size               = 1;
     const size_t output_dim_size    = shape[dim];
-    for(size_t i = 0; i < dim; i++)
+    for(size_t i = 0; i < dim; ++i)
     {
         outer_size *= shape[i];
     }
 
-    for(size_t i = dim + 1; i < shape.size(); i++)
+    for(size_t i = dim + 1; i < shape.size(); ++i)
     {
         inner_size *= shape[i];
     }
@@ -233,9 +233,9 @@ int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t
         const size_t copy_size = inner_size * dim_size;
         for (size_t o = 0; o < outer_size; ++o)
         {
-            const size_t copy_size_by_o = copy_size * o;
+            const size_t input_offset = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
-            std::copy_n(&input[copy_size_by_o], copy_size, &outputhost[output_offset]);
+            std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
         }
         output_start_offset += copy_size;
     });

--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -331,13 +331,28 @@ int CatDriver<Tgpu, Tref>::GetandSetData()
     auto in_lens           = GetInputTensorLengthsFromCmdLine();
     dim                    = inflags.GetValueInt("dim");
 
+    int64_t t = 0;
+
     for(auto in_len : in_lens)
     {
         miopenCreateTensorDescriptor(&inputDesc);
         SetTensorNd(inputDesc, in_len, data_type);
         inputDescs.push_back(inputDesc);
         output_dim_size += in_len[dim];
+
+        int64_t s = 1;
+
+        for (const auto i : in_len)
+        {
+            s *= int64_t(i);
+            std::cout << i << " ";
+        }
+
+        t += s;
+
+        std::cout << "-> " << s << std::endl;
     }
+    std::cout << "Tot: " << t << std::endl;
     auto out_len = in_lens[0];
     out_len[dim] = output_dim_size;
 

--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -42,6 +42,10 @@
 #include <../test/tensor_holder.hpp>
 #include <../test/verify.hpp>
 
+#include <fstream>
+#include <iostream>
+#include <../test/ford.hpp>
+
 #ifndef MLO_CATHOST_H_
 #define MLO_CATHOST_H_
 
@@ -52,6 +56,7 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
                              Tcheck* outputhost,
                              uint32_t dim)
 {
+    const auto t0 = std::chrono::high_resolution_clock::now();
     auto shape             = miopen::deref(outputDesc).GetLengths();
     size_t outer_size      = 1;
     size_t inner_size      = 1;
@@ -84,6 +89,120 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
         }
         output_start_offset += copy_size;
     }
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+    std::cout << "Original CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+
+    std::fstream of("/data/Dev/mloCatForwardRunHost.txt", std::ofstream::app);
+    of << ns << std::endl;
+
+    return ret;
+}
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloCatForwardRunHost_upd(std::vector<miopenTensorDescriptor_t> inputDescs,
+                             std::vector<Tgpu*> inputs,
+                             miopenTensorDescriptor_t outputDesc,
+                             Tcheck* outputhost,
+                             uint32_t dim)
+{
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    const auto& shape               = miopen::deref(outputDesc).GetLengths();
+    size_t outer_size               = 1;
+    size_t inner_size               = 1;
+    const size_t output_dim_size    = shape[dim];
+    for(size_t i = 0; i < dim; i++)
+    {
+        outer_size *= shape[i];
+    }
+
+    for(size_t i = dim + 1; i < shape.size(); i++)
+    {
+        inner_size *= shape[i];
+    }
+
+    int32_t ret                = 0;
+    size_t output_start_offset = 0;
+    const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
+
+    for(size_t i = 0; i < inputs.size(); i++)
+    {
+        const auto input       = inputs[i];
+        const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
+        const size_t copy_size = inner_size * dim_size;
+        for(size_t o = 0; o < outer_size; o++)
+        {
+            const size_t copy_size_by_o = copy_size * o;
+            const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
+            for(size_t j = 0; j < copy_size; j++)
+            {
+                outputhost[output_offset + j] = input[copy_size_by_o + j];
+            }
+        }
+        output_start_offset += copy_size;
+    }
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+    std::cout << "Updated CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+
+    std::fstream of("/data/Dev/mloCatForwardRunHost_upd.txt", std::ofstream::app);
+    of << ns << std::endl;
+
+    return ret;
+}
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloCatForwardRunHost_upd_mt(std::vector<miopenTensorDescriptor_t> inputDescs,
+                             std::vector<Tgpu*> inputs,
+                             miopenTensorDescriptor_t outputDesc,
+                             Tcheck* outputhost,
+                             uint32_t dim)
+{
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    const auto& shape               = miopen::deref(outputDesc).GetLengths();
+    size_t outer_size               = 1;
+    size_t inner_size               = 1;
+    const size_t output_dim_size    = shape[dim];
+    for(size_t i = 0; i < dim; i++)
+    {
+        outer_size *= shape[i];
+    }
+
+    for(size_t i = dim + 1; i < shape.size(); i++)
+    {
+        inner_size *= shape[i];
+    }
+
+    int32_t ret                = 0;
+    size_t output_start_offset = 0;
+    const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
+
+    par_ford(inputs.size())([&](size_t i){
+        const auto input       = inputs[i];
+        const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
+        const size_t copy_size = inner_size * dim_size;
+        par_ford(outer_size)([&](size_t o){
+            const size_t copy_size_by_o = copy_size * o;
+            const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
+            for(size_t j = 0; j < copy_size; j++)
+            {
+                outputhost[output_offset + j] = input[copy_size_by_o + j];
+            }            
+        });
+        output_start_offset += copy_size;
+    });
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+    std::cout << "Updated multi-threaded CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+
+    std::fstream of("/data/Dev/mloCatForwardRunHost_upd_mt.txt", std::ofstream::app);
+    of << ns << std::endl;
 
     return ret;
 }
@@ -139,6 +258,9 @@ private:
     std::vector<std::vector<Tgpu>> ins;
     std::vector<Tgpu> out;
     std::vector<Tref> outhost;
+
+    std::vector<Tref> outhost_upd;
+    std::vector<Tref> outhost_upd_mt;
 
     std::vector<void*> in_devs_ptr;
     std::vector<Tgpu*> ins_ptr;
@@ -245,6 +367,9 @@ int CatDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     out     = std::vector<Tgpu>(out_sz, static_cast<Tgpu>(0));
     outhost = std::vector<Tref>(out_sz, static_cast<Tref>(0));
 
+    outhost_upd = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+    outhost_upd_mt = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+
     if(out_dev->ToGPU(GetStream(), out.data()) != 0)
         std::cerr << "Error copying (out) to GPU, size: " << out_dev->GetSize() << std::endl;
 
@@ -300,6 +425,10 @@ int CatDriver<Tgpu, Tref>::RunForwardCPU()
 {
     mloCatForwardRunHost<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost.data(), dim);
 
+    mloCatForwardRunHost_upd<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd.data(), dim);
+
+    mloCatForwardRunHost_upd_mt<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_mt.data(), dim);
+
     return miopenStatusSuccess;
 }
 
@@ -314,15 +443,37 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
 {
     RunForwardCPU();
     auto error = miopen::rms_range(outhost, out);
+    auto error_upd = miopen::rms_range(outhost_upd, out);
+    auto error_upd_mt = miopen::rms_range(outhost_upd_mt, out);
 
     if(!std::isfinite(error) || error != 0)
     {
-        std::cout << "Forward Cat FAILED: " << error << " > 0" << std::endl;
+        std::cout << "Forward Cat FAILED against original CPU reference: " << error << " > 0" << std::endl;
         return EC_VerifyFwd;
     }
     else
     {
         std::cout << "Forward Cat Verifies OK on CPU reference" << std::endl;
+    }
+
+    if(!std::isfinite(error_upd) || error_upd != 0)
+    {
+        std::cout << "Forward Cat FAILED against updated CPU reference: " << error_upd << " > 0" << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        std::cout << "Forward Cat Verifies OK on updated CPU reference" << std::endl;
+    }
+
+    if(!std::isfinite(error_upd_mt) || error_upd_mt != 0)
+    {
+        std::cout << "Forward Cat FAILED against updated multi-threaded CPU reference: " << error_upd_mt << " > 0" << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        std::cout << "Forward Cat Verifies OK on updated multi-threaded CPU reference" << std::endl;
     }
 
     return miopenStatusSuccess;

--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef GUARD_MIOPEN_CAT_DRIVER_HPP
 #define GUARD_MIOPEN_CAT_DRIVER_HPP
 
@@ -55,9 +33,9 @@ int32_t mloCatForwardRunHost(const std::vector<miopenTensorDescriptor_t>& inputD
                              bool multi_threaded)
 {
     const auto& shape            = miopen::deref(outputDesc).GetLengths();
+    const size_t output_dim_size = shape[dim];
     size_t outer_size            = 1;
     size_t inner_size            = 1;
-    const size_t output_dim_size = shape[dim];
 
     for(size_t i = 0; i < dim; ++i)
     {
@@ -69,22 +47,41 @@ int32_t mloCatForwardRunHost(const std::vector<miopenTensorDescriptor_t>& inputD
         inner_size *= shape[i];
     }
 
-    int32_t ret                                = 0;
-    size_t output_start_offset                 = 0;
     const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
     const size_t n                             = inputs.size();
-    const size_t min_grain                     = multi_threaded ? 8 : n;
+    const size_t min_grain                     = multi_threaded ? 1 : n;
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // 1. Precompute output start offsets to avoid race conditions in the multi-threaded version.
+    // 2. Cache copy_size values, since they are needed by the start offsets computation anyway.
+    std::vector<size_t> copy_sizes;
+    std::vector<size_t> output_start_offsets;
+
+    copy_sizes.reserve(n);
+    output_start_offsets.reserve(n);
+
+    copy_sizes.emplace_back(inner_size * miopen::deref(inputDescs[0]).GetLengths()[dim]);
+    output_start_offsets.emplace_back(0);
+
+    for(size_t i{1}; i < n; ++i)
+    {
+        const size_t dim_size = miopen::deref(inputDescs[i]).GetLengths()[dim];
+
+        output_start_offsets.emplace_back(output_start_offsets.back() + copy_sizes.back());
+        copy_sizes.emplace_back(inner_size * dim_size);
+    }
+    /////////////////////////////////////////////////////////////////////////////////////////////
 
     miopen::par_for(n, min_grain, [&](size_t i) {
         const auto input                = inputs[i];
-        const size_t dim_size           = miopen::deref(inputDescs[i]).GetLengths()[dim];
-        const size_t copy_size          = inner_size * dim_size;
+        const size_t copy_size          = copy_sizes[i];
         const size_t copy_size_in_bytes = copy_size * sizeof(*outputhost);
 
         for(size_t o = 0; o < outer_size; ++o)
         {
-            const size_t input_offset  = copy_size * o;
-            const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
+            const size_t input_offset = copy_size * o;
+            const size_t output_offset =
+                output_start_offsets[i] + (o * inner_size_by_output_dim_size);
 
             if constexpr(std::is_same_v<Tgpu, Tcheck> && std::is_trivially_copyable_v<Tgpu>)
             {
@@ -98,11 +95,9 @@ int32_t mloCatForwardRunHost(const std::vector<miopenTensorDescriptor_t>& inputD
                 }
             }
         }
-
-        output_start_offset += copy_size;
     });
 
-    return ret;
+    return 0;
 }
 
 #endif
@@ -231,7 +226,7 @@ std::vector<std::vector<int>> CatDriver<Tgpu, Tref>::GetInputTensorLengthsFromCm
     const int max_input_count = 8;
     std::vector<std::vector<int>> ret;
     std::string name = "input";
-    for(int i = 1; i < max_input_count; i++)
+    for(int i = 1; i <= max_input_count; i++)
     {
         auto tensor = inflags.GetValueTensor(name + std::to_string(i));
         if(!tensor.lengths.empty())

--- a/projects/miopen/driver/cat_driver.hpp
+++ b/projects/miopen/driver/cat_driver.hpp
@@ -44,7 +44,7 @@
 
 #include <fstream>
 #include <iostream>
-#include <../test/ford.hpp>
+#include <miopen/ford.hpp>
 
 #ifndef MLO_CATHOST_H_
 #define MLO_CATHOST_H_
@@ -57,7 +57,7 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
                              uint32_t dim)
 {
     // std::vector<size_t> copySizes(inputs.size());
-    const auto t0 = std::chrono::high_resolution_clock::now();
+    const auto t0          = std::chrono::high_resolution_clock::now();
     auto shape             = miopen::deref(outputDesc).GetLengths();
     size_t outer_size      = 1;
     size_t inner_size      = 1;
@@ -103,7 +103,8 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
     const auto t1 = std::chrono::high_resolution_clock::now();
     const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
 
-    std::cout << "Original CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+    std::cout << "Original CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0)
+              << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost.txt", std::ofstream::app);
     // of << ns << ";";
@@ -122,18 +123,18 @@ int32_t mloCatForwardRunHost(std::vector<miopenTensorDescriptor_t> inputDescs,
 
 template <typename Tgpu, typename Tcheck>
 int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& inputDescs,
-                             const std::vector<Tgpu*>& inputs,
-                             miopenTensorDescriptor_t outputDesc,
-                             Tcheck* outputhost,
-                             uint32_t dim)
+                                 const std::vector<Tgpu*>& inputs,
+                                 miopenTensorDescriptor_t outputDesc,
+                                 Tcheck* outputhost,
+                                 uint32_t dim)
 {
     // std::vector<size_t> copySizes(inputs.size());
-    size_t total_data_size {0};
-    const auto t0 = std::chrono::high_resolution_clock::now();
-    const auto& shape               = miopen::deref(outputDesc).GetLengths();
-    size_t outer_size               = 1;
-    size_t inner_size               = 1;
-    const size_t output_dim_size    = shape[dim];
+    size_t total_data_size{0};
+    const auto t0                = std::chrono::high_resolution_clock::now();
+    const auto& shape            = miopen::deref(outputDesc).GetLengths();
+    size_t outer_size            = 1;
+    size_t inner_size            = 1;
+    const size_t output_dim_size = shape[dim];
     for(size_t i = 0; i < dim; ++i)
     {
         outer_size *= shape[i];
@@ -144,30 +145,30 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
         inner_size *= shape[i];
     }
 
-    int32_t ret                = 0;
-    size_t output_start_offset = 0;
+    int32_t ret                                = 0;
+    size_t output_start_offset                 = 0;
     const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
 
-    for (size_t i = 0; i < inputs.size(); ++i)
+    for(size_t i = 0; i < inputs.size(); ++i)
     {
-        const auto input       = inputs[i];
-        const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
-        const size_t copy_size = inner_size * dim_size;
+        const auto input                = inputs[i];
+        const size_t dim_size           = miopen::deref(inputDescs[i]).GetLengths()[dim];
+        const size_t copy_size          = inner_size * dim_size;
         const size_t copy_size_in_bytes = copy_size * sizeof(*outputhost);
         // copySizes[i] = copy_size;
         for(size_t o = 0; o < outer_size; ++o)
         {
-            const size_t input_offset = copy_size * o;
+            const size_t input_offset  = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
             total_data_size += copy_size_in_bytes;
             // std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
-            if constexpr (std::is_same_v<Tgpu, Tcheck> && std::is_trivially_copyable_v<Tgpu>)
+            if constexpr(std::is_same_v<Tgpu, Tcheck> && std::is_trivially_copyable_v<Tgpu>)
             {
                 memcpy(&outputhost[output_offset], &input[input_offset], copy_size_in_bytes);
             }
             else
             {
-                for (size_t j = 0; j < copy_size; ++j)
+                for(size_t j = 0; j < copy_size; ++j)
                 {
                     outputhost[output_offset + j] = input[input_offset + j];
                 }
@@ -179,7 +180,8 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
     const auto t1 = std::chrono::high_resolution_clock::now();
     const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
 
-    std::cout << "Updated CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+    std::cout << "Updated CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0)
+              << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost_upd.txt", std::ofstream::app);
     of << ns << ";" << total_data_size << ";" << std::endl;
@@ -195,17 +197,17 @@ int32_t mloCatForwardRunHost_upd(const std::vector<miopenTensorDescriptor_t>& in
 
 template <typename Tgpu, typename Tcheck>
 int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>& inputDescs,
-                             const std::vector<Tgpu*>& inputs,
-                             miopenTensorDescriptor_t outputDesc,
-                             Tcheck* outputhost,
-                             uint32_t dim)
+                                    const std::vector<Tgpu*>& inputs,
+                                    miopenTensorDescriptor_t outputDesc,
+                                    Tcheck* outputhost,
+                                    uint32_t dim)
 {
     // std::vector<size_t> copySizes(inputs.size());
-    const auto t0 = std::chrono::high_resolution_clock::now();
-    const auto& shape               = miopen::deref(outputDesc).GetLengths();
-    size_t outer_size               = 1;
-    size_t inner_size               = 1;
-    const size_t output_dim_size    = shape[dim];
+    const auto t0                = std::chrono::high_resolution_clock::now();
+    const auto& shape            = miopen::deref(outputDesc).GetLengths();
+    size_t outer_size            = 1;
+    size_t inner_size            = 1;
+    const size_t output_dim_size = shape[dim];
     for(size_t i = 0; i < dim; ++i)
     {
         outer_size *= shape[i];
@@ -216,20 +218,20 @@ int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>&
         inner_size *= shape[i];
     }
 
-    int32_t ret                = 0;
-    size_t output_start_offset = 0;
+    int32_t ret                                = 0;
+    size_t output_start_offset                 = 0;
     const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
 
-    par_ford(inputs.size())([&](size_t i){
+    miopen::par_ford(inputs.size())([&](size_t i) {
         const auto input       = inputs[i];
         const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
         const size_t copy_size = inner_size * dim_size;
         // copySizes[i] = copy_size;
-        par_ford(outer_size)([&](size_t o){
-            const size_t input_offset = copy_size * o;
+        miopen::par_ford(outer_size)([&](size_t o) {
+            const size_t input_offset  = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
             // std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
-            for (size_t j = 0; j < copy_size; j++)
+            for(size_t j = 0; j < copy_size; j++)
             {
                 outputhost[output_offset + j] = input[input_offset + j];
             }
@@ -240,7 +242,8 @@ int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>&
     const auto t1 = std::chrono::high_resolution_clock::now();
     const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
 
-    std::cout << "Updated multi-threaded CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+    std::cout << "Updated multi-threaded CPU CAT solver: " << ns << "ns ("
+              << (double(ns) / 1000000000.0) << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost_upd_mt.txt", std::ofstream::app);
     of << ns; // << ";";// << outer_size << ";";
@@ -255,17 +258,17 @@ int32_t mloCatForwardRunHost_upd_mt(const std::vector<miopenTensorDescriptor_t>&
 
 template <typename Tgpu, typename Tcheck>
 int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t>& inputDescs,
-                             const std::vector<Tgpu*>& inputs,
-                             miopenTensorDescriptor_t outputDesc,
-                             Tcheck* outputhost,
-                             uint32_t dim)
+                                      const std::vector<Tgpu*>& inputs,
+                                      miopenTensorDescriptor_t outputDesc,
+                                      Tcheck* outputhost,
+                                      uint32_t dim)
 {
     // std::vector<size_t> copySizes(inputs.size());
-    const auto t0 = std::chrono::high_resolution_clock::now();
-    const auto& shape               = miopen::deref(outputDesc).GetLengths();
-    size_t outer_size               = 1;
-    size_t inner_size               = 1;
-    const size_t output_dim_size    = shape[dim];
+    const auto t0                = std::chrono::high_resolution_clock::now();
+    const auto& shape            = miopen::deref(outputDesc).GetLengths();
+    size_t outer_size            = 1;
+    size_t inner_size            = 1;
+    const size_t output_dim_size = shape[dim];
     for(size_t i = 0; i < dim; ++i)
     {
         outer_size *= shape[i];
@@ -276,21 +279,21 @@ int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t
         inner_size *= shape[i];
     }
 
-    int32_t ret                = 0;
-    size_t output_start_offset = 0;
+    int32_t ret                                = 0;
+    size_t output_start_offset                 = 0;
     const size_t inner_size_by_output_dim_size = inner_size * output_dim_size;
 
-    par_ford(inputs.size())([&](size_t i){
+    miopen::par_ford(inputs.size())([&](size_t i) {
         const auto input       = inputs[i];
         const size_t dim_size  = miopen::deref(inputDescs[i]).GetLengths()[dim];
         const size_t copy_size = inner_size * dim_size;
         // copySizes[i] = copy_size;
-        for (size_t o = 0; o < outer_size; ++o)
+        for(size_t o = 0; o < outer_size; ++o)
         {
-            const size_t input_offset = copy_size * o;
+            const size_t input_offset  = copy_size * o;
             const size_t output_offset = output_start_offset + (o * inner_size_by_output_dim_size);
             // std::copy_n(&input[input_offset], copy_size, &outputhost[output_offset]);
-            for (size_t j = 0; j < copy_size; j++)
+            for(size_t j = 0; j < copy_size; j++)
             {
                 outputhost[output_offset + j] = input[input_offset + j];
             }
@@ -301,7 +304,8 @@ int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t
     const auto t1 = std::chrono::high_resolution_clock::now();
     const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
 
-    std::cout << "Updated multi-threaded CPU CAT solver [2]: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+    std::cout << "Updated multi-threaded CPU CAT solver [2]: " << ns << "ns ("
+              << (double(ns) / 1000000000.0) << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost_upd_mt_2.txt", std::ofstream::app);
     of << ns; // << ";";// << outer_size << ";";
@@ -316,10 +320,10 @@ int32_t mloCatForwardRunHost_upd_mt_2(const std::vector<miopenTensorDescriptor_t
 
 template <typename Tgpu, typename Tcheck>
 int32_t mloCatForwardRunHost_upd_2(std::vector<miopenTensorDescriptor_t> inputDescs,
-                             std::vector<Tgpu*> inputs,
-                             miopenTensorDescriptor_t outputDesc,
-                             Tcheck* outputhost,
-                             uint32_t dim)
+                                   std::vector<Tgpu*> inputs,
+                                   miopenTensorDescriptor_t outputDesc,
+                                   Tcheck* outputhost,
+                                   uint32_t dim)
 {
     // std::vector<size_t> copySizes(inputs.size());
     const auto t0 = std::chrono::high_resolution_clock::now();
@@ -389,7 +393,8 @@ int32_t mloCatForwardRunHost_upd_2(std::vector<miopenTensorDescriptor_t> inputDe
     const auto t1 = std::chrono::high_resolution_clock::now();
     const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
 
-    std::cout << "Updated CPU CAT solver [2]: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+    std::cout << "Updated CPU CAT solver [2]: " << ns << "ns (" << (double(ns) / 1000000000.0)
+              << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost_upd_2.txt", std::ofstream::app);
     of << ns; // << ";";// << outer_size << ";";
@@ -404,10 +409,10 @@ int32_t mloCatForwardRunHost_upd_2(std::vector<miopenTensorDescriptor_t> inputDe
 
 template <typename Tgpu, typename Tcheck>
 int32_t mloCatForwardRunHost_upd_3(std::vector<miopenTensorDescriptor_t> inputDescs,
-                             std::vector<Tgpu*> inputs,
-                             miopenTensorDescriptor_t outputDesc,
-                             Tcheck* __restrict outputhost,
-                             uint32_t dim)
+                                   std::vector<Tgpu*> inputs,
+                                   miopenTensorDescriptor_t outputDesc,
+                                   Tcheck* __restrict outputhost,
+                                   uint32_t dim)
 {
     // std::vector<size_t> copySizes(inputs.size());
     const auto t0 = std::chrono::high_resolution_clock::now();
@@ -427,20 +432,20 @@ int32_t mloCatForwardRunHost_upd_3(std::vector<miopenTensorDescriptor_t> inputDe
     const size_t output_stride   = inner_size * output_dim_size;
 
     size_t output_start_offset = 0;
-    int32_t ret = 0;
+    int32_t ret                = 0;
 
     // Scorri tutti gli input concatenati
     for(size_t i = 0; i < inputs.size(); ++i)
     {
         const Tgpu* __restrict input = inputs[i];
-        const auto& in_shape = miopen::deref(inputDescs[i]).GetLengths();
-        const size_t dim_size = in_shape[dim];
-        const size_t copy_elems = inner_size * dim_size;
-        const size_t copy_bytes = copy_elems * sizeof(Tgpu);
+        const auto& in_shape         = miopen::deref(inputDescs[i]).GetLengths();
+        const size_t dim_size        = in_shape[dim];
+        const size_t copy_elems      = inner_size * dim_size;
+        const size_t copy_bytes      = copy_elems * sizeof(Tgpu);
         // copySizes[i] = copy_elems;
 
         // Percorso veloce: stesso tipo → blocchi contigui, memcpy
-        if constexpr (std::is_same<Tgpu, Tcheck>::value)
+        if constexpr(std::is_same<Tgpu, Tcheck>::value)
         {
             for(size_t o = 0; o < outer_size; ++o)
             {
@@ -458,7 +463,7 @@ int32_t mloCatForwardRunHost_upd_3(std::vector<miopenTensorDescriptor_t> inputDe
                 const Tgpu* src = input + o * copy_elems;
                 Tcheck* dst     = outputhost + output_start_offset + o * output_stride;
 
-                size_t j = 0;
+                size_t j           = 0;
                 const size_t limit = copy_elems - (copy_elems % BLOCK);
 
                 // copia a blocchi
@@ -467,8 +472,8 @@ int32_t mloCatForwardRunHost_upd_3(std::vector<miopenTensorDescriptor_t> inputDe
                     // Prefetch futura cache line (aiuta per grandi buffer)
                     __builtin_prefetch(src + j + 64, 0, 0);
 
-                    // copia blocco manuale
-                    #pragma unroll
+// copia blocco manuale
+#pragma unroll
                     for(size_t k = 0; k < BLOCK; ++k)
                         dst[j + k] = static_cast<Tcheck>(src[j + k]);
                 }
@@ -484,7 +489,8 @@ int32_t mloCatForwardRunHost_upd_3(std::vector<miopenTensorDescriptor_t> inputDe
     const auto t1 = std::chrono::high_resolution_clock::now();
     const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
 
-    std::cout << "Updated CPU CAT solver [3]: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+    std::cout << "Updated CPU CAT solver [3]: " << ns << "ns (" << (double(ns) / 1000000000.0)
+              << " sec)" << std::endl;
 
     std::fstream of("/data/Dev/mloCatForwardRunHost_upd_3.txt", std::ofstream::app);
     of << ns; // << ";";// << outer_size << ";";
@@ -557,6 +563,8 @@ private:
 
     std::vector<void*> in_devs_ptr;
     std::vector<Tgpu*> ins_ptr;
+
+    bool use_multithread = false;
 };
 
 template <typename Tgpu, typename Tref>
@@ -578,6 +586,7 @@ int CatDriver<Tgpu, Tref>::GetandSetData()
     size_t output_dim_size = 0;
     auto in_lens           = GetInputTensorLengthsFromCmdLine();
     dim                    = inflags.GetValueInt("dim");
+    use_multithread        = (inflags.GetValueInt("mt") != 0);
 
     // int64_t t = 0;
 
@@ -640,6 +649,8 @@ int CatDriver<Tgpu, Tref>::AddCmdLineArgs()
     inflags.AddInputFlag(
         "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
 
+    inflags.AddInputFlag("mt", 'M', "0", "Use multithreaded version (Default=0)", "int");
+
     return miopenStatusSuccess;
 }
 
@@ -686,10 +697,10 @@ int CatDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     out     = std::vector<Tgpu>(out_sz, static_cast<Tgpu>(0));
     outhost = std::vector<Tref>(out_sz, static_cast<Tref>(0));
 
-    outhost_upd = std::vector<Tref>(out_sz, static_cast<Tref>(0));
-    outhost_upd_2 = std::vector<Tref>(out_sz, static_cast<Tref>(0));
-    outhost_upd_3 = std::vector<Tref>(out_sz, static_cast<Tref>(0));
-    outhost_upd_mt = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+    outhost_upd      = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+    outhost_upd_2    = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+    outhost_upd_3    = std::vector<Tref>(out_sz, static_cast<Tref>(0));
+    outhost_upd_mt   = std::vector<Tref>(out_sz, static_cast<Tref>(0));
     outhost_upd_mt_2 = std::vector<Tref>(out_sz, static_cast<Tref>(0));
 
     if(out_dev->ToGPU(GetStream(), out.data()) != 0)
@@ -781,12 +792,14 @@ int CatDriver<Tgpu, Tref>::RunForwardCPU()
 
     //         const auto t3 = std::chrono::high_resolution_clock::now();
 
-    //         const auto nsMemcpy = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-    //         const auto nsFor = std::chrono::duration_cast<std::chrono::nanoseconds>(t3 - t2).count();
+    //         const auto nsMemcpy = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 -
+    //         t0).count(); const auto nsFor =
+    //         std::chrono::duration_cast<std::chrono::nanoseconds>(t3 - t2).count();
 
     //         std::cout
     //             << "Copia di " << i << " elementi:\n"
-    //             << "    memcpy: " << nsMemcpy << "ns (" << (double(nsMemcpy) / 1000000000.0) << "s)\n"
+    //             << "    memcpy: " << nsMemcpy << "ns (" << (double(nsMemcpy) / 1000000000.0) <<
+    //             "s)\n"
     //             << "    for: " << nsFor << "ns (" << (double(nsFor) / 1000000000.0) << "s)\n"
     //             << std::endl
     //             ;
@@ -797,13 +810,17 @@ int CatDriver<Tgpu, Tref>::RunForwardCPU()
 
     mloCatForwardRunHost_upd<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd.data(), dim);
 
-    mloCatForwardRunHost_upd_2<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_2.data(), dim);
+    mloCatForwardRunHost_upd_2<Tgpu, Tref>(
+        inputDescs, ins_ptr, outputDesc, outhost_upd_2.data(), dim);
 
-    mloCatForwardRunHost_upd_3<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_3.data(), dim);
+    mloCatForwardRunHost_upd_3<Tgpu, Tref>(
+        inputDescs, ins_ptr, outputDesc, outhost_upd_3.data(), dim);
 
-    mloCatForwardRunHost_upd_mt<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_mt.data(), dim);
+    mloCatForwardRunHost_upd_mt<Tgpu, Tref>(
+        inputDescs, ins_ptr, outputDesc, outhost_upd_mt.data(), dim);
 
-    mloCatForwardRunHost_upd_mt_2<Tgpu, Tref>(inputDescs, ins_ptr, outputDesc, outhost_upd_mt_2.data(), dim);
+    mloCatForwardRunHost_upd_mt_2<Tgpu, Tref>(
+        inputDescs, ins_ptr, outputDesc, outhost_upd_mt_2.data(), dim);
 
     return miopenStatusSuccess;
 }
@@ -818,16 +835,17 @@ template <typename Tgpu, typename Tref>
 int CatDriver<Tgpu, Tref>::VerifyForward()
 {
     RunForwardCPU();
-    const auto error = miopen::rms_range(outhost, out);
-    const auto error_upd = miopen::rms_range(outhost_upd, out);
-    const auto error_upd_2 = miopen::rms_range(outhost_upd_2, out);
-    const auto error_upd_3 = miopen::rms_range(outhost_upd_3, out);
-    const auto error_upd_mt = miopen::rms_range(outhost_upd_mt, out);
+    const auto error          = miopen::rms_range(outhost, out);
+    const auto error_upd      = miopen::rms_range(outhost_upd, out);
+    const auto error_upd_2    = miopen::rms_range(outhost_upd_2, out);
+    const auto error_upd_3    = miopen::rms_range(outhost_upd_3, out);
+    const auto error_upd_mt   = miopen::rms_range(outhost_upd_mt, out);
     const auto error_upd_mt_2 = miopen::rms_range(outhost_upd_mt_2, out);
 
     if(!std::isfinite(error) || error != 0)
     {
-        std::cout << "Forward Cat FAILED against original CPU reference: " << error << " > 0" << std::endl;
+        std::cout << "Forward Cat FAILED against original CPU reference: " << error << " > 0"
+                  << std::endl;
         return EC_VerifyFwd;
     }
     else
@@ -837,7 +855,8 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
 
     if(!std::isfinite(error_upd) || error_upd != 0)
     {
-        std::cout << "Forward Cat FAILED against updated CPU reference: " << error_upd << " > 0" << std::endl;
+        std::cout << "Forward Cat FAILED against updated CPU reference: " << error_upd << " > 0"
+                  << std::endl;
         return EC_VerifyFwd;
     }
     else
@@ -847,7 +866,8 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
 
     if(!std::isfinite(error_upd_2) || error_upd_2 != 0)
     {
-        std::cout << "Forward Cat FAILED against updated CPU reference [2]: " << error_upd_2 << " > 0" << std::endl;
+        std::cout << "Forward Cat FAILED against updated CPU reference [2]: " << error_upd_2
+                  << " > 0" << std::endl;
         return EC_VerifyFwd;
     }
     else
@@ -857,7 +877,8 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
 
     if(!std::isfinite(error_upd_3) || error_upd_3 != 0)
     {
-        std::cout << "Forward Cat FAILED against updated CPU reference [3]: " << error_upd_2 << " > 0" << std::endl;
+        std::cout << "Forward Cat FAILED against updated CPU reference [3]: " << error_upd_2
+                  << " > 0" << std::endl;
         return EC_VerifyFwd;
     }
     else
@@ -867,7 +888,8 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
 
     if(!std::isfinite(error_upd_mt) || error_upd_mt != 0)
     {
-        std::cout << "Forward Cat FAILED against updated multi-threaded CPU reference: " << error_upd_mt << " > 0" << std::endl;
+        std::cout << "Forward Cat FAILED against updated multi-threaded CPU reference: "
+                  << error_upd_mt << " > 0" << std::endl;
         return EC_VerifyFwd;
     }
     else
@@ -877,12 +899,14 @@ int CatDriver<Tgpu, Tref>::VerifyForward()
 
     if(!std::isfinite(error_upd_mt_2) || error_upd_mt_2 != 0)
     {
-        std::cout << "Forward Cat FAILED against updated multi-threaded CPU reference [2]: " << error_upd_mt_2 << " > 0" << std::endl;
+        std::cout << "Forward Cat FAILED against updated multi-threaded CPU reference [2]: "
+                  << error_upd_mt_2 << " > 0" << std::endl;
         return EC_VerifyFwd;
     }
     else
     {
-        std::cout << "Forward Cat Verifies OK on updated multi-threaded CPU reference [2]" << std::endl;
+        std::cout << "Forward Cat Verifies OK on updated multi-threaded CPU reference [2]"
+                  << std::endl;
     }
 
     return miopenStatusSuccess;

--- a/projects/miopen/test/cpu_cat.hpp
+++ b/projects/miopen/test/cpu_cat.hpp
@@ -26,11 +26,15 @@
 #ifndef GUARD_CPU_CAT_HPP
 #define GUARD_CPU_CAT_HPP
 
+#include <fstream>
+#include <iostream>
+
 #include "tensor_holder.hpp"
 
 template <class T>
 void cpu_cat_forward(std::vector<tensor<T>> inputs, tensor<T>& ref_output, int32_t dim)
 {
+    const auto t0 = std::chrono::high_resolution_clock::now();
     auto dims              = ref_output.desc.GetLengths();
     size_t output_dim_size = dims[dim];
     size_t outer_size      = 1;
@@ -62,5 +66,109 @@ void cpu_cat_forward(std::vector<tensor<T>> inputs, tensor<T>& ref_output, int32
 
         output_start_offset += copy_size;
     });
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+    std::cout << "Original CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+
+    std::fstream of("/data/Dev/cpu_cat_forward.txt", std::ofstream::app);
+    of << ns << std::endl;
 }
+
+template <class T>
+void cpu_cat_forward_upd(std::vector<tensor<T>> inputs, tensor<T>& ref_output, int32_t dim)
+{
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    const auto& dims                = ref_output.desc.GetLengths();
+    const size_t output_dim_size    = dims[dim];
+    size_t outer_size               = 1;
+    size_t inner_size               = 1;
+    size_t i                        = 0;
+    for(; i < dim; i++)
+    {
+        outer_size *= dims[i];
+    }
+
+    for(; i < dims.size(); i++)
+    {
+        inner_size *= dims[i];
+    }
+
+    const size_t inner_size_on_output_dim_size = inner_size / output_dim_size;
+    size_t output_start_offset = 0;
+
+    par_ford(inputs.size())([&](int32_t i) {
+        const auto& input       = inputs[i];
+        const size_t dim_size   = inputs[i].desc.GetLengths()[dim];
+        const size_t copy_size  = inner_size_on_output_dim_size * dim_size;
+        const size_t input_size = outer_size * copy_size;
+        ford(input_size)([&](int32_t o) {
+            const size_t outer_idx = o / copy_size;
+            const size_t copy_idx  = o % copy_size;
+            ref_output[output_start_offset + (outer_idx * inner_size) + copy_idx] =
+                input[copy_size * outer_idx + copy_idx];
+        });
+
+        output_start_offset += copy_size;
+    });
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+    std::cout << "Updated CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+
+    std::fstream of("/data/Dev/cpu_cat_forward_upd.txt", std::ofstream::app);
+    of << ns << std::endl;
+}
+
+template <class T>
+void cpu_cat_forward_upd_st(std::vector<tensor<T>> inputs, tensor<T>& ref_output, int32_t dim)
+{
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    const auto& dims                = ref_output.desc.GetLengths();
+    const size_t output_dim_size    = dims[dim];
+    size_t outer_size               = 1;
+    size_t inner_size               = 1;
+    size_t i                        = 0;
+    for(; i < dim; i++)
+    {
+        outer_size *= dims[i];
+    }
+
+    for(; i < dims.size(); i++)
+    {
+        inner_size *= dims[i];
+    }
+
+    const size_t inner_size_on_output_dim_size = inner_size / output_dim_size;
+    size_t output_start_offset = 0;
+
+    for (size_t i = 0; i < inputs.size(); ++i)
+    {
+        const auto& input       = inputs[i];
+        const size_t dim_size   = inputs[i].desc.GetLengths()[dim];
+        const size_t copy_size  = inner_size_on_output_dim_size * dim_size;
+        const size_t input_size = outer_size * copy_size;
+
+        for (size_t o = 0; o < input_size; ++o)
+        {
+            const size_t outer_idx = o / copy_size;
+            const size_t copy_idx  = o % copy_size;
+            ref_output[output_start_offset + (outer_idx * inner_size) + copy_idx] =
+                input[copy_size * outer_idx + copy_idx];            
+        }
+
+        output_start_offset += copy_size;
+    }
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+    std::cout << "Updated single-threaded CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
+
+    std::fstream of("/data/Dev/cpu_cat_forward_upd_st.txt", std::ofstream::app);
+    of << ns << std::endl;
+}
+
 #endif

--- a/projects/miopen/test/cpu_cat.hpp
+++ b/projects/miopen/test/cpu_cat.hpp
@@ -98,12 +98,12 @@ void cpu_cat_forward_upd(std::vector<tensor<T>> inputs, tensor<T>& ref_output, i
     const size_t inner_size_on_output_dim_size = inner_size / output_dim_size;
     size_t output_start_offset = 0;
 
-    par_ford(inputs.size())([&](int32_t i) {
+    par_ford(inputs.size())([&](size_t i) {
         const auto& input       = inputs[i];
         const size_t dim_size   = inputs[i].desc.GetLengths()[dim];
         const size_t copy_size  = inner_size_on_output_dim_size * dim_size;
         const size_t input_size = outer_size * copy_size;
-        ford(input_size)([&](int32_t o) {
+        ford(input_size)([&](size_t o) {
             const size_t outer_idx = o / copy_size;
             const size_t copy_idx  = o % copy_size;
             ref_output[output_start_offset + (outer_idx * inner_size) + copy_idx] =

--- a/projects/miopen/test/cpu_cat.hpp
+++ b/projects/miopen/test/cpu_cat.hpp
@@ -32,8 +32,9 @@
 #include "tensor_holder.hpp"
 
 template <class T>
-void cpu_cat_forward(std::vector<tensor<T>> inputs, tensor<T>& ref_output, int32_t dim)
+void cpu_cat_forward(const std::vector<tensor<T>>& inputs, tensor<T>& ref_output, int32_t dim)
 {
+<<<<<<< HEAD
     const auto t0 = std::chrono::high_resolution_clock::now();
     auto dims              = ref_output.desc.GetLengths();
     size_t output_dim_size = dims[dim];
@@ -80,6 +81,8 @@ template <class T>
 void cpu_cat_forward_upd(std::vector<tensor<T>> inputs, tensor<T>& ref_output, int32_t dim)
 {
     const auto t0 = std::chrono::high_resolution_clock::now();
+=======
+>>>>>>> f84b3a0971 (Added GTEsts for float16 and bfloat16 data types)
     const auto& dims                = ref_output.desc.GetLengths();
     const size_t output_dim_size    = dims[dim];
     size_t outer_size               = 1;
@@ -103,29 +106,22 @@ void cpu_cat_forward_upd(std::vector<tensor<T>> inputs, tensor<T>& ref_output, i
         const size_t dim_size   = inputs[i].desc.GetLengths()[dim];
         const size_t copy_size  = inner_size_on_output_dim_size * dim_size;
         const size_t input_size = outer_size * copy_size;
-        ford(input_size)([&](size_t o) {
+
+        for (size_t o = 0; o < input_size; ++o)
+        {
             const size_t outer_idx = o / copy_size;
             const size_t copy_idx  = o % copy_size;
             ref_output[output_start_offset + (outer_idx * inner_size) + copy_idx] =
                 input[copy_size * outer_idx + copy_idx];
-        });
+        }
 
         output_start_offset += copy_size;
     });
-
-    const auto t1 = std::chrono::high_resolution_clock::now();
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-
-    std::cout << "Updated CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
-
-    std::fstream of("/data/Dev/cpu_cat_forward_upd.txt", std::ofstream::app);
-    of << ns << std::endl;
 }
 
 template <class T>
-void cpu_cat_forward_upd_st(std::vector<tensor<T>> inputs, tensor<T>& ref_output, int32_t dim)
+void cpu_cat_forward_st(const std::vector<tensor<T>>& inputs, tensor<T>& ref_output, int32_t dim)
 {
-    const auto t0 = std::chrono::high_resolution_clock::now();
     const auto& dims                = ref_output.desc.GetLengths();
     const size_t output_dim_size    = dims[dim];
     size_t outer_size               = 1;
@@ -161,14 +157,6 @@ void cpu_cat_forward_upd_st(std::vector<tensor<T>> inputs, tensor<T>& ref_output
 
         output_start_offset += copy_size;
     }
-
-    const auto t1 = std::chrono::high_resolution_clock::now();
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-
-    std::cout << "Updated single-threaded CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
-
-    std::fstream of("/data/Dev/cpu_cat_forward_upd_st.txt", std::ofstream::app);
-    of << ns << std::endl;
 }
 
 #endif

--- a/projects/miopen/test/cpu_cat.hpp
+++ b/projects/miopen/test/cpu_cat.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,88 +26,42 @@
 #ifndef GUARD_CPU_CAT_HPP
 #define GUARD_CPU_CAT_HPP
 
-#include <fstream>
-#include <iostream>
-
 #include "tensor_holder.hpp"
 
 template <class T>
-void cpu_cat_forward(const std::vector<tensor<T>>& inputs, tensor<T>& ref_output, int32_t dim)
+void cpu_cat_forward(const std::vector<tensor<T>>& inputs,
+                     tensor<T>& ref_output,
+                     int32_t dim,
+                     bool multi_threaded)
 {
-<<<<<<< HEAD
-    const auto t0 = std::chrono::high_resolution_clock::now();
-    auto dims              = ref_output.desc.GetLengths();
-    size_t output_dim_size = dims[dim];
-    size_t outer_size      = 1;
-    size_t inner_size      = 1;
-    size_t i               = 0;
-    for(; i < dim; i++)
+    const auto& dims             = ref_output.desc.GetLengths();
+    const size_t output_dim_size = dims[dim];
+    size_t outer_size            = 1;
+    size_t inner_size            = 1;
+    size_t k                     = 0;
+
+    for(; k < dim; ++k)
     {
-        outer_size *= dims[i];
+        outer_size *= dims[k];
     }
 
-    for(; i < dims.size(); i++)
+    for(; k < dims.size(); ++k)
     {
-        inner_size *= dims[i];
-    }
-
-    size_t output_start_offset = 0;
-
-    miopen::par_ford(inputs.size())([&](int32_t i) {
-        auto input        = inputs[i];
-        size_t dim_size   = inputs[i].desc.GetLengths()[dim];
-        size_t copy_size  = inner_size / output_dim_size * dim_size;
-        size_t input_size = outer_size * copy_size;
-        miopen::ford(input_size)([&](int32_t o) {
-            size_t outer_idx = o / copy_size;
-            size_t copy_idx  = o % copy_size;
-            ref_output[output_start_offset + (outer_idx * inner_size) + copy_idx] =
-                input[copy_size * outer_idx + copy_idx];
-        });
-
-        output_start_offset += copy_size;
-    });
-
-    const auto t1 = std::chrono::high_resolution_clock::now();
-    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-
-    std::cout << "Original CPU CAT solver: " << ns << "ns (" << (double(ns) / 1000000000.0) << " sec)" << std::endl;
-
-    std::fstream of("/data/Dev/cpu_cat_forward.txt", std::ofstream::app);
-    of << ns << std::endl;
-}
-
-template <class T>
-void cpu_cat_forward_upd(std::vector<tensor<T>> inputs, tensor<T>& ref_output, int32_t dim)
-{
-    const auto t0 = std::chrono::high_resolution_clock::now();
-=======
->>>>>>> f84b3a0971 (Added GTEsts for float16 and bfloat16 data types)
-    const auto& dims                = ref_output.desc.GetLengths();
-    const size_t output_dim_size    = dims[dim];
-    size_t outer_size               = 1;
-    size_t inner_size               = 1;
-    size_t i                        = 0;
-    for(; i < dim; i++)
-    {
-        outer_size *= dims[i];
-    }
-
-    for(; i < dims.size(); i++)
-    {
-        inner_size *= dims[i];
+        inner_size *= dims[k];
     }
 
     const size_t inner_size_on_output_dim_size = inner_size / output_dim_size;
-    size_t output_start_offset = 0;
+    const size_t n                             = inputs.size();
+    const size_t min_grain                     = multi_threaded ? 8 : n;
+    size_t output_start_offset                 = 0;
 
-    par_ford(inputs.size())([&](size_t i) {
+    miopen::par_for(n, min_grain, [&](size_t i) {
         const auto& input       = inputs[i];
         const size_t dim_size   = inputs[i].desc.GetLengths()[dim];
         const size_t copy_size  = inner_size_on_output_dim_size * dim_size;
         const size_t input_size = outer_size * copy_size;
 
-        for (size_t o = 0; o < input_size; ++o)
+        for(size_t o = 0; o < input_size; ++o)
         {
             const size_t outer_idx = o / copy_size;
             const size_t copy_idx  = o % copy_size;
@@ -117,46 +71,6 @@ void cpu_cat_forward_upd(std::vector<tensor<T>> inputs, tensor<T>& ref_output, i
 
         output_start_offset += copy_size;
     });
-}
-
-template <class T>
-void cpu_cat_forward_st(const std::vector<tensor<T>>& inputs, tensor<T>& ref_output, int32_t dim)
-{
-    const auto& dims                = ref_output.desc.GetLengths();
-    const size_t output_dim_size    = dims[dim];
-    size_t outer_size               = 1;
-    size_t inner_size               = 1;
-    size_t i                        = 0;
-    for(; i < dim; i++)
-    {
-        outer_size *= dims[i];
-    }
-
-    for(; i < dims.size(); i++)
-    {
-        inner_size *= dims[i];
-    }
-
-    const size_t inner_size_on_output_dim_size = inner_size / output_dim_size;
-    size_t output_start_offset = 0;
-
-    for (size_t i = 0; i < inputs.size(); ++i)
-    {
-        const auto& input       = inputs[i];
-        const size_t dim_size   = inputs[i].desc.GetLengths()[dim];
-        const size_t copy_size  = inner_size_on_output_dim_size * dim_size;
-        const size_t input_size = outer_size * copy_size;
-
-        for (size_t o = 0; o < input_size; ++o)
-        {
-            const size_t outer_idx = o / copy_size;
-            const size_t copy_idx  = o % copy_size;
-            ref_output[output_start_offset + (outer_idx * inner_size) + copy_idx] =
-                input[copy_size * outer_idx + copy_idx];            
-        }
-
-        output_start_offset += copy_size;
-    }
 }
 
 #endif

--- a/projects/miopen/test/cpu_cat.hpp
+++ b/projects/miopen/test/cpu_cat.hpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #ifndef GUARD_CPU_CAT_HPP
 #define GUARD_CPU_CAT_HPP
 
@@ -52,24 +30,41 @@ void cpu_cat_forward(const std::vector<tensor<T>>& inputs,
 
     const size_t inner_size_on_output_dim_size = inner_size / output_dim_size;
     const size_t n                             = inputs.size();
-    const size_t min_grain                     = multi_threaded ? 8 : n;
-    size_t output_start_offset                 = 0;
+    const size_t min_grain                     = multi_threaded ? 1 : n;
+
+    /////////////////////////////////////////////////////////////////////////////////////////////
+    // 1. Precompute output start offsets to avoid race conditions in the multi-threaded version.
+    // 2. Cache copy_size values, since they are needed by the start offsets computation anyway.
+    std::vector<size_t> copy_sizes;
+    std::vector<size_t> output_start_offsets;
+
+    copy_sizes.reserve(n);
+    output_start_offsets.reserve(n);
+
+    copy_sizes.emplace_back(inner_size_on_output_dim_size * inputs[0].desc.GetLengths()[dim]);
+    output_start_offsets.emplace_back(0);
+
+    for(size_t i{1}; i < n; ++i)
+    {
+        const size_t dim_size = inputs[i].desc.GetLengths()[dim];
+
+        output_start_offsets.emplace_back(output_start_offsets.back() + copy_sizes.back());
+        copy_sizes.emplace_back(inner_size_on_output_dim_size * dim_size);
+    }
+    /////////////////////////////////////////////////////////////////////////////////////////////
 
     miopen::par_for(n, min_grain, [&](size_t i) {
         const auto& input       = inputs[i];
-        const size_t dim_size   = inputs[i].desc.GetLengths()[dim];
-        const size_t copy_size  = inner_size_on_output_dim_size * dim_size;
+        const size_t copy_size  = copy_sizes[i];
         const size_t input_size = outer_size * copy_size;
 
         for(size_t o = 0; o < input_size; ++o)
         {
             const size_t outer_idx = o / copy_size;
             const size_t copy_idx  = o % copy_size;
-            ref_output[output_start_offset + (outer_idx * inner_size) + copy_idx] =
+            ref_output[output_start_offsets[i] + (outer_idx * inner_size) + copy_idx] =
                 input[copy_size * outer_idx + copy_idx];
         }
-
-        output_start_offset += copy_size;
     });
 }
 

--- a/projects/miopen/test/gtest/cat.cpp
+++ b/projects/miopen/test/gtest/cat.cpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include "cat.hpp"
 #include "test_parameter_name_generator.hpp"
 

--- a/projects/miopen/test/gtest/cat.cpp
+++ b/projects/miopen/test/gtest/cat.cpp
@@ -31,6 +31,14 @@ struct GPU_Cat_FP32 : CatTest<float>
 {
 };
 
+struct GPU_Cat_FP16 : CatTest<half_float::half>
+{
+};
+
+struct GPU_Cat_BFP16 : CatTest<bfloat16>
+{
+};
+
 } // namespace cat
 using namespace cat;
 
@@ -40,16 +48,36 @@ TEST_P(GPU_Cat_FP32, CatTestFw)
     Verify();
 };
 
-TEST_P(GPU_Cat_FP32, CatTestUpdFw)
+TEST_P(GPU_Cat_FP32, CatTestStFw)
 {
-    RunTestUpd();
+    RunTestSt();
     Verify();
 };
 
-TEST_P(GPU_Cat_FP32, CatTestUpdStFw)
+TEST_P(GPU_Cat_FP16, CatTestFw)
 {
-    RunTestUpdSt();
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_Cat_FP16, CatTestStFw)
+{
+    RunTestSt();
+    Verify();
+};
+
+TEST_P(GPU_Cat_BFP16, CatTestFw)
+{
+    RunTest();
+    Verify();
+};
+
+TEST_P(GPU_Cat_BFP16, CatTestStFw)
+{
+    RunTestSt();
     Verify();
 };
 
 INSTANTIATE_TEST_SUITE_P(Full, GPU_Cat_FP32, testing::ValuesIn(CatTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(Full, GPU_Cat_FP16, testing::ValuesIn(CatTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(Full, GPU_Cat_BFP16, testing::ValuesIn(CatTestConfigs()));

--- a/projects/miopen/test/gtest/cat.cpp
+++ b/projects/miopen/test/gtest/cat.cpp
@@ -40,4 +40,16 @@ TEST_P(GPU_Cat_FP32, CatTestFw)
     Verify();
 };
 
+TEST_P(GPU_Cat_FP32, CatTestUpdFw)
+{
+    RunTestUpd();
+    Verify();
+};
+
+TEST_P(GPU_Cat_FP32, CatTestUpdStFw)
+{
+    RunTestUpdSt();
+    Verify();
+};
+
 INSTANTIATE_TEST_SUITE_P(Full, GPU_Cat_FP32, testing::ValuesIn(CatTestConfigs()));

--- a/projects/miopen/test/gtest/cat.cpp
+++ b/projects/miopen/test/gtest/cat.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
  *
  *******************************************************************************/
 #include "cat.hpp"
+#include "test_parameter_name_generator.hpp"
 
 namespace cat {
 
@@ -42,42 +43,66 @@ struct GPU_Cat_BFP16 : CatTest<bfloat16>
 } // namespace cat
 using namespace cat;
 
-TEST_P(GPU_Cat_FP32, CatTestFw)
+TEST_P(GPU_Cat_FP32, CatTestFP32Fw)
 {
     RunTest();
     Verify();
 };
 
-TEST_P(GPU_Cat_FP32, CatTestStFw)
-{
-    RunTestSt();
-    Verify();
-};
-
-TEST_P(GPU_Cat_FP16, CatTestFw)
+TEST_P(GPU_Cat_FP16, CatTestFP16Fw)
 {
     RunTest();
     Verify();
 };
 
-TEST_P(GPU_Cat_FP16, CatTestStFw)
-{
-    RunTestSt();
-    Verify();
-};
-
-TEST_P(GPU_Cat_BFP16, CatTestFw)
+TEST_P(GPU_Cat_BFP16, CatTestBFP16Fw)
 {
     RunTest();
     Verify();
 };
 
-TEST_P(GPU_Cat_BFP16, CatTestStFw)
+///////////////////////////////////////////////////////////////////////////////////
+
+struct TestNameGenerator
 {
-    RunTestSt();
-    Verify();
+    std::string operator()(const auto& info)
+    {
+        const auto& tc = info.param;
+        auto it        = tc.inputs.begin();
+        std::stringstream ss;
+
+        ss << "inputs_" << GetRangeAsString(*it, "x");
+        ++it;
+
+        for(; it != tc.inputs.end(); ++it)
+        {
+            ss << "," << GetRangeAsString(*it, "x");
+        }
+
+        ss << "_dim_" << tc.dim << "_test_id_" << info.index;
+
+        std::string str(ss.str());
+
+        // Name format only supports letters, numbers and underscores.
+        std::transform(str.begin(), str.end(), str.begin(), [](char c) -> char {
+            return (c == '.') ? 'p' : (std::isalnum(c) ? c : '_');
+        });
+
+        return str;
+    }
 };
 
-INSTANTIATE_TEST_SUITE_P(Full, GPU_Cat_FP32, testing::ValuesIn(CatTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(Full, GPU_Cat_FP16, testing::ValuesIn(CatTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(Full, GPU_Cat_BFP16, testing::ValuesIn(CatTestConfigs()));
+///////////////////////////////////////////////////////////////////////////////////
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_Cat_FP32,
+                         testing::ValuesIn(CatTestConfigs()),
+                         TestNameGenerator{});
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_Cat_FP16,
+                         testing::ValuesIn(CatTestConfigs()),
+                         TestNameGenerator{});
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_Cat_BFP16,
+                         testing::ValuesIn(CatTestConfigs()),
+                         TestNameGenerator{});

--- a/projects/miopen/test/gtest/cat.hpp
+++ b/projects/miopen/test/gtest/cat.hpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #define MIOPEN_BETA_API 1
 #include "../driver/tensor_driver.hpp"
 #include "cpu_cat.hpp"
@@ -141,7 +119,7 @@ protected:
         std::vector<miopen::TensorDescriptor*> inputDescs;
         std::vector<ConstData_t> inputData;
 
-        cpu_cat_forward<T>(inputs, ref_output, dim, true);
+        cpu_cat_forward<T>(inputs, ref_output, dim, false);
 
         std::transform(inputs.begin(),
                        inputs.end(),

--- a/projects/miopen/test/gtest/cat.hpp
+++ b/projects/miopen/test/gtest/cat.hpp
@@ -165,6 +165,66 @@ protected:
         output.data = handle.Read<T>(output_dev, output.data.size());
     }
 
+    void RunTestUpd()
+    {
+        auto&& handle = get_handle();
+
+        cpu_cat_forward_upd<T>(inputs, ref_output, dim);
+        std::vector<miopen::TensorDescriptor*> inputDescs;
+        std::vector<ConstData_t> inputData;
+
+        std::transform(inputs.begin(),
+                       inputs.end(),
+                       std::back_inserter(inputDescs),
+                       [](auto& input) { return &input.desc; });
+        std::transform(inputs_dev.begin(),
+                       inputs_dev.end(),
+                       std::back_inserter(inputData),
+                       [](auto& input_dev) { return input_dev.get(); });
+
+        miopenStatus_t status = miopen::CatForward(handle,
+                                                   inputDescs.size(),
+                                                   inputDescs.data(),
+                                                   inputData.data(),
+                                                   output.desc,
+                                                   output_dev.get(),
+                                                   dim);
+
+        EXPECT_EQ(status, miopenStatusSuccess);
+
+        output.data = handle.Read<T>(output_dev, output.data.size());
+    }
+
+    void RunTestUpdSt()
+    {
+        auto&& handle = get_handle();
+
+        cpu_cat_forward_upd_st<T>(inputs, ref_output, dim);
+        std::vector<miopen::TensorDescriptor*> inputDescs;
+        std::vector<ConstData_t> inputData;
+
+        std::transform(inputs.begin(),
+                       inputs.end(),
+                       std::back_inserter(inputDescs),
+                       [](auto& input) { return &input.desc; });
+        std::transform(inputs_dev.begin(),
+                       inputs_dev.end(),
+                       std::back_inserter(inputData),
+                       [](auto& input_dev) { return input_dev.get(); });
+
+        miopenStatus_t status = miopen::CatForward(handle,
+                                                   inputDescs.size(),
+                                                   inputDescs.data(),
+                                                   inputData.data(),
+                                                   output.desc,
+                                                   output_dev.get(),
+                                                   dim);
+
+        EXPECT_EQ(status, miopenStatusSuccess);
+
+        output.data = handle.Read<T>(output_dev, output.data.size());
+    }
+
     void Verify()
     {
         auto error = miopen::rms_range(ref_output, output);

--- a/projects/miopen/test/gtest/cat.hpp
+++ b/projects/miopen/test/gtest/cat.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -138,40 +138,10 @@ protected:
     void RunTest()
     {
         auto&& handle = get_handle();
-
-        cpu_cat_forward<T>(inputs, ref_output, dim);
         std::vector<miopen::TensorDescriptor*> inputDescs;
         std::vector<ConstData_t> inputData;
 
-        std::transform(inputs.begin(),
-                       inputs.end(),
-                       std::back_inserter(inputDescs),
-                       [](auto& input) { return &input.desc; });
-        std::transform(inputs_dev.begin(),
-                       inputs_dev.end(),
-                       std::back_inserter(inputData),
-                       [](auto& input_dev) { return input_dev.get(); });
-
-        miopenStatus_t status = miopen::CatForward(handle,
-                                                   inputDescs.size(),
-                                                   inputDescs.data(),
-                                                   inputData.data(),
-                                                   output.desc,
-                                                   output_dev.get(),
-                                                   dim);
-
-        EXPECT_EQ(status, miopenStatusSuccess);
-
-        output.data = handle.Read<T>(output_dev, output.data.size());
-    }
-
-    void RunTestSt()
-    {
-        auto&& handle = get_handle();
-
-        cpu_cat_forward_st<T>(inputs, ref_output, dim);
-        std::vector<miopen::TensorDescriptor*> inputDescs;
-        std::vector<ConstData_t> inputData;
+        cpu_cat_forward<T>(inputs, ref_output, dim, true);
 
         std::transform(inputs.begin(),
                        inputs.end(),
@@ -197,10 +167,11 @@ protected:
 
     void Verify()
     {
-        auto error = miopen::rms_range(ref_output, output);
-        EXPECT_TRUE(miopen::range_distance(ref_output) == miopen::range_distance(output));
-        EXPECT_TRUE(error == 0) << "Outputs do not match each other. Error:" << error;
+        const auto error = miopen::rms_range(ref_output, output);
+        EXPECT_EQ(miopen::range_distance(ref_output), miopen::range_distance(output));
+        EXPECT_FLOAT_EQ(error, 0) << "Outputs do not match each other. Error:" << error;
     }
+
     CatTestCase cat_config;
 
     std::vector<tensor<T>> inputs;

--- a/projects/miopen/test/gtest/cat.hpp
+++ b/projects/miopen/test/gtest/cat.hpp
@@ -165,41 +165,11 @@ protected:
         output.data = handle.Read<T>(output_dev, output.data.size());
     }
 
-    void RunTestUpd()
+    void RunTestSt()
     {
         auto&& handle = get_handle();
 
-        cpu_cat_forward_upd<T>(inputs, ref_output, dim);
-        std::vector<miopen::TensorDescriptor*> inputDescs;
-        std::vector<ConstData_t> inputData;
-
-        std::transform(inputs.begin(),
-                       inputs.end(),
-                       std::back_inserter(inputDescs),
-                       [](auto& input) { return &input.desc; });
-        std::transform(inputs_dev.begin(),
-                       inputs_dev.end(),
-                       std::back_inserter(inputData),
-                       [](auto& input_dev) { return input_dev.get(); });
-
-        miopenStatus_t status = miopen::CatForward(handle,
-                                                   inputDescs.size(),
-                                                   inputDescs.data(),
-                                                   inputData.data(),
-                                                   output.desc,
-                                                   output_dev.get(),
-                                                   dim);
-
-        EXPECT_EQ(status, miopenStatusSuccess);
-
-        output.data = handle.Read<T>(output_dev, output.data.size());
-    }
-
-    void RunTestUpdSt()
-    {
-        auto&& handle = get_handle();
-
-        cpu_cat_forward_upd_st<T>(inputs, ref_output, dim);
+        cpu_cat_forward_st<T>(inputs, ref_output, dim);
         std::vector<miopen::TensorDescriptor*> inputDescs;
         std::vector<ConstData_t> inputData;
 


### PR DESCRIPTION
## Motivation

This PR replaces the CAT CPU solver in the MIOpen driver with an optimized one which also supports multi-threading.

## Technical Details

The updated solver has been optimized for speed, and a multithreaded version of it has also been implemented.
The driver code has been modified to allow the user to choose between a single-threaded and multi-threaded version of the solver using a new command line parameter (--mt).

## Test Plan

The driver and the GTest related source code have been instrumented to measure (and save to a file) the execution time of each solver while being tested on bench. Such instrumentation is not present in this PR.

## Test Result

The optimized solvers show a better performance in the majority of the tests compared to the original solver.
Detailed timings have been attached to this PR.

[Performance test results.zip](https://github.com/user-attachments/files/25607857/Performance.test.results.zip)

<img width="6132" height="3158" alt="Cat CPU Solver" src="https://github.com/user-attachments/assets/3ef997ae-c2e5-4f4d-b5d9-004f08a92517" />
<img width="4565" height="2468" alt="Cat GTest" src="https://github.com/user-attachments/assets/e1ac6256-5a3f-45c7-a137-233c1db71e53" />

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
