### PR TITLE
[rocsolver] Prefer using fmt-header-only

### DIFF
--- a/projects/rocsolver/clients/CMakeLists.txt
+++ b/projects/rocsolver/clients/CMakeLists.txt
@@ -62,7 +62,7 @@ if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   target_link_libraries(clients-common INTERFACE
     ${LAPACK_LIBRARIES}
     $<$<PLATFORM_ID:Linux>:stdc++fs>
-    fmt::fmt
+    fmt::fmt-header-only
   )
   target_link_options(clients-common INTERFACE
     ${LAPACK_LINKER_FLAGS}


### PR DESCRIPTION
## Motivation

So, PR #1588 has caused a bit of chaos. One thing that is happening is some install target messiness induced by RocRoller (via HipBLASLt), including libfmt v11 files. CI fails in one case where the wrong libfmt.a is linked instead of the v7 one that rocSolver currently prefers.

This is a quick fix to get things compiling again.  A proper fix to address the install targets of RocRoller will follow shortly.

## Technical Details

rocSolver clients link libfmt. We now specify it to use the header-only version, like in the main library.  Doing this allows us to sidestep the issue with libfmt.a linking while we address the root cause.

## Test Plan

Targets using clients-common like rocsolver-bench and rocsolver-test should compile in CI environments. Of special interest is the case where HipBLASLt was installed.

## Test Result

TBD by CI runs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
