### PR TITLE
[hipDNN] Add SDK utility for integration tests to get current binary path

### DIFF
--- a/projects/hipdnn/plugins/miopen_legacy_plugin/CMakeLists.txt
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/CMakeLists.txt
@@ -140,8 +140,6 @@ if(BUILD_PLUGIN_AS_DEPENDENCY)
     clang_tidy_check(miopen_legacy_plugin)
 endif()
 
-set(MIOPEN_LEGACY_PLUGIN_PATH ./hipdnn_plugins/engines/miopen_legacy_plugin CACHE INTERNAL "miopen legacy plugin dir" FORCE)
-
 if(NOT HIP_DNN_SKIP_TESTS)
     add_subdirectory(tests)
     add_subdirectory(integration_tests)

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/CMakeLists.txt
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(miopen_plugin_integration_test
 
 target_compile_options(miopen_plugin_integration_test PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 target_compile_definitions(miopen_plugin_integration_test PRIVATE
-    PLUGIN_PATH="${MIOPEN_LEGACY_PLUGIN_PATH}"
+    PLUGIN_PATH="../lib/${MIOPEN_LEGACY_PLUGIN_PATH}"
 )
 
 target_link_libraries(miopen_plugin_integration_test PUBLIC 

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/CMakeLists.txt
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/CMakeLists.txt
@@ -18,8 +18,9 @@ add_executable(miopen_plugin_integration_test
 target_compile_options(miopen_plugin_integration_test PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 
 # To use the build tree plugin, we use the path relative to the test binary instead of the installed libhipdnn_backend.so
+# HIPDNN_PLUGIN_ENGINE_SUBDIR is provided by the sdk
 target_compile_definitions(miopen_plugin_integration_test PRIVATE
-    PLUGIN_PATH="../lib/hipdnn_plugins/engines/miopen_legacy_plugin"
+    PLUGIN_PATH="../lib/${HIPDNN_PLUGIN_ENGINE_SUBDIR}/miopen_legacy_plugin"
 )
 
 target_link_libraries(miopen_plugin_integration_test PUBLIC 

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/CMakeLists.txt
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/CMakeLists.txt
@@ -16,8 +16,10 @@ add_executable(miopen_plugin_integration_test
 )
 
 target_compile_options(miopen_plugin_integration_test PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+
+# To use the build tree plugin, we use the path relative to the test binary instead of the installed libhipdnn_backend.so
 target_compile_definitions(miopen_plugin_integration_test PRIVATE
-    PLUGIN_PATH="../lib/${MIOPEN_LEGACY_PLUGIN_PATH}"
+    PLUGIN_PATH="../lib/hipdnn_plugins/engines/miopen_legacy_plugin"
 )
 
 target_link_libraries(miopen_plugin_integration_test PUBLIC 

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <cmath>
+#include <filesystem>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>
 #include <memory>
@@ -15,6 +16,7 @@
 #include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/TestUtilities.hpp>
 #include <hipdnn_sdk/utilities/MigratableMemory.hpp>
+#include <hipdnn_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_sdk/utilities/Tensor.hpp>
 
@@ -126,7 +128,10 @@ protected:
         ASSERT_EQ(hipGetDevice(&_deviceId), hipSuccess);
 
         // Note: The plugin paths has to be set before we create the hipdnn handle.
-        const std::array<const char*, 1> paths = {PLUGIN_PATH};
+        auto testBinaryDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
+        auto pluginPath = std::filesystem::weakly_canonical(testBinaryDir / PLUGIN_PATH);
+        const std::string pluginPathStr = pluginPath.string();
+        const std::array<const char*, 1> paths = {pluginPathStr.c_str()};
         ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
                       paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
                   HIPDNN_STATUS_SUCCESS);

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
@@ -128,8 +128,8 @@ protected:
         ASSERT_EQ(hipGetDevice(&_deviceId), hipSuccess);
 
         // Note: The plugin paths has to be set before we create the hipdnn handle.
-        auto testBinaryDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
-        auto pluginPath = std::filesystem::weakly_canonical(testBinaryDir / PLUGIN_PATH);
+        auto pluginPath
+            = std::filesystem::weakly_canonical(getCurrentExecutableDirectory() / PLUGIN_PATH);
         const std::string pluginPathStr = pluginPath.string();
         const std::array<const char*, 1> paths = {pluginPathStr.c_str()};
         ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -126,8 +126,8 @@ protected:
         ASSERT_EQ(hipGetDevice(&_deviceId), hipSuccess);
 
         // Note: The plugin paths has to be set before we create the hipdnn handle.
-        auto testBinaryDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
-        auto pluginPath = std::filesystem::weakly_canonical(testBinaryDir / PLUGIN_PATH);
+        auto pluginPath
+            = std::filesystem::weakly_canonical(getCurrentExecutableDirectory() / PLUGIN_PATH);
         const std::string pluginPathStr = pluginPath.string();
         const std::array<const char*, 1> paths = {pluginPathStr.c_str()};
         ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <cmath>
+#include <filesystem>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>
 #include <memory>
@@ -15,6 +16,7 @@
 #include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/TestUtilities.hpp>
 #include <hipdnn_sdk/utilities/MigratableMemory.hpp>
+#include <hipdnn_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_sdk/utilities/Tensor.hpp>
 
@@ -124,7 +126,10 @@ protected:
         ASSERT_EQ(hipGetDevice(&_deviceId), hipSuccess);
 
         // Note: The plugin paths has to be set before we create the hipdnn handle.
-        const std::array<const char*, 1> paths = {PLUGIN_PATH};
+        auto testBinaryDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
+        auto pluginPath = std::filesystem::weakly_canonical(testBinaryDir / PLUGIN_PATH);
+        const std::string pluginPathStr = pluginPath.string();
+        const std::array<const char*, 1> paths = {pluginPathStr.c_str()};
         ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
                       paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
                   HIPDNN_STATUS_SUCCESS);

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuConvForward.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuConvForward.cpp
@@ -1,6 +1,7 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include <filesystem>
 #include <random>
 
 #include <gtest/gtest.h>
@@ -13,6 +14,7 @@
 #include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/TestUtilities.hpp>
 #include <hipdnn_sdk/utilities/MigratableMemory.hpp>
+#include <hipdnn_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_sdk/utilities/StringUtil.hpp>
 #include <hipdnn_sdk/utilities/Tensor.hpp>
 #include <hipdnn_sdk/utilities/Workspace.hpp>
@@ -60,7 +62,10 @@ protected:
         ASSERT_EQ(hipGetDevice(&_deviceId), hipSuccess);
 
         // Note: The plugin paths has to be set before we create the hipdnn handle.
-        const std::array<const char*, 1> paths = {PLUGIN_PATH};
+        auto testBinaryDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
+        auto pluginPath = std::filesystem::weakly_canonical(testBinaryDir / PLUGIN_PATH);
+        const std::string pluginPathStr = pluginPath.string();
+        const std::array<const char*, 1> paths = {pluginPathStr.c_str()};
         ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
                       paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
                   HIPDNN_STATUS_SUCCESS);

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuConvForward.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuConvForward.cpp
@@ -62,8 +62,8 @@ protected:
         ASSERT_EQ(hipGetDevice(&_deviceId), hipSuccess);
 
         // Note: The plugin paths has to be set before we create the hipdnn handle.
-        auto testBinaryDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
-        auto pluginPath = std::filesystem::weakly_canonical(testBinaryDir / PLUGIN_PATH);
+        auto pluginPath
+            = std::filesystem::weakly_canonical(getCurrentExecutableDirectory() / PLUGIN_PATH);
         const std::string pluginPathStr = pluginPath.string();
         const std::array<const char*, 1> paths = {pluginPathStr.c_str()};
         ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/PlatformUtils.linux.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/PlatformUtils.linux.hpp
@@ -4,7 +4,11 @@
 #pragma once
 
 #if defined(__linux__)
+#include <array>
+#include <climits>
 #include <filesystem>
+#include <stdexcept>
+#include <unistd.h>
 namespace hipdnn_sdk
 {
 namespace utilities
@@ -44,6 +48,18 @@ inline void unsetEnv(const char* var)
 inline bool pathCompEq(const std::filesystem::path& a, const std::filesystem::path& b)
 {
     return a.native() == b.native();
+}
+
+inline std::filesystem::path getCurrentExecutableDirectory()
+{
+    std::array<char, PATH_MAX> result{};
+    ssize_t count = readlink("/proc/self/exe", result.data(), PATH_MAX);
+    if(count == -1)
+    {
+        throw std::runtime_error("Failed to get executable path");
+    }
+    return std::filesystem::path(std::string(result.data(), static_cast<size_t>(count)))
+        .parent_path();
 }
 
 }

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/PlatformUtils.windows.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/PlatformUtils.windows.hpp
@@ -60,6 +60,18 @@ inline bool pathCompEq(const std::filesystem::path& a, const std::filesystem::pa
     std::transform(B.begin(), B.end(), B.begin(), ::towlower);
     return A == B;
 }
+
+inline std::filesystem::path getCurrentExecutableDirectory()
+{
+    wchar_t result[MAX_PATH];
+    DWORD length = GetModuleFileNameW(nullptr, result, MAX_PATH);
+    if(length == 0 || length == MAX_PATH)
+    {
+        throw std::runtime_error("Failed to get executable path");
+    }
+    return std::filesystem::path(result).parent_path();
+}
+
 }
 
 #else

--- a/projects/hipdnn/sdk/tests/utilities/TestPlatformUtils.cpp
+++ b/projects/hipdnn/sdk/tests/utilities/TestPlatformUtils.cpp
@@ -6,7 +6,13 @@
 #include <hipdnn_sdk/utilities/PlatformUtils.hpp>
 #include <iostream>
 
-// TODO: More tests for PlatformUtils since it is untested
+#if defined(__linux__)
+#include <array>
+#include <climits>
+#include <unistd.h>
+#endif
+
+// TODO: More tests for PlatformUtils since it is largely untested
 
 TEST(TestPlatformUtils, PathCompEqIdenticalPaths)
 {
@@ -31,3 +37,46 @@ TEST(TestPlatformUtils, PathCompEqEmptyPaths)
 
     EXPECT_TRUE(hipdnn_sdk::utilities::pathCompEq(path1, path2));
 }
+
+TEST(TestPlatformUtils, GetCurrentExecutableDirectoryReturnsValidPath)
+{
+    auto execDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
+
+    EXPECT_FALSE(execDir.empty());
+}
+
+TEST(TestPlatformUtils, GetCurrentExecutableDirectoryExists)
+{
+    auto execDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
+
+    EXPECT_TRUE(std::filesystem::exists(execDir));
+}
+
+TEST(TestPlatformUtils, GetCurrentExecutableDirectoryIsAbsolute)
+{
+    auto execDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
+
+    EXPECT_TRUE(execDir.is_absolute());
+}
+
+TEST(TestPlatformUtils, GetCurrentExecutableDirectoryIsDirectory)
+{
+    auto execDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
+
+    EXPECT_TRUE(std::filesystem::is_directory(execDir));
+}
+
+#if defined(__linux__)
+TEST(TestPlatformUtils, GetCurrentExecutableDirectoryContainsExecutable)
+{
+    auto execDir = hipdnn_sdk::utilities::getCurrentExecutableDirectory();
+
+    std::array<char, PATH_MAX> execPath{};
+    ssize_t len = readlink("/proc/self/exe", execPath.data(), PATH_MAX);
+    ASSERT_NE(len, -1);
+
+    std::filesystem::path actualExecPath(std::string(execPath.data(), static_cast<size_t>(len)));
+
+    EXPECT_TRUE(std::filesystem::exists(execDir / actualExecPath.filename()));
+}
+#endif // defined(__linux__)


### PR DESCRIPTION
## Motivation

MIOpen plugin standalone integration tests were using the installed plugin because it was loaded relative to the installed backend shared library. 

## Technical Details

There is no way to circumvent this through the API besides using an absolute path, so we create an SDK helper to retrieve the current executable path at runtime.

An alternative option is to add another parameter to the API for selecting a relative loading mode.

## Test Plan

Tests for platform utils.

## Test Result

All tests pass, including MIOpen standalone integration.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
