### PR TITLE
[hipfft][doc] Revisions to hipfft docs and hipfft samples

### DIFF
--- a/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
@@ -24,14 +24,13 @@
 #include <vector>
 
 #include <hipfft/hipfft.h>
+#include <hipfft/hipfftXt.h>
 
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_DEPRECATED_DECLARATIONS
 DISABLE_WARNING_RETURN_TYPE
 #include <hip/hip_runtime_api.h>
 DISABLE_WARNING_POP
-
-#include "../hipfft_params.h"
 
 int main()
 {
@@ -73,12 +72,12 @@ int main()
     }
 
     // Define list of GPUs to use
-    std::array<int, 2> gpus = {0, 1};
+    std::vector<int> gpus = {0, 1};
 
     // Create the multi-gpu plan
     hipLibXtDesc* desc; // input descriptor
 
-    hipfftHandle plan = hipfft_params::INVALID_PLAN_HANDLE;
+    hipfftHandle plan;
     if(hipfftCreate(&plan) != HIPFFT_SUCCESS)
         throw std::runtime_error("failed to create plan");
 
@@ -101,7 +100,7 @@ int main()
         throw std::runtime_error("hipfftMakePlan2d failed.");
 
     // Copy input data to GPUs
-    hipfftXtSubFormat_t format = HIPFFT_XT_FORMAT_INPLACE_SHUFFLED;
+    hipfftXtSubFormat_t format = HIPFFT_XT_FORMAT_INPLACE;
     hipfft_rt                  = hipfftXtMalloc(plan, &desc, format);
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftXtMalloc failed.");

--- a/projects/hipfft/clients/samples/hipfft_planmany_2d_r2c.cpp
+++ b/projects/hipfft/clients/samples/hipfft_planmany_2d_r2c.cpp
@@ -44,10 +44,10 @@ int main()
 
     int istride    = 1;
     int ostride    = istride;
-    int inembed[2] = {istride * n[0], istride * n1_padding_real_elements};
-    int onembed[2] = {ostride * n[0], ostride * n1_complex_elements};
-    int idist      = inembed[0] * inembed[1];
-    int odist      = onembed[0] * onembed[1];
+    int inembed[2] = {n[0], n1_padding_real_elements};
+    int onembed[2] = {n[0], n1_complex_elements};
+    int idist      = istride * inembed[0] * inembed[1];
+    int odist      = ostride * onembed[0] * onembed[1];
 
     std::cout << "n: " << n[0] << " " << n[1] << "\n"
               << "howmany: " << howmany << "\n"
