### PR TITLE
[MIOpen] Enable gfx942 for precheckin CI

### DIFF
--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
             description: "")
         booleanParam(
             name: "TARGET_GFX942",
-            defaultValue: env.BRANCH_NAME == "develop" ? true : false,
+            defaultValue: true,
             description: "")
         booleanParam(
             name: "TARGET_NAVI32",


### PR DESCRIPTION
## Motivation

This PR aims to enable gfx942 for the MIOpen pre-checkin CI.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Test Plan

Verify that gfx942 tests are triggered when a PR is created.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
