### PR TITLE
hipfft-test: link CMAKE_DL_LIBS, as dlopen is used for hipfftw tests

### DIFF
--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -249,6 +249,7 @@ endif( )
 target_link_libraries( hipfft-test
   PRIVATE
   Threads::Threads
+  ${CMAKE_DL_LIBS}
   )
 
 # hipfft-test will opens the hipfftw library but does not link to it


### PR DESCRIPTION
## Motivation

Fix hipfft-test link error on platforms where dlopen needs a separate library.

## Technical Details

hipfft-test was not linking CMAKE_DL_LIBS, but needs to for dlopen support on older Linuxes (e.g. RHEL 8).

## Test Plan

Existing tests will cover this, as long as hipfft-test can be linked.

## Test Result

Build is successful and hipfft-test can be launched.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
