### PR TITLE
[MIOpen] Fix Bnorm tuning

### DIFF
--- a/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
@@ -308,8 +308,9 @@ ConvSolution BnFwdTrainingSpatial::GetSolution(const ExecutionContext& context,
             {"MIOPEN_USE_FPMIX", static_cast<int>(bfpmixparm)},
             {"MIOPEN_USE_BFPMIX", static_cast<int>(bbfpmixparam)},
             {"MIO_SAVE_MEAN_VARIANCE", static_cast<int>(problem.GetResultSave())},
-            {"MIO_RUNNING_RESULT", context.is_for_generic_search ?
-                static_cast<int>(0) : static_cast<int>(problem.GetResultRunning())},
+            {"MIO_RUNNING_RESULT",
+             context.is_for_generic_search ? static_cast<int>(0)
+                                           : static_cast<int>(problem.GetResultRunning())},
             {"MIO_BN_VARIANT", variant},
             {"MIO_BN_LDS_SIZE", ldsnogcn},
             {"MIO_BN_LDSGCN_SIZE", std::to_string(ldsgcn)},
@@ -397,9 +398,9 @@ ConvSolution BnFwdTrainingSpatial::GetSolution(const ExecutionContext& context,
             decltype(auto) params = raw_params.CastTo<miopen::batchnorm::FwdTrainInvokeParams>();
             const auto resultsave =
                 params.resultSaveMean != nullptr && params.resultSaveInvVariance != nullptr;
-            const auto resultrunning =
-                params.resultRunningMean != nullptr && params.resultRunningVariance != nullptr &&
-                !context.is_for_generic_search;
+            const auto resultrunning = params.resultRunningMean != nullptr &&
+                                       params.resultRunningVariance != nullptr &&
+                                       !context.is_for_generic_search;
 
             float alpha_activ = problem.GetActivationDesc().GetAlpha();
             float beta_activ  = problem.GetActivationDesc().GetBeta();

--- a/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
@@ -308,7 +308,8 @@ ConvSolution BnFwdTrainingSpatial::GetSolution(const ExecutionContext& context,
             {"MIOPEN_USE_FPMIX", static_cast<int>(bfpmixparm)},
             {"MIOPEN_USE_BFPMIX", static_cast<int>(bbfpmixparam)},
             {"MIO_SAVE_MEAN_VARIANCE", static_cast<int>(problem.GetResultSave())},
-            {"MIO_RUNNING_RESULT", static_cast<int>(problem.GetResultRunning())},
+            {"MIO_RUNNING_RESULT", context.is_for_generic_search ?
+                static_cast<int>(0) : static_cast<int>(problem.GetResultRunning())},
             {"MIO_BN_VARIANT", variant},
             {"MIO_BN_LDS_SIZE", ldsnogcn},
             {"MIO_BN_LDSGCN_SIZE", std::to_string(ldsgcn)},
@@ -397,7 +398,8 @@ ConvSolution BnFwdTrainingSpatial::GetSolution(const ExecutionContext& context,
             const auto resultsave =
                 params.resultSaveMean != nullptr && params.resultSaveInvVariance != nullptr;
             const auto resultrunning =
-                params.resultRunningMean != nullptr && params.resultRunningVariance != nullptr;
+                params.resultRunningMean != nullptr && params.resultRunningVariance != nullptr &&
+                !context.is_for_generic_search;
 
             float alpha_activ = problem.GetActivationDesc().GetAlpha();
             float beta_activ  = problem.GetActivationDesc().GetBeta();


### PR DESCRIPTION
## Motivation

Incorrect results while tuning bnorm fwd train using running mean / variance.

## Technical Details

Disable running mean/variance during tuning and re-enable it for the last run with the best configuration

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
