### PR TITLE
[hipDNN] [ALMIOPEN-304] - Fixed memory leak in JSON tests

### DIFF
--- a/projects/hipdnn/sdk/tests/utilities/TestJson.cpp
+++ b/projects/hipdnn/sdk/tests/utilities/TestJson.cpp
@@ -32,7 +32,9 @@ void toJsonAndBackTestSuite(const hipdnn_sdk::data_objects::Graph* graph,
     auto t2 = newGraph->tensors()->begin();
     for(; t1 != graph->tensors()->end() && t2 != newGraph->tensors()->end(); t1++, t2++)
     {
-        EXPECT_EQ(*t1->UnPack(), *t2->UnPack()) << context;
+        std::unique_ptr<TensorAttributesT> t1ptr(t1->UnPack());
+        std::unique_ptr<TensorAttributesT> t2ptr(t2->UnPack());
+        EXPECT_EQ(*t1ptr, *t2ptr) << context;
     }
 
     ASSERT_EQ(graph->nodes()->size(), newGraph->nodes()->size()) << context;
@@ -40,7 +42,9 @@ void toJsonAndBackTestSuite(const hipdnn_sdk::data_objects::Graph* graph,
     auto n2 = newGraph->nodes()->begin();
     for(; n1 != graph->nodes()->end() && n2 != newGraph->nodes()->end(); n1++, n2++)
     {
-        EXPECT_EQ(*n1->UnPack(), *n2->UnPack()) << context;
+        std::unique_ptr<NodeT> n1ptr(n1->UnPack());
+        std::unique_ptr<NodeT> n2ptr(n2->UnPack());
+        EXPECT_EQ(*n1ptr, *n2ptr) << context;
     }
 }
 


### PR DESCRIPTION
## Motivation

Fixed a small memory leak in the JSON graph conversion tests.

## Technical Details

- The results from a flatbuffer UnPack() operation weren't being cleaned up appropriately

## Test Plan

- Run all tests

## Test Result

- [x] Unit tests pass
- [x] Integration tests pass
- [x] ASAN tests pass (naturally) 

## Submission Checklist

- [x] clang-tidy
- [x] clang-format
