### PR TITLE
Gemm driver cpu improvement

### DIFF
--- a/projects/miopen/driver/gemm_driver.hpp
+++ b/projects/miopen/driver/gemm_driver.hpp
@@ -49,69 +49,6 @@
 #define GEMM_DRIVER_DEBUG 0
 
 template <typename T>
-void callCpuGemmStridedBatched(bool isColMajor,
-                               bool transA,
-                               bool transB,
-                               int m,
-                               int n,
-                               int k,
-                               T alpha,
-                               const void* A,
-                               int a_offset,
-                               int lda,
-                               long long int strideA,
-                               const void* B,
-                               int b_offset,
-                               int ldb,
-                               long long int strideB,
-                               T beta,
-                               void* C,
-                               int c_offset,
-                               int ldc,
-                               long long int strideC,
-                               int batch_count)
-{
-    const T* a_ptr = static_cast<const T*>(A);
-    const T* b_ptr = static_cast<const T*>(B);
-    T* c_ptr       = static_cast<T*>(C);
-
-    // our cpu GEMM logic is row-major
-    if(isColMajor)
-    {
-        isColMajor = false;
-        std::swap(a_ptr, b_ptr);
-        std::swap(a_offset, b_offset);
-        std::swap(transA, transB);
-        std::swap(m, n);
-        std::swap(lda, ldb);
-        std::swap(strideA, strideB);
-    }
-
-    for(int bi = 0; bi < batch_count; ++bi)
-    {
-        for(int mi = 0; mi < m; ++mi)
-        {
-            for(int ni = 0; ni < n; ++ni)
-            {
-                double y = 0;
-                for(int ki = 0; ki < k; ++ki)
-                {
-                    int aindex = transA ? a_offset + strideA * bi + lda * ki + mi
-                                        : a_offset + strideA * bi + lda * mi + ki;
-                    int bindex = transB ? b_offset + strideB * bi + ldb * ni + ki
-                                        : b_offset + strideB * bi + ldb * ki + ni;
-                    y += static_cast<double>(a_ptr[aindex]) * static_cast<double>(b_ptr[bindex]);
-                }
-                int cindex = c_offset + strideC * bi + ldc * mi + ni;
-                c_ptr[cindex] =
-                    static_cast<T>(static_cast<double>(alpha) * y +
-                                   static_cast<double>(beta) * static_cast<double>(c_ptr[cindex]));
-            }
-        }
-    }
-}
-
-template <typename T>
 void callCpuGemmStridedBatchedPar(bool isColMajor,
                                bool transA,
                                bool transB,
@@ -132,7 +69,8 @@ void callCpuGemmStridedBatchedPar(bool isColMajor,
                                int c_offset,
                                int ldc,
                                long long int strideC,
-                               int batch_count)
+                               int batch_count,
+                               bool parallel)
 {
     const T* a_ptr = static_cast<const T*>(A);
     const T* b_ptr = static_cast<const T*>(B);
@@ -172,7 +110,7 @@ void callCpuGemmStridedBatchedPar(bool isColMajor,
         }
     };
 
-    if(m * n * k * batch_count > 1<<18) {
+    if(parallel) {
         par_ford(m)(work);
     } else {
         for(int mi = 0; mi < m; mi++) {
@@ -219,6 +157,7 @@ private:
     std::vector<T> chost;
 
     T alpha, beta;
+    bool multithreaded;
 
     miopen::GemmDescriptor gemm_desc = {
         false, false, false, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1.0f, 0.0f, miopenFloat, false};
@@ -241,6 +180,7 @@ int GemmDriver<T>::AddCmdLineArgs()
     inflags.AddInputFlag("iter", 'i', "10", "Number of Iterations (Default=10)", "int");
     inflags.AddInputFlag("verify", 'V', "1", "Verify Each Layer (Default=1)", "int");
     inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
+    inflags.AddInputFlag("multithreaded", 'm', "0", "Run CPU part in parallel (Default=0)", "int");
 
     return 0;
 }
@@ -254,6 +194,9 @@ int GemmDriver<T>::ParseCmdLineArgs(int argc, char* argv[])
     {
         miopenEnableProfiling(GetHandle(), true);
     }
+
+    multithreaded = static_cast<bool>(inflags.GetValueInt("multithreaded"));
+
     return 0;
 }
 
@@ -464,7 +407,8 @@ int GemmDriver<T>::RunForwardCPU()
                                  0,
                                  gemm_desc.ldc,
                                  gemm_desc.strideC,
-                                 gemm_desc.batch_count);
+                                 gemm_desc.batch_count,
+                                 multithreaded);
 
     return 0;
 }

