### PR TITLE
[rocSOLVER] Apply out-of-place sort to eigensolvers and SVD

### DIFF
--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.cpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,29 +73,33 @@ rocblas_status rocsolver_bdsqr_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size of re-usable workspace
-    size_t size_splits_map, size_work, size_completed;
-    rocsolver_bdsqr_getMemorySize<S>(n, nv, nu, nc, batch_count, &size_splits_map, &size_work,
-                                     &size_completed);
+    size_t size_splits_map, size_work, size_tmpV, size_tmpU, size_tmpC, size_completed;
+    rocsolver_bdsqr_getMemorySize<T, S>(n, nv, nu, nc, batch_count, &size_splits_map, &size_work,
+                                        &size_tmpV, &size_tmpU, &size_tmpC, &size_completed);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_splits_map, size_work,
-                                                      size_completed);
+        return rocblas_set_optimal_device_memory_size(handle, size_splits_map, size_work, size_tmpV,
+                                                      size_tmpU, size_tmpC, size_completed);
 
     // memory workspace allocation
-    void *splits_map, *work, *completed;
-    rocblas_device_malloc mem(handle, size_splits_map, size_work, size_completed);
+    void *splits_map, *work, *tmpV, *tmpU, *tmpC, *completed;
+    rocblas_device_malloc mem(handle, size_splits_map, size_work, size_tmpV, size_tmpU, size_tmpC,
+                              size_completed);
     if(!mem)
         return rocblas_status_memory_error;
 
     splits_map = mem[0];
     work = mem[1];
-    completed = mem[2];
+    tmpV = mem[2];
+    tmpU = mem[3];
+    tmpC = mem[4];
+    completed = mem[5];
 
     // execution
