### PR TITLE
[hipDNN] Dockerfile build modes

### DIFF
--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -69,7 +69,7 @@ RUN tar -xf $THEROCK_TARBALL -C /opt/rocm --strip-components=1
 # docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_ASIC=gfx950 --build-arg THEROCK_GIT_HASH=abc123def456 -t hipdnn:custom_source_build .
 #
 # Build mode options:
-# - THEROCK_BUILD_MODE can be: Preset (default), Debug, or Release
+# - THEROCK_BUILD_MODE can be: Preset, Debug, or Release (default)
 # - When using "Preset", specify the preset with THEROCK_BUILD_PRESET
 # - When using "Debug" or "Release", standard CMake build types are used
 #
@@ -90,7 +90,7 @@ FROM base AS install_therock_fullbuild
 
 ARG THEROCK_ASIC=gfx90a
 ARG THEROCK_GIT_HASH=default
-ARG THEROCK_BUILD_MODE=Preset
+ARG THEROCK_BUILD_MODE=Release
 ARG THEROCK_BUILD_PRESET=linux-release-package
 ARG BUILD_JOBS=0
 

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -67,12 +67,32 @@ RUN tar -xf $THEROCK_TARBALL -C /opt/rocm --strip-components=1
 #
 # Example build command for overriding ASIC and git hash:
 # docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_ASIC=gfx950 --build-arg THEROCK_GIT_HASH=abc123def456 -t hipdnn:custom_source_build .
+#
+# Build mode options:
+# - THEROCK_BUILD_MODE can be: Preset (default), Debug, or Release
+# - When using "Preset", specify the preset with THEROCK_BUILD_PRESET
+# - When using "Debug" or "Release", standard CMake build types are used
+#
+# Note: When THEROCK_BUILD_MODE=Preset, the THEROCK_BUILD_PRESET value is used.
+#       When THEROCK_BUILD_MODE=Debug/Release, THEROCK_BUILD_PRESET is ignored.
+#
+# Build parallelism:
+# - BUILD_JOBS controls the number of parallel build jobs
+# - Default is 0, which means use all available CPU cores
+#
+# Example build command for Debug build with 4 cores:
+# docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_BUILD_MODE=Debug --build-arg BUILD_JOBS=4 -t hipdnn:debug .
+#
+# Example build command with custom TheRock preset:
+# docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_BUILD_MODE=Preset --build-arg THEROCK_BUILD_PRESET=linux-debug-package -t hipdnn:custom-preset .
 # ============================================================================
 FROM base AS install_therock_fullbuild
 
 ARG THEROCK_ASIC=gfx90a
 ARG THEROCK_GIT_HASH=default
+ARG THEROCK_BUILD_MODE=Preset
 ARG THEROCK_BUILD_PRESET=linux-release-package
+ARG BUILD_JOBS=0
 
 RUN git config --global user.email "docker@build.local" && \
     git config --global user.name "Docker Build"
@@ -101,14 +121,31 @@ RUN git config --global url."https://github.com/".insteadOf git@github.com: && \
 RUN mkdir build
 WORKDIR /TheRock/build
 
-RUN cmake .. \
-    --preset=$THEROCK_BUILD_PRESET \
-    -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-    -DTHEROCK_ENABLE_ALL=OFF \
-    -DTHEROCK_ENABLE_MIOPEN=ON \
-    -DTHEROCK_AMDGPU_FAMILIES=$THEROCK_ASIC
+RUN if [ "$THEROCK_BUILD_MODE" = "Preset" ]; then \
+        echo "Building with TheRock preset: $THEROCK_BUILD_PRESET"; \
+        cmake .. \
+            --preset=$THEROCK_BUILD_PRESET \
+            -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+            -DTHEROCK_ENABLE_ALL=OFF \
+            -DTHEROCK_ENABLE_MIOPEN=ON \
+            -DTHEROCK_AMDGPU_FAMILIES=$THEROCK_ASIC; \
+    else \
+        echo "Building with CMake build type: $THEROCK_BUILD_MODE"; \
+        cmake .. \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=$THEROCK_BUILD_MODE \
+            -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+            -DTHEROCK_ENABLE_ALL=OFF \
+            -DTHEROCK_ENABLE_MIOPEN=ON \
+            -DTHEROCK_AMDGPU_FAMILIES=$THEROCK_ASIC; \
+    fi
 