--- a/projects/miopen/driver/gemm_driver.hpp
+++ b/projects/miopen/driver/gemm_driver.hpp
@@ -38,6 +38,7 @@
 
 #include <miopen/gemm_v2.hpp>
 #include <miopen/miopen.h>
+#include <miopen/ford.hpp>
 
 #include <algorithm>
 #include <cstdlib>
@@ -111,7 +112,7 @@ void callCpuGemmStridedBatched(bool isColMajor,
 
     if(parallel)
     {
-        par_ford(m)(work);
+        miopen::par_ford(m)(work);
     }
     else
     {

--- a/projects/miopen/driver/gemm_driver.hpp
+++ b/projects/miopen/driver/gemm_driver.hpp
@@ -182,7 +182,7 @@ int GemmDriver<T>::AddCmdLineArgs()
     inflags.AddInputFlag("transA", 'u', "0", "Transpose A matrix (Default=0)", "int");
     inflags.AddInputFlag("transB", 'v', "0", "Transpose B matrix (Default=0)", "int");
     inflags.AddInputFlag("iter", 'i', "10", "Number of Iterations (Default=10)", "int");
-    inflags.AddInputFlag("verify", 'V', "1", "Verify Each Layer (Default=1)", "int");
+    inflags.AddInputFlag("verify", 'V', "0", "Verify Each Layer (Default=0)", "int");
     inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
     inflags.AddInputFlag("parallel", 'p', "0", "Run CPU part in parallel (Default=0)", "int");
 

--- a/projects/miopen/driver/gemm_driver.hpp
+++ b/projects/miopen/driver/gemm_driver.hpp
@@ -26,7 +26,6 @@
 #ifndef GUARD_MIOPEN_GEMM_DRIVER_HPP
 #define GUARD_MIOPEN_GEMM_DRIVER_HPP
 
-#include "timer.hpp"
 #include <miopen/config.h>
 
 #if MIOPEN_USE_GEMM
@@ -49,7 +48,7 @@
 #define GEMM_DRIVER_DEBUG 0
 
 template <typename T>
-void callCpuGemmStridedBatchedPar(bool isColMajor,
+void callCpuGemmStridedBatched(bool isColMajor,
                                bool transA,
                                bool transB,
                                int m,
@@ -142,7 +141,7 @@ public:
 
     int VerifyBackward() override;
     int VerifyForward() override;
-    ~GemmDriver() override {}
+    ~GemmDriver() override = default;
 
 private:
     InputFlags inflags;
@@ -270,9 +269,9 @@ int GemmDriver<T>::AllocateBuffersAndCopy()
 #if MIOPEN_BACKEND_OPENCL
     clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
 #endif
-    a_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, a_sz, sizeof(T)));
-    b_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, b_sz, sizeof(T)));
-    c_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, c_sz, sizeof(T)));
+    a_dev = std::make_unique<GPUMem>(ctx, a_sz, sizeof(T));
+    b_dev = std::make_unique<GPUMem>(ctx, b_sz, sizeof(T));
+    c_dev = std::make_unique<GPUMem>(ctx, c_sz, sizeof(T));
 
     a = std::vector<T>(a_sz);
     b = std::vector<T>(b_sz);

--- a/projects/miopen/driver/gemm_driver.hpp
+++ b/projects/miopen/driver/gemm_driver.hpp
@@ -161,7 +161,7 @@ private:
     std::vector<T> chost;
 
     T alpha, beta;
-    bool multithreaded;
+    bool parallel;
 
     miopen::GemmDescriptor gemm_desc = {
         false, false, false, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1.0f, 0.0f, miopenFloat, false};
@@ -184,7 +184,7 @@ int GemmDriver<T>::AddCmdLineArgs()
     inflags.AddInputFlag("iter", 'i', "10", "Number of Iterations (Default=10)", "int");
     inflags.AddInputFlag("verify", 'V', "1", "Verify Each Layer (Default=1)", "int");
     inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