-    return rocsolver_bdsqr_template<T>(handle, uplo, n, nv, nu, nc, D, strideD, E, strideE, V,
-                                       shiftV, ldv, strideV, U, shiftU, ldu, strideU, C, shiftC,
-                                       ldc, strideC, info, batch_count, (rocblas_int*)splits_map,
-                                       (S*)work, (rocblas_int*)completed);
+    return rocsolver_bdsqr_template<T>(
+        handle, uplo, n, nv, nu, nc, D, strideD, E, strideE, V, shiftV, ldv, strideV, U, shiftU,
+        ldu, strideU, C, shiftC, ldc, strideC, info, batch_count, (rocblas_int*)splits_map,
+        (S*)work, (T*)tmpV, (T*)tmpU, (T*)tmpC, (rocblas_int*)completed);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
@@ -966,7 +966,7 @@ ROCSOLVER_KERNEL void bdsqr_chk_completed(const rocblas_int n,
 
 /** BDSQR_FINALIZE sets the output values for BDSQR, and sorts the singular values and
     vectors by shell sort or selection sort if applicable. **/
-template <typename T, typename S, typename W1, typename W2, typename W3>
+template <typename T, typename S, typename U>
 ROCSOLVER_KERNEL void bdsqr_finalize(const rocblas_int n,
                                      const rocblas_int nv,
                                      const rocblas_int nu,
@@ -975,20 +975,11 @@ ROCSOLVER_KERNEL void bdsqr_finalize(const rocblas_int n,
                                      const rocblas_stride strideD,
                                      S* EE,
                                      const rocblas_stride strideE,
-                                     W1 VV,
+                                     U VV,
                                      const rocblas_int shiftV,
                                      const rocblas_int ldv,
                                      const rocblas_stride strideV,
-                                     W2 UU,
-                                     const rocblas_int shiftU,
-                                     const rocblas_int ldu,
-                                     const rocblas_stride strideU,
-                                     W3 CC,
-                                     const rocblas_int shiftC,
-                                     const rocblas_int ldc,
-                                     const rocblas_stride strideC,
                                      rocblas_int* info,
-                                     rocblas_int* splits_map,
                                      rocblas_int* completed)
 {
     auto const tid = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
@@ -1011,9 +1002,6 @@ ROCSOLVER_KERNEL void bdsqr_finalize(const rocblas_int n,
     S* const D = DD + bid * strideD;
     S* const E = EE + bid * strideE;
     T* const V = (VV ? load_ptr_batch<T>(VV, bid, shiftV, strideV) : nullptr);
-    T* const U = (UU ? load_ptr_batch<T>(UU, bid, shiftU, strideU) : nullptr);
-    T* const C = (CC ? load_ptr_batch<T>(CC, bid, shiftC, strideC) : nullptr);
-    rocblas_int* map = (splits_map ? splits_map + bid * (2 * n) : nullptr);
 
     // ensure all singular values converged and are positive
     for(rocblas_int i = 0; i < n; i++)
@@ -1042,76 +1030,12 @@ ROCSOLVER_KERNEL void bdsqr_finalize(const rocblas_int n,
         return;
     }
     __syncthreads();
-
-    // sort singular values & vectors
-    if(map)
-    {
-        if(nv || nu || nc)
-        {
-            shell_sort_descending(n, D, map);
-            __syncthreads();
-            bdsqr_permute_swap(n, nv, V, ldv, nu, U, ldu, nc, C, ldc, map);
-        }
-        else
-        {
-            rocblas_int* const null_map = nullptr;
-            shell_sort_descending(n, D, null_map);
-        }
-
-        __syncthreads();
-    }
-    else
-    {
-        S p;
-        for(i = 0; i < n - 1; i++)
-        {
-            m = i;
-            p = D[i];
-            for(j = i + 1; j < n; j++)
-            {
-                if(D[j] > p)
-                {
-                    m = j;
-                    p = D[j];
-                }
-            }
-            __syncthreads();
-
-            if(m != i)
-            {
-                if(tid == 0)
-                {
-                    D[m] = D[i];
-                    D[i] = p;
-                }
-
-                if(nv)
-                {
-                    for(j = tid; j < nv; j += hipBlockDim_x)
-                        swap(V[m + j * ldv], V[i + j * ldv]);
-                    __syncthreads();
-                }
-                if(nu)
-                {
-                    for(j = tid; j < nu; j += hipBlockDim_x)
-                        swap(U[j + m * ldu], U[j + i * ldu]);
-                    __syncthreads();
-                }
-                if(nc)
-                {
-                    for(j = tid; j < nc; j += hipBlockDim_x)
-                        swap(C[m + j * ldc], C[i + j * ldc]);
-                    __syncthreads();
-                }
-            }
-        }
-    }
 }
 
 /****** Template function, workspace size and argument validation **********/
 /***************************************************************************/
 
-template <typename T>
+template <typename T, typename S>
 void rocsolver_bdsqr_getMemorySize(const rocblas_int n,
                                    const rocblas_int nv,
                                    const rocblas_int nu,
@@ -1119,6 +1043,9 @@ void rocsolver_bdsqr_getMemorySize(const rocblas_int n,
                                    const rocblas_int batch_count,
                                    size_t* size_splits_map,
                                    size_t* size_work,
+                                   size_t* size_tmpV,
+                                   size_t* size_tmpU,
+                                   size_t* size_tmpC,
                                    size_t* size_completed)
 {
     // if quick return, no workspace is needed
@@ -1126,6 +1053,9 @@ void rocsolver_bdsqr_getMemorySize(const rocblas_int n,
     {
         *size_splits_map = 0;
         *size_work = 0;
+        *size_tmpV = 0;
+        *size_tmpU = 0;
+        *size_tmpC = 0;
         *size_completed = 0;
         return;
     }
@@ -1139,7 +1069,12 @@ void rocsolver_bdsqr_getMemorySize(const rocblas_int n,
         incW += 2;
     if(nu || nc)
         incW += 2;
-    *size_work = sizeof(T) * (4 + incW * n) * batch_count;
+    *size_work = sizeof(S) * (4 + incW * n) * batch_count;
+
+    // size of temporary copy for sort
+    *size_tmpV = sizeof(T) * n * nv * batch_count;
+    *size_tmpU = sizeof(T) * n * nu * batch_count;
+    *size_tmpC = sizeof(T) * n * nc * batch_count;
 
     // size of temporary workspace to indicate problem completion
     *size_completed = sizeof(rocblas_int) * (batch_count + 2);
@@ -1213,6 +1148,9 @@ rocblas_status rocsolver_bdsqr_template(rocblas_handle handle,
                                         const rocblas_int batch_count,
                                         rocblas_int* splits_map,
                                         S* work,
+                                        T* tmpV,
+                                        T* tmpU,
+                                        T* tmpC,
                                         rocblas_int* completed)
 {
     ROCSOLVER_ENTER("bdsqr", "uplo:", uplo, "n:", n, "nv:", nv, "nu:", nu, "nc:", nc,
@@ -1351,10 +1289,14 @@ rocblas_status rocsolver_bdsqr_template(rocblas_handle handle,
         }
     }
 
-    // sort the singular values and vectors
+    // set the output values for BDSQR
     ROCSOLVER_LAUNCH_KERNEL((bdsqr_finalize<T>), gridBasic, threadsVUC, 0, stream, n, nv, nu, nc, D,
-                            strideD, E, strideE, V, shiftV, ldv, strideV, U, shiftU, ldu, strideU,
-                            C, shiftC, ldc, strideC, info, splits_map, completed);
+                            strideD, E, strideE, V, shiftV, ldv, strideV, info, completed);
+
+    // sort the singular values and vectors
+    run_svd_sort<512, T>(handle, n, nv, nu, nc, batch_count, work, n, D, 0, strideD, tmpV, 0, n,
+                         n * nv, V, shiftV, ldv, strideV, tmpU, 0, nu, n * nu, U, shiftU, ldu,
+                         strideU, tmpC, 0, n, n * nc, C, shiftC, ldc, strideC);
 
     return rocblas_status_success;
 }

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsvdx.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsvdx.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -173,6 +173,9 @@ void rocsolver_bdsvdx_getMemorySize(const rocblas_int n,
 
     *size_work1_iwork = std::max(*size_work1_iwork, a1);
     *size_work2_pivmin = std::max(*size_work2_pivmin, b1);
+
+    // size of arrays for temporary matrix copy for eig sort
+    *size_work2_pivmin = std::max(*size_work2_pivmin, sizeof(T) * (4 * n * n) * batch_count);
 
     // size of arrays for temporary submatrix indices
     *size_nsplit = sizeof(rocblas_int) * batch_count;
@@ -346,10 +349,18 @@ rocblas_status rocsolver_bdsvdx_template(rocblas_handle handle,
                                     iblock, ntgk, isplit_map, ntgk, Z, shiftZ, ldz, strideZ, ifail,
                                     strideF, info, batch_count, work2_pivmin, work1_iwork);
 
-        // sort eigenvalues and vectors
-        ROCSOLVER_LAUNCH_KERNEL(syevx_sort_eigs<T>, dim3(1, batch_count, 1), dim3(BS1, 1, 1), 0,
-                                stream, ntgk, nsv, Stmp, ntgk, Z, shiftZ, ldz, strideZ, ifail,
-                                strideF, info, isplit_map);
+        // sort eigenvalues and eigenvectors
+        run_eigen_sort<512, T>(handle, ntgk, batch_count, Dtgk, ntgk, Stmp, 0, ntgk, work2_pivmin,
+                               0, ntgk, ntgk * ntgk, Z, shiftZ, ldz, strideZ, nsv, isplit_map);
+
+        // sort ifail
+        if(ifail)
+        {
+            ROCSOLVER_LAUNCH_KERNEL(sort_copy_values<512>, dim3(1, batch_count), dim3(512), 0,
+                                    stream, ntgk, ifail, strideF, iblock, ntgk);
+            ROCSOLVER_LAUNCH_KERNEL(sort_ifail<512>, dim3(1, batch_count), dim3(512), 0, stream,
+                                    ntgk, iblock, ntgk, ifail, strideF, info, isplit_map);
+        }
 
         // take absolute value of eigenvalues, reorder and normalize eigenvector elements, and negate elements of V
         ROCSOLVER_LAUNCH_KERNEL(bdsvdx_reorder_vect<T>, dim3(1, batch_count, 1), dim3(BS1, 1, 1), 0,

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_stedc.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_stedc.hpp
@@ -1520,43 +1520,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM)
     }
 }
 
-template <typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyD(const rocblas_int n,
-                                                                S* DDin,
-                                                                const rocblas_stride strideDin,
-                                                                S* DDout,
-                                                                const rocblas_stride strideDout)
-{
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-
-    S* Din = DDin + bid * strideDin;
-    S* Dout = DDout + bid * strideDout;
-
-    int tid = hipThreadIdx_x;
-
-    constexpr int regs = 16;
-    const int chunk_width = regs * hipBlockDim_x;
-    const int n_chunks = (n - 1) / chunk_width + 1;
-    S bval[regs];
-
-    for(int chunk = 0; chunk < n_chunks; chunk++)
-    {
-        for(int i = 0; i < regs; i++)
-        {
-            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
-                bval[i] = Din[x];
-        }
-        for(int i = 0; i < regs; i++)
-        {
-            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
-                Dout[x] = bval[i];
-        }
-    }
-}
-
 template <typename T, typename U1, typename U2>
 ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_copyC(const rocblas_int n,
                                                                 U1 CCin,
@@ -1652,123 +1615,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_reshuffleC(const rocbl
     }
 }
 
-/** STEDC_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
-template <typename T, typename S, typename U1, typename U2>
-ROCSOLVER_KERNEL void __launch_bounds__(STEDC_BDIM) stedc_sort(const rocblas_int n,
-                                                               S* DDin,
-                                                               const rocblas_stride strideDin,
-                                                               S* DDout,
-                                                               const rocblas_stride strideDout,
-                                                               U1 CCin,
-                                                               const rocblas_int shiftCin,
-                                                               const rocblas_int ldcin,
-                                                               const rocblas_stride strideCin,
-                                                               U2 CCout,
-                                                               const rocblas_int shiftCout,
-                                                               const rocblas_int ldcout,
-                                                               const rocblas_stride strideCout
-
-)
-{
-    // batch instance id
-    rocblas_int bid = hipBlockIdx_y;
-    // group id
-    rocblas_int gid = hipBlockIdx_x;
-
-    S* Din = DDin + bid * strideDin;
-    S* Dout = DDout + bid * strideDout;
-
-    int tid = hipThreadIdx_x;
-
-    S d = Din[gid];
-
-    constexpr int regs = 16;
-    const int chunk_width = regs * hipBlockDim_x;
-    const int n_chunks = (n - 1) / chunk_width + 1;
-    T bvalT[regs];
-    S* bvalS = reinterpret_cast<S*>(bvalT);
-
-    int nan = 0;
-    int lt = 0;
-    int eq = 0;
-
-    for(int chunk = 0; chunk < n_chunks; chunk++)
-    {
-        for(int i = 0; i < regs; i++)
-        {
-            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
-            {
-                bvalS[i] = Din[x];
-            }
-        }
-        for(int i = 0; i < regs; i++)
-        {
-            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
-            {
-                nan += std::isnan(bvalS[i]);
-                // lt - how many values are less then the current
-                // eq - how many values are equal to the current
-                lt += (bvalS[i] < d);
-                eq += (bvalS[i] == d && x < gid);
-            }
-        }
-    }
-
-    int pos = lt + eq;
-    // reduction
-    __shared__ int lpos[STEDC_BDIM];
-    lpos[hipThreadIdx_x] = pos;
-    for(int r = hipBlockDim_x / 2; r > 0; r /= 2)
-    {
-        __syncthreads();
-        if(hipThreadIdx_x < r)
-        {
-            pos += lpos[hipThreadIdx_x + r];
-            lpos[hipThreadIdx_x] = pos;
-        }
-    }
-    __syncthreads();
-    pos = lpos[0];
-
-    if(hipThreadIdx_x == 0)
-    {
-        Dout[pos] = d;
-    }
-
-    // The NAN fp value is unordered, so it is possible that with computed
-    // new positions it would be silently overwriten with non NAN value.
-    // Make sure we propagate NAN. It is likely to have more NANs in the output
-    // than in the input, but the following computations are doomed anyway.
-    if(nan)
-    {
-        Dout[gid] = NAN;
-    }
-
-    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
-    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
-
-    T* src = Cin + ldcin * gid;
-    T* dst = Cout + ldcout * pos;
-
-    for(int chunk = 0; chunk < n_chunks; chunk++)
-    {
-        for(int i = 0; i < regs; i++)
-        {
-            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
-                bvalT[i] = src[x];
-        }
-        for(int i = 0; i < regs; i++)
-        {
-            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
-                dst[x] = bvalT[i];
-        }
-    }
-}
-
 /******************* Host functions *********************************************/
 /*******************************************************************************/
 
@@ -1830,25 +1676,25 @@ void rocsolver_stedc_getMemorySize(const rocblas_evect evect,
     else if(n < STEDC_MIN_DC_SIZE)
     {
         *size_tempvect = 0;
-        *size_tempgemm = 0;
         *size_workArr = 0;
         *size_splits_map = 0;
         *size_tmpz = 0;
-        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_stack);
+        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_stack, size_tempgemm);
     }
 
     // otherwise use divide and conquer algorithm:
     else
     {
         // requirements for solver of small independent blocks
-        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_stack);
+        size_t t1;
+        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_stack, &t1);
 
         // extra requirements for original eigenvectors of small independent blocks
         if(evect != rocblas_evect_tridiagonal)
             *size_tempvect = sizeof(S) * (n * n) * batch_count;
         else
             *size_tempvect = 0;
-        *size_tempgemm = sizeof(S) * get_tempgemm_size(n) * batch_count;
+        *size_tempgemm = std::max(sizeof(S) * get_tempgemm_size(n) * batch_count, t1);
         // blocks for batched GEMM are at least 8 x 8
         auto max_n_merges = 1 << (stedc_num_levels(n) - 1);
         *size_workArr = sizeof(S*) * std::max(max_n_merges * 3, batch_count);
@@ -1959,7 +1805,8 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
     else if(n < STEDC_MIN_DC_SIZE)
     {
         rocsolver_steqr_template<T>(handle, evect, n, D, shiftD, strideD, E, shiftE, strideE, C,
-                                    shiftC, ldc, strideC, info, batch_count, work_stack);
+                                    shiftC, ldc, strideC, info, batch_count, work_stack,
+                                    (T*)tempgemm);
     }
 
     // otherwise use divide and conquer algorithm:
@@ -2180,15 +2027,8 @@ rocblas_status rocsolver_stedc_template(rocblas_handle handle,
                                     ldc, strideC, tempgemm);
         }
 
-        ROCSOLVER_LAUNCH_KERNEL(stedc_copyD, dim3(1, batch_count), dim3(STEDC_BDIM), 0, stream, n,
-                                D + shiftD, strideD, tmpz, n);
-
-        ROCSOLVER_LAUNCH_KERNEL(stedc_copyC<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream,
-                                n, C, shiftC, ldc, strideC, (T*)tempgemm, 0, n, n * n);
-
-        ROCSOLVER_LAUNCH_KERNEL(stedc_sort<T>, dim3(n, batch_count), dim3(STEDC_BDIM), 0, stream, n,
-                                tmpz, n, D + shiftD, strideD, (T*)tempgemm, 0, n, n * n, C, shiftC,
-                                ldc, strideC);
+        run_eigen_sort<STEDC_BDIM, T>(handle, n, batch_count, tmpz, n, D, shiftD, strideD,
+                                      (T*)tempgemm, 0, n, n * n, C, shiftC, ldc, strideC);
 
         rocblas_set_pointer_mode(handle, old_mode);
     }

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_stedcj.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_stedcj.hpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 
+#include "auxiliary/rocauxiliary_stedc.hpp"
 #include "lapack/roclapack_syevj_heevj.hpp"
 #include "lapack_device_functions.hpp"
 #include "rocblas.hpp"
