### PR TITLE
[rocsparse] Fix std::fma casting in host routines to properly deduce types

### DIFF
--- a/projects/rocsparse/clients/common/rocsparse_host.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_host.cpp
@@ -4669,8 +4669,8 @@ void host_csrgeam_nnz(J                    M,
         int nthreads = omp_get_num_threads();
         int tid      = omp_get_thread_num();
 #else
-        int nthreads = 1;
-        int tid      = 0;
+        int           nthreads = 1;
+        int           tid      = 0;
 #endif
 
         J rows_per_thread = (M + nthreads - 1) / nthreads;
@@ -4763,8 +4763,8 @@ void host_csrgeam(J                    M,
         int nthreads = omp_get_num_threads();
         int tid      = omp_get_thread_num();
 #else
-        int nthreads = 1;
-        int tid      = 0;
+        int           nthreads = 1;
+        int           tid      = 0;
 #endif
 
         J rows_per_thread = (M + nthreads - 1) / nthreads;

--- a/projects/rocsparse/clients/common/rocsparse_host.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_host.cpp
@@ -52,7 +52,8 @@ void host_axpby(
 
     for(I i = 0; i < nnz; ++i)
     {
-        y[x_ind[i] - base] = std::fma(static_cast<T>(alpha), static_cast<T>(x_val[i]), static_cast<T>(y[x_ind[i] - base]));
+        y[x_ind[i] - base] = std::fma(
+            static_cast<T>(alpha), static_cast<T>(x_val[i]), static_cast<T>(y[x_ind[i] - base]));
     }
 }
 
@@ -66,7 +67,8 @@ void host_doti(
 
     for(I i = 0; i < nnz; ++i)
     {
-        *result = std::fma(y[x_ind[i] - base], x_val[i], *result);
+        *result = std::fma(
+            static_cast<T>(y[x_ind[i] - base]), static_cast<T>(x_val[i]), static_cast<T>(*result));
     }
 }
 
@@ -80,7 +82,9 @@ void host_dotci(
 
     for(I i = 0; i < nnz; ++i)
     {
-        *result = std::fma(rocsparse_conj(x_val[i]), y[x_ind[i] - base], *result);
+        *result = std::fma(static_cast<T>(rocsparse_conj(x_val[i])),
+                           static_cast<T>(y[x_ind[i] - base]),
+                           static_cast<T>(*result));
     }
 }
 
@@ -1400,8 +1404,9 @@ void host_coomv(rocsparse_operation  trans,
 
         for(int64_t i = 0; i < nnz; ++i)
         {
-            y[coo_row_ind[i] - base]
-                = std::fma(alpha * coo_val[i], x[coo_col_ind[i] - base], y[coo_row_ind[i] - base]);
+            y[coo_row_ind[i] - base] = std::fma(static_cast<T>(alpha * coo_val[i]),
+                                                static_cast<T>(x[coo_col_ind[i] - base]),
+                                                static_cast<T>(y[coo_row_ind[i] - base]));
         }
     }
     else
@@ -1421,7 +1426,8 @@ void host_coomv(rocsparse_operation  trans,
             T val = (trans == rocsparse_operation_transpose) ? coo_val[i]
                                                              : rocsparse_conj(coo_val[i]);
 
-            y[col] = std::fma(alpha * val, x[row], y[col]);
+            y[col] = std::fma(
+                static_cast<T>(alpha * val), static_cast<T>(x[row]), static_cast<T>(y[col]));
         }
     }
 }
