### PR TITLE
Runtime Configurable WGMXCC

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/ValidParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/ValidParameters.py
@@ -510,12 +510,13 @@ validParameters = { # we need to make sure this matches develop
         range(-1024, 1024 + 1)
     ),  # change a workgroup's id so that the all the workgroups on the gpu at a time are hitting L2 cache the best
     "WorkGroupMappingXCC": [
-        1,
-        2,
-        4,
-        8,
-        16,
-        32,
+        -1,
+         1,
+         2,
+         4,
+         8,
+         16,
+         32,
     ],  # change a workgroup's id so that contiguous workgroup can map on same XCC
     # -1 : WorkGroupMappingXCCGroup will be set to CU_count at runtime. Please ensure that (CU_count % WGMXCC == 0).
     "WorkGroupMappingXCCGroup": list(
@@ -684,7 +685,7 @@ validParameters = { # we need to make sure this matches develop
     "StreamKAtomic": [0, 1],
     # Enables XCC-based remapping of workgroups, set the value to the number of XCCs
     # for the device/configuration being used
-    # 0: uses default workgroup assignment
+    #  0: uses default workgroup assignment
     # 2+: remaps workgroups to be contiguous within an XCC for a given number of XCCs
     "StreamKXCCMapping": [0] + list(range(2, 9)),
     # Enables using a Tree-reduction for the fixup step of StreamK algorithm

--- a/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
@@ -96,67 +96,112 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
     sgprWGM = "WGM"
     label_skipWGMXCC = Label(label="skip_WGMXCC", comment="skip WGMXCC if no enough WGs to remap")
 
-    with writer.allocTmpSgpr(6, 2) as tmpSgprRes:
-        tmpSgpr      = tmpSgprRes.idx
-        tmpSgpr0     = tmpSgpr+1
-        tmpSgpr1     = tmpSgpr0+1
-        tmpSgpr2     = tmpSgpr1+1
-        WGMXCCSgpr   = tmpSgpr2+1
-        CU_CountSgpr = WGMXCCSgpr+1
+    if(kernel["StreamK"] != 0 and kernel["WorkGroupMappingXCC"] == -1):
+        """
+        Formula:
+        x, g   = divmod(old_wg, WGMXCC)
+        q, r   = divmod(WG, WGMXCC)
+        group  = q + (1 if x < r else 0)
+        offset = 0 if x < r else r
+        new    = g + x * group + offset
+        """
+        with writer.allocTmpSgpr(5, 2) as tmpSgprRes:
+            SgprWGMXCC = tmpSgprRes.idx
+            SgprX      = tmpSgprRes.idx + 1
+            SgprG      = tmpSgprRes.idx + 2
+            SgprQ      = tmpSgprRes.idx + 3
+            SgprR      = tmpSgprRes.idx + 4
+            # Reuse some sgprs
+            tmpSgpr = SgprWGMXCC
+            group   = SgprQ
+            offset  = SgprR
+            
+            tmpVgpr     = writer.vgprPool.checkOutAligned(4,2)
+            tmpVgprRes  = ContinuousRegister(tmpVgpr, 4)
 
-        module.add(SLShiftRightB32(dst=sgpr(WGMXCCSgpr), shiftHex=hex(16), src=sgpr(sgprWGM), comment="Get WGMXCC"))
-        module.add(SFf1B32(dst=sgpr(WGMXCCSgpr), src=sgpr(WGMXCCSgpr), comment="Get log(WGMXCC)"))
-        module.add(SLShiftRightB32(dst=sgpr(CU_CountSgpr), shiftHex=hex(22), src=sgpr(sgprWGM), comment="Get CU_Count"))
+            module.add(SLShiftRightB32(dst=sgpr(SgprWGMXCC), shiftHex=hex(16), src=sgpr(sgprWGM), comment="Get WGMXCC"))
+            module.add(SAndB32(dst=sgpr(SgprWGMXCC), shiftHex=sgpr(SgprWGMXCC), src=hex(63), comment="Get WGMXCC"))
+            module.addComment0("remap WGs if WGMXCC > 1")
+            module.add(SCmpGtI32(src0=sgpr(SgprWGMXCC), src1=1))
+            module.add(SCBranchSCC0(label_skipWGMXCC.getLabelName()))
+            module.addComment0("divmod(old_wg, WGMXCC)")
+            module.add(scalarUInt24DivideAndRemainder(qReg=SgprX, rReg=SgprG, dReg="WorkGroup0", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
+            module.addComment0("divmod(WG, WGMXCC)")
+            module.add(scalarUInt24DivideAndRemainder(qReg=SgprQ, rReg=SgprR, dReg="skGrid", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))            
+            writer.vgprPool.checkIn(tmpVgpr)
+            # Check if current group requires a remainder WG or not
+            module.add(SCmpLtU32(src0=sgpr(SgprX), src1=sgpr(SgprR)))
+            module.add(SCSelectB32(dst=sgpr(tmpSgpr), src0=hex(1), src1=hex(0), comment="Select multiplier"))
+            module.add(SCSelectB32(dst=sgpr(offset), src0=0, src1=sgpr(SgprR), comment="Select remainder"))
+            module.add(SAddU32(dst=sgpr(group), src0=sgpr(group), src1=sgpr(tmpSgpr), comment="Select multiplier"))
+            # Assemble everything
+            module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr(SgprG), src1=sgpr(offset)))
+            module.add(SMulI32(dst=sgpr(tmpSgpr), src0=sgpr(SgprX), src1=sgpr(group)))
+            module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr)))
 
-        module.addComment0("remap WGs if WGMXCC > 1 ( log(WGMXCC) > 0 )")
-        module.add(SCmpGtI32(src0=sgpr(WGMXCCSgpr), src1=0))
-        module.add(SCBranchSCC0(label_skipWGMXCC.getLabelName()))
+            module.add(label_skipWGMXCC)
+    else:
+        with writer.allocTmpSgpr(6, 2) as tmpSgprRes:
+            tmpSgpr      = tmpSgprRes.idx
+            tmpSgpr0     = tmpSgpr+1
+            tmpSgpr1     = tmpSgpr0+1
+            tmpSgpr2     = tmpSgpr1+1
+            WGMXCCSgpr   = tmpSgpr2+1
+            CU_CountSgpr = WGMXCCSgpr+1
 
