### PR TITLE
[rocBLAS] Fix precision errors in GEMV on MI200

### DIFF
--- a/projects/rocblas/clients/gtest/gemm_gtest.yaml
+++ b/projects/rocblas/clients/gtest/gemm_gtest.yaml
@@ -3685,6 +3685,22 @@ Tests:
   use_hipblaslt: 0
   os_flags: LINUX
 
+- name: gemm_ex_h2f #SWDEV-560127
+  category: pre_checkin
+  function: gemm_ex
+  matrix_size:
+    - { M:     1, N:     1, K:    32, lda:    32, ldb:     1, ldc:     1, ldd:     1 }
+    - { M:     1, N:     1, K:    64, lda:    64, ldb:     1, ldc:     1, ldd:     1 }
+  precision:
+    - *hpa_half_in_single_out_precision
+    - *hpa_bf16_in_single_out_precision
+  transA_transB:
+    - { transA: N, transB: N }
+    - { transA: T, transB: T }
+    - { transA: T, transB: N }
+  alpha_beta: *alpha_beta_range
+  initialization: hpl
+  os_flags: LINUX
 
 # Commented out as the category known_bug has currently no good purpose
 # This is category known_bug until the sizes are supported by Tensile,

--- a/projects/rocblas/library/src/blas2/gemv_device.hpp
+++ b/projects/rocblas/library/src/blas2/gemv_device.hpp
@@ -1214,10 +1214,10 @@ ROCBLAS_KERNEL_ILF void rocblas_gemvt_kernel_calc(rocblas_int m,
     rocblas_int m_full = (m / NB_X) * NB_X;
 
     for(rocblas_int i = 0; i < m_full; i += NB_X)
-        res += (CONJ ? conj(A[i]) : A[i]) * x[(tx + i) * int64_t(incx)];
+        res += Tex((CONJ ? conj(A[i]) : A[i])) * Tex(x[(tx + i) * int64_t(incx)]);
 
     if(tx + m_full < m)
-        res += (CONJ ? conj(A[m_full]) : A[m_full]) * x[(tx + m_full) * int64_t(incx)];
+        res += Tex((CONJ ? conj(A[m_full]) : A[m_full])) * Tex(x[(tx + m_full) * int64_t(incx)]);
 
     sdata[tx] = res;
 

--- a/projects/rocblas/library/src/blas2/gemv_device.hpp
+++ b/projects/rocblas/library/src/blas2/gemv_device.hpp
@@ -1283,10 +1283,10 @@ ROCBLAS_KERNEL_ILF void rocblas_gemvt_reduce_kernel_calc(rocblas_int m,
     //Each column of Matrix A is multiplied with vector x and the resultant value is stored in res.
     //If m > NB_X, then the threads are reused and the multiplied values will be accumalated.
     for(rocblas_int i = 0; tx + i < m_full; i += NB_X)
-        res += (CONJ ? conj(A[i]) : A[i]) * x[(tx + i) * (incx)];
+        res += Tex((CONJ ? conj(A[i]) : A[i])) * Tex(x[(tx + i) * (incx)]);
 
     if(tx + m_full < m)
-        res += (CONJ ? conj(A[m_full]) : A[m_full]) * x[(tx + m_full) * (incx)];
+        res += Tex((CONJ ? conj(A[m_full]) : A[m_full])) * Tex(x[(tx + m_full) * (incx)]);
 
     static_assert(NB_X > WARP_32);
 


### PR DESCRIPTION
## Motivation
[SWDEV-560127](https://ontrack-internal.amd.com/browse/SWDEV-560127) rocblas MI200 accuracy regression in ROCm 7.0 for fp16 or bf16 input with fp32 output

## Technical Details

Fixed the cumulative rounding errors in GEMV to convert to required datatype before the multiplication. 

## Test Plan
- Validate rocBLAS build using the './install.sh -dc -a auto' command
- Run pre_checkin tests
```shell
./rocblas-test --gtest_filter=*pre_checkin*
``` 
- Run specific tests related to this PR 
```shell
./rocblas-test --gtest_filter=*gemm_ex_h2f*
``` 

## Test Result

- rocBLAS Build successful
- rocblas-test pre_checkin passed
- rocblas-test gemm_ex_h2f tests passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
