### PR TITLE
[TheRock CI] Updating TheRock commit hash bump to resolve rocPRIM timeouts

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 21b40919154d8bc44bbbc0f951df7e0c45bda6fb # 2025-10-06 commit
+          ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 21b40919154d8bc44bbbc0f951df7e0c45bda6fb # 2025-10-06 commit
+          ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 21b40919154d8bc44bbbc0f951df7e0c45bda6fb # 2025-10-06 commit
+          ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 21b40919154d8bc44bbbc0f951df7e0c45bda6fb # 2025-10-06 commit
+          ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
Added new timeouts and ignoring flaky tests, so bumping TheRock hash to get these changes

Eventually, we will remove this but as we are continuing to make items more stable, this is needed