### PR TITLE
[hipblaslt] Use new TheRock integration for configuring ASAN python launcher.

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -155,16 +155,16 @@ if(HIPBLASLT_ENABLE_LLVM)
 endif()
 
 if(HIPBLASLT_ENABLE_DEVICE)
-    if(HIPBLASLT_ENABLE_ASAN AND NOT WIN32)
-        set(ASAN_LIB_PATH "unset")
+    if(NOT WIN32 AND (HIPBLASLT_ENABLE_ASAN OR THEROCK_SANITIZER STREQUAL "ASAN"))
         execute_process(
             COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_PATH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            COMMAND_ERROR_IS_FATAL ANY
         )
         # If ASAN_LIB_PATH is libclang_rt.asan-x86_64.so
         # rather than /path/to/libclang_rt.asan-x86_64.so then
         # we failed to locate it and HAS_PARENT_PATH is false.
-        string(STRIP ${ASAN_LIB_PATH} ASAN_LIB_PATH)
         cmake_path(HAS_PARENT_PATH ASAN_LIB_PATH result)
         if(NOT result)
             message(FATAL_ERROR "Failed to locate libclang_rt.asan-x86_64.so ")


### PR DESCRIPTION
We are switching to TheRock managing all ASAN configuration for a project vs having this duplicated in each place. For most projects, this requires no changes, but there is a sharp edge for projects that need to launch system-python interpreters with ASAN built extensions. This makes a minimal change to detect this mode and do the appropriate preloading. It can be simplified in the future when not supporting multiple outer build systems. (See docs in the referenced PR for details)

See implementation: https://github.com/ROCm/TheRock/pull/1663
