### PR TITLE
[rocBLAS] Fix/rocblas rtest.py on Windows

### DIFF
--- a/projects/rocblas/rtest.py
+++ b/projects/rocblas/rtest.py
@@ -272,7 +272,7 @@ def batch(script, xml):
     global OS_info
     global args
     #
-    cwd = pathlib.os.curdir
+    cwd = os.curdir
     rtest_cwd_path = os.path.abspath( os.path.join( cwd, 'rtest.xml') )
     rtest_path = test_xml()
     if 'rocblas_rtest.xml' in rtest_path:

--- a/projects/rocblas/rtest.py
+++ b/projects/rocblas/rtest.py
@@ -40,36 +40,82 @@ timeout = False
 test_proc = None
 stop = 0
 
-test_script = [ '%XML%' ] # [ 'cd %IDIR%', '%XML%' ]
+test_script = ["%XML%"]  # [ 'cd %IDIR%', '%XML%' ]
+
 
 def parse_args():
     """Parse command-line arguments"""
-    parser = argparse.ArgumentParser(description="""
+    parser = argparse.ArgumentParser(
+        description="""
     Checks build arguments
-    """)
-    parser.add_argument(      '--ci_labels', type=str, required=False, default="",
-                    help='Semi-colon seperated list of labels that may modify test runs (optional, e.g. "gfx12;TestLevel1Only")')
-    parser.add_argument(      '--ci_gfx', type=str, required=False, default="",
-                    help='Semi-colon seperated list of gfx targets expected on test runs (optional, e.g. "gfx1030;gfx1201")')
-    parser.add_argument('-e', '--emulation', type=str, required=False,
-                        help='Emulation test set to run from rtest.xml (e.g. smoke, regression, extended')
-    parser.add_argument('-t', '--test', required=False,
-                        help='Test set to run from rtest.xml (e.g. osdb)')
-    parser.add_argument('-g', '--debug', required=False, default=False,  action='store_true',
-                        help='Test Debug build (optional, default: false)')
-    parser.add_argument('-o', '--output', type=str, required=False, default="xml",
-                        help='Test output file (optional, default: test_detail.xml)')
-    parser.add_argument(      '--install_dir', type=str, required=False, default="build",
-                        help='Installation directory where build or release folders are (optional, default: build)')
-    parser.add_argument(      '--fail_test', default=False, required=False, action='store_true',
-                        help='Return as if test failed (optional, default: false)')
+    """
+    )
+    parser.add_argument(
+        "--ci_labels",
+        type=str,
+        required=False,
+        default="",
+        help='Semi-colon seperated list of labels that may modify test runs (optional, e.g. "gfx12;TestLevel1Only")',
+    )
+    parser.add_argument(
+        "--ci_gfx",
+        type=str,
+        required=False,
+        default="",
+        help='Semi-colon seperated list of gfx targets expected on test runs (optional, e.g. "gfx1030;gfx1201")',
+    )
+    parser.add_argument(
+        "-e",
+        "--emulation",
+        type=str,
+        required=False,
+        help="Emulation test set to run from rtest.xml (e.g. smoke, regression, extended",
+    )
+    parser.add_argument(
+        "-t",
+        "--test",
+        required=False,
+        help="Test set to run from rtest.xml (e.g. osdb)",
+    )
+    parser.add_argument(
+        "-g",
+        "--debug",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Test Debug build (optional, default: false)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        required=False,
+        default="xml",
+        help="Test output file (optional, default: test_detail.xml)",
+    )
+    parser.add_argument(
+        "--install_dir",
+        type=str,
+        required=False,
+        default="build",
+        help="Installation directory where build or release folders are (optional, default: build)",
+    )
+    parser.add_argument(
+        "--fail_test",
+        default=False,
+        required=False,
+        action="store_true",
+        help="Return as if test failed (optional, default: false)",
+    )
     # parser.add_argument('-v', '--verbose', required=False, default = False, action='store_true',
     #                     help='Verbose install (optional, default: False)')
     return parser.parse_args()
 
+
 def arg_into_list(arg) -> list:
-    arg = re.sub(r"['\"]|['\']",'', arg)
-    return arg.split(';')
+    arg = re.sub(r"['\"]|['\']", "", arg)
+    return arg.split(";")
+
 
 def vram_detect():
     global OS_info
@@ -78,17 +124,18 @@ def vram_detect():
         cmd = "hipinfo.exe"
         process = subprocess.run([cmd], stdout=subprocess.PIPE)
         for line_in in process.stdout.decode().splitlines():
-            if 'totalGlobalMem' in line_in:
+            if "totalGlobalMem" in line_in:
                 OS_info["VRAM"] = float(line_in.split()[1])
                 break
     else:
         cmd = "rocminfo"
         process = subprocess.run([cmd], stdout=subprocess.PIPE)
         for line_in in process.stdout.decode().splitlines():
