### PR TITLE
RoPE driver cpu improvement

### DIFF
--- a/projects/miopen/driver/rope_driver.hpp
+++ b/projects/miopen/driver/rope_driver.hpp
@@ -31,7 +31,6 @@
 #include "tensor_driver.hpp"
 #include "timer.hpp"
 #include "random.hpp"
-#include <algorithm>
 #include <cfloat>
 #include <cstdlib>
 #include <memory>
@@ -45,8 +44,6 @@
 template <typename Tgpu, typename Tcheck>
 int32_t mloRoPEForwardRunHost(miopenTensorDescriptor_t xDesc,
                               miopenTensorDescriptor_t cosDesc,
-                              miopenTensorDescriptor_t sinDesc,
-                              miopenTensorDescriptor_t yDesc,
                               Tgpu* x,
                               Tgpu* cos,
                               Tgpu* sin,
@@ -80,10 +77,42 @@ int32_t mloRoPEForwardRunHost(miopenTensorDescriptor_t xDesc,
 }
 
 template <typename Tgpu, typename Tcheck>
+int32_t mloRoPEForwardRunHostPar(miopenTensorDescriptor_t xDesc,
+                              miopenTensorDescriptor_t cosDesc,
+                              Tgpu* x,
+                              Tgpu* cos,
+                              Tgpu* sin,
+                              Tcheck* yhost)
+{
+    auto x_dims   = miopen::deref(xDesc).GetLengths();
+    auto cos_dims = miopen::deref(cosDesc).GetLengths();
+    auto input_numel =
+        std::accumulate(x_dims.begin(), x_dims.end(), 1LL, std::multiplies<int64_t>());
+    auto rotary_numel =
+        std::accumulate(cos_dims.begin(), cos_dims.end(), 1LL, std::multiplies<int64_t>());
+
+    int32_t ret = 0;
+
+    par_for(input_numel, [&](std::size_t o) {
+        size_t freq_idx = o % rotary_numel;
+        Tcheck input    = static_cast<Tcheck>(x[o]);
+        Tcheck input_rotate_half =
+            (o % 2 == 0) ? static_cast<Tcheck>(-x[o + 1]) : static_cast<Tcheck>(x[o - 1]);
+
+        Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
+        Tcheck sin_val = static_cast<Tcheck>(sin[freq_idx]);
+
+        Tcheck val = (input * cos_val) + (input_rotate_half * sin_val);
+
+        yhost[o] = val;
+    });
+
+    return ret;
+}
+
+template <typename Tgpu, typename Tcheck>
 int32_t mloRoPEBackwardRunHost(miopenTensorDescriptor_t dyDesc,
                                miopenTensorDescriptor_t cosDesc,
-                               miopenTensorDescriptor_t sinDesc,
-                               miopenTensorDescriptor_t dxDesc,
                                Tgpu* dy,
                                Tgpu* cos,
                                Tgpu* sin,
@@ -114,6 +143,42 @@ int32_t mloRoPEBackwardRunHost(miopenTensorDescriptor_t dyDesc,
 
         dxhost[o] = val;
     }
+
+    return ret;
+}
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloRoPEBackwardRunHostPar(miopenTensorDescriptor_t dyDesc,
+                               miopenTensorDescriptor_t cosDesc,
+                               Tgpu* dy,
+                               Tgpu* cos,
+                               Tgpu* sin,
+                               Tcheck* dxhost)
+{
+    auto dy_dims = miopen::deref(dyDesc).GetLengths();
+    auto input_numel =
+        std::accumulate(dy_dims.begin(), dy_dims.end(), 1LL, std::multiplies<int64_t>());
+    auto cos_dims = miopen::deref(cosDesc).GetLengths();
+    auto rotary_numel =
+        std::accumulate(cos_dims.begin(), cos_dims.end(), 1LL, std::multiplies<int64_t>());
+
+    int32_t ret = 0;
+
+    par_for(input_numel, [&](std::size_t o) {
+        size_t freq_idx = o % rotary_numel;
+
+        Tcheck output_grad = static_cast<Tcheck>(dy[o]);
+        Tcheck output_grad_rotate_half =
+            (o % 2 == 0) ? static_cast<Tcheck>(dy[o + 1]) : static_cast<Tcheck>(-dy[o - 1]);
+
+        Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
+        Tcheck sin_val = (freq_idx % 2 == 0) ? static_cast<Tcheck>(sin[freq_idx + 1])
+                                             : static_cast<Tcheck>(sin[freq_idx - 1]);
+
+        Tcheck val = (output_grad * cos_val) + (output_grad_rotate_half * sin_val);
+
+        dxhost[o] = val;
+    });
 
     return ret;
 }
@@ -177,6 +242,7 @@ private:
     std::vector<Tgpu> sin;
     std::vector<Tgpu> y_dx;
     std::vector<Tref> y_dxhost;
+    std::vector<Tref> y_dxhost_par;
 };
 
 template <typename Tgpu, typename Tref>
