### PR TITLE
[rocfft] Fix heap overflow in extraction of rtc error log.

### DIFF
--- a/projects/rocfft/library/src/rtc_compile.cpp
+++ b/projects/rocfft/library/src/rtc_compile.cpp
@@ -54,7 +54,7 @@ std::vector<char> compile_inprocess(const std::string& kernel_src, const std::st
         {
             std::vector<char> log(logSize, '\0');
             if(hiprtcGetProgramLog(prog, log.data()) == HIPRTC_SUCCESS)
-                throw std::runtime_error(log.data());
+                throw std::runtime_error(std::string(log.begin(), log.end()));
         }
         throw std::runtime_error("compile failed without log");
     }


### PR DESCRIPTION
* This was implicitly attempting to convert a raw `char*` to a `std::string`, assuming it was nul terminated.
* Changed to use proper construction from a range.
* rocfft seems to do non-successful compilations as a course of routine and skips them silently, so this was surfacing as fairly random segfaults for things that would not be a user visible error. I haven't looked further into the logic to discover if this is intentended (just fixed the error handling path to not randomly crash).

