### PR TITLE
[rocsparse] Fix find_package rocblas so that it is required and uses the correct version

### DIFF
--- a/projects/rocsparse/CMakeLists.txt
+++ b/projects/rocsparse/CMakeLists.txt
@@ -198,12 +198,27 @@ endif()
 
 message(STATUS "GPU_TARGETS: ${GPU_TARGETS}")
 
+# Setup version
+set(VERSION_STRING "4.2.0")
+set(SOVERSION_STRING "1.0")
+set(MIN_ROCPRIM_VERSION "4.0.0" CACHE STRING "Minimum version of rocPRIM.")
+set(MIN_ROCBLAS_VERSION "4.1.0" CACHE STRING "Minimum version of rocBLAS.")
+
+rocm_setup_version(VERSION ${VERSION_STRING})
+set(rocsparse_SOVERSION ${SOVERSION_STRING})
+
 # Find rocprim package
 find_package(rocprim REQUIRED)
+if (${rocprim_VERSION} VERSION_LESS ${MIN_ROCPRIM_VERSION})
+  message(FATAL_ERROR "The version of rocPRIM found was incompatible. Found: ${rocprim_VERSION} Required: ${MIN_ROCPRIM_VERSION}")
+endif()
 
 # Find rocblas package
 if (BUILD_WITH_ROCBLAS)
   find_package(rocblas REQUIRED)
+  if (${rocblas_VERSION} VERSION_LESS ${MIN_ROCBLAS_VERSION})
+    message(FATAL_ERROR "The version of rocBLAS found was incompatible. Found: ${rocblas_VERSION} Required: ${MIN_ROCBLAS_VERSION}")
+  endif()
 else()
   message("-- Build rocSPARSE with rocBLAS is disabled")
 endif()
@@ -211,13 +226,6 @@ endif()
 if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
   find_package( hip REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm )
 endif( )
-
-# Setup version
-set(VERSION_STRING "4.2.0")
-set(SOVERSION_STRING "1.0")
-
-rocm_setup_version(VERSION ${VERSION_STRING})
-set(rocsparse_SOVERSION ${SOVERSION_STRING})
 
 if( BUILD_CLIENTS_ONLY OR BUILD_CLIENTS_SAMPLES OR BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
   set( BUILD_CLIENTS ON )

--- a/projects/rocsparse/CMakeLists.txt
+++ b/projects/rocsparse/CMakeLists.txt
@@ -199,11 +199,11 @@ endif()
 message(STATUS "GPU_TARGETS: ${GPU_TARGETS}")
 
 # Find rocprim package
-find_package(rocprim 4.0.0 REQUIRED)
+find_package(rocprim REQUIRED)
 
 # Find rocblas package
 if (BUILD_WITH_ROCBLAS)
-  find_package(rocblas 5.0.0 REQUIRED)
+  find_package(rocblas REQUIRED)
 else()
   message("-- Build rocSPARSE with rocBLAS is disabled")
 endif()

--- a/projects/rocsparse/CMakeLists.txt
+++ b/projects/rocsparse/CMakeLists.txt
@@ -203,7 +203,7 @@ find_package(rocprim 4.0.0 REQUIRED)
 
 # Find rocblas package
 if (BUILD_WITH_ROCBLAS)
-  find_package(rocblas 4.1.0 QUIET)
+  find_package(rocblas 5.0.0 REQUIRED)
 else()
   message("-- Build rocSPARSE with rocBLAS is disabled")
 endif()


### PR DESCRIPTION
## Motivation

Fix find_package rocblas so that it is required and uses the correct 5.0.0 version for this major release cycle. This fixes https://github.com/ROCm/rocm-libraries/issues/2074

## Technical Details

When a user requests using rocblas we were finding the rocblas package in QUIET mode meaning that we would silently not find it even though the user had asked for it. Instead we should make it required so that if a users asks for it, it will either be found or an error will be generated indicating no compatible version could be found. The user can still decide to not use rocblas by setting `BUILD_WITH_ROCBLAS=OFF`.

Additionally when building rocsparse on a system with ROCm 7.0 or later (which will have rocBLAS version 5.0.0 or later), calling `find_package(rocblas 4.1.0 REQUIRED)` will cause errors as rocblas 4.1.0 is not compatible with rocblas 5.0.0. Solution is to call `find_package(rocblas REQUIRED)` and then verify that the version found is greater than or equal to the minimum required version.

## Test Plan

All CI tests should pass
