### PR TITLE
[TheRock CI] Skipping proper tests

### DIFF
--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           project_to_test: ${{ inputs.project_to_test }}
           TEST_TYPE: ${{ inputs.test_type }}
+          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 


### PR DESCRIPTION
Errors noted here: https://github.com/ROCm/rocm-libraries/actions/runs/18567098618/job/52936568114?pr=1331

Currently, TheRock skips over rocsparse tests for gfx1151 windows (SPARSE team is actively fixing bugs). However, due to my mistake of missing an argument, the rocsparse tests were getting run and causing test failures. 

This PR will fix that issue and skip the proper tests