### PR TITLE
Add preset for rocm 7.0.0 config

### DIFF
--- a/projects/hipblaslt/CMakePresets.json
+++ b/projects/hipblaslt/CMakePresets.json
@@ -88,6 +88,31 @@
           "TENSILELITE_ENABLE_CLIENT": "OFF",
           "HIPBLASLT_ENABLE_SAMPLES": "OFF"
         }
+      },
+      {
+        "name": "rocm-7.0.0",
+        "displayName": "hipblaslt 7.0.0 config",
+        "description": "Configuration command used in 7.0.0 builds",
+        "cacheVariables": {
+          "CMAKE_Fortran_COMPILER": "gfortran",
+          "CMAKE_CXX_COMPILER": "/opt/rocm/bin/amdclang++",
+          "CMAKE_C_COMPILER": "/opt/rocm/bin/amdclang",
+          "CMAKE_PREFIX_PATH": "/opt/rocm-7.0.0/lib/llvm;/opt/rocm-7.0.0",
+          "CMAKE_SHARED_LINKER_FLAGS_INIT": "-Wl,--enable-new-dtags,--build-id=sha1,--rpath,\\$ORIGIN",
+          "CMAKE_EXE_LINKER_FLAGS_INIT": "-Wl,--enable-new-dtags,--build-id=sha1,--rpath,\\$ORIGIN/../lib",
+          "CMAKE_INSTALL_PREFIX": "/opt/rocm-7.0.0",
+          "CMAKE_PACKAGING_INSTALL_PREFIX": "/opt/rocm-7.0.0",
+          "ROCM_SYMLINK_LIBS": "OFF",
+          "ROCM_DISABLE_LDCONFIG": "ON",
+          "CPACK_SET_DESTDIR": "OFF",
+          "CPACK_DEBIAN_DEBUGINFO_PACKAGE": "FALSE",
+          "ROCM_PATH": "/opt/rocm-7.0.0",
+          "GPU_TARGETS": "gfx950;gfx942",
+          "CMAKE_BUILD_TYPE": "Release",
+          "HIPBLASLT_ENABLE_FETCH": "ON",
+          "CMAKE_INSTALL_LIBDIR": "lib",
+          "BLA_STATIC": "ON"
+        }
       }
-  ]
+    ]
 }


### PR DESCRIPTION
## Motivation

Ad prefix to clean up configuration when replicating rocm-7.0.0 builds.

## Technical Details

- Adds a preset with configure options used to generate hipblaslt build for rocm-7.0.0.

## Test Plan

Tested by hand in ubuntu 22.04 image.

## Test Result

Configures and builds assuming all dependencies are met.
