### PR TITLE
feat(rocprim): trim outlier iteration times

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -23,6 +23,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Improved performance of many algorithms, by updating their tuned configs.
   * 891 specializations have been improved.
   * 399 specializations have been added.
+* Improved benchmark stability by trimming outlier iteration times.
 
 ### Upcoming changes
 

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -70,12 +70,6 @@
 #define TUNING_SHARED_MEMORY_MAX 65536u
 // Support half operators on host side
 
-inline const char* get_seed_message()
-{
-    return "seed for input generation, either an unsigned integer value for determinisic results "
-           "or 'random' for different inputs for each repetition";
-}
-
 /// \brief Provides a sequence of seeds.
 class managed_seed
 {
@@ -2043,36 +2037,36 @@ private:
                                    bool         default_cold,
                                    int          default_trials)
     {
-        parser.set_optional<size_t>("size", "size", default_bytes, "size in bytes");
+        parser.set_optional<size_t>("size", "size", default_bytes, "Size of the randomly generated input array in bytes.");
         parser.set_optional<size_t>("batch_iterations",
                                     "batch_iterations",
                                     default_batch_iterations,
-                                    "number of batch iterations");
+                                    "Number of batch iterations.");
         parser.set_optional<size_t>("warmup_iterations",
                                     "warmup_iterations",
                                     default_warmup_iterations,
-                                    "number of warmup iterations");
+                                    "Number of warmup iterations.");
         parser.set_optional<bool>("hot",
                                   "hot",
                                   !default_cold,
-                                  "don't clear the gpu cache on every batch iteration");
+                                  "Don't clear the gpu cache on every batch iteration.");
 
-        parser.set_optional<std::string>("seed", "seed", "random", get_seed_message());
+        parser.set_optional<std::string>("seed", "seed", "random", "Seed for input generation. Either an unsigned integer value for determinisic results, or 'random' for different inputs for each repetition.");
         parser.set_optional<int>("trials", "trials", default_trials, "number of iterations");
         parser.set_optional<std::string>("name_format",
                                          "name_format",
                                          "json",
-                                         "either json, human, or txt");
+                                         "Either json, human, or txt.");
 
         // Optionally run an evenly split subset of benchmarks for autotuning.
         parser.set_optional<int>("parallel_instance",
                                  "parallel_instance",
                                  0,
-                                 "parallel instance index");
+                                 "Parallel instance index.");
         parser.set_optional<int>("parallel_instances",
                                  "parallel_instances",
                                  1,
-                                 "total parallel instances");
+                                 "Total parallel instances.");
 
         parser.set_optional<std::string>(
             "iteration_info_out",

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -1523,7 +1523,9 @@ public:
     // This function doesn't use a JSON library,
     // since it just appends text onto the end of a JSON file.
     // Seeking and writing to the end of a huge file is very fast.
-    void output_specialization_info(const std::string& name) const
+    void output_specialization_info(const std::string& name,
+                                    double             lower_bound,
+                                    double             upper_bound) const
     {
         if(!m_is_active)
             return;
@@ -1577,7 +1579,7 @@ public:
         }
 
         // Append the serialized benchmark
-        outfile << serialize_benchmark(name);
+        outfile << serialize_benchmark(name, lower_bound, upper_bound);
 
         // Close benchmarks array and JSON
         outfile << "]}";
@@ -1594,7 +1596,8 @@ private:
 #endif
     };
 
