### PR TITLE
[MIOpen] Adding authentication to Docker image pulls

### DIFF
--- a/projects/miopen/vars/utils.groovy
+++ b/projects/miopen/vars/utils.groovy
@@ -269,7 +269,9 @@ def getDockerImage(Map conf=[:])
     try{
         echo "Pulling down image: ${image}"
         dockerImage = docker.image("${image}")
-        dockerImage.pull()
+        withDockerRegistry([ credentialsId: "docker_test_cred", url: "" ]) {
+            dockerImage.pull()
+        }
     }
     catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e){
         echo "The job was cancelled or aborted"
@@ -297,7 +299,9 @@ def getDockerImage(Map conf=[:])
         try{
             echo "Pulling down perf test image: ${image}"
             dockerImage = docker.image("${image}")
-            dockerImage.pull()
+            withDockerRegistry([ credentialsId: "docker_test_cred", url: "" ]) {
+                dockerImage.pull()
+            }
         }
         catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e){
             echo "The job was cancelled or aborted"
@@ -405,7 +409,9 @@ def RunPerfTest(Map conf=[:]){
         def docker_image = conf.get("docker_image")
         def miopen_install_path = conf.get("miopen_install_path", "/opt/rocm")
         def results_dir = conf.get("results_dir", "${env.WORKSPACE}/${env.REPO_DIR}/results")
-        docker_image.pull()
+        withDockerRegistry([ credentialsId: "docker_test_cred", url: "" ]) {
+            docker_image.pull()
+        }
         echo "docker image: ${docker_image}"
         //grab root of node workspace. not guaranteed to be /var/jenkins
         String remote_root = env.WORKSPACE.substring(0, env.WORKSPACE.lastIndexOf("workspace/"))


### PR DESCRIPTION
## Motivation

Docker pulls are currently being done unauthenticated and MIOpen CI is running into Docker pull rate limits on days where we have many branches being CI'd. This leads to intermittent CI failures.

## Technical Details

We already have the ability to make authenticated calls to the Docker API using credentials from our CI environment using the Jenkins Docker plugin's `withDockerRegistry`. This PR adds that mechanism to our `.pull()` calls.

## Test Plan

Running the existing CI to ensure that Docker image pulls continue to succeed when credentials are supplied.

## Test Result

CI is in progress

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
