### PR TITLE
Add multi-batch support in subcommunicator based alltoall exchanges - Including 64bit MPI support

### DIFF
--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -205,6 +205,57 @@ if( ROCFFT_MPI_ENABLE )
   include_directories(SYSTEM ${MPI_INCLUDE_PATH})
 endif()
 
+# Prefer modern MPI with 64-bit support if provided
+if(TARGET MPI::MPI_C)
+  set(_MPI_C_LINK_TARGET MPI::MPI_C)
+# fall back to classic variables provided by find_package(MPI)
+else()
+  set(_MPI_C_LINK_TARGET ${MPI_C_LIBRARIES})
+endif()
+
+# Create a small test program that attempts to call MPI_Ialltoall_c / MPI_Ialltoallv_c
+set(_check_src "${CMAKE_BINARY_DIR}/CMakeFiles/check_mpi_c_collectives.c")
+file(WRITE "${_check_src}"
+"#include <mpi.h>
+int main(int argc, char** argv)
+{
+  int rc = MPI_Init(&argc, &argv);
+#if defined(MPI_VERSION) && (MPI_VERSION >= 4)
+  /* attempt to reference the _c APIs */
+  /* not executed, only ensures link symbol is present */
+  MPI_Request req;
+  MPI_Ialltoall_c(NULL, (MPI_Count)0, MPI_CHAR, NULL, (MPI_Count)0, MPI_CHAR, MPI_COMM_WORLD, &req);
+  MPI_Ialltoallv_c(NULL, (MPI_Count*)NULL, (MPI_Aint*)NULL, MPI_CHAR, NULL, (MPI_Count*)NULL, (MPI_Aint*)NULL, MPI_CHAR, MPI_COMM_WORLD, &req);
+#endif
+  MPI_Finalize();
+  return rc;
+}
+")
+
+# Try to compile and link the test program. try_compile returns result in variable ENABLE_MPI_IALLTOALL_C
+# Use the proper link target (imported target or libraries)
+if(TARGET MPI::MPI_C)
+  try_compile(ENABLE_MPI_IALLTOALL_C
+              ${CMAKE_BINARY_DIR}
+              "${_check_src}"
+              LINK_LIBRARIES MPI::MPI_C
+              OUTPUT_VARIABLE _try_compile_out)
+else()
+try_compile(ENABLE_MPI_IALLTOALL_C
+            ${CMAKE_BINARY_DIR}
+            "${_check_src}"
+            LINK_LIBRARIES "${_MPI_C_LINK_TARGET}"
+            CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${MPI_C_INCLUDE_PATH}"
+            OUTPUT_VARIABLE _try_compile_out)
+endif()
+
+if(ENABLE_MPI_IALLTOALL_C)
+  add_compile_definitions(ENABLE_MPI_C_COLLECTIVES=1)
+  message(STATUS "MPI large-count _c collectives available: enabling ENABLE_MPI_C_COLLECTIVES")
+else()
+  message(STATUS "MPI large-count _c collectives NOT available; building fallback (int-conversion/splitting) path")
+endif()
+
 add_subdirectory( library )
 
 include( clients/cmake/build-options.cmake )

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -2728,7 +2728,7 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
     std::vector<size_t>    currentAntecedents = inputFFTItems;
 
     // using MPI sub-communicators for optimized pencil-to-pencil
-    if(pencil_to_pencil && batch == 1)
+    if(pencil_to_pencil)
     {
         // plan global transposes and local FFTs
         for(size_t i = 0; i < transpose_sequence.size(); ++i)

--- a/projects/rocfft/library/src/tree_node.cpp
+++ b/projects/rocfft/library/src/tree_node.cpp
@@ -928,23 +928,122 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
 #ifdef ROCFFT_MPI_ENABLE
     auto mpi_comm = ActiveMPIComm(plan);
 
-    const auto  elem_size = element_size(precision, arrayType);
-    MPI_Request request;
-    const int   local_comm_rank = plan->get_local_comm_rank();
+    MPI_Request  request;
+    MPI_Datatype mpi_elem_type   = rocfft_type_to_mpi_type(precision, arrayType);
+    const int    local_comm_rank = plan->get_local_comm_rank();
+
+// use MPI-4 large-count _c interfaces when available
+#if defined(MPI_VERSION) && (MPI_VERSION >= 4) && defined(ENABLE_MPI_C_COLLECTIVES)
+    std::cout << "using 64bit" << std::endl;
 
     if(uniform_counts)
     {
         if(LOG_PLAN_ENABLED())
-            log_plan("Using MPI_Ialltoall\n");
+            log_plan("Using MPI_Ialltoall_c (MPI_Count)\n");
 
-        const int send_count_bytes = static_cast<int>(sendCounts[0] * elem_size);
+        std::cout << "going to alan MPI_Ialltoall_c " << std::endl;
+
+        MPI_Count sendcount = static_cast<MPI_Count>(sendCounts[0]); // uses MPI_Count (large)
+
+        const int mpiret = MPI_Ialltoall_c(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                           sendcount,
+                                           mpi_elem_type,
+                                           recvBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                           sendcount,
+                                           mpi_elem_type,
+                                           mpi_comm,
+                                           &request);
+
+        if(mpiret != MPI_SUCCESS)
+        {
+            char errmsg[MPI_MAX_ERROR_STRING];
+            int  errlen = 0;
+            MPI_Error_string(mpiret, errmsg, &errlen);
+
+            comm_status   = COMM_MPI_ERROR;
+            error_message = "MPI_Ialltoall_c failed on rank " + std::to_string(local_comm_rank)
+                            + ": " + std::string(errmsg);
+            return;
+        }
+    }
+    else
+    {
+        if(LOG_PLAN_ENABLED())
+            log_plan("Using MPI_Ialltoallv_c (MPI_Count / MPI_Aint)\n");
+
+        std::cout << "going to alan MPI_Ialltoallv_c " << std::endl;
+
+        // create MPI_Count counts (no truncation)
+        std::vector<MPI_Count> cntSend, cntRecv;
+        cntSend.reserve(sendCounts.size());
+        cntRecv.reserve(recvCounts.size());
+
+        const auto elem_size = element_size(precision, arrayType);
+
+        for(size_t v : sendCounts)
+            cntSend.push_back(static_cast<MPI_Count>(v));
+        for(size_t v : recvCounts)
+            cntRecv.push_back(static_cast<MPI_Count>(v));
+
+        // create MPI_Aint displacements — MPI_Alltoallv_c expects byte displacements
+        std::vector<MPI_Aint> offSend, offRecv;
+        offSend.reserve(sendOffsets.size());
+        offRecv.reserve(recvOffsets.size());
+        for(size_t v : sendOffsets)
+            offSend.push_back(static_cast<MPI_Aint>(v * static_cast<size_t>(elem_size)));
+        for(size_t v : recvOffsets)
+            offRecv.push_back(static_cast<MPI_Aint>(v * static_cast<size_t>(elem_size)));
+
+        const int mpiret = MPI_Ialltoallv_c(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                            cntSend.data(),
+                                            offSend.data(),
+                                            mpi_elem_type,
+                                            recvBuf.get(in_buffer, out_buffer, local_comm_rank),
+                                            cntRecv.data(),
+                                            offRecv.data(),
+                                            mpi_elem_type,
+                                            mpi_comm,
+                                            &request);
+
+        if(mpiret != MPI_SUCCESS)
+        {
+            char errmsg[MPI_MAX_ERROR_STRING];
+            int  errlen = 0;
+            MPI_Error_string(mpiret, errmsg, &errlen);
+
+            comm_status   = COMM_MPI_ERROR;
+            error_message = "MPI_Ialltoallv_c failed on rank " + std::to_string(local_comm_rank)
+                            + ": " + std::string(errmsg);
+            return;
+        }
+    }
+#else
+    std::cout << "NOTTT using 64bit" << std::endl;
+
+    // fallback for older MPI implementations: safe convert to int and use legacy calls
+    if(uniform_counts)
+    {
+        if(LOG_PLAN_ENABLED())
+            log_plan("Using MPI_Ialltoall (fallback, int counts)\n");
+
+        // check that per-destination count fits in int to avoid overflow
+        const size_t send_count_elems = sendCounts[0];
+        if(send_count_elems > static_cast<size_t>(std::numeric_limits<int>::max()))
+        {
+            comm_status   = COMM_MPI_ERROR;
+            error_message = "send count too large to fit in MPI int on rank "
+                            + std::to_string(local_comm_rank)
+                            + " (build/upgrade MPI >= 4 for large-count support)";
+            return;
+        }
+        const int send_count = static_cast<int>(send_count_elems);
 
         const auto mpiret = MPI_Ialltoall(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
-                                          send_count_bytes,
-                                          MPI_CHAR,
+                                          send_count,
+                                          mpi_elem_type,
                                           recvBuf.get(in_buffer, out_buffer, local_comm_rank),
-                                          send_count_bytes,
-                                          MPI_CHAR,
+                                          send_count,
+                                          mpi_elem_type,
                                           mpi_comm,
                                           &request);
 
@@ -957,40 +1056,52 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
             comm_status   = COMM_MPI_ERROR;
             error_message = "MPI_Ialltoall failed on rank " + std::to_string(local_comm_rank) + ": "
                             + std::string(errmsg);
-
             return;
         }
     }
     else
     {
         if(LOG_PLAN_ENABLED())
-            log_plan("Using MPI_Ialltoallv\n");
+            log_plan("Using MPI_Ialltoallv (fallback with int conversion)\n");
 
-        // non-uniform exchange case (default)
-
-        // MPI takes ints for everything, convert our size_t elements to int bytes
-        auto convertToInt = [](const std::vector<size_t>& src, std::vector<int>& dest) {
+        // helper: safe convert size_t -> int with overflow detection
+        auto convertToInt = [](const std::vector<size_t>& src, std::vector<int>& dest) -> bool {
+            dest.clear();
             dest.reserve(src.size());
-            std::copy(src.begin(), src.end(), std::back_inserter(dest));
+            for(size_t v : src)
+            {
+                if(v > static_cast<size_t>(std::numeric_limits<int>::max()))
+                    return false; // overflow
+                dest.push_back(static_cast<int>(v));
+            }
+            return true;
         };
 
         std::vector<int> intSendOffsets;
         std::vector<int> intSendCounts;
         std::vector<int> intRecvOffsets;
         std::vector<int> intRecvCounts;
-        convertToInt(sendOffsets, intSendOffsets);
-        convertToInt(sendCounts, intSendCounts);
-        convertToInt(recvOffsets, intRecvOffsets);
-        convertToInt(recvCounts, intRecvCounts);
+
+        // convert counts and offsets to int, with overflow checks
+        if(!convertToInt(sendOffsets, intSendOffsets) || !convertToInt(sendCounts, intSendCounts)
+           || !convertToInt(recvOffsets, intRecvOffsets)
+           || !convertToInt(recvCounts, intRecvCounts))
+        {
+            comm_status   = COMM_MPI_ERROR;
+            error_message = "send/recv counts or offsets too large to fit in MPI int on rank "
+                            + std::to_string(local_comm_rank)
+                            + " (build/upgrade MPI >= 4 for large-count support)";
+            return;
+        }
 
         const auto mpiret = MPI_Ialltoallv(sendBuf.get(in_buffer, out_buffer, local_comm_rank),
                                            intSendCounts.data(),
                                            intSendOffsets.data(),
-                                           rocfft_type_to_mpi_type(precision, arrayType),
+                                           mpi_elem_type,
                                            recvBuf.get(in_buffer, out_buffer, local_comm_rank),
                                            intRecvCounts.data(),
                                            intRecvOffsets.data(),
-                                           rocfft_type_to_mpi_type(precision, arrayType),
+                                           mpi_elem_type,
                                            mpi_comm,
                                            &request);
 
@@ -1003,10 +1114,10 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
             comm_status   = COMM_MPI_ERROR;
             error_message = "MPI_Ialltoallv failed on rank " + std::to_string(local_comm_rank)
                             + ": " + std::string(errmsg);
-
             return;
         }
     }
+#endif
 
     comm_requests.push_back(request);
 

--- a/projects/rocfft/library/src/tree_node.cpp
+++ b/projects/rocfft/library/src/tree_node.cpp
@@ -934,8 +934,6 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
 
 // use MPI-4 large-count _c interfaces when available
 #if defined(MPI_VERSION) && (MPI_VERSION >= 4) && defined(ENABLE_MPI_C_COLLECTIVES)
-    std::cout << "using 64bit" << std::endl;
-
     if(uniform_counts)
     {
         if(LOG_PLAN_ENABLED())
@@ -1018,8 +1016,6 @@ void CommAllToAll::ExecuteAsync(const rocfft_plan     plan,
         }
     }
 #else
-    std::cout << "NOTTT using 64bit" << std::endl;
-
     // fallback for older MPI implementations: safe convert to int and use legacy calls
     if(uniform_counts)
     {


### PR DESCRIPTION
## Motivation

Multi-batch multi-process transforms are widely required.
Large batched transforms may need to send a message size the exceeds int limits, therefore we add support to 64bit MPI, whenever available.

## Technical Details

Add support for multi-batch transforms using sub-communicators with alltoall global exchanges and overflow checks, conditionally supports 64bit MPI.

## Test Plan

Locally ran MPI and single-process multi-GPU test cases. CI also runs
multi-GPU tests.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at
https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.