@@ -253,6 +319,7 @@ int RoPEDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     sin      = std::vector<Tgpu>(sin_sz, Tgpu0val);
     y_dx     = std::vector<Tgpu>(y_dx_sz, Tgpu0val);
     y_dxhost = std::vector<Tref>(y_dx_sz, Tref0ref);
+    y_dxhost_par = std::vector<Tref>(y_dx_sz, Tref0ref);
 
     for(int i = 0; i < x_dy_sz; ++i)
     {
@@ -329,7 +396,20 @@ template <typename Tgpu, typename Tref>
 int RoPEDriver<Tgpu, Tref>::RunForwardCPU()
 {
     mloRoPEForwardRunHost<Tgpu, Tref>(
-        x_dyDesc, cosDesc, sinDesc, y_dxDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost.data());
+        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost.data());
+    mloRoPEForwardRunHostPar<Tgpu, Tref>(
+        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost_par.data());
+
+    auto error = miopen::rms_range(y_dxhost, y_dxhost_par);
+    const double tolerance = GetTolerance();
+    if(!std::isfinite(error) || error > tolerance)
+    {
+        std::cout << std::string("Forward RoPE FAILED: ") << error << std::endl;
+    }
+    else
+    {
+        printf("Forward RoPE Verifies serial and parallel (err=%f)\n", error);
+    }
 
     return miopenStatusSuccess;
 }
@@ -387,7 +467,20 @@ template <typename Tgpu, typename Tref>
 int RoPEDriver<Tgpu, Tref>::RunBackwardCPU()
 {
     mloRoPEBackwardRunHost<Tgpu, Tref>(
-        x_dyDesc, cosDesc, sinDesc, y_dxDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost.data());
+        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost.data());
+    mloRoPEBackwardRunHostPar<Tgpu, Tref>(
+        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost_par.data());
+
+    auto error = miopen::rms_range(y_dxhost, y_dxhost_par);
+    const double tolerance = GetTolerance();
+    if(!std::isfinite(error) || error > tolerance)
+    {
+        std::cout << std::string("Backward RoPE FAILED: ") << error << std::endl;
+    }
+    else
+    {
+        printf("Backward RoPE Verifies serial and parallel (err=%f)\n", error);
+    }
 
     return miopenStatusSuccess;
 }