-    std::string serialize_benchmark(const std::string& name) const
+    std::string
+        serialize_benchmark(const std::string& name, double lower_bound, double upper_bound) const
     {
         std::ostringstream ss;
         ss << "{";
@@ -1602,11 +1605,12 @@ private:
         ss << "\"batches\":[";
         for(size_t i = 0; i < m_batches.size(); i++)
         {
-            if(i != 0)
+            if(i > 0)
                 ss << ",";
 
             ss << "{";
-            ss << "\"iterations_ms\":" << serialize_batch_times(m_batches[i].batch_times);
+            ss << "\"iterations_ms\":"
+               << serialize_batch_times(m_batches[i].batch_times, lower_bound, upper_bound);
 
 #ifdef BENCHMARK_USE_AMDSMI
             ss << ",\"amdsmi_stats_after_iterations\":"
@@ -1620,15 +1624,21 @@ private:
         return ss.str();
     }
 
-    std::string serialize_batch_times(const std::vector<double>& batch_times) const
+    std::string serialize_batch_times(const std::vector<double>& batch_times,
+                                      double                     lower_bound,
+                                      double                     upper_bound) const
     {
         std::ostringstream ss;
         ss << "[";
-        for(size_t i = 0; i < batch_times.size(); i++)
+        size_t output_batches = 0;
+        for(auto t : batch_times)
         {
-            if(i != 0)
+            if(t < lower_bound || t > upper_bound)
+                continue;
+            if(output_batches > 0)
                 ss << ",";
-            ss << batch_times[i];
+            ss << t;
+            output_batches++;
         }
         ss << "]";
         return ss.str();
@@ -1790,15 +1800,19 @@ public:
                                        * type_size);
         gbench_state.SetItemsProcessed(m_total_gbench_iterations * batch_iterations * actual_size);
 
-        if(m_iteration_times_iqr_multiplier != -1)
-        {
-            m_times = drop_outliers_using_iqr(m_times);
-        }
+        struct bounds bounds = get_outlier_bounds_using_iqr(m_times);
+
+        // Remove outliers using bounds
+        m_times.erase(std::remove_if(m_times.begin(),
+                                     m_times.end(),
+                                     [&](double t)
+                                     { return t < bounds.lower_bound || t > bounds.upper_bound; }),
+                      m_times.end());
 
         output_statistics();
 
         std::string name = get_escaped_name(gbench_state.name());
-        m_logger.output_specialization_info(name);
+        m_logger.output_specialization_info(name, bounds.lower_bound, bounds.upper_bound);
     }
 
     // These are directly read by benchmarks.
@@ -1809,6 +1823,12 @@ public:
     benchmark::State& gbench_state;
 
 private:
+    struct bounds
+    {
+        double lower_bound;
+        double upper_bound;
+    };
+
     // Zeros a 256 MiB buffer, used to clear the cache before each kernel call.
     // 256 MiB is the size of the largest cache on any AMD GPU.
     // It is currently not possible to fetch the L3 cache size from the runtime.
@@ -1838,11 +1858,13 @@ private:
 
     // IQR stands for Interquartile range.
     // It's used to drop outlier iteration times, in order to reduce noise.
-    std::vector<double> drop_outliers_using_iqr(const std::vector<double>& values) const
+    bounds get_outlier_bounds_using_iqr(const std::vector<double>& values) const
     {
-        if(values.size() < 4)
+        // If IQR filtering is turned off, or there are not enough values to filter.
+        if(m_iteration_times_iqr_multiplier == -1 || values.size() < 4)
         {
-            return values; // Not enough data to define outliers
+            return {.lower_bound = std::numeric_limits<double>::lowest(),
+                    .upper_bound = std::numeric_limits<double>::max()};
         }
 
         std::vector<double> sorted_vals = values;
@@ -1870,18 +1892,7 @@ private:
         double lower_bound = q1 - m_iteration_times_iqr_multiplier * iqr;
         double upper_bound = q3 + m_iteration_times_iqr_multiplier * iqr;
 
-        std::vector<double> filtered;
-        filtered.reserve(values.size());
-
-        for(double v : values)
-        {
-            if(v >= lower_bound && v <= upper_bound)
-            {
-                filtered.push_back(v);
-            }
-        }
-
-        return filtered;
+        return {.lower_bound = lower_bound, .upper_bound = upper_bound};
     }
 
     void output_statistics() const

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -1838,27 +1838,33 @@ private:
 
     // IQR stands for Interquartile range.
     // It's used to drop outlier iteration times, in order to reduce noise.