@@ -1465,60 +1466,6 @@ ROCSOLVER_KERNEL void __launch_bounds__(STEDCJ_BDIM)
     }
 }
 
-/** STEDCJ_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
-template <typename T, typename S, typename U>
-ROCSOLVER_KERNEL void __launch_bounds__(BS1) stedcj_sort(const rocblas_int n,
-                                                         S* DD,
-                                                         const rocblas_stride strideD,
-                                                         U CC,
-                                                         const rocblas_int shiftC,
-                                                         const rocblas_int ldc,
-                                                         const rocblas_stride strideC,
-                                                         const rocblas_int batch_count,
-                                                         rocblas_int* work,
-                                                         rocblas_int* nev = nullptr)
-{
-    // -----------------------------------
-    // use z-grid dimension as batch index
-    // -----------------------------------
-    rocblas_int bid_start = hipBlockIdx_z;
-    rocblas_int bid_inc = hipGridDim_z;
-
-    int tid = hipThreadIdx_x;
-
-    rocblas_int* const map = work + bid_start * ((int64_t)n);
-
-    for(auto bid = bid_start; bid < batch_count; bid += bid_inc)
-    {
-        // ---------------------------------------------
-        // select batch instance to work with
-        // (avoiding arithmetics with possible nullptrs)
-        // ---------------------------------------------
-        T* C = nullptr;
-        if(CC)
-            C = load_ptr_batch<T>(CC, bid, shiftC, strideC);
-        S* D = DD + (bid * strideD);
-        rocblas_int nn;
-        if(nev)
-            nn = nev[bid];
-        else
-            nn = n;
-
-        bool constexpr use_shell_sort = true;
-
-        __syncthreads();
-
-        if(use_shell_sort)
-            shell_sort(nn, D, map);
-        else
-            selection_sort(nn, D, map);
-        __syncthreads();
-
-        permute_swap(n, C, ldc, map, nn);
-        __syncthreads();
-    }
-}
-
 /******************* Host functions *********************************************/
 /*******************************************************************************/
 
@@ -1746,8 +1693,8 @@ rocblas_status rocsolver_stedcj_template(rocblas_handle handle,
                                     static_cast<S*>(work_stack), 0, ldt, strideT, batch_count,
                                     workArr);
 
-    ROCSOLVER_LAUNCH_KERNEL((stedcj_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n, D,
-                            strideD, C, shiftC, ldc, strideC, batch_count, splits_map);
+    run_eigen_sort<STEDC_BDIM, T>(handle, n, batch_count, tmpz, n, D, 0, strideD, (T*)tempgemm, 0,
+                                  n, n * n, C, shiftC, ldc, strideC);
 
     return rocblas_status_success;
 }

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_stedcx.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_stedcx.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "auxiliary/rocauxiliary_stebz.hpp"
+#include "auxiliary/rocauxiliary_stedc.hpp"
 #include "auxiliary/rocauxiliary_stein.hpp"
 #include "auxiliary/rocauxiliary_steqr.hpp"
 #include "lapack_device_functions.hpp"
@@ -1672,10 +1673,10 @@ void rocsolver_stedcx_getMemorySize(const rocblas_evect evect,
         return;
     }
 
-    size_t s1, s2;
+    size_t s1, s2, unused;
 
     // requirements for solver of small independent blocks
-    rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_steqr);
+    rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, size_work_steqr, &unused);
     s1 = sizeof(S) * (4 * n + 2) * batch_count;
 
     // extra requirements for original eigenvectors of small independent blocks
@@ -1909,8 +1910,8 @@ rocblas_status rocsolver_stedcx_template(rocblas_handle handle,
                                     work_stack, 0, ldt, strideT, batch_count, workArr);
 
     // sort eigenvalues and eigenvectors
-    ROCSOLVER_LAUNCH_KERNEL((stedcx_sort<T>), dim3(1, 1, batch_count), dim3(BS1), 0, stream, n, W,
-                            strideW, C, shiftC, ldc, strideC, batch_count, splits, nev);
+    run_eigen_sort<STEDC_BDIM, T>(handle, n, batch_count, tmpz, n, W, 0, strideW, (T*)tempgemm, 0,
+                                  n, n * n, C, shiftC, ldc, strideC, nev);
 
     return rocblas_status_success;
 }

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_steqr.cpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_steqr.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,23 +62,25 @@ rocblas_status rocsolver_steqr_impl(rocblas_handle handle,
 
     // memory workspace sizes:
     // size for lasrt stack/steqr workspace
-    size_t size_work_stack;
-    rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, &size_work_stack);
+    size_t size_work_stack, size_tempc;
+    rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, &size_work_stack, &size_tempc);
 
     if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_work_stack);
+        return rocblas_set_optimal_device_memory_size(handle, size_work_stack, size_tempc);
 
     // memory workspace allocation
-    void* work_stack;
-    rocblas_device_malloc mem(handle, size_work_stack);
+    void *work_stack, *tempc;
+    rocblas_device_malloc mem(handle, size_work_stack, size_tempc);
     if(!mem)
         return rocblas_status_memory_error;
 
     work_stack = mem[0];
+    tempc = mem[1];
 
     // execution
     return rocsolver_steqr_template<T>(handle, evect, n, D, shiftD, strideD, E, shiftE, strideE, C,
-                                       shiftC, ldc, strideC, info, batch_count, work_stack);
+                                       shiftC, ldc, strideC, info, batch_count, work_stack,
+                                       (T*)tempc);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_steqr.hpp
@@ -684,7 +684,8 @@ ROCSOLVER_KERNEL void steqr_kernel(const rocblas_int n,
                                    const rocblas_int max_iters,
                                    const S eps,
                                    const S ssfmin,
-                                   const S ssfmax)
+                                   const S ssfmax,
+                                   const bool ordered = true)
 {
     // select bacth instance
     rocblas_int tid = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -699,19 +700,21 @@ ROCSOLVER_KERNEL void steqr_kernel(const rocblas_int n,
     rocblas_int* info = iinfo + bid;
 
     // execute
-    run_steqr(tid, tid_inc, n, D, E, C, ldc, info, work, max_iters, eps, ssfmin, ssfmax);
+    run_steqr(tid, tid_inc, n, D, E, C, ldc, info, work, max_iters, eps, ssfmin, ssfmax, ordered);
 }
 
 template <typename T, typename S>
 void rocsolver_steqr_getMemorySize(const rocblas_evect evect,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
-                                   size_t* size_work_stack)
+                                   size_t* size_work_stack,
+                                   size_t* size_tempc)
 {
+    *size_work_stack = 0;
+    *size_tempc = 0;
     // if quick return no workspace needed
     if(n == 0 || !batch_count)
     {
-        *size_work_stack = 0;
         return;
     }
 
@@ -719,7 +722,10 @@ void rocsolver_steqr_getMemorySize(const rocblas_evect evect,
     if(evect == rocblas_evect_none)
         *size_work_stack = sizeof(rocblas_int) * (2 * 32) * batch_count;
     else
+    {
         *size_work_stack = sizeof(S) * (2 * n) * batch_count;
+        *size_tempc = sizeof(T) * (n * n) * batch_count;
+    }
 }
 
 template <typename T, typename S>
@@ -772,7 +778,8 @@ rocblas_status rocsolver_steqr_template(rocblas_handle handle,
                                         const rocblas_stride strideC,
                                         rocblas_int* info,
                                         const rocblas_int batch_count,
-                                        void* work_stack)
+                                        void* work_stack,
+                                        T* tempc)
 {
     ROCSOLVER_ENTER("steqr", "evect:", evect, "n:", n, "shiftD:", shiftD, "shiftE:", shiftE,
                     "shiftC:", shiftC, "ldc:", ldc, "bc:", batch_count);
@@ -832,8 +839,12 @@ rocblas_status rocsolver_steqr_template(rocblas_handle handle,
             const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
 
             ROCSOLVER_LAUNCH_KERNEL((steqr_kernel<T>), dim3(1, batch_count), dim3(props->warpSize),
-                                    0, stream, n, D + shiftD, strideD, E + shiftE, strideE, C, shiftC,
-                                    ldc, strideC, info, (S*)work_stack, 30 * n, eps, ssfmin, ssfmax);
+                                    0, stream, n, D + shiftD, strideD, E + shiftE, strideE, C,
+                                    shiftC, ldc, strideC, info, (S*)work_stack, 30 * n, eps, ssfmin,
+                                    ssfmax, false);
+
+            run_eigen_sort<512, T>(handle, n, batch_count, (S*)work_stack, n, D, shiftD, strideD,
+                                   tempc, 0, n, n * n, C, shiftC, ldc, strideC);
         }
     }
 

--- a/projects/rocsolver/library/src/include/lapack_device_functions.hpp
+++ b/projects/rocsolver/library/src/include/lapack_device_functions.hpp
@@ -3071,4 +3071,252 @@ void local_gemm(rocblas_handle handle,
                             strideA, temp);
 }
 
