### PR TITLE
Fix tailloop reload bug

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4942,6 +4942,7 @@ class KernelWriterAssembly(KernelWriter):
       do = doA if  tc == "A" else doB
       strSize = "SizeI" if tc == "A" else "SizeJ"
       strMacroTile = "MacroTile0" if tc == "A" else "MacroTile1"
+      strWG = "WorkGroup0" if tc == "A" else "WorkGroup1"
       tP = tPA if tc == "A" else tPB
       nlp = nlpA if tc == "A" else nlpB
       nlc = nlcA if tc == "A" else nlcB
@@ -4964,19 +4965,21 @@ class KernelWriterAssembly(KernelWriter):
       loopIdx = self.states.unrollIdx
       if do:
         imod.addComment("Calculate %s %% %s"%(strSize, strMacroTile))
-        imod.add(scalarStaticDivideAndRemainder(sTmp0, sTmp0, sgpr(strSize), \
-                                                kernel[strMacroTile], \
-                                                ContinuousRegister(sx2Tmp0, 2), 1))
-        imod.add(SCmpEQU32(src0=sgpr(sTmp0), src1=0, comment=""))
-        imod.add(SCMovB32(dst=sgpr(sTmp0), src=kernel[strMacroTile]))
+        imod.add(SMulI32(dst=sgpr(sTmp0), src0=sgpr(strWG), src1=kernel[strMacroTile], \
+                         comment="Calculate the remaining dimension along I/J direction."))
+        imod.add(SSubU32(dst=sgpr(sTmp0), src0=sgpr(strSize), src1=sgpr(sTmp0), \
+                         comment="Calculate the remaining dimension along I/J direction."))
+        imod.add(SMulI32(dst=sgpr(sTmp0), src0=sgpr(sTmp0), src1=tP["bpeGR"], \
+                         comment="In bytes"))
         imod.add(SAndB32(dst=sgpr(sTmp1), src0=sgpr("SizeL"), src1=(kernel["DepthU"] - 1), \
-                         comment="Calculate how many sizes along L direction in tail"))
+                         comment="Calculate the remaining dimension along L direction."))
         imod.add(SLShiftRightB32(dst=sgpr(sx2Tmp1), shiftHex=hex(log2(lsc)), \
                                  src=sgpr(sTmp1), comment="Divided by lsc(%s)"%(lsc)))
