### PR TITLE
Temporary workaround for hang in partition_three_way on gfx1151

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
@@ -1131,6 +1131,14 @@ struct partition_kernel_impl_
             selected_in_block = prefix_op.get_reduction();
             selected_prefix   = prefix_op.get_prefix();
         }
+        // Temporary workaround: In ROCm versions 7.0.2, for large data sizes, on Linux,
+        // gfx1151 devices may hang here without an extra syncthreads call.
+        // Logically, this should not be necessary, since the work performed within prefix_op
+        // (to compute the reduction and prefix) has already been performed within the block-level
+        // exclusive_scan call above.
+#if defined(__gfx1151__) && !defined(_WIN32)
+        ::rocprim::syncthreads();
+#endif
 
         // Scatter selected and rejected values
         partition_scatter<OnlySelected, block_size>(keys,


### PR DESCRIPTION
## Motivation

On Linux, gfx1151 devices may encounter a hang in rocprim::partition_threeway with large input data sizes.

## Technical Details

This change introduces a temporary workaround that adds an extra syncthreads() call, which resolve the issue. Logically, this extra synchronization should not be necessary, but it resolves the problem.

This issue does not occur in ROCm builds for 7.0.2, but begins occuring for later builds (using the same rocPRIM commit). We should remove this temporary fix as soon as we've identified and fixed the underying component that changed and caused the problem.

## Test Plan

Build and run rocPRIM's test_device_partition target. All tests should pass with no soft hangs.

## Test Result

All tests pass with no soft hangs.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
