### PR TITLE
[rocFFT & hipFFT shared] Revisions to aliasing array identifications

### DIFF
--- a/projects/hipfft/shared/arithmetic.h
+++ b/projects/hipfft/shared/arithmetic.h
@@ -61,6 +61,12 @@ typename Titer::value_type product(Titer begin, Titer end)
         begin, end, typename Titer::value_type(1), std::multiplies<typename Titer::value_type>());
 }
 
+template <typename Titer>
+typename Titer::value_type sum(Titer begin, Titer end, typename Titer::value_type start_sum = 0)
+{
+    return std::accumulate(begin, end, start_sum, std::plus<typename Titer::value_type>());
+}
+
 // count the number of total iterations for 1-, 2-, and 3-D dimensions
 template <typename T1>
 static inline size_t count_iters(const T1& i)

--- a/projects/hipfft/shared/array_validator.cpp
+++ b/projects/hipfft/shared/array_validator.cpp
@@ -22,6 +22,7 @@
 #include <numeric>
 #include <unordered_set>
 
+#include "arithmetic.h"
 #include "array_validator.h"
 #include "increment.h"
 
@@ -64,8 +65,8 @@ bool valid_length_stride_1d_multi(const unsigned int        idx,
 
     // We only need to go to the maximum pointer offset for (l1,s1).
     const auto max_offset
-        = std::accumulate(l1.begin(), l1.end(), (size_t)1, std::multiplies<size_t>())
-          - std ::inner_product(l1.begin(), l1.end(), s1.begin(), (size_t)0);
+        = product(l1.begin(), l1.end())
+          - std ::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0));
     std::unordered_set<size_t> a0{};
     for(size_t i = 1; i < l0; ++i)
     {
@@ -99,7 +100,8 @@ bool valid_length_stride_1d_multi(const unsigned int        idx,
     std::fill(index.begin(), index.end(), 0);
     do
     {
-        const int i = std::inner_product(index.begin(), index.end(), s1.begin(), (size_t)0);
+        const auto i
+            = std::inner_product(index.begin(), index.end(), s1.begin(), static_cast<size_t>(0));
         if(i > 0 && (i % s0 == 0))
         {
             // TODO: use an ordered set and binary search
@@ -136,13 +138,14 @@ bool valid_length_stride_multi_multi(const std::vector<size_t> l0,
     std::unordered_set<size_t> a0{};
 
     const auto max_offset
-        = std::accumulate(l1.begin(), l1.end(), (size_t)1, std::multiplies<size_t>())
-          - std::inner_product(l1.begin(), l1.end(), s1.begin(), (size_t)0);
+        = product(l1.begin(), l1.end())
+          - std::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0));
     std::vector<size_t> index0(l0.size()); // TODO: check this
     std::fill(index0.begin(), index0.end(), 0);
     do
     {
-        const auto i = std::inner_product(index0.begin(), index0.end(), s0.begin(), (size_t)0);
+        const auto i
+            = std::inner_product(index0.begin(), index0.end(), s0.begin(), static_cast<size_t>(0));
         if(i > max_offset)
             a0.insert(i);
     } while(increment_rowmajor(index0, l0));
@@ -151,7 +154,8 @@ bool valid_length_stride_multi_multi(const std::vector<size_t> l0,
     std::fill(index1.begin(), index1.end(), 0);
     do
     {
-        const auto i = std::inner_product(index1.begin(), index1.end(), s1.begin(), (size_t)0);
+        const auto i
+            = std::inner_product(index1.begin(), index1.end(), s1.begin(), static_cast<size_t>(0));
         if(i > 0)
         {
             // TODO: use an ordered set and binary search

--- a/projects/hipfft/shared/array_validator.cpp
+++ b/projects/hipfft/shared/array_validator.cpp
@@ -63,10 +63,11 @@ bool valid_length_stride_1d_multi(const unsigned int        idx,
         std::cout << "l0: " << l0 << "\ts0: " << s0 << std::endl;
     }
 
-    // We only need to go to the maximum pointer offset for (l1,s1).
+    // We only need to go to the maximum pointer offset for (index, s1), wherein
+    // 0 <= index < l1 (element-wise inequalities: max index values are l1 - 1):
     const auto max_offset
-        = product(l1.begin(), l1.end())
-          - std ::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0));
+        = std::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0))
+          - sum(s1.begin(), s1.end());
     std::unordered_set<size_t> a0{};
     for(size_t i = 1; i < l0; ++i)
     {
@@ -137,16 +138,22 @@ bool valid_length_stride_multi_multi(const std::vector<size_t> l0,
 {
     std::unordered_set<size_t> a0{};
 
+    // We only need to go to the min between the max of (index0, s0) and the max
+    // of (index1, s1), wherein 0 <= index{i} < l{i} (i in {0,1}, element-wise
+    // inequalities: max index values are l{i} - 1):
     const auto max_offset
-        = product(l1.begin(), l1.end())
-          - std::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0));
+        = std::min(std::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0))
+                       - sum(s1.begin(), s1.end()),
+                   std::inner_product(l0.begin(), l0.end(), s0.begin(), static_cast<size_t>(0))
+                       - sum(s0.begin(), s0.end()));
+
     std::vector<size_t> index0(l0.size()); // TODO: check this
     std::fill(index0.begin(), index0.end(), 0);
     do
     {
         const auto i
             = std::inner_product(index0.begin(), index0.end(), s0.begin(), static_cast<size_t>(0));
-        if(i > max_offset)
+        if(i > 0 && i <= max_offset)
             a0.insert(i);
     } while(increment_rowmajor(index0, l0));
 
@@ -156,12 +163,11 @@ bool valid_length_stride_multi_multi(const std::vector<size_t> l0,
     {
         const auto i
             = std::inner_product(index1.begin(), index1.end(), s1.begin(), static_cast<size_t>(0));
-        if(i > 0)
+        if(i > 0 && i <= max_offset)
         {
             // TODO: use an ordered set and binary search
             if(a0.find(i) != a0.end())
             {
-
                 return false;
             }
         }
@@ -259,6 +265,10 @@ bool valid_length_stride_4d(const std::vector<size_t>& l,
             std::cout << "\n";
         }
     } while(std::next_permutation(v.begin(), v.end()));
+    // TODO: permutations a and b are equivalent if they complement one another,
+    // i.e., if a + b == 1 element-wise ([l0, s0] swap roles with [l1, s1] below).
+    // Only half the permutations are not redundant, one could/should reduce the
+    // workload below by half.
 
     // Then loop over all of the permutations.
 #ifdef _OPENMP
@@ -266,10 +276,10 @@ bool valid_length_stride_4d(const std::vector<size_t>& l,
 #endif
     for(size_t iperm = 0; iperm < perms.size(); ++iperm)
     {
-        std::vector<size_t> l0(2);
-        std::vector<size_t> s0(2);
-        std::vector<size_t> l1(2);
-        std::vector<size_t> s1(2);
+        std::vector<size_t> l0;
+        std::vector<size_t> s0;
+        std::vector<size_t> l1;
+        std::vector<size_t> s1;
         for(size_t i = 0; i < l.size(); ++i)
         {
             if(perms[iperm][i] == 0)
@@ -338,8 +348,8 @@ bool valid_length_stride_generald(const std::vector<size_t> l,
     // Recurse on d-1 hyper-faces:
     for(unsigned int idx = 0; idx < l.size(); ++idx)
     {
-        std::vector<size_t> l0{};
-        std::vector<size_t> s0{};
+        std::vector<size_t> l0;
+        std::vector<size_t> s0;
         for(size_t i = 0; i < l.size(); ++i)
         {
             if(i != idx)
@@ -396,14 +406,14 @@ bool valid_length_stride_generald(const std::vector<size_t> l,
 #endif
         for(size_t iperm = 0; iperm < perms.size(); ++iperm)
         {
-            std::vector<size_t> l0(dim0);
-            std::vector<size_t> s0(dim0);
-            std::vector<size_t> l1(dim1);
-            std::vector<size_t> s1(dim1);
+            std::vector<size_t> l0;
+            std::vector<size_t> s0;
+            std::vector<size_t> l1;
+            std::vector<size_t> s1;
 
             for(size_t i = 0; i < l.size(); ++i)
             {
-                if(v[i] == 0)
+                if(perms[iperm][i] == 0)
                 {
                     l0.push_back(l[i]);
                     s0.push_back(s[i]);

--- a/projects/rocfft/clients/tests/validate_length_stride.cpp
+++ b/projects/rocfft/clients/tests/validate_length_stride.cpp
@@ -25,7 +25,7 @@
 #include <random>
 #include <unordered_set>
 
-inline auto generate_valid_length_stride()
+inline auto generate_length_stride()
 {
     // Array of tuples of length, stride.
     std::vector<std::tuple<std::vector<size_t>, std::vector<size_t>>> vals = {
@@ -40,7 +40,10 @@ inline auto generate_valid_length_stride()
         {{8, 8, 8, 8, 8}, {4096, 512, 64, 7, 1}},
         {{8, 8, 8, 8, 8, 8}, {32768, 4096, 512, 64, 8, 1}},
         {{299, 307, 495}, {1006, 50, 674}},
-
+        // invalid due to collision for (11, 0, 0, 1) and (0, 1, 1, 0):
+        {{12, 2, 2, 2}, {7, 37, 43, 3}},
+        // invalid due to collision for (1, 0, 0, 0, 3) and (0, 4, 1, 1, 0):
+        {{2, 5, 4, 6, 4}, {750, 201, 16, 17, 29}},
     };
 
     return vals;
@@ -120,4 +123,4 @@ TEST_P(valid_length_stride, direct_comparison)
 
 INSTANTIATE_TEST_SUITE_P(reference_test,
                          valid_length_stride,
-                         ::testing::ValuesIn(generate_valid_length_stride()));
+                         ::testing::ValuesIn(generate_length_stride()));

--- a/projects/rocfft/shared/arithmetic.h
+++ b/projects/rocfft/shared/arithmetic.h
@@ -61,6 +61,12 @@ typename Titer::value_type product(Titer begin, Titer end)
         begin, end, typename Titer::value_type(1), std::multiplies<typename Titer::value_type>());
 }
 
+template <typename Titer>
+typename Titer::value_type sum(Titer begin, Titer end, typename Titer::value_type start_sum = 0)
+{
+    return std::accumulate(begin, end, start_sum, std::plus<typename Titer::value_type>());
+}
+
 // count the number of total iterations for 1-, 2-, and 3-D dimensions
 template <typename T1>
 static inline size_t count_iters(const T1& i)

--- a/projects/rocfft/shared/array_validator.cpp
+++ b/projects/rocfft/shared/array_validator.cpp
@@ -63,10 +63,11 @@ bool valid_length_stride_1d_multi(const unsigned int        idx,
         std::cout << "l0: " << l0 << "\ts0: " << s0 << std::endl;
     }
 
-    // We only need to go to the maximum pointer offset for (l1,s1).
+    // We only need to go to the maximum pointer offset for (index, s1), wherein
+    // 0 <= index < l1 (element-wise inequalities: max index values are l1 - 1):
     const auto max_offset
-        = product(l1.begin(), l1.end())
-          - std ::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0));
+        = std::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0))
+          - sum(s1.begin(), s1.end());
     std::unordered_set<size_t> a0{};
     for(size_t i = 1; i < l0; ++i)
     {
@@ -137,16 +138,22 @@ bool valid_length_stride_multi_multi(const std::vector<size_t> l0,
 {
     std::unordered_set<size_t> a0{};
 
+    // We only need to go to the min between the max of (index0, s0) and the max
+    // of (index1, s1), wherein 0 <= index{i} < l{i} (i in {0,1}, element-wise
+    // inequalities: max index values are l{i} - 1):
     const auto max_offset
-        = product(l1.begin(), l1.end())
-          - std::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0));
+        = std::min(std::inner_product(l1.begin(), l1.end(), s1.begin(), static_cast<size_t>(0))
+                       - sum(s1.begin(), s1.end()),
+                   std::inner_product(l0.begin(), l0.end(), s0.begin(), static_cast<size_t>(0))
+                       - sum(s0.begin(), s0.end()));
+
     std::vector<size_t> index0(l0.size()); // TODO: check this
     std::fill(index0.begin(), index0.end(), 0);
     do
     {
         const auto i
             = std::inner_product(index0.begin(), index0.end(), s0.begin(), static_cast<size_t>(0));
-        if(i > max_offset)
+        if(i > 0 && i <= max_offset)
             a0.insert(i);
     } while(increment_rowmajor(index0, l0));
 
@@ -156,12 +163,11 @@ bool valid_length_stride_multi_multi(const std::vector<size_t> l0,
     {
         const auto i
             = std::inner_product(index1.begin(), index1.end(), s1.begin(), static_cast<size_t>(0));
-        if(i > 0)
+        if(i > 0 && i <= max_offset)
         {
             // TODO: use an ordered set and binary search
             if(a0.find(i) != a0.end())
             {
-
                 return false;
             }
         }
@@ -259,6 +265,10 @@ bool valid_length_stride_4d(const std::vector<size_t>& l,
             std::cout << "\n";
         }
     } while(std::next_permutation(v.begin(), v.end()));
+    // TODO: permutations a and b are equivalent if they complement one another,
+    // i.e., if a + b == 1 element-wise ([l0, s0] swap roles with [l1, s1] below).
+    // Only half the permutations are not redundant, one could/should reduce the
+    // workload below by half.
 
     // Then loop over all of the permutations.
 #ifdef _OPENMP
@@ -266,10 +276,10 @@ bool valid_length_stride_4d(const std::vector<size_t>& l,
 #endif
     for(size_t iperm = 0; iperm < perms.size(); ++iperm)
     {
-        std::vector<size_t> l0(2);
-        std::vector<size_t> s0(2);
-        std::vector<size_t> l1(2);
-        std::vector<size_t> s1(2);
+        std::vector<size_t> l0;
+        std::vector<size_t> s0;
+        std::vector<size_t> l1;
+        std::vector<size_t> s1;
         for(size_t i = 0; i < l.size(); ++i)
         {
             if(perms[iperm][i] == 0)
@@ -338,8 +348,8 @@ bool valid_length_stride_generald(const std::vector<size_t> l,
     // Recurse on d-1 hyper-faces:
     for(unsigned int idx = 0; idx < l.size(); ++idx)
     {
-        std::vector<size_t> l0{};
-        std::vector<size_t> s0{};
+        std::vector<size_t> l0;
+        std::vector<size_t> s0;
         for(size_t i = 0; i < l.size(); ++i)
         {
             if(i != idx)
@@ -396,14 +406,14 @@ bool valid_length_stride_generald(const std::vector<size_t> l,
 #endif
         for(size_t iperm = 0; iperm < perms.size(); ++iperm)
         {
-            std::vector<size_t> l0(dim0);
-            std::vector<size_t> s0(dim0);
-            std::vector<size_t> l1(dim1);
-            std::vector<size_t> s1(dim1);
+            std::vector<size_t> l0;
+            std::vector<size_t> s0;
+            std::vector<size_t> l1;
+            std::vector<size_t> s1;
 
             for(size_t i = 0; i < l.size(); ++i)
             {
-                if(v[i] == 0)
+                if(perms[iperm][i] == 0)
                 {
                     l0.push_back(l[i]);
                     s0.push_back(s[i]);


### PR DESCRIPTION
## Motivation

I believe there are mistakes/typos/bugs in the current implementation details of `array_valid`. For instance, the test token `complex_forward_len_12_2_2_single_ip_batch_2_istride_7_37_43_CI_ostride_7_37_43_CI_idist_3_odist_3_ioffset_0_0_ooffset_0_0` is not rejected as of now, yet element of index $(11, 0, 0)$ in batch index $1$ does conflict with element of index $(0, 1, 1)$ in batch index $0$ for that layout configuration.

## Technical Details

The suggested changes boil down to algebraic- and logic-based revisions of the current implementations. More details in original comments from the PR author.

## Test Plan

- The modified code paths are possibly taken only for assessing the validity of highly unusual data layouts (current test coverage thereof is very limited);
- Tested manually with the token mentioned above (and others of the same kind): any suggestion regarding "easy" test improvement(s) specifically for the modified paths is welcome.

## Test Result

For the token mentioned above for instance: it is incorrectly accepted by the test clients on the current status of develop, failing to pass the accuracy test thereafter; with the suggested changes, the token is rejected as it should be.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