-    std::vector<double> drop_outliers_using_iqr(const std::vector<double>& values) const {
-        if (values.size() < 4) {
+    std::vector<double> drop_outliers_using_iqr(const std::vector<double>& values) const
+    {
+        if(values.size() < 4)
+        {
             return values; // Not enough data to define outliers
         }
 
         std::vector<double> sorted_vals = values;
         std::sort(sorted_vals.begin(), sorted_vals.end());
 
-        auto get_percentile = [&](double p) {
-            double idx = p * (sorted_vals.size() - 1);
-            size_t i = static_cast<size_t>(idx);
+        auto get_percentile = [&](double p)
+        {
+            double idx  = p * (sorted_vals.size() - 1);
+            size_t i    = static_cast<size_t>(idx);
             double frac = idx - i;
-            if (i + 1 < sorted_vals.size()) {
+            if(i + 1 < sorted_vals.size())
+            {
                 return sorted_vals[i] * (1.0 - frac) + sorted_vals[i + 1] * frac;
-            } else {
+            }
+            else
+            {
                 return sorted_vals[i];
             }
         };
 
-        double q1 = get_percentile(0.25);
-        double q3 = get_percentile(0.75);
+        double q1  = get_percentile(0.25);
+        double q3  = get_percentile(0.75);
         double iqr = q3 - q1;
 
         double lower_bound = q1 - m_iteration_times_iqr_multiplier * iqr;
@@ -1867,8 +1873,10 @@ private:
         std::vector<double> filtered;
         filtered.reserve(values.size());
 
-        for (double v : values) {
-            if (v >= lower_bound && v <= upper_bound) {
+        for(double v : values)
+        {
+            if(v >= lower_bound && v <= upper_bound)
+            {
                 filtered.push_back(v);
             }
         }
@@ -2037,7 +2045,10 @@ private:
                                    bool         default_cold,
                                    int          default_trials)
     {
-        parser.set_optional<size_t>("size", "size", default_bytes, "Size of the randomly generated input array in bytes.");
+        parser.set_optional<size_t>("size",
+                                    "size",
+                                    default_bytes,
+                                    "Size of the randomly generated input array in bytes.");
         parser.set_optional<size_t>("batch_iterations",
                                     "batch_iterations",
                                     default_batch_iterations,
@@ -2051,7 +2062,12 @@ private:
                                   !default_cold,
                                   "Don't clear the gpu cache on every batch iteration.");
 
-        parser.set_optional<std::string>("seed", "seed", "random", "Seed for input generation. Either an unsigned integer value for determinisic results, or 'random' for different inputs for each repetition.");
+        parser.set_optional<std::string>(
+            "seed",
+            "seed",
+            "random",
+            "Seed for input generation. Either an unsigned integer value for determinisic results, "
+            "or 'random' for different inputs for each repetition.");
         parser.set_optional<int>("trials", "trials", default_trials, "number of iterations");
         parser.set_optional<std::string>("name_format",
                                          "name_format",
@@ -2072,11 +2088,13 @@ private:
             "iteration_info_out",
             "iteration_info_out",
             "",
-            "optional output path for a JSON file containing iteration info");
-        parser.set_optional<double>("iteration_times_iqr_multiplier",
-                                  "iteration_times_iqr_multiplier",
-                                  1.5,
-                                  "Multiplier for the IQR filter that discards outlier iteration times. A larger multiplier discards less. -1 will discard nothing.");
+            "Optional output path for a JSON file containing iteration info.");
+        parser.set_optional<double>(
+            "iteration_times_iqr_multiplier",
+            "iteration_times_iqr_multiplier",
+            1.5,
+            "Multiplier for the IQR filter that discards outlier iteration times. A larger "
+            "multiplier discards less. -1 discards nothing.");
     }
 
     void parse(cli::Parser& parser)

--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -1661,7 +1661,8 @@ public:
           benchmark::State&   gbench_state,
           size_t              warmup_iterations,
           bool                cold,
-          std::string         iteration_info_out)
+          std::string         iteration_info_out,
+          double              iteration_times_iqr_multiplier)
         : stream(stream)
         , bytes(bytes)
         , seed(seed)
@@ -1669,6 +1670,7 @@ public:
         , gbench_state(gbench_state)
         , m_warmup_iterations(warmup_iterations)
         , m_cold(cold)
+        , m_iteration_times_iqr_multiplier(iteration_times_iqr_multiplier)
         , m_events(batch_iterations * 2)
         , m_logger(iteration_info_out)
     {
@@ -1794,6 +1796,11 @@ public:
                                        * type_size);
         gbench_state.SetItemsProcessed(m_total_gbench_iterations * batch_iterations * actual_size);
 
+        if(m_iteration_times_iqr_multiplier != -1)
+        {
+            m_times = drop_outliers_using_iqr(m_times);
+        }
+
         output_statistics();
 
         std::string name = get_escaped_name(gbench_state.name());
@@ -1833,6 +1840,46 @@ private:
         }
         escaped_name += "/manual_time";
         return escaped_name;
+    }
+
+    // IQR stands for Interquartile range.
+    // It's used to drop outlier iteration times, in order to reduce noise.
+    std::vector<double> drop_outliers_using_iqr(const std::vector<double>& values) const {
+        if (values.size() < 4) {
+            return values; // Not enough data to define outliers
+        }
+
+        std::vector<double> sorted_vals = values;
+        std::sort(sorted_vals.begin(), sorted_vals.end());
+
+        auto get_percentile = [&](double p) {
+            double idx = p * (sorted_vals.size() - 1);
+            size_t i = static_cast<size_t>(idx);
+            double frac = idx - i;
+            if (i + 1 < sorted_vals.size()) {
+                return sorted_vals[i] * (1.0 - frac) + sorted_vals[i + 1] * frac;
+            } else {
+                return sorted_vals[i];
+            }
+        };
+
+        double q1 = get_percentile(0.25);
+        double q3 = get_percentile(0.75);
+        double iqr = q3 - q1;
+
+        double lower_bound = q1 - m_iteration_times_iqr_multiplier * iqr;
+        double upper_bound = q3 + m_iteration_times_iqr_multiplier * iqr;
+
+        std::vector<double> filtered;
+        filtered.reserve(values.size());
+
+        for (double v : values) {
+            if (v >= lower_bound && v <= upper_bound) {
+                filtered.push_back(v);
+            }
+        }
+
+        return filtered;
     }
 
     void output_statistics() const
@@ -1894,6 +1941,7 @@ private:
 
     size_t m_warmup_iterations;
     bool   m_cold;
+    double m_iteration_times_iqr_multiplier;
 
     std::vector<hipEvent_t> m_events;
     logger                  m_logger;
@@ -2031,6 +2079,10 @@ private:
             "iteration_info_out",
             "",
             "optional output path for a JSON file containing iteration info");
