### PR TITLE
[hipblaslt] allow A type not equal to B type for a setProblem cpp API

### DIFF
--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -1938,7 +1938,7 @@ Tests:
   alpha: 1
   beta: [ 0, 2 ]
   use_ext: [1]
-  use_ext_setproblem: [1]
+  use_ext_setproblem: [0, 1]
   bias_vector: 1
   bias_type: [f32_r]
   unit_check: 1

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -1085,7 +1085,7 @@ rocblaslt_status rocblaslt_gemm_create_cpp(const rocblaslt_handle           hand
         return rocblaslt_status_invalid_handle;
     }
 
-    if(matA->type != matB->type || matC->type != matD->type)
+    if(matC->type != matD->type)
     {
         log_error(__func__, "invalid matrix datatype");
         return rocblaslt_status_type_mismatch;


### PR DESCRIPTION
## Motivation

setProblem with hipblasLtMatmulDesc_t originally has this restriction. setProblem without hipblasLtMatmulDesc_t doesn't have this restriction

## Technical Details

allow A type not equal to B type for a setProblem cpp API

## Test Plan

Add test 

## Test Result

pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