-RUN cmake --build . && \
+RUN if [ "$BUILD_JOBS" = "0" ]; then \
+        cmake --build .; \
+    else \
+        echo "Building with $BUILD_JOBS parallel jobs"; \
+        cmake --build . -j$BUILD_JOBS; \
+    fi && \
     cmake --install .
 
 # ============================================================================

--- a/projects/hipdnn/dockerfiles/README.md
+++ b/projects/hipdnn/dockerfiles/README.md
@@ -46,7 +46,9 @@ The Dockerfile supports two build types: **prebuilt** (using nightly tarballs) a
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `THEROCK_GIT_HASH` | `default` | Specific git commit hash to checkout (uses default branch if not specified) |
-| `THEROCK_BUILD_PRESET` | `linux-release-package` | Specify which build preset to use when building TheRock |
+| `THEROCK_BUILD_MODE` | `Preset` | Build mode: `Preset` (uses TheRock presets), `Debug`, or `Release` (uses CMake build types) |
+| `THEROCK_BUILD_PRESET` | `linux-release-package` | Specify which build preset to use when THEROCK_BUILD_MODE=Preset |
+| `BUILD_JOBS` | `0` | Number of parallel build jobs. 0 uses all available CPU cores |
 
 > **Note**: Fullbuild mode clones and compiles TheRock from source (slower but more flexible)
 
@@ -69,6 +71,21 @@ docker build -f Dockerfile.ubuntu24 --build-arg THEROCK_ASIC=gfx950 --build-arg 
 **Default fullbuild** (gfx90a, default branch):
 ```bash
 docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild -t hipdnn:fullbuild .
+```
+
+**Debug build** (gfx90a, debug mode):
+```bash
+docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_BUILD_MODE=Debug -t hipdnn:debug .
+```
+
+**Release build with limited cores** (gfx90a, release mode, 4 cores):
+```bash
+docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_BUILD_MODE=Release --build-arg BUILD_JOBS=4 -t hipdnn:release .
+```
+
+**Custom preset with all cores** (gfx90a, custom preset):
+```bash
+docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_BUILD_MODE=Preset --build-arg THEROCK_BUILD_PRESET=linux-debug-package -t hipdnn:custom-preset .
 ```
 
 **Custom ASIC and Git Hash** (gfx950, hash abcd1234):

--- a/projects/hipdnn/dockerfiles/README.md
+++ b/projects/hipdnn/dockerfiles/README.md
@@ -46,7 +46,7 @@ The Dockerfile supports two build types: **prebuilt** (using nightly tarballs) a
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `THEROCK_GIT_HASH` | `default` | Specific git commit hash to checkout (uses default branch if not specified) |
-| `THEROCK_BUILD_MODE` | `Preset` | Build mode: `Preset` (uses TheRock presets), `Debug`, or `Release` (uses CMake build types) |
+| `THEROCK_BUILD_MODE` | `Release` | Build mode: `Preset` (uses TheRock presets), `Debug`, or `Release` (uses CMake build types) |
 | `THEROCK_BUILD_PRESET` | `linux-release-package` | Specify which build preset to use when THEROCK_BUILD_MODE=Preset |
 | `BUILD_JOBS` | `0` | Number of parallel build jobs. 0 uses all available CPU cores |
 


### PR DESCRIPTION
## Motivation

Adds option to use TheRock preset or CMake build type during Docker fullbuild. Also adds a number of CPU cores build arg.

## Technical Details

Modifies the dockerfile and updates docs.

## Test Plan

Manual testing through `docker build`.

## Test Result

No issues so far.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