-            match = re.search(r'.*Size:.*([0-9]+)\(.*\).*KB', line_in, re.IGNORECASE)
+            match = re.search(r".*Size:.*([0-9]+)\(.*\).*KB", line_in, re.IGNORECASE)
             if match:
-                OS_info["VRAM"] = float(match.group(1))/(1024*1024)
+                OS_info["VRAM"] = float(match.group(1)) / (1024 * 1024)
                 break
+
 
 def os_detect():
     global OS_info
@@ -100,8 +147,8 @@ def os_detect():
             with open(inf_file) as f:
                 for line in f:
                     if "=" in line:
-                        k,v = line.strip().split("=")
-                        OS_info[k] = v.replace('"','')
+                        k, v = line.strip().split("=")
+                        OS_info[k] = v.replace('"', "")
     OS_info["NUM_PROC"] = os.cpu_count()
     vram_detect()
     print(OS_info)
@@ -111,20 +158,21 @@ def create_dir(dir_path):
     if os.path.isabs(dir_path):
         full_path = dir_path
     else:
-        full_path = os.path.join( os.getcwd(), dir_path )
+        full_path = os.path.join(os.getcwd(), dir_path)
     return pathlib.Path(full_path).mkdir(parents=True, exist_ok=True)
 
-def delete_dir(dir_path) :
-    if (not os.path.exists(dir_path)):
+
+def delete_dir(dir_path):
+    if not os.path.exists(dir_path):
         return
     if os.name == "nt":
-        return run_cmd( "RMDIR" , f"/S /Q {dir_path}")
+        return run_cmd("RMDIR", f"/S /Q {dir_path}")
     else:
         linux_path = pathlib.Path(dir_path).absolute()
-        return run_cmd( "rm" , f"-rf {linux_path}")
+        return run_cmd("rm", f"-rf {linux_path}")
+
 
 class TimerProcess(multiprocessing.Process):
-
     def __init__(self, start, stop, kill_pid):
         multiprocessing.Process.__init__(self)
         self.quit = multiprocessing.Event()
@@ -135,14 +183,14 @@ class TimerProcess(multiprocessing.Process):
 
     def run(self):
         while not self.quit.is_set():
-            #print( f'time_stop {self.start_time} limit {self.max_time}')
-            if (self.max_time == 0):
+            # print( f'time_stop {self.start_time} limit {self.max_time}')
+            if self.max_time == 0:
                 return
             t = time.monotonic()
-            if ( t - self.start_time > self.max_time ):
-                print( f'killing {self.kill_pid} t {t}')
+            if t - self.start_time > self.max_time:
+                print(f"killing {self.kill_pid} t {t}")
                 if os.name == "nt":
-                    cmd = ['TASKKILL', '/F', '/T', '/PID', str(self.kill_pid)]
+                    cmd = ["TASKKILL", "/F", "/T", "/PID", str(self.kill_pid)]
                     proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
                 else:
                     os.kill(self.kill_pid, signal.SIGKILL)
@@ -159,15 +207,15 @@ class TimerProcess(multiprocessing.Process):
 
 def time_stop(start, pid):
     global timeout, stop
-    while (True):
-        print( f'time_stop {start} limit {stop}')
+    while True:
+        print(f"time_stop {start} limit {stop}")
         t = time.monotonic()
-        if (stop == 0):
+        if stop == 0:
             return
-        if ( (stop > 0) and (t - start > stop) ):
-            print( f'killing {pid} t {t}')
+        if (stop > 0) and (t - start > stop):
+            print(f"killing {pid} t {t}")
             if os.name == "nt":
-                cmd = ['TASKKILL', '/F', '/T', '/PID', str(pid)]
+                cmd = ["TASKKILL", "/F", "/T", "/PID", str(pid)]
                 proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
             else:
                 test_proc.kill()
@@ -175,17 +223,24 @@ def time_stop(start, pid):
             stop = 0
         time.sleep(0)
 
+
 def gfilter_subset(filter, groups) -> str:
     new_filter = ""
     patterns = ["nightly"] if "nightly" in filter else ["quick", "pre_checkin"]
     for i in groups:
         for j in patterns:
-            new_filter += f'*{i}*{j}*:'
+            new_filter += f"*{i}*{j}*:"
     return new_filter
+
 
 def label_modifiers(cmd, labels) -> str:
     original_cmd = cmd
-    processed = ["TestTensileOnly", "TestLevel3Only", "TestLevel2Only", "TestLevel1Only"]
+    processed = [
+        "TestTensileOnly",
+        "TestLevel3Only",
+        "TestLevel2Only",
+        "TestLevel1Only",
+    ]
     overlap = [v for v in processed if v in labels]
     if len(overlap):
         tok = " --gtest_filter="
@@ -195,28 +250,31 @@ def label_modifiers(cmd, labels) -> str:
 
     filter = ""
     if "TestTensileOnly" in overlap:
