### PR TITLE
[TheRock CI] optimizing the TheRock CI with fewer jobs 

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -9,6 +9,7 @@ import fnmatch
 import json
 import logging
 import subprocess
+from pathlib import Path
 import sys
 from therock_matrix import subtree_to_project_map, project_map
 import time
@@ -18,6 +19,7 @@ from pr_detect_changed_subtrees import get_valid_prefixes, find_matched_subtrees
 from config_loader import load_repo_config
 
 logging.basicConfig(level=logging.INFO)
+SCRIPT_DIR = Path(__file__).resolve().parent
 
 
 def set_github_output(d: Mapping[str, str]):
@@ -85,7 +87,8 @@ def check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> boo
 
 
 def get_changed_path_projects(paths: Optional[Iterable[str]]) -> Iterable[str]:
-    config = load_repo_config("./repos-config.json")
+    repo_config_path = Path(SCRIPT_DIR / ".." / "repos-config.json")
+    config = load_repo_config(str(repo_config_path))
     print(config)
     valid_prefixes = get_valid_prefixes(config)
     print(valid_prefixes)

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -14,6 +14,8 @@ from therock_matrix import subtree_to_project_map, project_map
 import time
 from typing import Mapping, Optional, Iterable
 import os
+from pr_detect_changed_subtrees import get_valid_prefixes, find_matched_subtrees, output_subtrees
+from config_loader import load_repo_config
 
 logging.basicConfig(level=logging.INFO)
 
@@ -82,9 +84,21 @@ def check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> boo
     return any(is_path_workflow_file_related_to_ci(p) for p in paths)
 
 
+def get_changed_path_projects(paths: Optional[Iterable[str]]) -> Iterable[str]:
+    config = load_repo_config("./repos-config.json")
+    valid_prefixes = get_valid_prefixes(config)
+    matched_subtrees = find_matched_subtrees(paths, valid_prefixes)
+    return matched_subtrees
+
+
 def retrieve_projects(args):
-    if args.get("is_pull_request"):
-        subtrees = args.get("input_subtrees").split("\n")
+    # We only test projects where the paths were updated for pushes and pull requests
+    base_ref = args.get("base_ref")
+    modified_paths = get_modified_paths(base_ref)
+    subtrees = get_changed_path_projects(modified_paths)
+    
+    # by default, we select full tests
+    test_type = "full"
 
     if args.get("is_workflow_dispatch"):
         if args.get("input_projects") == "all":
@@ -92,18 +106,16 @@ def retrieve_projects(args):
         else:
             subtrees = args.get("input_projects").split()
 
-    # If a push event to develop happens, we run tests on all subtrees
-    if args.get("is_push"):
-        subtrees = list(subtree_to_project_map.keys())
-
     # If .github/*/therock* were changed for a push or pull request, run all subtrees
     if args.get("is_push") or args.get("is_pull_request"):
-        base_ref = args.get("base_ref")
-        modified_paths = get_modified_paths(base_ref)
-        print("modified_paths (max 200):", modified_paths[:200])
         related_to_therock_ci = check_for_workflow_file_related_to_ci(modified_paths)
         if related_to_therock_ci:
             subtrees = list(subtree_to_project_map.keys())
+            test_type = "smoke"
+            
+    # for nightly runs, run everything with full tests
+    if args.get("is_nightly"):
+        subtrees = list(subtree_to_project_map.keys())
 
     projects = set()
     # collect the associated subtree to project
@@ -117,12 +129,15 @@ def retrieve_projects(args):
         if project in project_map:
             project_to_run.append(project_map.get(project))
 
-    return project_to_run
+    return project_to_run, test_type
 
 
 def run(args):
-    project_to_run = retrieve_projects(args)
-    set_github_output({"projects": json.dumps(project_to_run)})
+    project_to_run, test_type = retrieve_projects(args)
+    set_github_output({
+        "projects": json.dumps(project_to_run),
+        "test_type": test_type
+    })
 
 
 if __name__ == "__main__":
@@ -131,9 +146,7 @@ if __name__ == "__main__":
     args["is_pull_request"] = github_event_name == "pull_request"
     args["is_push"] = github_event_name == "push"
     args["is_workflow_dispatch"] = github_event_name == "workflow_dispatch"
-
-    input_subtrees = os.getenv("SUBTREES", "")
-    args["input_subtrees"] = input_subtrees
+    args["is_nightly"] = github_event_name == "schedule"
 
     input_projects = os.getenv("PROJECTS", "")
     args["input_projects"] = input_projects

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -86,8 +86,11 @@ def check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> boo
 
 def get_changed_path_projects(paths: Optional[Iterable[str]]) -> Iterable[str]:
     config = load_repo_config("./repos-config.json")
+    print(config)
     valid_prefixes = get_valid_prefixes(config)
+    print(valid_prefixes)
     matched_subtrees = find_matched_subtrees(paths, valid_prefixes)
+    print(matched_subtrees)
     return matched_subtrees
 
 

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -15,7 +15,7 @@ from therock_matrix import subtree_to_project_map, project_map
 import time
 from typing import Mapping, Optional, Iterable
 import os
