### PR TITLE
[hipDNN] Swap include paths to use full path to prevent issues with TheRock

### DIFF
--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/json/Common.hpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier:  MIT
 #pragma once
 
-#include "data_types_generated.h"
 #include <flatbuffers/flatbuffer_builder.h>
+#include <hipdnn_sdk/data_objects/data_types_generated.h>
 #include <nlohmann/detail/macro_scope.hpp>
 #include <nlohmann/json.hpp>
 

--- a/projects/hipdnn/sdk/tests/utilities/TestJson.cpp
+++ b/projects/hipdnn/sdk/tests/utilities/TestJson.cpp
@@ -1,16 +1,15 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include "data_types_generated.h"
-#include "graph_generated.h"
-#include "hipdnn_sdk/test_utilities/FlatbufferGraphTestUtils.hpp"
-#include "tensor_attributes_generated.h"
 #include <flatbuffers/flatbuffer_builder.h>
 #include <gtest/gtest.h>
 
+#include <hipdnn_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_sdk/data_objects/graph_generated.h>
+#include <hipdnn_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_sdk/test_utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_sdk/test_utilities/TestUtilities.hpp>
 #include <hipdnn_sdk/utilities/json/Graph.hpp>
-#include <spdlog/fmt/bundled/format.h>
 
 using namespace hipdnn_sdk::data_objects;
 


### PR DESCRIPTION
## Motivation

With adding hipDNN to TheRock, some of the include paths started to have issues due to needing to change how we add the SDK include paths. Changing these locations to use the full SDK path.
