### PR TITLE
[MIOpen] Use specific CK libs

### DIFF
--- a/projects/miopen/CMakeLists.txt
+++ b/projects/miopen/CMakeLists.txt
@@ -352,7 +352,7 @@ if( MIOPEN_BACKEND STREQUAL "HIP" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_B
             endif()
             miopen_add_dependency(composable_kernel HASH ${COMPOSABLE_KERNEL_HASH} options NO_LOCAL)
         else()
-            find_package(composable_kernel 1.0.0 COMPONENTS device_conv_operations)
+            find_package(composable_kernel 1.0.0 COMPONENTS device_conv_ndhwgc_operations device_conv_nhwgc_operations device_conv_old_operations)
         endif()
     endif()
     if( MIOPEN_BACKEND STREQUAL "HIPNOGPU")

--- a/projects/miopen/requirements.txt
+++ b/projects/miopen/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.22
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@38c52448b1a4996b3e0e435a877d02441098b1dd
-ROCm/composable_kernel@8fe3838c65ab4c290423ff0e952e882c19e2c60d -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@8bdf814805e3fdb3f1c5750f9f2c92f91a17f91d -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0

--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -885,7 +885,7 @@ if(MIOPEN_USE_COMPOSABLEKERNEL)
     if(MIOPEN_BUILD_CK )
         # the aliased target doesnt exist when we build CK inline as part of MIOPEN.  The aliased target only is not
         # global when you build it so we dont have access to it.
-        set(MIOPEN_CK_LINK_FLAGS device_conv_operations hip::host)
+        set(MIOPEN_CK_LINK_FLAGS device_conv_ndhwgc_operations device_conv_nhwgc_operations device_conv_old_operations hip::host)
 
         # The include directories also dont propagate correctly when using the non aliased targets.
         # Manually including them fixes this problem for inline builds.
@@ -895,7 +895,7 @@ if(MIOPEN_USE_COMPOSABLEKERNEL)
             ${MIOPEN_CK_LIBRARY_INCLUDE_DIR})
     else()
         # Use the aliased targets when we pull CK from /opt/rocm or other place on disc.
-        set(MIOPEN_CK_LINK_FLAGS composable_kernel::device_conv_operations hip::host)
+        set(MIOPEN_CK_LINK_FLAGS composable_kernel::device_conv_ndhwgc_operations composable_kernel::device_conv_nhwgc_operations composable_kernel::device_conv_old_operations hip::host)
     endif()
 endif()
 


### PR DESCRIPTION
## Motivation

MIOpen only uses a subset of the CK convolution kernels.  To help reduce build times, CK has started partitioning its conv kernels into multiple static libraries since that will allow just the subset of CK that MIOpen needs to be built. 

## Technical Details

The CK convolution library, device_conv_operations, is replaced by three smaller libraries:  device_conv_ndhwgc_operations, device_conv_nhwgc_operations, and device_conv_old_operations.

## Test Plan

It is sufficient to build the changes and run through CI.  For now this includes a temporary commit for the associated CK changes.

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [ ] Temporary CK commit has been reverted (and associated CK changes merged/staged): https://github.com/ROCm/composable_kernel/pull/3010
