### PR TITLE
[hipDNN] Update dependencies to match TheRock versions

### DIFF
--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.25.2)
 
 # hipDNN dependency versions to use
-set(HIPDNN_SPDLOG_VERSION "1.15.2" CACHE STRING "Version of spdlog to use")
+set(HIPDNN_SPDLOG_VERSION "1.15.3" CACHE STRING "Version of spdlog to use")
 set(HIPDNN_FLATBUFFERS_VERSION "25.9.23" CACHE STRING "Version of flatbuffers to use")
 set(HIPDNN_NLOHMANN_JSON_VERSION "3.12.0" CACHE STRING "Version of nlohmann_json to use")
 set(HIPDNN_GTEST_VERSION "1.16.0" CACHE STRING "Version of googletest to use")

--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -45,7 +45,6 @@ set(HIPDNN_INSTALL_PLUGIN_ENGINE_DIR "lib/${HIPDNN_PLUGIN_ENGINE_SUBDIR}" CACHE 
 
 set(HIPDNN_TEST_PLUGIN_DIR "${CMAKE_BINARY_DIR}/lib/test_plugins" CACHE INTERNAL "Build directory for test plugins")
 
-
 option(HIP_DNN_BUILD_BACKEND "Build the backend code" ON)
 option(HIP_DNN_BUILD_FRONTEND "Build the frontend code" ON)
 option(HIP_DNN_SKIP_TESTS "Skips building all tests" OFF)

--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -3,6 +3,12 @@
 
 cmake_minimum_required(VERSION 3.25.2)
 
+# hipDNN dependency versions to use
+set(HIPDNN_SPDLOG_VERSION "1.15.2" CACHE STRING "Version of spdlog to use")
+set(HIPDNN_FLATBUFFERS_VERSION "25.9.23" CACHE STRING "Version of flatbuffers to use")
+set(HIPDNN_NLOHMANN_JSON_VERSION "3.12.0" CACHE STRING "Version of nlohmann_json to use")
+set(HIPDNN_GTEST_VERSION "1.16.0" CACHE STRING "Version of googletest to use")
+
 add_compile_definitions(__HIP_PLATFORM_AMD__)
 
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/ClangToolChain.cmake" CACHE STRING "Toolchain file")
@@ -38,6 +44,7 @@ set(HIPDNN_BUILD_PLUGIN_ENGINE_DIR "${CMAKE_BINARY_DIR}/lib/${HIPDNN_PLUGIN_ENGI
 set(HIPDNN_INSTALL_PLUGIN_ENGINE_DIR "lib/${HIPDNN_PLUGIN_ENGINE_SUBDIR}" CACHE STRING "Install directory for official hipDNN engine plugins (relative to CMAKE_INSTALL_PREFIX)")
 
 set(HIPDNN_TEST_PLUGIN_DIR "${CMAKE_BINARY_DIR}/lib/test_plugins" CACHE INTERNAL "Build directory for test plugins")
+
 
 option(HIP_DNN_BUILD_BACKEND "Build the backend code" ON)
 option(HIP_DNN_BUILD_FRONTEND "Build the frontend code" ON)

--- a/projects/hipdnn/cmake/Tests.cmake
+++ b/projects/hipdnn/cmake/Tests.cmake
@@ -5,7 +5,7 @@ if(HIP_DNN_SKIP_TESTS)
     return()
 endif()
 
-hipdnn_add_dependency(GTest v1.16.0)
+hipdnn_add_dependency(GTest VERSION ${HIPDNN_GTEST_VERSION})
 include(GoogleTest)
 
 find_package(Python3 COMPONENTS Interpreter)

--- a/projects/hipdnn/sdk/CMakeLists.txt
+++ b/projects/hipdnn/sdk/CMakeLists.txt
@@ -5,7 +5,9 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 SET(HIP_DNN_SDK_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/hipdnn/sdk")
 
-hipdnn_add_dependency(flatbuffers VERSION 23.1.21)
+hipdnn_add_dependency(flatbuffers VERSION ${HIPDNN_FLATBUFFERS_VERSION})
+hipdnn_add_dependency(spdlog VERSION ${HIPDNN_SPDLOG_VERSION})
+hipdnn_add_dependency(nlohmann_json VERSION ${HIPDNN_NLOHMANN_JSON_VERSION})
 
 # Hack to workaround an issue with how flatbuffers sets up its INSTALL_INTERFACE.
 # internally it uses the following: $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
@@ -55,10 +57,6 @@ set_target_properties(flatc PROPERTIES COMPILE_FLAGS "-w")
 
 
 _restore_var(FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS)
-
-hipdnn_add_dependency(spdlog VERSION 1.15.2)
-
-hipdnn_add_dependency(nlohmann_json VERSION 3.12.0)
 
 add_library(hipdnn_sdk INTERFACE)
 target_link_libraries(hipdnn_sdk INTERFACE FlatBuffers spdlog_header_only nlohmann_json)

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/batchnorm_attributes_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/batchnorm_attributes_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 namespace hipdnn_sdk {

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/batchnorm_backward_attributes_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/batchnorm_backward_attributes_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 namespace hipdnn_sdk {

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/batchnorm_inference_attributes_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/batchnorm_inference_attributes_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 namespace hipdnn_sdk {

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/convolution_bwd_attributes_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/convolution_bwd_attributes_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 #include "convolution_common_generated.h"

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/convolution_common_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/convolution_common_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/convolution_fwd_attributes_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/convolution_fwd_attributes_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 #include "convolution_common_generated.h"

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/data_types_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/engine_config_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/engine_config_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 namespace hipdnn_sdk {

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/engine_details_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/engine_details_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 namespace hipdnn_sdk {

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/graph_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/graph_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 #include "batchnorm_attributes_generated.h"
@@ -649,8 +649,8 @@ inline void Graph::UnPackTo(GraphT *_o, const ::flatbuffers::resolver_function_t
   { auto _e = compute_type(); _o->compute_type = _e; }
   { auto _e = intermediate_type(); _o->intermediate_type = _e; }
   { auto _e = io_type(); _o->io_type = _e; }
-  { auto _e = tensors(); if (_e) { _o->tensors.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { if(_o->tensors[_i]) { _e->Get(_i)->UnPackTo(_o->tensors[_i].get(), _resolver); } else { _o->tensors[_i] = std::unique_ptr<hipdnn_sdk::data_objects::TensorAttributesT>(_e->Get(_i)->UnPack(_resolver)); }; } } else { _o->tensors.resize(0); } }
-  { auto _e = nodes(); if (_e) { _o->nodes.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { if(_o->nodes[_i]) { _e->Get(_i)->UnPackTo(_o->nodes[_i].get(), _resolver); } else { _o->nodes[_i] = std::unique_ptr<hipdnn_sdk::data_objects::NodeT>(_e->Get(_i)->UnPack(_resolver)); }; } } else { _o->nodes.resize(0); } }
+  { auto _e = tensors(); if (_e) { _o->tensors.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { if(_o->tensors[_i]) { _e->Get(_i)->UnPackTo(_o->tensors[_i].get(), _resolver); } else { _o->tensors[_i] = std::unique_ptr<hipdnn_sdk::data_objects::TensorAttributesT>(_e->Get(_i)->UnPack(_resolver)); } } } else { _o->tensors.resize(0); } }
+  { auto _e = nodes(); if (_e) { _o->nodes.resize(_e->size()); for (::flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { if(_o->nodes[_i]) { _e->Get(_i)->UnPackTo(_o->nodes[_i].get(), _resolver); } else { _o->nodes[_i] = std::unique_ptr<hipdnn_sdk::data_objects::NodeT>(_e->Get(_i)->UnPack(_resolver)); } } } else { _o->nodes.resize(0); } }
 }
 
 inline ::flatbuffers::Offset<Graph> Graph::Pack(::flatbuffers::FlatBufferBuilder &_fbb, const GraphT* _o, const ::flatbuffers::rehasher_function_t *_rehasher) {

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/pointwise_attributes_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/pointwise_attributes_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 #include "data_types_generated.h"

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/tensor_attributes_generated.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/data_objects/tensor_attributes_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 1 &&
-              FLATBUFFERS_VERSION_REVISION == 21,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 25 &&
+              FLATBUFFERS_VERSION_MINOR == 9 &&
+              FLATBUFFERS_VERSION_REVISION == 23,
              "Non-compatible flatbuffers version included");
 
 #include "data_types_generated.h"


### PR DESCRIPTION
## Motivation

With adding hipDNN to TheRock we need to be using matching versions for the third party deps.
This change updates our dependencies to match the versions on TheRock, and consolidates the versions into the root CMake to make it easier to update / find.

## Technical Details

Updating:
- HIPDNN_SPDLOG_VERSION  1.15.2 -> 1.15.3
- HIPDNN_FLATBUFFERS_VERSION 23.1.12 -> 25.9.23

Gtest & nlohmann json were matching already.

## Test Plan

Existing tests cover changes.

## Test Result

Tests passed.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