-    inflags.AddInputFlag("multithreaded", 'm', "0", "Run CPU part in parallel (Default=0)", "int");
+    inflags.AddInputFlag("parallel", 'p', "0", "Run CPU part in parallel (Default=0)", "int");
 
     return 0;
 }
@@ -199,7 +199,7 @@ int GemmDriver<T>::ParseCmdLineArgs(int argc, char* argv[])
         miopenEnableProfiling(GetHandle(), true);
     }
 
-    multithreaded = static_cast<bool>(inflags.GetValueInt("multithreaded"));
+    parallel = static_cast<bool>(inflags.GetValueInt("parallel"));
 
     return 0;
 }
@@ -412,7 +412,7 @@ int GemmDriver<T>::RunForwardCPU()
                                  gemm_desc.ldc,
                                  gemm_desc.strideC,
                                  gemm_desc.batch_count,
-                                 multithreaded);
+                                 parallel);
 
     return 0;
 }

--- a/projects/miopen/driver/gemm_driver.hpp
+++ b/projects/miopen/driver/gemm_driver.hpp
@@ -26,6 +26,7 @@
 #ifndef GUARD_MIOPEN_GEMM_DRIVER_HPP
 #define GUARD_MIOPEN_GEMM_DRIVER_HPP
 
+#include "timer.hpp"
 #include <miopen/config.h>
 
 #if MIOPEN_USE_GEMM
@@ -43,7 +44,6 @@
 #include <cstdlib>
 #include <float.h>
 #include <memory>
-#include <numeric>
 #include <vector>
 
 #define GEMM_DRIVER_DEBUG 0
@@ -112,6 +112,76 @@ void callCpuGemmStridedBatched(bool isColMajor,
 }
 
 template <typename T>
+void callCpuGemmStridedBatchedPar(bool isColMajor,
+                               bool transA,
+                               bool transB,
+                               int m,
+                               int n,
+                               int k,
+                               T alpha,
+                               const void* A,
+                               int a_offset,
+                               int lda,
+                               long long int strideA,
+                               const void* B,
+                               int b_offset,
+                               int ldb,
+                               long long int strideB,
+                               T beta,
+                               void* C,
+                               int c_offset,
+                               int ldc,
+                               long long int strideC,
+                               int batch_count)
+{
+    const T* a_ptr = static_cast<const T*>(A);
+    const T* b_ptr = static_cast<const T*>(B);
+    T* c_ptr       = static_cast<T*>(C);
+
+    // our cpu GEMM logic is row-major
+    if(isColMajor)
+    {
+        isColMajor = false;
+        std::swap(a_ptr, b_ptr);
+        std::swap(a_offset, b_offset);
+        std::swap(transA, transB);
+        std::swap(m, n);
+        std::swap(lda, ldb);
+        std::swap(strideA, strideB);
+    }
+
+    auto work = [&](const int mi) {
+        for(int bi = 0; bi < batch_count; ++bi)
+        {
+            for(int ni = 0; ni < n; ++ni)
+            {
+                double y = 0;
+                for(int ki = 0; ki < k; ++ki)
+                {
+                    int aindex = transA ? a_offset + strideA * bi + lda * ki + mi
+                                        : a_offset + strideA * bi + lda * mi + ki;
+                    int bindex = transB ? b_offset + strideB * bi + ldb * ni + ki
+                                        : b_offset + strideB * bi + ldb * ki + ni;
+                    y += static_cast<double>(a_ptr[aindex]) * static_cast<double>(b_ptr[bindex]);
+                }
+                int cindex = c_offset + strideC * bi + ldc * mi + ni;
+                c_ptr[cindex] =
+                    static_cast<T>(static_cast<double>(alpha) * y +
+                                   static_cast<double>(beta) * static_cast<double>(c_ptr[cindex]));
+            }
+        }
+    };
+
+    if(m * n * k * batch_count > 1<<18) {
+        par_ford(m)(work);
+    } else {
+        for(int mi = 0; mi < m; mi++) {
+            work(mi);
+        }
+    }
+}
+
+template <typename T>
 class GemmDriver : public Driver
 {
 public:
@@ -169,7 +239,7 @@ int GemmDriver<T>::AddCmdLineArgs()
     inflags.AddInputFlag("transA", 'u', "0", "Transpose A matrix (Default=0)", "int");
     inflags.AddInputFlag("transB", 'v', "0", "Transpose B matrix (Default=0)", "int");
     inflags.AddInputFlag("iter", 'i', "10", "Number of Iterations (Default=10)", "int");
-    inflags.AddInputFlag("verify", 'V', "0", "Verify Each Layer (Default=1)", "int");
+    inflags.AddInputFlag("verify", 'V', "1", "Verify Each Layer (Default=1)", "int");
     inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
 
     return 0;

--- a/projects/miopen/driver/gemm_driver.hpp
+++ b/projects/miopen/driver/gemm_driver.hpp
@@ -109,10 +109,14 @@ void callCpuGemmStridedBatched(bool isColMajor,
         }
     };
 
