### PR TITLE
[hipDNN] Fix position independent code in cmake to work properly with TheRock

### DIFF
--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -9,6 +9,8 @@ set(HIPDNN_FLATBUFFERS_VERSION "25.9.23" CACHE STRING "Version of flatbuffers to
 set(HIPDNN_NLOHMANN_JSON_VERSION "3.12.0" CACHE STRING "Version of nlohmann_json to use")
 set(HIPDNN_GTEST_VERSION "1.16.0" CACHE STRING "Version of googletest to use")
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 add_compile_definitions(__HIP_PLATFORM_AMD__)
 
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/ClangToolChain.cmake" CACHE STRING "Toolchain file")

--- a/projects/hipdnn/cmake/ClangToolChain.cmake
+++ b/projects/hipdnn/cmake/ClangToolChain.cmake
@@ -26,8 +26,6 @@ if(UNIX)
         message(FATAL_ERROR "The directory ${ROCM_LLVM_BIN_DIR} does not exist. Cannot auto select clang compilers.")
     endif()
 
-    add_compile_options(-fPIC) # Position Independent Code (not needed/supported on Windows)
-
 elseif(WIN32)
     # Windows: Use Clang from TheRock build
     set(WINDOWS_ROCM_DIR "C:/src/TheRock/build/dist/rocm" CACHE PATH "Path to Windows ROCm installation")


### PR DESCRIPTION
## Motivation

Fix PIC setting to use CMake option instead of adding the compile option directly.
This was found in TheRock since the ToolChain is set up differently.
