### PR TITLE
Update TheRock commit in workflow files

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: a58f3a3b207955e463f5079d2cd57f1c34d3cbd0 # 2025-10-01 commit
+          ref: dc05d637054ad197c84b00e24b6262af0ec797c6 # 2025-10-03 commit
 
       - name: Install python deps
         run: |
@@ -70,7 +70,6 @@ jobs:
 
       - name: Patch rocm-libraries
         run: |
-          rm ./TheRock/patches/amd-mainline/rocm-libraries/0009-Use-workgroupMappingDim-in-rocroller_host.patch
           git -c user.name="therockbot" -c "user.email=therockbot@amd.com" am --whitespace=nowarn ./TheRock/patches/amd-mainline/rocm-libraries/*.patch
 
       - name: Configure Projects

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: a58f3a3b207955e463f5079d2cd57f1c34d3cbd0 # 2025-10-01 commit
+          ref: dc05d637054ad197c84b00e24b6262af0ec797c6 # 2025-10-03 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -58,7 +58,6 @@ jobs:
 
       - name: Patch rocm-libraries
         run: |
-          rm ./TheRock/patches/amd-mainline/rocm-libraries/0009-Use-workgroupMappingDim-in-rocroller_host.patch
           git -c user.name="therockbot" -c "user.email=therockbot@amd.com" am --whitespace=nowarn ./TheRock/patches/amd-mainline/rocm-libraries/*.patch
 
       - name: Install requirements

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: a58f3a3b207955e463f5079d2cd57f1c34d3cbd0 # 2025-10-01 commit
+          ref: dc05d637054ad197c84b00e24b6262af0ec797c6 # 2025-10-03 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'


### PR DESCRIPTION
## Motivation

TheRock temporarily carries patch files to resolve discrepancies between dependent rocm-libraries subprojects that are out-of-sync. In rocm-libraries, hipBLASLt and rocroller are now in sync and the patch files have been deleted from TheRock and no longer need to be considered in the workflow files.

## Technical Details

- bump TheRock hash
- delete rm of TheRock patch files

## Test Plan

- [x] verify with GitHub workflows