--- a/projects/miopen/driver/rope_driver.hpp
+++ b/projects/miopen/driver/rope_driver.hpp
@@ -47,7 +47,8 @@ int32_t mloRoPEForwardRunHost(miopenTensorDescriptor_t xDesc,
                               Tgpu* x,
                               Tgpu* cos,
                               Tgpu* sin,
-                              Tcheck* yhost)
+                              Tcheck* yhost,
+                              bool parallel)
 {
     auto x_dims   = miopen::deref(xDesc).GetLengths();
     auto cos_dims = miopen::deref(cosDesc).GetLengths();
@@ -58,54 +59,39 @@ int32_t mloRoPEForwardRunHost(miopenTensorDescriptor_t xDesc,
 
     int32_t ret = 0;
 
-    for(size_t o = 0; o < input_numel; o++)
+    if(parallel)
     {
-        size_t freq_idx = o % rotary_numel;
-        Tcheck input    = static_cast<Tcheck>(x[o]);
-        Tcheck input_rotate_half =
-            (o % 2 == 0) ? static_cast<Tcheck>(-x[o + 1]) : static_cast<Tcheck>(x[o - 1]);
+        par_for(input_numel, [&](std::size_t o) {
+            size_t freq_idx = o % rotary_numel;
+            Tcheck input    = static_cast<Tcheck>(x[o]);
+            Tcheck input_rotate_half =
+                (o % 2 == 0) ? static_cast<Tcheck>(-x[o + 1]) : static_cast<Tcheck>(x[o - 1]);
 
-        Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
-        Tcheck sin_val = static_cast<Tcheck>(sin[freq_idx]);
+            Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
+            Tcheck sin_val = static_cast<Tcheck>(sin[freq_idx]);
 
-        Tcheck val = (input * cos_val) + (input_rotate_half * sin_val);
+            Tcheck val = (input * cos_val) + (input_rotate_half * sin_val);
 
-        yhost[o] = val;
+            yhost[o] = val;
+        });
     }
+    else
+    {
+        for(size_t o = 0; o < input_numel; o++)
+        {
+            size_t freq_idx = o % rotary_numel;
+            Tcheck input    = static_cast<Tcheck>(x[o]);
+            Tcheck input_rotate_half =
+                (o % 2 == 0) ? static_cast<Tcheck>(-x[o + 1]) : static_cast<Tcheck>(x[o - 1]);
 
-    return ret;
-}
+            Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
+            Tcheck sin_val = static_cast<Tcheck>(sin[freq_idx]);
 
-template <typename Tgpu, typename Tcheck>
-int32_t mloRoPEForwardRunHostPar(miopenTensorDescriptor_t xDesc,
-                              miopenTensorDescriptor_t cosDesc,
-                              Tgpu* x,
-                              Tgpu* cos,
-                              Tgpu* sin,
-                              Tcheck* yhost)
-{
-    auto x_dims   = miopen::deref(xDesc).GetLengths();
-    auto cos_dims = miopen::deref(cosDesc).GetLengths();
-    auto input_numel =
-        std::accumulate(x_dims.begin(), x_dims.end(), 1LL, std::multiplies<int64_t>());
-    auto rotary_numel =
-        std::accumulate(cos_dims.begin(), cos_dims.end(), 1LL, std::multiplies<int64_t>());
+            Tcheck val = (input * cos_val) + (input_rotate_half * sin_val);
 
-    int32_t ret = 0;
-
-    par_for(input_numel, [&](std::size_t o) {
-        size_t freq_idx = o % rotary_numel;
-        Tcheck input    = static_cast<Tcheck>(x[o]);
-        Tcheck input_rotate_half =
-            (o % 2 == 0) ? static_cast<Tcheck>(-x[o + 1]) : static_cast<Tcheck>(x[o - 1]);
-
-        Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
-        Tcheck sin_val = static_cast<Tcheck>(sin[freq_idx]);
-
-        Tcheck val = (input * cos_val) + (input_rotate_half * sin_val);
-
-        yhost[o] = val;
-    });
+            yhost[o] = val;
+        }
+    }
 
     return ret;
 }
@@ -116,7 +102,8 @@ int32_t mloRoPEBackwardRunHost(miopenTensorDescriptor_t dyDesc,
                                Tgpu* dy,
                                Tgpu* cos,
                                Tgpu* sin,
-                               Tcheck* dxhost)
+                               Tcheck* dxhost,
+                               bool parallel)
 {
     auto dy_dims = miopen::deref(dyDesc).GetLengths();
     auto input_numel =
@@ -127,58 +114,43 @@ int32_t mloRoPEBackwardRunHost(miopenTensorDescriptor_t dyDesc,
 
     int32_t ret = 0;
 
-    for(size_t o = 0; o < input_numel; o++)
+    if(parallel)
     {
-        size_t freq_idx = o % rotary_numel;
+        par_for(input_numel, [&](std::size_t o) {
+            size_t freq_idx = o % rotary_numel;
 
-        Tcheck output_grad = static_cast<Tcheck>(dy[o]);
-        Tcheck output_grad_rotate_half =
-            (o % 2 == 0) ? static_cast<Tcheck>(dy[o + 1]) : static_cast<Tcheck>(-dy[o - 1]);
+            Tcheck output_grad = static_cast<Tcheck>(dy[o]);
+            Tcheck output_grad_rotate_half =
+                (o % 2 == 0) ? static_cast<Tcheck>(dy[o + 1]) : static_cast<Tcheck>(-dy[o - 1]);
 
-        Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
-        Tcheck sin_val = (freq_idx % 2 == 0) ? static_cast<Tcheck>(sin[freq_idx + 1])
-                                             : static_cast<Tcheck>(sin[freq_idx - 1]);
+            Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
+            Tcheck sin_val = (freq_idx % 2 == 0) ? static_cast<Tcheck>(sin[freq_idx + 1])
+                                                 : static_cast<Tcheck>(sin[freq_idx - 1]);
 
-        Tcheck val = (output_grad * cos_val) + (output_grad_rotate_half * sin_val);
+            Tcheck val = (output_grad * cos_val) + (output_grad_rotate_half * sin_val);
 
-        dxhost[o] = val;
+            dxhost[o] = val;
+        });
     }
+    else
+    {
+        for(size_t o = 0; o < input_numel; o++)
+        {
+            size_t freq_idx = o % rotary_numel;
 
-    return ret;
-}
+            Tcheck output_grad = static_cast<Tcheck>(dy[o]);
+            Tcheck output_grad_rotate_half =
+                (o % 2 == 0) ? static_cast<Tcheck>(dy[o + 1]) : static_cast<Tcheck>(-dy[o - 1]);
 
-template <typename Tgpu, typename Tcheck>
-int32_t mloRoPEBackwardRunHostPar(miopenTensorDescriptor_t dyDesc,
-                               miopenTensorDescriptor_t cosDesc,
-                               Tgpu* dy,
-                               Tgpu* cos,
-                               Tgpu* sin,
-                               Tcheck* dxhost)
-{
-    auto dy_dims = miopen::deref(dyDesc).GetLengths();
-    auto input_numel =
-        std::accumulate(dy_dims.begin(), dy_dims.end(), 1LL, std::multiplies<int64_t>());
-    auto cos_dims = miopen::deref(cosDesc).GetLengths();
-    auto rotary_numel =
-        std::accumulate(cos_dims.begin(), cos_dims.end(), 1LL, std::multiplies<int64_t>());
+            Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
+            Tcheck sin_val = (freq_idx % 2 == 0) ? static_cast<Tcheck>(sin[freq_idx + 1])
+                                                 : static_cast<Tcheck>(sin[freq_idx - 1]);
 
-    int32_t ret = 0;
+            Tcheck val = (output_grad * cos_val) + (output_grad_rotate_half * sin_val);
 
-    par_for(input_numel, [&](std::size_t o) {
-        size_t freq_idx = o % rotary_numel;
-
-        Tcheck output_grad = static_cast<Tcheck>(dy[o]);
-        Tcheck output_grad_rotate_half =
-            (o % 2 == 0) ? static_cast<Tcheck>(dy[o + 1]) : static_cast<Tcheck>(-dy[o - 1]);
-
-        Tcheck cos_val = static_cast<Tcheck>(cos[freq_idx]);
-        Tcheck sin_val = (freq_idx % 2 == 0) ? static_cast<Tcheck>(sin[freq_idx + 1])
-                                             : static_cast<Tcheck>(sin[freq_idx - 1]);
-
-        Tcheck val = (output_grad * cos_val) + (output_grad_rotate_half * sin_val);
-
-        dxhost[o] = val;
-    });
+            dxhost[o] = val;
+        }
+    }
 
     return ret;
 }
@@ -226,6 +198,7 @@ public:
 
 private:
     InputFlags inflags;
+    bool multithreaded;
 
     miopenTensorDescriptor_t x_dyDesc;
     miopenTensorDescriptor_t cosDesc;
@@ -254,6 +227,8 @@ int RoPEDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     {
         miopenEnableProfiling(GetHandle(), true);
     }
+
+    multithreaded = static_cast<bool>(inflags.GetValueInt("multithreaded"));
     return miopenStatusSuccess;
 }
 
