### PR TITLE
added missing header

### DIFF
--- a/projects/hipsparse/clients/include/hipsparse_test.hpp
+++ b/projects/hipsparse/clients/include/hipsparse_test.hpp
@@ -29,6 +29,7 @@
 #include "hipsparse_arguments.hpp"
 #include "hipsparse_test_cleanup.hpp"
 
+#include <algorithm>
 #include <cstdio>
 #include <sstream>
 #include <type_traits>


### PR DESCRIPTION
Added missing `algorithm` header in order to be able to use `std::replace` etc.