### PR TITLE
[hipsparse] Use snprintf instead of sprintf

### DIFF
--- a/projects/hipsparse/clients/benchmarks/hipsparse_bench.cpp
+++ b/projects/hipsparse/clients/benchmarks/hipsparse_bench.cpp
@@ -29,7 +29,7 @@
 std::string hipsparse_get_version()
 {
     int  hipsparse_ver;
-    char hipsparse_rev[64];
+    char hipsparse_rev[256];
 
     hipsparseStatus_t status;
 

--- a/projects/hipsparse/clients/common/utility.cpp
+++ b/projects/hipsparse/clients/common/utility.cpp
@@ -127,8 +127,8 @@ void query_version(char* version)
     }
 
     snprintf(version,
-             256,
-             "v%d.%d.%d-%.64s",
+             512,
+             "v%d.%d.%d-%.256s",
              hipsparse_ver / 100000,
              hipsparse_ver / 100 % 1000,
              hipsparse_ver % 100,

--- a/projects/hipsparse/clients/common/utility.cpp
+++ b/projects/hipsparse/clients/common/utility.cpp
@@ -92,7 +92,7 @@ extern "C" {
 void query_version(char* version)
 {
     int  hipsparse_ver;
-    char hipsparse_rev[64];
+    char hipsparse_rev[256];
 
     hipsparseStatus_t status;
 
@@ -126,12 +126,13 @@ void query_version(char* version)
         throw(status);
     }
 
-    sprintf(version,
-            "v%d.%d.%d-%s",
-            hipsparse_ver / 100000,
-            hipsparse_ver / 100 % 1000,
-            hipsparse_ver % 100,
-            hipsparse_rev);
+    snprintf(version,
+             256,
+             "v%d.%d.%d-%.64s",
+             hipsparse_ver / 100000,
+             hipsparse_ver / 100 % 1000,
+             hipsparse_ver % 100,
+             hipsparse_rev);
 }
 
 /* ============================================================================================ */

--- a/projects/hipsparse/clients/samples/example_handle.cpp
+++ b/projects/hipsparse/clients/samples/example_handle.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
     int version;
     HIPSPARSE_CHECK(hipsparseGetVersion(handle, &version));
 
-    char rev[128];
+    char rev[256];
     HIPSPARSE_CHECK(hipsparseGetGitRevision(handle, rev));
 
     printf("hipSPARSE version %d.%d.%d-%s\n",

--- a/projects/hipsparse/clients/tests/hipsparse_gtest_main.cpp
+++ b/projects/hipsparse/clients/tests/hipsparse_gtest_main.cpp
@@ -173,7 +173,7 @@ bool display_timing_info_is_stdout_disabled()
 int main(int argc, char** argv)
 {
     // Print version
-    char version[256];
+    char version[512];
     query_version(version);
 
     // Get device id from command line

--- a/projects/hipsparse/library/src/amd_detail/hipsparse_auxiliary.cpp
+++ b/projects/hipsparse/library/src/amd_detail/hipsparse_auxiliary.cpp
@@ -39,17 +39,17 @@ hipsparseStatus_t hipsparseCreate(hipsparseHandle_t* handle)
         return HIPSPARSE_STATUS_INVALID_VALUE;
     }
 
-    int               deviceId;
-    hipError_t        err;
-    hipsparseStatus_t retval = HIPSPARSE_STATUS_SUCCESS;
+    int        deviceId;
+    hipError_t err;
 
     err = hipGetDevice(&deviceId);
     if(err == hipSuccess)
     {
-        retval = hipsparse::rocSPARSEStatusToHIPStatus(
+        return hipsparse::rocSPARSEStatusToHIPStatus(
             rocsparse_create_handle((rocsparse_handle*)handle));
     }
-    return retval;
+
+    return hipsparse::hipErrorToHIPSPARSEStatus(err);
 }
 
 hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle)
@@ -107,13 +107,14 @@ hipsparseStatus_t hipsparseGetGitRevision(hipsparseHandle_t handle, char* rev)
     RETURN_IF_ROCSPARSE_ERROR(rocsparse_get_version((rocsparse_handle)handle, &rocsparse_ver));
 
     // Combine
-    sprintf(rev,
-            "%s (rocSPARSE %d.%d.%d-%s)",
-            hipsparse_rev,
-            rocsparse_ver / 100000,
-            rocsparse_ver / 100 % 1000,
-            rocsparse_ver % 100,
-            rocsparse_rev);
+    snprintf(rev,
+             256,
+             "%.64s (rocSPARSE %d.%d.%d-%.64s)",
+             hipsparse_rev,
+             rocsparse_ver / 100000,
+             rocsparse_ver / 100 % 1000,
+             rocsparse_ver % 100,
+             rocsparse_rev);
 
     return HIPSPARSE_STATUS_SUCCESS;
 }

--- a/projects/hipsparse/library/src/nvidia_detail/hipsparse_auxiliary.cpp
+++ b/projects/hipsparse/library/src/nvidia_detail/hipsparse_auxiliary.cpp
@@ -85,12 +85,13 @@ hipsparseStatus_t hipsparseGetGitRevision(hipsparseHandle_t handle, char* rev)
     RETURN_IF_CUSPARSE_ERROR(cusparseGetVersion((cusparseHandle_t)handle, &cusparse_ver));
 
     // Combine
-    sprintf(rev,
-            "%s (cuSPARSE %d.%d.%d)",
-            hipsparse_rev,
-            cusparse_ver / 100000,
-            cusparse_ver / 100 % 1000,
-            cusparse_ver % 100);
+    snprintf(rev,
+             256,
+             "%.64s (cuSPARSE %d.%d.%d)",
+             hipsparse_rev,
+             cusparse_ver / 100000,
+             cusparse_ver / 100 % 1000,
+             cusparse_ver % 100);
 
     return HIPSPARSE_STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Motivation

Use snprintf instead of sprintf in `hipsparseGetGitRevision` as it is safe and does not risk buffer overflow

## Technical Details

In at least some recent versions of ROCm the version strings are longer (they now include the date). For example on some systems the version looks like:

`hipsparse_rev: 20250912-42-369-g917aa4dd15-dirty (rocSPARSE 4.0.3-20250912-42-369-g917aa4dd15)`

whereas previously it was shorter:

`hipSPARSE version: v4.1.0-41d63053ef-dirty (rocSPARSE 4.0.2-87ccad8df3-dirty)`

This was causing buffer overflow because our buffer was only 64 bytes long. I have increased this version buffer to 256 and also swapped out `sprintf` for the safe version `snprintf`. This fixes `*** stack smashing detected ***: terminated` errors that were occuring on Strix Halo ROCm 7.0 machines.

## Test Plan

Ensure all CI tests pass