+        parser.set_optional<double>("iteration_times_iqr_multiplier",
+                                  "iteration_times_iqr_multiplier",
+                                  1.5,
+                                  "Multiplier for the IQR filter that discards outlier iteration times. A larger multiplier discards less. -1 will discard nothing.");
     }
 
     void parse(cli::Parser& parser)
@@ -2046,6 +2098,8 @@ private:
         m_cold = !parser.get<bool>("hot");
 
         m_iteration_info_out = parser.get<std::string>("iteration_info_out");
+
+        m_iteration_times_iqr_multiplier = parser.get<double>("iteration_times_iqr_multiplier");
 
         m_trials             = parser.get<int>("trials");
         m_parallel_instance  = parser.get<int>("parallel_instance");
@@ -2177,7 +2231,8 @@ private:
                      gbench_state,
                      m_warmup_iterations,
                      m_cold,
-                     m_iteration_info_out);
+                     m_iteration_info_out,
+                     m_iteration_times_iqr_multiplier);
     }
 
     void apply_settings(benchmark::internal::Benchmark* b)
@@ -2225,6 +2280,7 @@ private:
     size_t       m_warmup_iterations;
     bool         m_cold;
     std::string  m_iteration_info_out;
+    double       m_iteration_times_iqr_multiplier;
 
     int m_trials;
     int m_parallel_instance;


### PR DESCRIPTION
## Motivation

Our current benchmarks are very noisy, because we are not trimming the iteration time outliers, as seen here:

