### PR TITLE
Upgrade sqlite from 3.49.1 to 3.50.4

### DIFF
--- a/projects/miopen/dev-requirements.txt
+++ b/projects/miopen/dev-requirements.txt
@@ -1,3 +1,3 @@
-ROCm/rocm-recipes@20dee476ed2c52f082376f2563d2efd3331f5b5f
+ROCm/rocm-recipes@d7827046100ac0ed8167e16c53999baa126e760d
 -f requirements.txt
 danmar/cppcheck@2.12.1

--- a/projects/miopen/install_deps.cmake
+++ b/projects/miopen/install_deps.cmake
@@ -124,5 +124,5 @@ cget(init ${TOOLCHAIN_FLAG} -DCMAKE_INSTALL_RPATH=${PREFIX}/lib ${PARSE_UNPARSED
 cget(ignore pcre)
 
 # Install dependencies
-cget(install ${CGET_EXTRA_OPTIONS} -U ROCm/rocm-recipes@20dee476ed2c52f082376f2563d2efd3331f5b5f)
+cget(install ${CGET_EXTRA_OPTIONS} -U ROCm/rocm-recipes@d7827046100ac0ed8167e16c53999baa126e760d)
 cget(install ${CGET_EXTRA_OPTIONS} -U -f requirements.txt)

--- a/projects/miopen/rbuild.ini
+++ b/projects/miopen/rbuild.ini
@@ -3,7 +3,7 @@ cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
 ignore = pcre
 deps =
-    ROCm/rocm-recipes@20dee476ed2c52f082376f2563d2efd3331f5b5f
+    ROCm/rocm-recipes@d7827046100ac0ed8167e16c53999baa126e760d
     -f requirements.txt
 
 [develop]
@@ -20,5 +20,5 @@ cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
 ignore = pcre
 deps =
-    ROCm/rocm-recipes@20dee476ed2c52f082376f2563d2efd3331f5b5f
+    ROCm/rocm-recipes@d7827046100ac0ed8167e16c53999baa126e760d
     -f dev-requirements.txt

--- a/projects/miopen/requirements.txt
+++ b/projects/miopen/requirements.txt
@@ -1,4 +1,4 @@
-sqlite3@3.49.1 -DCMAKE_POSITION_INDEPENDENT_CODE=On
+sqlite3@3.50.4 -DCMAKE_POSITION_INDEPENDENT_CODE=On
 boost@1.83 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build -DCMAKE_CXX_FLAGS=" -std=c++20 -Wno-enum-constexpr-conversion -Wno-deprecated-builtins -Wno-deprecated-declarations "
 facebook/zstd@v1.4.5 -X subdir -DCMAKE_DIR=build/cmake
 # ROCm/half@10abd99e7815f0ca5d892f58dd7d15a23b7cf92c --build


### PR DESCRIPTION
 - Upgrade the version number to 3.50.4
 - Update the 4 SHAs to the rocm-recipes repo

## Motivation

A security vulnerability was found and fixed in sqlite.  Upgrading the version to fix this issue.

## Technical Details

Updated the rocm-recipes repo and used the new SHA for this changeset:
https://github.com/ROCm/rocm-recipes/commit/d7827046100ac0ed8167e16c53999baa126e760d
