### PR TITLE
[rocsparse] Fix building rocsparse with install script on centos9

### DIFF
--- a/projects/rocsparse/install.sh
+++ b/projects/rocsparse/install.sh
@@ -183,7 +183,7 @@ install_packages( )
     else
       library_dependencies_centos+=( "numactl-libs" )
     fi
-    elif [[ "${MAJORVERSION}" == "9" ]]; then
+    if [[ "${MAJORVERSION}" == "9" ]]; then
       client_dependencies_centos8+=( "python3-pyyaml" )
     elif [[ "${MAJORVERSION}" == "8" ]]; then
       client_dependencies_centos8+=( "python3-pyyaml" )

--- a/projects/rocsparse/install.sh
+++ b/projects/rocsparse/install.sh
@@ -173,7 +173,7 @@ install_packages( )
 
   local client_dependencies_ubuntu=( "python3" "python3-yaml" )
   local client_dependencies_centos=( "python36" "python3-pip" )
-  local client_dependencies_centos8=( "python36" "python3-pip" )
+  local client_dependencies_centos8=( "python39" "python3-pip" )
   local client_dependencies_fedora=( "python36" "PyYAML" "python3-pip" )
   local client_dependencies_sles=( "pkg-config" "dpkg" "python3-pip" )
 
@@ -183,7 +183,9 @@ install_packages( )
     else
       library_dependencies_centos+=( "numactl-libs" )
     fi
-    if [[ "${MAJORVERSION}" == "8" ]]; then
+    elif [[ "${MAJORVERSION}" == "9" ]]; then
+      client_dependencies_centos8+=( "python3-pyyaml" )
+    elif [[ "${MAJORVERSION}" == "8" ]]; then
       client_dependencies_centos8+=( "python3-pyyaml" )
     else
       client_dependencies_centos8+=( "PyYAML" )


### PR DESCRIPTION
## Motivation

Fix building rocsparse with install script on centos9

## Technical Details

Fix failures in getting python and pyyaml dependencies on centos stream 9:

Installing python36 from distro package manager
Last metadata expiration check: 0:14:40 ago on Wed 08 Oct 2025 06:18:11 PM UTC.
No match for argument: python36
Error: Unable to find a match: python36

## Test Plan

Ensure all CI tests pass
