### PR TITLE
[rocPRIM] Add gfx942 configs for device_batch_memcpy, device_batch_copy

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_batch_copy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_batch_copy.hpp
@@ -253,6 +253,41 @@ struct default_batch_copy_config<static_cast<unsigned int>(target_arch::gfx90a),
     : batch_copy_config<256, 2, 8, 128, 32, 128, 1024>
 {};
 
+// Based on value_type = int64_t
+template<class value_type>
+struct default_batch_copy_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    value_type,
+    std::enable_if_t<((sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : batch_copy_config<256, 2, 8, 128, 32, 128, 1024>
+{};
+
+// Based on value_type = int
+template<class value_type>
+struct default_batch_copy_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    value_type,
+    std::enable_if_t<((sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : batch_copy_config<256, 2, 8, 128, 32, 128, 1024>
+{};
+
+// Based on value_type = short
+template<class value_type>
+struct default_batch_copy_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    value_type,
+    std::enable_if_t<((sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : batch_copy_config<256, 2, 8, 128, 32, 128, 1024>
+{};
+
+// Based on value_type = int8_t
+template<class value_type>
+struct default_batch_copy_config<static_cast<unsigned int>(target_arch::gfx942),
+                                 value_type,
+                                 std::enable_if_t<((sizeof(value_type) <= 1))>>
+    : batch_copy_config<256, 2, 8, 128, 32, 128, 1024>
+{};
+
 } // end namespace detail
 
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_batch_memcpy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_batch_memcpy.hpp
@@ -253,6 +253,41 @@ struct default_batch_memcpy_config<static_cast<unsigned int>(target_arch::gfx90a
     : batch_memcpy_config<256, 2, 8, 128, 32, 128, 1024>
 {};
 
+// Based on value_type = int64_t
+template<class value_type>
+struct default_batch_memcpy_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    value_type,
+    std::enable_if_t<((sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : batch_memcpy_config<256, 2, 8, 128, 32, 128, 1024>
+{};
+
+// Based on value_type = int
+template<class value_type>
+struct default_batch_memcpy_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    value_type,
+    std::enable_if_t<((sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : batch_memcpy_config<256, 2, 8, 128, 32, 128, 1024>
+{};
+
+// Based on value_type = short
+template<class value_type>
+struct default_batch_memcpy_config<
+    static_cast<unsigned int>(target_arch::gfx942),
+    value_type,
+    std::enable_if_t<((sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : batch_memcpy_config<256, 2, 8, 128, 32, 128, 1024>
+{};
+
+// Based on value_type = int8_t
+template<class value_type>
+struct default_batch_memcpy_config<static_cast<unsigned int>(target_arch::gfx942),
+                                   value_type,
+                                   std::enable_if_t<((sizeof(value_type) <= 1))>>
+    : batch_memcpy_config<256, 2, 8, 128, 32, 128, 1024>
+{};
+
 } // end namespace detail
 
 END_ROCPRIM_NAMESPACE


### PR DESCRIPTION
## Motivation

Currently, we are missing specialized configs for gfx942 for device_batch_memcpy and device_batch_copy. The default config that's used is causing problems for some higher level libraries because the items_per_thread setting too high, resulting in out-of-shared-memory errors (even with the limit_block_size struct cutting down the block size to a single warp).

## Technical Details

Autotuning is not currently enabled for benchmark_device_batch_memcpy, but all other architectures use the same specialized config. I compared the performance of this config on gfx942 with that of the default config. The specialized config improves performance for all data sizes with no regressions. In addition, because it provides a lower items_per_thread, it also allows the higher level libraries I mentioned to build on gfx942 without issue.
With this in mind, this change adds the specialized configs for gfx942.

## Test Plan

Run the test_device_batch_memcpy test suite on gfx942, ensure all tests pass. Run the benchmarks and ensure there are no regressions vs. the default config.

## Test Result

All tests pass. No regressions were observed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