-        filter += gfilter_subset( original_cmd, ["blas3_tensile", "blas2_tensile"] )
+        filter += gfilter_subset(original_cmd, ["blas3_tensile", "blas2_tensile"])
     if "TestLevel3Only" in overlap:
-        filter += gfilter_subset( original_cmd, ["blas3"] )
+        filter += gfilter_subset(original_cmd, ["blas3"])
     if "TestLevel2Only" in overlap:
-        filter += gfilter_subset( original_cmd, ["blas2"] )
+        filter += gfilter_subset(original_cmd, ["blas2"])
     if "TestLevel1Only" in overlap:
-        filter += gfilter_subset( original_cmd, ["blas1"] )
+        filter += gfilter_subset(original_cmd, ["blas1"])
     return cmd + f'"{filter}"'
 
-def run_cmd(cmd, test = False, time_limit = 0, path = "" ):
+
+def run_cmd(cmd, test=False, time_limit=0, path=""):
     global args
     global test_proc, timer_thread
     global stop
-    if (cmd.startswith('cd ')):
+    if cmd.startswith("cd "):
         return os.chdir(cmd[3:])
-    if (cmd.startswith('mkdir ')):
+    if cmd.startswith("mkdir "):
         return create_dir(cmd[6:])
     cmdline = f"{cmd}"
     print(cmdline)
     try:
         if not test:
-            proc = subprocess.run(cmdline, check=True, stderr=subprocess.STDOUT, shell=True)
+            proc = subprocess.run(
+                cmdline, check=True, stderr=subprocess.STDOUT, shell=True
+            )
             status = proc.returncode
         else:
             sub_env = os.environ.copy()
@@ -224,20 +282,27 @@ def run_cmd(cmd, test = False, time_limit = 0, path = "" ):
                 sub_env["PATH"] = path + os.pathsep + sub_env["PATH"]
             error = False
             timeout = False
-            test_proc = subprocess.Popen(cmdline, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, env=sub_env)
+            test_proc = subprocess.Popen(
+                cmdline,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                shell=True,
+                env=sub_env,
+            )
             if time_limit > 0:
                 start = time.monotonic()
-                #p = multiprocessing.Process(target=time_stop, args=(start, test_proc.pid))
+                # p = multiprocessing.Process(target=time_stop, args=(start, test_proc.pid))
                 p = TimerProcess(start, time_limit, test_proc.pid)
                 p.start()
             while True:
                 output = test_proc.stdout.readline()
-                if output == '' and test_proc.poll() is not None:
+                if output == "" and test_proc.poll() is not None:
                     break
                 elif output:
                     outstring = output.strip()
-                    print (outstring)
-                    error = error or re.search(r'error|fail', outstring, re.IGNORECASE)
+                    print(outstring)
+                    error = error or re.search(r"error|fail", outstring, re.IGNORECASE)
             status = test_proc.poll()
             if time_limit > 0:
                 p.stop()
@@ -252,71 +317,78 @@ def run_cmd(cmd, test = False, time_limit = 0, path = "" ):
                 status = test_proc.returncode
     except:
         import traceback
+
         exc = traceback.format_exc()
-        print( "Python Exception: {0}".format(exc) )
+        print("Python Exception: {0}".format(exc))
         status = 3
     return status
+
 
 def test_xml():
     # Get the full path of the currently executing script look for installed name first
     exe_path = os.path.dirname(os.path.abspath(sys.argv[0]))
-    installed_file = os.path.join( exe_path, 'rocblas_rtest.xml')
-    if (os.path.exists(installed_file)):
+    installed_file = os.path.join(exe_path, "rocblas_rtest.xml")
+    if os.path.exists(installed_file):
         xmlPath = installed_file
     else:
         cwd = os.curdir
-        xmlPath = os.path.join( cwd, 'rtest.xml')
+        xmlPath = os.path.join(cwd, "rtest.xml")
     return xmlPath
+
 
 def batch(script, xml):
     global OS_info
     global args
     #
     cwd = os.curdir
-    rtest_cwd_path = os.path.abspath( os.path.join( cwd, 'rtest.xml') )
+    rtest_cwd_path = os.path.abspath(os.path.join(cwd, "rtest.xml"))
     rtest_path = test_xml()
-    if 'rocblas_rtest.xml' in rtest_path:
-        test_dir = os.path.dirname( rtest_path )
-    elif os.path.isfile(rtest_cwd_path) and os.path.dirname(rtest_cwd_path).endswith( "staging" ):
+    if "rocblas_rtest.xml" in rtest_path:
+        test_dir = os.path.dirname(rtest_path)
+    elif os.path.isfile(rtest_cwd_path) and os.path.dirname(rtest_cwd_path).endswith(
+        "staging"
+    ):
         # if in a staging directory then test locally
         test_dir = cwd
     else:
-        if args.debug: build_type = "debug"
-        else: build_type = "release"
+        if args.debug:
+            build_type = "debug"
+        else:
+            build_type = "release"
         test_dir = f"{args.install_dir}//{build_type}//clients//staging"
     fail = False
     for i in range(len(script)):
         cmdline = script[i]