-        module.addComment0("only remap WGs in the range")
-        tmpVgpr     = writer.vgprPool.checkOutAligned(4,2)
-        tmpVgprRes  = ContinuousRegister(tmpVgpr, 4)
-        module.add(SLShiftRightB32(dst=sgpr(tmpSgpr0), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgprNumWorkGroups)))
-        module.add(SLShiftLeftB32(dst=sgpr(tmpSgpr0), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgpr0)))
-        module.add(SCmpGeU32(src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr0)))
-        module.add(SCBranchSCC1(label_skipWGMXCC.getLabelName()))
+            module.add(SLShiftRightB32(dst=sgpr(WGMXCCSgpr), shiftHex=hex(16), src=sgpr(sgprWGM), comment="Get WGMXCC"))
+            module.add(SFf1B32(dst=sgpr(WGMXCCSgpr), src=sgpr(WGMXCCSgpr), comment="Get log(WGMXCC)"))
+            module.add(SLShiftRightB32(dst=sgpr(CU_CountSgpr), shiftHex=hex(22), src=sgpr(sgprWGM), comment="Get CU_Count"))
 
-        label_XCCG_nonzero = Label(label="XCCG_nonzero", comment="")
-        module.add(SCmpEQU32(src0=sgpr(CU_CountSgpr), src1=0, comment="CU_Count == 0 ?"))
-        module.add(SCBranchSCC0(label_XCCG_nonzero.getLabelName()))
+            module.addComment0("remap WGs if WGMXCC > 1 ( log(WGMXCC) > 0 )")
+            module.add(SCmpGtI32(src0=sgpr(WGMXCCSgpr), src1=0))
+            module.add(SCBranchSCC0(label_skipWGMXCC.getLabelName()))
 
-        # CU_count == 0
-        module.add(SLShiftRightB32(dst=sgpr(tmpSgpr0), shiftHex=sgpr(WGMXCCSgpr), src=sgpr("WorkGroup0")))
-        module.add(SBfmB32(dst=sgpr(tmpSgpr1), src0=sgpr(WGMXCCSgpr), src1=0))
-        module.add(SAndB32(dst=sgpr(tmpSgpr1), src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr1)))
-        module.add(SLShiftRightB32(dst=sgpr(tmpSgpr2), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgprNumWorkGroups)))
-        module.add(SMulI32(dst=sgpr(tmpSgpr1), src0=sgpr(tmpSgpr1), src1=sgpr(tmpSgpr2)))
-        module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr(tmpSgpr0), src1=sgpr(tmpSgpr1)))
-        module.add(SBranch(label_skipWGMXCC.getLabelName()))
+            module.addComment0("only remap WGs in the range")
+            tmpVgpr     = writer.vgprPool.checkOutAligned(4,2)
+            tmpVgprRes  = ContinuousRegister(tmpVgpr, 4)
+            module.add(SLShiftRightB32(dst=sgpr(tmpSgpr0), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgprNumWorkGroups)))
+            module.add(SLShiftLeftB32(dst=sgpr(tmpSgpr0), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgpr0)))
+            module.add(SCmpGeU32(src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr0)))
+            module.add(SCBranchSCC1(label_skipWGMXCC.getLabelName()))
 
-        # CU_count > 0
-        module.add(label_XCCG_nonzero)
-        module.addComment0("temp0 = (wg//CU_Count)*CU_Count")
-        module.add(scalarUInt24DivideAndRemainder(qReg=tmpSgpr0, dReg="WorkGroup0", divReg=CU_CountSgpr, rReg=tmpSgpr1, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
-        module.add(SMulI32(dst=sgpr(tmpSgpr0), src0=sgpr(tmpSgpr0), src1=sgpr(CU_CountSgpr)))
-        module.addComment0("temp1 = (wg%CU_Count)//WGMXCC")
-        module.add(SLShiftRightB32(dst=sgpr(tmpSgpr1), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgpr1)))
-        module.addComment0("temp0 = temp0 + temp1")
-        module.add(SAddU32(dst=sgpr(tmpSgpr0), src0=sgpr(tmpSgpr0), src1=sgpr(tmpSgpr1)))
-        module.addComment0("temp1 = (wg%WGMXCC) * ((WGs - (WGs//CU_Count) * CU_Count) if (wg > (WGs//CU_Count) * CU_Count) else CU_Count)//WGMXCC")
-        module.add(scalarUInt24DivideAndRemainder(qReg=tmpSgpr1, dReg=tmpSgprNumWorkGroups, divReg=CU_CountSgpr, rReg=-1, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=False))
-        module.add(SMulI32(dst=sgpr(tmpSgpr1), src0=sgpr(tmpSgpr1), src1=sgpr(CU_CountSgpr)))
-        module.add(SSubU32(dst=sgpr(tmpSgpr2), src0=sgpr(tmpSgprNumWorkGroups), src1=sgpr(tmpSgpr1)))
-        module.add(SCmpGtU32(src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr1)))
-        module.add(SCSelectB32(dst=sgpr(tmpSgpr1), src0=sgpr(tmpSgpr2), src1=sgpr(CU_CountSgpr)))
-        module.add(SLShiftRightB32(dst=sgpr(tmpSgpr1), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgpr1)))
-        module.add(SBfmB32(dst=sgpr(tmpSgpr2), src0=sgpr(WGMXCCSgpr), src1=0))
-        module.add(SAndB32(dst=sgpr(tmpSgpr2), src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr2)))
-        writer.vgprPool.checkIn(tmpVgpr)
-        module.add(SMulI32(dst=sgpr(tmpSgpr1), src0=sgpr(tmpSgpr1), src1=sgpr(tmpSgpr2)))
-        module.addComment0("WorkGroup0 = temp0 + temp1")
-        module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr(tmpSgpr0), src1=sgpr(tmpSgpr1)))
+            label_XCCG_nonzero = Label(label="XCCG_nonzero", comment="")
+            module.add(SCmpEQU32(src0=sgpr(CU_CountSgpr), src1=0, comment="CU_Count == 0 ?"))
+            module.add(SCBranchSCC0(label_XCCG_nonzero.getLabelName()))
 