@@ -1455,8 +1461,9 @@ void host_coomv_aos(rocsparse_operation  trans,
 
         for(int64_t i = 0; i < nnz; ++i)
         {
-            y[coo_ind[2 * i] - base] = std::fma(
-                alpha * coo_val[i], x[coo_ind[2 * i + 1] - base], y[coo_ind[2 * i] - base]);
+            y[coo_ind[2 * i] - base] = std::fma(static_cast<T>(alpha * coo_val[i]),
+                                                static_cast<T>(x[coo_ind[2 * i + 1] - base]),
+                                                static_cast<T>(y[coo_ind[2 * i] - base]));
         }
 
         break;
@@ -1479,7 +1486,8 @@ void host_coomv_aos(rocsparse_operation  trans,
             T val = (trans == rocsparse_operation_transpose) ? coo_val[i]
                                                              : rocsparse_conj(coo_val[i]);
 
-            y[col] = std::fma(alpha * val, x[row], y[col]);
+            y[col] = std::fma(
+                static_cast<T>(alpha * val), static_cast<T>(x[row]), static_cast<T>(y[col]));
         }
 
         break;
@@ -1556,9 +1564,10 @@ static void host_csrmv_general(rocsparse_operation  trans,
                     {
                         if(j + k < row_end)
                         {
-                            sum[k] = std::fma(alpha * conj_val(csr_val[j + k], conj),
-                                              x[csr_col_ind[j + k] - base],
-                                              sum[k]);
+                            sum[k]
+                                = std::fma(static_cast<T>(alpha * conj_val(csr_val[j + k], conj)),
+                                           static_cast<T>(x[csr_col_ind[j + k] - base]),
+                                           static_cast<T>(sum[k]));
                         }
                     }
                 }
@@ -1577,7 +1586,8 @@ static void host_csrmv_general(rocsparse_operation  trans,
                 }
                 else
                 {
-                    y[i] = std::fma(beta, y[i], sum[0]);
+                    y[i] = std::fma(
+                        static_cast<T>(beta), static_cast<T>(y[i]), static_cast<T>(sum[0]));
                 }
             }
         }
@@ -1605,7 +1615,8 @@ static void host_csrmv_general(rocsparse_operation  trans,
 
                 if(beta != static_cast<T>(0))
                 {
-                    y[i] = std::fma(beta, y[i], sum + err);
+                    y[i] = std::fma(
+                        static_cast<T>(beta), static_cast<T>(y[i]), static_cast<T>(sum + err));
                 }
                 else
                 {
@@ -1702,7 +1713,9 @@ static void host_csrmv_symmetric(rocsparse_operation  trans,
                     if(j + k < row_end)
                     {
                         A val  = conj_val(csr_val[j + k], conj);
-                        sum[k] = std::fma(alpha * val, x[csr_col_ind[j + k] - base], sum[k]);
+                        sum[k] = std::fma(static_cast<T>(alpha * val),
+                                          static_cast<T>(x[csr_col_ind[j + k] - base]),
+                                          static_cast<T>(sum[k]));
                     }
                 }
             }
@@ -1721,7 +1734,7 @@ static void host_csrmv_symmetric(rocsparse_operation  trans,
             }
             else
             {
-                y[i] = std::fma(beta, y[i], sum[0]);
+                y[i] = std::fma(static_cast<T>(beta), static_cast<T>(y[i]), static_cast<T>(sum[0]));
             }
         }
 
@@ -2556,7 +2569,9 @@ void host_bsrmm(rocsparse_handle     handle,
                         idx_B = (block_dim * (bsr_col_ind_A[s] - base) + t) * ldb + j;
                     }
 
-                    sum = std::fma(bsr_val_A[idx_A], dense_B[idx_B], sum);
+                    sum = std::fma(static_cast<T>(bsr_val_A[idx_A]),
+                                   static_cast<T>(dense_B[idx_B]),
+                                   static_cast<T>(sum));
                 }
             }
 
@@ -2566,7 +2581,9 @@ void host_bsrmm(rocsparse_handle     handle,
             }
             else
             {
-                dense_C[idx_C] = std::fma(beta, dense_C[idx_C], alpha * sum);
+                dense_C[idx_C] = std::fma(static_cast<T>(beta),
+                                          static_cast<T>(dense_C[idx_C]),
+                                          static_cast<T>(alpha * sum));
             }
         }
     }
