### PR TITLE
[MIOpen] Return not applicable for CK BWD deterministic

### DIFF
--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -577,6 +577,8 @@ bool ConvHipImplicitGemmGroupBwdXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_GROUP_BWD_XDLOPS))
         return false;
+    if(problem.GetConv().attribute.deterministic)
+        return false;
     if(problem.HasMixedDataTypes())
         return false;
     if(!problem.AllTensorsDimsFitIntoInt())

--- a/projects/miopen/test/gtest/unit_conv_ConvolutionDescriptor.hpp
+++ b/projects/miopen/test/gtest/unit_conv_ConvolutionDescriptor.hpp
@@ -36,7 +36,7 @@ struct ConvolutionDescriptorParams
     ConvolutionDescriptorParams(std::vector<int>&& pads_in,
                                 std::vector<int>&& strides_in,
                                 std::vector<int>&& dilations_in,
-                                int group_count_in = 1,
+                                int group_count_in    = 1,
                                 bool deterministic_in = false)
         : pads(std::move(pads_in)),
           strides(std::move(strides_in)),

--- a/projects/miopen/test/gtest/unit_conv_ConvolutionDescriptor.hpp
+++ b/projects/miopen/test/gtest/unit_conv_ConvolutionDescriptor.hpp
@@ -52,7 +52,15 @@ struct ConvolutionDescriptorParams
     miopen::ConvolutionDescriptor GetConvolutionDescriptor() const
     {
         const auto trans_output_pads = std::vector<int>(pads.size(), 0);
-        return {pads, strides, dilations, trans_output_pads, group_count, deterministic};
+        auto desc =
+            miopen::ConvolutionDescriptor{pads, strides, dilations, trans_output_pads, group_count};
+
+        // SET DETERMINISTIC ATTRIBUTE
+        if(deterministic)
+        {
+            desc.attribute.deterministic.value = 1;
+        }
+        return desc;
     }
 
     friend std::ostream& operator<<(std::ostream& os, const ConvolutionDescriptorParams& cp)

--- a/projects/miopen/test/gtest/unit_conv_ConvolutionDescriptor.hpp
+++ b/projects/miopen/test/gtest/unit_conv_ConvolutionDescriptor.hpp
@@ -58,7 +58,7 @@ struct ConvolutionDescriptorParams
         // SET DETERMINISTIC ATTRIBUTE
         if(deterministic)
         {
-            desc.attribute.deterministic.value = 1;
+            desc.attribute.Set(MIOPEN_CONVOLUTION_ATTRIB_DETERMINISTIC, 1);
         }
         return desc;
     }

--- a/projects/miopen/test/gtest/unit_conv_ConvolutionDescriptor.hpp
+++ b/projects/miopen/test/gtest/unit_conv_ConvolutionDescriptor.hpp
@@ -36,11 +36,13 @@ struct ConvolutionDescriptorParams
     ConvolutionDescriptorParams(std::vector<int>&& pads_in,
                                 std::vector<int>&& strides_in,
                                 std::vector<int>&& dilations_in,
-                                int group_count_in = 1)
+                                int group_count_in = 1,
+                                bool deterministic_in = false)
         : pads(std::move(pads_in)),
           strides(std::move(strides_in)),
           dilations(std::move(dilations_in)),
-          group_count(group_count_in)
+          group_count(group_count_in),
+          deterministic(deterministic_in)
     {
     }
 
@@ -50,7 +52,7 @@ struct ConvolutionDescriptorParams
     miopen::ConvolutionDescriptor GetConvolutionDescriptor() const
     {
         const auto trans_output_pads = std::vector<int>(pads.size(), 0);
-        return {pads, strides, dilations, trans_output_pads, group_count};
+        return {pads, strides, dilations, trans_output_pads, group_count, deterministic};
     }
 
     friend std::ostream& operator<<(std::ostream& os, const ConvolutionDescriptorParams& cp)
@@ -67,6 +69,7 @@ private:
     std::vector<int> strides;
     std::vector<int> dilations;
     int group_count;
+    bool deterministic;
 };
 
 } // namespace unit_tests

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
@@ -102,7 +102,7 @@ using GPU_UnitTestConvSolverImplicitGemmBwdXdlops_BFP16 = GPU_UnitTestConvSolver
 using GPU_UnitTestConvSolverImplicitGemmBwdXdlops_FP32  = GPU_UnitTestConvSolverBwd_FP32;
 using CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDevApplicability_FP16 =
     CPU_UnitTestConvSolverDevApplicabilityBwd_NONE;
-using CPU_UnitTestConvSolverImplicitGemmBwdXdlopsApplicability_Deterministic =
+using CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDeterministicApplicability_NONE =
     CPU_UnitTestConvSolverDevApplicabilityBwd_NONE;
 
 TEST_P(GPU_UnitTestConvSolverImplicitGemmBwdXdlops_FP16, ConvHipImplicitGemmBwdXdlops)
@@ -125,7 +125,7 @@ TEST_P(CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDevApplicability_FP16, SOLVER_
     this->RunTest(miopen::solver::conv::ConvHipImplicitGemmBwdXdlops{});
 };
 
