### PR TITLE
rocfft: fix issues with length-1 transforms

### DIFF
--- a/projects/rocfft/CHANGELOG.md
+++ b/projects/rocfft/CHANGELOG.md
@@ -17,6 +17,10 @@ Documentation for rocFFT is available at
   - (64,32,128)
 * Improved performance of 3D MPI pencil decompositions by using sub-communicators for global transpose operations.
 
+### Resolved issues
+
+* Fixed potential division by zero when constructing plans using dimensions of length 1.
+
 ## rocFFT 1.0.34 for ROCm 7.0.0
 
 ### Added

--- a/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
+++ b/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
@@ -354,7 +354,7 @@ const auto adhoc_tokens = {
     "complex_forward_len_1_single_op_batch_2_istride_1_CI_ostride_1_CI_idist_1_odist_1_ioffset_0_0_ooffset_0_0",
     "real_forward_len_2_single_ip_batch_1_istride_1_R_ostride_1_HI_idist_4_odist_2_ioffset_0_0_ooffset_0_0",
     "real_forward_len_2_single_op_batch_1_istride_1_R_ostride_1_HI_idist_4_odist_2_ioffset_0_0_ooffset_0_0",
-    "real_forward_len_1_2_single_ip_batch_2_istride_1_1_R_ostride_1_1_HI_idist_2_odist_2_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_1_2_single_ip_batch_2_istride_1_1_R_ostride_1_1_HI_idist_4_odist_2_ioffset_0_0_ooffset_0_0",
     "real_forward_len_1_2_single_op_batch_2_istride_1_1_R_ostride_1_1_HI_idist_2_odist_2_ioffset_0_0_ooffset_0_0",
     // clang-format on
 };

--- a/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
+++ b/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
@@ -349,6 +349,13 @@ const auto adhoc_tokens = {
     "real_forward_len_378_42_single_ip_batch_66000_istride_44_1_R_ostride_22_1_HI_idist_16632_odist_8316_ioffset_0_0_ooffset_0_0",
     "real_forward_len_527_25_single_ip_batch_67500_istride_26_1_R_ostride_13_1_HI_idist_13702_odist_6851_ioffset_0_0_ooffset_0_0",
     "real_forward_len_630_38_single_ip_batch_65540_istride_40_1_R_ostride_20_1_HI_idist_25200_odist_12600_ioffset_0_0_ooffset_0_0",
+    // degenerate length-1 test cases
+    "complex_forward_len_1_single_ip_batch_2_istride_1_CI_ostride_1_CI_idist_1_odist_1_ioffset_0_0_ooffset_0_0",
+    "complex_forward_len_1_single_op_batch_2_istride_1_CI_ostride_1_CI_idist_1_odist_1_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_2_single_ip_batch_1_istride_1_R_ostride_1_HI_idist_4_odist_2_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_2_single_op_batch_1_istride_1_R_ostride_1_HI_idist_4_odist_2_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_1_2_single_ip_batch_2_istride_1_1_R_ostride_1_1_HI_idist_2_odist_2_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_1_2_single_op_batch_2_istride_1_1_R_ostride_1_1_HI_idist_2_odist_2_ioffset_0_0_ooffset_0_0",
     // clang-format on
 };
 

--- a/projects/rocfft/library/src/tree_node.cpp
+++ b/projects/rocfft/library/src/tree_node.cpp
@@ -410,6 +410,8 @@ void TreeNode::CollapseContiguousDims()
         auto curStride = dist;
         for(auto i = collapsibleDims.rbegin(); i != collapsibleDims.rend(); ++i)
         {
+            if(stride[*i] == 0)
+                break;
             if(curStride % stride[*i] != 0)
                 break;
             if(curStride / stride[*i] != length[*i])

--- a/projects/rocfft/shared/data_gen_device.h
+++ b/projects/rocfft/shared/data_gen_device.h
@@ -1172,9 +1172,6 @@ static void impose_hermitian_symmetry_interleaved(const std::vector<size_t>& len
                                                   Tcomplex*                  input_data,
                                                   const hipDeviceProp_t&     deviceProp)
 {
-    if(length[0] < 2)
-        return;
-
     auto blockSize = DATA_GEN_THREADS;
     auto blockDim  = generate_blockDim(length, blockSize);
     auto gridDim   = generate_hermitian_gridDim(length, batch, blockSize);

--- a/projects/rocfft/shared/data_gen_device.h
+++ b/projects/rocfft/shared/data_gen_device.h
@@ -1172,6 +1172,9 @@ static void impose_hermitian_symmetry_interleaved(const std::vector<size_t>& len
                                                   Tcomplex*                  input_data,
                                                   const hipDeviceProp_t&     deviceProp)
 {
+    if(length[0] < 2)
+        return;
+
     auto blockSize = DATA_GEN_THREADS;
     auto blockDim  = generate_blockDim(length, blockSize);
     auto gridDim   = generate_hermitian_gridDim(length, batch, blockSize);


### PR DESCRIPTION
## Motivation

Pytorch tests exercise length-1 FFTs.  These have no real-world use, but rocFFT was not handling them properly.

## Technical Details

rocFFT planner would potentially divide-by-zero on a 2D length-2 real-inverse FFT, part of which involves doing a length-1 complex FFT.  rocfft-bench also needed an update to be able to test this case properly.

## Test Plan

Ran the pytorch tests:

PYTORCH_TEST_WITH_ROCM=0 python functorch/test_vmap.py -v -k test_op_has_batch_rule_fft_irfft2_cuda_float32

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
