### PR TITLE
[rocPRIM] Add host memory check for device_merge_inplace test

### DIFF
--- a/projects/rocprim/test/rocprim/test_device_merge_inplace.cpp
+++ b/projects/rocprim/test/rocprim/test_device_merge_inplace.cpp
@@ -48,6 +48,15 @@
 #include <type_traits>
 #include <vector>
 
+#if !defined(_WIN32)
+#include <unistd.h>
+unsigned long long get_available_host_memory()
+{
+    // See "man sysconf 3" for more information on this system call.
+    return sysconf(_SC_AVPHYS_PAGES) * sysconf(_SC_PAGE_SIZE);
+}
+#endif
+
 TEST(RocprimDeviceMergeInplaceTests, Basic)
 {
     using value_type    = int;
@@ -316,7 +325,10 @@ TYPED_TEST(DeviceMergeInplaceTests, MergeInplace)
 
     binary_op compare_op{};
 
-    hipStream_t stream = hipStreamDefault;
+    hipStream_t stream = 0;
+
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    HIP_CHECK(hipSetDevice(device_id));
 
     for(auto size : sizes)
     {
@@ -325,6 +337,7 @@ TYPED_TEST(DeviceMergeInplaceTests, MergeInplace)
         size_t size_a     = std::get<0>(size);
         size_t size_b     = std::get<1>(size);
         size_t size_total = size_a + size_b;
+        size_t total_bytes = sizeof(value_type) * size_total;
 
         // hipMallocManaged() currently doesnt support zero byte allocation
         if((size_a == 0 || size_b == 0) && common::use_hmm())
@@ -341,22 +354,34 @@ TYPED_TEST(DeviceMergeInplaceTests, MergeInplace)
             continue;
         }
 
+        // Limit the total size to slightly saner numbers.
+        if(total_bytes >= 1LL << 35 /* 32 GiB */)
+        {
+            continue;
+        }
+
+        // For large sizes, we may run out of host memory.
+        // Currently, on Linux, std::vector::resize may not always throw an
+        // exception in this case (it may hang instead).
+        // Because of this, manually check if we have enough available
+        // here - if not, skip this size.
+        // This problem does not currently occur on Windows.
+#if !defined(_WIN32)
+        if (total_bytes > get_available_host_memory())
+        {
+            std::cout << "skipping - not enough host mem" << std::endl;
+            continue;
+        }
+#endif
+
         // Wrap the host vector allocation in a try/catch, since
-        // we may actually run out of host memory here on some systems.
+        // std::vector may throw an exception if we run out of host memory.
         std::vector<value_type> h_data(0);
         try
         {
             h_data.resize(size_total);
         }
         catch (const std::bad_alloc& err)
-        {
-            continue;
-        }
-
-        size_t total_bytes = sizeof(value_type) * size_total;
-
-        // Limit the total size to slightly saner numbers.
-        if(total_bytes >= 1LL << 35 /* 32 GiB */)
         {
             continue;
         }
@@ -370,8 +395,7 @@ TYPED_TEST(DeviceMergeInplaceTests, MergeInplace)
                                          compare_op,
                                          stream));
 
-        // ensure tests always fit on device
-        HIP_CHECK(hipSetDevice(hipGetStreamDeviceId(stream)));
+        // Check if we have enough available device memory.
         size_t free_vram;
         size_t available_vram;
         HIP_CHECK(hipMemGetInfo(&free_vram, &available_vram));


### PR DESCRIPTION
## Motivation

On Linux, one of the tests in `test_device_merge_inplace` can hang because it runs out of host memory for large input sizes.

## Technical Details

It seems that on some Linux systems, `std::vector::resize` does not always throw an exception when its allocation fails. This change adds a check on the amount of available host memory. If there is not enough, the test is skipped.

## Test Plan

Run test_device_merge_inplace on a Linux system with <= 64 GB of host memory. Verify that the tests pass.

## Test Result

Test passes on Linux.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
