### PR TITLE
[MIOPEN] GLU driver CPU improvement

### DIFF
--- a/projects/miopen/driver/glu_driver.hpp
+++ b/projects/miopen/driver/glu_driver.hpp
@@ -41,6 +41,7 @@
 #include <../test/verify.hpp>
 
 #include <miopen/errors.hpp>
+#include <miopen/par_for.hpp>
 #include <miopen/miopen.h>
 
 template <typename T>
@@ -63,7 +64,7 @@ int mloGLUForwardContiguousDim0RunHost(const Tgpu* input,
 
     if(parallel)
     {
-        par_for(output_numel, [&](const size_t& o) {
+        miopen::par_for(output_numel, [&](const size_t& o) {
             Tcheck valA   = static_cast<Tcheck>(inputFirstHalf[o]);
             Tcheck valB   = static_cast<Tcheck>(inputSecondHalf[o]);
             Tcheck val    = valA * sigmoid(valB);
@@ -101,7 +102,7 @@ int mloGLUBackwardCongiguousDim0RunHost(const Tgpu* input,
 
     if(parallel)
     {
-        par_for(outputGrad_numel, [&](const auto& o) {
+        miopen::par_for(outputGrad_numel, [&](const auto& o) {
             Tcheck inputFirstHalf_v = static_cast<Tcheck>(inputFirstHalf[o]);
             Tcheck sigmoid_v        = sigmoid(static_cast<Tcheck>(inputSecondHalf[o]));
             Tcheck grad_v           = static_cast<Tcheck>(outputGrad[o]);
@@ -273,8 +274,11 @@ int GLUDriver<Tgpu, Tref>::AddCmdLineArgs()
     inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
     inflags.AddInputFlag(
         "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
-    inflags.AddInputFlag(
-        "multithreaded", 'm', "0", "Run CPU forward/backward in multithreaded mode (Default=0)", "int");
+    inflags.AddInputFlag("multithreaded",
+                         'm',
+                         "0",
+                         "Run CPU forward/backward in multithreaded mode (Default=0)",
+                         "int");
 
     return miopenStatusSuccess;
 }
@@ -405,7 +409,8 @@ template <typename Tgpu, typename Tref>
 int GLUDriver<Tgpu, Tref>::RunForwardCPU()
 {
     MIOPEN_THROW_IF(dim != 0, "This driver only supports dim = 0");
-    mloGLUForwardContiguousDim0RunHost<Tgpu, Tref>(in.data(), outputTensor, outhost.data(), multithreaded);
+    mloGLUForwardContiguousDim0RunHost<Tgpu, Tref>(
+        in.data(), outputTensor, outhost.data(), multithreaded);
 
     return miopenStatusSuccess;
 }

--- a/projects/miopen/driver/glu_driver.hpp
+++ b/projects/miopen/driver/glu_driver.hpp
@@ -60,13 +60,12 @@ int mloGLUForwardContiguousDim0RunHost(const Tgpu* input,
 
     int ret = 0;
 
-    for(size_t o = 0; o < output_numel; o++)
-    {
+    par_for(output_numel, 1<<17, [&](const size_t& o){
         Tcheck valA   = static_cast<Tcheck>(inputFirstHalf[o]);
         Tcheck valB   = static_cast<Tcheck>(inputSecondHalf[o]);
         Tcheck val    = valA * sigmoid(valB);
         outputHost[o] = val;
-    }
+    });
 
     return ret;
 }
@@ -85,7 +84,7 @@ int mloGLUBackwardCongiguousDim0RunHost(const Tgpu* input,
     auto inputFistHalf_grad   = inputGradHost;
     auto inputSecondHalf_grad = inputGradHost + outputGrad_numel;
 
-    for(size_t o = 0; o < outputGrad_numel; o++)
+    par_for(outputGrad_numel, 1<<17, [&](const auto& o)
     {
         Tcheck inputFirstHalf_v = static_cast<Tcheck>(inputFirstHalf[o]);
         Tcheck sigmoid_v        = sigmoid(static_cast<Tcheck>(inputSecondHalf[o]));
@@ -93,7 +92,7 @@ int mloGLUBackwardCongiguousDim0RunHost(const Tgpu* input,
 
         inputFistHalf_grad[o]   = sigmoid_v * grad_v;
         inputSecondHalf_grad[o] = (1 - sigmoid_v) * sigmoid_v * grad_v * inputFirstHalf_v;
-    }
+    });
 
     return ret;
 }

--- a/projects/miopen/driver/glu_driver.hpp
+++ b/projects/miopen/driver/glu_driver.hpp
@@ -52,7 +52,8 @@ T sigmoid(T x)
 template <typename Tgpu, typename Tcheck>
 int mloGLUForwardContiguousDim0RunHost(const Tgpu* input,
                                        miopenTensorDescriptor_t outputDesc,
-                                       Tcheck* outputHost)
+                                       Tcheck* outputHost,
+                                       bool parallel)
 {
     auto output_numel    = miopen::deref(outputDesc).GetElementSize();
     auto inputFirstHalf  = input;
@@ -60,12 +61,25 @@ int mloGLUForwardContiguousDim0RunHost(const Tgpu* input,
 
     int ret = 0;
 
-    par_for(output_numel, 1<<17, [&](const size_t& o){
-        Tcheck valA   = static_cast<Tcheck>(inputFirstHalf[o]);
-        Tcheck valB   = static_cast<Tcheck>(inputSecondHalf[o]);
-        Tcheck val    = valA * sigmoid(valB);
-        outputHost[o] = val;
-    });
+    if(parallel)
+    {
+        par_for(output_numel, [&](const size_t& o) {
+            Tcheck valA   = static_cast<Tcheck>(inputFirstHalf[o]);
+            Tcheck valB   = static_cast<Tcheck>(inputSecondHalf[o]);
+            Tcheck val    = valA * sigmoid(valB);
+            outputHost[o] = val;
+        });
+    }
+    else
+    {
+        for(size_t o = 0; o < output_numel; ++o)
+        {
+            Tcheck valA   = static_cast<Tcheck>(inputFirstHalf[o]);
+            Tcheck valB   = static_cast<Tcheck>(inputSecondHalf[o]);
+            Tcheck val    = valA * sigmoid(valB);
+            outputHost[o] = val;
+        }
+    }
 
     return ret;
 }
@@ -74,7 +88,8 @@ template <typename Tgpu, typename Tcheck>
 int mloGLUBackwardCongiguousDim0RunHost(const Tgpu* input,
                                         miopenTensorDescriptor_t outputGradDesc,
                                         const Tgpu* outputGrad,
-                                        Tcheck* inputGradHost)
+                                        Tcheck* inputGradHost,
+                                        bool parallel)
 {
     int ret = 0;
 
@@ -84,15 +99,29 @@ int mloGLUBackwardCongiguousDim0RunHost(const Tgpu* input,
     auto inputFistHalf_grad   = inputGradHost;
     auto inputSecondHalf_grad = inputGradHost + outputGrad_numel;
 
-    par_for(outputGrad_numel, 1<<17, [&](const auto& o)
+    if(parallel)
     {
-        Tcheck inputFirstHalf_v = static_cast<Tcheck>(inputFirstHalf[o]);
-        Tcheck sigmoid_v        = sigmoid(static_cast<Tcheck>(inputSecondHalf[o]));
-        Tcheck grad_v           = static_cast<Tcheck>(outputGrad[o]);
+        par_for(outputGrad_numel, [&](const auto& o) {
+            Tcheck inputFirstHalf_v = static_cast<Tcheck>(inputFirstHalf[o]);
+            Tcheck sigmoid_v        = sigmoid(static_cast<Tcheck>(inputSecondHalf[o]));
+            Tcheck grad_v           = static_cast<Tcheck>(outputGrad[o]);
 
-        inputFistHalf_grad[o]   = sigmoid_v * grad_v;
-        inputSecondHalf_grad[o] = (1 - sigmoid_v) * sigmoid_v * grad_v * inputFirstHalf_v;
-    });
+            inputFistHalf_grad[o]   = sigmoid_v * grad_v;
+            inputSecondHalf_grad[o] = (1 - sigmoid_v) * sigmoid_v * grad_v * inputFirstHalf_v;
+        });
+    }
+    else
+    {
+        for(size_t o = 0; o < outputGrad_numel; ++o)
+        {
+            Tcheck inputFirstHalf_v = static_cast<Tcheck>(inputFirstHalf[o]);
+            Tcheck sigmoid_v        = sigmoid(static_cast<Tcheck>(inputSecondHalf[o]));
+            Tcheck grad_v           = static_cast<Tcheck>(outputGrad[o]);
+
+            inputFistHalf_grad[o]   = sigmoid_v * grad_v;
+            inputSecondHalf_grad[o] = (1 - sigmoid_v) * sigmoid_v * grad_v * inputFirstHalf_v;
+        }
+    }
 
     return ret;
 }
@@ -142,6 +171,7 @@ private:
     InputFlags inflags;
 
     int forw;
+    bool multithreaded;
 
     miopenTensorDescriptor_t inputTensor;
     miopenTensorDescriptor_t outputTensor;
@@ -183,6 +213,8 @@ int GLUDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     {
         MIOPEN_THROW("Invalid Forward Mode");
     }
+
+    multithreaded = static_cast<bool>(inflags.GetValueInt("multithreaded"));
 
     return miopenStatusSuccess;
 }
@@ -241,6 +273,8 @@ int GLUDriver<Tgpu, Tref>::AddCmdLineArgs()
     inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
     inflags.AddInputFlag(
         "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
+    inflags.AddInputFlag(
+        "multithreaded", 'm', "0", "Run CPU forward/backward in multithreaded mode (Default=0)", "int");
 
     return miopenStatusSuccess;
 }
@@ -371,7 +405,7 @@ template <typename Tgpu, typename Tref>
 int GLUDriver<Tgpu, Tref>::RunForwardCPU()
 {
     MIOPEN_THROW_IF(dim != 0, "This driver only supports dim = 0");
-    mloGLUForwardContiguousDim0RunHost<Tgpu, Tref>(in.data(), outputTensor, outhost.data());
+    mloGLUForwardContiguousDim0RunHost<Tgpu, Tref>(in.data(), outputTensor, outhost.data(), multithreaded);
 
     return miopenStatusSuccess;
 }
@@ -455,7 +489,7 @@ int GLUDriver<Tgpu, Tref>::RunBackwardCPU()
 {
     MIOPEN_THROW_IF(dim != 0, "This driver only supports dim = 0");
     mloGLUBackwardCongiguousDim0RunHost<Tgpu, Tref>(
-        in.data(), outputTensorGrad, outGrad.data(), inGradhost.data());
+        in.data(), outputTensorGrad, outGrad.data(), inGradhost.data(), multithreaded);
 
     return miopenStatusSuccess;
 }


### PR DESCRIPTION
## Motivation

Make the CPU loop parallel.

## Technical Details

Add new input flag which uses parallel version of algorithm.

## Test Plan

Run GLU (all versions) on various of inputs.

## Test Result

Test performed on:
CPU: AMD Ryzen 9 5900X 12-Core Processor
RAM: 62 GB
GPU: AMD Radeon RX 6800 XT

### FP32 results
| Case | D (N×C×H×W)        | Fwd Serial (ms) | Fwd Parallel (ms) | Bwd Serial (ms) | Bwd Parallel (ms) |
|-----:|---------------------|----------------:|------------------:|----------------:|------------------:|
| 01   | 32x128x64x64        | 22.774          | 3.833             | 29.216          | 6.306             |
| 05   | 8x256x32x32         | 2.790           | 0.933             | 3.443           | 0.947             |
| 09   | 16x96x33x66         | 4.454           | 1.032             | 5.524           | 1.091             |
| 12   | 32x56x56x128        | 16.979          | 2.742             | 20.878          | 4.650             |
| 14   | 2x1x1x1048576       | 2.794           | 0.937             | 3.451           | 0.952             |
| 16   | 2x2x64x64           | 0.023           | 0.865             | 0.029           | 0.847             |
| 18   | 128x64x7x7          | 0.540           | 0.933             | 0.660           | 0.940             |
| 20   | 4x512x14x28         | 1.054           | 0.896             | 1.313           | 0.954             |
| L01  | 16x512x256x256      | 777.442         | 134.809           | 2707.317        | 260.952           |
| L04  | 64x1024x112x112     | 1134.726        | 282.580           | 1479.700        | 499.668           |
| L08  | 32x4096x28x28       | 135.723         | 25.677            | 172.410         | 42.557            |
| L11  | 2x1x1x33554432      | 90.335          | 16.528            | 112.402         | 28.120            |
| L13  | 2x1x1x134217728     | 386.086         | 68.657            | 1379.708        | 128.124           |
| L14  | 512x256x14x14       | 33.736          | 5.888             | 41.808          | 10.125            |
| L15  | 1024x128x7x7        | 8.409           | 1.491             | 10.385          | 1.788             |
| L16  | 8x1024x64x512       | 388.523         | 68.798            | 1343.900        | 129.673           |
| L18  | 32x2048x64x64       | 389.711         | 69.303            | 1352.475        | 128.542           |



### BFP16 results
| Case | D (N×C×H×W)        | Fwd Serial (ms) | Fwd Parallel (ms) | Bwd Serial (ms) | Bwd Parallel (ms) |
|-----:|---------------------|----------------:|------------------:|----------------:|------------------:|
| 01   | 32x128x64x64        | 21.977          | 3.069             | 31.222          | 4.940             |
| 05   | 8x256x32x32         | 2.791           | 0.920             | 3.915           | 0.972             |
| 09   | 16x96x33x66         | 4.457           | 1.029             | 6.293           | 1.149             |
| 12   | 32x56x56x128        | 16.765          | 2.312             | 23.811          | 3.198             |
| 14   | 2x1x1x1048576       | 2.788           | 0.931             | 3.910           | 0.958             |
| 16   | 2x2x64x64           | 0.023           | 0.868             | 0.031           | 0.837             |
| 18   | 128x64x7x7          | 0.553           | 0.904             | 0.764           | 0.899             |
| 20   | 4x512x14x28         | 1.074           | 0.905             | 1.507           | 0.895             |
| L01  | 16x512x256x256      | 973.078         | 110.053           | 2656.484        | 219.094           |
| L04  | 64x1024x112x112     | 1077.691        | 161.168           | 1516.252        | 270.617           |
| L08  | 32x4096x28x28       | 135.325         | 20.602            | 191.355         | 35.400            |
| L11  | 2x1x1x33554432      | 88.439          | 12.924            | 126.971         | 21.875            |
| L13  | 2x1x1x134217728     | 400.302         | 54.745            | 1262.266        | 110.024           |
| L14  | 512x256x14x14       | 33.552          | 4.758             | 48.065          | 7.748             |
| L15  | 1024x128x7x7        | 8.574           | 1.446             | 12.060          | 1.674             |
| L16  | 8x1024x64x512       | 402.515         | 55.437            | 1266.324        | 108.989           |
| L18  | 32x2048x64x64       | 402.203         | 55.410            | 1253.760        | 109.933           |



### FP16 results
| Case | D (N×C×H×W)        | Fwd Serial (ms) | Fwd Parallel (ms) | Bwd Serial (ms) | Bwd Parallel (ms) |
|-----:|---------------------|----------------:|------------------:|----------------:|------------------:|
| 01   | 32x128x64x64        | 29.474          | 3.528             | 43.324          | 5.374             |
| 05   | 8x256x32x32         | 3.770           | 0.956             | 5.436           | 1.041             |
| 09   | 16x96x33x66         | 6.082           | 1.157             | 8.788           | 1.294             |
| 12   | 32x56x56x128        | 22.889          | 2.982             | 32.682          | 3.938             |
| 14   | 2x1x1x1048576       | 3.789           | 0.969             | 5.505           | 1.029             |
| 16   | 2x2x64x64           | 0.030           | 0.878             | 0.048           | 0.834             |
| 18   | 128x64x7x7          | 0.721           | 0.912             | 1.066           | 0.899             |
| 20   | 4x512x14x28         | 1.454           | 0.895             | 2.105           | 0.902             |
| L01  | 16x512x256x256      | 1119.205        | 116.243           | 2566.298        | 220.066           |
| L04  | 64x1024x112x112     | 1553.668        | 179.130           | 2228.351        | 301.272           |
| L08  | 32x4096x28x28       | 183.664         | 21.396            | 266.117         | 37.948            |
| L11  | 2x1x1x33554432      | 119.582         | 13.759            | 181.377         | 23.349            |
| L13  | 2x1x1x134217728     | 571.820         | 60.966            | 1294.613        | 110.321           |
| L14  | 512x256x14x14       | 45.915          | 5.958             | 66.384          | 8.377             |
| L15  | 1024x128x7x7        | 11.494          | 1.688             | 16.546          | 2.006             |
| L16  | 8x1024x64x512       | 569.065         | 59.544            | 1288.911        | 107.978           |
| L18  | 32x2048x64x64       | 570.638         | 61.798            | 1290.926        | 108.063           |



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
