### PR TITLE
Tensile: fix toolchain searching taking empty Windows ROCm directory

### DIFF
--- a/shared/tensile/Tensile/Utilities/Toolchain.py
+++ b/shared/tensile/Tensile/Utilities/Toolchain.py
@@ -51,7 +51,9 @@ def _windowsLatestRocmBin(path: Union[Path, str]) -> Path:
     """
     path = Path(path)
     pattern = re.compile(r"^\d+\.\d+$")
-    versions = filter(lambda d: d.is_dir() and pattern.match(d.name), path.iterdir())
+    versions = [d for d in path.iterdir() if d.is_dir() and pattern.match(d.name)]
+    if not versions:
+        return None
     latest = max(versions, key=lambda d: tuple(map(int, d.name.split("."))))
     return latest / "bin"
 
@@ -65,7 +67,9 @@ def _windowsSearchPaths() -> List[Path]:
         searchPaths.extend(hipPaths)
 
     if Path(defaultPath).exists():
-        searchPaths.append(_windowsLatestRocmBin(defaultPath))
+        latestRocmBin = _windowsLatestRocmBin(defaultPath)
+        if latestRocmBin:
+            searchPaths.append(latestRocmBin)
 
     if os.environ.get("PATH"):
         envPath = [Path(p) for p in os.environ["PATH"].split(os.pathsep)]


### PR DESCRIPTION
## Motivation
On uninstallation of ROCm toolchain on Windows, it can leave behind empty C:\Program Files\AMD\ROCm directory. Causes Tensile to error on looking for toolchain.

Fixes https://github.com/ROCm/TheRock/issues/1258

## Technical Details

Tensile as a hardcoded default path `C:\Program Files\AMD\ROCm` to look for toolchains on Windows, but it is not taking into account if the folder exists but is just empty.

Fix by returning and handling no versions available.

## Test Plan

Tensile builds correctly with empty `C:\Program Files\AMD\ROCm` folder.

## Test Result

Tensile runs correctly.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
