### PR TITLE
[hipsparselt] Enable ASAN for hipblaslt via hipsparselt

### DIFF
--- a/projects/hipsparselt/CMakeLists.txt
+++ b/projects/hipsparselt/CMakeLists.txt
@@ -176,6 +176,7 @@ else()
           set(HIPBLASLT_ENABLE_CLIENT OFF CACHE BOOL "" FORCE)
           # Builds tensilelite's device libraries (.co/.dat)
           set(HIPBLASLT_ENABLE_DEVICE ON CACHE BOOL "" FORCE)
+          set(HIPBLASLT_ENABLE_ASAN ${BUILD_ADDRESS_SANITIZER} CACHE BOOL "" FORCE)
           # Builds tensilelite::tensilelite-host target
           set(TENSILELITE_ENABLE_HOST ON CACHE BOOL "" FORCE)
           if( Tensile_NO_LAZY_LIBRARY_LOADING )


### PR DESCRIPTION
## Motivation

ASAN builds are broken for the 7.1 release in hipsparselt because its enablement isn't forwarded to hipblaslt.

## Technical Details

Before calling `add_subdirectory` set HIPBLASLT_ENABLE_ASAN to BUILD_ADDRESS_SANITIZER.

## Test Plan

ROCm CI testing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