@@ -291,6 +266,7 @@ int RoPEDriver<Tgpu, Tref>::AddCmdLineArgs()
     inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
     inflags.AddInputFlag(
         "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
+    inflags.AddInputFlag("multithreaded", 'm', "0", "Run CPU RoPE in parallel (Default=0)", "int");
 
     return miopenStatusSuccess;
 }
@@ -314,11 +290,11 @@ int RoPEDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     sin_dev  = std::unique_ptr<GPUMem>(new GPUMem(ctx, sin_sz, sizeof(Tgpu)));
     y_dx_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, y_dx_sz, sizeof(Tgpu)));
 
-    x_dy     = std::vector<Tgpu>(x_dy_sz, Tgpu0val);
-    cos      = std::vector<Tgpu>(cos_sz, Tgpu0val);
-    sin      = std::vector<Tgpu>(sin_sz, Tgpu0val);
-    y_dx     = std::vector<Tgpu>(y_dx_sz, Tgpu0val);
-    y_dxhost = std::vector<Tref>(y_dx_sz, Tref0ref);
+    x_dy         = std::vector<Tgpu>(x_dy_sz, Tgpu0val);
+    cos          = std::vector<Tgpu>(cos_sz, Tgpu0val);
+    sin          = std::vector<Tgpu>(sin_sz, Tgpu0val);
+    y_dx         = std::vector<Tgpu>(y_dx_sz, Tgpu0val);
+    y_dxhost     = std::vector<Tref>(y_dx_sz, Tref0ref);
     y_dxhost_par = std::vector<Tref>(y_dx_sz, Tref0ref);
 
     for(int i = 0; i < x_dy_sz; ++i)
