### PR TITLE
[TheRock CI] Adding windows proxy fix for choco

### DIFF
--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -59,7 +59,10 @@ jobs:
           git -c user.name="therockbot" -c "user.email=therockbot@amd.com" am --whitespace=nowarn ./TheRock/patches/amd-mainline/rocm-libraries/*.patch
 
       - name: Install requirements
+        # The first two lines removes the default commmunity feed and uses the internal proxy feed
         run: |
+          choco source disable -n=chocolatey
+          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-proxy/ --priority=1
           choco install --no-progress -y ccache
           choco install --no-progress -y ninja
           choco install --no-progress -y strawberryperl

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -62,7 +62,7 @@ jobs:
         # The first two lines removes the default commmunity feed and uses the internal proxy feed
         run: |
           choco source disable -n=chocolatey
-          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-proxy/ --priority=1
+          choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
           choco install --no-progress -y ccache
           choco install --no-progress -y ninja
           choco install --no-progress -y strawberryperl


### PR DESCRIPTION
After getting `Too many requests` failures for windows, we were able to get a proxy server up to use internal packages. This way, we will have no more rate limiting issues.

works here: https://github.com/ROCm/TheRock/actions/runs/18420282704/job/52492915128 (please check the install requirements.txt step)