### PR TITLE
[hipBLASLt] Improve device memory allocation failure handling in hipBLASLt client

### DIFF
--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -97,7 +97,7 @@ public:
         char* d = nullptr;
         if((use_HMM ? hipMallocManaged(&d, capacity) : hipMalloc(&d, capacity)) != hipSuccess)
         {
-            hipblaslt_cerr << "Error allocating (" << (m_size >> 30) << " GB) device memory"
+            hipblaslt_cerr << "Insufficient memory to  allocate (" << (m_size >> 30) << " GB) in device "
                            << std::endl;
             d      = nullptr;
             m_size = m_capacity = 0;
@@ -201,9 +201,15 @@ private:
             auto e = M(bytes, bytes * 1.2, use_HMM);
             if(e.get())
                 return e;
-            hipblaslt_cerr << "Clearing memory pool" << std::endl;
+            hipblaslt_cerr << "Clearing memory pool and retrying" << std::endl;
             // allocation failed, so clear the pool and try again (without the 20%)
             pool.clear();
+
+            // reset the error code from previous hipMalloc failure and try again to allocate memory
+            hipError_t err = hipPeekAtLastError();
+            if(err == hipErrorOutOfMemory || err == hipErrorMemoryAllocation )
+                hipGetLastError();
+
             return M(bytes, bytes, use_HMM);
         }
     }

--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -171,6 +171,16 @@ public:
         Instance().restore(dm);
     }
 
+    // Helper: get total device mem in bytes
+    size_t total_device_mem()
+    {
+        int device;
+        (void)hipGetDevice(&device);
+        hipDeviceProp_t prop;
+        (void)hipGetDeviceProperties(&prop, device);
+        return static_cast<size_t>(prop.totalGlobalMem);
+    }
+
 private:
     std::vector<M> m_pool, m_pool_managed;
 
@@ -185,7 +195,7 @@ private:
         auto& pool = use_HMM ? m_pool_managed : m_pool;
         auto  it   = std::lower_bound(pool.begin(), pool.end(), bytes);
         if(it != pool.end() && // found a buffer that is large enough ..
-           it->capacity() < 4 * bytes) // but not way too large
+           it->capacity() < 2 * bytes) // but not way too large
         {
             auto p = std::move(*it);
             p.resize(bytes);
@@ -194,11 +204,18 @@ private:
         }
         else
         {
+            // Threshold for "huge" allocations — skip 20% extra allocation 
+            static const size_t big_thresh = total_device_mem() / 4;
+            bool huge_request = (bytes >= big_thresh);
+
             // remove the (largest) buffer that was too small
             if(it != pool.begin())
                 pool.erase(it - 1);
-            // Allocate 20% extra for later reuse
-            auto e = M(bytes, bytes * 1.2, use_HMM);
+
+            // Allocate 20% extra if it is not huge_request for later reuse
+            size_t alloc_capacity = huge_request ? bytes : static_cast<size_t>(bytes * 1.2); 
+
+            auto e = M(bytes, alloc_capacity, use_HMM);
             if(e.get())
                 return e;
             hipblaslt_cerr << "Clearing memory pool and retrying" << std::endl;
@@ -208,7 +225,7 @@ private:
             // reset the error code from previous hipMalloc failure and try again to allocate memory
             hipError_t err = hipPeekAtLastError();
             if(err == hipErrorOutOfMemory || err == hipErrorMemoryAllocation )
-                hipGetLastError();
+                (void)hipGetLastError();
 
             return M(bytes, bytes, use_HMM);
         }

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -1724,66 +1724,83 @@ void testing_matmul_with_bias(const Arguments& arg,
 
         // allocate memory on device
         dA.emplace_back(TiA, size_dA[i] * block_count, HMM);
+        CHECK_DEVICE_ALLOCATION(hipGetLastError());
         dB.emplace_back(TiB, size_dB[i] * block_count, HMM);
+        CHECK_DEVICE_ALLOCATION(hipGetLastError());
         dC.emplace_back(To, size_C[i] * block_count, HMM);
+        CHECK_DEVICE_ALLOCATION(hipGetLastError());
 
         if(!arg.c_equal_d)
         {
             dD.emplace_back(To, size_D[i] * block_count, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
             dDp = &dD;
         }
         else
             dDp = &dC;
 
         if(size_bias[i] * block_count != 0)
+        {
             dBias.emplace_back(Tbias, size_bias[i] * block_count, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
+        }
 
         if(arg.scaleAlpha_vector)
         {
             dScaleAlphaVec.emplace_back(Talpha, size_scaleAlphaVec[i] * block_count, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
 
         if(arg.use_e)
         {
             dE.emplace_back(Taux, size_E[i] * block_count, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
 
         if(arg.scaleA == hipblaslt_scaling_format::Scalar
            || arg.scaleA == hipblaslt_scaling_format::Vector)
         {
             dScaleA.emplace_back(Talpha, size_scaleAVec[i] * block_count, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
         else if(arg.scaleA == hipblaslt_scaling_format::Block)
         {
             // For MX format, use uin8_t for the scale (E8M0)
             dScaleA.emplace_back(HIP_R_8U, size_scaleAVec[i] * block_count, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
         if(arg.scaleB == hipblaslt_scaling_format::Scalar
            || arg.scaleB == hipblaslt_scaling_format::Vector)
         {
             dScaleB.emplace_back(Talpha, size_scaleBVec[i] * block_count, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
         else if(arg.scaleB == hipblaslt_scaling_format::Block)
         {
             // For MX format, use uin8_t for the scale (E8M0)
             dScaleB.emplace_back(HIP_R_8U, size_scaleBVec[i] * block_count, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
         if(arg.scaleC)
         {
             dScaleC.emplace_back(Talpha, 1, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
         if(arg.scaleD)
         {
             dScaleD.emplace_back(Talpha, 1, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
         if(arg.amaxD)
         {
             epilogue_on[i] = true;
             dAmaxD.emplace_back(Talpha, 1, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
         if(arg.scaleE)
         {
             dScaleE.emplace_back(Talpha, 1, HMM);
+            CHECK_DEVICE_ALLOCATION(hipGetLastError());
         }
 
         // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory


### PR DESCRIPTION

## Motivation

To stop tests from aborting due to false failure.

## Technical Details

1. Reset the HIP error code after the first allocation if it fails.
2. Catch the HIP error if it fails even after second allocation attempt in testing_matmul.hpp
