### PR TITLE
Revert "[rocThrust] fix: HIP compiler rejects THRUST_NODISCARD after THRUST_DEPRECATED"

### DIFF
--- a/projects/rocthrust/thrust/async/copy.h
+++ b/projects/rocthrust/thrust/async/copy.h
@@ -115,7 +115,7 @@ struct copy_fn final
           THRUST_FWD(output)))
 
           template <typename... Args>
-          THRUST_DEPRECATED THRUST_NODISCARD THRUST_HOST auto operator()(Args&&... args) const
+          THRUST_NODISCARD THRUST_DEPRECATED THRUST_HOST auto operator()(Args&&... args) const
     THRUST_RETURNS(call(THRUST_FWD(args)...))
 };
 

--- a/projects/rocthrust/thrust/async/for_each.h
+++ b/projects/rocthrust/thrust/async/for_each.h
@@ -92,7 +92,7 @@ struct for_each_fn final
         THRUST_FWD(f)))
 
         template <typename... Args>
-        THRUST_DEPRECATED THRUST_NODISCARD THRUST_HOST auto operator()(Args&&... args) const
+        THRUST_NODISCARD THRUST_DEPRECATED THRUST_HOST auto operator()(Args&&... args) const
     THRUST_RETURNS(call(THRUST_FWD(args)...))
 };
 

--- a/projects/rocthrust/thrust/async/reduce.h
+++ b/projects/rocthrust/thrust/async/reduce.h
@@ -162,7 +162,7 @@ struct reduce_fn final
             ::internal::remove_cvref_t<typename iterator_traits<::internal::remove_cvref_t<ForwardIt>>::value_type>>{}))
 
           template <typename... Args>
-          THRUST_DEPRECATED THRUST_NODISCARD THRUST_HOST auto operator()(Args&&... args) const
+          THRUST_NODISCARD THRUST_DEPRECATED THRUST_HOST auto operator()(Args&&... args) const
     THRUST_RETURNS(call(THRUST_FWD(args)...))
 };
 
@@ -310,7 +310,7 @@ struct reduce_into_fn final
         thrust::is_execution_policy<::internal::remove_cvref_t<T1>>{}))
 
         template <typename... Args>
-        THRUST_DEPRECATED THRUST_NODISCARD THRUST_HOST auto operator()(Args&&... args) const
+        THRUST_NODISCARD THRUST_DEPRECATED THRUST_HOST auto operator()(Args&&... args) const
     THRUST_RETURNS(call(THRUST_FWD(args)...))
 };
 

--- a/projects/rocthrust/thrust/async/sort.h
+++ b/projects/rocthrust/thrust/async/sort.h
@@ -144,12 +144,11 @@ THRUST_SUPPRESS_DEPRECATED_PUSH
   )
 
   template <typename... Args>
-  THRUST_DEPRECATED
   #if !(defined(__CUDA__) && THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG)
   // clang in CUDA mode can only handle one attribute
   THRUST_NODISCARD THRUST_HOST
   #endif
-  auto operator()(Args&&... args) const
+ THRUST_DEPRECATED auto operator()(Args&&... args) const
   THRUST_RETURNS(
     call(THRUST_FWD(args)...)
   )
@@ -268,12 +267,11 @@ struct sort_fn final
   )
 
   template <typename... Args>
-  THRUST_DEPRECATED
   #if !(defined(__CUDA__) && THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG)
   // clang in CUDA mode can only handle one attribute
   THRUST_NODISCARD THRUST_HOST
   #endif
-  auto operator()(Args&&... args) const
+ THRUST_DEPRECATED auto operator()(Args&&... args) const
   THRUST_RETURNS(
     call(THRUST_FWD(args)...)
   )

--- a/projects/rocthrust/thrust/async/transform.h
+++ b/projects/rocthrust/thrust/async/transform.h
@@ -123,7 +123,7 @@ struct transform_fn final
   )
 
   template <typename... Args>