@@ -396,20 +372,7 @@ template <typename Tgpu, typename Tref>
 int RoPEDriver<Tgpu, Tref>::RunForwardCPU()
 {
     mloRoPEForwardRunHost<Tgpu, Tref>(
-        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost.data());
-    mloRoPEForwardRunHostPar<Tgpu, Tref>(
-        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost_par.data());
-
-    auto error = miopen::rms_range(y_dxhost, y_dxhost_par);
-    const double tolerance = GetTolerance();
-    if(!std::isfinite(error) || error > tolerance)
-    {
-        std::cout << std::string("Forward RoPE FAILED: ") << error << std::endl;
-    }
-    else
-    {
-        printf("Forward RoPE Verifies serial and parallel (err=%f)\n", error);
-    }
+        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost.data(), multithreaded);
 
     return miopenStatusSuccess;
 }
@@ -467,20 +430,7 @@ template <typename Tgpu, typename Tref>
 int RoPEDriver<Tgpu, Tref>::RunBackwardCPU()
 {
     mloRoPEBackwardRunHost<Tgpu, Tref>(
-        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost.data());
-    mloRoPEBackwardRunHostPar<Tgpu, Tref>(
-        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost_par.data());
-
-    auto error = miopen::rms_range(y_dxhost, y_dxhost_par);
-    const double tolerance = GetTolerance();
-    if(!std::isfinite(error) || error > tolerance)
-    {
-        std::cout << std::string("Backward RoPE FAILED: ") << error << std::endl;
-    }
-    else
-    {
-        printf("Backward RoPE Verifies serial and parallel (err=%f)\n", error);
-    }
+        x_dyDesc, cosDesc, x_dy.data(), cos.data(), sin.data(), y_dxhost.data(), multithreaded);
 
     return miopenStatusSuccess;
 }

--- a/projects/miopen/driver/rope_driver.hpp
+++ b/projects/miopen/driver/rope_driver.hpp
@@ -31,15 +31,18 @@
 #include "tensor_driver.hpp"
 #include "timer.hpp"
 #include "random.hpp"
+#include <../test/tensor_holder.hpp>
+#include <../test/verify.hpp>
+
+#include <miopen/miopen.h>
+#include <miopen/tensor.hpp>
+#include <miopen/par_for.hpp>
+
 #include <cfloat>
 #include <cstdlib>
 #include <memory>
-#include <miopen/miopen.h>
-#include <miopen/tensor.hpp>
 #include <numeric>
 #include <vector>