@@ -2716,8 +2733,9 @@ void host_csrmm(J                    M,
                         idx_B = (j + (csr_col_ind_A[k] - base) * ldb);
                     }
 
-                    sum = std::fma(
-                        conj_val(csr_val_A[k], conj_A), conj_val(dense_B[idx_B], conj_B), sum);
+                    sum = std::fma(static_cast<T>(conj_val(csr_val_A[k], conj_A)),
+                                   static_cast<T>(conj_val(dense_B[idx_B], conj_B)),
+                                   static_cast<T>(sum));
                 }
 
                 int64_t idx_C = (order_C == rocsparse_order_column) ? i + j * ldc : i * ldc + j;
@@ -2728,7 +2746,9 @@ void host_csrmm(J                    M,
                 }
                 else
                 {
-                    dense_C[idx_C] = std::fma(beta, dense_C[idx_C], alpha * sum);
+                    dense_C[idx_C] = std::fma(static_cast<T>(beta),
+                                              static_cast<T>(dense_C[idx_C]),
+                                              static_cast<T>(alpha * sum));
                 }
             }
         }
@@ -2957,7 +2977,9 @@ void host_coomm(I                    M,
                     idx_B = (j + col * ldb);
                 }
 
-                dense_C[idx_C] = std::fma(val, conj_val(dense_B[idx_B], conj_B), dense_C[idx_C]);
+                dense_C[idx_C] = std::fma(static_cast<T>(val),
+                                          static_cast<T>(conj_val(dense_B[idx_B], conj_B)),
+                                          static_cast<T>(dense_C[idx_C]));
             }
         }
     }
@@ -2999,7 +3021,9 @@ void host_coomm(I                    M,
                     idx_B = (j + row * ldb);
                 }
 
-                dense_C[idx_C] = std::fma(val, conj_val(dense_B[idx_B], conj_B), dense_C[idx_C]);
+                dense_C[idx_C] = std::fma(static_cast<T>(val),
+                                          static_cast<T>(conj_val(dense_B[idx_B], conj_B)),
+                                          static_cast<T>(dense_C[idx_C]));
             }
         }
     }
@@ -4645,8 +4669,8 @@ void host_csrgeam_nnz(J                    M,
         int nthreads = omp_get_num_threads();
         int tid      = omp_get_thread_num();
 #else
-        int           nthreads = 1;
-        int           tid      = 0;
+        int nthreads = 1;
+        int tid      = 0;
 #endif
 
         J rows_per_thread = (M + nthreads - 1) / nthreads;
@@ -4739,8 +4763,8 @@ void host_csrgeam(J                    M,
         int nthreads = omp_get_num_threads();
         int tid      = omp_get_thread_num();
 #else
-        int           nthreads = 1;
-        int           tid      = 0;
+        int nthreads = 1;
+        int tid      = 0;
 #endif
 
         J rows_per_thread = (M + nthreads - 1) / nthreads;

--- a/projects/rocsparse/clients/common/rocsparse_host.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_host.cpp
@@ -52,7 +52,7 @@ void host_axpby(
 
     for(I i = 0; i < nnz; ++i)
     {
-        y[x_ind[i] - base] = std::fma(alpha, x_val[i], y[x_ind[i] - base]);
+        y[x_ind[i] - base] = std::fma(static_cast<T>(alpha), static_cast<T>(x_val[i]), static_cast<T>(y[x_ind[i] - base]));
     }
 }
 


### PR DESCRIPTION
## Motivation

Fixes errors that were occurring on some machines related to deducing the correct type to use with `std::fma`

## Technical Details

Was getting compilation errors like: `error: call to '__test' is ambiguous` because the correct type passed to `std::fma` could not be properly deduced. This was occurring in host functions like host_axpby where we were using std::fma with the mixed types `rocsparse_bfloat16` and `float` for the parameters. Solution is to always static cast to the compute type T in these functions (which will be `float`, `double` or their complex equivalents).

## Test Plan

Verify all CI tests pass