-from pr_detect_changed_subtrees import get_valid_prefixes, find_matched_subtrees, output_subtrees
+from pr_detect_changed_subtrees import get_valid_prefixes, find_matched_subtrees
 from config_loader import load_repo_config
 
 logging.basicConfig(level=logging.INFO)
@@ -89,16 +89,16 @@ def check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> boo
 def get_changed_path_projects(paths: Optional[Iterable[str]]) -> Iterable[str]:
     repo_config_path = Path(SCRIPT_DIR / ".." / "repos-config.json")
     config = load_repo_config(str(repo_config_path))
-    print(config)
     valid_prefixes = get_valid_prefixes(config)
     print(valid_prefixes)
     matched_subtrees = find_matched_subtrees(paths, valid_prefixes)
     print(matched_subtrees)
+    print(paths)
     return matched_subtrees
 
 
 def retrieve_projects(args):
-    # We only test projects where the paths were updated for pushes and pull requests
+    # For pushes and pull_requests, we only want to test changed projects
     base_ref = args.get("base_ref")
     modified_paths = get_modified_paths(base_ref)
     subtrees = get_changed_path_projects(modified_paths)

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -90,10 +90,7 @@ def get_changed_path_projects(paths: Optional[Iterable[str]]) -> Iterable[str]:
     repo_config_path = Path(SCRIPT_DIR / ".." / "repos-config.json")
     config = load_repo_config(str(repo_config_path))
     valid_prefixes = get_valid_prefixes(config)
-    print(valid_prefixes)
     matched_subtrees = find_matched_subtrees(paths, valid_prefixes)
-    print(matched_subtrees)
-    print(paths)
     return matched_subtrees
 
 

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
+          ref: c11594642430b64e73774652e3d9137dd096358c # 2025-10-13 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -7,7 +7,8 @@ on:
         type: string
       project_to_test:
         type: string
-
+      test_type:
+        type: string
 
 permissions:
   contents: read
@@ -127,3 +128,4 @@ jobs:
       amdgpu_families: "gfx94X-dcgpu"
       test_runs_on: "linux-mi325-1gpu-ossci-rocm"
       platform: "linux"
+      test_type: ${{ inputs.test_type }}

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -7,6 +7,8 @@ on:
         type: string
       project_to_test:
         type: string
+      test_type:
+        type: string
 
 permissions:
   contents: read
@@ -152,3 +154,4 @@ jobs:
       amdgpu_families: ${{ needs.therock-build-windows.outputs.AMDGPU_FAMILIES }}
       test_runs_on: "windows-strix-halo-gpu-rocm"
       platform: "windows"
+      test_type: ${{ inputs.test_type }}

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
+          ref: c11594642430b64e73774652e3d9137dd096358c # 2025-10-13 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -1,6 +1,8 @@
 name: TheRock CI
 
 on:
+  schedule:
+    - cron: "0 7 * * *" # Runs nightly at 7 AM UTC
   push:
     branches:
       - develop