-        xcmd = cmdline.replace('%IDIR%', test_dir)
-        cmd = xcmd.replace('%ODIR%', args.output)
-        if cmd.startswith('tdir '):
+        xcmd = cmdline.replace("%IDIR%", test_dir)
+        cmd = xcmd.replace("%ODIR%", args.output)
+        if cmd.startswith("tdir "):
             if pathlib.Path(cmd[5:]).exists():
-                return 0 # all further cmds skipped
+                return 0  # all further cmds skipped
             else:
                 continue
         error = False
-        if cmd.startswith('%XML%'):
+        if cmd.startswith("%XML%"):
             # run the matching tests listed in the xml test file
             var_subs = {}
-            for var in xml.getElementsByTagName('var'):
-                name = var.getAttribute('name')
-                val = var.getAttribute('value')
+            for var in xml.getElementsByTagName("var"):
+                name = var.getAttribute("name")
+                val = var.getAttribute("value")
                 var_subs[name] = val
-            var_subs['EXE_DIR'] = test_dir + os.path.sep
-            for test in xml.getElementsByTagName('test'):
-                sets = test.getAttribute('sets')
-                runset = sets.split(',')
+            var_subs["EXE_DIR"] = test_dir + os.path.sep
+            for test in xml.getElementsByTagName("test"):
+                sets = test.getAttribute("sets")
+                runset = sets.split(",")
                 if args.test in runset:
-                    for run in test.getElementsByTagName('run'):
-                        name = run.getAttribute('name')
-                        vram_limit = run.getAttribute('vram_min')
+                    for run in test.getElementsByTagName("run"):
+                        name = run.getAttribute("name")
+                        vram_limit = run.getAttribute("vram_min")
                         if vram_limit:
                             if OS_info["VRAM"] < float(vram_limit):
-                                print( f'***\n*** Skipped: {name} due to VRAM req.\n***')
+                                print(f"***\n*** Skipped: {name} due to VRAM req.\n***")
                                 continue
                         if name:
-                            print( f'***\n*** Running: {name}\n***')
-                        time_limit = run.getAttribute('time_max')
+                            print(f"***\n*** Running: {name}\n***")
+                        time_limit = run.getAttribute("time_max")
                         if time_limit:
                             timeout = float(time_limit)
                         else:
@@ -325,24 +397,26 @@ def batch(script, xml):
                         raw_cmd = run.firstChild.data
                         var_cmd = raw_cmd.format_map(var_subs)
                         if args.ci_labels:
-                            var_cmd = label_modifiers(var_cmd, arg_into_list(args.ci_labels))
+                            var_cmd = label_modifiers(
+                                var_cmd, arg_into_list(args.ci_labels)
+                            )
                         error = run_cmd(var_cmd, True, timeout, test_dir)
-                        if (error == 2):
-                            print( f'***\n*** Timed out when running: {name}\n***')
+                        if error == 2:
+                            print(f"***\n*** Timed out when running: {name}\n***")
         else:
             error = run_cmd(cmd)
         fail = fail or error
 
-    if (fail):
-        if (cmd == "%XML%"):
+    if fail:
+        if cmd == "%XML%":
             print(f"FAILED xml test suite!")
         else:
             print(f"ERROR running: {cmd}")
-        if (os.curdir != cwd):
-            os.chdir( cwd )
+        if os.curdir != cwd:
+            os.chdir(cwd)
         return 1
-    if (os.curdir != cwd):
-        os.chdir( cwd )
+    if os.curdir != cwd:
+        os.chdir(cwd)
     return 0
 
 
@@ -354,19 +428,20 @@ def run_tests():
     cwd = os.curdir
 
     xmlPath = test_xml()
-    xmlDoc = minidom.parse( xmlPath )
+    xmlDoc = minidom.parse(xmlPath)
 
     scripts = []
-    scripts.append( test_script )
+    scripts.append(test_script)
     for i in scripts:
-        if (batch(i, xmlDoc)):
-            #print("Failure in script. ABORTING")
-            if (os.curdir != cwd):
-                os.chdir( cwd )
+        if batch(i, xmlDoc):
+            # print("Failure in script. ABORTING")
+            if os.curdir != cwd:
+                os.chdir(cwd)
             return 1
-    if (os.curdir != cwd):
-        os.chdir( cwd )
+    if os.curdir != cwd:
+        os.chdir(cwd)
     return 0
+
 
 def main():
     global args
@@ -376,18 +451,20 @@ def main():
     args = parse_args()
 
     if args.emulation:
-        args.test = f'emulation_{args.emulation}'
+        args.test = f"emulation_{args.emulation}"
 
     if not (args.test or args.emulation):
-        print('Either -t/--test or -e/--emulation is required.')
+        print("Either -t/--test or -e/--emulation is required.")
         args.fail_test = True
     else:
         status = run_tests()
 
