### PR TITLE
[hipblaslt] Add environment variable HIPBLASLT_OVERRIDE_COMPUTE_TYPE_XF32 (TF32)

### DIFF
--- a/projects/hipblaslt/docs/reference/env-variables.rst
+++ b/projects/hipblaslt/docs/reference/env-variables.rst
@@ -119,3 +119,22 @@ For more information, see :doc:`Use Stream-K with hipBLASLt <../how-to/how-to-us
       - | Integer value specifying maximum compute units
         | Example: 32 (limits GEMM kernels to 32 compute units)
         | Default: All available compute units
+
+Type overrides
+======================
+
+Overrides for specific types.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 70,30
+
+    * - **Environment variable**
+      - **Value**
+
+    * - | ``HIPBLASLT_OVERRIDE_COMPUTE_TYPE_XF32``
+        | Overrides the compute type used for GEMMs which specify a compute type of ``XF32``.
+      - | -1: Off (Default)
+        | 0: F32
+        | 1: XF32(eg TF32)
+        | 2: F32_BF16

--- a/projects/hipblaslt/library/src/amd_detail/hipblaslt.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/hipblaslt.cpp
@@ -217,6 +217,21 @@ hipblasStatus_t hipblasLtMatmulDescCreate(hipblasLtMatmulDesc_t* matmulDesc,
 try
 {
     rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulDescCreate");
+    char* override = std::getenv("HIPBLASLT_OVERRIDE_COMPUTE_TYPE_XF32");
+    if (override && (computeType == hipblasComputeType_t::HIPBLAS_COMPUTE_32F_FAST_TF32)
+        && (std::string(override) != "")) {
+        switch (std::stoi(std::string(override))) {
+            case 0:
+                computeType = hipblasComputeType_t::HIPBLAS_COMPUTE_32F;
+                break;
+            case 2:
+                computeType = hipblasComputeType_t::HIPBLAS_COMPUTE_32F_FAST_16BF;
+                break;
+            case 1:
+            default:
+                break;
+        }
+    }
     auto status = RocBlasLtStatusToHIPStatus(rocblaslt_matmul_desc_create(
         (rocblaslt_matmul_desc*)matmulDesc, (rocblaslt_compute_type)computeType, scaleType));
     rocblaslt::Debug::Instance().markerStop();


### PR DESCRIPTION
## Motivation

Adding override to tf32 type.

## Technical Details

I decided to make this only override xf32 based on early feedback, though the override could easily be expanded to cover others. I also decided to make it a simple int instead of a string selection to match existing HIPBLASLT env vars.