@@ -33,6 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       projects: ${{ steps.projects.outputs.projects }}
+      test_type: ${{ steps.projects.outputs.test_type }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -51,21 +54,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install pydantic requests
 
-      - name: Detect changed subtrees
-        id: detect
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          python .github/scripts/pr_detect_changed_subtrees.py \
-            --repo "${{ github.repository }}" \
-            --pr "${{ github.event.pull_request.number }}" \
-            --config ".github/repos-config.json"
-
       - name: Determine projects to run
         id: projects
         env:
-          SUBTREES: ${{ steps.detect.outputs.subtrees }}
           PROJECTS: ${{ inputs.projects }}
         run: |
           python .github/scripts/therock_configure_ci.py
@@ -86,6 +77,7 @@ jobs:
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       project_to_test: ${{ matrix.projects.project_to_test }}
+      test_type: ${{ needs.setup.outputs.test_type }}
 
   therock-ci-windows:
     name: Windows (${{ matrix.projects.project_to_test }})
@@ -103,6 +95,7 @@ jobs:
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       project_to_test: ${{ matrix.projects.project_to_test }}
+      test_type: ${{ needs.setup.outputs.test_type }}
 
   therock_ci_summary:
     name: TheRock CI Summary

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          # for test! UPDATE!!!
+          # TODO: Update this ref
           ref: users/geomin12/ci-optimize
           # ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
 

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,9 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          # TODO: Update this ref
-          ref: users/geomin12/ci-optimize
-          # ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
+          ref: c11594642430b64e73774652e3d9137dd096358c # 2025-10-13 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,9 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
+          # for test! UPDATE!!!
+          ref: users/geomin12/ci-optimize
+          # ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'
@@ -81,6 +83,7 @@ jobs:
         env:
           SHARD_INDEX: ${{ matrix.shard }}
           TOTAL_SHARDS: ${{ fromJSON(inputs.component).total_shards }}
+          TEST_TYPE: ${{ fromJSON(inputs.component).test_type }}
         run: |
           ${{ fromJSON(inputs.component).test_script }}
 

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -43,9 +43,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          # TODO: Update this ref
-          ref: users/geomin12/ci-optimize
-          # ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
+          ref: c11594642430b64e73774652e3d9137dd096358c # 2025-10-13 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -11,6 +11,8 @@ on:
         type: string
       platform:
         type: string
+      test_type:
+        type: string
 
 permissions:
   contents: read
@@ -41,7 +43,9 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
+          # for test! UPDATE!!!
+          ref: users/geomin12/ci-optimize
+          # ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -52,6 +56,7 @@ jobs:
         env:
           PLATFORM: ${{ inputs.platform }}
           project_to_test: ${{ inputs.project_to_test }}
+          TEST_TYPE: ${{ inputs.test_type }}
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          # for test! UPDATE!!!
+          # TODO: Update this ref
           ref: users/geomin12/ci-optimize
           # ref: 67b14d45696cf31a7cf5adbb0743814502e7d190 # 2025-10-08 commit
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -6,18 +6,19 @@
 This document is to detail the various continuous integration (CI) systems that are run on the rocm-libraries monorepo.
 
 ## Table of Contents
-1. [Azure Pipelines](#azure-pipelines)
-    1. [Overview](#az-overview)
-    2. [PR Workflow](#az-workflow)
-    3. [Interpreting Results](#az-results)
-    4. [Build and Test Coverage](#az-coverage)
-    5. [Downstream Job Triggers](#az-downstream)
-2. [Math CI](#math-ci)
-    1. [Overview](#math-overview)
-3. [Windows CI](#windows-ci)
-    1. [Overview](#win-overview)
-4. [TheRock CI](#therock-ci)
-    1. [Overview](#rock-overview)
+- [Continuous Integration](#continuous-integration)
+  - [Table of Contents](#table-of-contents)
+  - [Azure Pipelines](#azure-pipelines)
+    - [Overview ](#overview-)
+    - [PR Workflow ](#pr-workflow-)
+    - [Build and Test Coverage ](#build-and-test-coverage-)
+    - [Downstream Job Triggers ](#downstream-job-triggers-)
+  - [Math CI](#math-ci)
+    - [Overview ](#overview--1)
+  - [Windows CI](#windows-ci)
+    - [Overview ](#overview--2)
+  - [TheRock CI](#therock-ci)
+    - [Overview ](#overview--3)
 
 ## Azure Pipelines
 
@@ -132,3 +133,15 @@ graph TD;
 ## TheRock CI
 
 ### Overview <a id="rock-overview"></a>
+
+TheRock CI runs Linux and Windows builds and tests for nightly jobs, pushes to develop, pull requests and workflow dispatches.
+
+TheRock CI builds using `rocm-libraries` at HEAD with TheRock build system. For testing, we test using TheRock's [`fetch_test_configurations.py`](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/fetch_test_configurations.py) along with [ROCm test machines](https://github.com/ROCm/TheRock/blob/main/build_tools/github_actions/amdgpu_family_matrix.py).
+
+For pull requests and pushes to `develop`:
+- If a change is made to `.github/workflows/therock-*` or `.github/scripts/therock-*`, all projects are built and smoke tests are run.
+- If a change is made to `projects/*` or `shared/*`, TheRock CI will determine which subtree has changed and run the corresponding builds and full tests, using [`therock_matrix.py`](../.github/scripts/therock_matrix.py)
+
+For nightly jobs, TheRock CI runs all builds and full tests for all projects from [`therock_matrix.py`](../.github/scripts/therock_matrix.py).
+
+For workflow dispatch triggers, TheRock CI will run builds and full tests for whichever projects are specified.

--- a/projects/rocprim/example/CMakeLists.txt
+++ b/projects/rocprim/example/CMakeLists.txt
@@ -69,3 +69,4 @@ endfunction()
 
 add_rocprim_example(example_temporary_storage.cpp)
 add_rocprim_example(example_type_traits_interface.cpp)
+add_rocprim_example(example_type_traits_interface.cpp)

--- a/projects/rocprim/example/CMakeLists.txt
+++ b/projects/rocprim/example/CMakeLists.txt
@@ -69,4 +69,3 @@ endfunction()
 
 add_rocprim_example(example_temporary_storage.cpp)
 add_rocprim_example(example_type_traits_interface.cpp)
-add_rocprim_example(example_type_traits_interface.cpp)


### PR DESCRIPTION
Currently, developers are having to wait 3-6+ hours for jobs to begin due to long queue times. We've added more test machines, but we still have long waits due to long test times.

Currently for all pushes, we test all math-libraries with full test suites. This will take up 11+ Linux machines and 9+ windows machines per develop push (at least 15 a day historically, sometimes up to 30+). This will increase over time as we continue to add more coverage.

In this PR, we will create a fine line of coverage and enabling faster tests.

Changes:
- for any `.github/scripts/therock-*` or `.github/workflows/therock-*` changes, we will only run smoke tests
- for pull_requests and pushes to `develop`, we only run full tests based on what has changed (i.e. `projects/hipblaslt` -> `hipblaslt, hipblas, rocblas` tests only
- adding nightly tests to run everything 