-    if args.fail_test: status = 1
+    if args.fail_test:
+        status = 1
 
-    if (status):
+    if status:
         sys.exit(status)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/projects/rocblas/rtest.py
+++ b/projects/rocblas/rtest.py
@@ -40,82 +40,36 @@ timeout = False
 test_proc = None
 stop = 0
 
-test_script = ["%XML%"]  # [ 'cd %IDIR%', '%XML%' ]
-
+test_script = [ '%XML%' ] # [ 'cd %IDIR%', '%XML%' ]
 
 def parse_args():
     """Parse command-line arguments"""
-    parser = argparse.ArgumentParser(
-        description="""
+    parser = argparse.ArgumentParser(description="""
     Checks build arguments
-    """
-    )
-    parser.add_argument(
-        "--ci_labels",
-        type=str,
-        required=False,
-        default="",
-        help='Semi-colon seperated list of labels that may modify test runs (optional, e.g. "gfx12;TestLevel1Only")',
-    )
-    parser.add_argument(
-        "--ci_gfx",
-        type=str,
-        required=False,
-        default="",
-        help='Semi-colon seperated list of gfx targets expected on test runs (optional, e.g. "gfx1030;gfx1201")',
-    )
-    parser.add_argument(
-        "-e",
-        "--emulation",
-        type=str,
-        required=False,
-        help="Emulation test set to run from rtest.xml (e.g. smoke, regression, extended",
-    )
-    parser.add_argument(
-        "-t",
-        "--test",
-        required=False,
-        help="Test set to run from rtest.xml (e.g. osdb)",
-    )
-    parser.add_argument(
-        "-g",
-        "--debug",
-        required=False,
-        default=False,
-        action="store_true",
-        help="Test Debug build (optional, default: false)",
-    )
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=str,
-        required=False,
-        default="xml",
-        help="Test output file (optional, default: test_detail.xml)",
-    )
-    parser.add_argument(
-        "--install_dir",
-        type=str,
-        required=False,
-        default="build",
-        help="Installation directory where build or release folders are (optional, default: build)",
-    )
-    parser.add_argument(
-        "--fail_test",
-        default=False,
-        required=False,
-        action="store_true",
-        help="Return as if test failed (optional, default: false)",
-    )
+    """)
+    parser.add_argument(      '--ci_labels', type=str, required=False, default="",
+                    help='Semi-colon seperated list of labels that may modify test runs (optional, e.g. "gfx12;TestLevel1Only")')
+    parser.add_argument(      '--ci_gfx', type=str, required=False, default="",
+                    help='Semi-colon seperated list of gfx targets expected on test runs (optional, e.g. "gfx1030;gfx1201")')
+    parser.add_argument('-e', '--emulation', type=str, required=False,
+                        help='Emulation test set to run from rtest.xml (e.g. smoke, regression, extended')
+    parser.add_argument('-t', '--test', required=False,
+                        help='Test set to run from rtest.xml (e.g. osdb)')
+    parser.add_argument('-g', '--debug', required=False, default=False,  action='store_true',
+                        help='Test Debug build (optional, default: false)')
+    parser.add_argument('-o', '--output', type=str, required=False, default="xml",
+                        help='Test output file (optional, default: test_detail.xml)')
+    parser.add_argument(      '--install_dir', type=str, required=False, default="build",
+                        help='Installation directory where build or release folders are (optional, default: build)')
+    parser.add_argument(      '--fail_test', default=False, required=False, action='store_true',
+                        help='Return as if test failed (optional, default: false)')
     # parser.add_argument('-v', '--verbose', required=False, default = False, action='store_true',
     #                     help='Verbose install (optional, default: False)')
     return parser.parse_args()
 
-
 def arg_into_list(arg) -> list:
-    arg = re.sub(r"['\"]|['\']", "", arg)
-    return arg.split(";")
-
+    arg = re.sub(r"['\"]|['\']",'', arg)
+    return arg.split(';')
 
 def vram_detect():
     global OS_info
@@ -124,18 +78,17 @@ def vram_detect():
         cmd = "hipinfo.exe"
         process = subprocess.run([cmd], stdout=subprocess.PIPE)
         for line_in in process.stdout.decode().splitlines():
-            if "totalGlobalMem" in line_in:
+            if 'totalGlobalMem' in line_in:
                 OS_info["VRAM"] = float(line_in.split()[1])
                 break
     else:
         cmd = "rocminfo"
         process = subprocess.run([cmd], stdout=subprocess.PIPE)
         for line_in in process.stdout.decode().splitlines():
-            match = re.search(r".*Size:.*([0-9]+)\(.*\).*KB", line_in, re.IGNORECASE)
+            match = re.search(r'.*Size:.*([0-9]+)\(.*\).*KB', line_in, re.IGNORECASE)
             if match:
-                OS_info["VRAM"] = float(match.group(1)) / (1024 * 1024)
+                OS_info["VRAM"] = float(match.group(1))/(1024*1024)
                 break
