### PR TITLE
[hipDNN] Add option to disable clang-format

### DIFF
--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -53,6 +53,7 @@ option(HIP_DNN_BUILD_PLUGINS "Builds the plugins as part of the main cmake" ON)
 option(CODE_COVERAGE "Build with code coverage flags" OFF)
 option(ENABLE_CLANG_TIDY "Enable Clang-Tidy checks" ON)
 option(BUILD_ADDRESS_SANITIZER "Build with Address Sanitizer enabled" OFF)
+option(ENABLE_CLANG_FORMAT "Enable Clang-Format checks" ON)
 
 list(
     APPEND

--- a/projects/hipdnn/cmake/ClangCheck.cmake
+++ b/projects/hipdnn/cmake/ClangCheck.cmake
@@ -1,23 +1,25 @@
 # Copyright © Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
-include(${CMAKE_CURRENT_LIST_DIR}/CheckToolVersion.cmake)
+if(ENABLE_CLANG_FORMAT)
+    include(${CMAKE_CURRENT_LIST_DIR}/CheckToolVersion.cmake)
 
-set(CLANG_FORMAT_PRUNE -path "./build" -prune -o -path "./sdk/include/hipdnn_sdk/data_objects" -prune -o)
+    set(CLANG_FORMAT_PRUNE -path "./build" -prune -o -path "./sdk/include/hipdnn_sdk/data_objects" -prune -o)
 
-# Find and check clang-format version using unified function
-findAndCheckClangFormat()
+    # Find and check clang-format version using unified function
+    findAndCheckClangFormat()
 
-add_custom_target(
-    check_format
-    COMMAND  find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|c\\|h\\)" -exec ${CLANG_FORMAT_BINARY} --dry-run --Werror {} +
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    VERBATIM
-)
+    add_custom_target(
+        check_format
+        COMMAND  find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|c\\|h\\)" -exec ${CLANG_FORMAT_BINARY} --dry-run --Werror {} +
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        VERBATIM
+    )
 
-add_custom_target(
-    format
-    COMMAND  find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|c\\|h\\)" -exec ${CLANG_FORMAT_BINARY} --verbose -i {} +
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    VERBATIM
-)
+    add_custom_target(
+        format
+        COMMAND  find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|c\\|h\\)" -exec ${CLANG_FORMAT_BINARY} --verbose -i {} +
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        VERBATIM
+    )
+endif()


### PR DESCRIPTION
## Motivation

For adding hipDNN to TheRock clang-format isn't available during configure stage, and causes issues.
Clang-format and other checks will happen separately during presubmit, and we need the option to disable them to prevent errors during configure.