@@ -76,11 +76,11 @@ int main()
     for(int ibatch = 0; ibatch < howmany; ++ibatch)
     {
         std::cout << "batch: " << ibatch << "\n";
-        for(int i = 0; i < inembed[0]; i++)
+        for(int i = 0; i < n[0]; i++)
         {
-            for(int j = 0; j < inembed[1]; j++)
+            for(int j = 0; j < n[1]; j++)
             {
-                const auto pos = ibatch * idist + i * inembed[1] + j;
+                const auto pos = ibatch * idist + istride * (i * inembed[1] + j);
                 std::cout << data[pos] << " ";
             }
             std::cout << "\n";
@@ -129,11 +129,11 @@ int main()
     for(int ibatch = 0; ibatch < howmany; ++ibatch)
     {
         std::cout << "batch: " << ibatch << "\n";
-        for(int i = 0; i < onembed[0]; i++)
+        for(int i = 0; i < n[0]; i++)
         {
-            for(int j = 0; j < onembed[1]; j++)
+            for(int j = 0; j < n1_complex_elements; j++)
             {
-                const auto pos = ibatch * odist + i * onembed[1] + j;
+                const auto pos = ibatch * odist + ostride * (i * onembed[1] + j);
                 std::cout << output[pos] << " ";
             }
             std::cout << "\n";

--- a/projects/hipfft/docs/conceptual/overview.rst
+++ b/projects/hipfft/docs/conceptual/overview.rst
@@ -175,10 +175,10 @@ Here's an example of a 2D single-precision real-to-complex transform using the h
       // Strides and distances
       int istride    = 1; // Stride between elements in input
       int ostride    = istride; // Stride between elements in output
-      int inembed[2] = {istride * n[0], istride * n1_padding_real_elements}; // Input layout
-      int onembed[2] = {ostride * n[0], ostride * n1_complex_elements}; // Output layout
-      int idist      = inembed[0] * inembed[1]; // Distance between batches in input
-      int odist      = onembed[0] * onembed[1]; // Distance between batches in output
+      int inembed[2] = {n[0], n1_padding_real_elements}; // Input layout
+      int onembed[2] = {n[0], n1_complex_elements};      // Output layout
+      int idist      = istride * inembed[0] * inembed[1]; // Distance between batches in input
+      int odist      = ostride * onembed[0] * onembed[1]; // Distance between batches in output
 
       // Print the layout parameters
       std::cout << "n: " << n[0] << " " << n[1] << "\n"
@@ -212,11 +212,11 @@ Here's an example of a 2D single-precision real-to-complex transform using the h
       for(int ibatch = 0; ibatch < howmany; ++ibatch)
       {
          std::cout << "batch: " << ibatch << "\n";
-         for(int i = 0; i < inembed[0]; i++)
+         for(int i = 0; i < n[0]; i++)
          {
-               for(int j = 0; j < inembed[1]; j++)
+               for(int j = 0; j < n[1]; j++)
                {
-                  const auto pos = ibatch * idist + i * inembed[1] + j;
+                  const auto pos = ibatch * idist + istride * (i * inembed[1] + j);
                   std::cout << data[pos] << " ";
                }
                std::cout << "\n";
@@ -268,11 +268,11 @@ Here's an example of a 2D single-precision real-to-complex transform using the h
       for(int ibatch = 0; ibatch < howmany; ++ibatch)
       {
          std::cout << "batch: " << ibatch << "\n";
-         for(int i = 0; i < onembed[0]; i++)
+         for(int i = 0; i < n[0]; i++)
          {
-               for(int j = 0; j < onembed[1]; j++)
+               for(int j = 0; j < n1_complex_elements; j++)
                {
-                  const auto pos = ibatch * odist + i * onembed[1] + j;
+                  const auto pos = ibatch * odist + ostride * (i * onembed[1] + j);
                   std::cout << output[pos] << " ";
                }
                std::cout << "\n";
@@ -332,14 +332,18 @@ the input data are reused across multiple FFT batches:
       // FFT configuration
       int rank = 2;
       int xformSz[2] = {512, 512};      // 2D FFT size: 512x512
-      int inEmbed[2] = {1, 2240};       // Input data layout
-      int onEmbed[2] = {1, 512};        // Output data layout
+      int inEmbed[2] = {512, 2240};     // Input data layout
+      int onEmbed[2] = {512, 512};      // Output data layout
       int istride = 1, ostride = 1;     // Stride for input and output
       int idist = 432, odist = 262144;  // Batch distance for input and output
       int batch = 5;                    // Number of FFTs to compute in parallel
 
       // Calculate input and output sizes in bytes
-      size_t inSize = idist * batch * sizeof(std::complex<float>);
+      // Input data sequences are all within an array of inEmbed[0] x inEmbed[1] complex
+      // floating-point values (of elementary stride istride):
+      size_t inSize = istride * inEmbed[0] * inEmbed[1] * sizeof(std::complex<float>);
+      // Output data sequences are made of odist complex floating-point values, stored
+      // contiguously without overlap:
       size_t outSize = odist * batch * sizeof(std::complex<float>);
 
       // Initialize HIP and hipFFT resources
@@ -366,14 +370,14 @@ the input data are reused across multiple FFT batches:
       }
 
       // Initialize input data on the host
-      std::vector<std::complex<float>> inputData(idist * batch, {0.0f, 0.0f});
+      std::vector<std::complex<float>> inputData(istride * inEmbed[0] * inEmbed[1], {0.0f, 0.0f});
       for (int ibatch = 0; ibatch < batch; ++ibatch)
       {
          for (int i = 0; i < xformSz[0]; ++i)
          {
                for (int j = 0; j < xformSz[1]; ++j)
                {
-                  int pos = ibatch * idist + i * inEmbed[1] + j;
+                  int pos = ibatch * idist + istride * (i * inEmbed[1] + j);
                   inputData[pos] = std::complex<float>(i + j, ibatch);
                }
          }
@@ -411,9 +415,9 @@ the input data are reused across multiple FFT batches:
          std::cout << "Batch " << ibatch << ":\n";
          for (int i = 0; i < xformSz[0]; ++i)
          {
-               for (int j = 0; j < xformSz[1] / 2 + 1; ++j)
+               for (int j = 0; j < xformSz[1]; ++j)
                {
-                  int pos = ibatch * odist + i * onEmbed[1] + j;
+                  int pos = ibatch * odist + ostride * (i * onEmbed[1] + j);
                   std::cout << outputData[pos] << " ";
                }
                std::cout << "\n";
@@ -434,8 +438,7 @@ the input data are reused across multiple FFT batches:
 Multi-GPU example
 =================
 
-The following example demonstrates a multi-GPU 2D double-precision complex-to-complex transform using the hipFFT library.
-It showcases how to perform a 2D Fast Fourier Transform (FFT) in double precision (complex-to-complex) across two GPUs.
+The following example illustrates how to compute a 2D double-precision complex-to-complex transform across two GPUs using the hipFFT library.
 The following concepts and API calls are used:
 
 *  ``hipfftXt``: This API lets users execute FFTs across multiple GPUs by managing multi-GPU plans.
@@ -472,8 +475,8 @@ For detailed API usage, see :ref:`hipfft-api-usage`.
    #include <iostream>
    #include <vector>
    #include <hipfft/hipfft.h>
+   #include <hipfft/hipfftXt.h>
    #include <hip/hip_runtime_api.h>
-   #include "../hipfft_params.h"
 
    int main()
    {
@@ -507,11 +510,11 @@ For detailed API usage, see :ref:`hipfft-api-usage`.
       }
 
       // Specify the GPUs you want to use for multi-GPU setup
-      std::array<int, 2> gpus = {0, 1};  // Use GPU 0 and GPU 1
+      std::vector<int> gpus = {0, 1};  // Use GPU 0 and GPU 1
 
       // Create a multi-GPU plan
       hipLibXtDesc* desc; // Input descriptor for the Xt format
-      hipfftHandle plan = hipfft_params::INVALID_PLAN_HANDLE;  // Initialize plan handle
+      hipfftHandle plan;  // Plan handle
 
       // Create the FFT plan
       if(hipfftCreate(&plan) != HIPFFT_SUCCESS)
@@ -536,7 +539,7 @@ For detailed API usage, see :ref:`hipfft-api-usage`.
          throw std::runtime_error("hipfftMakePlan2d failed.");
 
       // Allocate memory for input data on the GPUs (Xt format handles the data distribution)
-      hipfftXtSubFormat_t format = HIPFFT_XT_FORMAT_INPLACE_SHUFFLED;
+      hipfftXtSubFormat_t format = HIPFFT_XT_FORMAT_INPLACE;
       hipfft_rt = hipfftXtMalloc(plan, &desc, format);  // Allocate memory for the descriptor
       if(hipfft_rt != HIPFFT_SUCCESS)
          throw std::runtime_error("hipfftXtMalloc failed.");
@@ -590,7 +593,6 @@ For detailed API usage, see :ref:`hipfft-api-usage`.
 
       return 0;
    }
-
 
 
 .. _rocFFT: https://rocm.docs.amd.com/projects/rocFFT/en/latest/index.html


### PR DESCRIPTION
## Motivation

The current form of the "hipFFT overview" documentation page contains usage examples which could be misleading and/or actually fail when built and executed. If actual copies of the hipfft samples, the latter are updated accordingly herein.
Note: there may be some overlap/conflicts with [PR#1732](https://github.com/ROCm/rocm-libraries/pull/1732).

## Technical Details

- `HIPFFT_XT_FORMAT_INPLACE_SHUFFLED` is not supported by [`hipfftXtMalloc`](https://github.com/ROCm/rocm-libraries/blob/462c66efd1bb1099db2933068d4a9f36712d2f71/projects/hipfft/library/src/amd_detail/hipfft.cpp#L1906C15-L1906C28). Other suggested changes to `projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp` align with [PR#1732](https://github.com/ROCm/rocm-libraries/pull/1732);
- Integrating the elementary strides `{i,o}stride` within the definition of the elements of `{i,o}nembed` is misleading in the illustrated usage. While harmless for unit strides, this would be incorrect for non-unit strides;
- Revisions to the (overview-only) example for sliding-window FFTs motivated by:
   - `{i,o}nembed[0] >= xformSz[0]` is not satisfied in the current form. These 0-th index values are arguably irrelevant but that is a [documented requirement](https://rocm.docs.amd.com/projects/hipFFT/en/latest/reference/fft-api-usage.html#_CPPv418hipfftMakePlanMany12hipfftHandleiPiPiiiPiii10hipfftTypeiP6size_t) nonetheless;
   - `inSize` inaccurately calculated, resulting in writing past bounds in data initialization.

## Test Plan

No change to source code requiring tests. Documentation pages built fine locally.

## Test Result

N/A.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