-
 
 def os_detect():
     global OS_info
@@ -147,8 +100,8 @@ def os_detect():
             with open(inf_file) as f:
                 for line in f:
                     if "=" in line:
-                        k, v = line.strip().split("=")
-                        OS_info[k] = v.replace('"', "")
+                        k,v = line.strip().split("=")
+                        OS_info[k] = v.replace('"','')
     OS_info["NUM_PROC"] = os.cpu_count()
     vram_detect()
     print(OS_info)
@@ -158,21 +111,20 @@ def create_dir(dir_path):
     if os.path.isabs(dir_path):
         full_path = dir_path
     else:
-        full_path = os.path.join(os.getcwd(), dir_path)
+        full_path = os.path.join( os.getcwd(), dir_path )
     return pathlib.Path(full_path).mkdir(parents=True, exist_ok=True)
 
-
-def delete_dir(dir_path):
-    if not os.path.exists(dir_path):
+def delete_dir(dir_path) :
+    if (not os.path.exists(dir_path)):
         return
     if os.name == "nt":
-        return run_cmd("RMDIR", f"/S /Q {dir_path}")
+        return run_cmd( "RMDIR" , f"/S /Q {dir_path}")
     else:
         linux_path = pathlib.Path(dir_path).absolute()
-        return run_cmd("rm", f"-rf {linux_path}")
-
+        return run_cmd( "rm" , f"-rf {linux_path}")
 
 class TimerProcess(multiprocessing.Process):
+
     def __init__(self, start, stop, kill_pid):
         multiprocessing.Process.__init__(self)
         self.quit = multiprocessing.Event()
@@ -183,14 +135,14 @@ class TimerProcess(multiprocessing.Process):
 
     def run(self):
         while not self.quit.is_set():
-            # print( f'time_stop {self.start_time} limit {self.max_time}')
-            if self.max_time == 0:
+            #print( f'time_stop {self.start_time} limit {self.max_time}')
+            if (self.max_time == 0):
                 return
             t = time.monotonic()
-            if t - self.start_time > self.max_time:
-                print(f"killing {self.kill_pid} t {t}")
+            if ( t - self.start_time > self.max_time ):
+                print( f'killing {self.kill_pid} t {t}')
                 if os.name == "nt":
-                    cmd = ["TASKKILL", "/F", "/T", "/PID", str(self.kill_pid)]
+                    cmd = ['TASKKILL', '/F', '/T', '/PID', str(self.kill_pid)]
                     proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
                 else:
                     os.kill(self.kill_pid, signal.SIGKILL)
@@ -207,15 +159,15 @@ class TimerProcess(multiprocessing.Process):
 
 def time_stop(start, pid):
     global timeout, stop
-    while True:
-        print(f"time_stop {start} limit {stop}")
+    while (True):
+        print( f'time_stop {start} limit {stop}')
         t = time.monotonic()
-        if stop == 0:
+        if (stop == 0):
             return
-        if (stop > 0) and (t - start > stop):
-            print(f"killing {pid} t {t}")
+        if ( (stop > 0) and (t - start > stop) ):
+            print( f'killing {pid} t {t}')
             if os.name == "nt":
-                cmd = ["TASKKILL", "/F", "/T", "/PID", str(pid)]
+                cmd = ['TASKKILL', '/F', '/T', '/PID', str(pid)]
                 proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
             else:
                 test_proc.kill()
@@ -223,24 +175,17 @@ def time_stop(start, pid):
             stop = 0
         time.sleep(0)
 
-
 def gfilter_subset(filter, groups) -> str:
     new_filter = ""
     patterns = ["nightly"] if "nightly" in filter else ["quick", "pre_checkin"]
     for i in groups:
         for j in patterns:
-            new_filter += f"*{i}*{j}*:"
+            new_filter += f'*{i}*{j}*:'
     return new_filter
-
 
 def label_modifiers(cmd, labels) -> str:
     original_cmd = cmd
-    processed = [
-        "TestTensileOnly",
-        "TestLevel3Only",
-        "TestLevel2Only",
-        "TestLevel1Only",
-    ]
+    processed = ["TestTensileOnly", "TestLevel3Only", "TestLevel2Only", "TestLevel1Only"]
     overlap = [v for v in processed if v in labels]
     if len(overlap):
         tok = " --gtest_filter="
@@ -250,31 +195,28 @@ def label_modifiers(cmd, labels) -> str:
 
     filter = ""
     if "TestTensileOnly" in overlap:
-        filter += gfilter_subset(original_cmd, ["blas3_tensile", "blas2_tensile"])
+        filter += gfilter_subset( original_cmd, ["blas3_tensile", "blas2_tensile"] )
     if "TestLevel3Only" in overlap:
-        filter += gfilter_subset(original_cmd, ["blas3"])
+        filter += gfilter_subset( original_cmd, ["blas3"] )
     if "TestLevel2Only" in overlap:
-        filter += gfilter_subset(original_cmd, ["blas2"])
+        filter += gfilter_subset( original_cmd, ["blas2"] )
     if "TestLevel1Only" in overlap:
-        filter += gfilter_subset(original_cmd, ["blas1"])
+        filter += gfilter_subset( original_cmd, ["blas1"] )
     return cmd + f'"{filter}"'
 
-
-def run_cmd(cmd, test=False, time_limit=0, path=""):
+def run_cmd(cmd, test = False, time_limit = 0, path = "" ):
     global args
     global test_proc, timer_thread
     global stop
-    if cmd.startswith("cd "):
+    if (cmd.startswith('cd ')):
         return os.chdir(cmd[3:])
-    if cmd.startswith("mkdir "):
+    if (cmd.startswith('mkdir ')):
         return create_dir(cmd[6:])
     cmdline = f"{cmd}"
     print(cmdline)
     try:
         if not test:
-            proc = subprocess.run(
-                cmdline, check=True, stderr=subprocess.STDOUT, shell=True
-            )
+            proc = subprocess.run(cmdline, check=True, stderr=subprocess.STDOUT, shell=True)
             status = proc.returncode
         else:
             sub_env = os.environ.copy()
@@ -282,27 +224,20 @@ def run_cmd(cmd, test=False, time_limit=0, path=""):
                 sub_env["PATH"] = path + os.pathsep + sub_env["PATH"]
             error = False
             timeout = False
-            test_proc = subprocess.Popen(
-                cmdline,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                shell=True,
-                env=sub_env,
-            )
+            test_proc = subprocess.Popen(cmdline, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, env=sub_env)
             if time_limit > 0:
                 start = time.monotonic()
-                # p = multiprocessing.Process(target=time_stop, args=(start, test_proc.pid))
+                #p = multiprocessing.Process(target=time_stop, args=(start, test_proc.pid))
                 p = TimerProcess(start, time_limit, test_proc.pid)
                 p.start()
             while True:
                 output = test_proc.stdout.readline()
-                if output == "" and test_proc.poll() is not None:
+                if output == '' and test_proc.poll() is not None:
                     break
                 elif output:
                     outstring = output.strip()
-                    print(outstring)
-                    error = error or re.search(r"error|fail", outstring, re.IGNORECASE)
+                    print (outstring)
+                    error = error or re.search(r'error|fail', outstring, re.IGNORECASE)
             status = test_proc.poll()
             if time_limit > 0:
                 p.stop()
@@ -317,78 +252,71 @@ def run_cmd(cmd, test=False, time_limit=0, path=""):
                 status = test_proc.returncode
     except:
         import traceback
-
         exc = traceback.format_exc()
-        print("Python Exception: {0}".format(exc))
+        print( "Python Exception: {0}".format(exc) )
         status = 3
     return status
-
 
 def test_xml():
     # Get the full path of the currently executing script look for installed name first
     exe_path = os.path.dirname(os.path.abspath(sys.argv[0]))
-    installed_file = os.path.join(exe_path, "rocblas_rtest.xml")
-    if os.path.exists(installed_file):
+    installed_file = os.path.join( exe_path, 'rocblas_rtest.xml')
+    if (os.path.exists(installed_file)):
         xmlPath = installed_file
     else:
         cwd = os.curdir
-        xmlPath = os.path.join(cwd, "rtest.xml")
+        xmlPath = os.path.join( cwd, 'rtest.xml')
     return xmlPath
-
 
 def batch(script, xml):
     global OS_info
     global args
     #
     cwd = os.curdir
-    rtest_cwd_path = os.path.abspath(os.path.join(cwd, "rtest.xml"))
+    rtest_cwd_path = os.path.abspath( os.path.join( cwd, 'rtest.xml') )
     rtest_path = test_xml()
-    if "rocblas_rtest.xml" in rtest_path:
-        test_dir = os.path.dirname(rtest_path)
-    elif os.path.isfile(rtest_cwd_path) and os.path.dirname(rtest_cwd_path).endswith(
-        "staging"
-    ):
+    if 'rocblas_rtest.xml' in rtest_path:
+        test_dir = os.path.dirname( rtest_path )
+    elif os.path.isfile(rtest_cwd_path) and os.path.dirname(rtest_cwd_path).endswith( "staging" ):
         # if in a staging directory then test locally
         test_dir = cwd
     else:
-        if args.debug:
-            build_type = "debug"
-        else:
-            build_type = "release"
+        if args.debug: build_type = "debug"
+        else: build_type = "release"
         test_dir = f"{args.install_dir}//{build_type}//clients//staging"
     fail = False
     for i in range(len(script)):
         cmdline = script[i]
-        xcmd = cmdline.replace("%IDIR%", test_dir)
-        cmd = xcmd.replace("%ODIR%", args.output)
-        if cmd.startswith("tdir "):
+        xcmd = cmdline.replace('%IDIR%', test_dir)
+        cmd = xcmd.replace('%ODIR%', args.output)
+        if cmd.startswith('tdir '):
             if pathlib.Path(cmd[5:]).exists():
