### PR TITLE
[fft] Resolving FFT patch for TheRock

### DIFF
--- a/projects/hipfft/clients/tests/CMakeLists.txt
+++ b/projects/hipfft/clients/tests/CMakeLists.txt
@@ -70,8 +70,13 @@ else()
   find_package(FFTW3f CONFIG QUIET )
   if( FFTW3_FOUND AND FFTW3f_FOUND )
     message(STATUS "FFTW3 found by using the FFTW3Config.cmake")
-    get_target_property(fftw3_libs FFTW3::fftw3 IMPORTED_LOCATION_RELEASE)
-    get_target_property(fftw3f_libs FFTW3::fftw3f IMPORTED_LOCATION_RELEASE)
+    if ( NOT WIN32 )
+      get_target_property(fftw3_libs FFTW3::fftw3 IMPORTED_LOCATION_RELEASE)
+      get_target_property(fftw3f_libs FFTW3::fftw3f IMPORTED_LOCATION_RELEASE)
+    else()
+      get_target_property(fftw3_libs FFTW3::fftw3 IMPORTED_IMPLIB_RELEASE)
+      get_target_property(fftw3f_libs FFTW3::fftw3f IMPORTED_IMPLIB_RELEASE)
+    endif()
 
     # Look for omp (preferred) or thread libraries. These are not a
     # hard requirement, but are nice to have to make FFTW run faster.

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -128,8 +128,13 @@ if( NOT BUILD_FFTW )
     find_package(FFTW3f CONFIG QUIET )
     if( FFTW3_FOUND AND FFTW3f_FOUND )
       message(STATUS "FFTW3 found by using the FFTW3Config.cmake")
-      get_target_property(fftw3_libs FFTW3::fftw3 IMPORTED_LOCATION_RELEASE)
-      get_target_property(fftw3f_libs FFTW3::fftw3f IMPORTED_LOCATION_RELEASE)
+      if ( NOT WIN32 )
+        get_target_property(fftw3_libs FFTW3::fftw3 IMPORTED_LOCATION_RELEASE)
+        get_target_property(fftw3f_libs FFTW3::fftw3f IMPORTED_LOCATION_RELEASE)
+      else()
+        get_target_property(fftw3_libs FFTW3::fftw3 IMPORTED_IMPLIB_RELEASE)
+        get_target_property(fftw3f_libs FFTW3::fftw3f IMPORTED_IMPLIB_RELEASE)
+      endif()
 
       # Look for omp (preferred) or thread libraries. These are not a
       # hard requirement, but are nice to have to make FFTW run faster.


### PR DESCRIPTION
## Motivation

This change allows rocFFT and hipFFT to search and find the correct fftw3 library for Windows

## Technical Details

During TheRock Window builds, we found errors such as: 

```
2025-10-13T20:39:47.0858659Z [rocFFT] lld-link: error: B:/build/third-party/fftw3/build_fftw3/dist/bin/fftw3.dll: bad file type. Did you specify a DLL instead of an import library?
2025-10-13T20:39:47.0859313Z [rocFFT] lld-link: error: B:/build/third-party/fftw3/build_fftw3f/dist/bin/fftw3f.dll: bad file type. Did you specify a DLL instead of an import library?
```

We initially had [a patch](https://github.com/ROCm/TheRock/blob/6d79cae0b946d8e7550f238eef5dea460e1a0448/patches/amd-mainline/rocm-libraries/0009-rocfft-test-and-hipfft-test-linking-fix-on-windows.patch), but better to just land upstream!

## Test Plan

TheRock builds and tests here: https://github.com/ROCm/TheRock/actions/runs/18515499120?pr=1380

## Test Result

TheRock builds and tests here: https://github.com/ROCm/TheRock/actions/runs/18515499120?pr=1380

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
