### PR TITLE
Revert "Fix rocThrust 2.8.5 NVCC job failures"

### DIFF
--- a/projects/rocthrust/thrust/system/hip/detail/future.inl
+++ b/projects/rocthrust/thrust/system/hip/detail/future.inl
@@ -43,7 +43,7 @@
 #  include _THRUST_STD_INCLUDE(__memory/unique_ptr.h)
 // clang-format on
 #else
-#  include <thrust/detail/memory_wrapper.h>
+#  include <memory>
 #endif
 
 #  include <type_traits>


### PR DESCRIPTION
Reverts ROCm/rocm-libraries#1770