### PR TITLE
[hipdnn] Attribute ordering

### DIFF
--- a/projects/hipdnn/sdk/include/hipdnn_sdk/plugin/EnginePluginApi.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/plugin/EnginePluginApi.h
@@ -45,7 +45,7 @@ extern "C" {
  *       The function can be called with `max_engines = 0` (in this case, `engine_ids` may be `NULL`)
  *       to retrieve the total count of available engines without returning their IDs.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIds(
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIds(
     int64_t* engine_ids, uint32_t max_engines, uint32_t* num_engines);
 
 /**
@@ -58,7 +58,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t hipdnnEnginePl
  *
  * @note The caller is responsible for ensuring that the handle is destroyed properly to avoid resource leaks.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginCreate(hipdnnEnginePluginHandle_t* handle);
 
 /**
@@ -70,7 +70,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *
  * @note The handle becomes invalid after this function is called.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginDestroy(hipdnnEnginePluginHandle_t handle);
 
 /**
@@ -84,7 +84,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  * @note The caller must ensure that the provided stream remains valid for the duration of operations performed
  *       using the engine plugin handle.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginSetStream(hipdnnEnginePluginHandle_t handle, hipStream_t stream);
 
 /**
@@ -107,7 +107,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *       The function can be called with `max_engines = 0` (in this case `engine_ids` may be `NULL`)
  *       to retrieve the total count of applicable engines without returning their IDs.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginGetApplicableEngineIds(hipdnnEnginePluginHandle_t handle,
                                              const hipdnnPluginConstData_t* op_graph,
                                              int64_t* engine_ids,
@@ -129,7 +129,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *       allocating the buffer for the serialized `EngineDetails`. After use, this memory must be freed using
  *       hipdnnEnginePluginDestroyEngineDetails().
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginGetEngineDetails(hipdnnEnginePluginHandle_t handle,
                                        int64_t engine_id,
                                        const hipdnnPluginConstData_t* op_graph,
@@ -146,7 +146,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *
  * @note This function takes a structure as input, deallocates the buffer, and sets all fields to 0.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginDestroyEngineDetails(hipdnnEnginePluginHandle_t handle,
                                            hipdnnPluginConstData_t* engine_details);
 
@@ -161,7 +161,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *
  * @return A value of type `hipdnnPluginStatus_t` indicating the status of the operation.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginGetWorkspaceSize(hipdnnEnginePluginHandle_t handle,
                                        const hipdnnPluginConstData_t* engine_config,
                                        const hipdnnPluginConstData_t* op_graph,
@@ -183,7 +183,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *       for the execution context, and the user is responsible for releasing these resources by calling
  *       `hipdnnEnginePluginDestroyExecutionContext()` when the execution context is no longer needed.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginCreateExecutionContext(
         hipdnnEnginePluginHandle_t handle,
         const hipdnnPluginConstData_t* engine_config,
@@ -200,7 +200,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *
  * @note The execution context becomes invalid after this function is called.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginDestroyExecutionContext(
         hipdnnEnginePluginHandle_t handle, hipdnnEnginePluginExecutionContext_t execution_context);
 
@@ -217,7 +217,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *
  * @return A value of type `hipdnnPluginStatus_t` indicating the status of the operation.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnEnginePluginExecuteOpGraph(hipdnnEnginePluginHandle_t handle,
                                      hipdnnEnginePluginExecutionContext_t execution_context,
                                      void* workspace,

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/plugin/PluginApi.h
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/plugin/PluginApi.h
@@ -50,7 +50,7 @@ extern "C" {
  *
  * @return A value of type `hipdnnPluginStatus_t` indicating the status of the operation.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnPluginGetName(const char** name);
 
 /**
@@ -60,7 +60,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *
  * @return A value of type `hipdnnPluginStatus_t` indicating the status of the operation.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnPluginGetVersion(const char** version);
 
 /**
@@ -70,7 +70,7 @@ HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
  *
  * @return A value of type `hipdnnPluginStatus_t` indicating the status of the operation.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnPluginGetType(hipdnnPluginType_t* type);
 
 /**
@@ -103,7 +103,7 @@ HIPDNN_PLUGIN_EXPORT void hipdnnPluginGetLastErrorString(const char** error_str)
  *
  * @return A value of type `hipdnnPluginStatus_t` indicating the status of the operation.
  */
-HIPDNN_PLUGIN_EXPORT HIPDNN_PLUGIN_NODISCARD hipdnnPluginStatus_t
+HIPDNN_PLUGIN_NODISCARD HIPDNN_PLUGIN_EXPORT hipdnnPluginStatus_t
     hipdnnPluginSetLoggingCallback(hipdnnCallback_t callback);
 
 /** @} */ // End of PluginFunctions group


### PR DESCRIPTION


## Motivation

Clang 18
```
Ubuntu clang version 18.1.3 (1ubuntu1)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```
complains if `[[nodiscard]]` comes after `__attribute__((visibility("default")))`

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

This simply changes the order of the attributes.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

It might be worth adding a stock `clang` to a testing matrix somewhere? I'm not sure which compilers complain about this attribute ordering and which don't.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