-  THRUST_DEPRECATED THRUST_NODISCARD THRUST_HOST
+  THRUST_NODISCARD THRUST_DEPRECATED THRUST_HOST
  auto operator()(Args&&... args) const
   THRUST_RETURNS(
     call(THRUST_FWD(args)...)

--- a/projects/rocthrust/thrust/detail/config/cpp_dialect.h
+++ b/projects/rocthrust/thrust/detail/config/cpp_dialect.h
@@ -30,6 +30,7 @@
 #endif // no system header
 
 #include <thrust/detail/config/compiler.h> // IWYU pragma: export
+#include <thrust/detail/config/deprecated.h> // IWYU pragma: export
 
 // Deprecation warnings may be silenced by defining the following macros. These
 // may be combined.
@@ -85,38 +86,6 @@
 #  undef THRUST_CPLUSPLUS // cleanup
 
 #endif // !THRUST_CPP_DIALECT
-
-// Macros to suppress deprecation compiler warnings, from "deprecated.h"
-// TODO: These macros start with `LIBCUDACXX`. So, when libhipcxx is
-// available in this scope, we should remove these macros and use the ones
-// from libhipcxx.
-// Check for deprecation opt-outs
-#if defined(LIBCUDACXX_IGNORE_DEPRECATED_CPP_DIALECT) || defined(CCCL_IGNORE_DEPRECATED_CPP_DIALECT) \
-  || defined(CUB_IGNORE_DEPRECATED_CPP_DIALECT)
-#  if !defined(THRUST_IGNORE_DEPRECATED_CPP_DIALECT)
-#    define THRUST_IGNORE_DEPRECATED_CPP_DIALECT
-#  endif
-#endif // suppress all dialect deprecation warnings
-#if defined(LIBCUDACXX_IGNORE_DEPRECATED_CPP_14) || defined(CCCL_IGNORE_DEPRECATED_CPP_14) \
-  || defined(CUB_IGNORE_DEPRECATED_CPP_14) || defined(THRUST_IGNORE_DEPRECATED_CPP_DIALECT)
-#  if !defined(THRUST_IGNORE_DEPRECATED_CPP_14)
-#    define THRUST_IGNORE_DEPRECATED_CPP_14
-#  endif
-#endif // suppress all c++14 dialect deprecation warnings
-#if defined(LIBCUDACXX_IGNORE_DEPRECATED_CPP_11) || defined(CCCL_IGNORE_DEPRECATED_CPP_11)  \
-  || defined(CUB_IGNORE_DEPRECATED_CPP_11) || defined(THRUST_IGNORE_DEPRECATED_CPP_DIALECT) \
-  || defined(THRUST_IGNORE_DEPRECATED_CPP_14)
-#  if !defined(THRUST_IGNORE_DEPRECATED_CPP_11)
-#    define THRUST_IGNORE_DEPRECATED_CPP_11
-#  endif
-#endif // suppress all c++11 dialect deprecation warnings
-#if defined(LIBCUDACXX_IGNORE_DEPRECATED_COMPILER) || defined(CCCL_IGNORE_DEPRECATED_COMPILER) \
-  || defined(CUB_IGNORE_DEPRECATED_COMPILER) || defined(THRUST_IGNORE_DEPRECATED_CPP_DIALECT)  \
-  || defined(THRUST_IGNORE_DEPRECATED_CPP_14) || defined(THRUST_IGNORE_DEPRECATED_CPP_11)
-#  if !defined(THRUST_IGNORE_DEPRECATED_COMPILER)
-#    define THRUST_IGNORE_DEPRECATED_COMPILER
-#  endif
-#endif // suppress all compiler deprecation warnings
 
 // Constexpr feature macros:
 #if THRUST_CPP_DIALECT >= 2023
@@ -180,7 +149,7 @@ THRUST_COMPILER_DEPRECATION_SOFT(C++ 17, C++ 11);
 #elif THRUST_CPP_DIALECT == 2014 && !defined(THRUST_IGNORE_DEPRECATED_CPP_14)
 // =C++14. Soft upgrade message:
 THRUST_COMPILER_DEPRECATION_SOFT(C++ 17, C++ 14);
-#endif // THRUST_CPP_DIALECT < 2011
+#endif // THRUST_CPP_DIALECT >= 2017
 
 #undef THRUST_COMPILER_DEPRECATION_SOFT
 #undef THRUST_COMPILER_DEPRECATION

--- a/projects/rocthrust/thrust/detail/config/deprecated.h
+++ b/projects/rocthrust/thrust/detail/config/deprecated.h
@@ -12,7 +12,7 @@
 #ifndef THRUST_DETAIL_CONFIG_DEPRECATED_H
 #define THRUST_DETAIL_CONFIG_DEPRECATED_H
 
-#include <thrust/detail/config/cpp_dialect.h>
+#include <thrust/detail/config/compiler.h>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -22,6 +22,33 @@
 #  pragma system_header
 #endif // no system header
 
+// Check for deprecation opt-outs
+#if defined(LIBCUDACXX_IGNORE_DEPRECATED_CPP_DIALECT) || defined(CCCL_IGNORE_DEPRECATED_CPP_DIALECT) \
+  || defined(CUB_IGNORE_DEPRECATED_CPP_DIALECT)
+#  if !defined(THRUST_IGNORE_DEPRECATED_CPP_DIALECT)
+#    define THRUST_IGNORE_DEPRECATED_CPP_DIALECT
+#  endif
+#endif // suppress all dialect deprecation warnings
+#if defined(LIBCUDACXX_IGNORE_DEPRECATED_CPP_14) || defined(CCCL_IGNORE_DEPRECATED_CPP_14) \
+  || defined(CUB_IGNORE_DEPRECATED_CPP_14) || defined(THRUST_IGNORE_DEPRECATED_CPP_DIALECT)
+#  if !defined(THRUST_IGNORE_DEPRECATED_CPP_14)
+#    define THRUST_IGNORE_DEPRECATED_CPP_14
+#  endif
+#endif // suppress all c++14 dialect deprecation warnings
+#if defined(LIBCUDACXX_IGNORE_DEPRECATED_CPP_11) || defined(CCCL_IGNORE_DEPRECATED_CPP_11)  \
+  || defined(CUB_IGNORE_DEPRECATED_CPP_11) || defined(THRUST_IGNORE_DEPRECATED_CPP_DIALECT) \
+  || defined(THRUST_IGNORE_DEPRECATED_CPP_14)
+#  if !defined(THRUST_IGNORE_DEPRECATED_CPP_11)
+#    define THRUST_IGNORE_DEPRECATED_CPP_11
+#  endif
+#endif // suppress all c++11 dialect deprecation warnings
+#if defined(LIBCUDACXX_IGNORE_DEPRECATED_COMPILER) || defined(CCCL_IGNORE_DEPRECATED_COMPILER) \
+  || defined(CUB_IGNORE_DEPRECATED_COMPILER) || defined(THRUST_IGNORE_DEPRECATED_CPP_DIALECT)  \
+  || defined(THRUST_IGNORE_DEPRECATED_CPP_14) || defined(THRUST_IGNORE_DEPRECATED_CPP_11)
+#  if !defined(THRUST_IGNORE_DEPRECATED_COMPILER)
+#    define THRUST_IGNORE_DEPRECATED_COMPILER
+#  endif
+#endif // suppress all compiler deprecation warnings
 #if defined(LIBCUDACXX_IGNORE_DEPRECATED_API) || defined(CCCL_IGNORE_DEPRECATED_API) \
   || defined(CUB_IGNORE_DEPRECATED_API)
 #  if !defined(THRUST_IGNORE_DEPRECATED_API)


### PR DESCRIPTION
Reverts ROCm/rocm-libraries#1720