### PR TITLE
[rocRAND]: Restore normal-double MT19937 generation throughput on MI100

### DIFF
--- a/projects/rocrand/library/src/rng/mt19937.hpp
+++ b/projects/rocrand/library/src/rng/mt19937.hpp
@@ -203,7 +203,7 @@ void jump_ahead_mt19937(dim3 block_idx,
                 unsigned int tm = temp[wrap_n(ptr + mt19937_constants::m)];
                 unsigned int y
                     = (t0 & mt19937_constants::upper_mask) | (t1 & mt19937_constants::lower_mask);
-                temp[ptr] = tm ^ (y >> 1) ^ ((y & 0x1U) ? mt19937_constants::matrix_a : 0);
+                temp[ptr] = tm ^ (y >> 1) ^ (((y & 1) ? -1 : 0) & mt19937_constants::matrix_a);
             }
             system::syncthreads<isDevice>{}();
             ptr = wrap_n(ptr + 1);

--- a/projects/rocrand/library/src/rng/mt19937_octo_engine.hpp
+++ b/projects/rocrand/library/src/rng/mt19937_octo_engine.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -188,7 +188,7 @@ struct mt19937_octo_engine
     {
         const unsigned int y
             = (mt_i & mt19937_constants::upper_mask) | (mt_i_1 & mt19937_constants::lower_mask);
-        const unsigned int mag = (y & 0x1U) * mt19937_constants::matrix_a;
+        unsigned int mag = ((y & 1) ? -1 : 0) & mt19937_constants::matrix_a;
         return mt_i_m ^ (y >> 1) ^ mag;
     }
 


### PR DESCRIPTION

## Motivation

 Restoring and gaining some performance for MT19937 generator for normal-double on MI100 GPU

## Technical Details

Two-liner change which produces more optimized assembly

## Test Plan

Benchmarks and tests

## Test Result

 2% performance improvement for the mentioned case compared to the "before-regression" state

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