-TEST_P(CPU_UnitTestConvSolverImplicitGemmBwdXdlopsApplicability_Deterministic,
+TEST_P(CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDeterministicApplicability_NONE,
        ConvHipImplicitGemmBwdXdlops)
 {
     this->RunTest(miopen::solver::conv::ConvHipImplicitGemmBwdXdlops{});
@@ -177,6 +177,6 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::Values(GetConvSmokeTestCases(miopenHalf)[0])));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverImplicitGemmBwdXdlopsApplicability_Deterministic,
+                         CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDeterministicApplicability_NONE,
                          testing::Combine(testing::Values(Gpu::None),
                                           testing::Values(GetConvSmokeTestCases(miopenHalf)[1])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
@@ -125,7 +125,8 @@ TEST_P(CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDevApplicability_FP16, SOLVER_
     this->RunTest(miopen::solver::conv::ConvHipImplicitGemmBwdXdlops{});
 };
 
-TEST_P(CPU_UnitTestConvSolverImplicitGemmBwdXdlopsApplicability_Deterministic, ConvHipImplicitGemmBwdXdlops)
+TEST_P(CPU_UnitTestConvSolverImplicitGemmBwdXdlopsApplicability_Deterministic,
+       ConvHipImplicitGemmBwdXdlops)
 {
     this->RunTest(miopen::solver::conv::ConvHipImplicitGemmBwdXdlops{});
 };

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
@@ -42,9 +42,14 @@ auto GetConvSmokeTestCases(miopenDataType_t datatype)
 
     return std::vector{
         // clang-format off
+        // Non-deterministic (default)
         TestCase{{datatype, miopenTensorNHWC, {1, 32, 8, 8}},
                  {datatype, miopenTensorNHWC, {32, 32, 1, 1}},
                  datatype, {{0, 0}, {1, 1}, {1, 1}}},
+        // Deterministic enabled
+        TestCase{{datatype, miopenTensorNHWC, {1, 32, 8, 8}},
+                 {datatype, miopenTensorNHWC, {32, 32, 1, 1}},
+                 datatype, {{0, 0}, {1, 1}, {1, 1}, 1, true}},
         // clang-format on
     };
 }
@@ -97,6 +102,8 @@ using GPU_UnitTestConvSolverImplicitGemmBwdXdlops_BFP16 = GPU_UnitTestConvSolver
 using GPU_UnitTestConvSolverImplicitGemmBwdXdlops_FP32  = GPU_UnitTestConvSolverBwd_FP32;
 using CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDevApplicability_FP16 =
     CPU_UnitTestConvSolverDevApplicabilityBwd_NONE;
+using CPU_UnitTestConvSolverImplicitGemmBwdXdlopsApplicability_Deterministic =
+    CPU_UnitTestConvSolverDevApplicabilityBwd_NONE;
 
 TEST_P(GPU_UnitTestConvSolverImplicitGemmBwdXdlops_FP16, ConvHipImplicitGemmBwdXdlops)
 {
@@ -114,6 +121,11 @@ TEST_P(GPU_UnitTestConvSolverImplicitGemmBwdXdlops_FP32, ConvHipImplicitGemmBwdX
 };
 
 TEST_P(CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDevApplicability_FP16, SOLVER_NAME_DEV_APP)
+{
+    this->RunTest(miopen::solver::conv::ConvHipImplicitGemmBwdXdlops{});
+};
+
+TEST_P(CPU_UnitTestConvSolverImplicitGemmBwdXdlopsApplicability_Deterministic, ConvHipImplicitGemmBwdXdlops)
 {
     this->RunTest(miopen::solver::conv::ConvHipImplicitGemmBwdXdlops{});
 };
@@ -162,3 +174,8 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDevApplicability_FP16,
                          testing::Combine(testing::Values(GetTestParams(miopenHalf)),
                                           testing::Values(GetConvSmokeTestCases(miopenHalf)[0])));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_UnitTestConvSolverImplicitGemmBwdXdlopsApplicability_Deterministic,
+                         testing::Combine(testing::Values(Gpu::None),
+                                          testing::Values(GetConvSmokeTestCases(miopenHalf)[1])));

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
@@ -36,17 +36,27 @@
 
 namespace {
 
+// Non-deterministic test cases (for GPU smoke tests)
 auto GetConvSmokeTestCases(miopenDataType_t datatype)
 {
     using TestCase = miopen::unit_tests::ConvTestCase;
 
     return std::vector{
         // clang-format off
-        // Non-deterministic (default)
         TestCase{{datatype, miopenTensorNHWC, {1, 32, 8, 8}},
                  {datatype, miopenTensorNHWC, {32, 32, 1, 1}},
                  datatype, {{0, 0}, {1, 1}, {1, 1}}},
-        // Deterministic enabled
+        // clang-format on
+    };
+}
+
+// Deterministic test case (for CPU deterministic applicability test)
+auto GetConvDeterministicTestCases(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
         TestCase{{datatype, miopenTensorNHWC, {1, 32, 8, 8}},
                  {datatype, miopenTensorNHWC, {32, 32, 1, 1}},
                  datatype, {{0, 0}, {1, 1}, {1, 1}, 1, true}},
@@ -176,7 +186,8 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          testing::Combine(testing::Values(GetTestParams(miopenHalf)),
                                           testing::Values(GetConvSmokeTestCases(miopenHalf)[0])));
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDeterministicApplicability_NONE,
-                         testing::Combine(testing::Values(Gpu::None),
-                                          testing::Values(GetConvSmokeTestCases(miopenHalf)[1])));
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDeterministicApplicability_NONE,
+    testing::Combine(testing::Values(Gpu::None),
+                     testing::Values(GetConvDeterministicTestCases(miopenHalf)[0])));


### PR DESCRIPTION
## Motivation

Resolve issue where CK BWD solver aren't skipping solution when deterministic is set.

## Technical Details

Return the solver is not applicable if the problem is deterministic 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Added changes to `ConvolutionDescriptorParams` to set deterministic attribute
- Add deterministic smoke testcase params
- `CPU_UnitTestConvSolverImplicitGemmBwdXdlopsDeterministicApplicability_NONE` tests the functional changes

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
