### PR TITLE
[hipsparselt] Add cblas for TheRock

### DIFF
--- a/projects/hipsparselt/CMakeLists.txt
+++ b/projects/hipsparselt/CMakeLists.txt
@@ -67,6 +67,7 @@ option(HIPSPARSELT_ENABLE_OPENMP "Enable OpenMP support." ON)
 option(HIPSPARSELT_ENABLE_MARKER "Enable rocTracer marker support." ON)
 option(HIPSPARSELT_ENABLE_ASAN "Build with address sanitizer enabled." OFF)
 option(HIPSPARSELT_ENABLE_FETCH "Fetch dependencies." OFF)
+option(HIPSPARSELT_ENABLE_THEROCK "Enable TheRock support." OFF)
 
 set(HIPSPARSELT_HIPBLASLT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../hipblaslt"
     CACHE PATH "Path to hipblaslt directory."

--- a/projects/hipsparselt/clients/CMakeLists.txt
+++ b/projects/hipsparselt/clients/CMakeLists.txt
@@ -6,6 +6,10 @@ include(FetchLAPACK)
 find_package(Threads REQUIRED)
 find_package(OpenMP REQUIRED)
 find_package(BLAS REQUIRED)
+if(HIPSPARSELT_ENABLE_THEROCK)
+  # This is required to support TheRock's cblas management
+  find_package(cblas REQUIRED)
+endif()
 
 if(HIPSPARSELT_ENABLE_BLIS)
   find_package(BLIS QUIET)


### PR DESCRIPTION
## Motivation

TheRock build system manages and internally generated cblas find module. This updates allows that find module to be called in TheRock without it affecting the rocm-libraries builds.

## Technical Details

Add a cmake variable to guard a call to `find_package(cblas)`.

## Test Plan

Standard CI testing.

## Test Result

See PR job report.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
