### PR TITLE
[TheRock CI] Updating docker sha

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:044b113562629f4bd2ec5d2e64b32eee11562d48fb1a75d7493daec9dd8d8292
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:2f3ebd0beb04c449fdb36933e54bdc69483b914fb9005594d3fc9444c206b54b
       options: -v /runner/config:/home/awsconfig/
     strategy:
       fail-fast: true


### PR DESCRIPTION
Seeing errors such as 

```
Submodule path 'compiler/hipify': checked out 'f5d07c5006d720dedf4a0560200a856c4c192898'
Submodule path 'compiler/spirv-llvm-translator': checked out '37f7ea5856785732839305e6a92af19ff2ea4958'
Submodule path 'profiler/rocprof-trace-decoder/binaries': checked out 'e2609d6e2ce1ab6fba6f7e095fc614ccd8b772ae'
Submodule path 'rocm-systems': checked out '538ebc5409e139d0c4c4e9b86c284f98ff488990'
`dvc` not found, skipping large file pull on Linux.
++ Exec [/__w/rocm-libraries/rocm-libraries/TheRock]$ git update-index --no-skip-worktree -- base/amdsmi base/half comm-libs/rccl comm-libs/rccl-tests base/rocm-cmake profiler/rocprof-trace-decoder/binaries compiler/hipify compiler/amd-llvm compiler/spirv-llvm-translator rocm-systems
```

New docker SHA will now include dvc