-        module.add(label_skipWGMXCC)
+            # CU_count == 0
+            module.add(SLShiftRightB32(dst=sgpr(tmpSgpr0), shiftHex=sgpr(WGMXCCSgpr), src=sgpr("WorkGroup0")))
+            module.add(SBfmB32(dst=sgpr(tmpSgpr1), src0=sgpr(WGMXCCSgpr), src1=0))
+            module.add(SAndB32(dst=sgpr(tmpSgpr1), src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr1)))
+            module.add(SLShiftRightB32(dst=sgpr(tmpSgpr2), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgprNumWorkGroups)))
+            module.add(SMulI32(dst=sgpr(tmpSgpr1), src0=sgpr(tmpSgpr1), src1=sgpr(tmpSgpr2)))
+            module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr(tmpSgpr0), src1=sgpr(tmpSgpr1)))
+            module.add(SBranch(label_skipWGMXCC.getLabelName()))
+
+            # CU_count > 0
+            module.add(label_XCCG_nonzero)
+            module.addComment0("temp0 = (wg//CU_Count)*CU_Count")
+            module.add(scalarUInt24DivideAndRemainder(qReg=tmpSgpr0, dReg="WorkGroup0", divReg=CU_CountSgpr, rReg=tmpSgpr1, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
+            module.add(SMulI32(dst=sgpr(tmpSgpr0), src0=sgpr(tmpSgpr0), src1=sgpr(CU_CountSgpr)))
+            module.addComment0("temp1 = (wg%CU_Count)//WGMXCC")
+            module.add(SLShiftRightB32(dst=sgpr(tmpSgpr1), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgpr1)))
+            module.addComment0("temp0 = temp0 + temp1")
+            module.add(SAddU32(dst=sgpr(tmpSgpr0), src0=sgpr(tmpSgpr0), src1=sgpr(tmpSgpr1)))
+            module.addComment0("temp1 = (wg%WGMXCC) * ((WGs - (WGs//CU_Count) * CU_Count) if (wg > (WGs//CU_Count) * CU_Count) else CU_Count)//WGMXCC")
+            module.add(scalarUInt24DivideAndRemainder(qReg=tmpSgpr1, dReg=tmpSgprNumWorkGroups, divReg=CU_CountSgpr, rReg=-1, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=False))
+            module.add(SMulI32(dst=sgpr(tmpSgpr1), src0=sgpr(tmpSgpr1), src1=sgpr(CU_CountSgpr)))
+            module.add(SSubU32(dst=sgpr(tmpSgpr2), src0=sgpr(tmpSgprNumWorkGroups), src1=sgpr(tmpSgpr1)))
+            module.add(SCmpGtU32(src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr1)))
+            module.add(SCSelectB32(dst=sgpr(tmpSgpr1), src0=sgpr(tmpSgpr2), src1=sgpr(CU_CountSgpr)))
+            module.add(SLShiftRightB32(dst=sgpr(tmpSgpr1), shiftHex=sgpr(WGMXCCSgpr), src=sgpr(tmpSgpr1)))
+            module.add(SBfmB32(dst=sgpr(tmpSgpr2), src0=sgpr(WGMXCCSgpr), src1=0))
+            module.add(SAndB32(dst=sgpr(tmpSgpr2), src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr2)))
+            writer.vgprPool.checkIn(tmpVgpr)
+            module.add(SMulI32(dst=sgpr(tmpSgpr1), src0=sgpr(tmpSgpr1), src1=sgpr(tmpSgpr2)))
+            module.addComment0("WorkGroup0 = temp0 + temp1")
+            module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr(tmpSgpr0), src1=sgpr(tmpSgpr1)))
+
+            module.add(label_skipWGMXCC)
 
     return module
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
@@ -101,20 +101,21 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
         Formula:
         x, g   = divmod(old_wg, WGMXCC)
         q, r   = divmod(WG, WGMXCC)
