### PR TITLE
rocfft/hipfft: init cxx flags properly in toolchain

### DIFF
--- a/projects/hipfft/toolchain-windows.cmake
+++ b/projects/hipfft/toolchain-windows.cmake
@@ -35,17 +35,17 @@ set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
 set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
 
 # our usage flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
 
 # flags for clang direct use
 
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
 # -Wno-unknown-attributes to avoid warning: unknown attribute '__dllimport__' ignored [-Wunknown-attributes], in boost
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-attributes -Wno-unknown-attributes")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHIP_CLANG_HCC_COMPAT_MODE=1 -DBOOST_USE_WINDOWS_H -DNOMINMAX")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wno-ignored-attributes -Wno-unknown-attributes")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DHIP_CLANG_HCC_COMPAT_MODE=1 -DBOOST_USE_WINDOWS_H -DNOMINMAX")
 
 # args also in hipcc.bat
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-extensions -fms-compatibility -D__HIP_ROCclr__=1 -D__HIP_PLATFORM_AMD__=1")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -fms-extensions -fms-compatibility -D__HIP_ROCclr__=1")
 
 if (DEFINED ENV{VCPKG_PATH})
   file(TO_CMAKE_PATH "$ENV{VCPKG_PATH}" VCPKG_PATH)

--- a/projects/hipfft/toolchain-windows.cmake
+++ b/projects/hipfft/toolchain-windows.cmake
@@ -31,8 +31,12 @@ else()
   set(rocm_bin "C:/hip/bin")
 endif()
 
-set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
-set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
+if( NOT DEFINED CMAKE_CXX_COMPILER )
+  set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
+endif()
+if( NOT DEFINED CMAKE_C_COMPILER )
+  set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
+endif()
 
 # our usage flags
 set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")

--- a/projects/rocfft/toolchain-windows.cmake
+++ b/projects/rocfft/toolchain-windows.cmake
@@ -35,17 +35,17 @@ set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
 set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
 
 # our usage flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
 
 # flags for clang direct use
 
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
 # -Wno-unknown-attributes to avoid warning: unknown attribute '__dllimport__' ignored [-Wunknown-attributes], in boost
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-attributes -Wno-unknown-attributes")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHIP_CLANG_HCC_COMPAT_MODE=1 -DBOOST_USE_WINDOWS_H -DNOMINMAX")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wno-ignored-attributes -Wno-unknown-attributes")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DHIP_CLANG_HCC_COMPAT_MODE=1 -DBOOST_USE_WINDOWS_H -DNOMINMAX")
 
 # args also in hipcc.bat
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-extensions -fms-compatibility -D__HIP_ROCclr__=1")
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -fms-extensions -fms-compatibility -D__HIP_ROCclr__=1")
 
 if (DEFINED ENV{VCPKG_PATH})
   file(TO_CMAKE_PATH "$ENV{VCPKG_PATH}" VCPKG_PATH)

--- a/projects/rocfft/toolchain-windows.cmake
+++ b/projects/rocfft/toolchain-windows.cmake
@@ -31,8 +31,12 @@ else()
   set(rocm_bin "C:/hip/bin")
 endif()
 
-set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
-set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
+if( NOT DEFINED CMAKE_CXX_COMPILER )
+  set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
+endif()
+if( NOT DEFINED CMAKE_C_COMPILER )
+  set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
+endif()
 
 # our usage flags
 set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")


### PR DESCRIPTION
## Motivation

Fix a potential failure to set CXX flags on Windows builds.

## Technical Details

CMake intends for toolchain files to set CMAKE_<LANG>_FLAGS_INIT rather than CMAKE_<LANG>_FLAGS directly.  cf: https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_INIT.html

Setting the flags directly is not guaranteed to work.

## Test Plan

Check if the Windows build succeeds, and run regular CI tests.

## Test Result

Tests pass as usual.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
