### PR TITLE
rocfft: handle 4-D bricks in DebugPrintHash

### DIFF
--- a/projects/rocfft/shared/fft_hash.h
+++ b/projects/rocfft/shared/fft_hash.h
@@ -338,6 +338,23 @@ static inline void compute_buffer_hash(const std::vector<hostbuf>& ibuffer,
             hash_real,
             hash_imag);
         break;
+    case 4:
+    {
+        // treat 4D brick as 3D + batch, but this needs to be
+        // unbatched until we add 4D support for copy_buffers
+        if(nbatch != 1)
+            throw std::runtime_error("cannot copy batched 4D bricks");
+        compute_buffer_hash<Tfloat, std::tuple<size_t, size_t, size_t>, Tint>(
+            ibuffer,
+            itype,
+            std::make_tuple(ilength[1], ilength[2], ilength[3]),
+            std::make_tuple(istride[1], istride[2], istride[3]),
+            istride[0],
+            ilength[0],
+            hash_real,
+            hash_imag);
+        break;
+    }
     default:
         abort();
     }


### PR DESCRIPTION


## Motivation

rocFFT aborts when LAYER=16 logging is enabled during multi-GPU transforms.

## Technical Details

Batch dimension is treated by bricks as a 4th dimension, and these bricks are directly passed to the logging code.  So allow LAYER=16 logging to handle this case.

## Test Plan

Manual testing for this non-default developer feature.

## Test Result

Logging works successfully now in this situation.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