-                return 0  # all further cmds skipped
+                return 0 # all further cmds skipped
             else:
                 continue
         error = False
-        if cmd.startswith("%XML%"):
+        if cmd.startswith('%XML%'):
             # run the matching tests listed in the xml test file
             var_subs = {}
-            for var in xml.getElementsByTagName("var"):
-                name = var.getAttribute("name")
-                val = var.getAttribute("value")
+            for var in xml.getElementsByTagName('var'):
+                name = var.getAttribute('name')
+                val = var.getAttribute('value')
                 var_subs[name] = val
-            var_subs["EXE_DIR"] = test_dir + os.path.sep
-            for test in xml.getElementsByTagName("test"):
-                sets = test.getAttribute("sets")
-                runset = sets.split(",")
+            var_subs['EXE_DIR'] = test_dir + os.path.sep
+            for test in xml.getElementsByTagName('test'):
+                sets = test.getAttribute('sets')
+                runset = sets.split(',')
                 if args.test in runset:
-                    for run in test.getElementsByTagName("run"):
-                        name = run.getAttribute("name")
-                        vram_limit = run.getAttribute("vram_min")
+                    for run in test.getElementsByTagName('run'):
+                        name = run.getAttribute('name')
+                        vram_limit = run.getAttribute('vram_min')
                         if vram_limit:
                             if OS_info["VRAM"] < float(vram_limit):
-                                print(f"***\n*** Skipped: {name} due to VRAM req.\n***")
+                                print( f'***\n*** Skipped: {name} due to VRAM req.\n***')
                                 continue
                         if name:
-                            print(f"***\n*** Running: {name}\n***")
-                        time_limit = run.getAttribute("time_max")
+                            print( f'***\n*** Running: {name}\n***')
+                        time_limit = run.getAttribute('time_max')
                         if time_limit:
                             timeout = float(time_limit)
                         else:
@@ -397,26 +325,24 @@ def batch(script, xml):
                         raw_cmd = run.firstChild.data
                         var_cmd = raw_cmd.format_map(var_subs)
                         if args.ci_labels:
-                            var_cmd = label_modifiers(
-                                var_cmd, arg_into_list(args.ci_labels)
-                            )
+                            var_cmd = label_modifiers(var_cmd, arg_into_list(args.ci_labels))
                         error = run_cmd(var_cmd, True, timeout, test_dir)
-                        if error == 2:
-                            print(f"***\n*** Timed out when running: {name}\n***")
+                        if (error == 2):
+                            print( f'***\n*** Timed out when running: {name}\n***')
         else:
             error = run_cmd(cmd)
         fail = fail or error
 
-    if fail:
-        if cmd == "%XML%":
+    if (fail):
+        if (cmd == "%XML%"):
             print(f"FAILED xml test suite!")
         else:
             print(f"ERROR running: {cmd}")
-        if os.curdir != cwd:
-            os.chdir(cwd)
+        if (os.curdir != cwd):
+            os.chdir( cwd )
         return 1
-    if os.curdir != cwd:
-        os.chdir(cwd)
+    if (os.curdir != cwd):
+        os.chdir( cwd )
     return 0
 
 
@@ -428,20 +354,19 @@ def run_tests():
     cwd = os.curdir
 
     xmlPath = test_xml()
-    xmlDoc = minidom.parse(xmlPath)
+    xmlDoc = minidom.parse( xmlPath )
 
     scripts = []
-    scripts.append(test_script)
+    scripts.append( test_script )
     for i in scripts:
-        if batch(i, xmlDoc):
-            # print("Failure in script. ABORTING")
-            if os.curdir != cwd:
-                os.chdir(cwd)
+        if (batch(i, xmlDoc)):
+            #print("Failure in script. ABORTING")
+            if (os.curdir != cwd):
+                os.chdir( cwd )
             return 1
-    if os.curdir != cwd:
-        os.chdir(cwd)
+    if (os.curdir != cwd):
+        os.chdir( cwd )
     return 0
-
 
 def main():
     global args
@@ -451,20 +376,18 @@ def main():
     args = parse_args()
 
     if args.emulation:
-        args.test = f"emulation_{args.emulation}"
+        args.test = f'emulation_{args.emulation}'
 
     if not (args.test or args.emulation):
-        print("Either -t/--test or -e/--emulation is required.")
+        print('Either -t/--test or -e/--emulation is required.')
         args.fail_test = True
     else:
         status = run_tests()
 
-    if args.fail_test:
-        status = 1
+    if args.fail_test: status = 1
 
-    if status:
+    if (status):
         sys.exit(status)
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Motivation

Running the script on Windows crashes.

## Technical Details

I don't think `pathlib` has an `os` module, for some reason on Linux it resolves correctly but the script crashes on Windows. Removing `pathlib` works on both platforms.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
