### PR TITLE
[hipblaslt] Separate architecture validation from sanitizer mode.

### DIFF
--- a/projects/hipblaslt/cmake/tensilelite_supported_architectures.cmake
+++ b/projects/hipblaslt/cmake/tensilelite_supported_architectures.cmake
@@ -1,18 +1,47 @@
 # Copyright Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
-# Base architectures - used when "all" is specified for GPU_TARGETS
-set(BASE_ARCHITECTURES "")
-
 # All supported architectures including xnack variants - used for validation of GPU_TARGETS
-set(SUPPORTED_ARCHITECTURES "")
+set(SUPPORTED_ARCHITECTURES
+    "gfx908"
+    "gfx90a"
+    "gfx942"
+    "gfx950"
+    "gfx1100"
+    "gfx1101"
+    "gfx1103"
+    "gfx1150"
+    "gfx1151"
+    "gfx1200"
+    "gfx1201"
+    "gfx908:xnack+"
+    "gfx908:xnack-"
+    "gfx90a:xnack+"
+    "gfx90a:xnack-"
+    "gfx942:xnack+"
+    "gfx950:xnack+"    
+)
+
+# Base architectures - used when "all" is specified for GPU_TARGETS
+# Different base architectures will be chosen depending on the build mode.
+# All base architectures must be in the SUPPORTED_ARCHITECTURES list.
+set(BASE_ARCHITECTURES)
 
 # Note:
 # gfx10XX architectures (e.g., gfx1010, gfx1011, gfx1030, etc...) are technically supported by tensilelite,
 # but are NOT included in the default "all" build in hipBLASLt. This is because "extops" builds are not supported
 # for legacy devices. Including these architectures would result in build failures or incomplete feature support.
-if(NOT BUILD_ADDRESS_SANITIZER)
-    list(APPEND BASE_ARCHITECTURES
+if(BUILD_ADDRESS_SANITIZER OR THEROCK_SANITIZER STREQUAL "ASAN")
+    # For address sanitizer builds, "all" is just the architectures that
+    # support xnack+.
+    set(BASE_ARCHITECTURES
+        "gfx908:xnack+"
+        "gfx90a:xnack+"
+        "gfx942:xnack+"
+        "gfx950:xnack+")
+else()
+    # For non address sanitizer builds, "all" is non-xnack architectures.
+    set(BASE_ARCHITECTURES
         "gfx908"
         "gfx90a"
         "gfx942"
@@ -24,23 +53,17 @@ if(NOT BUILD_ADDRESS_SANITIZER)
         "gfx1151"
         "gfx1200"
         "gfx1201")
-
-    set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
-    list(APPEND SUPPORTED_ARCHITECTURES
-        "gfx908:xnack+"
-        "gfx908:xnack-"
-        "gfx90a:xnack+"
-        "gfx90a:xnack-")
-
-else()
-    # For address sanitizer builds, base and supported are the same
-    list(APPEND BASE_ARCHITECTURES
-        "gfx908:xnack+"
-        "gfx90a:xnack+"
-        "gfx942:xnack+"
-        "gfx950:xnack+")
-    set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
 endif()
+
+# Validate that all BASE_ARCHITECTURES are in the SUPPORTED_ARCHITECTURES list
+# so that we eagerly fail if these ever get out of sync.
+block()
+    foreach(_arch ${BASE_ARCHITECTURES})
+        if(NOT "${_arch}" IN_LIST SUPPORTED_ARCHITECTURES)
+            message(FATAL_ERROR "Assertion failed: ${_arch} not in SUPPORTED_ARCHITECTURES")
+        endif()
+    endforeach()
+endblock()
 
 function(tensilelite_validate_gpu_targets targets)
     set(supported_list ${SUPPORTED_ARCHITECTURES})

--- a/projects/hipblaslt/cmake/tensilelite_supported_architectures.cmake
+++ b/projects/hipblaslt/cmake/tensilelite_supported_architectures.cmake
@@ -31,7 +31,7 @@ set(BASE_ARCHITECTURES)
 # gfx10XX architectures (e.g., gfx1010, gfx1011, gfx1030, etc...) are technically supported by tensilelite,
 # but are NOT included in the default "all" build in hipBLASLt. This is because "extops" builds are not supported
 # for legacy devices. Including these architectures would result in build failures or incomplete feature support.
-if(BUILD_ADDRESS_SANITIZER OR THEROCK_SANITIZER STREQUAL "ASAN")
+if(HIPBLASLT_ENABLE_ASAN OR THEROCK_SANITIZER STREQUAL "ASAN")
     # For address sanitizer builds, "all" is just the architectures that
     # support xnack+.
     set(BASE_ARCHITECTURES


### PR DESCRIPTION
* Prior to this, we were coupling the overall ASAN mode (which includes both host and device ASAN) with validation of which architectures are allowed to be generated.
* gfx942/gfx950 xnack+ variants were not available to build except in the component level ASAN setup.
* Changes to validate explicit GFX targets against all targets that the library knows about while making the ASAN mode only control interpretation of the "all" target (which I think was the original intent of the patch which introduced this logic).
* All component specific ASAN processing is now deprecated and being brought into alignment with the overall design doc https://github.com/ROCm/TheRock/blob/main/docs/development/sanitizers.md
* This brings hipblaslt target selection into compliance with that doc and is needed to unblock new ASAN build pipelines.
* Should be NFC for existing pipelines.