<img width="500" src="https://github.com/user-attachments/assets/29c5de27-a8f9-432c-b22b-2f535c01cac5" />

The bottom of that graph its legend states that there is 4.4% noise, which means it's very noisy.

This high noise is problematic, because it is blocking over 600 config improvements from being merged. See [this PR](https://github.com/ROCm/rocm-libraries/pull/497):

<img width="500" src="https://github.com/user-attachments/assets/df41be5b-a10e-4618-8670-dc287b28d727" />

This merge request discards the noisy outliers by calculating an IQR (interquartile range, [wikipedia](https://en.wikipedia.org/wiki/Interquartile_range)):

<img width="500" src="https://github.com/user-attachments/assets/23ddb506-bed6-4d5e-95df-f7eb34653193" />

The below image shows off how big of a difference the default IQR multiplier of 1.5 makes, bringing the noise down from 4.0% to 1.2%:

<img width="500" src="https://github.com/user-attachments/assets/5e2db7b2-0030-4037-978c-2135aeb2b56a" />

Notice how in the above graph there are red peaks of around 80 μs (1 microsecond is 1/1000 ms). These red peaks are most likely caused by thermal throttling, so the blue points discarding those measurements is great.

This MR also makes my issue [Investigate the effect of GPU throttling on throughput and noise](https://projects.streamhpc.com/amd/libraries/rocm-libraries/-/work_items/88) less urgent. That issue describes how nvbench measures the GPU's clock frequency to discard measurements that were collected during thermal throttling.

The user can pass `--iteration_times_iqr_multiplier -1` in order to turn IQR filtering off entirely, as shown by the first image in this MR.

What is VERY important to note, is that all of the graphs in this MR manage to lower the noise, while keeping the `mean` time in the legend roughly the same.

## More graphs

Passing `--iteration_times_iqr_multiplier 15` is practically the same as passing `--iteration_times_iqr_multiplier -1`:

<img width="500" src="https://github.com/user-attachments/assets/3c82836d-3312-40cd-8a0f-e067fe7e0649" />

Passing `--iteration_times_iqr_multiplier 0.15` in this case brings the noise from 5.6% to 2.8%:

<img width="500" src="https://github.com/user-attachments/assets/fae99068-e288-497c-a53f-cd06d7426d0e" />

Passing `--iteration_times_iqr_multiplier 0.015` in this case brings the noise from 3.1% to 0.6%:

<img width="500" src="https://github.com/user-attachments/assets/e0ec5a92-2990-44a9-aa81-0897492d3ba2" />

## How to verify
### Setup
1. Clone rocm-libraries.
2. Checkout this MR.
3. Run `gfx="$(rocminfo | grep -o 'gfx[0-9|a-f]\+' | head -n1)"`
4. Run `mkdir build && cd build && CXX=hipcc cmake -GNinja -DBUILD_BENCHMARK=ON -DBENCHMARK_CONFIG_TUNING=OFF -DGPU_TARGETS="$gfx" ..`

### Running benchmark_device_find_first_of
1. Generate `original.json` by running `ninja benchmark_device_find_first_of && benchmark/benchmark_device_find_first_of --seed 42 --benchmark_out=foo.json --iteration_info_out original.json --benchmark_min_time=0s --trials 1000 --iteration_times_iqr_multiplier -1`
2. Generate `mult0.015.json` by running `ninja benchmark_device_find_first_of && benchmark/benchmark_device_find_first_of --seed 42 --benchmark_out=foo.json --iteration_info_out mult0.015.json --benchmark_min_time=0s --trials 1000 --iteration_times_iqr_multiplier 0.015`
3. Generate `graph.svg` in the benchmark-visualization repository by running `python3 plot_iteration_info.py --old-json original.json --new-json mult0.015.json --graph-dir graphs --specialization '{"lvl":"device","algo":"find_first_of","keys_size":1,"first_occurrence":"0.100000","value_type":"int8_t","cfg":"default_config"}/manual_time'`

### Expected output

<img width="500" src="https://github.com/user-attachments/assets/a68a7198-cb16-4480-bf44-5a929f14505a" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