+template <int DIM, typename S>
+ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyD(const rocblas_int n,
+                                                              S* DDin,
+                                                              const rocblas_stride strideDin,
+                                                              S* DDout,
+                                                              const rocblas_stride strideDout)
+{
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+
+    S* Din = DDin + bid * strideDin;
+    S* Dout = DDout + bid * strideDout;
+
+    int tid = hipThreadIdx_x;
+
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (n - 1) / chunk_width + 1;
+    S bval[regs];
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                bval[i] = Din[x];
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                Dout[x] = bval[i];
+        }
+    }
+}
+
+template <int DIM, typename T, typename U1, typename U2>
+ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyC(const rocblas_int n,
+                                                              U1 CCin,
+                                                              const rocblas_int shiftCin,
+                                                              const rocblas_int ldcin,
+                                                              const rocblas_stride strideCin,
+                                                              U2 CCout,
+                                                              const rocblas_int shiftCout,
+                                                              const rocblas_int ldcout,
+                                                              const rocblas_stride strideCout)
+{
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
+
+    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
+    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
+
+    T* src = Cin + ldcin * gid;
+    T* dst = Cout + ldcout * gid;
+
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (n - 1) / chunk_width + 1;
+    T bval[regs];
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                bval[i] = src[x];
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                dst[x] = bval[i];
+        }
+    }
+}
+
+/** EIGEN_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
+template <int DIM, typename T, typename S, typename U1, typename U2>
+ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort(const rocblas_int n,
+                                                        S* DDin,
+                                                        const rocblas_stride strideDin,
+                                                        S* DDout,
+                                                        const rocblas_stride strideDout,
+                                                        U1 CCin,
+                                                        const rocblas_int shiftCin,
+                                                        const rocblas_int ldcin,
+                                                        const rocblas_stride strideCin,
+                                                        U2 CCout,
+                                                        const rocblas_int shiftCout,
+                                                        const rocblas_int ldcout,
+                                                        const rocblas_stride strideCout,
+                                                        rocblas_int* nev = nullptr,
+                                                        rocblas_int* mmap = nullptr
+
+)
+{
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
+
+    S* Din = DDin + bid * strideDin;
+    S* Dout = DDout + bid * strideDout;
+
+    int tid = hipThreadIdx_x;
+
+    const rocblas_int nn = (nev) ? nev[bid] : n;
+    auto const map = (mmap) ? mmap + (bid * n) : (rocblas_int*)nullptr;
+
+    if(gid >= nn)
+        return;
+
+    S d = Din[gid];
+
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    const int n_chunks = (nn - 1) / chunk_width + 1;
+    T bvalT[regs];
+    S* bvalS = reinterpret_cast<S*>(bvalT);
+
+    int nan = 0;
+    int lt = 0;
+    int eq = 0;
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < nn)
+            {
+                bvalS[i] = Din[x];
+            }
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < nn)
+            {
+                nan += std::isnan(bvalS[i]);
+                // lt - how many values are less then the current
+                // eq - how many values are equal to the current
+                lt += (bvalS[i] < d);
+                eq += (bvalS[i] == d && x < gid);
+            }
+        }
+    }
+
+    int pos = lt + eq;
+    // reduction
+    __shared__ int lpos[DIM];
+    lpos[hipThreadIdx_x] = pos;
+    for(int r = hipBlockDim_x / 2; r > 0; r /= 2)
+    {
+        __syncthreads();
+        if(hipThreadIdx_x < r)
+        {
+            pos += lpos[hipThreadIdx_x + r];
+            lpos[hipThreadIdx_x] = pos;
+        }
+    }
+    __syncthreads();
+    pos = lpos[0];
+
+    if(hipThreadIdx_x == 0)
+    {
+        Dout[pos] = d;
+
+        if(map)
+        {
+            map[gid] = pos;
+        }
+    }
+
+    // The NAN fp value is unordered, so it is possible that with computed
+    // new positions it would be silently overwriten with non NAN value.
+    // Make sure we propagate NAN. It is likely to have more NANs in the output
+    // than in the input, but the following computations are doomed anyway.
+    if(nan)
+    {
+        Dout[gid] = NAN;
+    }
+
+    T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
+    T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
+
+    T* src = Cin + ldcin * gid;
+    T* dst = Cout + ldcout * pos;
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                bvalT[i] = src[x];
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < n)
+                dst[x] = bvalT[i];
+        }
+    }
+}
+
+/** EIGEN_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
+template <int DIM, typename T, typename S, typename U1, typename U2>
+void run_eigen_sort(rocblas_handle handle,
+                    const rocblas_int n,
+                    const rocblas_int batch_count,
+                    S* tempD,
+                    const rocblas_stride strideTempD,
+                    S* D,
+                    const rocblas_int shiftD,
+                    const rocblas_stride strideD,
+                    U1 tempC,
+                    const rocblas_int shiftTempC,
+                    const rocblas_int ldtempc,
+                    const rocblas_stride strideTempC,
+                    U2 C,
+                    const rocblas_int shiftC,
+                    const rocblas_int ldc,
+                    const rocblas_stride strideC,
+                    rocblas_int* nev = nullptr,
+                    rocblas_int* map = nullptr
+
+)
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    ROCSOLVER_LAUNCH_KERNEL(eigen_sort_copyD<DIM>, dim3(1, batch_count), dim3(DIM), 0, stream, n,
+                            D + shiftD, strideD, tempD, strideTempD);
+
+    ROCSOLVER_LAUNCH_KERNEL((eigen_sort_copyC<DIM, T>), dim3(n, batch_count), dim3(DIM), 0, stream,
+                            n, C, shiftC, ldc, strideC, tempC, shiftTempC, ldtempc, strideTempC);
+
+    ROCSOLVER_LAUNCH_KERNEL((eigen_sort<DIM, T>), dim3(n, batch_count), dim3(DIM), 0, stream, n,
+                            tempD, strideTempD, D + shiftD, strideD, tempC, shiftTempC, ldtempc,
+                            strideTempC, C, shiftC, ldc, strideC, nev, map);
+}
+
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/include/lapack_device_functions.hpp
+++ b/projects/rocsolver/library/src/include/lapack_device_functions.hpp
@@ -3076,7 +3076,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyD(const rocblas_int 
                                                               S* DDin,
                                                               const rocblas_stride strideDin,
                                                               S* DDout,
-                                                              const rocblas_stride strideDout)
+                                                              const rocblas_stride strideDout,
+                                                              rocblas_int* nev = nullptr)
 {
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
@@ -3086,9 +3087,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyD(const rocblas_int 
 
     int tid = hipThreadIdx_x;
 
+    const rocblas_int nn = (nev) ? nev[bid] : n;
+
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
-    const int n_chunks = (n - 1) / chunk_width + 1;
+    const int n_chunks = (nn - 1) / chunk_width + 1;
     S bval[regs];
 
     for(int chunk = 0; chunk < n_chunks; chunk++)
@@ -3096,13 +3099,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyD(const rocblas_int 
         for(int i = 0; i < regs; i++)
         {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
+            if(x < nn)
                 bval[i] = Din[x];
         }
         for(int i = 0; i < regs; i++)
         {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
+            if(x < nn)
                 Dout[x] = bval[i];
         }
     }
@@ -3117,7 +3120,8 @@ ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyC(const rocblas_int 
                                                               U2 CCout,
                                                               const rocblas_int shiftCout,
                                                               const rocblas_int ldcout,
-                                                              const rocblas_stride strideCout)
+                                                              const rocblas_stride strideCout,
+                                                              rocblas_int* nev = nullptr)
 {
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
@@ -3129,6 +3133,11 @@ ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyC(const rocblas_int 
 
     T* src = Cin + ldcin * gid;
     T* dst = Cout + ldcout * gid;
+
+    const rocblas_int nn = (nev) ? nev[bid] : n;
+
+    if(gid >= nn)
+        return;
 
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
@@ -3309,10 +3318,10 @@ void run_eigen_sort(rocblas_handle handle,
     rocblas_get_stream(handle, &stream);
 
     ROCSOLVER_LAUNCH_KERNEL(eigen_sort_copyD<DIM>, dim3(1, batch_count), dim3(DIM), 0, stream, n,
-                            D + shiftD, strideD, tempD, strideTempD);
+                            D + shiftD, strideD, tempD, strideTempD, nev);
 
     ROCSOLVER_LAUNCH_KERNEL((eigen_sort_copyC<DIM, T>), dim3(n, batch_count), dim3(DIM), 0, stream,
-                            n, C, shiftC, ldc, strideC, tempC, shiftTempC, ldtempc, strideTempC);
+                            n, C, shiftC, ldc, strideC, tempC, shiftTempC, ldtempc, strideTempC, nev);
 
     ROCSOLVER_LAUNCH_KERNEL((eigen_sort<DIM, T>), dim3(n, batch_count), dim3(DIM), 0, stream, n,
                             tempD, strideTempD, D + shiftD, strideD, tempC, shiftTempC, ldtempc,

--- a/projects/rocsolver/library/src/include/lapack_device_functions.hpp
+++ b/projects/rocsolver/library/src/include/lapack_device_functions.hpp
@@ -3072,7 +3072,7 @@ void local_gemm(rocblas_handle handle,
 }
 
 template <int DIM, typename S>
-ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyD(const rocblas_int n,
+ROCSOLVER_KERNEL void __launch_bounds__(DIM) sort_copy_values(const rocblas_int n,
                                                               S* DDin,
                                                               const rocblas_stride strideDin,
                                                               S* DDout,
@@ -3112,16 +3112,17 @@ ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyD(const rocblas_int 
 }
 
 template <int DIM, typename T, typename U1, typename U2>
-ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyC(const rocblas_int n,
-                                                              U1 CCin,
-                                                              const rocblas_int shiftCin,
-                                                              const rocblas_int ldcin,
-                                                              const rocblas_stride strideCin,
-                                                              U2 CCout,
-                                                              const rocblas_int shiftCout,
-                                                              const rocblas_int ldcout,
-                                                              const rocblas_stride strideCout,
-                                                              rocblas_int* nev = nullptr)
+ROCSOLVER_KERNEL void __launch_bounds__(DIM) sort_copy_vectors(const rocblas_int m,
+                                                               const rocblas_int n,
+                                                               U1 CCin,
+                                                               const rocblas_int shiftCin,
+                                                               const rocblas_int ldcin,
+                                                               const rocblas_stride strideCin,
+                                                               U2 CCout,
+                                                               const rocblas_int shiftCout,
+                                                               const rocblas_int ldcout,
+                                                               const rocblas_stride strideCout,
+                                                               rocblas_int* nev = nullptr)
 {
     // batch instance id
     rocblas_int bid = hipBlockIdx_y;
@@ -3141,7 +3142,7 @@ ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyC(const rocblas_int 
 
     constexpr int regs = 16;
     const int chunk_width = regs * hipBlockDim_x;
-    const int n_chunks = (n - 1) / chunk_width + 1;
+    const int n_chunks = (m - 1) / chunk_width + 1;
     T bval[regs];
 
     for(int chunk = 0; chunk < n_chunks; chunk++)
@@ -3149,13 +3150,13 @@ ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort_copyC(const rocblas_int 
         for(int i = 0; i < regs; i++)
         {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
+            if(x < m)
                 bval[i] = src[x];
         }
         for(int i = 0; i < regs; i++)
         {
             int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
-            if(x < n)
+            if(x < m)
                 dst[x] = bval[i];
         }
     }
@@ -3291,6 +3292,214 @@ ROCSOLVER_KERNEL void __launch_bounds__(DIM) eigen_sort(const rocblas_int n,
     }
 }
 
+/** SVD_SORT sorts computed singular values and vectors in decreasing order **/
+template <int DIM, typename T, typename S, typename V1, typename V2, typename U1, typename U2, typename C1, typename C2>
+ROCSOLVER_KERNEL void __launch_bounds__(DIM) svd_sort(const rocblas_int n,
+                                                      const rocblas_int nv,
+                                                      const rocblas_int nu,
+                                                      const rocblas_int nc,
+                                                      S* DDin,
+                                                      const rocblas_stride strideDin,
+                                                      S* DDout,
+                                                      const rocblas_stride strideDout,
+                                                      V1 VVin,
+                                                      const rocblas_int shiftVin,
+                                                      const rocblas_int ldvin,
+                                                      const rocblas_stride strideVin,
+                                                      V2 VVout,
+                                                      const rocblas_int shiftVout,
+                                                      const rocblas_int ldvout,
+                                                      const rocblas_stride strideVout,
+                                                      U1 UUin,
+                                                      const rocblas_int shiftUin,
+                                                      const rocblas_int lduin,
+                                                      const rocblas_stride strideUin,
+                                                      U2 UUout,
+                                                      const rocblas_int shiftUout,
+                                                      const rocblas_int lduout,
+                                                      const rocblas_stride strideUout,
+                                                      C1 CCin,
+                                                      const rocblas_int shiftCin,
+                                                      const rocblas_int ldcin,
+                                                      const rocblas_stride strideCin,
+                                                      C2 CCout,
+                                                      const rocblas_int shiftCout,
+                                                      const rocblas_int ldcout,
+                                                      const rocblas_stride strideCout,
+                                                      rocblas_int* nev = nullptr,
+                                                      rocblas_int* mmap = nullptr
+
+)
+{
+    // batch instance id
+    rocblas_int bid = hipBlockIdx_y;
+    // group id
+    rocblas_int gid = hipBlockIdx_x;
+
+    S* Din = DDin + bid * strideDin;
+    S* Dout = DDout + bid * strideDout;
+
+    int tid = hipThreadIdx_x;
+
+    const rocblas_int nn = (nev) ? nev[bid] : n;
+    auto const map = (mmap) ? mmap + (bid * n) : (rocblas_int*)nullptr;
+
+    if(gid >= nn)
+        return;
+
+    S d = Din[gid];
+
+    constexpr int regs = 16;
+    const int chunk_width = regs * hipBlockDim_x;
+    int n_chunks = (nn - 1) / chunk_width + 1;
+    T bvalT[regs];
+    S* bvalS = reinterpret_cast<S*>(bvalT);
+
+    int nan = 0;
+    int gt = 0;
+    int eq = 0;
+
+    for(int chunk = 0; chunk < n_chunks; chunk++)
+    {
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < nn)
+            {
+                bvalS[i] = Din[x];
+            }
+        }
+        for(int i = 0; i < regs; i++)
+        {
+            int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+            if(x < nn)
+            {
+                nan += std::isnan(bvalS[i]);
+                // gt - how many values are greater then the current
+                // eq - how many values are equal to the current
+                gt += (bvalS[i] > d);
+                eq += (bvalS[i] == d && x < gid);
+            }
+        }
+    }
+
+    int pos = gt + eq;
+    // reduction
+    __shared__ int lpos[DIM];
+    lpos[hipThreadIdx_x] = pos;
+    for(int r = hipBlockDim_x / 2; r > 0; r /= 2)
+    {
+        __syncthreads();
+        if(hipThreadIdx_x < r)
+        {
+            pos += lpos[hipThreadIdx_x + r];
+            lpos[hipThreadIdx_x] = pos;
+        }
+    }
+    __syncthreads();
+    pos = lpos[0];
+
+    if(hipThreadIdx_x == 0)
+    {
+        Dout[pos] = d;
+
+        if(map)
+        {
+            map[gid] = pos;
+        }
+    }
+
+    // The NAN fp value is unordered, so it is possible that with computed
+    // new positions it would be silently overwriten with non NAN value.
+    // Make sure we propagate NAN. It is likely to have more NANs in the output
+    // than in the input, but the following computations are doomed anyway.
+    if(nan)
+    {
+        Dout[gid] = NAN;
+    }
+
+    // permute V
+    if(nv)
+    {
+        T* Vin = load_ptr_batch<T>(VVin, bid, shiftVin, strideVin);
+        T* Vout = load_ptr_batch<T>(VVout, bid, shiftVout, strideVout);
+
+        T* vsrc = Vin + gid;
+        T* vdst = Vout + pos;
+
+        n_chunks = (nv - 1) / chunk_width + 1;
+        for(int chunk = 0; chunk < n_chunks; chunk++)
+        {
+            for(int i = 0; i < regs; i++)
+            {
+                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                if(x < nv)
+                    bvalT[i] = vsrc[ldvin * x];
+            }
+            for(int i = 0; i < regs; i++)
+            {
+                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                if(x < nv)
+                    vdst[ldvout * x] = bvalT[i];
+            }
+        }
+    }
+
+    // permute U
+    if(nu)
+    {
+        T* Uin = load_ptr_batch<T>(UUin, bid, shiftUin, strideUin);
+        T* Uout = load_ptr_batch<T>(UUout, bid, shiftUout, strideUout);
+
+        T* usrc = Uin + lduin * gid;
+        T* udst = Uout + lduout * pos;
+
+        n_chunks = (nu - 1) / chunk_width + 1;
+        for(int chunk = 0; chunk < n_chunks; chunk++)
+        {
+            for(int i = 0; i < regs; i++)
+            {
+                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                if(x < nu)
+                    bvalT[i] = usrc[x];
+            }
+            for(int i = 0; i < regs; i++)
+            {
+                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                if(x < nu)
+                    udst[x] = bvalT[i];
+            }
+        }
+    }
+
+    // permute C
+    if(nc)
+    {
+        T* Cin = load_ptr_batch<T>(CCin, bid, shiftCin, strideCin);
+        T* Cout = load_ptr_batch<T>(CCout, bid, shiftCout, strideCout);
+
+        T* csrc = Cin + gid;
+        T* cdst = Cout + pos;
+
+        n_chunks = (nc - 1) / chunk_width + 1;
+        for(int chunk = 0; chunk < n_chunks; chunk++)
+        {
+            for(int i = 0; i < regs; i++)
+            {
+                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                if(x < nc)
+                    bvalT[i] = csrc[ldcin * x];
+            }
+            for(int i = 0; i < regs; i++)
+            {
+                int x = chunk * chunk_width + i * hipBlockDim_x + hipThreadIdx_x;
+                if(x < nc)
+                    cdst[ldcout * x] = bvalT[i];
+            }
+        }
+    }
+}
+
 /** EIGEN_SORT sorts computed eigenvalues and eigenvectors in increasing order **/
 template <int DIM, typename T, typename S, typename U1, typename U2>
 void run_eigen_sort(rocblas_handle handle,
@@ -3317,15 +3526,86 @@ void run_eigen_sort(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    ROCSOLVER_LAUNCH_KERNEL(eigen_sort_copyD<DIM>, dim3(1, batch_count), dim3(DIM), 0, stream, n,
+    ROCSOLVER_LAUNCH_KERNEL(sort_copy_values<DIM>, dim3(1, batch_count), dim3(DIM), 0, stream, n,
                             D + shiftD, strideD, tempD, strideTempD, nev);
 
-    ROCSOLVER_LAUNCH_KERNEL((eigen_sort_copyC<DIM, T>), dim3(n, batch_count), dim3(DIM), 0, stream,
-                            n, C, shiftC, ldc, strideC, tempC, shiftTempC, ldtempc, strideTempC, nev);
+    ROCSOLVER_LAUNCH_KERNEL((sort_copy_vectors<DIM, T>), dim3(n, batch_count), dim3(DIM), 0, stream,
+                            n, n, C, shiftC, ldc, strideC, tempC, shiftTempC, ldtempc, strideTempC,
+                            nev);
 
     ROCSOLVER_LAUNCH_KERNEL((eigen_sort<DIM, T>), dim3(n, batch_count), dim3(DIM), 0, stream, n,
                             tempD, strideTempD, D + shiftD, strideD, tempC, shiftTempC, ldtempc,
                             strideTempC, C, shiftC, ldc, strideC, nev, map);
+}
+
+/** SVD_SORT sorts computed singular values and vectors in decreasing order **/
+template <int DIM, typename T, typename S, typename V1, typename V2, typename U1, typename U2, typename C1, typename C2>
+void run_svd_sort(rocblas_handle handle,
+                  const rocblas_int n,
+                  const rocblas_int nv,
+                  const rocblas_int nu,
+                  const rocblas_int nc,
+                  const rocblas_int batch_count,
+                  S* tempD,
+                  const rocblas_stride strideTempD,
+                  S* D,
+                  const rocblas_int shiftD,
+                  const rocblas_stride strideD,
+                  V1 tempV,
+                  const rocblas_int shiftTempV,
+                  const rocblas_int ldtempv,
+                  const rocblas_stride strideTempV,
+                  V2 V,
+                  const rocblas_int shiftV,
+                  const rocblas_int ldv,
+                  const rocblas_stride strideV,
+                  U1 tempU,
+                  const rocblas_int shiftTempU,
+                  const rocblas_int ldtempu,
+                  const rocblas_stride strideTempU,
+                  U2 U,
+                  const rocblas_int shiftU,
+                  const rocblas_int ldu,
+                  const rocblas_stride strideU,
+                  C1 tempC,
+                  const rocblas_int shiftTempC,
+                  const rocblas_int ldtempc,
+                  const rocblas_stride strideTempC,
+                  C2 C,
+                  const rocblas_int shiftC,
+                  const rocblas_int ldc,
+                  const rocblas_stride strideC,
+                  rocblas_int* nev = nullptr,
+                  rocblas_int* map = nullptr
+
+)
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    ROCSOLVER_LAUNCH_KERNEL(sort_copy_values<DIM>, dim3(1, batch_count), dim3(DIM), 0, stream, n,
+                            D + shiftD, strideD, tempD, strideTempD, nev);
+
+    if(nv)
+        ROCSOLVER_LAUNCH_KERNEL((sort_copy_vectors<DIM, T>), dim3(nv, batch_count), dim3(DIM), 0,
+                                stream, n, nv, V, shiftV, ldv, strideV, tempV, shiftTempV, ldtempv,
+                                strideTempV, nev);
+
+    if(nu)
+        ROCSOLVER_LAUNCH_KERNEL((sort_copy_vectors<DIM, T>), dim3(n, batch_count), dim3(DIM), 0,
+                                stream, nu, n, U, shiftU, ldu, strideU, tempU, shiftTempU, ldtempu,
+                                strideTempU, nev);
+
+    if(nc)
+        ROCSOLVER_LAUNCH_KERNEL((sort_copy_vectors<DIM, T>), dim3(nc, batch_count), dim3(DIM), 0,
+                                stream, n, nc, C, shiftC, ldc, strideC, tempC, shiftTempC, ldtempc,
+                                strideTempC, nev);
+
+    ROCSOLVER_LAUNCH_KERNEL((svd_sort<DIM, T>), dim3(n, batch_count), dim3(DIM), 0, stream, n, nv,
+                            nu, nc, tempD, strideTempD, D + shiftD, strideD, tempV, shiftTempV,
+                            ldtempv, strideTempV, V, shiftV, ldv, strideV, tempU, shiftTempU,
+                            ldtempu, strideTempU, U, shiftU, ldu, strideU, tempC, shiftTempC,
+                            ldtempc, strideTempC, C, shiftC, ldc, strideC, nev, map);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -193,8 +193,9 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
 
     size_t w[6] = {0, 0, 0, 0, 0, 0};
     size_t a[6] = {0, 0, 0, 0, 0, 0};
-    size_t x[6] = {0, 0, 0, 0, 0, 0};
-    size_t y[3] = {0, 0, 0};
+    size_t x[7] = {0, 0, 0, 0, 0, 0, 0};
+    size_t y[4] = {0, 0, 0, 0};
+    size_t c[2] = {0, 0};
     size_t unused;
 
     // booleans used to determine the path that the execution will follow:
@@ -237,8 +238,7 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
     // size of arrays to store temporary copies
     *size_tempArrayT
         = (fast_thinSVD || (thinSVD && leadvO && othervN)) ? sizeof(T) * k * k * batch_count : 0;
-    *size_tempArrayC
-        = (fast_thinSVD && (othervN || othervO || leadvO)) ? sizeof(T) * m * n * batch_count : 0;
+    c[0] = (fast_thinSVD && (othervN || othervO || leadvO)) ? sizeof(T) * m * n * batch_count : 0;
 
     // workspace required for the bidiagonalization
     if(thinSVD)
@@ -249,7 +249,8 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
                                                   &x[0], &y[0]);
 
     // workspace required for the SVD of the bidiagonal form
-    rocsolver_bdsqr_getMemorySize<S>(k, nv, nu, 0, batch_count, size_tau_splits, &w[1], &a[1]);
+    rocsolver_bdsqr_getMemorySize<T, S>(k, nv, nu, 0, batch_count, size_tau_splits, &w[1], &y[1],
+                                        &x[1], &c[1], &a[1]);
 
     // size of array tau to store householder scalars on intermediate
     // orthonormal/unitary matrices
@@ -259,46 +260,46 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
     if(thinSVD)
     {
         if(row)
-            rocsolver_geqrf_getMemorySize<BATCHED, T>(m, n, batch_count, &unused, &w[2], &x[1],
-                                                      &y[1], &unused);
+            rocsolver_geqrf_getMemorySize<BATCHED, T>(m, n, batch_count, &unused, &w[2], &x[2],
+                                                      &y[2], &unused);
         else
-            rocsolver_gelqf_getMemorySize<BATCHED, T>(m, n, batch_count, &unused, &w[2], &x[1],
-                                                      &y[1], &unused);
+            rocsolver_gelqf_getMemorySize<BATCHED, T>(m, n, batch_count, &unused, &w[2], &x[2],
+                                                      &y[2], &unused);
     }
 
     // extra requirements for orthonormal/unitary matrix generation
     // ormbr
     if(thinSVD && !fast_thinSVD && !leadvN)
         rocsolver_ormbr_unmbr_getMemorySize<BATCHED, T>(storev_lead, side, m, n, k, batch_count,
-                                                        &unused, &a[2], &y[2], &x[2], &unused);
+                                                        &unused, &a[2], &y[3], &x[3], &unused);
     // orgbr
     if(thinSVD)
     {
         if(!othervN)
             rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(storev_other, k, k, k, batch_count,
-                                                            &unused, &w[3], &a[3], &x[3], &unused);
+                                                            &unused, &w[3], &a[3], &x[4], &unused);
 
         if(fast_thinSVD && !leadvN)
             rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(storev_lead, k, k, k, batch_count,
-                                                            &unused, &w[4], &a[4], &x[4], &unused);
+                                                            &unused, &w[4], &a[4], &x[5], &unused);
     }
     else
     {
         mn = (row && leftvS) ? n : m;
         if(leftvS || leftvA)
             rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(
-                rocblas_column_wise, m, mn, n, batch_count, &unused, &w[3], &a[3], &x[3], &unused);
+                rocblas_column_wise, m, mn, n, batch_count, &unused, &w[3], &a[3], &x[4], &unused);
         else if(leftvO)
             rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(
-                rocblas_column_wise, m, k, n, batch_count, &unused, &w[3], &a[3], &x[3], &unused);
+                rocblas_column_wise, m, k, n, batch_count, &unused, &w[3], &a[3], &x[4], &unused);
 
         mn = (!row && rightvS) ? m : n;
         if(rightvS || rightvA)
             rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(rocblas_row_wise, mn, n, m, batch_count,
-                                                            &unused, &w[4], &a[4], &x[4], &unused);
+                                                            &unused, &w[4], &a[4], &x[5], &unused);
         else if(rightvO)
             rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(rocblas_row_wise, k, n, m, batch_count,
-                                                            &unused, &w[4], &a[4], &x[4], &unused);
+                                                            &unused, &w[4], &a[4], &x[5], &unused);
     }
     // orgqr/orglq
     if(thinSVD && !leadvN)
