### PR TITLE
Fix specifying toolchain in install script

### DIFF
--- a/projects/rocthrust/install
+++ b/projects/rocthrust/install
@@ -120,7 +120,7 @@ fi
 # See README.md under "Build And Install" for options and defaults.
 
 cmake_executable="cmake"
-cmake_common_options="--toolchain=toolchain-linux.cmake"
+cmake_common_options="-DCMAKE_TOOLCHAIN_FILE=toolchain-linux.cmake"
 
 if [[ "${build_clients}" == true ]]; then
     build_test="-DBUILD_TEST=ON"


### PR DESCRIPTION
## Motivation

This commit ce663e3f8669b431c2831a03e90c674ec9180c26 added the ability to read the toolchain for linux, however as far as I can tell `--toolchain` is not actually a valid command-line option to cmake, and causes the install script to break.  The common.groovy file was modified too, but the .jenkins folder has been removed so there is need to fix that.

## Technical Details

The fix is to use -DCMAKE_TOOLCHAIN_FILE instead to specify the toolchain file.

## Test Plan

Retest the install script

## Test Result

Install script works

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
