### PR TITLE
Move the builtin to a seperate if statements

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_crosslane.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_crosslane.hpp
@@ -47,11 +47,15 @@ private:
         // We use a dispatch here because when we target SPIR-V, we have to know after
         // compiling SPIR-V whether DPP is available. Therefore, this check cannot
         // be done at the C++ constexpr-level.
-        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
+        if constexpr(UseDPP)
         {
-            if constexpr(UseDPP)
+            if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP())
             {
                 f(warp_reduce_dpp<T, VirtualWaveSize, UseAllReduce>{});
+            }
+            else
+            {
+                f(warp_reduce_shuffle<T, VirtualWaveSize, UseAllReduce>{});
             }
         }
         else

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_crosslane.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_crosslane.hpp
@@ -44,11 +44,15 @@ private:
         // We use a dispatch here because when we target SPIR-V, we have to know after
         // compiling SPIR-V whether DPP is available. Therefore, this check cannot
         // be done at the C++ constexpr-level.
-        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP() && UseDPP)
+        if constexpr(UseDPP)
         {
-            if constexpr(UseDPP)
+            if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP())
             {
                 f(warp_scan_dpp<T, VirtualWaveSize>{});
+            }
+            else
+            {
+                f(warp_scan_shuffle<T, VirtualWaveSize>{});
             }
         }
         else


### PR DESCRIPTION
## Motivation

The __builtin_amdgcn_is_invocable can not be used with the && operator with booleans. This is the same logic just without using &&.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
