### PR TITLE
Change the description for selecting kernel configuration in device code

### DIFF
--- a/projects/rocprim/docs/reference/developer.rst
+++ b/projects/rocprim/docs/reference/developer.rst
@@ -158,13 +158,15 @@ The default configuration depends on the types of the input values of the algori
     }
     const ALGO_config_params params = dispatch_target_arch<config>(target_arch);
 
-In device code the device architecture is known at compile time, and thus the configuration can also be selected at compile time. All that is needed, is the following pattern:
+In device code, when targeting generic AMDGPU architectures, the device architecture is known at compile time, during the host pass. With SPIR-V targets, however, the architecture is only known at runtime, during the device pass. To bridge this, we compile one kernel for each supported architecture during the host pass. That way, the final binary always contains a kernel compiled with the right configuration, and the device pass can select it at runtime. The difference is that for generic targets we compile only the real (matching) kernel; the other per-arch kernels are empty.
+
+The method to access the configuration in device code is as follows:
 
 .. code:: cpp
 
-    constexpr ALGO_CONFIG_PARAMS params = device_params<config>();
+    constexpr ALGO_CONFIG_PARAMS params = Config::template architecture_config<Arch>::params;
 
-The ``device_params`` function selects the configuration based on the predefined compiler macro ``__amdgcn_processor__``. In the example, ``config`` is of type ``wrapped_ALGO_config`` as in the host example.
+In the example, ``config`` is of type ``wrapped_ALGO_config`` as in the host example.
 
 Common patterns
 ===============

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -400,7 +400,7 @@ struct target_config
 
 // trampoline_kernel that is fully specialized at compile-time for a single GPU architecture.
 // By instantiating this template once per supported `target_arch`,the correct tuned config
-// will be derived from the template
+// will be derived from the template.
 template<typename Config,
          target_arch Arch,
          class Kernel,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_histogram.hpp
@@ -523,7 +523,6 @@ inline hipError_t histogram_impl(void*          temporary_storage,
         plan.device_callback.shared_histograms = chosen_shared_histograms;
         plan.device_callback.rows_per_block    = rows_per_block;
 
-        // 4) 发射（无需再做任何按架构分发）
         plan.launch(grid_size,
                     dim3(block_size, 1),
                     chosen_shared_histograms * block_histogram_bytes,


### PR DESCRIPTION
## Motivation

We have changed the method to access `kernel_config` in device code, but the docs were not changed accordingly. In this PR this part is updated for an explanation.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
