### PR TITLE
Disable tailLoopOpt for 1Byte GEMMs on GFX950

### DIFF
--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -1829,6 +1829,7 @@ Tests:
   function:
     matmul: *i8_precision_dst_i32
   matrix_size:
+    - { M:    6,  N:   65,  K:    1  }
     - { M:  1,    N:  131,  K:  131  }
     - { M:  131,  N:  1,    K:  131  }
     - { M:  128,  N:  128,  K:  128  }
@@ -1846,6 +1847,7 @@ Tests:
   function:
     matmul: *i8_precision_dst_i32
   matrix_size:
+    - { M:    6,  N:   65,  K:    1  }
     - { M:  1,    N:  131,  K:  131  }
     - { M:  131,  N:  1,    K:  131  }
     - { M:  128,  N:  128,  K:  128  }
@@ -1865,7 +1867,6 @@ Tests:
   function:
     matmul: *i8_precision_dst_i8
   matrix_size:
-    - { M:    6,  N:   65,  K:    1  }
     - { M:  128,  N:  128,  K:  128  }
     - { M:  131,  N:  131,  K:  131  }
     - { M:  1024, N:  1024, K:  1024 }
@@ -1881,7 +1882,6 @@ Tests:
   function:
     matmul: *i8_precision_dst_i8
   matrix_size:
-    - { M:    6,  N:   65,  K:    1  }
     - { M:  128,  N:  128,  K:  128  }
     - { M:  131,  N:  131,  K:  131  }
     - { M:  1024, N:  1024, K:  1024 }

--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -1865,6 +1865,7 @@ Tests:
   function:
     matmul: *i8_precision_dst_i8
   matrix_size:
+    - { M:    6,  N:   65,  K:    1  }
     - { M:  128,  N:  128,  K:  128  }
     - { M:  131,  N:  131,  K:  131  }
     - { M:  1024, N:  1024, K:  1024 }
@@ -1880,6 +1881,7 @@ Tests:
   function:
     matmul: *i8_precision_dst_i8
   matrix_size:
+    - { M:    6,  N:   65,  K:    1  }
     - { M:  128,  N:  128,  K:  128  }
     - { M:  131,  N:  131,  K:  131  }
     - { M:  1024, N:  1024, K:  1024 }

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -391,7 +391,7 @@ class Solution(collections.abc.Mapping):
       state["NonDTLTailLoopB"] = True
 
     if (state["ISA"] != (9, 4, 2) and state["ISA"] != (9, 5, 0)) or \
-       (state["ISA"] == (9, 5, 0) and state["ProblemType"]["ComputeDataType"].isInt32()) or \
+       (state["ISA"] == (9, 5, 0) and (bpeA == 1 or bpeB == 1)) or \
        (state["ProblemType"]["Sparse"]) or \
        (state["UseDotInstruction"]):
       state["tailLoopOptA"] = False

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -390,7 +390,9 @@ class Solution(collections.abc.Mapping):
     if (aemB * bpeB) % 4 != 0 or not state["BufferLoad"]:
       state["NonDTLTailLoopB"] = True
 
+    # 
     if (state["ISA"] != (9, 4, 2) and state["ISA"] != (9, 5, 0)) or \
+       (state["ISA"] == (9, 5, 0) and state["ProblemType"]["ComputeDataType"].isInt32()) or \
        (state["ProblemType"]["Sparse"]) or \
        (state["UseDotInstruction"]):
       state["tailLoopOptA"] = False

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -390,7 +390,6 @@ class Solution(collections.abc.Mapping):
     if (aemB * bpeB) % 4 != 0 or not state["BufferLoad"]:
       state["NonDTLTailLoopB"] = True
 
-    # 
     if (state["ISA"] != (9, 4, 2) and state["ISA"] != (9, 5, 0)) or \
        (state["ISA"] == (9, 5, 0) and state["ProblemType"]["ComputeDataType"].isInt32()) or \
        (state["ProblemType"]["Sparse"]) or \


### PR DESCRIPTION
This PR disables tail loop optimization for 1Byte GEMMs on GFX950 as it gives wrong results for some sizes.