@@ -307,19 +308,19 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
         {
             if(row)
                 rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(kk, kk, k, batch_count, &unused,
-                                                                &w[5], &a[5], &x[5], &unused);
+                                                                &w[5], &a[5], &x[6], &unused);
             else
                 rocsolver_orglq_unglq_getMemorySize<BATCHED, T>(kk, kk, k, batch_count, &unused,
-                                                                &w[5], &a[5], &x[5], &unused);
+                                                                &w[5], &a[5], &x[6], &unused);
         }
         else
         {
             if(row)
                 rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(m, n, k, batch_count, &unused,
-                                                                &w[5], &a[5], &x[5], &unused);
+                                                                &w[5], &a[5], &x[6], &unused);
             else
                 rocsolver_orglq_unglq_getMemorySize<BATCHED, T>(m, n, k, batch_count, &unused,
-                                                                &w[5], &a[5], &x[5], &unused);
+                                                                &w[5], &a[5], &x[6], &unused);
         }
     }
 
@@ -328,6 +329,7 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
     *size_Abyx_norms_tmptr_cmplt = *std::max_element(std::begin(a), std::end(a));
     *size_Abyx_norms_trfact_X = *std::max_element(std::begin(x), std::end(x));
     *size_diag_tmptr_Y = *std::max_element(std::begin(y), std::end(y));