-#include <../test/tensor_holder.hpp>
-#include <../test/verify.hpp>
 
 template <typename Tgpu, typename Tcheck>
 int32_t mloRoPEForwardRunHost(miopenTensorDescriptor_t xDesc,
@@ -61,7 +64,7 @@ int32_t mloRoPEForwardRunHost(miopenTensorDescriptor_t xDesc,
 
     if(parallel)
     {
-        par_for(input_numel, [&](std::size_t o) {
+        miopen::par_for(input_numel, [&](std::size_t o) {
             size_t freq_idx = o % rotary_numel;
             Tcheck input    = static_cast<Tcheck>(x[o]);
             Tcheck input_rotate_half =
@@ -116,7 +119,7 @@ int32_t mloRoPEBackwardRunHost(miopenTensorDescriptor_t dyDesc,
 
     if(parallel)
     {
-        par_for(input_numel, [&](std::size_t o) {
+        miopen::par_for(input_numel, [&](std::size_t o) {
             size_t freq_idx = o % rotary_numel;
 
             Tcheck output_grad = static_cast<Tcheck>(dy[o]);

--- a/projects/miopen/driver/rope_driver.hpp
+++ b/projects/miopen/driver/rope_driver.hpp
@@ -218,7 +218,6 @@ private:
     std::vector<Tgpu> sin;
     std::vector<Tgpu> y_dx;
     std::vector<Tref> y_dxhost;
-    std::vector<Tref> y_dxhost_par;
 };
 
 template <typename Tgpu, typename Tref>
@@ -293,12 +292,11 @@ int RoPEDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     sin_dev  = std::unique_ptr<GPUMem>(new GPUMem(ctx, sin_sz, sizeof(Tgpu)));
     y_dx_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, y_dx_sz, sizeof(Tgpu)));
 
-    x_dy         = std::vector<Tgpu>(x_dy_sz, Tgpu0val);
-    cos          = std::vector<Tgpu>(cos_sz, Tgpu0val);
-    sin          = std::vector<Tgpu>(sin_sz, Tgpu0val);
-    y_dx         = std::vector<Tgpu>(y_dx_sz, Tgpu0val);
-    y_dxhost     = std::vector<Tref>(y_dx_sz, Tref0ref);
-    y_dxhost_par = std::vector<Tref>(y_dx_sz, Tref0ref);
+    x_dy     = std::vector<Tgpu>(x_dy_sz, Tgpu0val);
+    cos      = std::vector<Tgpu>(cos_sz, Tgpu0val);
+    sin      = std::vector<Tgpu>(sin_sz, Tgpu0val);
+    y_dx     = std::vector<Tgpu>(y_dx_sz, Tgpu0val);
+    y_dxhost = std::vector<Tref>(y_dx_sz, Tref0ref);
 
     for(int i = 0; i < x_dy_sz; ++i)
     {


### PR DESCRIPTION
## Motivation

Make the CPU RoPE execution run in parallel.

## Technical Details

Add new input flag which uses parallel version of algorithm.

## Test Plan

Run RoPE (all versions) on various of inputs.

## Test Result

Tests performed on:
CPU: AMD Ryzen 9 5900X 12-Core Processor
RAM: 62 GB
GPU: AMD Radeon RX 6800 XT

### FP32
Case | X (N×C×H×W) | Fwd Serial (ms) | Fwd Parallel (ms) | Bwd Serial (ms) | Bwd Parallel (ms)
-- | -- | -- | -- | -- | --
01 | 32×128×64×64 | 21.932 | 5.227 | 22.185 | 5.477
02 | 8×256×32×32 | 2.692 | 0.992 | 2.779 | 0.953
03 | 16×96×33×66 | 4.427 | 1.044 | 4.446 | 1.070
04 | 32×56×56×128 | 16.829 | 3.710 | 16.879 | 3.725
05 | 2×1×1×1048576 | 2.766 | 0.941 | 2.785 | 0.960
06 | 2×2×64×64 | 0.023 | 0.880 | 0.027 | 0.869
07 | 128×64×7×7 | 0.534 | 0.920 | 0.530 | 0.921
08 | 4×512×14×28 | 1.062 | 0.913 | 1.074 | 0.915
L01 | 16×512×256×256 | 773.577 | 234.517 | 817.451 | 240.018
L02 | 64×1024×112×112 | 1090.550 | 352.741 | 1080.084 | 357.352
L03 | 32×4096×28×28 | 133.571 | 38.946 | 134.441 | 39.814
L04 | 2×1×1×33554432 | 96.249 | 33.906 | 99.278 | 33.771
L05 | 2×1×1×134217728 | 357.292 | 136.150 | 360.166 | 136.868
L06 | 512×256×14×14 | 33.260 | 8.206 | 33.239 | 8.594
L07 | 1024×128×7×7 | 8.445 | 1.556 | 8.612 | 1.740
L08 | 8×1024×64×512 | 386.979 | 116.250 | 397.019 | 117.642
L09 | 32×2048×64×64 | 386.996 | 114.966 | 376.919 | 118.299

### FP16
Case | X (N×C×H×W) | Fwd Serial (ms) | Fwd Parallel (ms) | Bwd Serial (ms) | Bwd Parallel (ms)
-- | -- | -- | -- | -- | --
01 | 32×128×64×64 | 48.356 | 5.491 | 45.405 | 6.262
02 | 8×256×32×32 | 5.984 | 1.081 | 5.756 | 1.148
03 | 16×96×33×66 | 9.518 | 1.419 | 9.156 | 1.559
04 | 32×56×56×128 | 37.570 | 4.461 | 35.002 | 4.988
05 | 2×1×1×1048576 | 5.889 | 1.097 | 5.772 | 1.163
06 | 2×2×64×64 | 0.039 | 0.839 | 0.043 | 0.847
07 | 128×64×7×7 | 1.041 | 0.903 | 1.062 | 0.942
08 | 4×512×14×28 | 2.171 | 0.940 | 2.137 | 0.927
L01 | 16×512×256×256 | 1644.279 | 206.854 | 1583.326 | 212.123
L02 | 64×1024×112×112 | 2403.465 | 307.379 | 2246.920 | 317.914
L03 | 32×4096×28×28 | 292.018 | 35.131 | 275.718 | 37.270
L04 | 2×1×1×33554432 | 207.232 | 31.335 | 199.818 | 31.524
L05 | 2×1×1×134217728 | 770.642 | 110.484 | 720.082 | 115.045
L06 | 512×256×14×14 | 72.865 | 8.355 | 69.913 | 8.946
L07 | 1024×128×7×7 | 17.990 | 2.313 | 17.024 | 2.517
L08 | 8×1024×64×512 | 824.845 | 107.904 | 791.261 | 108.918
L09 | 32×2048×64×64 | 754.985 | 100.474 | 717.864 | 103.940

### BFP16
Case | X (N×C×H×W) | Fwd Serial (ms) | Fwd Parallel (ms) | Bwd Serial (ms) | Bwd Parallel (ms)
-- | -- | -- | -- | -- | --
01 | 32×128×64×64 | 25.743 | 4.360 | 29.566 | 4.929
02 | 8×256×32×32 | 3.184 | 0.946 | 3.641 | 0.949
03 | 16×96×33×66 | 5.184 | 1.104 | 5.952 | 1.198
04 | 32×56×56×128 | 19.682 | 3.195 | 22.500 | 3.554
05 | 2×1×1×1048576 | 3.175 | 0.950 | 3.649 | 0.961
06 | 2×2×64×64 | 0.026 | 0.842 | 0.030 | 0.870
07 | 128×64×7×7 | 0.621 | 0.885 | 0.704 | 0.866
08 | 4×512×14×28 | 1.221 | 0.896 | 1.393 | 0.914
L01 | 16×512×256×256 | 893.918 | 197.268 | 1060.643 | 196.023
L02 | 64×1024×112×112 | 1257.115 | 290.513 | 1444.070 | 291.218
L03 | 32×4096×28×28 | 158.175 | 33.152 | 179.177 | 33.370
L04 | 2×1×1×33554432 | 112.821 | 29.200 | 130.743 | 29.386
L05 | 2×1×1×134217728 | 409.386 | 107.948 | 467.314 | 108.337
L06 | 512×256×14×14 | 39.110 | 7.241 | 45.183 | 7.671
L07 | 1024×128×7×7 | 10.296 | 1.695 | 11.408 | 1.861
L08 | 8×1024×64×512 | 443.132 | 96.987 | 516.980 | 99.438
L09 | 32×2048×64×64 | 408.457 | 92.720 | 467.828 | 94.876


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