-        group  = q + (1 if x < r else 0)
-        offset = 0 if x < r else r
-        new    = g + x * group + offset
+        group  = q + (1 if g < r else 0)
+        offset = 0 if g < r else r
+        new    = x + offset + g * group
         """
-        with writer.allocTmpSgpr(5, 2) as tmpSgprRes:
+        with writer.allocTmpSgpr(6, 2) as tmpSgprRes:
             SgprWGMXCC = tmpSgprRes.idx
             SgprX      = tmpSgprRes.idx + 1
             SgprG      = tmpSgprRes.idx + 2
             SgprQ      = tmpSgprRes.idx + 3
             SgprR      = tmpSgprRes.idx + 4
+            SgprO      = tmpSgprRes.idx + 5
             # Reuse some sgprs
             tmpSgpr = SgprWGMXCC
             group   = SgprQ
-            offset  = SgprR
+            # offset  = SgprR
             
             tmpVgpr     = writer.vgprPool.checkOutAligned(4,2)
             tmpVgprRes  = ContinuousRegister(tmpVgpr, 4)
@@ -122,21 +123,22 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
             module.add(SLShiftRightB32(dst=sgpr(SgprWGMXCC), shiftHex=hex(16), src=sgpr(sgprWGM), comment="Get WGMXCC"))
             module.add(SAndB32(dst=sgpr(SgprWGMXCC), src0=sgpr(SgprWGMXCC), src1=hex(63), comment="Get WGMXCC"))
             module.addComment0("remap WGs if WGMXCC > 1")
-            module.add(SCmpGtI32(src0=sgpr(SgprWGMXCC), src1=1))
+            module.add(SCmpGtU32(src0=sgpr(SgprWGMXCC), src1=1))
             module.add(SCBranchSCC0(label_skipWGMXCC.getLabelName()))
             module.addComment0("divmod(old_wg, WGMXCC)")
             module.add(scalarUInt24DivideAndRemainder(qReg=SgprX, rReg=SgprG, dReg="WorkGroup0", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
+            module.add(SWaitCnt(kmcnt=0, comment="wait for args to load"))
             module.addComment0("divmod(WG, WGMXCC)")
             module.add(scalarUInt24DivideAndRemainder(qReg=SgprQ, rReg=SgprR, dReg="skGrid", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))            
             writer.vgprPool.checkIn(tmpVgpr)
             # Check if current group requires a remainder WG or not
-            module.add(SCmpLtU32(src0=sgpr(SgprX), src1=sgpr(SgprR)))
+            module.add(SCmpLtU32(src0=sgpr(SgprG), src1=sgpr(SgprR)))
             module.add(SCSelectB32(dst=sgpr(tmpSgpr), src0=hex(1), src1=hex(0), comment="Select multiplier"))
-            module.add(SCSelectB32(dst=sgpr(offset), src0=0, src1=sgpr(SgprR), comment="Select remainder"))
-            module.add(SAddU32(dst=sgpr(group), src0=sgpr(group), src1=sgpr(tmpSgpr), comment="Select multiplier"))
+            module.add(SCSelectB32(dst=sgpr(SgprO), src0=hex(0), src1=sgpr(SgprR), comment="Select remainder"))
+            module.add(SAddU32(dst=sgpr(group), src0=sgpr(SgprQ), src1=sgpr(tmpSgpr), comment="Adjust multiplier"))
             # Assemble everything
-            module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr(SgprG), src1=sgpr(offset)))
-            module.add(SMulI32(dst=sgpr(tmpSgpr), src0=sgpr(SgprX), src1=sgpr(group)))
+            module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr(SgprX), src1=sgpr(SgprO)))
+            module.add(SMulI32(dst=sgpr(tmpSgpr), src0=sgpr(SgprG), src1=sgpr(group)))
             module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr)))
 
             module.add(label_skipWGMXCC)
@@ -204,7 +206,6 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
             module.add(label_skipWGMXCC)
 
     return module
-
 
 def DefaultWGM(writer, kernel, sgprWGM):
     module = Module("graWGMCalc")

--- a/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
@@ -120,7 +120,7 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
             tmpVgprRes  = ContinuousRegister(tmpVgpr, 4)
 
             module.add(SLShiftRightB32(dst=sgpr(SgprWGMXCC), shiftHex=hex(16), src=sgpr(sgprWGM), comment="Get WGMXCC"))
-            module.add(SAndB32(dst=sgpr(SgprWGMXCC), shiftHex=sgpr(SgprWGMXCC), src=hex(63), comment="Get WGMXCC"))
+            module.add(SAndB32(dst=sgpr(SgprWGMXCC), src0=sgpr(SgprWGMXCC), src1=hex(63), comment="Get WGMXCC"))
             module.addComment0("remap WGs if WGMXCC > 1")
             module.add(SCmpGtI32(src0=sgpr(SgprWGMXCC), src1=1))
             module.add(SCBranchSCC0(label_skipWGMXCC.getLabelName()))

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1183,8 +1183,13 @@ class Solution(collections.abc.Mapping):
     state["LocalWriteUseSgprB"] = False
     state["StoreSwapAddr"] = False
 
-    state["WorkGroupMappingXCC"] = abs(state["WorkGroupMappingXCC"])
-
+    if state["WorkGroupMappingXCC"] == -1:
+      if state["StreamK"] == 0:
+        reject(state, printRejectionReason, "Can only use auto WGMXCC with StreamK.")
+        return False
+      if state["StreamKXCCMapping"] != 0:
+        reject(state, printRejectionReason, "Cannot use auto WGMXCC with SKXCC.")
+        return False
 
     problemType = state["ProblemType"]
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_sgemm_quick.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_sgemm_quick.yaml
@@ -798,3 +798,43 @@ BenchmarkProblems:
     #   BenchmarkFinalParameters:
     #     - ProblemSizes:
     #       - Range: [ [32, 249, 2048], [32, 249, 2048], [1], [32, 249, 2048] ]
+    - # SGEMM TT - Test WorkGroupMappingXCC: -1
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - 1LDSBuffer: [0, 1]
+        - DepthU: [16]
+        - ExpandPointerSwap: [False]
+        - GlobalReadVectorWidthA: [4]
+        - GlobalReadVectorWidthB: [4]
+        - GlobalSplitU: [0]
+        - LocalReadVectorWidth: [1]
+        - MatrixInstruction:
+          # - [16, 16, 4, 1, 1, 8,8, 2,2]
+          - [16, 16, 4, 1, 1, 4,4, 2,2]
+        - MIArchVgpr: [0]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - StaggerU: [0, 32]
+        - ScheduleIterAlg: [3]
+        - SourceSwap: [False, True]
+        - StoreRemapVectorWidth: [0, 4]
+        - StoreVectorWidth: [1]
+        - StreamK: [3]
+        - StreamKFixupTreeReduction: [0, 1]
+        - PrefetchLocalRead: [1, 3]
+        - TransposeLDS: [0, 1]
+        - VectorWidthA: [4]
+        - VectorWidthB: [4]
+        - WorkGroupMapping: [1, 8]
+        - WorkGroupMappingXCC: [-1]
+
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [512, 512, 1, 512]
+          - Exact: [2055, 2055, 1, 1031]

--- a/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
@@ -229,6 +229,7 @@ namespace TensileLite
         int         skDynamicGrid    = 6;
         int         skDynamicWGM     = 0;
         int         fixedWGM         = std::numeric_limits<int>::max();
+        int         fixedWGMXCC      = std::numeric_limits<int>::max();
         int         skMaxCUs         = 0;
         int         skGridMultiplier = 1;
         int         skFixedGrid      = 0;
@@ -267,6 +268,13 @@ namespace TensileLite
         const int getFixedWGM() const
         {
             static const char* envStr = std::getenv("TENSILE_FIXED_WGM");
+            static const int   value  = (envStr == NULL ? std::numeric_limits<int>::max() : std::atoi(envStr));
+            return value;
+        }
+
+        const int getFixedWGMXCC() const
+        {
+            static const char* envStr = std::getenv("TENSILE_FIXED_WGMXCC");
             static const int   value  = (envStr == NULL ? std::numeric_limits<int>::max() : std::atoi(envStr));
             return value;
         }

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblem.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblem.hpp
@@ -88,12 +88,12 @@ namespace TensileLite
             return m_wgm;
         }
 
-        void setWGMXCC(uint16_t wgmxcc)
+        void setWGMXCC(int16_t wgmxcc)
         {
             m_wgmxcc = wgmxcc;
         }
 
-        uint16_t wgmxcc() const
+        int16_t wgmxcc() const
         {
             return m_wgmxcc;
         }
@@ -159,7 +159,7 @@ namespace TensileLite
         bool             m_gsuc           = false; // default value
         bool             m_gsuwgmrr       = false; // default value
         int16_t          m_wgm            = 0; // default value
-        uint16_t         m_wgmxcc         = 0; // default value
+        int16_t          m_wgmxcc         = 0; // default value
         int16_t          m_wgmxccg        = 0; // default value
         rocisa::DataType m_biasType       = rocisa::DataType::None;
         int              m_factorDim      = 0;

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -2792,11 +2792,14 @@ namespace TensileLite
 
                 virtual bool operator()(ContractionProblemGemm const& problem) const override
                 {
+                    // If XCC == -1, we automatically set it to the number XCCs.
+                    // In this case, no predicate is needed.
+                    if(value[0] == -1)
+                        return true;
                     // NB: If this solution is a cu-fallback for current hardware.
                     // We overwrite the XCC to 1 to make sure this can pass.
                     // But we also have to notice we are passing the correct XCC to kernel.
                     // (i.e. Remember to do param.setWGMXCC(1) when running the kernel)
-
                     size_t XCC  = (problem.getParams().fallbackStatus()) ? 1 : value[0];
                     size_t XCCG = (value[1] == -1) ? cuCount : value[1];
                     return ((XCC & (XCC - 1)) == 0) && XCCG % XCC == 0;
@@ -2805,6 +2808,8 @@ namespace TensileLite
                 virtual bool debugEval(ContractionProblemGemm const& problem,
                                        std::ostream&                 stream) const override
                 {
+                    if(value[0] == -1)
+                        return true;
                     size_t XCC  = (problem.getParams().fallbackStatus()) ? 1 : value[0];
                     size_t XCCG = (value[1] == -1) ? cuCount : value[1];
                     return debugEvalCmp(problem,

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
@@ -380,6 +380,7 @@ namespace TensileLite
                         Hardware const*                     hardware,
                         const ContractionProblemParameters& param,
                         int32_t                             defaultWGM,
+                        uint32_t                            defaultWGMXCC,
                         uint32_t                            autoGsuVal) const;
 
         template <typename KA>
@@ -558,6 +559,7 @@ namespace TensileLite
         uint32_t magicNumber(int magicDivAlg, uint32_t x, uint32_t* magicShift) const;
         uint32_t smallMagicNumber(uint32_t x) const;
 
+        std::pair<int32_t, uint32_t> calculateAutoWGM(Problem const& problem, Hardware const* hardware) const;
         uint32_t calculateAutoGSU(Problem const& problem, Hardware const* hardware) const;
     };
 

--- a/projects/hipblaslt/tensilelite/src/AMDGPU.cpp
+++ b/projects/hipblaslt/tensilelite/src/AMDGPU.cpp
@@ -54,6 +54,7 @@ namespace TensileLite
         , skDynamicGrid(getSKDynamicGrid())
         , skDynamicWGM(getSKDynamicWGM())
         , fixedWGM(getFixedWGM())
+        , fixedWGMXCC(getFixedWGMXCC())
         , skMaxCUs(getSKMaxCUs())
         , skGridMultiplier(getSKGridMultiplier())
         , skFixedGrid(getSKFixedGrid())

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -565,6 +565,7 @@ namespace TensileLite
         TensorDescriptor const& compressed = problem.compressed();
         TensorDescriptor const& metadata   = problem.metadata();
 
+        auto [autoWGM, autoWGMXCC] = calculateAutoWGM(problem, hardware);
         uint32_t autoGsuVal = calculateAutoGSU(problem, hardware);
         uint32_t gsu = problem.getParams().gsu() > 0 ? problem.getParams().gsu() : autoGsuVal;
 
@@ -823,7 +824,8 @@ namespace TensileLite
                                           0,
                                           hardware,
                                           problem.getParams(),
-                                          sizeMapping.workGroupMapping,
+                                          autoWGM,
+                                          autoWGMXCC,
                                           autoGsuVal);
 
         if(!problemType.useScaleAB.empty()) //kernel input data
@@ -989,6 +991,74 @@ namespace TensileLite
         return (double)(std::ceil(m / mt0) * std::ceil(n / mt1) * gsu / cuCount)
                / std::ceil(std::ceil(m / mt0) * std::ceil(n / mt1) * gsu / cuCount);
     }
+    
+    std::pair<int32_t, uint32_t> ContractionSolution::calculateAutoWGM(
+        Problem const&  problem,
+        Hardware const* hardware) const
+    {
+        // Default
+        int32_t defaultWGM = sizeMapping.workGroupMapping;
+        uint32_t defaultWGMXCC;
+        if(sizeMapping.workGroupMappingXCC == -1)
+        {
+            hip::HipAMDGPU const* hipAMDGPU
+                    = dynamic_cast<hip::HipAMDGPU const*>(hardware);
+            defaultWGMXCC = hipAMDGPU->analyticalHardware->NUM_XCD;
+        }
+        else
+            defaultWGMXCC = sizeMapping.workGroupMappingXCC;
+
+        // Run-time prediction
+        if(sizeMapping.streamK != 0)
+        {
+            AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(hardware);
+            // Runtime selection for WGM and WGMXCC
+            if(pAMDGPU->skDynamicWGM == 1)
+            {
+                hip::HipAMDGPU const* hipAMDGPU
+                    = dynamic_cast<hip::HipAMDGPU const*>(hardware);
+                auto sizes = problem.problemSizes();
+                if(sizes.size() >= 4)
+                {
+                    defaultWGM = origami::select_best_wgm(*(hipAMDGPU->analyticalHardware),
+                                                            sizes[0],
+                                                            sizes[1],
+                                                            sizes[3],
+                                                            sizes[2],
+                                                            sizeMapping.macroTile.x,
+                                                            sizeMapping.macroTile.y,
+                                                            sizeMapping.depthU,
+                                                            false);
+                    defaultWGMXCC = origami::select_best_wgmxcc(*(hipAMDGPU->analyticalHardware),
+                                                                sizes[0],
+                                                                sizes[1],
+                                                                sizes[3],
+                                                                sizes[2],
+                                                                sizeMapping.macroTile.x,
+                                                                sizeMapping.macroTile.y,
+                                                                sizeMapping.depthU,
+                                                                false);
+                }
+            }
+
+            // If WGM and WGMXCC are explicitly specified at runtime, they override default and predictions
+            if(pAMDGPU->fixedWGM != std::numeric_limits<int>::max())
+            {
+                defaultWGM = pAMDGPU->fixedWGM;
+            }
+            if(pAMDGPU->fixedWGMXCC != std::numeric_limits<int>::max())
+            {
+                defaultWGMXCC = pAMDGPU->fixedWGMXCC;
+            }
+
+            // WGM should be in this range: [-1023, -1022, ..., -1, 0, 1, ..., 1023]
+            assert(std::fabs(defaultWGM) < 1024);
+            // WGMXCC should be in this range: [1, 2, 3, ..., 63]
+            assert(defaultWGMXCC > 0 && defaultWGMXCC < 64);
+        }
+
+        return std::make_pair(defaultWGM, defaultWGMXCC);
+    }
 
     uint32_t ContractionSolution::calculateAutoGSU(Problem const&  problem,
                                                Hardware const* hardware) const
@@ -1051,7 +1121,8 @@ namespace TensileLite
                                          uint32_t                            numWorkGroups,
                                          Hardware const*                     hardware,
                                          const ContractionProblemParameters& param,
-                                         int32_t                             defaultWGM,
+                                         int32_t                             autoWGM,
+                                         uint32_t                            autoWGMXCC,
                                          uint32_t                            autoGsuVal) const
     {
         if constexpr(!Legacy)
@@ -1065,8 +1136,8 @@ namespace TensileLite
         uint32_t       gsu          = param.gsu() > 0 ? param.gsu() : autoGsuVal;
         bool           gsuc         = false; // initialized false
         bool           gsuwgmrr     = false; // initialized false
-        int32_t        wgm          = param.wgm() != 0 ? param.wgm() : defaultWGM;
-        uint32_t       wgmxcc       = 1;
+        int32_t        wgm          = param.wgm() != 0 ? param.wgm() : autoWGM;
+        uint32_t       wgmxcc       = param.wgmxcc() != 0 ? param.wgmxcc() : autoWGMXCC;
         int32_t        wgmxccg      = -1;
         const uint32_t mask16       = 0xFFFF;
         const uint32_t mask14       = 0x3FFF;
@@ -1095,9 +1166,7 @@ namespace TensileLite
                 // NB: get value from param= set in runtime / vs value from sizeMapping: from logic yaml.
                 //     param: default values: [xcc = 0, xccg = 0]. So when we never set xcc/xccg in runtime: we always get from sizeMapping.
                 //     From sizeMapping = from logic yaml. If not set in Config-Yaml, use default value [1, -1]
-                wgmxcc = param.wgmxcc() > 0 ? param.wgmxcc() : sizeMapping.workGroupMappingXCC;
-                wgmxccg
-                    = param.wgmxccg() != 0 ? param.wgmxccg() : sizeMapping.workGroupMappingXCCGroup;
+                wgmxccg = param.wgmxccg() != 0 ? param.wgmxccg() : sizeMapping.workGroupMappingXCCGroup;
                 if(wgmxcc >= 1 && wgmxccg == -1)
                 {
                     AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(hardware);
@@ -1247,49 +1316,14 @@ namespace TensileLite
 
         if(internalArgsSupport.useUniversalArgs)
         {
-            auto defaultWGM = sizeMapping.workGroupMapping;
-            if(sizeMapping.streamK != 0)
+            auto [autoWGM, autoWGMXCC] = calculateAutoWGM(problem, &hardware);
+            if(T_Debug)
             {
-                AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
-                if(pAMDGPU->fixedWGM >= -1024 && pAMDGPU->fixedWGM <= 1024)
-                {
-                    defaultWGM = pAMDGPU->fixedWGM;
-                }
-                else if(pAMDGPU->skDynamicWGM == 1)
-                {
-                    hip::HipAMDGPU const* hipAMDGPU
-                        = dynamic_cast<hip::HipAMDGPU const*>(&hardware);
-                    auto sizes = problem.problemSizes();
-                    if(sizes.size() >= 4)
-                    {
-                        std::vector<size_t> wgmList
-                            = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-                        size_t elementSize = GetElementSize(problemType.aType);
-                        double H_L2        = 0.0; // TODO
-                        auto   bestWGM     = origami::select_best_wgm(sizes[0],
-                                                                   sizes[1],
-                                                                   sizes[3],
-                                                                   sizes[2],
-                                                                   *(hipAMDGPU->analyticalHardware),
-                                                                   sizeMapping.macroTile.x,
-                                                                   sizeMapping.macroTile.y,
-                                                                   sizeMapping.depthU,
-                                                                   sizeMapping.matrixInstruction[0],
-                                                                   sizeMapping.matrixInstruction[1],
-                                                                   sizeMapping.matrixInstruction[2],
-                                                                   wgmList,
-                                                                   elementSize,
-                                                                   H_L2,
-                                                                   false);
-                        defaultWGM         = bestWGM.second;
-                        if(T_Debug)
-                            std::cout << "Predicted WGM: " << defaultWGM << std::endl;
-                    }
-                }
+                std::cout << "AutoWGM: " << autoWGM << std::endl;
+                std::cout << "AutoWGMXCC: " << autoWGMXCC << std::endl;
             }
-
             kernelArgs<T_Debug, false>(
-                1, 0, rv.args, getNumWorkGroups(rv), &hardware, problem.getParams(), defaultWGM, autoGsuVal);
+                1, 0, rv.args, getNumWorkGroups(rv), &hardware, problem.getParams(), autoWGM, autoWGMXCC, autoGsuVal);
         }
         singleCallArgs<T_Debug, true>(
             problem, inputs, 0, &hardware, problemNumGroupTiles, rv.numWorkGroups, rv.args, sk);
@@ -1453,6 +1487,8 @@ namespace TensileLite
 
         if constexpr(!std::is_same<KA, KernelArgumentsCounter>::value)
         {
+            auto [autoWGM, autoWGMXCC] = calculateAutoWGM(problems[0], &hardware);
+
             if(internalArgsSupport.useUniversalArgs)
             {
                 KERNELARGTYPE argType = KERNELARGTYPE::HBM;
@@ -1466,7 +1502,8 @@ namespace TensileLite
                                            getNumWorkGroups(rv),
                                            &hardware,
                                            problems[0].getParams(),
-                                           sizeMapping.workGroupMapping,
+                                           autoWGM,
+                                           autoWGMXCC,
                                            autoGsuVal);
                 // For user input
                 if(argType == KERNELARGTYPE::USERARGS)
@@ -1493,7 +1530,8 @@ namespace TensileLite
                                           0,
                                           &hardware,
                                           problems[0].getParams(),
-                                          sizeMapping.workGroupMapping,
+                                          autoWGM,
+                                          autoWGMXCC,
                                           autoGsuVal);
             }
 

--- a/shared/origami/include/origami/utils.hpp
+++ b/shared/origami/include/origami/utils.hpp
@@ -92,22 +92,25 @@ namespace origami
                                                         = {},
                                                         bool print = false);
 
-        std::pair<double, size_t> select_best_wgm(
-            size_t                     M,
-            size_t                     N,
-            size_t                     K,
-            size_t                     batch,
-            const hardware_t&          hardware,
-            size_t                     MT_M,
-            size_t                     MT_N,
-            size_t                     MT_K,
-            size_t                     MI_M,
-            size_t                     MI_N,
-            size_t                     MI_K,
-            const std::vector<size_t>& WGM_list,
-            size_t                     element_size,
-            double H_L2, // not needed for L2 hit rate but retained if your code expects it
-            bool   print);
+        size_t select_best_wgmxcc(const hardware_t& hardware,
+                                  size_t            M,
+                                  size_t            N,
+                                  size_t            K,
+                                  size_t            batch,
+                                  size_t            MT_M,
+                                  size_t            MT_N,
+                                  size_t            MT_K,
+                                  bool              print);
+
+        size_t select_best_wgm(const hardware_t& hardware,
+                               size_t            M,
+                               size_t            N,
+                               size_t            K,
+                               size_t            batch,
+                               size_t            MT_M,
+                               size_t            MT_N,
+                               size_t            MT_K,
+                               bool              print);
 
         double compute_tflops_from_latency(double latency_cycles,
                                            size_t M,

--- a/shared/origami/include/origami/utils.hpp
+++ b/shared/origami/include/origami/utils.hpp
@@ -102,15 +102,15 @@ namespace origami
                                   size_t            MT_K,
                                   bool              print);
 
-        size_t select_best_wgm(const hardware_t& hardware,
-                               size_t            M,
-                               size_t            N,
-                               size_t            K,
-                               size_t            batch,
-                               size_t            MT_M,
-                               size_t            MT_N,
-                               size_t            MT_K,
-                               bool              print);
+        int32_t select_best_wgm(const hardware_t& hardware,
+                                size_t            M,
+                                size_t            N,
+                                size_t            K,
+                                size_t            batch,
+                                size_t            MT_M,
+                                size_t            MT_N,
+                                size_t            MT_K,
+                                bool              print);
 
         double compute_tflops_from_latency(double latency_cycles,
                                            size_t M,

--- a/shared/origami/src/origami/utils.cpp
+++ b/shared/origami/src/origami/utils.cpp
@@ -333,59 +333,63 @@ namespace origami
     }
 
     /*!
+         * \brief Selects the best WGMXCC (maximizing L2 hit rate) given fixed macro tile sizes.
+         *
+         * \param[in] hardware          - Hardware
+         * \param[in] M, N, K, batch    - Problem
+         * \param[in] MT_M, MT_N, MT_K  - Solution
+         * \param[in] print             - whether to print the final best result
+         *
+         * \return best WGMXCC.
+         */
+    size_t select_best_wgmxcc(const hardware_t& hardware,
+                              size_t            M,
+                              size_t            N,
+                              size_t            K,
+                              size_t            batch,
+                              size_t            MT_M,
+                              size_t            MT_N,
+                              size_t            MT_K,
+                              bool              print)
+    {
+        // Return the number of XCDs
+        return hardware.NUM_XCD;
+    }
+
+    /*!
          * \brief Selects the best WGM (maximizing L2 hit rate) given fixed macro tile sizes.
          *
-         * \param[in] M, N, K    - your overall problem sizes
-         * \param[in] hardware   - a struct describing your hardware capabilities
-         * \param[in] MT_M,MT_N,MT_K,MI_M,MI_N,MI_K - chosen macro/MI tile sizes
-         * \param[in] WGM_list   - candidate WGM values to try
-         * \param[in] element_size
-         * \param[in] H_L2       - some hardware-related constant or factor (no longer used here,
-         *                         but kept if your signature or other usage requires it)
-         * \param[in] print      - whether to print the final best result
+         * \param[in] hardware          - Hardware
+         * \param[in] M, N, K, batch    - Problem
+         * \param[in] MT_M, MT_N, MT_K  - Solution
+         * \param[in] print             - whether to print the final best result
          *
-         * \return A pair: (best_l2_hit_rate, best_WGM).
+         * \return best WGM.
          */
-    std::pair<double, size_t> select_best_wgm(
-        size_t                     M,
-        size_t                     N,
-        size_t                     K,
-        size_t                     batch,
-        const hardware_t&          hardware,
-        size_t                     MT_M,
-        size_t                     MT_N,
-        size_t                     MT_K,
-        size_t                     MI_M,
-        size_t                     MI_N,
-        size_t                     MI_K,
-        const std::vector<size_t>& WGM_list,
-        size_t                     element_size,
-        double H_L2, // not needed for L2 hit rate but retained if your code expects it
-        bool   print)
+    size_t select_best_wgm(const hardware_t& hardware,
+                           size_t            M,
+                           size_t            N,
+                           size_t            K,
+                           size_t            batch,
+                           size_t            MT_M,
+                           size_t            MT_N,
+                           size_t            MT_K,
+                           bool              print)
     {
+        constexpr size_t element_size = 32; // L2 scales linearly with element size so it doesn't matter
+        
+        std::vector<size_t> wgmList = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+        
         using WGMResult = std::pair<double, size_t>; // (l2_hit_rate, WGM)
-
         std::vector<WGMResult> valid_results;
-        valid_results.reserve(WGM_list.size());
+        valid_results.reserve(wgmList.size());
 
         // Iterate over all candidate WGM values
-        for(const auto& candidate_wgm : WGM_list)
+        for(const auto& candidate_wgm : wgmList)
         {
             if(hardware_t::is_debug_enabled())
             {
                 std::cout << "Evaluating WGM=" << candidate_wgm << "\n";
-            }
-
-            // Optionally ensure we do not exceed LDS capacity
-            // (If you want to factor in WGM, add it to your check_lds_capacity signature.)
-            // For now, let's just check the tile itself:
-            if(!check_lds_capacity(hardware, MT_M, MT_N, MT_K, element_size))
-            {
-                if(hardware_t::is_debug_enabled())
-                {
-                    std::cout << "Skipping WGM=" << candidate_wgm << " due to LDS capacity.\n";
-                }
-                continue;
             }
 
             // Compute L2 hit rate for this WGM
@@ -416,12 +420,9 @@ namespace origami
             valid_results.begin(), valid_results.end(), [](const WGMResult& a, const WGMResult& b) {
                 return a.first < b.first; // "less" => a has smaller hit rate than b
             });
-
-        double best_l2_hit = best_it->first;
-        size_t best_wgm    = best_it->second;
-
-        // Return (l2_hit_rate, WGM)
-        return std::make_pair(best_l2_hit, best_wgm);
+        
+        // Return best WGM
+        return best_it->second;
     }
 
     // Logic to decide between two MT that are "tied"

--- a/shared/origami/src/origami/utils.cpp
+++ b/shared/origami/src/origami/utils.cpp
@@ -366,15 +366,15 @@ namespace origami
          *
          * \return best WGM.
          */
-    size_t select_best_wgm(const hardware_t& hardware,
-                           size_t            M,
-                           size_t            N,
-                           size_t            K,
-                           size_t            batch,
-                           size_t            MT_M,
-                           size_t            MT_N,
-                           size_t            MT_K,
-                           bool              print)
+    int32_t select_best_wgm(const hardware_t& hardware,
+                            size_t            M,
+                            size_t            N,
+                            size_t            K,
+                            size_t            batch,
+                            size_t            MT_M,
+                            size_t            MT_N,
+                            size_t            MT_K,
+                            bool              print)
     {
         constexpr size_t element_size = 32; // L2 scales linearly with element size so it doesn't matter
         

--- a/shared/origami/tests/include/testing_origami.hpp
+++ b/shared/origami/tests/include/testing_origami.hpp
@@ -584,65 +584,42 @@ void BestWGM(const origami::hardware_t& hardware,
              size_t                     batch,
              size_t                     MT_M,
              size_t                     MT_N,
-             size_t                     MT_K,
-             size_t                     MI_M,
-             size_t                     MI_N,
-             size_t                     MI_K,
-             size_t                     element_size,
-             double H_L2) // not needed for L2 hit rate but retained if your code expects it
+             size_t                     MT_K)
 {
     std::vector<size_t> WGM_list = {1, 2, 4, 6, 8, 12};
 
-    auto best_wgm_large_tile = select_best_wgm(M,
+    auto best_wgm_large_tile = select_best_wgm(hardware,
+                                               M,
                                                N,
                                                K,
                                                batch,
-                                               hardware,
                                                MT_M,
                                                MT_N,
                                                MT_K,
-                                               MI_M,
-                                               MI_N,
-                                               MI_K,
-                                               WGM_list,
-                                               element_size,
-                                               H_L2,
                                                false);
 
-    auto best_wgm_small_tile = select_best_wgm(M / 4,
+    auto best_wgm_small_tile = select_best_wgm(hardware,
+                                               M / 4,
                                                N / 4,
                                                K,
                                                batch,
-                                               hardware,
                                                MT_M,
                                                MT_N,
                                                MT_K * 2,
-                                               MI_M,
-                                               MI_N,
-                                               MI_K,
-                                               WGM_list,
-                                               element_size,
-                                               H_L2,
                                                false);
 
-    auto best_wgm_nonsquare = select_best_wgm(1024,
+    auto best_wgm_nonsquare = select_best_wgm(hardware,
+                                              1024,
                                               5120,
                                               K,
                                               batch,
-                                              hardware,
                                               MT_M,
                                               MT_N,
                                               MT_K,
-                                              MI_M,
-                                              MI_N,
-                                              MI_K,
-                                              WGM_list,
-                                              element_size,
-                                              H_L2,
                                               false);
 
-    EXPECT_GT(best_wgm_large_tile.second, best_wgm_small_tile.second);
-    EXPECT_NE(best_wgm_large_tile.second, best_wgm_nonsquare.second);
+    EXPECT_GT(best_wgm_large_tile, best_wgm_small_tile);
+    EXPECT_NE(best_wgm_large_tile, best_wgm_nonsquare);
 }
 
 void UtilsTFlopsFromLatency(size_t M, size_t N, size_t K, double latency_cycles, double clock_GHz)

--- a/shared/origami/tests/origami_gtest.cpp
+++ b/shared/origami/tests/origami_gtest.cpp
@@ -321,8 +321,7 @@ TEST_P(AnalyticalGtest, DynamicDispatch)
         for(const auto& input_case : test.inputs)
         {
             BestWGM(gpuInfo, input_case.values.at("M"), input_case.values.at("N"), input_case.values.at("K"), input_case.values.at("batch"),
-                          input_case.values.at("MT_M"), input_case.values.at("MT_N"), input_case.values.at("MT_K"), input_case.values.at("MI_M"), 
-                          input_case.values.at("MI_N"), input_case.values.at("MI_K"), input_case.values.at("element_size"), input_case.values.at("H_L2"));
+                          input_case.values.at("MT_M"), input_case.values.at("MT_N"), input_case.values.at("MT_K"));
         }
     }
     else if(test.name == "UtilsTFlopsFromLatency")


### PR DESCRIPTION
## Motivation

This PR enables runtime configurable WGMXCC so libraries can be shared across different architectures without changing the current state of libraries.

## Technical Details

Prior to this PR, there were two versions of WGMXCC (StreamKXCCMapping and WorkGroupMappingXCC), it was possible to have both present in one kernel. Although both were supposed to the same thing, there was slight differences between the two in terms of the implementation. For example, WorkGroupMappingXCC checks to have the same WGs per group and avoids mapping if the remaining WGs cannot be distributed evenly in the groups. Moreover, it also distributes according to the number of CUs in some cases.
In this PR, `WorkGroupMappingXCC: -1` is introduced. This parameter uses the same algorithm as in `StreamKXCCMapping`, but the value can be configured at runtime to be equal to the number of XCCs on the architecture. We can also use Origami prediction to change this value at runtime. Moreover, an env variable is introduced to change the runtime WGMXCC to any value in the acceptable range for this parameter.

## Test Plan

Tested locally and CI.

## Test Result

-

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