+    *size_tempArrayC = *std::max_element(std::begin(c), std::end(c));
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename TT, typename W>
@@ -542,17 +544,17 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
 
             //*** STAGE 5: Compute singular values and vectors from the bidiagonal form ***//
             if(row)
-                rocsolver_bdsqr_template<T>(handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E,
-                                            strideE, A, shiftA, lda, strideA, U, shiftU, ldu,
-                                            strideU, (W) nullptr, 0, 1, 1, info, batch_count,
-                                            (rocblas_int*)tau_splits, (TT*)work_workArr,
-                                            (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                rocsolver_bdsqr_template<T>(
+                    handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E, strideE, A, shiftA,
+                    lda, strideA, U, shiftU, ldu, strideU, (W) nullptr, 0, 1, 1, info, batch_count,
+                    (rocblas_int*)tau_splits, (TT*)work_workArr, diag_tmptr_Y, Abyx_norms_trfact_X,
+                    tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
             else
-                rocsolver_bdsqr_template<T>(handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E,
-                                            strideE, V, shiftV, ldv, strideV, A, shiftA, lda,
-                                            strideA, (W) nullptr, 0, 1, 1, info, batch_count,
-                                            (rocblas_int*)tau_splits, (TT*)work_workArr,
-                                            (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                rocsolver_bdsqr_template<T>(
+                    handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E, strideE, V, shiftV,
+                    ldv, strideV, A, shiftA, lda, strideA, (W) nullptr, 0, 1, 1, info, batch_count,
+                    (rocblas_int*)tau_splits, (TT*)work_workArr, diag_tmptr_Y, Abyx_norms_trfact_X,
+                    tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
 
             //*** STAGE 6: update vectors with orthonormal/unitary matrices ***//
             if(othervS || othervA)
@@ -632,17 +634,17 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
 
             //*** STAGE 5: Compute singular values and vectors from the bidiagonal form ***//
             if(row)
-                rocsolver_bdsqr_template<T>(handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E,
-                                            strideE, bufferC, shiftC, ldc, strideC, bufferT, shiftT,
-                                            ldt, strideT, (T*)nullptr, 0, 1, 1, info, batch_count,
-                                            (rocblas_int*)tau_splits, (TT*)work_workArr,
-                                            (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                rocsolver_bdsqr_template<T>(
+                    handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E, strideE, bufferC,
+                    shiftC, ldc, strideC, bufferT, shiftT, ldt, strideT, (T*)nullptr, 0, 1, 1, info,
+                    batch_count, (rocblas_int*)tau_splits, (TT*)work_workArr, diag_tmptr_Y,
+                    Abyx_norms_trfact_X, tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
             else
-                rocsolver_bdsqr_template<T>(handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E,
-                                            strideE, bufferT, shiftT, ldt, strideT, bufferC, shiftC,
-                                            ldc, strideC, (T*)nullptr, 0, 1, 1, info, batch_count,
-                                            (rocblas_int*)tau_splits, (TT*)work_workArr,
-                                            (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                rocsolver_bdsqr_template<T>(
+                    handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E, strideE, bufferT,
+                    shiftT, ldt, strideT, bufferC, shiftC, ldc, strideC, (T*)nullptr, 0, 1, 1, info,
+                    batch_count, (rocblas_int*)tau_splits, (TT*)work_workArr, diag_tmptr_Y,
+                    Abyx_norms_trfact_X, tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
 
             //*** STAGE 6: update vectors with orthonormal/unitary matrices ***//
             if(leadvO)
@@ -819,27 +821,27 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             uplo = rocblas_fill_upper;
             if(!leftvO && !rightvO)
             {
-                rocsolver_bdsqr_template<T>(handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V,
-                                            shiftV, ldv, strideV, U, shiftU, ldu, strideU,
-                                            (T*)nullptr, 0, 1, 1, info, batch_count,
-                                            (rocblas_int*)tau_splits, (TT*)work_workArr,
-                                            (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                rocsolver_bdsqr_template<T>(
+                    handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V, shiftV, ldv, strideV, U,
+                    shiftU, ldu, strideU, (T*)nullptr, 0, 1, 1, info, batch_count,
+                    (rocblas_int*)tau_splits, (TT*)work_workArr, diag_tmptr_Y, Abyx_norms_trfact_X,
+                    tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
             }
             else if(leftvO && !rightvO)
             {
-                rocsolver_bdsqr_template<T>(handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V,
-                                            shiftV, ldv, strideV, A, shiftA, lda, strideA,
-                                            (W) nullptr, 0, 1, 1, info, batch_count,
-                                            (rocblas_int*)tau_splits, (TT*)work_workArr,
-                                            (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                rocsolver_bdsqr_template<T>(
+                    handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V, shiftV, ldv, strideV, A,
+                    shiftA, lda, strideA, (W) nullptr, 0, 1, 1, info, batch_count,
+                    (rocblas_int*)tau_splits, (TT*)work_workArr, diag_tmptr_Y, Abyx_norms_trfact_X,
+                    tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
             }
             else
             {
-                rocsolver_bdsqr_template<T>(handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, A,
-                                            shiftA, lda, strideA, U, shiftU, ldu, strideU,
-                                            (W) nullptr, 0, 1, 1, info, batch_count,
-                                            (rocblas_int*)tau_splits, (TT*)work_workArr,
-                                            (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                rocsolver_bdsqr_template<T>(
+                    handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, A, shiftA, lda, strideA, U,
+                    shiftU, ldu, strideU, (W) nullptr, 0, 1, 1, info, batch_count,
+                    (rocblas_int*)tau_splits, (TT*)work_workArr, diag_tmptr_Y, Abyx_norms_trfact_X,
+                    tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
             }
 
             //*** STAGE 6: update vectors with orthonormal/unitary matrices ***//
@@ -916,7 +918,8 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             rocsolver_bdsqr_template<T>(handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V,
                                         shiftV, ldv, strideV, U, shiftU, ldu, strideU, (T*)nullptr,
                                         0, 1, 1, info, batch_count, (rocblas_int*)tau_splits,
-                                        (TT*)work_workArr, (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                                        (TT*)work_workArr, diag_tmptr_Y, Abyx_norms_trfact_X,
+                                        tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
         }
 
         else if(leftvO && !rightvO)
@@ -924,7 +927,8 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             rocsolver_bdsqr_template<T>(handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V,
                                         shiftV, ldv, strideV, A, shiftA, lda, strideA, (W) nullptr,
                                         0, 1, 1, info, batch_count, (rocblas_int*)tau_splits,
-                                        (TT*)work_workArr, (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                                        (TT*)work_workArr, diag_tmptr_Y, Abyx_norms_trfact_X,
+                                        tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
         }
 
         else
@@ -932,7 +936,8 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
             rocsolver_bdsqr_template<T>(handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, A,
                                         shiftA, lda, strideA, U, shiftU, ldu, strideU, (W) nullptr,
                                         0, 1, 1, info, batch_count, (rocblas_int*)tau_splits,
-                                        (TT*)work_workArr, (rocblas_int*)Abyx_norms_tmptr_cmplt);
+                                        (TT*)work_workArr, diag_tmptr_Y, Abyx_norms_trfact_X,
+                                        tempArrayC, (rocblas_int*)Abyx_norms_tmptr_cmplt);
         }
 
         //*** STAGE 6: update vectors with orthonormal/unitary matrices ***//

--- a/projects/rocsolver/library/src/lapack/roclapack_syev_heev.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_syev_heev.hpp
@@ -70,7 +70,7 @@ void rocsolver_syev_heev_getMemorySize(const rocblas_evect evect,
     size_t unused;
     size_t w1 = 0, w2 = 0, w3 = 0;
     size_t a1 = 0, a2 = 0;
-    size_t t1 = 0, t2 = 0;
+    size_t t1 = 0, t2 = 0, t3 = 0;
 
     // requirements for tridiagonalization (sytrd/hetrd)
     rocsolver_sytrd_hetrd_getMemorySize<BATCHED, T>(n, batch_count, size_scalars, &w1, &a1, &t1,
@@ -83,7 +83,7 @@ void rocsolver_syev_heev_getMemorySize(const rocblas_evect evect,
                                                         &t2, &unused);
 
         // extra requirements for computing eigenvalues and vectors (steqr)
-        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, &w3);
+        rocsolver_steqr_getMemorySize<T, S>(evect, n, batch_count, &w3, &t3);
     }
     else
     {
@@ -94,7 +94,7 @@ void rocsolver_syev_heev_getMemorySize(const rocblas_evect evect,
     // get max values
     *size_work_stack = std::max({w1, w2, w3});
     *size_Abyx_norms_tmptr = std::max(a1, a2);
-    *size_tmptau_trfact = std::max(t1, t2);
+    *size_tmptau_trfact = std::max({t1, t2, t3});
 
     // size of array for temporary householder scalars
     *size_tau = sizeof(T) * n * batch_count;
@@ -206,7 +206,7 @@ rocblas_status rocsolver_syev_heev_template(rocblas_handle handle,
 
         // compute eigenvalues and eigenvectors
         rocsolver_steqr_template<T>(handle, evect, n, D, 0, strideD, E, 0, strideE, A, shiftA, lda,
-                                    strideA, info, batch_count, work_stack);
+                                    strideA, info, batch_count, work_stack, tmptau_trfact);
     }
 
     return rocblas_status_success;

--- a/projects/rocsolver/library/src/lapack/roclapack_syevdx_heevdx.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_syevdx_heevdx.hpp
@@ -158,6 +158,8 @@ void rocsolver_syevdx_heevdx_getMemorySize(const rocblas_evect evect,
         {
             // extra requirements for computing the eigenvectors (stein)
             rocsolver_stein_getMemorySize<T, S>(n, batch_count, &a4, &b4);
+            *size_work4 = std::max(*size_work4, sizeof(T) * (n * n) * batch_count);
+            *size_work5 = std::max(*size_work5, sizeof(S) * n * batch_count);
             *size_work6_ifail = std::max(*size_work6_ifail, sizeof(rocblas_int) * n * batch_count);
         }
 
@@ -284,10 +286,8 @@ rocblas_status rocsolver_syevdx_heevdx_template(rocblas_handle handle,
                 (T*)work2, (T*)work3, (T**)nsplit_workArr);
 
             // sort eigenvalues and eigenvectors
-            dim3 grid(1, batch_count, 1);
-            dim3 threads(BS1, 1, 1);
-            ROCSOLVER_LAUNCH_KERNEL(syevx_sort_eigs<T>, grid, threads, 0, stream, n, nev, W, strideW,
-                                    Z, shiftZ, ldz, strideZ, work6_ifail, strideF, info, isplit);
+            run_eigen_sort<STEDC_BDIM, T>(handle, n, batch_count, (S*)work5, n, W, 0, strideW,
+                                          (T*)work4, 0, n, n * n, Z, shiftZ, ldz, strideZ, nev);
         }
     }
 

--- a/projects/rocsolver/library/src/lapack/roclapack_syevdx_heevdx_inplace.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_syevdx_heevdx_inplace.hpp
@@ -165,6 +165,7 @@ void rocsolver_syevdx_heevdx_inplace_getMemorySize(const rocblas_evect evect,
 
             // extra space to store A
             *size_work4 = std::max(*size_work4, sizeof(T) * n * n * batch_count);
+            *size_work5 = std::max(*size_work5, sizeof(S) * n * batch_count);
         }
 
         // size of arrays for temporary submatrix indices
@@ -303,11 +304,8 @@ rocblas_status rocsolver_syevdx_heevdx_inplace_template(rocblas_handle handle,
                 (T*)work2, (T*)work3, (T**)nsplit_workArr);
 
             // sort eigenvalues and eigenvectors
-            dim3 grid(1, batch_count, 1);
-            dim3 threads(BS1, 1, 1);
-            ROCSOLVER_LAUNCH_KERNEL(syevx_sort_eigs<T>, grid, threads, 0, stream, n, d_nev, W,
-                                    strideW, A, shiftA, lda, strideA, work6_ifail, strideF, info,
-                                    isplit_map);
+            run_eigen_sort<STEDC_BDIM, T>(handle, n, batch_count, (S*)work5, n, W, 0, strideW,
+                                          (T*)work4, 0, n, n * n, A, shiftA, lda, strideA, d_nev);
         }
     }
     else

--- a/projects/rocsolver/library/src/lapack/roclapack_syevj_heevj.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_syevj_heevj.hpp
@@ -2155,9 +2155,11 @@ void rocsolver_syevj_heevj_getMemorySize(const rocblas_evect evect,
     // size of temporary workspace for copying A
     *size_Acpy = sizeof(T) * n * n * batch_count;
 
+    // size of temporary workspace for sorting eigenvalues/vectors
+    *size_J = sizeof(S) * n * batch_count;
+
     if(n <= SYEVJ_BLOCKED_SWITCH)
     {
-        *size_J = 0;
         *size_norms = 0;
         *size_top = 0;
         *size_bottom = 0;
@@ -2173,11 +2175,11 @@ void rocsolver_syevj_heevj_getMemorySize(const rocblas_evect evect,
     // size of temporary workspace to store the block rotation matrices
     if(half_blocks == 1 && evect == rocblas_evect_none)
     {
-        *size_J = sizeof(T) * blocks * nb_max * nb_max * batch_count;
+        *size_J = std::max(*size_J, sizeof(T) * blocks * nb_max * nb_max * batch_count);
     }
     else
     {
-        *size_J = sizeof(T) * half_blocks * 4 * nb_max * nb_max * batch_count;
+        *size_J = std::max(*size_J, sizeof(T) * half_blocks * 4 * nb_max * nb_max * batch_count);
     }
 
     // size of temporary workspace to store the full matrix norm
@@ -2297,6 +2299,14 @@ rocblas_status rocsolver_syevj_heevj_template(rocblas_handle handle,
     rocblas_int even_n = n + n % 2;
     rocblas_int half_n = even_n / 2;
 
+    // sort inside kernel if no vectors
+    rocblas_esort esort_val = (esort == rocblas_esort_ascending && evect == rocblas_evect_none)
+        ? rocblas_esort_ascending
+        : rocblas_esort_none;
+    rocblas_esort esort_vec = (esort == rocblas_esort_ascending && evect != rocblas_evect_none)
+        ? rocblas_esort_ascending
+        : rocblas_esort_none;
+
     if(n <= SYEVJ_BLOCKED_SWITCH)
     {
         // *** USE SINGLE SMALL-SIZE KERNEL ***
@@ -2308,7 +2318,7 @@ rocblas_status rocsolver_syevj_heevj_template(rocblas_handle handle,
         dim3 threads(ddx * ddy, 1, 1);
         size_t lmemsize = (sizeof(S) + sizeof(T)) * ddx + 2 * sizeof(rocblas_int) * half_n;
 
-        ROCSOLVER_LAUNCH_KERNEL(syevj_small_kernel<T>, grid, threads, lmemsize, stream, esort,
+        ROCSOLVER_LAUNCH_KERNEL(syevj_small_kernel<T>, grid, threads, lmemsize, stream, esort_val,
                                 evect, uplo, n, A, shiftA, lda, strideA, atol, eps, residual,
                                 max_sweeps, n_sweeps, W, strideW, info, Acpy);
     }
@@ -2566,9 +2576,15 @@ rocblas_status rocsolver_syevj_heevj_template(rocblas_handle handle,
         }
 
         // set outputs and sort eigenvalues & vectors
-        ROCSOLVER_LAUNCH_KERNEL(syevj_finalize<T>, grid, threads, 0, stream, esort, evect, n, A,
+        ROCSOLVER_LAUNCH_KERNEL(syevj_finalize<T>, grid, threads, 0, stream, esort_val, evect, n, A,
                                 shiftA, lda, strideA, residual, max_sweeps, n_sweeps, W, strideW,
                                 info, Acpy, completed);
+    }
+
+    if(esort_vec)
+    {
+        run_eigen_sort<512, T>(handle, n, batch_count, (S*)J, n, W, 0, strideW, Acpy, 0, n, n * n,
+                               A, shiftA, lda, strideA);
     }
 
     return rocblas_status_success;

--- a/projects/rocsolver/library/src/lapack/roclapack_syevx_heevx.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_syevx_heevx.hpp
@@ -442,7 +442,7 @@ rocblas_status rocsolver_syevx_heevx_template(rocblas_handle handle,
         // sort ifail
         if(ifail)
         {
-            ROCSOLVER_LAUNCH_KERNEL(eigen_sort_copyD<512>, dim3(1, batch_count), dim3(512), 0,
+            ROCSOLVER_LAUNCH_KERNEL(sort_copy_values<512>, dim3(1, batch_count), dim3(512), 0,
                                     stream, n, ifail, strideF, iblock, n);
             ROCSOLVER_LAUNCH_KERNEL(sort_ifail<512>, dim3(1, batch_count), dim3(512), 0, stream, n,
                                     iblock, n, ifail, strideF, info, isplit_map);

--- a/projects/rocsolver/library/src/lapack/roclapack_syevx_heevx.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_syevx_heevx.hpp
@@ -176,6 +176,31 @@ ROCSOLVER_KERNEL void __launch_bounds__(BS1) syevx_sort_eigs(const rocblas_int n
     __syncthreads();
 }
 
+template <int DIM>
+ROCSOLVER_KERNEL void __launch_bounds__(DIM) sort_ifail(const rocblas_int n,
+                                                        rocblas_int* ifailIn,
+                                                        const rocblas_stride strideIfailIn,
+                                                        rocblas_int* ifailOut,
+                                                        const rocblas_stride strideIfailOut,
+                                                        rocblas_int* infoA,
+                                                        rocblas_int* isplit_map)
+{
+    // batch instance id
+    int bid = hipBlockIdx_y;
+    int tid = hipThreadIdx_x;
+
+    auto const info = infoA[bid];
+    auto const map = isplit_map + (bid * n);
+
+    auto const src = ifailIn + (bid * strideIfailIn);
+    auto const dst = ifailOut + (bid * strideIfailOut);
+
+    for(int k = tid; k < info; k += DIM)
+    {
+        dst[k] = map[src[k]];
+    }
+}
+
 /** Argument checking **/
 template <typename T, typename S>
 rocblas_status rocsolver_syevx_heevx_argCheck(rocblas_handle handle,
@@ -271,7 +296,7 @@ void rocsolver_syevx_heevx_getMemorySize(const rocblas_evect evect,
     }
 
     size_t unused;
-    size_t a1 = 0, a2 = 0, a3 = 0, a4 = 0;
+    size_t a1 = 0, a2 = 0, a3 = 0, a4 = 0, a5 = 0;
     size_t b1 = 0, b2 = 0, b3 = 0, b4 = 0;
     size_t c1 = 0, c2 = 0, c3 = 0;
 
@@ -291,10 +316,13 @@ void rocsolver_syevx_heevx_getMemorySize(const rocblas_evect evect,
 
         // extra requirements for computing the eigenvectors (stein)
         rocsolver_stein_getMemorySize<T, S>(n, batch_count, &a4, &b4);
+
+        // extra requirements for sorting eigenvectors
+        a5 = sizeof(T) * (n * n) * batch_count;
     }
 
     // get max values
-    *size_work1 = std::max({a1, a2, a3, a4});
+    *size_work1 = std::max({a1, a2, a3, a4, a5});
     *size_work2 = std::max({b1, b2, b3, b4});
     *size_work3 = std::max({c1, c2, c3});
 
@@ -408,10 +436,17 @@ rocblas_status rocsolver_syevx_heevx_template(rocblas_handle handle,
             (T*)work2, (T*)work3, (T**)nsplit_workArr);
 
         // sort eigenvalues and eigenvectors
-        dim3 grid(1, batch_count, 1);
-        dim3 threads(BS1, 1, 1);
-        ROCSOLVER_LAUNCH_KERNEL(syevx_sort_eigs<T>, grid, threads, 0, stream, n, nev, W, strideW, Z,
-                                shiftZ, ldz, strideZ, ifail, strideF, info, isplit_map);
+        run_eigen_sort<512, T>(handle, n, batch_count, D, n, W, 0, strideW, (T*)work1, 0, n, n * n,
+                               Z, shiftZ, ldz, strideZ, nev, isplit_map);
+
+        // sort ifail
+        if(ifail)
+        {
+            ROCSOLVER_LAUNCH_KERNEL(eigen_sort_copyD<512>, dim3(1, batch_count), dim3(512), 0,
+                                    stream, n, ifail, strideF, iblock, n);
+            ROCSOLVER_LAUNCH_KERNEL(sort_ifail<512>, dim3(1, batch_count), dim3(512), 0, stream, n,
+                                    iblock, n, ifail, strideF, info, isplit_map);
+        }
     }
 
     return rocblas_status_success;


### PR DESCRIPTION
## Motivation
Apply the out-of-place eigenvalues and eigenvectors sort developed for `syevd` to other eigensolvers. Apply the same methodology to SVD function to sort singular values and vectors.

## Test Plan
Run `rocsolver-test` and CI to validate correctness.
Run PTS to validate no performance loss.

## Test Result
waiting for results.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