-    if(parallel) {
+    if(parallel)
+    {
         par_ford(m)(work);
-    } else {
-        for(int mi = 0; mi < m; mi++) {
+    }
+    else
+    {
+        for(int mi = 0; mi < m; mi++)
+        {
             work(mi);
         }
     }


### PR DESCRIPTION
## Motivation

Make the GEMM CPU part run in parallel.

## Technical Details

Add new input flag which uses parallel version of algorithm.

## Test Plan

Run GEMM driver (all versions) on various of inputs.

## Test Result

Tests performed on:
CPU: AMD Ryzen 9 5900X 12-Core Processor
RAM: 62 GB
GPU: AMD Radeon RX 6800 XT

### FP32
Case | m (a_h) | k (a_w) | n (b_w) | transA | transB | colMajor | batch | alpha | beta | CPU serial (ms) | CPU parallel (ms)
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
S01 | 1024 | 1024 | 1024 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 2620.426 | 229.870
S02 | 4096 | 512 | 128 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 283.777 | 29.952
S03 | 128 | 512 | 4096 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 602.223 | 58.824
S04 | 512 | 4096 | 512 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 1872.573 | 214.417
S05 | 769 | 513 | 997 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 316.197 | 42.775
B01 | 256 | 256 | 256 | 0 | 0 | 0 | 64 | 1.0 | 0.0 | 1118.076 | 119.786
B02 | 384 | 192 | 768 | 0 | 0 | 0 | 32 | 1.0 | 0.0 | 1849.321 | 212.444
B03 | 128 | 128 | 128 | 0 | 0 | 0 | 1024 | 1.0 | 0.0 | 2518.811 | 309.995
T01 | 512 | 1024 | 256 | 1 | 0 | 0 | 1 | 1.0 | 0.0 | 209.534 | 24.341
T02 | 512 | 256 | 1024 | 0 | 1 | 0 | 1 | 1.0 | 0.0 | 91.801 | 9.728
T03 | 640 | 320 | 960 | 1 | 1 | 0 | 1 | 1.0 | 0.0 | 224.425 | 30.652
C01 | 1024 | 768 | 512 | 0 | 0 | 1 | 1 | 1.0 | 0.0 | 891.532 | 89.286
C02 | 512 | 1024 | 256 | 0 | 1 | 1 | 1 | 1.0 | 0.0 | 220.686 | 28.027
C03 | 256 | 1024 | 768 | 1 | 0 | 1 | 16 | 1.0 | 0.0 | 2256.320 | 260.102
A01 | 512 | 512 | 512 | 0 | 0 | 0 | 1 | 0.5 | 0.25 | 134.652 | 15.516
A02 | 384 | 640 | 320 | 1 | 1 | 0 | 8 | 0.75 | 0.5 | 707.432 | 87.168
E01 | 1 | 1 | 1 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 0.001 | 0.006
E02 | 1 | 8192 | 1 | 0 | 0 | 0 | 4 | 1.0 | 0.0 | 0.023 | 0.029
E03 | 8192 | 1 | 1 | 0 | 0 | 0 | 4 | 1.0 | 0.0 | 0.172 | 0.912
B04 | 16 | 16 | 16 | 0 | 0 | 0 | 4096 | 1.0 | 0.0 | 13.448 | 7.617
B05 | 32 | 8 | 64 | 0 | 0 | 0 | 2048 | 1.0 | 0.0 | 30.101 | 7.898
TB01 | 384 | 640 | 256 | 1 | 0 | 0 | 16 | 1.0 | 0.0 | 1396.837 | 172.826
TB02 | 320 | 320 | 640 | 0 | 1 | 0 | 32 | 1.0 | 0.0 | 1503.900 | 170.421
CB01 | 256 | 256 | 384 | 0 | 0 | 1 | 64 | 1.0 | 0.0 | 1664.596 | 177.252
CB02 | 192 | 768 | 192 | 1 | 1 | 1 | 8 | 1.0 | 0.0 | 223.688 | 33.815
ACC1 | 512 | 512 | 512 | 0 | 0 | 0 | 1 | 0.75 | 0.5 | 129.485 | 15.612
P01 | 255 | 257 | 511 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 23.788 | 3.192


### FP16
Case | m (a_h) | k (a_w) | n (b_w) | transA | transB | colMajor | batch | alpha | beta | CPU serial (ms) | CPU parallel (ms) | 
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- 
S01 | 1024 | 1024 | 1024 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 3474.203 | 333.897 | 0.000099
S02 | 4096 | 512 | 128 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 623.877 | 79.801 | 
S03 | 128 | 512 | 4096 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 831.231 | 103.372 | 
S04 | 512 | 4096 | 512 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 2817.588 | 312.431 | 
S05 | 769 | 513 | 997 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 1144.364 | 137.174 | 
B01 | 256 | 256 | 256 | 0 | 0 | 0 | 64 | 1.0 | 0.0 | 2649.071 | 317.062 | 
B02 | 384 | 192 | 768 | 0 | 0 | 0 | 32 | 1.0 | 0.0 | 4520.202 | 533.119 | 
B03 | 128 | 128 | 128 | 0 | 0 | 0 | 1024 | 1.0 | 0.0 | 5479.919 | 645.962 | 
T01 | 512 | 1024 | 256 | 1 | 0 | 0 | 1 | 1.0 | 0.0 | 471.415 | 54.904 | 
T02 | 512 | 256 | 1024 | 0 | 1 | 0 | 1 | 1.0 | 0.0 | 321.616 | 41.177 | 
T03 | 640 | 320 | 960 | 1 | 1 | 0 | 1 | 1.0 | 0.0 | 470.621 | 64.501 | 
C01 | 1024 | 768 | 512 | 0 | 0 | 1 | 1 | 1.0 | 0.0 | 1234.785 | 138.524 | 
C02 | 512 | 1024 | 256 | 0 | 1 | 1 | 1 | 1.0 | 0.0 | 439.637 | 50.691 | 
C03 | 256 | 1024 | 768 | 1 | 0 | 1 | 16 | 1.0 | 0.0 | 7368.796 | 913.610 | 
A01 | 512 | 512 | 512 | 0 | 0 | 0 | 1 | 0.5 | 0.25 | 353.388 | 46.822 | 
A02 | 384 | 640 | 320 | 1 | 1 | 0 | 8 | 0.75 | 0.5 | 1556.303 | 202.714 | 
E01 | 1 | 1 | 1 | 0 | 0 | 0 | 1 | 1.0 | 0.0 | 0.001 | 0.006 | 
E02 | 1 | 8192 | 1 | 0 | 0 | 0 | 4 | 1.0 | 0.0 | 0.069 | 0.075 | 
E03 | 8192 | 1 | 1 | 0 | 0 | 0 | 4 | 1.0 | 0.0 | 0.421 | 0.952 | 
B04 | 16 | 16 | 16 | 0 | 0 | 0 | 4096 | 1.0 | 0.0 | 47.651 | 26.276 |
B05 | 32 | 8 | 64 | 0 | 0 | 0 | 2048 | 1.0 | 0.0 | 109.218 | 31.291 |
TB01 | 384 | 640 | 256 | 1 | 0 | 0 | 16 | 1.0 | 0.0 | 3053.500 | 357.166 |
TB02 | 320 | 320 | 640 | 0 | 1 | 0 | 32 | 1.0 | 0.0 | 5120.705 | 553.073 |
CB01 | 256 | 256 | 384 | 0 | 0 | 1 | 64 | 1.0 | 0.0 | 4130.823 | 506.051 |
CB02 | 192 | 768 | 192 | 1 | 1 | 1 | 8 | 1.0 | 0.0 | 618.383 | 85.341 | 
ACC1 | 512 | 512 | 512 | 0 | 0 | 0 | 1 | 0.75 | 0.5 | 392.704 | 46.445 | 



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
