### PR TITLE
[rocRoller] Add M0 write hazard observer

### DIFF
--- a/shared/rocroller/lib/include/CMakeLists.txt
+++ b/shared/rocroller/lib/include/CMakeLists.txt
@@ -331,6 +331,7 @@ target_sources(rocroller
         "${CMAKE_CURRENT_SOURCE_DIR}/rocRoller/Scheduling/Observers/FunctionalUnit/WMMAObserver.hpp"
 
         "${CMAKE_CURRENT_SOURCE_DIR}/rocRoller/Scheduling/Observers/WaitState/BufferStoreDwordXXRead.hpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/rocRoller/Scheduling/Observers/WaitState/M0Write.hpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/rocRoller/Scheduling/Observers/WaitState/OPSEL94x.hpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/rocRoller/Scheduling/Observers/WaitState/VALUTransWrite94x.hpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/rocRoller/Scheduling/Observers/WaitState/VALUWriteReadlane94x.hpp"

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/M0Write.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/M0Write.hpp
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2024-2025 AMD ROCm(TM) Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <rocRoller/Scheduling/Observers/WaitState/WaitStateObserver.hpp>
+
+namespace rocRoller
+{
+    namespace Scheduling
+    {
+        /**
+         * @brief Rules for writing M0
+         *
+         * | Arch | 1st Inst        | 2nd Inst                  | NOPs |
+         * | ---- | --------------- | ------------------------- | ---- |
+         * | Any  | s_* writes M0   | LDS "add-TID" instruction | 1    |
+         *
+         * An LDS "add-TID" instruction can be a buffer_load_dword* with lds set.
+         *
+         */
+        class M0Write : public WaitStateObserver<M0Write>
+        {
+        public:
+            M0Write() {}
+            M0Write(ContextPtr context)
+                : WaitStateObserver<M0Write>(context){};
+
+            constexpr static bool required(GPUArchitectureTarget const& target)
+            {
+                return true;
+            }
+
+            /**
+             * Overriden as we need to target M0
+             */
+            void observeHazard(Instruction const& inst) override;
+
+            int                   getMaxNops(Instruction const& inst) const;
+            bool                  trigger(Instruction const& inst) const;
+            static constexpr bool writeTrigger()
+            {
+                return true;
+            }
+            int         getNops(Instruction const& inst) const;
+            std::string getComment() const
+            {
+                return "M0 Write Hazard";
+            }
+
+        private:
+            int const m_maxNops = 1;
+        };
+
+        static_assert(CWaitStateObserver<M0Write>);
+    }
+}

--- a/shared/rocroller/lib/source/Observers/CMakeLists.txt
+++ b/shared/rocroller/lib/source/Observers/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(rocroller
         "${CMAKE_CURRENT_SOURCE_DIR}/DGEMM4x4x4Write.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/DLWrite.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/FileWritingObserver.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/M0Write.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MEMObserver.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MFMAObserver.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/ObserverCreation.cpp"

--- a/shared/rocroller/lib/source/Observers/M0Write.cpp
+++ b/shared/rocroller/lib/source/Observers/M0Write.cpp
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2024-2025 AMD ROCm(TM) Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <rocRoller/GPUArchitecture/GPUInstructionInfo.hpp>
+#include <rocRoller/Scheduling/Observers/WaitState/M0Write.hpp>
+
+namespace rocRoller
+{
+    namespace Scheduling
+    {
+        void M0Write::observeHazard(Instruction const& inst)
+        {
+            if(trigger(inst))
+            {
+                for(auto const& regId : m_context.lock()->getM0()->getRegisterIds())
+                {
+                    (*m_hazardMap)[regId].push_back(
+                        WaitStateHazardCounter(getMaxNops(inst), writeTrigger()));
+                }
+            }
+        }
+
+        int M0Write::getMaxNops(Instruction const& inst) const
+        {
+            return m_maxNops;
+        }
+
+        bool M0Write::trigger(Instruction const& inst) const
+        {
+            if(GPUInstructionInfo::isSALU(inst.getOpCode()))
+            {
+                for(auto const& dst : inst.getAllDsts())
+                {
+                    if(dst != nullptr && dst->regType() == Register::Type::M0)
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        int M0Write::getNops(Instruction const& inst) const
+        {
+            if(GPUInstructionInfo::isVMEM(inst.getOpCode()))
+            {
+                for(auto const& mod : inst.getModifiers())
+                {
+                    if(mod == "lds")
+                        return checkRegister(m_context.lock()->getM0()).value_or(0);
+                }
+            }
+            return 0;
+        }
+    }
+}

--- a/shared/rocroller/lib/source/Observers/ObserverCreation.cpp
+++ b/shared/rocroller/lib/source/Observers/ObserverCreation.cpp
@@ -50,6 +50,7 @@
 #include <rocRoller/Scheduling/Observers/WaitState/MFMA/XDLWrite94x.hpp>
 
 #include <rocRoller/Scheduling/Observers/WaitState/BufferStoreDwordXXRead.hpp>
+#include <rocRoller/Scheduling/Observers/WaitState/M0Write.hpp>
 #include <rocRoller/Scheduling/Observers/WaitState/OPSEL94x.hpp>
 #include <rocRoller/Scheduling/Observers/WaitState/VALUTransWrite94x.hpp>
 #include <rocRoller/Scheduling/Observers/WaitState/VALUWriteReadlane94x.hpp>
@@ -80,6 +81,7 @@ namespace rocRoller
                 ACCVGPRReadWrite,
                 ACCVGPRWriteWrite,
                 BufferStoreDwordXXRead,
+                M0Write,
                 CMPXWriteExec,
                 DGEMM4x4x4Write,
                 DGEMM16x16x4Write,

--- a/shared/rocroller/test/catch/HazardObserverTest.cpp
+++ b/shared/rocroller/test/catch/HazardObserverTest.cpp
@@ -785,4 +785,39 @@ namespace HazardObserverTest
         }
     }
 
+    TEST_CASE("M0 Write", "[observer]")
+    {
+        SUPPORTED_ARCH_SECTION(arch)
+        {
+            if(arch.isRDNAGPU())
+            {
+                SKIP("RDNA not supported yet");
+            }
+
+            SECTION("NOP added for S0 write followed by direct to LDS buffer load")
+            {
+                auto context = TestContext::ForTarget(arch);
+                auto v = createRegisters(context, Register::Type::Vector, DataType::Float, 1, 1)[0];
+                auto addr = createRegisters(context, Register::Type::Vector, DataType::Raw32, 1)[0];
+                auto sValue
+                    = createRegisters(context, Register::Type::Scalar, DataType::Int32, 1, 1)[0];
+                auto s = createRegisters(context, Register::Type::Scalar, DataType::Raw32, 1, 4)[0];
+
+                std::vector<Instruction> insts
+                    = {Instruction("s_mov_b32", {context->getM0()}, {sValue}, {}, ""),
+                       Instruction("buffer_store_dwordx4",
+                                   {},
+                                   {v, addr, s, Register::Value::Literal(0)},
+                                   {"lds"},
+                                   ""),
+                       Instruction("s_endpgm", {}, {}, {}, "")};
+
+                peekAndSchedule(context, insts[0]);
+                peekAndSchedule(context, insts[1], 1);
+                peekAndSchedule(context, insts[2]);
+
+                CHECK_THAT(context.output(), ContainsSubstring("s_nop"));
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

Add an observer to handle hazards caused by SALU writes to the M0 register.

## Technical Details

This hazard is realized when certain LDS related instructions are called too quickly after M0 is written to.

## Test Plan

Existing tests should pass. Additional unit tests added to ensure correct functionality of new observer.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
