### PR TITLE
[hipfftw][helper and tests] Some refactoring and helper generalization in preparation of advanced and guru hipfftw plans

### DIFF
--- a/projects/hipfft/CMakeLists.txt
+++ b/projects/hipfft/CMakeLists.txt
@@ -123,7 +123,7 @@ string( TOUPPER "${BUILD_WITH_LIB}" BUILD_WITH_LIB )
 
 # nvc++ doesn't understand warning flags
 if( NOT CMAKE_CXX_COMPILER MATCHES ".*nvc\\+\\+" )
-  set( WARNING_FLAGS -Wall -Wno-unused-function -Wimplicit-fallthrough -Wunreachable-code -Wno-unknown-pragmas)
+  set( WARNING_FLAGS -Wall -Wno-unused-function -Wimplicit-fallthrough -Wunreachable-code -Wsign-compare -Wno-unknown-pragmas)
   if( WERROR )
     set( WARNING_FLAGS ${WARNING_FLAGS} -Werror )
   endif()

--- a/projects/hipfft/clients/hipfft_params.h
+++ b/projects/hipfft/clients/hipfft_params.h
@@ -1267,7 +1267,7 @@ private:
         if(externally_managed_workareas.size() < get_num_used_gpus())
             externally_managed_workareas.resize(get_num_used_gpus());
         std::vector<void*> workareas(get_num_used_gpus(), nullptr);
