### PR TITLE
[rocsparse] Remove log_trace from subroutine template

### DIFF
--- a/projects/rocsparse/docs/conceptual/rocsparse-design.rst
+++ b/projects/rocsparse/docs/conceptual/rocsparse-design.rst
@@ -187,32 +187,6 @@ and ``<subroutine>_device.h``.
            return rocsparse_status_invalid_handle;
        }
 
-       // Logging
-       if(handle->pointer_mode == rocsparse_pointer_mode_host)
-       {
-           log_trace(handle,
-                     rocsparse::replaceX<T>("rocsparse_Xsubroutine"),
-                     m,
-                     *alpha,
-                     (const void*&)val);
-
-           log_bench(handle,
-                     "./rocsparse-bench -f subroutine -r",
-                     rocsparse::replaceX<T>("X"),
-                     "-m",
-                     m,
-                     "--alpha",
-                     *alpha);
-       }
-       else
-       {
-           log_trace(handle,
-                     rocsparse::replaceX<T>("rocsparse_Xsubroutine"),
-                     m,
-                     (const void*&)alpha,
-                     (const void*&)val);
-       }
-
        // Check size
        if(m < 0)
        {


### PR DESCRIPTION
## Motivation

Remove log_trace from subroutine template now that the tracing is deprecated and contributors should no longer use it going forward.

## Technical Details

We deprecated the use of log_trace in https://github.com/ROCm/rocm-libraries/pull/1247 and therefore we should remove it from the subroutine template documentation as users going forward should avoid using it.

## Test Plan

This is a documentation only change. Regular CI should run and pass.
