### PR TITLE
[MIOpen] Cleanup HIP error generated during invalid device ordinal test

### DIFF
--- a/projects/miopen/test/gtest/handle_hip_device.cpp
+++ b/projects/miopen/test/gtest/handle_hip_device.cpp
@@ -26,6 +26,13 @@ protected:
         }
     }
 
+    void TearDown() override
+    {
+        // Clear any HIP error triggered by asking for an invalid device ordinal
+        hipGetLastError();
+        hipExtGetLastError();
+    }
+
     int device_count_ = 0;
 };
 
@@ -57,10 +64,6 @@ TEST_F(CPU_HandleHipDevice_NONE, NegativeDeviceIdThrowsWithCorrectMessage)
         std::string error_msg = ex.what();
         EXPECT_NE(error_msg.find("Error setting device"), std::string::npos);
         EXPECT_NE(error_msg.find("-10"), std::string::npos);
-        
-        // Clear any HIP error triggered by asking for an invalid device ordinal
-        hipGetLastError();
-        hipExtGetLastError();
     }
 }
 

--- a/projects/miopen/test/gtest/handle_hip_device.cpp
+++ b/projects/miopen/test/gtest/handle_hip_device.cpp
@@ -57,6 +57,10 @@ TEST_F(CPU_HandleHipDevice_NONE, NegativeDeviceIdThrowsWithCorrectMessage)
         std::string error_msg = ex.what();
         EXPECT_NE(error_msg.find("Error setting device"), std::string::npos);
         EXPECT_NE(error_msg.find("-10"), std::string::npos);
+        
+        // Clear any HIP error triggered by asking for an invalid device ordinal
+        hipGetLastError();
+        hipExtGetLastError();
     }
 }
 


### PR DESCRIPTION
## Motivation

MIOpen has a test that tries to set the current device to one with an invalid device ID to ensure that this triggers an exception. When this exception is caught, there is still an error inside HIP that will be retrieved by the next call to hipExtGetLastError or hipGetLastError. Many of our tests do not check for any existing errors when they run, but our CK tests do. If one of these tests runs after this one, it will throw an exception. This was causing intermittent test failures that were dependent on test execution order.

## Technical Details

Clear the HIP errors after the exception is caught during this test.

## Test Plan

Running full test pass

## Test Result

Test pass in progress

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