-        for(auto workarea_idx = 0; workarea_idx < get_num_used_gpus(); workarea_idx++)
+        for(size_t workarea_idx = 0; workarea_idx < get_num_used_gpus(); workarea_idx++)
         {
             const auto req_size = req_workarea_sizes[workarea_idx];
             auto&      buf      = externally_managed_workareas[workarea_idx];

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -584,7 +584,7 @@ static bool
     if(!rank_is_valid_for_hipfftw(intended_rank))
         return false; // impossible to validate values for an invalid intended_rank
     // check that vals are all in [min_valid_val, max_valid_val]
-    return vals.size() == intended_rank
+    return vals.size() == static_cast<size_t>(intended_rank)
            && std::all_of(vals.begin(), vals.end(), [&](const ptrdiff_t& val) {
                   return val >= min_valid_val && val <= max_valid_val;
               });
@@ -1115,7 +1115,7 @@ public:
         {
             for(const auto& vec : {lengths_to_set, istrides_to_set, ostrides_to_set})
             {
-                if(!vec.empty() && vec.size() != rank_to_set)
+                if(!vec.empty() && vec.size() != static_cast<size_t>(rank_to_set))
                 {
                     throw std::invalid_argument(
                         "Inconsistent size for non-empty lengths, istrides, or ostrides given to "
@@ -1127,7 +1127,7 @@ public:
         {
             for(const auto& vec : {batches_to_set, idist_to_set, odist_to_set})
             {
-                if(!vec.empty() && vec.size() != batch_rank_to_set)
+                if(!vec.empty() && vec.size() != static_cast<size_t>(batch_rank_to_set))
                 {
                     throw std::invalid_argument("Inconsistent size for non-empty batches, idist, "
                                                 "or odist given to hipfftw::set_creation_args.");
@@ -1211,7 +1211,7 @@ public:
         if(io != fft_io::fft_io_in && io != fft_io::fft_io_out)
             throw std::invalid_argument("invalid io passed to hipfftw_helper::get_distance");
         const auto& distances = io == fft_io::fft_io_in ? idist : odist;
-        if(batch_rank != 1 || distances.size() != batch_rank)
+        if(batch_rank != 1 || batch_rank < 0 || distances.size() != static_cast<size_t>(batch_rank))
             throw std::runtime_error("hipfftw_helper::get_distance: a single distance value cannot "
                                      "be queried for this configuration");
         const auto tmp = convert_vector_to<size_t>(distances);
@@ -1219,7 +1219,7 @@ public:
     }
     size_t get_nbatch() const
     {
-        if(batch_rank != 1 || batches.size() != batch_rank)
+        if(batch_rank != 1 || batch_rank < 0 || batches.size() != static_cast<size_t>(batch_rank))
             throw std::runtime_error("hipfftw_helper::get_nbatch: a single batch size cannot be "
                                      "queried for this configuration");
         const auto tmp = convert_vector_to<size_t>(batches);

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -603,54 +603,6 @@ static bool flags_are_valid_for_hipfftw(unsigned f)
     return (f & hipfftw_valid_flags_mask) == f;
 }
 
-static std::vector<ptrdiff_t> default_strides(fft_transform_type            dft_type,
-                                              fft_result_placement          placement,
-                                              fft_io                        io,
-                                              const std::vector<ptrdiff_t>& lengths)
-{
-    std::vector<ptrdiff_t> ret(lengths.size());
-    ptrdiff_t              def_stride = 1;
-    for(auto dim_idx = lengths.size(); dim_idx-- > 0;)
-    {
-        ret[dim_idx] = def_stride;
-        if(dim_idx == lengths.size() - 1 && is_real(dft_type))
-        {
-            if((io == fft_io_out) == is_fwd(dft_type))
-                def_stride *= (lengths[dim_idx] / 2 + 1);
-            else
-            {
-                if(placement == fft_placement_inplace)
-                    def_stride *= 2 * (lengths[dim_idx] / 2 + 1);
-                else
-                    def_stride *= lengths[dim_idx];
-            }
-        }
-        else
-            def_stride *= lengths[dim_idx];
-    }
-    return ret;
-}
-
-static std::vector<ptrdiff_t> default_distances(fft_transform_type            dft_type,
-                                                fft_result_placement          placement,
-                                                fft_io                        io,
-                                                const std::vector<ptrdiff_t>& lengths,
-                                                const std::vector<ptrdiff_t>& batches)
-{
-    std::vector<ptrdiff_t> ret(batches.size());
-    if(batches.empty() || lengths.empty())
-        return ret;
-    auto temp_lengths = lengths;
-    temp_lengths.insert(temp_lengths.begin(), 1);
-    auto def_dist = default_strides(dft_type, placement, io, temp_lengths).front();
-    for(auto batch_dim = 0; batch_dim < batches.size(); batch_dim++)
-    {
-        ret[batch_dim] = def_dist;
-        def_dist *= batches[batch_dim];
-    }
-    return ret;
-}
-
 template <
     fft_precision prec,
     std::enable_if_t<prec == fft_precision_single || prec == fft_precision_double, bool> = true>

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -321,6 +321,7 @@ HIPFFTW_FUNCS_SPECIALIZATION(fftw_, fft_precision_double);
 // to a runtime buffer throughout its lifetime (unless it was already enabled prior/externally)
 struct hipfftw_exception_logger
 {
+private:
     bool                  active;
     std::stringstream     buffer;
     std::streambuf* const original_cerr_rdbuf = nullptr;
@@ -553,16 +554,39 @@ static bool rank_is_valid_for_hipfftw(int r)
 {
     return r > 0;
 }
+
 template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
-static bool lengths_are_valid_for_hipfftw_as(const std::vector<ptrdiff_t> len, int intended_rank)
+static constexpr ptrdiff_t min_ptrdiff_t_representable_as()
+{
+    if constexpr(std::is_unsigned_v<T> || sizeof(T) <= sizeof(ptrdiff_t))
+        return std::numeric_limits<T>::lowest();
+    else
+        return std::numeric_limits<ptrdiff_t>::lowest();
+}
+
+template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+static constexpr ptrdiff_t max_ptrdiff_t_representable_as()
+{
+    if constexpr(sizeof(T) < sizeof(ptrdiff_t)
+                 || (sizeof(T) == sizeof(ptrdiff_t) && std::is_signed_v<T>))
+        return std::numeric_limits<T>::max();
+    else
+        return std::numeric_limits<ptrdiff_t>::max();
+}
+
+template <typename T>
+static bool
+    vector_has_valid_values_as(const std::vector<ptrdiff_t>& vals,
+                               int                           intended_rank,
+                               ptrdiff_t min_valid_val = min_ptrdiff_t_representable_as<T>(),
+                               ptrdiff_t max_valid_val = max_ptrdiff_t_representable_as<T>())
 {
     if(!rank_is_valid_for_hipfftw(intended_rank))
-        return false; // impossible to validate lengths for an invalid rank
-    // check that lengths are all strictly positive and representable with
-    // type T without data loss
-    return len.size() == intended_rank
-           && std::all_of(len.begin(), len.end(), [](const decltype(len)::value_type& val) {
-                  return val > 0 && val <= std::numeric_limits<T>::max();
+        return false; // impossible to validate values for an invalid intended_rank
+    // check that vals are all in [min_valid_val, max_valid_val]
+    return vals.size() == intended_rank
+           && std::all_of(vals.begin(), vals.end(), [&](const ptrdiff_t& val) {
+                  return val >= min_valid_val && val <= max_valid_val;
               });
 }
 static bool sign_is_valid_for_hipfftw(int s, const fft_transform_type& dft_kind)
@@ -577,6 +601,54 @@ static constexpr unsigned hipfftw_valid_flags_mask
 static bool flags_are_valid_for_hipfftw(unsigned f)
 {
     return (f & hipfftw_valid_flags_mask) == f;
+}
+
+static std::vector<ptrdiff_t> default_strides(fft_transform_type            dft_type,
+                                              fft_result_placement          placement,
+                                              fft_io                        io,
+                                              const std::vector<ptrdiff_t>& lengths)
+{
+    std::vector<ptrdiff_t> ret(lengths.size());
+    ptrdiff_t              def_stride = 1;
+    for(auto dim_idx = lengths.size(); dim_idx-- > 0;)
+    {
+        ret[dim_idx] = def_stride;
+        if(dim_idx == lengths.size() - 1 && is_real(dft_type))
+        {
+            if((io == fft_io_out) == is_fwd(dft_type))
+                def_stride *= (lengths[dim_idx] / 2 + 1);
+            else
+            {
+                if(placement == fft_placement_inplace)
+                    def_stride *= 2 * (lengths[dim_idx] / 2 + 1);
+                else
+                    def_stride *= lengths[dim_idx];
+            }
+        }
+        else
+            def_stride *= lengths[dim_idx];
+    }
+    return ret;
+}
+
+static std::vector<ptrdiff_t> default_distances(fft_transform_type            dft_type,
+                                                fft_result_placement          placement,
+                                                fft_io                        io,
+                                                const std::vector<ptrdiff_t>& lengths,
+                                                const std::vector<ptrdiff_t>& batches)
+{
+    std::vector<ptrdiff_t> ret(batches.size());
+    if(batches.empty() || lengths.empty())
+        return ret;
+    auto temp_lengths = lengths;
+    temp_lengths.insert(temp_lengths.begin(), 1);
+    auto def_dist = default_strides(dft_type, placement, io, temp_lengths).front();
+    for(auto batch_dim = 0; batch_dim < batches.size(); batch_dim++)
+    {
+        ret[batch_dim] = def_dist;
+        def_dist *= batches[batch_dim];
+    }
+    return ret;
 }
 
 template <
@@ -594,8 +666,14 @@ private:
     mutable std::shared_ptr<hipfftw_plan_bundle_t<prec>> plan_bundle;
 
     fft_transform_type     dft_kind;
-    int                    rank = 0;
+    int                    rank       = 0;
+    int                    batch_rank = 0;
     std::vector<ptrdiff_t> lengths;
+    std::vector<ptrdiff_t> istrides;
+    std::vector<ptrdiff_t> ostrides;
+    std::vector<ptrdiff_t> batches;
+    std::vector<ptrdiff_t> idist;
+    std::vector<ptrdiff_t> odist;
     fft_result_placement   plan_placement;
     int                    sign  = 0;
     unsigned               flags = std::numeric_limits<unsigned>::max();
@@ -613,12 +691,13 @@ private:
     hipfftw_plan_creation_func get_creation_func(hipfftw_plan_creation_func creation_options) const
     {
         if(!hipfftw_creation_options_are_well_defined(creation_options))
-            throw std::invalid_argument("invalid creation_options for get_creation_func");
+            throw std::invalid_argument(
+                "invalid creation_options for hipfftw_helper::get_creation_func");
         if(!can_use_creation_options(creation_options))
         {
             // e.g., rank < 0 with creation_options == hipfftw_plan_creation_func::PLAN_DFT_ND
             throw std::invalid_argument(
-                "The plan creation options "
+                "hipfftw_helper::get_creation_func: the plan creation options "
                 + hipfftw_creation_options_to_string(creation_options, dft_kind, rank)
                 + " cannot be used with this object");
         }
@@ -655,10 +734,15 @@ private:
         {
             throw std::invalid_argument("Invalid chosen_creation for hipfftw_helper::make_plan");
         }
+        const auto effective_placement
+            = in == out ? fft_placement_inplace : fft_placement_notinplace;
+        if(effective_placement != plan_placement)
+            throw std::invalid_argument("hipfftw_helper::make_plan: invalid I/O argument for plan "
+                                        "creation w.r.t. expected plan placement.");
 
         // fetch/infer plan creation function arguments
         const auto& hipfftw_impl = hipfftw_funcs<prec>::get_instance();
-        const auto  int_len      = get_length_as<int>();
+        const auto  int_len      = get_lengths_as<int>();
         const int*  int_len_ptr  = int_len.empty() ? nullptr : int_len.data();
 
         switch(chosen_creation)
@@ -666,7 +750,8 @@ private:
         case hipfftw_plan_creation_func::PLAN_DFT_ND:
         {
             if(!can_use_creation_options(hipfftw_plan_creation_func::PLAN_DFT_ND))
-                throw std::runtime_error("hipfftw_plan_creation_func::PLAN_DFT_ND cannot be used.");
+                throw std::runtime_error("hipfftw_helper::make_plan: "
+                                         "hipfftw_plan_creation_func::PLAN_DFT_ND cannot be used.");
             if(rank == 1)
             {
                 if(dft_kind == fft_transform_type_real_forward)
@@ -767,7 +852,8 @@ private:
         case hipfftw_plan_creation_func::PLAN_DFT:
         {
             if(!can_use_creation_options(hipfftw_plan_creation_func::PLAN_DFT))
-                throw std::runtime_error("hipfftw_plan_creation_func::PLAN_DFT cannot be used.");
+                throw std::runtime_error("hipfftw_helper::make_plan: "
+                                         "hipfftw_plan_creation_func::PLAN_DFT cannot be used.");
 
             if(dft_kind == fft_transform_type_real_forward)
             {
@@ -804,13 +890,227 @@ private:
         case hipfftw_plan_creation_func::PLAN_GURU:
             [[fallthrough]];
         case hipfftw_plan_creation_func::PLAN_GURU64:
-            throw std::runtime_error("Enforced plan creation is not implemented yet");
+            throw std::runtime_error(
+                "hipfftw_helper::make_plan: enforced plan creation is not implemented yet");
             break;
         default:
-            throw std::runtime_error("Unknown kind of plan creation");
+            throw std::runtime_error("hipfftw_helper::make_plan: unknown kind of plan creation");
             break;
         }
         // unreachable
+    }
+
+    // converts vec to an std::vector<T> if it can be done so without underflow/overflow
+    // [throws a type_conversion_exception if not]
+    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+    static std::vector<T> convert_vector_to(const std::vector<ptrdiff_t>& vec)
+    {
+        if constexpr(std::is_same_v<T, ptrdiff_t>)
+            return vec;
+        std::vector<T> ret;
+        if(vec.empty())
+            return ret;
+        if(!vector_has_valid_values_as<T>(vec, vec.size()))
+        {
+            throw type_conversion_exception(
+                "a hipfftw_helper object could not convert one of its std::vector<ptrdiff> members "
+                "to a vector of another integral type (value(s) out of representable range).");
+        }
+        ret.assign(vec.begin(), vec.end());
+        return ret;
+    }
+
+    // (private) validity checks
+    bool has_valid_rank(hipfftw_plan_creation_func creation_options
+                        = hipfftw_plan_creation_func::ANY) const
+    {
+        if(!hipfftw_creation_options_are_well_defined(creation_options))
+            throw std::invalid_argument(
+                "ill-defined creation_options passed to hipfftw_helper::has_valid_rank");
+        // check if valid for any of the possible plan creation functions
+        bool ret = false;
+        for(auto creation_func : hipfftw_plan_creation_func_candidates)
+        {
+            if(ret)
+                break;
+            if(!(creation_options & creation_func))
+                continue;
+            switch(creation_func)
+            {
+            case hipfftw_plan_creation_func::PLAN_DFT_ND:
+                ret = rank == 1 || rank == 2 || rank == 3;
+                break;
+            case hipfftw_plan_creation_func::PLAN_DFT:
+                [[fallthrough]];
+            case hipfftw_plan_creation_func::PLAN_MANY:
+                [[fallthrough]];
+            case hipfftw_plan_creation_func::PLAN_GURU64:
+                [[fallthrough]];
+            case hipfftw_plan_creation_func::PLAN_GURU:
+                ret = rank_is_valid_for_hipfftw(rank);
+                break;
+            default:
+                throw std::runtime_error("hipfftw_helper::has_valid_rank: internal error "
+                                         "encountered (unexpected value for creation_func)");
+            }
+        }
+        return ret;
+    }
+    bool has_valid_lengths() const
+    {
+        constexpr ptrdiff_t min_len = 1;
+        return vector_has_valid_values_as<ptrdiff_t>(lengths, rank, min_len);
+    }
+    bool has_valid_sign() const
+    {
+        return sign_is_valid_for_hipfftw(sign, dft_kind);
+    }
+    bool has_valid_flags() const
+    {
+        return flags_are_valid_for_hipfftw(flags);
+    }
+    bool has_valid_batch_rank(hipfftw_plan_creation_func creation_options
+                              = hipfftw_plan_creation_func::ANY) const
+    {
+        if(!hipfftw_creation_options_are_well_defined(creation_options))
+            throw std::invalid_argument(
+                "ill-defined creation_options passed to hipfftw_helper::has_valid_batch_rank");
+        // check if valid for any of the possible plan creation functions
+        bool ret = false;
+        for(auto creation_func : hipfftw_plan_creation_func_candidates)
+        {
+            if(ret)
+                break;
+            if(!(creation_options & creation_func))
+                continue;
+            switch(creation_func)
+            {
+            case hipfftw_plan_creation_func::PLAN_DFT_ND:
+                [[fallthrough]];
+            case hipfftw_plan_creation_func::PLAN_DFT:
+                [[fallthrough]];
+            case hipfftw_plan_creation_func::PLAN_MANY:
+                ret = batch_rank == 1;
+                break;
+            case hipfftw_plan_creation_func::PLAN_GURU64:
+                [[fallthrough]];
+            case hipfftw_plan_creation_func::PLAN_GURU:
+                ret = rank_is_valid_for_hipfftw(batch_rank);
+                break;
+            default:
+                throw std::runtime_error("hipfftw_helper::has_valid_batych_rank internal error "
+                                         "encountered (unexpected value for creation_func)");
+            }
+        }
+        return ret;
+    }
+    bool has_valid_batches() const
+    {
+        constexpr ptrdiff_t min_batch = 1;
+        return vector_has_valid_values_as<ptrdiff_t>(batches, batch_rank, min_batch);
+    }
+
+    bool has_valid_strides(fft_io io, hipfftw_plan_creation_func creation_options) const
+    {
+        if(io != fft_io::fft_io_in && io != fft_io::fft_io_out)
+            throw std::invalid_argument("invalid io passed to hipfftw_helper::has_valid_strides");
+
+        if(!hipfftw_creation_options_are_well_defined(creation_options))
+            throw std::invalid_argument(
+                "ill-defined creation_options passed to hipfftw_helper::has_valid_strides");
+        const auto& strides = io == fft_io::fft_io_in ? istrides : ostrides;
+        bool        ret     = vector_has_valid_values_as<ptrdiff_t>(strides, rank);
+        // 0 stride values are invalid for any nontrivial length
+        for(auto dim = 0; ret && dim < rank; dim++)
+        {
+            if(lengths[dim] != 1 && strides[dim] == 0)
+                ret = false;
+        }
+        if(ret && plan_placement == fft_placement_inplace)
+        {
+            // for in-place operations, input and output strides cannot
+            // be considered independent of each other
+            if(!vector_has_valid_values_as<ptrdiff_t>(istrides, rank)
+               || !vector_has_valid_values_as<ptrdiff_t>(ostrides, rank))
+            {
+                ret = false;
+            }
+            const auto ifact = dft_kind == fft_transform_type_real_forward ? 1 : 2;
+            const auto ofact = dft_kind == fft_transform_type_real_inverse ? 1 : 2;
+            for(int dim = 0; ret && dim < rank - 1; dim++)
+            {
+                if(lengths[dim] == 1)
+                    continue;
+                ret = ifact * istrides[dim] == ofact * ostrides[dim];
+            }
+            if(ret)
+            {
+                if(is_complex(dft_kind))
+                    ret = istrides.back() == ostrides.back();
+                else // unit elementary strides only for in-place real transforms
+                    ret = istrides.back() == 1 && ostrides.back() == 1;
+            }
+        }
+        if(!ret)
+            return ret;
+        // check if valid for any of the possible plan creation functions
+        ret = false;
+        for(auto creation_func : hipfftw_plan_creation_func_candidates)
+        {
+            if(ret)
+                break;
+            if(!(creation_options & creation_func))
+                continue;
+            switch(creation_func)
+            {
+            case hipfftw_plan_creation_func::PLAN_DFT_ND:
+                [[fallthrough]];
+            case hipfftw_plan_creation_func::PLAN_DFT:
+                ret = strides == default_strides(dft_kind, plan_placement, io, lengths);
+                break;
+            case hipfftw_plan_creation_func::PLAN_MANY:
+                [[fallthrough]];
+            case hipfftw_plan_creation_func::PLAN_GURU64:
+                [[fallthrough]];
+            case hipfftw_plan_creation_func::PLAN_GURU:
+                ret = false; // for now... to be defined when guru apis are enabled
+                break;
+            default:
+                throw std::runtime_error("hipfftw_helper::has_valid_strides: internal error "
+                                         "encountered (unexpected value for creation_func)");
+            }
+        }
+        return ret;
+    }
+    bool has_valid_distances(fft_io io) const
+    {
+        if(io != fft_io::fft_io_in && io != fft_io::fft_io_out)
+            throw std::invalid_argument("invalid io passed to hipfftw_helper::has_valid_distances");
+
+        const auto& distances = io == fft_io::fft_io_in ? idist : odist;
+        bool        ret       = vector_has_valid_values_as<ptrdiff_t>(distances, batch_rank);
+        // 0 distance values are invalid for any nontrivial batch
+        for(auto batch_dim = 0; ret && batch_dim < batch_rank; batch_dim++)
+        {
+            if(batches[batch_dim] != 1 && distances[batch_dim] == 0)
+                ret = false;
+        }
+        if(ret && plan_placement == fft_placement_inplace)
+        {
+            // for in-place operations, input and output distances cannot
+            // be considered independent of each other
+            if(!vector_has_valid_values_as<ptrdiff_t>(idist, batch_rank)
+               || !vector_has_valid_values_as<ptrdiff_t>(odist, batch_rank))
+            {
+                ret = false;
+            }
+            const auto ifact = dft_kind == fft_transform_type_real_forward ? 1 : 2;
+            const auto ofact = dft_kind == fft_transform_type_real_inverse ? 1 : 2;
+            for(int batch_dim = 0; ret && batch_dim < batch_rank; batch_dim++)
+                ret = batches[batch_dim] == 1
+                      || ifact * idist[batch_dim] == ofact * odist[batch_dim];
+        }
+        return ret;
     }
 
 public:
@@ -821,6 +1121,7 @@ public:
     hipfftw_helper(const hipfftw_helper& other)       = default;
     hipfftw_helper& operator=(const hipfftw_helper& rhs) = default;
 
+    // overload for default, unbatched configurations (compatible with plan_dft* funcs)
     void set_creation_args(fft_transform_type            dft_kind_to_set,
                            int                           rank_to_set,
                            const std::vector<ptrdiff_t>& lengths_to_set,
@@ -828,13 +1129,74 @@ public:
                            int                           sign_to_set,
                            unsigned                      flags_to_set)
     {
+        set_creation_args(
+            dft_kind_to_set,
+            rank_to_set,
+            lengths_to_set,
+            placement_to_set,
+            sign_to_set,
+            flags_to_set,
+            /* default strides + unit batch + zero distances */
+            default_strides(dft_kind_to_set, placement_to_set, fft_io::fft_io_in, lengths_to_set),
+            default_strides(dft_kind_to_set, placement_to_set, fft_io::fft_io_out, lengths_to_set),
+            1,
+            std::vector<ptrdiff_t>(1, 1),
+            std::vector<ptrdiff_t>(1, 0),
+            std::vector<ptrdiff_t>(1, 0));
+    }
+
+    // most general overload
+    void set_creation_args(fft_transform_type            dft_kind_to_set,
+                           int                           rank_to_set,
+                           const std::vector<ptrdiff_t>& lengths_to_set,
+                           fft_result_placement          placement_to_set,
+                           int                           sign_to_set,
+                           unsigned                      flags_to_set,
+                           const std::vector<ptrdiff_t>& istrides_to_set,
+                           const std::vector<ptrdiff_t>& ostrides_to_set,
+                           int                           batch_rank_to_set,
+                           const std::vector<ptrdiff_t>& batches_to_set,
+                           const std::vector<ptrdiff_t>& idist_to_set,
+                           const std::vector<ptrdiff_t>& odist_to_set)
+    {
+        if(rank_is_valid_for_hipfftw(rank_to_set))
+        {
+            for(const auto& vec : {lengths_to_set, istrides_to_set, ostrides_to_set})
+            {
+                if(!vec.empty() && vec.size() != rank_to_set)
+                {
+                    throw std::invalid_argument(
+                        "Inconsistent size for non-empty lengths, istrides, or ostrides given to "
+                        "hipfftw::set_creation_args.");
+                }
+            }
+        }
+        if(rank_is_valid_for_hipfftw(batch_rank_to_set))
+        {
+            for(const auto& vec : {batches_to_set, idist_to_set, odist_to_set})
+            {
+                if(!vec.empty() && vec.size() != batch_rank_to_set)
+                {
+                    throw std::invalid_argument("Inconsistent size for non-empty batches, idist, "
+                                                "or odist given to hipfftw::set_creation_args.");
+                }
+            }
+        }
+
         reset_member_value(dft_kind, dft_kind_to_set);
         reset_member_value(rank, rank_to_set);
         reset_member_value(lengths, lengths_to_set);
         reset_member_value(plan_placement, placement_to_set);
         reset_member_value(sign, sign_to_set);
         reset_member_value(flags, flags_to_set);
+        reset_member_value(istrides, istrides_to_set);
+        reset_member_value(ostrides, ostrides_to_set);
+        reset_member_value(batch_rank, batch_rank_to_set);
+        reset_member_value(batches, batches_to_set);
+        reset_member_value(idist, idist_to_set);
+        reset_member_value(odist, odist_to_set);
     }
+
     // getters
     fft_transform_type get_dft_kind() const
     {
@@ -845,25 +1207,15 @@ public:
         return rank;
     }
     // returns the lengths as an std::vector<T> if they may all be safely converted to T
-    // (the returned vector is empty otherwise)
+    // (a type_conversion_exception is thrown otherwise)
     template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
-    std::vector<T> get_length_as() const
+    std::vector<T> get_lengths_as() const
     {
-        if constexpr(std::is_same_v<T, typename decltype(lengths)::value_type>)
-            return lengths;
-        std::vector<T> ret;
-        if(std::any_of(lengths.begin(),
-                       lengths.end(),
-                       [](const typename decltype(lengths)::value_type& val) {
-                           return val < std::numeric_limits<T>::lowest()
-                                  || val > std::numeric_limits<T>::max();
-                       }))
-        {
-            // not a safe conversion, return empty lengths
-            return ret;
-        }
-        ret.assign(lengths.begin(), lengths.end());
-        return ret;
+        return convert_vector_to<T>(lengths);
+    }
+    const decltype(lengths)& get_lengths() const
+    {
+        return lengths;
     }
     fft_result_placement get_placement() const
     {
@@ -877,123 +1229,73 @@ public:
     {
         return flags;
     }
-    std::shared_ptr<hipfftw_plan_bundle_t<prec>> get_plan_bundle() const
-    {
-        return plan_bundle;
-    }
+    // returns the strides as an std::vector<T> if they may all be safely converted to T
+    // (a type_conversion_exception is thrown otherwise)
     template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
     std::vector<T> get_strides_as(fft_io io) const
     {
-        if(!rank_is_valid_for_hipfftw(rank) || !has_valid_lengths())
-            throw std::runtime_error(
-                "cannot calculate default strides with invalid rank or invalid lengths");
-        // only default strides for now
-        std::vector<ptrdiff_t> strides(rank, 1);
-        if(rank > 1)
-        {
-            if(is_complex(dft_kind))
-                strides[rank - 2] = lengths.back();
-            else
-            {
-                if(is_fwd(dft_kind) == (io == fft_io::fft_io_out))
-                    strides[rank - 2] = lengths.back() / 2 + 1;
-                else
-                {
-                    if(plan_placement == fft_placement_inplace)
-                        strides[rank - 2] = 2 * (lengths.back() / 2 + 1);
-                    else
-                        strides[rank - 2] = lengths.back();
-                }
-            }
-        }
-        for(auto dim = rank - 3; dim >= 0; dim--)
-            strides[dim] = strides[dim + 1] * lengths[dim + 1];
-
-        std::vector<T> ret;
-        if(std::any_of(strides.begin(),
-                       strides.end(),
-                       [](const typename decltype(strides)::value_type& val) {
-                           return val < std::numeric_limits<T>::lowest()
-                                  || val > std::numeric_limits<T>::max();
-                       }))
-        {
-            // not a safe conversion, return empty lengths
-            return ret;
-        }
-        ret.assign(strides.begin(), strides.end());
-        return ret;
+        if(io != fft_io::fft_io_in && io != fft_io::fft_io_out)
+            throw std::invalid_argument("invalid io passed to hipfftw_helper::get_strides_as");
+        const std::vector<ptrdiff_t>& strides = io == fft_io::fft_io_in ? istrides : ostrides;
+        return convert_vector_to<T>(strides);
     }
-    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
-    T get_dist_as(fft_io io) const
+    const decltype(istrides)& get_strides(fft_io io) const
     {
-        if(!rank_is_valid_for_hipfftw(rank) || !has_valid_lengths())
-            throw std::runtime_error(
-                "cannot calculate default distance(s) with invalid rank or invalid lengths");
-        // only default distances for now
-        ptrdiff_t dist = 0;
-        if(rank == 1)
-        {
-            if(is_complex(dft_kind))
-                dist = lengths.back();
-            else
-            {
-                if(is_fwd(dft_kind) == (io == fft_io::fft_io_out))
-                    dist = lengths.back() / 2 + 1;
-                else
-                {
-                    if(plan_placement == fft_placement_inplace)
-                        dist = 2 * (lengths.back() / 2 + 1);
-                    else
-                        dist = lengths.back();
-                }
-            }
-        }
-        else
-        {
-            const auto strides = get_strides_as<ptrdiff_t>(io);
-            dist               = strides.front() * lengths.front();
-        }
-        if(dist < std::numeric_limits<T>::lowest() || dist > std::numeric_limits<T>::max())
-            throw std::runtime_error("distance cannot be safely converted to the desired type");
-        return static_cast<T>(dist);
-    }
-    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
-    T get_nbatch_as(fft_io io) const
-    {
-        // only unbatched for now
-        T ret = 1;
-        return ret;
+        static_assert(std::is_same_v<decltype(istrides), decltype(ostrides)>);
+        if(io != fft_io::fft_io_in && io != fft_io::fft_io_out)
+            throw std::invalid_argument("invalid io passed to hipfftw_helper::get_strides");
+        return io == fft_io::fft_io_in ? istrides : ostrides;
     }
 
-    // validity checks
-    bool has_valid_rank() const
+    int get_batch_rank() const
     {
-        return rank_is_valid_for_hipfftw(rank);
+        return batch_rank;
     }
-    bool has_valid_lengths() const
+
+    // interfacing routines to be used only for valid and supported cases
+    // (i.e., strictly positive values, batch_rank = 1, etc.)
+    size_t get_distance(fft_io io) const
     {
-        return lengths_are_valid_for_hipfftw_as<ptrdiff_t>(lengths, rank);
+        if(io != fft_io::fft_io_in && io != fft_io::fft_io_out)
+            throw std::invalid_argument("invalid io passed to hipfftw_helper::get_distance");
+        const auto& distances = io == fft_io::fft_io_in ? idist : odist;
+        if(batch_rank != 1 || distances.size() != batch_rank)
+            throw std::runtime_error("hipfftw_helper::get_distance: a single distance value cannot "
+                                     "be queried for this configuration");
+        const auto tmp = convert_vector_to<size_t>(distances);
+        return tmp[0];
     }
-    bool has_valid_sign() const
+    size_t get_nbatch() const
     {
-        return sign_is_valid_for_hipfftw(sign, dft_kind);
+        if(batch_rank != 1 || batches.size() != batch_rank)
+            throw std::runtime_error("hipfftw_helper::get_nbatch: a single batch size cannot be "
+                                     "queried for this configuration");
+        const auto tmp = convert_vector_to<size_t>(batches);
+        return tmp[0];
     }
-    bool has_valid_flags() const
+
+    hipfftw_plan_creation_func get_plan_creation_function() const
     {
-        return flags_are_valid_for_hipfftw(flags);
+        if(!plan_bundle)
+            return hipfftw_plan_creation_func::NONE;
+        return plan_bundle->creation_func;
+    }
+    hipfftw_plan_t<prec> get_plan() const
+    {
+        if(!plan_bundle)
+            return nullptr;
+        return plan_bundle->plan;
     }
     // checks if the current parameters can be used with (any of) the given option(s) of
-    // plan creation (NOT whether they're valid or not). For instance, one cannot possibly
-    // communicate rank > 3 with hipfftw_plan_creation_func::PLAN_DFT_ND, or communicate
-    // non-default strides with hipfftw_plan_creation_func::PLAN_DFT_ND or
-    // hipfftw_plan_creation_func::PLAN_DFT...
-    // TODO: expand logic when extra configuration parameters are added (e.g. batch sizes,
-    // strides, etc.)
+    // plan creation, given the corresponding plan creation's signature (NOT whether they're
+    // valid or not). For instance, one cannot possibly communicate rank > 3 with
+    // hipfftw_plan_creation_func::PLAN_DFT_ND, or communicate non-default strides with
+    // hipfftw_plan_creation_func::PLAN_DFT_ND or hipfftw_plan_creation_func::PLAN_DFT...
     bool can_use_creation_options(hipfftw_plan_creation_func creation_options) const
     {
         if(!hipfftw_creation_options_are_well_defined(creation_options))
             throw std::invalid_argument(
-                "ill-defined creation_options used in can_use_creation_options");
+                "ill-defined creation_options passed to hipfftw_helper::can_use_creation_options");
         if(creation_options == hipfftw_plan_creation_func::NONE)
             return false;
         if(std::find(hipfftw_plan_creation_func_candidates.begin(),
@@ -1014,27 +1316,46 @@ public:
         switch(creation_options)
         {
         case hipfftw_plan_creation_func::PLAN_DFT_ND:
-            // rank is not passed as an argument but dictated by the called function,
-            // (must be 1, 2, or 3), and as many lengths must be passed as individual
-            // integer values
-            return (rank == 1 || rank == 2 || rank == 3) && get_length_as<int>().size() == rank;
-            break;
+            [[fallthrough]];
         case hipfftw_plan_creation_func::PLAN_DFT:
-            // the lengths must be representable as integers, if not empty (supposedly
-            // intentionally, e.g., for input validation testing purposes)
-            return lengths.empty() || get_length_as<int>().size() == rank;
-            break;
+        {
+            // only unbatched cases (making distances irrelevant)
+            if(batch_rank != 1 || batches.size() != 1 || batches[0] != 1)
+                return false;
+            // no empty lengths (~> nullptr lengths) for PLAN_DFT_ND
+            if(creation_options == hipfftw_plan_creation_func::PLAN_DFT_ND && lengths.empty())
+                return false;
+            // only default strides (this check is relevant only for non-empty lengths)
+            if(!lengths.empty())
+            {
+                if(istrides != default_strides(dft_kind, plan_placement, fft_io::fft_io_in, lengths)
+                   || ostrides
+                          != default_strides(dft_kind, plan_placement, fft_io::fft_io_out, lengths))
+                    return false;
+            }
+            // lengths must be representable as int
+            try
+            {
+                auto tmp = get_lengths_as<int>();
+            }
+            catch(const type_conversion_exception& e)
+            {
+                return false;
+            }
+            // rank is not passed as an argument but dictated by the called function
+            // (must be 1, 2, or 3) if not using PLAN_DFT
+            return creation_options == hipfftw_plan_creation_func::PLAN_DFT
+                   || (rank >= 1 && rank <= 3);
+        }
         case hipfftw_plan_creation_func::PLAN_MANY:
             [[fallthrough]];
         case hipfftw_plan_creation_func::PLAN_GURU:
             [[fallthrough]];
         case hipfftw_plan_creation_func::PLAN_GURU64:
             return false;
-            break;
         default:
-            throw std::runtime_error("hipfftw_helper: internal error encountered (unexpected value "
-                                     "for creation_options)");
-            break;
+            throw std::runtime_error("hipfftw_helper::can_use_creation_options: internal error "
+                                     "encountered (unexpected value for creation_options)");
         }
         // unreachable
     }
@@ -1044,12 +1365,17 @@ public:
     bool is_valid_for_creation_with(hipfftw_plan_creation_func creation_options) const
     {
         if(!hipfftw_creation_options_are_well_defined(creation_options))
-            throw std::invalid_argument("invalid creation_options for is_valid_for_creation_with");
+            throw std::invalid_argument(
+                "invalid creation_options passed to hipfftw_helper::is_valid_for_creation_with");
 
-        // TODO: expand the global validity checks below when this struct is
-        // expanded to cover more configurations (e.g., batching, srides, etc.)
-        return has_valid_rank() && has_valid_lengths() && has_valid_sign() && has_valid_flags()
-               && can_use_creation_options(creation_options);
+        auto ret = has_valid_rank(creation_options) && has_valid_lengths() && has_valid_sign()
+                   && has_valid_flags() && has_valid_batch_rank(creation_options)
+                   && has_valid_batches() && has_valid_strides(fft_io::fft_io_in, creation_options)
+                   && has_valid_strides(fft_io::fft_io_out, creation_options)
+                   && has_valid_distances(fft_io::fft_io_in)
+                   && has_valid_distances(fft_io::fft_io_out)
+                   && can_use_creation_options(creation_options);
+        return ret;
     }
     bool is_valid_for_creation() const
     {
@@ -1058,20 +1384,19 @@ public:
     // check expected support by (any of) the given option(s)
     bool has_unsupported_args_for(hipfftw_plan_creation_func creation_options) const
     {
-        // extra conditions for configurations supported by hipfftw:
+        // extra conditions for valid configurations that are not supported by hipfftw:
         if(rank > 3)
+            return true;
+        if(batch_rank > 1)
             return true;
         if(flags & FFTW_WISDOM_ONLY)
             return true;
         if(dft_kind == fft_transform_type_real_inverse && rank > 1 && (flags & FFTW_PRESERVE_INPUT))
             return true;
-        if(!(creation_options & hipfftw_plan_creation_func::PLAN_GURU64) && has_valid_rank()
-           && has_valid_lengths())
+        // negative strides and distances are not supported
+        for(const std::vector<ptrdiff_t>& tmp : {istrides, ostrides, idist, odist})
         {
-            // cannot handle data sizes involving more elements than the
-            // largest representable int value
-            if(get_num_elements_in(fft_io_in) > std::numeric_limits<int>::max()
-               || get_num_elements_in(fft_io_out) > std::numeric_limits<int>::max())
+            if(std::any_of(tmp.begin(), tmp.end(), [](const ptrdiff_t& val) { return val < 0; }))
                 return true;
         }
         return false;
@@ -1079,7 +1404,8 @@ public:
     bool can_create_plan_with(hipfftw_plan_creation_func creation_options) const
     {
         if(!hipfftw_creation_options_are_well_defined(creation_options))
-            throw std::invalid_argument("invalid creation_option for can_create_plan_with");
+            throw std::invalid_argument(
+                "invalid creation_option for hipfftw_helper::can_create_plan_with");
 
         if(!is_valid_for_creation_with(creation_options))
             return false;
@@ -1127,56 +1453,95 @@ public:
             ret << "real_inverse";
             break;
         default:
-            throw std::runtime_error("unknown type of transform");
+            throw std::runtime_error("hipfftw_helper::token: unknown type of transform");
         }
 
-        // report rank if invalid
-        if(!has_valid_rank() || lengths.empty())
-            ret << "_invalid_rank" << (rank < 0 ? "_negative_" : "_") << std::abs(rank);
-        ret << "_len";
-        if(lengths.empty())
-            ret << "_none";
-        else
-        {
-            for(const auto& len : lengths)
-                ret << (len < 0 ? "_negative_" : "_") << std::abs(len);
-        }
+        auto append_vec = [&](const std::string& vec_name, const std::vector<ptrdiff_t>& vec) {
+            ret << "_" << vec_name;
+            if(vec.empty())
+                ret << "_none";
+            else
+            {
+                for(const auto& elem : vec)
+                    ret << (elem < 0 ? "_negative_" : "_") << std::abs(elem);
+            }
+        };
+
+        // report rank if invalid and/or empty lengths (distinguishing tokens resulting in failing creation)
+        if(!rank_is_valid_for_hipfftw(rank) || lengths.empty())
+            ret << "_rank" << (rank < 0 ? "_negative_" : "_") << std::abs(rank);
+        append_vec("len", lengths);
         if constexpr(prec == fft_precision_single)
             ret << "_single";
         else
             ret << "_double";
         ret << (plan_placement == fft_placement_inplace ? "_ip" : "_op");
-        // only supporting unbatched cases as of now
-        ret << "_batch_1";
-        if(has_valid_rank() && has_valid_lengths())
-        {
-            ret << "_istride";
-            for(const auto& stride : get_strides_as<size_t>(fft_io::fft_io_in))
-                ret << "_" << stride;
-            if(!is_real(dft_kind))
-                ret << "_CI";
-            else if(dft_kind == fft_transform_type_real_forward)
-                ret << "_R";
-            else
-                ret << "_HI";
-            ret << "_ostride";
-            for(const auto& stride : get_strides_as<size_t>(fft_io::fft_io_out))
-                ret << "_" << stride;
-            if(!is_real(dft_kind))
-                ret << "_CI";
-            else if(dft_kind == fft_transform_type_real_forward)
-                ret << "_HI";
-            else
-                ret << "_R";
-            ret << "_idist_" << get_dist_as<size_t>(fft_io::fft_io_in);
-            ret << "_odist_" << get_dist_as<size_t>(fft_io::fft_io_out);
-            ret << "_ioffset_0_0_ooffset_0_0";
-        }
+        if(batch_rank != 1)
+            ret << "_batch_rank_" << (batch_rank < 0 ? "_negative_" : "_") << std::abs(batch_rank);
+        append_vec("batch", batches);
+        append_vec("istride", istrides);
+        if(!is_real(dft_kind))
+            ret << "_CI";
+        else if(dft_kind == fft_transform_type_real_forward)
+            ret << "_R";
+        else
+            ret << "_HI";
+        append_vec("ostride", ostrides);
+        if(!is_real(dft_kind))
+            ret << "_CI";
+        else if(dft_kind == fft_transform_type_real_forward)
+            ret << "_HI";
+        else
+            ret << "_R";
+        append_vec("idist", idist);
+        append_vec("odist", odist);
+
+        // for simple copy-pasting of token for testing the same DFT via hipFFT/rocFFT
+        ret << "_ioffset_0_0_ooffset_0_0";
+
         if(!has_valid_sign())
             ret << "_invalid_sign" << (sign < 0 ? "_negative_" : "_") << std::abs(sign);
         ret << "_flags_" << flags;
         return ret.str();
     }
+
+    // NOTE: from_token only supports configurations that fft_params itself supports
+    void from_token(const std::string& token)
+    {
+        fft_params tmp;
+        tmp.from_token(token);
+        if(tmp.istride.size() != tmp.ostride.size() || tmp.istride.size() != tmp.length.size())
+            throw std::runtime_error("hipfftw_helper::from_token: unexpected mismatch of vector "
+                                     "sizes in hipfftw_helper::from_token");
+        dft_kind   = tmp.transform_type;
+        rank       = tmp.length.size();
+        batch_rank = 1;
+        lengths.resize(rank);
+        istrides.resize(rank);
+        ostrides.resize(rank);
+        for(auto dim = 0; dim < rank; dim++)
+        {
+            lengths[dim]  = tmp.length[dim];
+            istrides[dim] = tmp.istride[dim];
+            ostrides[dim] = tmp.ostride[dim];
+        }
+
+        batches        = std::vector<ptrdiff_t>(1, tmp.nbatch);
+        idist          = std::vector<ptrdiff_t>(1, tmp.idist);
+        odist          = std::vector<ptrdiff_t>(1, tmp.odist);
+        plan_placement = tmp.placement;
+        sign           = is_fwd(dft_kind) ? FFTW_FORWARD : FFTW_BACKWARD;
+        flags          = FFTW_ESTIMATE;
+
+        const std::string flags_label = "flags";
+        auto              pos         = token.find(flags_label);
+        if(pos != std::string::npos)
+        {
+            pos += flags_label.size() + 1;
+            flags = std::stoull(token.substr(pos, token.find("_", pos)));
+        }
+    }
+
     // create_plan invokes an hipfftw plan creation function for the object's configuration
     // parameters, the corresponding plan pointer returned by hipfftw is stored internally.
     // IMPORTANT NOTE: if one wants to target a specific creation function (as represented
@@ -1275,42 +1640,44 @@ public:
         }
     }
 
-    // TODO: revise/expand logic below when the structure is expanded for more cases (batches,
-    // non-default strides, etc.)
     size_t get_num_elements_in(fft_io in_or_out) const
     {
         if(in_or_out != fft_io_in && in_or_out != fft_io_out)
-            throw std::invalid_argument("invalid in_or_out for get_num_elements_in");
-        if(!has_valid_rank() || !has_valid_lengths())
-            throw std::runtime_error("get_num_elements_in requires valid rank and lengths");
-        const auto tmp = get_length_as<size_t>();
-        if(tmp.empty() || tmp.size() != rank)
+            throw std::invalid_argument(
+                "invalid in_or_out passed to hipfftw_helper::get_num_elements_in");
+        if(!has_valid_rank() || !has_valid_lengths() || !has_valid_batch_rank()
+           || !has_valid_batches())
+            throw num_elements_calc_exception(
+                "hipfftw_helper::get_num_elements_in requires valid rank, batch_rank, lengths, and "
+                "batches");
+        const auto& strides   = in_or_out == fft_io::fft_io_in ? istrides : ostrides;
+        const auto& distances = in_or_out == fft_io::fft_io_in ? idist : odist;
+        if(!vector_has_valid_values_as<ptrdiff_t>(strides, rank, 0)
+           || !vector_has_valid_values_as<ptrdiff_t>(distances, batch_rank, 0))
+            throw num_elements_calc_exception(
+                "hipfftw_helper::get_num_elements_in assumes non-negative strides and distances.");
+        size_t elem_count = 1;
+        for(auto len_dim = lengths.size(); len_dim-- > 0;)
         {
-            throw std::runtime_error(
-                "get_num_elements_in failed to correctly convert lengths to size_t values");
-        }
-        size_t num_elems = 1;
-        if(is_complex(dft_kind))
-        {
-            num_elems *= tmp[rank - 1];
-        }
-        else
-        {
-            const size_t cmplx_len = tmp[rank - 1] / 2 + 1;
-            if(is_fwd(dft_kind) == (in_or_out == fft_io_out))
-                num_elems *= cmplx_len;
+            if(((dft_kind == fft_transform_type_real_forward && in_or_out == fft_io::fft_io_out)
+                || (dft_kind == fft_transform_type_real_inverse && in_or_out == fft_io::fft_io_in))
+               && len_dim == lengths.size() - 1)
+            {
+                elem_count += (lengths[len_dim] / 2) * strides[len_dim];
+            }
             else
-                num_elems
-                    *= plan_placement == fft_placement_inplace ? 2 * cmplx_len : tmp[rank - 1];
+                elem_count += (lengths[len_dim] - 1) * strides[len_dim];
         }
-        num_elems *= product(tmp.begin(), tmp.begin() + rank - 1);
-        return num_elems;
+        for(auto batch_dim = batches.size(); batch_dim-- > 0;)
+            elem_count += (batches[batch_dim] - 1) * distances[batch_dim];
+        return elem_count;
     }
 
     size_t get_data_byte_size(fft_io in_or_out) const
     {
         if(in_or_out != fft_io_in && in_or_out != fft_io_out)
-            throw std::invalid_argument("invalid in_or_out for get_data_byte_size");
+            throw std::invalid_argument(
+                "invalid in_or_out passed to hipfftw_helper::get_data_byte_size");
         // for in-place, input and output data sizes are enforced equal
         std::vector<fft_io> io_range_to_consider = {in_or_out};
         if(plan_placement == fft_placement_inplace)
@@ -1332,6 +1699,31 @@ public:
     {
         plan_bundle.reset();
     }
+    bool is_using_default_strides() const
+    {
+        return istrides == default_strides(dft_kind, plan_placement, fft_io::fft_io_in, lengths)
+               && ostrides
+                      == default_strides(dft_kind, plan_placement, fft_io::fft_io_out, lengths);
+    }
+    bool is_using_default_distances() const
+    {
+        return idist
+                   == default_distances(
+                       dft_kind, plan_placement, fft_io::fft_io_in, lengths, batches)
+               && odist
+                      == default_distances(
+                          dft_kind, plan_placement, fft_io::fft_io_out, lengths, batches);
+    }
+    // public ad-hoc exceptions, specific to hipfftw_helper
+    struct type_conversion_exception : std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
+
+    struct num_elements_calc_exception : std::runtime_error
+    {
+        using std::runtime_error::runtime_error;
+    };
 };
 
 #endif

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -374,7 +374,7 @@ public:
 // function(s) to consider
 enum hipfftw_plan_creation_func : unsigned
 {
-    NONE        = 0x0, // not to be used (exceptfor validating values)
+    NONE        = 0x0, // not to be used (except for validating values)
     PLAN_DFT_ND = 0x1 << 0,
     PLAN_DFT    = 0x1 << 1,
     PLAN_MANY   = 0x1 << 2,
@@ -998,7 +998,7 @@ private:
                 ret = rank_is_valid_for_hipfftw(batch_rank);
                 break;
             default:
-                throw std::runtime_error("hipfftw_helper::has_valid_batych_rank internal error "
+                throw std::runtime_error("hipfftw_helper::has_valid_batch_rank internal error "
                                          "encountered (unexpected value for creation_func)");
             }
         }

--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -53,8 +53,6 @@ size_t             random_seed;
 std::random_device default_seed_dev;
 // Overall probability of running conventional tests
 double test_prob;
-// Probability of running non-minimal hipfftw tests
-double hipfftw_test_prob;
 // Modifier for probability of running tests with complex interleaved data
 double complex_interleaved_prob_factor;
 // Modifier for probability of running tests with real data
@@ -294,11 +292,6 @@ int main(int argc, char* argv[])
                    "Probability of running individual tests (excluding non-minimal hipfftw tests)")
         ->default_val(1.0)
         ->check(CLI::Range(0.0, 1.0));
-    app.add_option("--hipfftw_test_prob",
-                   hipfftw_test_prob,
-                   "Probability of running non-minimal hipfftw tests")
-        ->default_val(1.0)
-        ->check(CLI::Range(0.0, 1.0));
     app.add_option("--real_prob",
                    real_prob_factor,
                    "Probability multiplier for running individual real/complex transforms")
@@ -368,8 +361,7 @@ int main(int argc, char* argv[])
         ->each([&](const std::string&) {
             // The objective is to have an test that takes about 5 minutes, so just set the
             // probability per test to a small value to achieve this result.
-            test_prob         = 0.002;
-            hipfftw_test_prob = 0.02;
+            test_prob = 0.002;
         });
     // Token string to fully specify fft params for the manual test.
     std::string test_token;

--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -53,6 +53,8 @@ size_t             random_seed;
 std::random_device default_seed_dev;
 // Overall probability of running conventional tests
 double test_prob;
+// Probability of running non-minimal hipfftw tests
+double hipfftw_test_prob;
 // Modifier for probability of running tests with complex interleaved data
 double complex_interleaved_prob_factor;
 // Modifier for probability of running tests with real data
@@ -62,8 +64,10 @@ double complex_planar_prob_factor;
 // Modifier for probability of running tests with callbacks
 double callback_prob_factor;
 // Constraints for the hipfftw tests
-size_t max_length_for_hipfftw_test;
-size_t max_io_gb_for_hipfftw_test;
+size_t      max_length_for_hipfftw_test;
+size_t      max_io_gb_for_hipfftw_test;
+size_t      max_num_arg_validation_tests_per_hipfftw_plan_type;
+std::string hipfftw_token_for_functional_test;
 
 // Transform parameters for manual test:
 hipfft_params manual_params;
@@ -285,7 +289,14 @@ int main(int argc, char* argv[])
     const auto opt_help = app.add_flag("-h, --help", "Produces this help message");
     app.add_option("-v, --verbose", verbose, "Print out detailed information for the tests")
         ->default_val(0);
-    app.add_option("--test_prob", test_prob, "Probability of running individual tests")
+    app.add_option("--test_prob",
+                   test_prob,
+                   "Probability of running individual tests (excluding non-minimal hipfftw tests)")
+        ->default_val(1.0)
+        ->check(CLI::Range(0.0, 1.0));
+    app.add_option("--hipfftw_test_prob",
+                   hipfftw_test_prob,
+                   "Probability of running non-minimal hipfftw tests")
         ->default_val(1.0)
         ->check(CLI::Range(0.0, 1.0));
     app.add_option("--real_prob",
@@ -320,6 +331,17 @@ int main(int argc, char* argv[])
         ->default_val(1) /* 1 GiB */
         ->check(CLI::PositiveNumber);
 
+    app.add_option(
+           "--max_num_arg_validation_tests_per_hipfftw_plan_type",
+           max_num_arg_validation_tests_per_hipfftw_plan_type,
+           "Maximum number of argument-validation tests per kind of hipfftw plan creation function")
+        ->default_val(256)
+        ->check(CLI::PositiveNumber);
+    app.add_option("--hipfftw_token",
+                   hipfftw_token_for_functional_test,
+                   "manual token for hipfftw functional test")
+        ->default_val("");
+
     app.add_option("--fftw_compare", fftw_compare, "Compare to FFTW in accuracy tests")
         ->default_val(true);
     app.add_option("--mp_lib", mp_lib, "Multi-process library type: none (default), mpi")
@@ -346,7 +368,8 @@ int main(int argc, char* argv[])
         ->each([&](const std::string&) {
             // The objective is to have an test that takes about 5 minutes, so just set the
             // probability per test to a small value to achieve this result.
-            test_prob = 0.002;
+            test_prob         = 0.002;
+            hipfftw_test_prob = 0.02;
         });
     // Token string to fully specify fft params for the manual test.
     std::string test_token;
@@ -494,6 +517,7 @@ int main(int argc, char* argv[])
     // set any "unset" parameters of manual_params before initiating gtests
     // (makes the token reported by gtest less ambiguous)
     manual_params.validate();
+    std::cout << "Using random_seed = " << random_seed << std::endl;
 
     // extract remaining arguments for subsequent gtest initialization
     std::vector<std::string> remaining_args = app.remaining();
@@ -542,7 +566,6 @@ int main(int argc, char* argv[])
         }
     }
 
-    std::cout << "Using random_seed = " << random_seed << std::endl;
     std::cout << "half epsilon: " << half_epsilon << "\tsingle epsilon: " << single_epsilon
               << "\tdouble epsilon: " << double_epsilon << std::endl;
 
@@ -637,6 +660,7 @@ int main(int argc, char* argv[])
     std::cout << "single precision max l2 epsilon:     " << max_l2_eps_single << std::endl;
     std::cout << "double precision max l-inf epsilon: " << max_linf_eps_double << std::endl;
     std::cout << "double precision max l2 epsilon:     " << max_l2_eps_double << std::endl;
+    std::cout << "Used random_seed = " << random_seed << std::endl;
 
     hipfft_params::externally_managed_workareas.clear();
 

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -38,8 +38,11 @@
 #include <omp.h>
 #endif
 
-extern size_t max_length_for_hipfftw_test;
-extern size_t max_io_gb_for_hipfftw_test;
+extern double      hipfftw_test_prob;
+extern size_t      max_length_for_hipfftw_test;
+extern size_t      max_io_gb_for_hipfftw_test;
+extern size_t      max_num_arg_validation_tests_per_hipfftw_plan_type;
+extern std::string hipfftw_token_for_functional_test;
 
 // test details
 namespace
@@ -77,6 +80,9 @@ namespace
         static const size_t io_byte_size_limit = get_io_byte_size_limit();
         return io_byte_size_limit;
     }
+    // for readability of template specializations
+    constexpr bool valid_value          = true;
+    constexpr int  min_unsupported_rank = 4;
 
     std::ranlux24_base& get_pseudo_rng()
     {
@@ -141,28 +147,35 @@ namespace
         }
         return ret;
     }
-    template <bool validity_flag, typename type_to_consider_for_validity>
+
+    template <bool strictly_positive_values, typename type_to_consider_for_validity>
     std::vector<ptrdiff_t>
-        get_random_lengths(int       desired_rank,
-                           ptrdiff_t max_abs_len
-                           = std::numeric_limits<type_to_consider_for_validity>::max(),
-                           ptrdiff_t min_abs_len = 0)
+        get_random_vector(int       desired_rank,
+                          ptrdiff_t max_abs_val
+                          = std::numeric_limits<type_to_consider_for_validity>::max(),
+                          ptrdiff_t min_abs_val = 0)
     {
         std::vector<ptrdiff_t> ret;
-        // cannot generate lengths for invalid ranks --> return empty lengths in that case
+        // cannot generate vectors for invalid ranks --> return an empty vector in that case
         if(!rank_is_valid_for_hipfftw(desired_rank))
             return ret;
-        if(min_abs_len < 0 || min_abs_len > max_abs_len)
-            throw std::invalid_argument("invalid bounds used for get_random_lengths");
+        if(min_abs_val < 0 || min_abs_val > max_abs_val)
+            throw std::invalid_argument("invalid bounds used for get_random_vector");
+        if constexpr(strictly_positive_values)
+        {
+            if(max_abs_val < 1)
+                throw std::runtime_error(
+                    "invalid bounds for generating a vector of strictly positive values");
+        }
         // generate values that are all representable as integers
         auto&                                    pseudo_rng = get_pseudo_rng();
-        std::uniform_int_distribution<ptrdiff_t> length_rng(min_abs_len, max_abs_len);
+        std::uniform_int_distribution<ptrdiff_t> val_rng(min_abs_val, max_abs_val);
         // setter lambda
-        auto set_random_len = [&]() {
+        auto set_random_values = [&]() {
             for(auto& l : ret)
             {
-                const ptrdiff_t val = length_rng(pseudo_rng);
-                if constexpr(validity_flag)
+                const ptrdiff_t val = val_rng(pseudo_rng);
+                if constexpr(strictly_positive_values)
                     l = val;
                 else
                 {
@@ -175,10 +188,14 @@ namespace
         };
 
         ret.resize(desired_rank);
-        set_random_len();
-        while(lengths_are_valid_for_hipfftw_as<type_to_consider_for_validity>(ret, desired_rank)
-              != validity_flag)
-            set_random_len();
+        set_random_values();
+        constexpr type_to_consider_for_validity min_valid_val = 1;
+        while(vector_has_valid_values_as<type_to_consider_for_validity>(
+                  ret, desired_rank, min_valid_val)
+              != strictly_positive_values)
+        {
+            set_random_values();
+        }
 
         return ret;
     }
@@ -217,6 +234,7 @@ namespace
             tmp = flags_rng(get_pseudo_rng());
         return tmp;
     }
+
     size_t get_random_idx(size_t upper_bound)
     {
         if(upper_bound == 0)
@@ -224,39 +242,48 @@ namespace
         std::uniform_int_distribution<size_t> idx_rng(0, upper_bound - 1);
         return idx_rng(get_pseudo_rng());
     }
+    template <typename T>
+    T get_random_element_in(const std::vector<T>& element_list)
+    {
+        return element_list[get_random_idx(element_list.size())];
+    }
 
-    // calculates the threshold value X such that the number of relevant elements
-    // is no greater (resp. larger) than num_elems, if all elements of lengths are
-    // all no greater (resp. larger) than X, and lengths.size() == rank [using bisection]
-    ptrdiff_t get_len_threshold(size_t num_elems, int rank, bool is_real_inplace)
+    // calculates the threshold value X such that the byte size of I/O default-layout data
+    // sets is no greater than max_byte_size, if all elements of lengths are no greater than X,
+    // and if lengths.size() == rank [using bisection]
+    template <fft_precision prec>
+    ptrdiff_t find_threshold_length_for_byte_size(size_t max_byte_size, int rank, bool real_dft)
     {
         if(rank < 1)
-            throw std::invalid_argument("invalid rank used in get_len_threshold");
-        if(num_elems == 0)
-            return 1;
+            throw std::invalid_argument("invalid rank used in find_threshold_length_for_byte_size");
+        if(max_byte_size == 0)
+            return 0;
         constexpr ptrdiff_t X_max = std::numeric_limits<ptrdiff_t>::max();
         // we need to find X in [0, X_max] s.t.
-        // largest_idx(X) <= num_elems && largest_idx(X + 1) > num_elems
-        auto largest_idx = [&](ptrdiff_t X) {
-            size_t ret = rank > 1 && is_real_inplace ? 2 * (X / 2 + 1) : X;
+        // byte_size(X) <= max_byte_size && byte_size(X + 1) > max_byte_size
+        auto byte_size = [&](ptrdiff_t X) {
+            // for real DFT, default layout's largest memory footprint are in the complex domain
+            size_t ret = real_dft ? (X / 2 + 1) : X;
             for(auto i = 1; i < rank; i++)
                 ret *= X;
+            ret *= sizeof(hipfftw_complex_t<prec>);
             return ret;
         };
         // initialization
-        ptrdiff_t X_down
-            = rank == 1 ? static_cast<ptrdiff_t>(num_elems)
-                        : static_cast<ptrdiff_t>(std::floor(std::pow(num_elems, 1.0 / rank)));
-        ptrdiff_t diff = 1;
-        ptrdiff_t X_up = X_down;
-        while(largest_idx(X_up) <= num_elems && X_up < X_max)
+        ptrdiff_t X_down = static_cast<ptrdiff_t>(std::floor(std::pow(
+            max_byte_size
+                / (real_dft ? sizeof(hipfftw_real_t<prec>) : sizeof(hipfftw_complex_t<prec>)),
+            1.0 / rank)));
+        ptrdiff_t diff   = 1;
+        ptrdiff_t X_up   = X_down;
+        while(byte_size(X_up) <= max_byte_size && X_up < X_max)
         {
             X_down = X_up;
             X_up   = X_up <= X_max - diff ? X_up + diff : X_max;
             diff *= 2;
         }
         diff = 1;
-        while(largest_idx(X_down) > num_elems && X_down > 0)
+        while(byte_size(X_down) > max_byte_size && X_down > 0)
         {
             X_up   = X_down;
             X_down = X_down >= diff ? X_down - diff : 0;
@@ -266,20 +293,12 @@ namespace
         while(X_up - X_down > 1)
         {
             const auto tmp = (X_up + X_down) / 2;
-            if(largest_idx(tmp) <= num_elems)
+            if(byte_size(tmp) <= max_byte_size)
                 X_down = tmp;
             else
                 X_up = tmp;
         }
         return X_down;
-    }
-
-    template <fft_precision prec>
-    size_t max_num_elems_for_data_size(size_t data_byte_size, fft_transform_type dft_kind)
-    {
-        return data_byte_size
-               / (is_real(dft_kind) ? sizeof(hipfftw_real_t<prec>)
-                                    : sizeof(hipfftw_complex_t<prec>));
     }
 
     // exception for hip runtime error(s) specifically
@@ -452,6 +471,11 @@ namespace
         bool operator==(const hipfftw_malloc_params& other) const
         {
             return to_string() == other.to_string();
+        }
+        friend std::ostream& operator<<(std::ostream& stream, const hipfftw_malloc_params& params)
+        {
+            stream << params.to_string();
+            return stream;
         }
     };
 
@@ -878,12 +902,13 @@ namespace
 
         // checks consistency between values for test parameters that may have
         // overlapping scopes/meaning, in some specific cases
-        bool can_be_tested(bool io_allocation_is_allowed = true) const
+        bool can_be_tested() const
         {
             if(!hipfftw_execution_io_args_are_well_defined(execution_io))
                 return false;
             if(!plan_helper.can_use_creation_options(creation_options))
                 return false;
+
             if(creation_placement() == fft_placement_inplace)
             {
                 if(creation_io_is_null.first != creation_io_is_null.second)
@@ -912,19 +937,25 @@ namespace
                    && is_execution_arg_null(fft_io::fft_io_out))
                     return false; // would be in-place at execution
             }
-            if(!io_allocation_is_allowed)
+            if(flags_are_valid_for_hipfftw(plan_helper.get_flags())
+               && !(plan_helper.get_flags() & FFTW_ESTIMATE))
             {
-                // do not tolerate allow SetUp to allocate
-                bool ret = creation_io_is_null.first
-                           && (creation_placement() == fft_placement_inplace
-                               || creation_io_is_null.second);
-                if(!use_creation_io_at_execution() && ret)
+                // I/O data pointers may be touched at creation. In that case,
+                // the I/O allocations must make sense and be large enough
+                // --> cannot test if I/O allocation sizes cannot be reliably calculated
+                try
                 {
-                    ret = is_execution_arg_null(fft_io::fft_io_in)
-                          && (execution_placement() == fft_placement_inplace
-                              || is_execution_arg_null(fft_io::fft_io_out));
+                    (void)plan_helper.get_data_byte_size(fft_io::fft_io_in);
+                    (void)plan_helper.get_data_byte_size(fft_io::fft_io_out);
                 }
-                return ret;
+                catch(const typename hipfftw_helper<prec>::num_elements_calc_exception& e)
+                {
+                    return false;
+                }
+                catch(...)
+                {
+                    throw; // escalate the unexpected exception
+                }
             }
             return true;
         }
@@ -975,6 +1006,7 @@ namespace
                 // plan cannot be created
                 if(valid_args_for_plan_creation)
                     return hipfftw_internal_exception::unsupported_args;
+
                 // plan cannot be created and arguments were invalid...
                 // We may however have a mixed bag of some invalid and other unsupported args.
                 // In such cases, the specific exception to expect would be ill-defined
@@ -1033,168 +1065,260 @@ namespace
         {
             return to_string() == other.to_string();
         }
+        friend std::ostream& operator<<(std::ostream&                          stream,
+                                        const hipfftw_input_validation_params& params)
+        {
+            stream << params.to_string();
+            return stream;
+        }
     };
+
+    std::vector<int> arg_validation_runtime_rank_range()
+    {
+        std::vector<int> ret = {
+            get_random_rank<!valid_value>(), // invalid
+            get_random_rank<valid_value, min_unsupported_rank>(), // valid but unsupported
+            get_random_rank<valid_value, 1, min_unsupported_rank - 1>() // valid and supported
+        };
+        return ret;
+    }
+
+    template <typename validation_t = int,
+              std::enable_if_t<
+                  std::is_same_v<validation_t, int> || std::is_same_v<validation_t, ptrdiff_t>,
+                  bool> = true>
+    std::vector<std::vector<ptrdiff_t>>
+        arg_validation_strictly_positive_vec_range(int vec_size, ptrdiff_t max_value)
+    {
+        std::vector<std::vector<ptrdiff_t>> ret;
+        if(vec_size < 1)
+            return ret;
+        if(max_value < 1)
+            throw std::invalid_argument("invalid max_val in arg_validation_strictly_positive_vec");
+        // always add valid values
+        ret.emplace_back(get_random_vector<valid_value, validation_t>(vec_size, max_value));
+        // invalid integer values (most likely nonzero)
+        ret.emplace_back(get_random_vector<!valid_value, validation_t>(vec_size, max_value));
+        // invalid integer values due to some zero(es)
+        auto tmp = get_random_vector<valid_value, validation_t>(vec_size, max_value);
+        tmp[get_random_idx(tmp.size())] = 0;
+        ret.emplace_back(tmp);
+        return ret;
+    }
+
+    std::vector<int> arg_validation_sign_range(fft_transform_type test_dft_type)
+    {
+        std::vector<int> ret = {get_random_sign<valid_value>(test_dft_type)};
+        if(is_complex(test_dft_type))
+            ret.push_back(get_random_sign<!valid_value>(test_dft_type));
+        return ret;
+    }
+
+    std::vector<unsigned> arg_validation_flags_range(fft_transform_type test_dft_type,
+                                                     int                test_rank)
+    {
+        // FFTW_ESTIMATE is always supported
+        std::vector<unsigned> ret = {FFTW_ESTIMATE};
+        // some invalid flags
+        ret.push_back(get_random_flags<!valid_value>());
+        // unsupported FFTW_WISDOM_ONLY
+        ret.push_back(FFTW_WISDOM_ONLY | get_random_flags<valid_value>());
+        if(test_dft_type == fft_transform_type_real_inverse && test_rank > 1)
+        {
+            // unsupported FFTW_PRESERVE_INPUT for multi-dimensional c2r
+            ret.push_back(FFTW_PRESERVE_INPUT | get_random_flags<valid_value>());
+        }
+        return ret;
+    }
+
+    template <fft_precision prec>
+    std::vector<hipfftw_helper<prec>> test_scope_for_arg_validation_of_plan_dft_nd()
+    {
+        std::vector<hipfftw_helper<prec>> ret;
+        while(ret.size() < max_num_arg_validation_tests_per_hipfftw_plan_type)
+        {
+            const auto dft_kind = get_random_element_in(trans_type_range_full);
+            // only ranks 1-3 for plan_dft_nd functions
+            const auto      rank      = get_random_rank<valid_value, 1, 3>();
+            const auto      placement = get_random_element_in(place_range);
+            const ptrdiff_t max_len
+                = std::min(static_cast<ptrdiff_t>(max_length_for_hipfftw_test),
+                           find_threshold_length_for_byte_size<prec>(
+                               max_byte_size_for_hipfftw_tests(), rank, is_real(dft_kind)));
+            const auto lengths
+                = get_random_element_in(arg_validation_strictly_positive_vec_range(rank, max_len));
+            const auto sign  = get_random_element_in(arg_validation_sign_range(dft_kind));
+            const auto flags = get_random_element_in(arg_validation_flags_range(dft_kind, rank));
+            hipfftw_helper<prec> helper_to_add;
+            helper_to_add.set_creation_args(dft_kind, rank, lengths, placement, sign, flags);
+            ret.push_back(helper_to_add);
+        }
+        return ret;
+    }
+
+    template <fft_precision prec>
+    std::vector<hipfftw_helper<prec>> test_scope_for_arg_validation_of_plan_dft()
+    {
+        std::vector<hipfftw_helper<prec>> ret;
+
+        while(ret.size() < max_num_arg_validation_tests_per_hipfftw_plan_type)
+        {
+            const auto dft_kind  = get_random_element_in(trans_type_range_full);
+            const auto rank      = get_random_element_in(arg_validation_runtime_rank_range());
+            const auto placement = get_random_element_in(place_range);
+            ptrdiff_t  max_len   = max_length_for_hipfftw_test;
+            if(rank_is_valid_for_hipfftw(rank))
+            {
+                max_len = std::min(max_len,
+                                   find_threshold_length_for_byte_size<prec>(
+                                       max_byte_size_for_hipfftw_tests(), rank, is_real(dft_kind)));
+            }
+            std::vector<std::vector<ptrdiff_t>> range_of_lengths
+                = arg_validation_strictly_positive_vec_range(rank, max_len);
+            // --> test for empty lengths, too (re-interpreted as a nullptr argument by hipfftw_helper)
+            range_of_lengths.push_back(std::vector<ptrdiff_t>());
+            const auto lengths = get_random_element_in(range_of_lengths);
+            const auto sign    = get_random_element_in(arg_validation_sign_range(dft_kind));
+            const auto flags   = get_random_element_in(arg_validation_flags_range(dft_kind, rank));
+            hipfftw_helper<prec> helper_to_add;
+            helper_to_add.set_creation_args(dft_kind, rank, lengths, placement, sign, flags);
+            ret.push_back(helper_to_add);
+        }
+        return ret;
+    }
+
+    // broad scope of hipfftw_helpers structs compatible with using a specific
+    // plan creation function and configured with (zero or possibly many)
+    // invalid/unsupported parameter value(s)
+    template <fft_precision prec>
+    std::vector<hipfftw_helper<prec>>
+        test_scope_for_arg_validation_of(hipfftw_plan_creation_func creation_func)
+    {
+        switch(creation_func)
+        {
+        case hipfftw_plan_creation_func::PLAN_DFT_ND:
+            return test_scope_for_arg_validation_of_plan_dft_nd<prec>();
+        case hipfftw_plan_creation_func::PLAN_DFT:
+            return test_scope_for_arg_validation_of_plan_dft<prec>();
+        case hipfftw_plan_creation_func::PLAN_MANY:
+            [[fallthrough]];
+        case hipfftw_plan_creation_func::PLAN_GURU:
+            [[fallthrough]];
+        case hipfftw_plan_creation_func::PLAN_GURU64:
+            throw std::runtime_error(
+                "PLAN_MANY, PLAN_GURU, and PLAN_GURU64 are not implemented yet "
+                "for test_scope_for_arg_validation_of");
+        default:
+            throw std::invalid_argument(
+                "creation_func unknown to test_scope_for_arg_validation_of");
+        }
+    }
+
+    template <fft_precision prec>
+    std::vector<hipfftw_plan_execution_func>
+        arg_validation_exec_func_range(const hipfftw_helper<prec>& test_helper)
+    {
+        const static std::vector<hipfftw_plan_execution_func> possible_exec_functions
+            = {hipfftw_plan_execution_func::EXECUTE,
+               hipfftw_plan_execution_func::EXECUTE_DFT,
+               hipfftw_plan_execution_func::EXECUTE_DFT_R2C,
+               hipfftw_plan_execution_func::EXECUTE_DFT_C2R};
+        std::vector<hipfftw_plan_execution_func> ret;
+        for(auto can_be_used : {true, false})
+        {
+            auto to_add = get_random_element_in(possible_exec_functions);
+            while(test_helper.can_use_execution_option(to_add) != can_be_used)
+            {
+                to_add = get_random_element_in(possible_exec_functions);
+            }
+            ret.push_back(to_add);
+        }
+        return ret;
+    }
+
+    template <fft_precision prec>
+    std::vector<hipfftw_execution_io_args>
+        arg_validation_exec_io_flags_range(const hipfftw_helper<prec>& test_helper)
+    {
+        auto create_possible_io_flags = []() {
+            std::vector<hipfftw_execution_io_args> ret;
+            for(std::underlying_type_t<hipfftw_execution_io_args> tmp
+                = hipfftw_execution_io_args::use_creation_io;
+                tmp < hipfftw_execution_io_args::clean_new_io;
+                tmp++)
+            {
+                ret.push_back(static_cast<hipfftw_execution_io_args>(tmp));
+            }
+            return ret;
+        };
+        const static auto possible_exec_io_flags = create_possible_io_flags();
+        // always add clean new io in range, to guarantee one testable combo
+        return {hipfftw_execution_io_args::clean_new_io,
+                get_random_element_in(possible_exec_io_flags)};
+    }
 
     template <fft_precision prec>
     std::vector<hipfftw_input_validation_params<prec>> params_for_testing_input_validation_params()
     {
-        // constexpr used for readability of template specialization values below
-        constexpr bool valid_value          = true;
-        constexpr int  min_unsupported_rank = 4;
-        // broad scope of hipfftw_helper structs configured with (zero or possibly
-        // many) invalid/unsupported parameter value(s)
-        std::vector<hipfftw_helper<prec>> helper_scope;
-        for(auto dft_kind : trans_type_range_full)
-        {
-            std::vector<int> rank_range = {1, 2, 3};
-            rank_range.push_back(get_random_rank<!valid_value>());
-            rank_range.push_back(get_random_rank<valid_value, min_unsupported_rank>());
-            for(auto rank : rank_range)
-            {
-                for(auto placement : place_range)
-                {
-                    std::vector<std::vector<ptrdiff_t>> range_of_lengths;
-                    // most creation funcs take lengths as pointers
-                    // --> test for empty lengths (re-interpreted as a nullptr
-                    // arg by hipfftw_helper)
-                    range_of_lengths.emplace_back(std::vector<ptrdiff_t>());
-                    if(rank > 0)
-                    {
-                        const bool is_real_inplace
-                            = is_real(dft_kind) && placement == fft_placement_inplace;
-                        const ptrdiff_t allocatable_len_threshold = std::min(
-                            get_len_threshold(max_num_elems_for_data_size<prec>(
-                                                  max_byte_size_for_hipfftw_tests(), dft_kind),
-                                              rank,
-                                              is_real_inplace),
-                            static_cast<ptrdiff_t>(max_length_for_hipfftw_test));
-                        const auto valid_int_lengths
-                            = get_random_lengths<valid_value, int>(rank, allocatable_len_threshold);
-                        // always add valid integer lengths for valid ranks
-                        range_of_lengths.emplace_back(valid_int_lengths);
-                        // invalid integer lengths (most likely nonzero)
-                        const auto invalid_int_lengths = get_random_lengths<!valid_value, int>(
-                            rank, allocatable_len_threshold);
-                        range_of_lengths.emplace_back(invalid_int_lengths);
-                        // invalid integer lengths (some zero)
-                        auto invalid_int_lengths_due_to_some_zero = valid_int_lengths;
-                        invalid_int_lengths_due_to_some_zero[get_random_idx(rank)] = 0;
-                        range_of_lengths.emplace_back(invalid_int_lengths_due_to_some_zero);
-                        if(rank > 1 && rank < min_unsupported_rank)
-                        {
-                            // no support for layouts that trigger an int overflow for any relevant
-                            // element index (unless GURU64 creation functions are used)
-                            const auto min_overflowing_len = get_len_threshold(
-                                std::numeric_limits<int>::max(), rank, is_real_inplace);
-                            const auto unsupported_int_lengths
-                                = get_random_lengths<valid_value, int>(
-                                    rank, std::numeric_limits<int>::max(), min_overflowing_len + 1);
-                            range_of_lengths.emplace_back(unsupported_int_lengths);
-                        }
-                    }
-                    for(const auto& lengths : range_of_lengths)
-                    {
-                        std::vector<int> sign_range = {get_random_sign<valid_value>(dft_kind)};
-                        if(is_complex(dft_kind))
-                            sign_range.push_back(get_random_sign<!valid_value>(dft_kind));
-                        for(auto sign : sign_range)
-                        {
-                            // FFTW_ESTIMATE is always supported
-                            std::vector<unsigned> flags_range = {FFTW_ESTIMATE};
-                            // some invalid flags
-                            flags_range.push_back(get_random_flags<!valid_value>());
-                            // unsupported FFTW_WISDOM_ONLY
-                            flags_range.push_back(FFTW_WISDOM_ONLY
-                                                  | get_random_flags<valid_value>());
-                            // unsupported FFTW_PRESERVE_INPUT for multi-dimensional c2r
-                            flags_range.push_back(FFTW_PRESERVE_INPUT
-                                                  | get_random_flags<valid_value>());
-                            for(auto flags : flags_range)
-                            {
-                                hipfftw_helper<prec> helper_to_add;
-                                helper_to_add.set_creation_args(
-                                    dft_kind, rank, lengths, placement, sign, flags);
-                                helper_scope.emplace_back(helper_to_add);
-                            }
-                        }
-                    }
-                }
-            }
-        }
         // create a full-scope map containing all the generated test parameters; the map keys
-        // capture the hipfftw's function name that the tests would target
+        // capture the hipfftw's function name that the test targets
         // --> ease for guaranteeing coverage even with low test probability in the end
         std::map<std::string, std::vector<hipfftw_input_validation_params<prec>>> full_scope_tests;
         hipfftw_input_validation_params<prec>                                     test_to_add;
 
-        for(const auto& helper : helper_scope)
+        const std::vector<std::pair<bool, bool>> possible_creation_io_is_null_inplace
+            = {{false, false}, {true, true}};
+        const std::vector<std::pair<bool, bool>> possible_creation_io_is_null_notinplace
+            = {{false, false}, {true, false}, {false, true}};
+
+        for(auto creation_func :
+            {hipfftw_plan_creation_func::PLAN_DFT_ND, hipfftw_plan_creation_func::PLAN_DFT})
         {
-            // do not allocate for the lengths designed to trigger an overflow
-            // (allocation sizes would be ridiculously large)
-            const bool test_may_allocate = helper.has_valid_rank() && helper.has_valid_lengths()
-                                           && helper.get_data_byte_size(fft_io::fft_io_in)
-                                                  <= max_byte_size_for_hipfftw_tests()
-                                           && helper.get_data_byte_size(fft_io::fft_io_out)
-                                                  <= max_byte_size_for_hipfftw_tests();
-            for(auto creation : hipfftw_plan_creation_func_candidates)
+            for(const auto& helper : test_scope_for_arg_validation_of<prec>(creation_func))
             {
-                for(auto execution : {hipfftw_plan_execution_func::EXECUTE,
-                                      hipfftw_plan_execution_func::EXECUTE_DFT,
-                                      hipfftw_plan_execution_func::EXECUTE_DFT_R2C,
-                                      hipfftw_plan_execution_func::EXECUTE_DFT_C2R})
+                const std::vector<std::pair<bool, bool>>& possible_creation_io_is_null
+                    = helper.get_placement() == fft_placement_inplace
+                          ? possible_creation_io_is_null_inplace
+                          : possible_creation_io_is_null_notinplace;
+                for(auto exec_func : arg_validation_exec_func_range(helper))
                 {
-                    // full range considered for creation_io_is_null and execution_io
-                    // parameters: some might be ruled out later on because they can't
-                    // be tested (e.g., "not_inplace" required yet using nullptr for
-                    // creation input and output would be nonsensical)
-                    const std::vector<std::pair<bool, bool>> creation_io_is_null_range
-                        = {{false, false}, {true, false}, {false, true}, {true, true}};
-                    for(auto set_creation_io_as_null : creation_io_is_null_range)
+                    for(auto exec_io_flags : arg_validation_exec_io_flags_range(helper))
                     {
-                        for(std::underlying_type_t<hipfftw_execution_io_args> exec_io
-                            = hipfftw_execution_io_args::use_creation_io;
-                            exec_io <= hipfftw_execution_io_args::clean_new_io;
-                            exec_io++)
+                        test_to_add.creation_options = creation_func;
+                        test_to_add.execution_option = exec_func;
+                        test_to_add.creation_io_is_null
+                            = get_random_element_in(possible_creation_io_is_null);
+                        test_to_add.execution_io = exec_io_flags;
+                        test_to_add.plan_helper  = helper;
+                        // skip params if they can't/shouldn't be tested anyways
+                        if(!test_to_add.can_be_tested())
+                            continue;
+
+                        // tests expect a failure at execution at least
+                        if(test_to_add.expected_internal_exception_for(hipfftw_step::plan_execution)
+                           == hipfftw_internal_exception::none)
+                            continue;
+                        std::string map_key;
+                        if(test_to_add.expected_internal_exception_for(hipfftw_step::plan_creation)
+                               == hipfftw_internal_exception::invalid_args
+                           || test_to_add.expected_internal_exception_for(
+                                  hipfftw_step::plan_creation)
+                                  == hipfftw_internal_exception::unsupported_args)
                         {
-                            test_to_add.creation_options    = creation;
-                            test_to_add.execution_option    = execution;
-                            test_to_add.creation_io_is_null = set_creation_io_as_null;
-                            test_to_add.execution_io
-                                = static_cast<hipfftw_execution_io_args>(exec_io);
-                            test_to_add.plan_helper = helper;
-                            // skip params if they can't/shouldn't be tested anyways
-                            if(!test_to_add.can_be_tested(test_may_allocate))
-                                continue;
-                            // tests expect a failure at execution at least
-                            if(test_to_add.expected_internal_exception_for(
-                                   hipfftw_step::plan_execution)
-                               == hipfftw_internal_exception::none)
-                                continue;
-                            if(test_to_add.expected_internal_exception_for(
-                                   hipfftw_step::plan_creation)
-                                   == hipfftw_internal_exception::invalid_args
-                               || test_to_add.expected_internal_exception_for(
-                                      hipfftw_step::plan_creation)
-                                      == hipfftw_internal_exception::unsupported_args)
-                            {
-                                insert_into_unique_sorted_params(
-                                    full_scope_tests[hipfftw_creation_options_to_string(
-                                        creation, helper.get_dft_kind(), helper.get_rank())],
-                                    test_to_add);
-                            }
-                            else
-                            {
-                                insert_into_unique_sorted_params(
-                                    full_scope_tests[hipfftw_execution_option_to_string(execution)],
-                                    test_to_add);
-                            }
+                            map_key = hipfftw_creation_options_to_string(
+                                creation_func, helper.get_dft_kind(), helper.get_rank());
                         }
+                        else
+                        {
+                            map_key = hipfftw_execution_option_to_string(exec_func);
+                        }
+                        insert_into_unique_sorted_params(full_scope_tests[map_key], test_to_add);
                     }
                 }
             }
         }
         std::vector<hipfftw_input_validation_params<prec>> ret;
-        for(auto pair : full_scope_tests)
+        for(auto& pair : full_scope_tests)
         {
             const auto& targeted_func  = pair.first;
             auto&       targeted_tests = pair.second;
@@ -1213,11 +1337,12 @@ namespace
             {
                 const double roll = hash_prob(random_seed, test.to_string());
                 // not distinguishing between real/complex for this list generation
-                if(roll > test_prob)
+                if(roll > hipfftw_test_prob)
                 {
                     if(verbose > 4)
                     {
-                        std::cout << "Test skipped: (roll=" << roll << " > " << test_prob << ")\n";
+                        std::cout << "Test skipped: (roll=" << roll << " > " << hipfftw_test_prob
+                                  << ")\n";
                     }
                     continue;
                 }
@@ -1238,18 +1363,36 @@ namespace
 
             if(!params.can_be_tested())
                 GTEST_FAIL() << "invalid parameters which cannot be tested";
+            safe_to_touch_nonnull_io = true;
 
             // get_data_byte_size requires valid ranks and lengths to be calculated (of course)
             // --> make sure the I/O data sizes are not zero for test consistency w.r.t. testing
             // for nullptr data args I/O
-            const size_t input_data_size
-                = params.plan_helper.has_valid_rank() && params.plan_helper.has_valid_lengths()
-                      ? params.plan_helper.get_data_byte_size(fft_io_in)
-                      : sizeof(hipfftw_complex_t<prec>);
-            const size_t output_data_size
-                = params.plan_helper.has_valid_rank() && params.plan_helper.has_valid_lengths()
-                      ? params.plan_helper.get_data_byte_size(fft_io_out)
-                      : sizeof(hipfftw_complex_t<prec>);
+            auto compute_io_size = [&](fft_io io) {
+                try
+                {
+                    return params.plan_helper.get_data_byte_size(io);
+                }
+                catch(const typename hipfftw_helper<prec>::num_elements_calc_exception& e)
+                {
+                    safe_to_touch_nonnull_io = false;
+                    return sizeof(hipfftw_complex_t<prec>); // some nonzero value
+                }
+                catch(...)
+                {
+                    throw;
+                }
+            };
+            const size_t input_data_size  = compute_io_size(fft_io::fft_io_in);
+            const size_t output_data_size = compute_io_size(fft_io::fft_io_out);
+            if(input_data_size > max_byte_size_for_hipfftw_tests()
+               || output_data_size > max_byte_size_for_hipfftw_tests())
+            {
+                GTEST_SKIP()
+                    << "Skipping test due to excessive I/O byte size (max of I/O byte size: "
+                    << std::max(input_data_size, output_data_size)
+                    << " vs limit: " << max_byte_size_for_hipfftw_tests() << ")";
+            }
 
             if(params.creation_io_is_null.first)
                 plan_creation_input.free();
@@ -1293,6 +1436,7 @@ namespace
         hostbuf plan_creation_output;
         hostbuf plan_execution_input;
         hostbuf plan_execution_output;
+        bool    safe_to_touch_nonnull_io;
 
         void expect_failure(hipfftw_step step_target)
         {
@@ -1316,25 +1460,29 @@ namespace
                     exception_logger  = std::make_unique<hipfftw_exception_logger>();
                     check_log_content = exception_logger->is_active();
                 }
-                params.plan_helper.create_plan(plan_creation_input.data(),
-                                               params.creation_placement() == fft_placement_inplace
-                                                   ? plan_creation_input.data()
-                                                   : plan_creation_output.data(),
-                                               params.creation_options);
+                void* creation_in  = plan_creation_input.data();
+                void* creation_out = params.creation_placement() == fft_placement_inplace
+                                         ? plan_creation_input.data()
+                                         : plan_creation_output.data();
+                if((creation_in || creation_out)
+                   && flags_are_valid_for_hipfftw(params.plan_helper.get_flags())
+                   && !(params.plan_helper.get_flags() & FFTW_ESTIMATE)
+                   && !safe_to_touch_nonnull_io)
+                {
+                    // I/O may be touched during plan creation, yet their size couldn't be clearly determined
+                    GTEST_SKIP() << "unsafe to test for these parameters (plan creation)";
+                }
+                params.plan_helper.create_plan(creation_in, creation_out, params.creation_options);
                 if(step_target == hipfftw_step::plan_creation)
                 {
                     log_content = exception_logger->get_log();
                     exception_logger.reset();
-                    const std::shared_ptr<hipfftw_plan_bundle_t<prec>> plan_bundle
-                        = params.plan_helper.get_plan_bundle();
-                    if(!plan_bundle)
+                    if(params.plan_helper.get_plan())
                         throw std::runtime_error(
-                            "the plan bundle could not be retrieved from the parameters");
-                    if(plan_bundle->plan)
-                        throw std::runtime_error(
-                            hipfftw_creation_options_to_string(plan_bundle->creation_func,
-                                                               params.plan_helper.get_dft_kind(),
-                                                               params.plan_helper.get_rank())
+                            hipfftw_creation_options_to_string(
+                                params.plan_helper.get_plan_creation_function(),
+                                params.plan_helper.get_dft_kind(),
+                                params.plan_helper.get_rank())
                             + " actually created a plan for these parameters");
                 }
                 else
@@ -1351,12 +1499,21 @@ namespace
                                             : (params.execution_placement() == fft_placement_inplace
                                                    ? plan_execution_input.data()
                                                    : plan_execution_output.data());
+
+                    if(params.plan_helper.get_plan() && (creation_in || creation_out)
+                       && !safe_to_touch_nonnull_io)
+                    {
+                        // A plan was successfully created and I/O may be touched during plan execution,
+                        // yet their size(s) couldn't be clearly determined
+                        GTEST_SKIP() << "unsafe to test for these parameters (plan execution)";
+                    }
                     // intentionally do not check that hipfftw_test_plan != nullptr as that's
                     // kind of the point of this test: even if it doesn't report error codes,
                     // execution must not misbehave (e.g. must not segfault) with invalid argument
                     // (if hipfftw's exception handler is made verbose, it should print failure
                     //  info to the log, and that's verified in the end)
                     params.plan_helper.execute(exec_in, exec_out, params.execution_option);
+
                     log_content = exception_logger->get_log();
                     exception_logger.reset();
                 }
@@ -1490,8 +1647,8 @@ namespace
             return "device";
             break;
         default:
-            throw std::runtime_error("internal error: unexpected value of mem_tye in "
-                                     "hipfftw_data_mem_type_to_string");
+            throw std::runtime_error(
+                "internal error: unexpected value of mem_type in hipfftw_data_mem_type_to_string");
             break;
         }
     };
@@ -1499,12 +1656,16 @@ namespace
     template <fft_precision prec>
     struct hipfftw_functional_validation_params
     {
+
         // define type of I/O argument memory to be tested at a given step (creation/execution)
         // by a map: mem_type[{step_label, io_label}] represents the test's target memory type to consider
         // for the "io_label" I/O argument at step "step_label"
         std::map<std::pair<hipfftw_step, fft_io>, hipfftw_data_memory_type> mem_type;
         hipfftw_execution_io_args                                           execution_io;
         hipfftw_helper<prec>                                                plan_helper;
+
+        hipfftw_functional_validation_params()
+            : manually_created(false){};
 
         fft_transform_type get_dft_kind() const
         {
@@ -1533,7 +1694,7 @@ namespace
         }
         std::vector<size_t> get_lengths() const
         {
-            return plan_helper.template get_length_as<size_t>();
+            return plan_helper.template get_lengths_as<size_t>();
         }
         std::vector<size_t> get_ilengths() const
         {
@@ -1541,6 +1702,13 @@ namespace
             if(plan_helper.get_dft_kind() == fft_transform_type_real_inverse)
                 ilengths.back() = ilengths.back() / 2 + 1;
             return ilengths;
+        }
+        std::vector<size_t> get_olengths() const
+        {
+            auto olengths = get_lengths();
+            if(plan_helper.get_dft_kind() == fft_transform_type_real_forward)
+                olengths.back() = olengths.back() / 2 + 1;
+            return olengths;
         }
         int get_rank() const
         {
@@ -1556,27 +1724,32 @@ namespace
         }
         size_t get_idist() const
         {
-            return plan_helper.template get_dist_as<size_t>(fft_io::fft_io_in);
+            return plan_helper.get_distance(fft_io::fft_io_in);
         }
         size_t get_odist() const
         {
-            return plan_helper.template get_dist_as<size_t>(fft_io::fft_io_out);
+            return plan_helper.get_distance(fft_io::fft_io_out);
         }
         size_t get_nbatch() const
         {
-            return plan_helper.template get_nbatch_as<size_t>(fft_io::fft_io_in);
+            return plan_helper.get_nbatch();
         }
-        std::vector<size_t> get_contiguous_istride() const
+        std::vector<size_t> get_contiguous_istrides() const
         {
-            // equivalent to plan's strides for now, to be reconsidered once more general
-            // configurations are enabled
-            return plan_helper.template get_strides_as<size_t>(fft_io::fft_io_in);
+            std::vector<size_t> contiguous_istrides(get_rank());
+            const auto          ilen   = get_ilengths();
+            contiguous_istrides.back() = 1;
+            for(auto dim = get_rank() - 1; dim-- > 0;)
+            {
+                contiguous_istrides[dim] = contiguous_istrides[dim + 1] * ilen[dim + 1];
+            }
+            return contiguous_istrides;
         }
         size_t get_contiguous_idist() const
         {
-            // equivalent to plan's strides for now, to be reconsidered once more general
-            // configurations are enabled
-            return plan_helper.template get_dist_as<size_t>(fft_io::fft_io_in);
+            const auto cont_istrides = get_contiguous_istrides();
+            const auto ilen          = get_ilengths();
+            return ilen.front() * cont_istrides.front();
         }
 
         bool can_be_tested() const
@@ -1634,29 +1807,93 @@ namespace
                 }
             }
             std::ostringstream ret;
+            if(manually_created)
+                ret << "manual_";
             ret << plan_helper.token();
-            ret << "_creation_input_mem_type_"
+            ret << "_" << creation_input_mem_type_label << "_"
                 << hipfftw_data_mem_type_to_string(
                        mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_in}));
             if(plan_helper.get_placement() == fft_placement_notinplace)
             {
-                ret << "_creation_output_mem_type_"
+                ret << "_" << creation_output_mem_type_label << "_"
                     << hipfftw_data_mem_type_to_string(
                            mem_type.at({hipfftw_step::plan_creation, fft_io::fft_io_out}));
             }
             if(execution_io == hipfftw_execution_io_args::clean_new_io)
             {
-                ret << "_execution_input_mem_type_"
+                ret << "_" << execution_input_mem_type_label << "_"
                     << hipfftw_data_mem_type_to_string(
                            mem_type.at({hipfftw_step::plan_execution, fft_io::fft_io_in}));
                 if(plan_helper.get_placement() == fft_placement_notinplace)
                 {
-                    ret << "_execution_output_mem_type_"
+                    ret << "_" << execution_output_mem_type_label << "_"
                         << hipfftw_data_mem_type_to_string(
                                mem_type.at({hipfftw_step::plan_execution, fft_io::fft_io_out}));
                 }
             }
             return ret.str();
+        }
+
+        // constructor from token
+        hipfftw_functional_validation_params(const std::string& manual_token)
+            : manually_created(true)
+        {
+            plan_helper.from_token(manual_token);
+
+            auto get_mem_type_from_str = [&](const std::string_view& which_io_label) {
+                std::ostringstream failure_info;
+                auto               pos = manual_token.find(which_io_label);
+                if(pos == std::string::npos)
+                {
+                    failure_info << which_io_label << " absent from manual token (" << manual_token
+                                 << ")";
+                    throw std::runtime_error(failure_info.str());
+                }
+                pos += which_io_label.size() + 1; // +1 for the '_' delimiter
+                for(auto tmp : get_possible_data_mem_types())
+                {
+                    const auto match = hipfftw_data_mem_type_to_string(tmp);
+                    if(manual_token.find(match, pos) == pos)
+                        return tmp;
+                }
+
+                failure_info
+                    << "A type of memory allocation testable by hipfftw cannot be determined from "
+                    << manual_token
+                    << ": the (partial) token might be invalid or the targeted type of memory is "
+                       "not accessible on this platform.";
+                throw std::runtime_error(failure_info.str());
+            };
+
+            execution_io = manual_token.find(execution_input_mem_type_label) != std::string::npos
+                               ? hipfftw_execution_io_args::clean_new_io
+                               : hipfftw_execution_io_args::use_creation_io;
+
+            mem_type[{hipfftw_step::plan_creation, fft_io::fft_io_in}]
+                = get_mem_type_from_str(creation_input_mem_type_label);
+            if(plan_helper.get_placement() == fft_placement_notinplace)
+                mem_type[{hipfftw_step::plan_creation, fft_io::fft_io_out}]
+                    = get_mem_type_from_str(creation_output_mem_type_label);
+            else
+                mem_type[{hipfftw_step::plan_creation, fft_io::fft_io_out}]
+                    = mem_type[{hipfftw_step::plan_creation, fft_io::fft_io_in}];
+            if(execution_io == hipfftw_execution_io_args::clean_new_io)
+            {
+                mem_type[{hipfftw_step::plan_execution, fft_io::fft_io_in}]
+                    = get_mem_type_from_str(execution_input_mem_type_label);
+                if(plan_helper.get_placement() == fft_placement_notinplace)
+                    mem_type[{hipfftw_step::plan_execution, fft_io::fft_io_out}]
+                        = get_mem_type_from_str(execution_output_mem_type_label);
+                else
+                    mem_type[{hipfftw_step::plan_execution, fft_io::fft_io_out}]
+                        = mem_type[{hipfftw_step::plan_execution, fft_io::fft_io_in}];
+            }
+            else
+            {
+                for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+                    mem_type[{hipfftw_step::plan_execution, io}]
+                        = mem_type[{hipfftw_step::plan_creation, io}];
+            }
         }
 
         // for using with insert_into_unique_sorted_params
@@ -1668,6 +1905,27 @@ namespace
         {
             return to_string() == other.to_string();
         }
+        friend std::ostream& operator<<(std::ostream&                               stream,
+                                        const hipfftw_functional_validation_params& params)
+        {
+            stream << params.to_string();
+            return stream;
+        }
+
+        bool is_manual_test() const
+        {
+            return manually_created;
+        }
+
+    private:
+        static constexpr std::string_view creation_input_mem_type_label = "creation_input_mem_type";
+        static constexpr std::string_view creation_output_mem_type_label
+            = "creation_output_mem_type";
+        static constexpr std::string_view execution_input_mem_type_label
+            = "execution_input_mem_type";
+        static constexpr std::string_view execution_output_mem_type_label
+            = "execution_output_mem_type";
+        bool manually_created;
     };
 
     template <fft_precision prec>
@@ -1740,28 +1998,19 @@ namespace
                     GTEST_FAIL() << "Verification IO buffer incorrectly initialized";
                 // generate input data
                 const std::vector<size_t> field_lower(params.get_rank(), 0);
-                const auto                ilength = params.get_ilengths();
-                std::vector<size_t>       contiguous_istride(params.get_rank());
-                size_t                    val = 1;
-                for(int dim = params.get_rank() - 1; dim >= 0; dim--)
-                {
-                    contiguous_istride[dim] = val;
-                    val *= ilength[dim];
-                }
-                const auto contiguous_idist = val;
                 set_input<hostbuf, hipfftw_real_t<prec>>(verification_input,
                                                          fft_input_random_generator_host,
                                                          params.get_array_type(fft_io::fft_io_in),
                                                          params.get_lengths(),
-                                                         ilength,
+                                                         params.get_ilengths(),
                                                          params.get_istride(),
                                                          params.get_idist(),
                                                          params.get_nbatch(),
                                                          get_curr_device_prop(),
                                                          field_lower,
                                                          0 /* field_lower_batch */,
-                                                         contiguous_istride,
-                                                         contiguous_idist);
+                                                         params.get_contiguous_istrides(),
+                                                         params.get_contiguous_idist());
                 // create the reference plan (systematically using the most general guru64 creation)
                 reference_plan = params.plan_helper.get_reference_plan(
                     verification_input[0].data(),
@@ -1920,6 +2169,20 @@ namespace
                 params.plan_helper.create_plan(
                     test_io_ptr.at({hipfftw_step::plan_creation, fft_io::fft_io_in}),
                     test_io_ptr.at({hipfftw_step::plan_creation, fft_io::fft_io_out}));
+                if(!params.plan_helper.get_plan())
+                {
+                    std::ostringstream gtest_info;
+                    gtest_info << "Plan creation failed";
+                    if(exception_logger.is_active())
+                    {
+                        const auto log_content = exception_logger.get_log();
+                        if(!log_content.empty())
+                        {
+                            gtest_info << "\nNon-empty log content detected:\n" << log_content;
+                        }
+                    }
+                    GTEST_FAIL() << gtest_info.str();
+                }
                 params.plan_helper.execute(
                     test_io_ptr.at({hipfftw_step::plan_execution, fft_io::fft_io_in}),
                     test_io_ptr.at({hipfftw_step::plan_execution, fft_io::fft_io_out}));
@@ -1958,17 +2221,14 @@ namespace
                 // compare results
                 if(reference_cpu_dft.valid())
                     reference_cpu_dft.get();
-                const auto test_lengths  = params.get_lengths();
-                auto       test_olengths = test_lengths;
-                if(params.get_dft_kind() == fft_transform_type_real_forward)
-                    test_olengths.back() = test_olengths.back() / 2 + 1;
+                const auto  test_lengths     = params.get_lengths();
                 const auto  total_length     = product(test_lengths.begin(), test_lengths.end());
                 const auto& reference_output = params.get_placement() == fft_placement_inplace
                                                    ? verification_input
                                                    : verification_output;
 
                 const auto   ref_norm = norm(reference_output,
-                                           test_olengths,
+                                           params.get_olengths(),
                                            params.get_nbatch(),
                                            prec,
                                            params.get_array_type(fft_io::fft_io_out),
@@ -1981,7 +2241,7 @@ namespace
                 // compare results
                 const auto diff = distance(reference_output,
                                            execution_results_on_host,
-                                           test_olengths,
+                                           params.get_olengths(),
                                            params.get_nbatch(),
                                            prec,
                                            params.get_array_type(fft_io::fft_io_out),
@@ -2041,38 +2301,65 @@ namespace
     };
 
     template <fft_precision prec>
+    void setup_random_default_plan(hipfftw_helper<prec>& helper)
+    {
+        const auto      dft_kind   = get_random_element_in(trans_type_range_full);
+        const auto      rank       = get_random_rank<valid_value, 1, 3>();
+        const auto      placement  = get_random_element_in(place_range);
+        constexpr int   batch_rank = 1;
+        const auto      batches    = get_random_vector<valid_value, int>(batch_rank, 1, 1);
+        const size_t    max_data_size_per_batch = max_byte_size_for_hipfftw_tests() / batches[0];
+        const ptrdiff_t max_len = std::min(static_cast<ptrdiff_t>(max_length_for_hipfftw_test),
+                                           find_threshold_length_for_byte_size<prec>(
+                                               max_data_size_per_batch, rank, is_real(dft_kind)));
+        const auto      lengths = get_random_vector<valid_value, int>(rank, max_len);
+
+        helper.set_creation_args(
+            dft_kind,
+            rank,
+            lengths,
+            placement,
+            is_fwd(dft_kind) ? FFTW_FORWARD : FFTW_BACKWARD,
+            FFTW_ESTIMATE,
+            default_strides(dft_kind, placement, fft_io::fft_io_in, lengths),
+            default_strides(dft_kind, placement, fft_io::fft_io_out, lengths),
+            batch_rank,
+            batches,
+            default_distances(dft_kind, placement, fft_io::fft_io_in, lengths, batches),
+            default_distances(dft_kind, placement, fft_io::fft_io_out, lengths, batches));
+        return;
+    }
+
+    template <fft_precision prec>
     std::vector<hipfftw_functional_validation_params<prec>>
-        params_for_functional_tests(size_t desired_full_suite_size)
+        params_for_functional_tests(size_t desired_full_suite_size, const std::string& manual_token)
     {
         std::vector<hipfftw_functional_validation_params<prec>> full_list;
         hipfftw_functional_validation_params<prec>              to_add;
-        std::uniform_int_distribution<int>                      coin_toss(0, 1);
-        // for readability of template specialization values below
-        constexpr bool valid_value        = true;
-        const auto&    possible_mem_types = get_possible_data_mem_types();
+
+        enum class test_layout
+        {
+            default_unbatched
+        };
+        const std::vector<test_layout>     possible_test_layouts = {test_layout::default_unbatched};
+        std::uniform_int_distribution<int> coin_toss(0, 1);
+        const auto&                        possible_mem_types = get_possible_data_mem_types();
         while(full_list.size() < desired_full_suite_size)
         {
-            to_add.execution_io = coin_toss(get_pseudo_rng()) == 0
-                                      ? hipfftw_execution_io_args::use_creation_io
-                                      : hipfftw_execution_io_args::clean_new_io;
-            const auto dft_kind
-                = trans_type_range_full[get_random_idx(trans_type_range_full.size())];
-            const auto rank            = get_random_rank<valid_value, 1, 3>();
-            const auto placement       = place_range[get_random_idx(place_range.size())];
-            const bool is_real_inplace = is_real(dft_kind) && placement == fft_placement_inplace;
-            const ptrdiff_t len_threshold
-                = std::min(get_len_threshold(max_num_elems_for_data_size<prec>(
-                                                 max_byte_size_for_hipfftw_tests(), dft_kind),
-                                             rank,
-                                             is_real_inplace),
-                           static_cast<ptrdiff_t>(max_length_for_hipfftw_test));
-            to_add.plan_helper.set_creation_args(
-                dft_kind,
-                rank,
-                get_random_lengths<valid_value, int>(rank, len_threshold),
-                placement,
-                is_fwd(dft_kind) ? FFTW_FORWARD : FFTW_BACKWARD,
-                FFTW_ESTIMATE);
+            to_add.execution_io    = coin_toss(get_pseudo_rng()) == 0
+                                         ? hipfftw_execution_io_args::use_creation_io
+                                         : hipfftw_execution_io_args::clean_new_io;
+            const auto data_layout = get_random_element_in(possible_test_layouts);
+            switch(data_layout)
+            {
+            case test_layout::default_unbatched:
+                setup_random_default_plan(to_add.plan_helper);
+                break;
+            default:
+                throw std::runtime_error(
+                    "unexpected value of data_layout in params_for_functional_tests");
+                break;
+            }
             for(auto step : {hipfftw_step::plan_creation, hipfftw_step::plan_execution})
             {
                 if(step == hipfftw_step::plan_execution
@@ -2090,7 +2377,8 @@ namespace
                 for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
                 {
                     const std::pair<hipfftw_step, fft_io> key = {step, io};
-                    if(placement == fft_placement_inplace && io == fft_io::fft_io_out)
+                    if(to_add.plan_helper.get_placement() == fft_placement_inplace
+                       && io == fft_io::fft_io_out)
                     {
                         auto input_key       = key;
                         input_key.second     = fft_io::fft_io_in;
@@ -2098,8 +2386,7 @@ namespace
                     }
                     else
                     {
-                        to_add.mem_type[key]
-                            = possible_mem_types[get_random_idx(possible_mem_types.size())];
+                        to_add.mem_type[key] = get_random_element_in(possible_mem_types);
                     }
                 }
             }
@@ -2108,14 +2395,13 @@ namespace
                 continue;
             insert_into_unique_sorted_params(full_list, to_add);
         }
-        if(test_prob == 1.0 && real_prob_factor == 1.0)
-            return full_list;
         std::vector<hipfftw_functional_validation_params<prec>> ret;
         for(const auto& test : full_list)
         {
             const double roll = hash_prob(random_seed, test.to_string());
             const double run_prob
-                = test_prob * (is_real(test.plan_helper.get_dft_kind()) ? real_prob_factor : 1.0);
+                = hipfftw_test_prob
+                  * (is_real(test.plan_helper.get_dft_kind()) ? real_prob_factor : 1.0);
 
             if(roll > run_prob)
             {
@@ -2127,6 +2413,15 @@ namespace
             }
             ret.emplace_back(test);
         }
+        // always add the manually-provided test, if matching target test's precision
+        if(!manual_token.empty()
+           && manual_token.find(prec == fft_precision_single ? "single" : "double")
+                  != std::string::npos)
+        {
+            insert_into_unique_sorted_params(
+                ret, hipfftw_functional_validation_params<prec>(manual_token));
+        }
+
         return ret;
     }
 
@@ -2208,16 +2503,16 @@ TEST_P(hipfftw_functional_validation_dp, accuracy_vs_fftw)
 }
 
 static constexpr size_t full_suite_size = 1024; // per precision
-INSTANTIATE_TEST_SUITE_P(
-    hipfftw_test,
-    hipfftw_functional_validation_sp,
-    ::testing::ValuesIn(params_for_functional_tests<fft_precision_single>(full_suite_size)),
-    hipfftw_functional_validation_sp::TestName);
-INSTANTIATE_TEST_SUITE_P(
-    hipfftw_test,
-    hipfftw_functional_validation_dp,
-    ::testing::ValuesIn(params_for_functional_tests<fft_precision_double>(full_suite_size)),
-    hipfftw_functional_validation_dp::TestName);
+INSTANTIATE_TEST_SUITE_P(hipfftw_test,
+                         hipfftw_functional_validation_sp,
+                         ::testing::ValuesIn(params_for_functional_tests<fft_precision_single>(
+                             full_suite_size, hipfftw_token_for_functional_test)),
+                         hipfftw_functional_validation_sp::TestName);
+INSTANTIATE_TEST_SUITE_P(hipfftw_test,
+                         hipfftw_functional_validation_dp,
+                         ::testing::ValuesIn(params_for_functional_tests<fft_precision_double>(
+                             full_suite_size, hipfftw_token_for_functional_test)),
+                         hipfftw_functional_validation_dp::TestName);
 
 // params_for_functional_tests may return empty vectors for low test probabilities.
 // The following ensures such cases do not make gtest report an error due to uninstantiated

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -80,9 +80,20 @@ namespace
         static const size_t io_byte_size_limit = get_io_byte_size_limit();
         return io_byte_size_limit;
     }
-    // for readability of template specializations
-    constexpr bool valid_value          = true;
-    constexpr int  min_unsupported_rank = 4;
+
+    // Random value generators are defined and used herein for the generation of
+    // argument-validation and/or functional test parameters. In the latter
+    // case, only valid (*and* supported) parameter values must be generated
+    // whereas invalid values need to be (knowingly) generated and thrown in
+    // the mix in the former case. To that end, several get_random* functions
+    // defined below are templated with a ``bool`` parameter reflecting
+    // whether a valid ('true' specialization) or invalid ('false' specialization)
+    // random parameter value is to be returned.
+    // The following constexpr is a self-explanatory placeholder introduced to
+    // improve code readability w.r.t. template specializations used in parameter
+    // generations here below, e.g., "get_random_rank<!valid_value>()" is
+    // a lot more intuitive to understand than "get_random_rank<false>()"
+    constexpr bool valid_value = true;
 
     std::ranlux24_base& get_pseudo_rng()
     {
@@ -952,10 +963,6 @@ namespace
                 {
                     return false;
                 }
-                catch(...)
-                {
-                    throw; // escalate the unexpected exception
-                }
             }
             return true;
         }
@@ -1075,6 +1082,8 @@ namespace
 
     std::vector<int> arg_validation_runtime_rank_range()
     {
+        constexpr int min_unsupported_rank = 4;
+
         std::vector<int> ret = {
             get_random_rank<!valid_value>(), // invalid
             get_random_rank<valid_value, min_unsupported_rank>(), // valid but unsupported
@@ -1377,10 +1386,6 @@ namespace
                 {
                     safe_to_touch_nonnull_io = false;
                     return sizeof(hipfftw_complex_t<prec>); // some nonzero value
-                }
-                catch(...)
-                {
-                    throw;
                 }
             };
             const size_t input_data_size  = compute_io_size(fft_io::fft_io_in);

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -38,7 +38,6 @@
 #include <omp.h>
 #endif
 
-extern double      hipfftw_test_prob;
 extern size_t      max_length_for_hipfftw_test;
 extern size_t      max_io_gb_for_hipfftw_test;
 extern size_t      max_num_arg_validation_tests_per_hipfftw_plan_type;
@@ -1346,12 +1345,11 @@ namespace
             {
                 const double roll = hash_prob(random_seed, test.to_string());
                 // not distinguishing between real/complex for this list generation
-                if(roll > hipfftw_test_prob)
+                if(roll > test_prob)
                 {
                     if(verbose > 4)
                     {
-                        std::cout << "Test skipped: (roll=" << roll << " > " << hipfftw_test_prob
-                                  << ")\n";
+                        std::cout << "Test skipped: (roll=" << roll << " > " << test_prob << ")\n";
                     }
                     continue;
                 }
@@ -2405,8 +2403,7 @@ namespace
         {
             const double roll = hash_prob(random_seed, test.to_string());
             const double run_prob
-                = hipfftw_test_prob
-                  * (is_real(test.plan_helper.get_dft_kind()) ? real_prob_factor : 1.0);
+                = test_prob * (is_real(test.plan_helper.get_dft_kind()) ? real_prob_factor : 1.0);
 
             if(roll > run_prob)
             {

--- a/projects/hipfft/clients/tests/multi_stream_test.cpp
+++ b/projects/hipfft/clients/tests/multi_stream_test.cpp
@@ -140,7 +140,7 @@ public:
             std::vector<size_t> sub_strides(sub_dft.length.size());
             for(int stride_idx = sub_strides.size() - 1; stride_idx >= 0; stride_idx--)
             {
-                if(stride_idx == sub_strides.size() - 1)
+                if(static_cast<size_t>(stride_idx) == sub_strides.size() - 1)
                 {
                     sub_strides[stride_idx] = total_batch_for_step;
                 }

--- a/projects/hipfft/library/include/hipfft/hipfft.h
+++ b/projects/hipfft/library/include/hipfft/hipfft.h
@@ -37,22 +37,25 @@
 // clang-format off
 #define DISABLE_WARNING_DEPRECATED_DECLARATIONS DISABLE_WARNING(-Wdeprecated-declarations)
 #define DISABLE_WARNING_RETURN_TYPE DISABLE_WARNING(-Wreturn-type)
+#define DISABLE_WARNING_IGNORED_ATTRIBUTES DISABLE_WARNING(-Wignored-attributes)
 // clang-format on
 #else
 #define DISABLE_WARNING_PUSH
 #define DISABLE_WARNING_POP
 #define DISABLE_WARNING_DEPRECATED_DECLARATIONS
 #define DISABLE_WARNING_RETURN_TYPE
+#define DISABLE_WARNING_IGNORED_ATTRIBUTES
 #endif
 
 #include "hipfft-export.h"
 #include "hipfft-version.h"
-#include <hip/hip_complex.h>
 #include <hip/library_types.h>
 
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
 DISABLE_WARNING_RETURN_TYPE
+DISABLE_WARNING_IGNORED_ATTRIBUTES
+#include <hip/hip_complex.h>
 #include <hip/hip_runtime_api.h>
 DISABLE_WARNING_POP
 

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -25,7 +25,6 @@
 #include <array>
 #include <cstdint> // std::int64_t
 #include <cstdlib>
-#include <hip/hip_runtime_api.h>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -33,6 +32,26 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+
+#if defined(__GNUC__) || defined(__clang__)
+#define DO_PRAGMA(X) _Pragma(#X)
+#define DISABLE_WARNING_PUSH DO_PRAGMA(GCC diagnostic push)
+#define DISABLE_WARNING_POP DO_PRAGMA(GCC diagnostic pop)
+#define DISABLE_WARNING(warningName) DO_PRAGMA(GCC diagnostic ignored #warningName)
+
+// clang-format off
+#define DISABLE_WARNING_IGNORED_ATTRIBUTES DISABLE_WARNING(-Wignored-attributes)
+// clang-format on
+#else
+#define DISABLE_WARNING_PUSH
+#define DISABLE_WARNING_POP
+#define DISABLE_WARNING_IGNORED_ATTRIBUTES
+#endif
+
+DISABLE_WARNING_PUSH
+DISABLE_WARNING_IGNORED_ATTRIBUTES
+#include <hip/hip_runtime_api.h>
+DISABLE_WARNING_POP
 
 // anonymous namespace for implementation details
 namespace
@@ -336,6 +355,71 @@ namespace
         static rocfft_initializer init;
     }
 
+    template <size_t rank,
+              size_t batch_rank,
+              std::enable_if_t<(rank > 0 && batch_rank > 0), bool> = true>
+    struct hipfftw_general_layout_data
+    {
+        std::array<ptrdiff_t, rank>       lengths; // row-major
+        std::array<ptrdiff_t, rank>       istrides; // row-major
+        std::array<ptrdiff_t, rank>       ostrides; // row-major
+        std::array<ptrdiff_t, batch_rank> batches;
+        std::array<ptrdiff_t, batch_rank> idist;
+        std::array<ptrdiff_t, batch_rank> odist;
+        // constexpr getters
+        constexpr inline size_t get_rank() const
+        {
+            return rank;
+        }
+        constexpr inline size_t get_batch_rank() const
+        {
+            return batch_rank;
+        }
+        template <rocfft_transform_type dft_type, rocfft_precision prec>
+        bool is_compatible_for_inplace() const
+        {
+            constexpr size_t ielem_sz
+                = sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>);
+            constexpr size_t oelem_sz
+                = sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>);
+            // Check that the memory location is identical on input an output for the first
+            // element of every leading dimension's sub-array. In other words, using row-major
+            // convention, check that for every integer arrays
+            // {k[0], k[1], ..., k[rank - 2], 0} ":= k" and every
+            // {m[0], m[1], .., m[batch_dim-1]} ":= m" (in applicable ranges), the byte offset
+            // on input, i.e.,
+            // ielem_sz * std::inner_product(m.begin(), m.end(), idist.begin(),
+            //                               std::inner_product(k.begin(), k.end(), istrides.begin(), 0))
+            // must be equal to the byte offset on output, i.e.,
+            // oelem_sz * std::inner_product(m.begin(), m.end(), odist.begin(),
+            //                               std::inner_product(k.begin(), k.end(), ostrides.begin(), 0)).
+            // This requirement translates into the followng element-wise conditions on
+            // idist, odist, istrides, and ostrides.
+            for(size_t batch_dim = 0; batch_dim < batch_rank; batch_dim++)
+            {
+                // 0 <= m[batch_dim] < batches[batch_dim], so the corresponding distance is
+                // irrelevant if batches[batch_dim] == 1.
+                if(batches[batch_dim] == 1)
+                    continue;
+                if(idist[batch_dim] * ielem_sz != odist[batch_dim] * oelem_sz)
+                    return false;
+            }
+            for(size_t dim = 0; dim < rank - 1 /* exclude leading dimension */; dim++)
+            {
+                if(lengths[dim] == 1)
+                    continue;
+                if(istrides[dim] * ielem_sz != ostrides[dim] * oelem_sz)
+                    return false;
+            }
+            if(lengths.back() == 1)
+                return true; // leading dimension's stride is irrelevant
+            if constexpr(!is_real(dft_type)) // elementary strides must be equal
+                return istrides.back() == ostrides.back();
+            else // elementary strides must both be 1
+                return istrides.back() == 1 && ostrides.back() == 1;
+        }
+    };
+
     template <rocfft_precision prec,
               // single or double precision only
               std::enable_if_t<prec == rocfft_precision_single || prec == rocfft_precision_double,
@@ -409,37 +493,45 @@ namespace
             internal_execute(new_exec_in, new_exec_out);
         }
 
-        template <rocfft_transform_type dft_type, size_t rank, typename T, size_t batch_rank>
-        void init(const std::array<T, rank>&                                          lengths_rm,
-                  const std::array<T, rank>&                                          istrides_rm,
-                  const std::array<T, rank>&                                          ostrides_rm,
+        template <rocfft_transform_type dft_type, size_t rank, size_t batch_rank>
+        void init(const hipfftw_general_layout_data<rank, batch_rank>&                data_layout,
                   hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  user_in,
                   hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* user_out,
-                  const std::array<T, batch_rank>&                                    batch,
-                  const std::array<T, batch_rank>&                                    idist,
-                  const std::array<T, batch_rank>&                                    odist,
                   unsigned                                                            flags)
         {
             // compile-time validations of template specialization values
             static_assert(1 <= rank && rank <= 3);
             static_assert(1 == batch_rank); // only supported case at the moment
-            // assuming no overflow when converting values from T into size_t below
-            static_assert(std::numeric_limits<T>::max() <= std::numeric_limits<size_t>::max());
+            // assuming no overflow when converting values from ptrdiff_t into size_t below
+            static_assert(std::numeric_limits<ptrdiff_t>::max()
+                          <= std::numeric_limits<size_t>::max());
             // Validation of input arguments:
-            auto is_strictly_negative = [](const T& val) { return val < static_cast<T>(0); };
-            auto is_strictly_positive = [](const T& val) { return val > static_cast<T>(0); };
-            if(!std::all_of(lengths_rm.begin(), lengths_rm.end(), is_strictly_positive))
-                throw hipfftw_invalid_arg("length(s) must be strictly positive.");
-            // Negative strides are not supported
-            for(const auto& strides : {istrides_rm, ostrides_rm})
-                if(std::any_of(strides.begin(), strides.end(), is_strictly_negative))
-                    throw hipfftw_unsupported("strides must be positive.");
-            if(!std::all_of(batch.begin(), batch.end(), is_strictly_positive))
-                throw hipfftw_invalid_arg("batch(es) must be strictly positive.");
-            // Negative distances are not supported
-            for(const auto& dist : {idist, odist})
-                if(std::any_of(dist.begin(), dist.end(), is_strictly_negative))
-                    throw hipfftw_unsupported("distance(s) must be positive.");
+            for(size_t dim = 0; dim < rank; dim++)
+            {
+                if(data_layout.lengths[dim] <= 0)
+                    throw hipfftw_invalid_arg("length(s) must be strictly positive.");
+                if(data_layout.lengths[dim] > 1)
+                {
+                    if(data_layout.istrides[dim] == 0 || data_layout.ostrides[dim] == 0)
+                        throw hipfftw_invalid_arg(
+                            "stride(s) must not be zero for nontrivial dimensions.");
+                    if(data_layout.istrides[dim] < 0 || data_layout.ostrides[dim] < 0)
+                        throw hipfftw_unsupported("negative stride(s) are not supported.");
+                }
+            }
+            for(size_t batch_dim = 0; batch_dim < batch_rank; batch_dim++)
+            {
+                if(data_layout.batches[batch_dim] <= 0)
+                    throw hipfftw_invalid_arg("batch(es) must be strictly positive.");
+                if(data_layout.batches[batch_dim] > 1)
+                {
+                    if(data_layout.idist[batch_dim] == 0 || data_layout.odist[batch_dim] == 0)
+                        throw hipfftw_invalid_arg(
+                            "distance(s) must not be zero for nontrivial batching dimensions.");
+                    if(data_layout.idist[batch_dim] < 0 || data_layout.odist[batch_dim] < 0)
+                        throw hipfftw_unsupported("negative distance(s) are not supported.");
+                }
+            }
             // Valid flag values are defined as bitwise OR of zero or more (unsigned) power-of-2
             // compile-time constants, (enabling well-defined identification via bitwise manipulations).
             if(flags
@@ -473,56 +565,13 @@ namespace
                                  ? rocfft_placement_inplace
                                  : rocfft_placement_notinplace;
             plan_dft_type  = dft_type;
-            if(plan_placement == rocfft_placement_inplace)
-            {
-                // Check that the memory location is identical on input an output for the first
-                // element of every leading dimension's sub-array. In order words, using row-major
-                // convention, check that for every integer arrays
-                // {k[0], k[1], ..., k[rank - 2], 0} ":= k" and every
-                // {m[0], m[1], .., m[batch_dim-1]} ":= m" (in applicable ranges), the byte offset
-                // on input, i.e.,
-                // sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>)*
-                //      std::inner_product(m.begin(), m.end(), idist.begin(),
-                //                         std::inner_product(k.begin(), k.end(), istrides_rm.begin(), 0))
-                // must be equal to the byte offset on output, i.e.,
-                // sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>)*
-                //      std::inner_product(m.begin(), m.end(), odist.begin(),
-                //                         std::inner_product(k.begin(), k.end(), ostrides_rm.begin(), 0)).
-                // This requirement translates into the followng element-wise conditions on
-                // idist, odist, istides_rm, and ostides_rm.
-                for(auto batch_dim = 0; batch_dim < batch_rank; batch_dim++)
-                {
-                    // 0 <= m[batch_dim] < batch[batch_dim], so the corresponding distance is
-                    // irrelevant if batch[batch_dim] == 1.
-                    if(batch[batch_dim] == 1)
-                        continue;
-                    if(idist[batch_dim]
-                           * sizeof(
-                               hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>)
-                       != odist[batch_dim]
-                              * sizeof(hipfftw_user_data_t<dft_type,
-                                                           prec,
-                                                           hipfftw_io_label::OUTPUT_DATA>))
-                        throw hipfftw_invalid_arg("distances rejected for in-place configuration.");
-                }
-                for(auto dim = 0; dim < rank - 1 /* exclude leading dimension */; dim++)
-                {
-                    if(lengths_rm[dim] == 1)
-                        continue;
-                    if(istrides_rm[dim]
-                           * sizeof(
-                               hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>)
-                       != ostrides_rm[dim]
-                              * sizeof(hipfftw_user_data_t<dft_type,
-                                                           prec,
-                                                           hipfftw_io_label::OUTPUT_DATA>))
-                    {
-                        throw hipfftw_invalid_arg("strides rejected for in-place configuration..");
-                    }
-                }
-            }
             // TODO (required when user-defined strides/distances may be used): add validity check
             // on strides and distances for non-aliasing data
+            if(plan_placement == rocfft_placement_inplace)
+            {
+                if(!data_layout.template is_compatible_for_inplace<dft_type, prec>())
+                    throw hipfftw_invalid_arg("data layout rejected for in-place configuration.");
+            }
 
             // Generalized input are validated... Let's initialize the plan!
             init_rocfft(); // "magic" common to all template specializations
@@ -531,31 +580,25 @@ namespace
             // (resp. strictly positive), as verified above
             size_t last_input_element_idx  = 0;
             size_t last_output_element_idx = 0;
-            for(auto dim = 0; dim < rank; dim++)
+            for(size_t dim = 0; dim < rank; dim++)
             {
                 const auto last_input_entry_for_dim
                     = dft_type == rocfft_transform_type_real_inverse && dim == rank - 1
-                          ? lengths_rm[dim] / 2
-                          : lengths_rm[dim] - 1;
+                          ? data_layout.lengths[dim] / 2
+                          : data_layout.lengths[dim] - 1;
                 const auto last_output_entry_for_dim
                     = dft_type == rocfft_transform_type_real_forward && dim == rank - 1
-                          ? lengths_rm[dim] / 2
-                          : lengths_rm[dim] - 1;
-                last_input_element_idx += last_input_entry_for_dim * istrides_rm[dim];
-                last_output_element_idx += last_output_entry_for_dim * ostrides_rm[dim];
+                          ? data_layout.lengths[dim] / 2
+                          : data_layout.lengths[dim] - 1;
+                last_input_element_idx += last_input_entry_for_dim * data_layout.istrides[dim];
+                last_output_element_idx += last_output_entry_for_dim * data_layout.ostrides[dim];
             }
-            for(auto batch_dim = 0; batch_dim < batch_rank; batch_dim++)
+            for(size_t batch_dim = 0; batch_dim < batch_rank; batch_dim++)
             {
-                last_input_element_idx += (batch[batch_dim] - 1) * idist[batch_dim];
-                last_output_element_idx += (batch[batch_dim] - 1) * odist[batch_dim];
-            }
-            if(last_input_element_idx > std::numeric_limits<T>::max()
-               || last_output_element_idx > std::numeric_limits<T>::max())
-            {
-                throw hipfftw_unsupported(
-                    "data layouts involving element indices that exceed the maximum value "
-                    "representable in the chosen integral type are not supported (consider using "
-                    "guru64 plan creation functions).");
+                last_input_element_idx
+                    += (data_layout.batches[batch_dim] - 1) * data_layout.idist[batch_dim];
+                last_output_element_idx
+                    += (data_layout.batches[batch_dim] - 1) * data_layout.odist[batch_dim];
             }
             in_bytes = sizeof(hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>)
                        * (last_input_element_idx + 1);
@@ -566,15 +609,15 @@ namespace
                 in_bytes = out_bytes = std::max(in_bytes, out_bytes);
             }
 
-            // Change row-major to col-major for all relevant inputs, converting from T to size_t
-            auto reverse = [](const std::array<T, rank>& in_array) {
+            // Change row-major to col-major for all relevant inputs, converting from ptrdiff_t to size_t
+            auto reverse = [](const std::array<ptrdiff_t, rank>& in_array) {
                 auto ret = std::array<size_t, rank>();
                 std::reverse_copy(in_array.begin(), in_array.end(), ret.begin());
                 return ret;
             };
-            const auto lengths_cm  = reverse(lengths_rm);
-            const auto istrides_cm = reverse(istrides_rm);
-            const auto ostrides_cm = reverse(ostrides_rm);
+            const auto lengths_cm  = reverse(data_layout.lengths);
+            const auto istrides_cm = reverse(data_layout.istrides);
+            const auto ostrides_cm = reverse(data_layout.ostrides);
 
             // Create plan description
             if(rocfft_plan_description_create(&internal_rocfft_desc) != rocfft_status_success)
@@ -590,10 +633,10 @@ namespace
                    nullptr /* out_offsets */,
                    rank /* in_strides_sizes */,
                    istrides_cm.data(),
-                   idist[0],
+                   data_layout.idist[0],
                    rank /* out_strides_size */,
                    ostrides_cm.data(),
-                   odist[0])
+                   data_layout.odist[0])
                != rocfft_status_success)
             {
                 throw rocfft_failure(
@@ -606,7 +649,7 @@ namespace
                                   prec,
                                   rank,
                                   lengths_cm.data(),
-                                  batch[0],
+                                  data_layout.batches[0],
                                   internal_rocfft_desc)
                != rocfft_status_success)
             {
@@ -743,70 +786,62 @@ namespace
         }
     };
 
-    template <size_t rank,
-              size_t batch_rank,
-              typename T,
-              std::enable_if_t<std::is_integral_v<T> && (rank > 0 && batch_rank > 0), bool> = true>
-    struct hipfftw_general_layout_data
-    {
-        std::array<T, rank>       lengths;
-        std::array<T, rank>       istrides;
-        std::array<T, rank>       ostrides;
-        std::array<T, batch_rank> batches;
-        std::array<T, batch_rank> idist;
-        std::array<T, batch_rank> odist;
-        // constexpr getters
-        constexpr inline size_t get_rank() const
-        {
-            return rank;
-        }
-        constexpr inline size_t get_batch_rank() const
-        {
-            return batch_rank;
-        }
-    };
-
+    // default values are consistent with basic plans' data layouts
     template <size_t rank, rocfft_transform_type dft_type>
-    hipfftw_general_layout_data<rank, 1, int> hipfftw_get_default_data_layout_info_rm(
-        bool is_in_place, const std::array<int, rank>& user_lengths_rm, size_t batch_sz = 1)
+    hipfftw_general_layout_data<rank, 1> hipfftw_get_data_layout(const int*  n,
+                                                                 const void* input_ptr,
+                                                                 const void* output_ptr,
+                                                                 const int   istride = 1,
+                                                                 const int   ostride = 1,
+                                                                 const int*  inembed = nullptr,
+                                                                 const int*  onembed = nullptr,
+                                                                 const int   howmany = 1,
+                                                                 const int   idist   = 0,
+                                                                 const int   odist   = 0)
     {
-        auto overflow_guarded_mult = [](int& a, const int& b) {
-            auto tmp = static_cast<std::int64_t>(a) * static_cast<std::int64_t>(b);
-            if(tmp > std::numeric_limits<int>::max() || tmp < std::numeric_limits<int>::min())
-                throw hipfftw_unsupported(
-                    "length(s) that trigger integer overflow(s) for default stride(s) and/or "
-                    "distance(s) are not supported via the default plan creation functions "
-                    "(consider guru64 plan creation functions).");
-            a = static_cast<int>(tmp);
-        };
+        if(!n)
+            throw hipfftw_invalid_arg("lengths argument must not be nullptr.");
 
-        hipfftw_general_layout_data<rank, 1, int> ret;
-        ret.lengths = user_lengths_rm;
-        int ival = 1, oval = 1;
+        hipfftw_general_layout_data<rank, 1> ret;
+        // length(s) and strides
+        ptrdiff_t ival = istride, oval = ostride;
         for(auto dim_idx = rank; dim_idx-- > 0;)
         {
-            ret.istrides[dim_idx] = ival;
-            ret.ostrides[dim_idx] = oval;
-            if(is_real(dft_type) && dim_idx == rank - 1)
+            ret.lengths[dim_idx] = n[dim_idx];
+            for(auto io : {hipfftw_io_label::INPUT_DATA, hipfftw_io_label::OUTPUT_DATA})
             {
-                int& cmplx_stride_val
-                    = dft_type == rocfft_transform_type_real_forward ? oval : ival;
-                int& real_stride_val = dft_type == rocfft_transform_type_real_forward ? ival : oval;
-                overflow_guarded_mult(cmplx_stride_val, ret.lengths[dim_idx] / 2 + 1);
-                if(is_in_place)
-                    overflow_guarded_mult(real_stride_val, 2 * (ret.lengths[dim_idx] / 2 + 1));
-                else
-                    overflow_guarded_mult(real_stride_val, ret.lengths[dim_idx]);
-            }
-            else
-            {
-                overflow_guarded_mult(ival, ret.lengths[dim_idx]);
-                overflow_guarded_mult(oval, ret.lengths[dim_idx]);
+                std::array<ptrdiff_t, rank>& strides
+                    = io == hipfftw_io_label::INPUT_DATA ? ret.istrides : ret.ostrides;
+                auto&      stride_val = io == hipfftw_io_label::INPUT_DATA ? ival : oval;
+                const int* nembed     = io == hipfftw_io_label::INPUT_DATA ? inembed : onembed;
+                int        default_embed_val = n[dim_idx];
+                if(is_real(dft_type) && dim_idx == rank - 1)
+                {
+                    if((io == hipfftw_io_label::INPUT_DATA)
+                       == (dft_type == rocfft_transform_type_real_inverse))
+                        default_embed_val = n[dim_idx] / 2 + 1; // hermition domain
+                    else if(input_ptr == output_ptr)
+                        default_embed_val = 2 * (n[dim_idx] / 2 + 1); // padded real domain
+                }
+
+                const auto embed_val = nembed ? nembed[dim_idx] : default_embed_val;
+                if(embed_val < default_embed_val)
+                {
+                    std::ostringstream exception_info;
+                    exception_info << "the value of "
+                                   << (io == hipfftw_io_label::INPUT_DATA ? "inembed" : "onembed")
+                                   << "[" << dim_idx << "], i.e., " << embed_val
+                                   << " is invalid (smaller than " << default_embed_val << ").";
+                    throw hipfftw_invalid_arg(exception_info.str());
+                }
+                strides[dim_idx] = stride_val;
+                stride_val *= embed_val;
             }
         }
-        ret.batches[0] = batch_sz;
-        ret.idist[0]   = ival;
-        ret.odist[0]   = oval;
+        // batch size and distances
+        ret.batches[0] = howmany;
+        ret.idist[0]   = idist;
+        ret.odist[0]   = odist;
         return ret;
     }
 
@@ -1038,50 +1073,20 @@ struct hipfftw_plan<rocfft_precision_double>
 template <rocfft_precision prec>
 using hipfftw_plan_t = typename hipfftw_plan<prec>::type;
 
-template <rocfft_transform_type dft_type,
-          rocfft_precision      prec,
-          size_t                rank,
-          typename T,
-          size_t batch_rank = 1>
+template <rocfft_transform_type dft_type, rocfft_precision prec, size_t rank, size_t batch_rank = 1>
 static hipfftw_plan_t<prec>* hipfftw_create_plan(
-    const std::array<T, rank>&                                          lengths_rm,
-    const std::array<T, rank>&                                          istrides_rm,
-    const std::array<T, rank>&                                          ostrides_rm,
+    const hipfftw_general_layout_data<rank, batch_rank>                 layout,
     hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  user_in,
     hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* user_out,
-    const std::array<T, batch_rank>&                                    batch,
-    const std::array<T, batch_rank>&                                    idist,
-    const std::array<T, batch_rank>&                                    odist,
     unsigned                                                            flags)
 {
     auto ret = std::make_unique<hipfftw_plan_t<prec>>();
-    ret->template init<dft_type, rank, T, batch_rank>(
-        lengths_rm, istrides_rm, ostrides_rm, user_in, user_out, batch, idist, odist, flags);
+    ret->template init<dft_type, rank, batch_rank>(layout, user_in, user_out, flags);
     return ret.release();
 }
 
-template <rocfft_transform_type dft_type, rocfft_precision prec, size_t rank>
-static hipfftw_plan_t<prec>* hipfftw_create_default_unbatched_plan(
-    const std::array<int, rank>&                                        n,
-    hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  in,
-    hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::OUTPUT_DATA>* out,
-    unsigned                                                            flags)
-{
-    auto layout_data = hipfftw_get_default_data_layout_info_rm<rank, dft_type>(
-        static_cast<void*>(in) == static_cast<void*>(out), n);
-    return hipfftw_create_plan<dft_type, prec, rank, int>(layout_data.lengths,
-                                                          layout_data.istrides,
-                                                          layout_data.ostrides,
-                                                          in,
-                                                          out,
-                                                          layout_data.batches,
-                                                          layout_data.idist,
-                                                          layout_data.odist,
-                                                          flags);
-}
-
 template <rocfft_transform_type dft_type, rocfft_precision prec>
-static hipfftw_plan_t<prec>* hipfftw_create_default_unbatched_plan(
+static hipfftw_plan_t<prec>* hipfftw_create_basic_plan(
     int                                                                 rank,
     const int*                                                          n,
     hipfftw_user_data_t<dft_type, prec, hipfftw_io_label::INPUT_DATA>*  in,
@@ -1089,61 +1094,45 @@ static hipfftw_plan_t<prec>* hipfftw_create_default_unbatched_plan(
     unsigned                                                            flags)
 {
     if(rank <= 0)
-        throw hipfftw_invalid_arg("ranks must be strictly positive.");
-    if(!n)
-        throw hipfftw_invalid_arg("lengths argument must not be nullptr.");
+        throw hipfftw_invalid_arg("rank values must be strictly positive.");
     // rank == 1, 2, 3, or unsupported
     switch(rank)
     {
     case 1:
-        return hipfftw_create_default_unbatched_plan<dft_type, prec, 1>(
-            std::array<int, 1>({n[0]}), in, out, flags);
+    {
+        const auto data_layout = hipfftw_get_data_layout<1, dft_type>(n, in, out);
+        return hipfftw_create_plan<dft_type, prec>(data_layout, in, out, flags);
+    }
     case 2:
-        return hipfftw_create_default_unbatched_plan<dft_type, prec, 2>(
-            std::array<int, 2>({n[0], n[1]}), in, out, flags);
+    {
+        const auto data_layout = hipfftw_get_data_layout<2, dft_type>(n, in, out);
+        return hipfftw_create_plan<dft_type, prec>(data_layout, in, out, flags);
+    }
     case 3:
-        return hipfftw_create_default_unbatched_plan<dft_type, prec, 3>(
-            std::array<int, 3>({n[0], n[1], n[2]}), in, out, flags);
+    {
+        const auto data_layout = hipfftw_get_data_layout<3, dft_type>(n, in, out);
+        return hipfftw_create_plan<dft_type, prec>(data_layout, in, out, flags);
+    }
     default:
         throw hipfftw_unsupported("rank values larger than 3 are not supported.");
     }
     // unreachable
 }
 
-template <rocfft_precision prec, size_t rank>
-static hipfftw_plan_t<prec>*
-    hipfftw_create_default_unbatched_complex_plan(const std::array<int, rank>&  n,
-                                                  int                           sign,
-                                                  hipfftw_complex_data_t<prec>* in,
-                                                  hipfftw_complex_data_t<prec>* out,
-                                                  unsigned                      flags)
-{
-    hipfftw_validate_sign(sign);
-    if(sign == FFTW_FORWARD)
-        return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_forward,
-                                                     prec,
-                                                     rank>(n, in, out, flags);
-    else
-        return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_inverse,
-                                                     prec,
-                                                     rank>(n, in, out, flags);
-}
-
 template <rocfft_precision prec>
-static hipfftw_plan_t<prec>*
-    hipfftw_create_default_unbatched_complex_plan(int                           rank,
-                                                  const int*                    n,
-                                                  int                           sign,
-                                                  hipfftw_complex_data_t<prec>* in,
-                                                  hipfftw_complex_data_t<prec>* out,
-                                                  unsigned                      flags)
+static hipfftw_plan_t<prec>* hipfftw_create_basic_complex_plan(int                           rank,
+                                                               const int*                    n,
+                                                               int                           sign,
+                                                               hipfftw_complex_data_t<prec>* in,
+                                                               hipfftw_complex_data_t<prec>* out,
+                                                               unsigned                      flags)
 {
     hipfftw_validate_sign(sign);
     if(sign == FFTW_FORWARD)
-        return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_forward, prec>(
+        return hipfftw_create_basic_plan<rocfft_transform_type_complex_forward, prec>(
             rank, n, in, out, flags);
     else
-        return hipfftw_create_default_unbatched_plan<rocfft_transform_type_complex_inverse, prec>(
+        return hipfftw_create_basic_plan<rocfft_transform_type_complex_inverse, prec>(
             rank, n, in, out, flags);
 }
 
@@ -1248,6 +1237,10 @@ void fftwf_destroy_plan(fftwf_plan plan)
 void fftw_cleanup() {}
 
 void fftwf_cleanup() {}
+
+/* ------------------------------------------------------------------------- */
+/*                          EXECUTION FUNCTIONS                              */
+/* ------------------------------------------------------------------------- */
 
 void fftw_execute(const fftw_plan plan)
 try
@@ -1373,13 +1366,17 @@ catch(...)
     return;
 }
 
+/* ------------------------------------------------------------------------- */
+/*                    BASIC PLAN CREATION FUNCTIONS                          */
+/* ------------------------------------------------------------------------- */
+
 fftw_plan fftw_plan_dft_1d(int n, fftw_complex* in, fftw_complex* out, int sign, unsigned flags)
 try
 {
-    constexpr int  rank = 1;
-    constexpr auto prec = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
-        std::array<int, rank>({n}), sign, in, out, flags);
+    constexpr int  rank      = 1;
+    constexpr auto prec      = rocfft_precision_double;
+    const int      len[rank] = {n};
+    return hipfftw_create_basic_complex_plan<prec>(rank, len, sign, in, out, flags);
 }
 catch(...)
 {
@@ -1390,10 +1387,10 @@ catch(...)
 fftwf_plan fftwf_plan_dft_1d(int n, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags)
 try
 {
-    constexpr int  rank = 1;
-    constexpr auto prec = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
-        std::array<int, rank>({n}), sign, in, out, flags);
+    constexpr int  rank      = 1;
+    constexpr auto prec      = rocfft_precision_single;
+    const int      len[rank] = {n};
+    return hipfftw_create_basic_complex_plan<prec>(rank, len, sign, in, out, flags);
 }
 catch(...)
 {
@@ -1405,10 +1402,10 @@ fftw_plan
     fftw_plan_dft_2d(int n0, int n1, fftw_complex* in, fftw_complex* out, int sign, unsigned flags)
 try
 {
-    constexpr int  rank = 2;
-    constexpr auto prec = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
-        std::array<int, rank>({n0, n1}), sign, in, out, flags);
+    constexpr int  rank      = 2;
+    constexpr auto prec      = rocfft_precision_double;
+    const int      len[rank] = {n0, n1};
+    return hipfftw_create_basic_complex_plan<prec>(rank, len, sign, in, out, flags);
 }
 catch(...)
 {
@@ -1420,10 +1417,10 @@ fftwf_plan fftwf_plan_dft_2d(
     int n0, int n1, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags)
 try
 {
-    constexpr int  rank = 2;
-    constexpr auto prec = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
-        std::array<int, rank>({n0, n1}), sign, in, out, flags);
+    constexpr int  rank      = 2;
+    constexpr auto prec      = rocfft_precision_single;
+    const int      len[rank] = {n0, n1};
+    return hipfftw_create_basic_complex_plan<prec>(rank, len, sign, in, out, flags);
 }
 catch(...)
 {
@@ -1435,10 +1432,10 @@ fftw_plan fftw_plan_dft_3d(
     int n0, int n1, int n2, fftw_complex* in, fftw_complex* out, int sign, unsigned flags)
 try
 {
-    constexpr int  rank = 3;
-    constexpr auto prec = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
-        std::array<int, rank>({n0, n1, n2}), sign, in, out, flags);
+    constexpr int  rank      = 3;
+    constexpr auto prec      = rocfft_precision_double;
+    const int      len[rank] = {n0, n1, n2};
+    return hipfftw_create_basic_complex_plan<prec>(rank, len, sign, in, out, flags);
 }
 catch(...)
 {
@@ -1450,10 +1447,10 @@ fftwf_plan fftwf_plan_dft_3d(
     int n0, int n1, int n2, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags)
 try
 {
-    constexpr int  rank = 3;
-    constexpr auto prec = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_complex_plan<prec, rank>(
-        std::array<int, rank>({n0, n1, n2}), sign, in, out, flags);
+    constexpr int  rank      = 3;
+    constexpr auto prec      = rocfft_precision_single;
+    const int      len[rank] = {n0, n1, n2};
+    return hipfftw_create_basic_complex_plan<prec>(rank, len, sign, in, out, flags);
 }
 catch(...)
 {
@@ -1466,7 +1463,7 @@ fftw_plan fftw_plan_dft(
 try
 {
     constexpr auto prec = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_complex_plan<prec>(rank, n, sign, in, out, flags);
+    return hipfftw_create_basic_complex_plan<prec>(rank, n, sign, in, out, flags);
 }
 catch(...)
 {
@@ -1479,7 +1476,7 @@ fftwf_plan fftwf_plan_dft(
 try
 {
     constexpr auto prec = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_complex_plan<prec>(rank, n, sign, in, out, flags);
+    return hipfftw_create_basic_complex_plan<prec>(rank, n, sign, in, out, flags);
 }
 catch(...)
 {
@@ -1490,11 +1487,11 @@ catch(...)
 fftw_plan fftw_plan_dft_r2c_1d(int n, double* in, fftw_complex* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 1;
-    constexpr auto dft_type = rocfft_transform_type_real_forward;
-    constexpr auto prec     = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n}), in, out, flags);
+    constexpr int  rank      = 1;
+    constexpr auto dft_type  = rocfft_transform_type_real_forward;
+    constexpr auto prec      = rocfft_precision_double;
+    const int      len[rank] = {n};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1505,11 +1502,11 @@ catch(...)
 fftwf_plan fftwf_plan_dft_r2c_1d(int n, float* in, fftwf_complex* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 1;
-    constexpr auto dft_type = rocfft_transform_type_real_forward;
-    constexpr auto prec     = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n}), in, out, flags);
+    constexpr int  rank      = 1;
+    constexpr auto dft_type  = rocfft_transform_type_real_forward;
+    constexpr auto prec      = rocfft_precision_single;
+    const int      len[rank] = {n};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1520,11 +1517,11 @@ catch(...)
 fftw_plan fftw_plan_dft_r2c_2d(int n0, int n1, double* in, fftw_complex* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 2;
-    constexpr auto dft_type = rocfft_transform_type_real_forward;
-    constexpr auto prec     = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n0, n1}), in, out, flags);
+    constexpr int  rank      = 2;
+    constexpr auto dft_type  = rocfft_transform_type_real_forward;
+    constexpr auto prec      = rocfft_precision_double;
+    const int      len[rank] = {n0, n1};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1535,11 +1532,11 @@ catch(...)
 fftwf_plan fftwf_plan_dft_r2c_2d(int n0, int n1, float* in, fftwf_complex* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 2;
-    constexpr auto dft_type = rocfft_transform_type_real_forward;
-    constexpr auto prec     = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n0, n1}), in, out, flags);
+    constexpr int  rank      = 2;
+    constexpr auto dft_type  = rocfft_transform_type_real_forward;
+    constexpr auto prec      = rocfft_precision_single;
+    const int      len[rank] = {n0, n1};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1551,11 +1548,11 @@ fftw_plan
     fftw_plan_dft_r2c_3d(int n0, int n1, int n2, double* in, fftw_complex* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 3;
-    constexpr auto dft_type = rocfft_transform_type_real_forward;
-    constexpr auto prec     = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n0, n1, n2}), in, out, flags);
+    constexpr int  rank      = 3;
+    constexpr auto dft_type  = rocfft_transform_type_real_forward;
+    constexpr auto prec      = rocfft_precision_double;
+    const int      len[rank] = {n0, n1, n2};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1567,11 +1564,11 @@ fftwf_plan
     fftwf_plan_dft_r2c_3d(int n0, int n1, int n2, float* in, fftwf_complex* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 3;
-    constexpr auto dft_type = rocfft_transform_type_real_forward;
-    constexpr auto prec     = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n0, n1, n2}), in, out, flags);
+    constexpr int  rank      = 3;
+    constexpr auto dft_type  = rocfft_transform_type_real_forward;
+    constexpr auto prec      = rocfft_precision_single;
+    const int      len[rank] = {n0, n1, n2};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1584,7 +1581,7 @@ try
 {
     constexpr auto dft_type = rocfft_transform_type_real_forward;
     constexpr auto prec     = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec>(rank, n, in, out, flags);
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, n, in, out, flags);
 }
 catch(...)
 {
@@ -1597,7 +1594,7 @@ try
 {
     constexpr auto dft_type = rocfft_transform_type_real_forward;
     constexpr auto prec     = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec>(rank, n, in, out, flags);
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, n, in, out, flags);
 }
 catch(...)
 {
@@ -1608,11 +1605,11 @@ catch(...)
 fftw_plan fftw_plan_dft_c2r_1d(int n, fftw_complex* in, double* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 1;
-    constexpr auto dft_type = rocfft_transform_type_real_inverse;
-    constexpr auto prec     = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n}), in, out, flags);
+    constexpr int  rank      = 1;
+    constexpr auto dft_type  = rocfft_transform_type_real_inverse;
+    constexpr auto prec      = rocfft_precision_double;
+    const int      len[rank] = {n};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1623,11 +1620,11 @@ catch(...)
 fftwf_plan fftwf_plan_dft_c2r_1d(int n, fftwf_complex* in, float* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 1;
-    constexpr auto dft_type = rocfft_transform_type_real_inverse;
-    constexpr auto prec     = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n}), in, out, flags);
+    constexpr int  rank      = 1;
+    constexpr auto dft_type  = rocfft_transform_type_real_inverse;
+    constexpr auto prec      = rocfft_precision_single;
+    const int      len[rank] = {n};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1638,11 +1635,11 @@ catch(...)
 fftw_plan fftw_plan_dft_c2r_2d(int n0, int n1, fftw_complex* in, double* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 2;
-    constexpr auto dft_type = rocfft_transform_type_real_inverse;
-    constexpr auto prec     = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n0, n1}), in, out, flags);
+    constexpr int  rank      = 2;
+    constexpr auto dft_type  = rocfft_transform_type_real_inverse;
+    constexpr auto prec      = rocfft_precision_double;
+    const int      len[rank] = {n0, n1};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1653,11 +1650,11 @@ catch(...)
 fftwf_plan fftwf_plan_dft_c2r_2d(int n0, int n1, fftwf_complex* in, float* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 2;
-    constexpr auto dft_type = rocfft_transform_type_real_inverse;
-    constexpr auto prec     = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n0, n1}), in, out, flags);
+    constexpr int  rank      = 2;
+    constexpr auto dft_type  = rocfft_transform_type_real_inverse;
+    constexpr auto prec      = rocfft_precision_single;
+    const int      len[rank] = {n0, n1};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1669,11 +1666,11 @@ fftw_plan
     fftw_plan_dft_c2r_3d(int n0, int n1, int n2, fftw_complex* in, double* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 3;
-    constexpr auto dft_type = rocfft_transform_type_real_inverse;
-    constexpr auto prec     = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n0, n1, n2}), in, out, flags);
+    constexpr int  rank      = 3;
+    constexpr auto dft_type  = rocfft_transform_type_real_inverse;
+    constexpr auto prec      = rocfft_precision_double;
+    const int      len[rank] = {n0, n1, n2};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1685,11 +1682,11 @@ fftwf_plan
     fftwf_plan_dft_c2r_3d(int n0, int n1, int n2, fftwf_complex* in, float* out, unsigned flags)
 try
 {
-    constexpr int  rank     = 3;
-    constexpr auto dft_type = rocfft_transform_type_real_inverse;
-    constexpr auto prec     = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec, rank>(
-        std::array<int, rank>({n0, n1, n2}), in, out, flags);
+    constexpr int  rank      = 3;
+    constexpr auto dft_type  = rocfft_transform_type_real_inverse;
+    constexpr auto prec      = rocfft_precision_single;
+    const int      len[rank] = {n0, n1, n2};
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, len, in, out, flags);
 }
 catch(...)
 {
@@ -1702,7 +1699,7 @@ try
 {
     constexpr auto dft_type = rocfft_transform_type_real_inverse;
     constexpr auto prec     = rocfft_precision_double;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec>(rank, n, in, out, flags);
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, n, in, out, flags);
 }
 catch(...)
 {
@@ -1715,13 +1712,17 @@ try
 {
     constexpr auto dft_type = rocfft_transform_type_real_inverse;
     constexpr auto prec     = rocfft_precision_single;
-    return hipfftw_create_default_unbatched_plan<dft_type, prec>(rank, n, in, out, flags);
+    return hipfftw_create_basic_plan<dft_type, prec>(rank, n, in, out, flags);
 }
 catch(...)
 {
     hipfftw_exception_handler(__func__);
     return nullptr;
 }
+
+/* ------------------------------------------------------------------------- */
+/*                           UTILITY FUNCTIONS                               */
+/* ------------------------------------------------------------------------- */
 
 void   fftw_print_plan(const fftw_plan) {}
 void   fftwf_print_plan(const fftwf_plan) {}

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -2009,8 +2009,10 @@ public:
     // checks if the parameters are consistent with a "default" data layout (considering strides and distances)
     bool is_using_default_layout() const
     {
-        return std::count(ioffset.begin(), ioffset.end(), 0) == ioffset.size()
-               && std::count(ooffset.begin(), ooffset.end(), 0) == ioffset.size()
+        static_assert(std::is_same_v<decltype(ioffset), decltype(ooffset)>);
+        auto is_zero = [](const decltype(ioffset)::value_type& i) { return i == 0; };
+        return std::all_of(ioffset.begin(), ioffset.end(), is_zero)
+               && std::all_of(ooffset.begin(), ooffset.end(), is_zero)
                && istride == default_strides(transform_type, placement, fft_io::fft_io_in, length)
                && ostride == default_strides(transform_type, placement, fft_io::fft_io_out, length)
                && idist

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -1702,7 +1702,8 @@ public:
             bool       samestride = true;
             for(unsigned int i = 0; i < stridesize; ++i)
             {
-                if(istride[i] != ostride[i])
+                // (strides are irrelevant for unit lengths)
+                if(istride[i] != ostride[i] && length[i] > 1)
                     samestride = false;
             }
             if((transform_type == fft_transform_type_complex_forward
@@ -1742,7 +1743,7 @@ public:
 
             if((transform_type == fft_transform_type_real_forward
                 || transform_type == fft_transform_type_real_inverse)
-               && (istride.back() != 1 || ostride.back() != 1))
+               && (istride.back() != 1 || ostride.back() != 1) && length.back() > 1)
             {
                 // In-place real/complex transforms require unit strides.
                 if(verbose)

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -211,6 +211,68 @@ inline Tsize var_size(const fft_precision precision, const fft_array_type type)
     return var_size;
 }
 
+template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+static std::vector<T> default_strides(fft_transform_type    dft_type,
+                                      fft_result_placement  placement,
+                                      fft_io                io,
+                                      const std::vector<T>& lengths)
+{
+    std::vector<T> ret(lengths.size());
+    T              def_stride = 1;
+    for(auto dim_idx = lengths.size(); dim_idx-- > 0;)
+    {
+        ret[dim_idx] = def_stride;
+        if(dim_idx == lengths.size() - 1 && is_real(dft_type))
+        {
+            if((io == fft_io_out) == is_fwd(dft_type))
+                def_stride *= (lengths[dim_idx] / 2 + 1);
+            else
+            {
+                if(placement == fft_placement_inplace)
+                    def_stride *= 2 * (lengths[dim_idx] / 2 + 1);
+                else
+                    def_stride *= lengths[dim_idx];
+            }
+        }
+        else
+            def_stride *= lengths[dim_idx];
+    }
+    return ret;
+}
+
+// NOTE: this is generalized for multidimensional batches
+template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+static std::vector<T> default_distances(fft_transform_type    dft_type,
+                                        fft_result_placement  placement,
+                                        fft_io                io,
+                                        const std::vector<T>& lengths,
+                                        const std::vector<T>& batches)
+{
+    if(batches.empty() || lengths.empty())
+        return std::vector<T>(); // empty as well
+    auto temp_lengths = lengths;
+    temp_lengths.insert(temp_lengths.begin(), batches.begin(), batches.end());
+    auto ret = default_strides(dft_type, placement, io, temp_lengths);
+    ret.resize(batches.size());
+    return ret;
+}
+// NOTE: this is for one-dimensional batches
+template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+static T default_distance(fft_transform_type    dft_type,
+                          fft_result_placement  placement,
+                          fft_io                io,
+                          const std::vector<T>& lengths,
+                          const T&              batch_sz)
+{
+    if(lengths.empty())
+        throw std::invalid_argument("empty lengths rejected by default_distance");
+    const auto tmp
+        = default_distances(dft_type, placement, io, lengths, std::vector<T>(1, batch_sz));
+    if(tmp.empty())
+        throw std::runtime_error("internal inconsistency encountered by default_distance");
+    return tmp.front();
+}
+
 #ifdef USE_HIPRAND
 // Given an array type and transform length, strides, etc, initialize
 // values into the input device buffer.
@@ -1947,52 +2009,16 @@ public:
     // checks if the parameters are consistent with a "default" data layout (considering strides and distances)
     bool is_using_default_layout() const
     {
-        auto is_zero                = [](const decltype(ioffset)::value_type& i) { return i == 0; };
-        bool default_layout_is_used = std::all_of(ioffset.begin(), ioffset.end(), is_zero)
-                                      && std::all_of(ooffset.begin(), ooffset.end(), is_zero);
-        size_t default_ival = 1;
-        size_t default_oval = 1;
-        default_layout_is_used
-            &= (default_ival == istride.back()) && (default_oval == ostride.back());
-        switch(transform_type)
-        {
-        case fft_transform_type_complex_forward:
-        case fft_transform_type_complex_inverse:
-        {
-            default_ival *= length.back();
-            default_oval *= length.back();
-            break;
-        }
-        case fft_transform_type_real_forward:
-        case fft_transform_type_real_inverse:
-        {
-            const size_t hermitian_symmetric_length = length.back() / 2 + 1;
-            size_t*      ptr_default_real_val       = &default_ival;
-            size_t*      ptr_default_cmplx_val      = &default_oval;
-            if(transform_type == fft_transform_type_real_inverse)
-                std::swap(ptr_default_real_val, ptr_default_cmplx_val);
-            *ptr_default_cmplx_val *= hermitian_symmetric_length;
-            if(placement == fft_placement_inplace)
-                *ptr_default_real_val *= 2 * hermitian_symmetric_length; // padding to be used
-            else
-                *ptr_default_real_val *= length.back();
-            break;
-        }
-        default:
-            throw std::runtime_error("Invalid transform type");
-        }
-        // check strides for multi-dimensional cases
-        for(int stride_idx = static_cast<int>(dim()) - 2; stride_idx >= 0 && default_layout_is_used;
-            stride_idx--)
-        {
-            default_layout_is_used
-                &= (default_ival == istride[stride_idx]) && (default_oval == ostride[stride_idx]);
-            default_ival *= length[stride_idx];
-            default_oval *= length[stride_idx];
-        }
-        // check distances
-        default_layout_is_used &= (idist == default_ival) && (odist == default_oval);
-        return default_layout_is_used;
+        return std::count(ioffset.begin(), ioffset.end(), 0) == ioffset.size()
+               && std::count(ooffset.begin(), ooffset.end(), 0) == ioffset.size()
+               && istride == default_strides(transform_type, placement, fft_io::fft_io_in, length)
+               && ostride == default_strides(transform_type, placement, fft_io::fft_io_out, length)
+               && idist
+                      == default_distance(
+                          transform_type, placement, fft_io::fft_io_in, length, nbatch)
+               && odist
+                      == default_distance(
+                          transform_type, placement, fft_io::fft_io_out, length, nbatch);
     }
 
     // Given a data type and dimensions, fill the buffer, imposing Hermitian symmetry if necessary.

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -2009,8 +2009,10 @@ public:
     // checks if the parameters are consistent with a "default" data layout (considering strides and distances)
     bool is_using_default_layout() const
     {
-        return std::count(ioffset.begin(), ioffset.end(), 0) == ioffset.size()
-               && std::count(ooffset.begin(), ooffset.end(), 0) == ioffset.size()
+        static_assert(std::is_same_v<decltype(ioffset), decltype(ooffset)>);
+        auto is_zero = [](const decltype(ioffset)::value_type& i) { return i == 0; };
+        return std::all_of(ioffset.begin(), ioffset.end(), is_zero)
+               && std::all_of(ooffset.begin(), ooffset.end(), is_zero)
                && istride == default_strides(transform_type, placement, fft_io::fft_io_in, length)
                && ostride == default_strides(transform_type, placement, fft_io::fft_io_out, length)
                && idist

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -1702,7 +1702,8 @@ public:
             bool       samestride = true;
             for(unsigned int i = 0; i < stridesize; ++i)
             {
-                if(istride[i] != ostride[i])
+                // (strides are irrelevant for unit lengths)
+                if(istride[i] != ostride[i] && length[i] > 1)
                     samestride = false;
             }
             if((transform_type == fft_transform_type_complex_forward
@@ -1742,7 +1743,7 @@ public:
 
             if((transform_type == fft_transform_type_real_forward
                 || transform_type == fft_transform_type_real_inverse)
-               && (istride.back() != 1 || ostride.back() != 1))
+               && (istride.back() != 1 || ostride.back() != 1) && length.back() > 1)
             {
                 // In-place real/complex transforms require unit strides.
                 if(verbose)

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -211,6 +211,68 @@ inline Tsize var_size(const fft_precision precision, const fft_array_type type)
     return var_size;
 }
 
+template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+static std::vector<T> default_strides(fft_transform_type    dft_type,
+                                      fft_result_placement  placement,
+                                      fft_io                io,
+                                      const std::vector<T>& lengths)
+{
+    std::vector<T> ret(lengths.size());
+    T              def_stride = 1;
+    for(auto dim_idx = lengths.size(); dim_idx-- > 0;)
+    {
+        ret[dim_idx] = def_stride;
+        if(dim_idx == lengths.size() - 1 && is_real(dft_type))
+        {
+            if((io == fft_io_out) == is_fwd(dft_type))
+                def_stride *= (lengths[dim_idx] / 2 + 1);
+            else
+            {
+                if(placement == fft_placement_inplace)
+                    def_stride *= 2 * (lengths[dim_idx] / 2 + 1);
+                else
+                    def_stride *= lengths[dim_idx];
+            }
+        }
+        else
+            def_stride *= lengths[dim_idx];
+    }
+    return ret;
+}
+
+// NOTE: this is generalized for multidimensional batches
+template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+static std::vector<T> default_distances(fft_transform_type    dft_type,
+                                        fft_result_placement  placement,
+                                        fft_io                io,
+                                        const std::vector<T>& lengths,
+                                        const std::vector<T>& batches)
+{
+    if(batches.empty() || lengths.empty())
+        return std::vector<T>(); // empty as well
+    auto temp_lengths = lengths;
+    temp_lengths.insert(temp_lengths.begin(), batches.begin(), batches.end());
+    auto ret = default_strides(dft_type, placement, io, temp_lengths);
+    ret.resize(batches.size());
+    return ret;
+}
+// NOTE: this is for one-dimensional batches
+template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+static T default_distance(fft_transform_type    dft_type,
+                          fft_result_placement  placement,
+                          fft_io                io,
+                          const std::vector<T>& lengths,
+                          const T&              batch_sz)
+{
+    if(lengths.empty())
+        throw std::invalid_argument("empty lengths rejected by default_distance");
+    const auto tmp
+        = default_distances(dft_type, placement, io, lengths, std::vector<T>(1, batch_sz));
+    if(tmp.empty())
+        throw std::runtime_error("internal inconsistency encountered by default_distance");
+    return tmp.front();
+}
+
 #ifdef USE_HIPRAND
 // Given an array type and transform length, strides, etc, initialize
 // values into the input device buffer.
@@ -1947,52 +2009,16 @@ public:
     // checks if the parameters are consistent with a "default" data layout (considering strides and distances)
     bool is_using_default_layout() const
     {
-        auto is_zero                = [](const decltype(ioffset)::value_type& i) { return i == 0; };
-        bool default_layout_is_used = std::all_of(ioffset.begin(), ioffset.end(), is_zero)
-                                      && std::all_of(ooffset.begin(), ooffset.end(), is_zero);
-        size_t default_ival = 1;
-        size_t default_oval = 1;
-        default_layout_is_used
-            &= (default_ival == istride.back()) && (default_oval == ostride.back());
-        switch(transform_type)
-        {
-        case fft_transform_type_complex_forward:
-        case fft_transform_type_complex_inverse:
-        {
-            default_ival *= length.back();
-            default_oval *= length.back();
-            break;
-        }
-        case fft_transform_type_real_forward:
-        case fft_transform_type_real_inverse:
-        {
-            const size_t hermitian_symmetric_length = length.back() / 2 + 1;
-            size_t*      ptr_default_real_val       = &default_ival;
-            size_t*      ptr_default_cmplx_val      = &default_oval;
-            if(transform_type == fft_transform_type_real_inverse)
-                std::swap(ptr_default_real_val, ptr_default_cmplx_val);
-            *ptr_default_cmplx_val *= hermitian_symmetric_length;
-            if(placement == fft_placement_inplace)
-                *ptr_default_real_val *= 2 * hermitian_symmetric_length; // padding to be used
-            else
-                *ptr_default_real_val *= length.back();
-            break;
-        }
-        default:
-            throw std::runtime_error("Invalid transform type");
-        }
-        // check strides for multi-dimensional cases
-        for(int stride_idx = static_cast<int>(dim()) - 2; stride_idx >= 0 && default_layout_is_used;
-            stride_idx--)
-        {
-            default_layout_is_used
-                &= (default_ival == istride[stride_idx]) && (default_oval == ostride[stride_idx]);
-            default_ival *= length[stride_idx];
-            default_oval *= length[stride_idx];
-        }
-        // check distances
-        default_layout_is_used &= (idist == default_ival) && (odist == default_oval);
-        return default_layout_is_used;
+        return std::count(ioffset.begin(), ioffset.end(), 0) == ioffset.size()
+               && std::count(ooffset.begin(), ooffset.end(), 0) == ioffset.size()
+               && istride == default_strides(transform_type, placement, fft_io::fft_io_in, length)
+               && ostride == default_strides(transform_type, placement, fft_io::fft_io_out, length)
+               && idist
+                      == default_distance(
+                          transform_type, placement, fft_io::fft_io_in, length, nbatch)
+               && odist
+                      == default_distance(
+                          transform_type, placement, fft_io::fft_io_out, length, nbatch);
     }
 
     // Given a data type and dimensions, fill the buffer, imposing Hermitian symmetry if necessary.


### PR DESCRIPTION
## Motivations

- Main motivation: the upcoming developments for advanced and guru hipfftw plans do require some amendments to hipfftw's implementation details and, mostly, significant generalization steps for its test code base. This PR intends to isolate the changes that are unrelated to the new upcoming hipfftw features, in order to ease the upcoming code reviews.
- Additional side motivations detailed below.

## Technical Details

- The next upcoming hipfftw features require `hipfftw_helper` to be augmented with more `std::vector<ptrdiff_t>` members; some pre-existing routines specific to its only such member thus far (`lengths`) are generalized to that end. The structure's logic needs to be expanded for non-default strides and/or (possibly multi-dimensional) batch sizes and distances to be considered, along with safe type-conversion helper routines;
- Given the specificities of hipfftw tests, being capable of reproducing one given hipfftw (functional) test can be very helpful for verification purposes and/or to easily compare with rocFFT (without the interfacing layers). These changes enable a way to initialize such a `hipfftw_functional_validation` test from a user-defined token (via the added `hipfftw_token` test option);
- All messages for invalid-argument and runtime exceptions thrown by the `hipfftw_helper` struct are revised for clarity;
- The changes to `hipfftw.cpp` mean to isolate data-layout-related details as much as possible from the remaining logic, and to simplify internal functions' signatures by expanding the `hipfftw_general_layout_data` structure. Only `size_t` values are used past user-facing entry points with these changes (the current limitation for data layouts made of less than $2^{31}$ elements unless via `guru64` APIs is actually inconsistent with FFTW3, hence removed herein);
- The motivations for the changes to `hipfftw_test.cpp` are twofold:
   1) aligning the test logic with the expanded `hipfftw_helper` structure and its corresponding members and member functions;
   2) revising the parameter-generation steps for argument-validation tests from an exhaustive brute-force strategy to probabilistic sampling instead: the brute-force exhaustive strategy was found to produce an excessive number of argument-validation tests for the (upcoming) advanced and guru plan creation functions without significant test benefits compared to a probabilistic sampling approach.
- The inclusion of `hip/hip_runtime_api.h` and/or `hip/hip_complex.h` emits new warnings about ignored attributes (from clang) starting from ROCm-7.0. These warnings are filtered out.

## Test Plan

These changes do not introduce new feature(s) and the current test base suffices to cover the suggested changes. CI tests are expected to pass reliably.

## Test Result

Successfully tested manually and by automated tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
2