### PR TITLE
[URGENT][miopen] Build fix with BUILD_TESTING=false

### DIFF
--- a/projects/miopen/src/hip/handlehip.cpp
+++ b/projects/miopen/src/hip/handlehip.cpp
@@ -28,9 +28,9 @@
 #include <miopen/handle.hpp>
 
 #include <miopen/binary_cache.hpp>
+#include <miopen/config.hpp>
 #include <miopen/env.hpp>
 #include <miopen/errors.hpp>
-#include <miopen/export_internals.h>
 #include <miopen/handle_lock.hpp>
 #include <miopen/invoker.hpp>
 #include <miopen/kernel_cache.hpp>

--- a/projects/miopen/src/include/miopen/sysinfo_utils.hpp
+++ b/projects/miopen/src/include/miopen/sysinfo_utils.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <miopen/export_internals.h>
+#include <miopen/config.hpp>
 #include <string>
 
 namespace miopen {


### PR DESCRIPTION
## Motivation

Fixes a bug where build fails with `-DBUILD_TESTING=false` flag, but works when set to true.

## Technical Details

Conditionally includes the `export_internals.h` using `miopen/config.hpp`.

## Test Plan

Compiling with the `-DBUILD_TESTING=false` after the changes, should not throw any build errors.

## Test Result

Can build with the flag set to `false`, after the fix.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