-        imod.add(SMulI32(dst=sgpr(sTmp2), src0=sgpr(sTmp0), src1=sgpr(sTmp1), \
-                         comment="Calculate total valid elements number of last tile"))
-        imod.add(SMulI32(dst=sgpr(sValidBytes), src0=sgpr(sTmp2), src1=tP["bpeGR"], \
-                         comment="Total valid bytes"))
+        imod.add(self.s_mul_u64_u32(sgpr(sValidBytes), sgpr(sReloadFlag), sgpr(sTmp0), sgpr(sTmp1), \
+                               comment="Calculate total number of valid elements."))
+        imod.add(SCmpGtU32(src0=sgpr(sReloadFlag), src1=0))
+        imod.add(SCMovB32(dst=sgpr(sValidBytes), src=hex(0xFFFFFFFF), \
+                          comment="If valid elements > max(U32), set the value to max"))
 
         if (kernel[strWSGR] == 0):
           tmpSgpr = sTmp0

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/tail_small_size.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/tail_small_size.yaml
@@ -1,0 +1,159 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx950, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  MinimumRequiredVersion: 5.0.0
+  PrintLevel: 1
+  PrintSolutionRejectionReason: True
+  Device: 0
+  CMakeBuildType: Release
+  KernelTime: True
+  MaxWorkspaceSize: 13421772800
+  DataInitTypeA: 21
+  DataInitTypeB: 21
+  DataInitTypeC: 21
+  DataInitTypeAlpha: 1
+  DataInitTypeBeta: 1
+  DataInitTypeBias: 21
+  DataInitTypeScaleAlphaVec: 21
+  NumElementsToValidate: -1
+  BoundsCheck: 2
+
+BenchmarkProblems:
+  ########################################
+  # FP8NHS
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: F8N
+      DestDataType: h
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+      Activation:    True
+      ActivationType: hipblaslt_all
+      UseScaleAB: "Scalar"
+      UseScaleCD: True
+      UseScaleAlphaVec: 1
+      UseBias: 1
+      BiasDataTypeList: [s]
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16,16,32, 1, 1, 1,1, 1,1]  # 16x16
+          - [16,16,32, 1, 1, 1,1, 2,1]  # 32x16
+          - [16,16,32, 1, 1, 1,1, 4,1]  # 64x16
+        - DepthU: [ 32, 64 ]
+        - AssertFree0ElementMultiple: [1]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - GlobalReadVectorWidthA: [1, 2, 4, 8, 16]
+        - GlobalReadVectorWidthB: [1, 2, 4, 8, 16]
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1]
+        - ExpandPointerSwap: [1]
+        - LdsBlockSizePerPadA: [0]
+        - LdsBlockSizePerPadB: [0]
+        - TransposeLDS: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+        - WaveSeparateGlobalReadA: [0, 1, 2]
+        - WaveSeparateGlobalReadB: [0, 1, 2]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1, 2]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - GlobalReadPerMfma: [1]
+        - LocalWritePerMfma: [-1]
+        - StoreVectorWidth: [-1]
+        - SourceSwap: [1]
+        - NumElementsPerBatchStore: [0]
+        - StorePriorityOpt: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [13, 13, 1, 1]
+          - Exact: [17, 17, 1, 1]
+          - Exact: [25, 25, 1, 1]
+          - Exact: [33, 33, 1, 1]
+          - Exact: [65, 65, 1, 1]
+          - Exact: [13, 13, 1, 3]
+          - Exact: [17, 17, 1, 3]
+          - Exact: [25, 25, 1, 3]
+          - Exact: [33, 33, 1, 3]
+          - Exact: [65, 65, 1, 3]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]
+
+  ########################################
+  # bf16 TN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: b
+      DestDataType: b
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      UseBias: 1
+      Batched: True
+      Activation: True
+      ActivationType: hipblaslt_all
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16,16, 1,  1,   1, 1,  1,1 ]
+          - [16, 16,16, 1,  1,   1, 1,  2,1 ]
+          - [16, 16,16, 1,  1,   1, 1,  4,1 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - DepthU: [32,64]
+        - LocalReadVectorWidth: [8]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1, 2]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - SourceSwap: [1]
+        - WaveSeparateGlobalReadA: [0, 1, 2]
+        - WaveSeparateGlobalReadB: [0, 1, 2]
+        - GlobalReadVectorWidthA: [1, 2, 4, 8]
+        - GlobalReadVectorWidthB: [1, 2, 4, 8]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [13, 13, 1, 1]
+          - Exact: [17, 17, 1, 1]
+          - Exact: [25, 25, 1, 1]
+          - Exact: [33, 33, 1, 1]
+          - Exact: [13, 13, 1, 5]
+          - Exact: [17, 17, 1, 5]
+          - Exact: [25, 25, 1, 5]
+          - Exact: [33, 33, 1, 5]
+          - Exact: [65, 65, 1, 5]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]


### PR DESCRIPTION
## Motivation

Some extremely small sizes with tail may fail.

## Technical Details

WorkGroup index need to be considered when calculating valid element size. Valid element size = (size - WG * MT) * (L % DU) * bpr

## Test Plan

run tox locally.
pass the failed test.

## Test Result

tox all pass:
<img width="746" height="117" alt="{1013649F-9B79-42C3-9772-D773F5EC0E6F}" src="https://github.com/user-attachments/assets/a69db17e-3649-4538-bf11-13046741569d" />

failed test pass:
<img width="767" height="141" alt="{E592C049-788A-4D4A-85C1-7346FDAA91FF}" src="https://github.com/user-attachments/assets/d088cccc-cd33-4089-8f73-3d53f240e139" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
