### PR TITLE
[hipfftw][docs] Documentation additions for hipFFTW

### DIFF
--- a/projects/hipfft/docs/conceptual/overview.rst
+++ b/projects/hipfft/docs/conceptual/overview.rst
@@ -1,11 +1,11 @@
 .. meta::
-  :description: hipFFT documentation and API reference library
-  :keywords: FFT, hipFFT, rocFFT, ROCm, API, documentation
+  :description: hipFFT documentation, hipFFTW documentation, and API reference library
+  :keywords: FFT, hipFFT, hipFFTW, rocFFT, ROCm, API, documentation
 
-.. _hipfft-overview:
+.. _overview-of-hipfft-and-hipfftw:
 
 ********************************************************************
-hipFFT overview
+Overview of hipFFT and hipFFTW
 ********************************************************************
 
 hipFFT is a GPU FFT marshalling library that supports
@@ -15,6 +15,19 @@ hipFFT exports an interface that does not require the client to
 change, regardless of the chosen backend. It sits between the
 application and the backend FFT library, marshalling inputs into the
 backend and results back to the application.
+
+hipFFTW exports an interface that is a subset of FFTW_'s interface. Applications using
+the latter for computing discrete Fourier transforms (on CPUs) may use hipFFTW as a
+drop-in substitution that would leverage GPU computations instead with minimal
+modifications to their source code. Namely, it is recommended to replace
+inclusions of ``fftw3.h`` by inclusions of ``hipfft/hipfftw.h`` and link
+with hipFFTW instead of fftw3 or fftw3f. For more details, see the
+:doc:`hipFFTW API reference <../reference/hipfftw-api-usage>`.
+
+.. note::
+   hipFFTW supports single- and double-precision calculations; long-double and
+   quad-precision floating point arithmetics are not supported.
+
 
 =====================
 Basic hipFFT usage
@@ -443,7 +456,7 @@ The following concepts and API calls are used:
 
 *  ``hipfftXt``: This API lets users execute FFTs across multiple GPUs by managing multi-GPU plans.
    ``hipfftXt`` provides an extended version of the hipFFT API to handle GPU-specific operations, such as memory allocation
-   and execution across multiple devices. For more details, see the :doc:`API reference <../reference/fft-api-usage>`.
+   and execution across multiple devices. For more details, see the :doc:`hipFFT API reference <../reference/hipfft-api-usage>`.
 
 *  :cpp:func:`hipfftCreate`: Creates a hipFFT plan that contains the FFT configuration. This plan is used to configure
    the FFT transform operation.
@@ -594,6 +607,6 @@ For detailed API usage, see :ref:`hipfft-api-usage`.
       return 0;
    }
 
-
 .. _rocFFT: https://rocm.docs.amd.com/projects/rocFFT/en/latest/index.html
 .. _cuFFT: https://developer.nvidia.com/cufft
+.. _FFTW: https://www.fftw.org/

--- a/projects/hipfft/docs/conceptual/overview.rst
+++ b/projects/hipfft/docs/conceptual/overview.rst
@@ -17,16 +17,16 @@ application and the backend FFT library, marshalling inputs into the
 backend and results back to the application.
 
 hipFFTW exports an interface that is a subset of FFTW_'s interface. Applications using
-the latter for computing discrete Fourier transforms (on CPUs) may use hipFFTW as a
-drop-in substitution that would leverage GPU computations instead with minimal
+the latter for computing discrete Fourier transforms (on CPUs) can use hipFFTW as a
+drop-in substitution to leverage GPU computations instead with minimal
 modifications to their source code. Namely, it is recommended to replace
-inclusions of ``fftw3.h`` by inclusions of ``hipfft/hipfftw.h`` and link
+inclusions of ``fftw3.h`` with inclusions of ``hipfft/hipfftw.h`` and link
 with hipFFTW instead of fftw3 or fftw3f. For more details, see the
 :doc:`hipFFTW API reference <../reference/hipfftw-api-usage>`.
 
 .. note::
    hipFFTW supports single- and double-precision calculations; long-double and
-   quad-precision floating point arithmetics are not supported.
+   quad-precision floating point operations are not supported.
 
 
 =====================

--- a/projects/hipfft/docs/index.rst
+++ b/projects/hipfft/docs/index.rst
@@ -12,16 +12,15 @@ hipFFT is an FFT (fast Fourier transform) marshalling library. It supports eithe
 NVIDIA CUDA cuFFT_ as the backend. hipFFT sits between the
 application and the backend FFT library, marshalling inputs into the
 backend and results back to the application.
-hipFFT requires its computational input and output data to be GPU-visible; data residing in device memory is
-recommended as it typically delivers best performance.
+hipFFT requires its computational input and output data to be GPU-visible. Data residing in device memory is
+recommended as it typically delivers the best performance.
 
-hipFFTW is a GPU-aware library for fast Fourier transforms using rocFFT_ as backend. It exports an interface
-borrowing the most commonly-used symbols of FFTW_. hipFFTW does not require its computational input and output
-to be directly accessible by the GPU.
+hipFFTW is a GPU-aware library for fast Fourier transforms using :doc:`rocFFT <rocfft:index>` as the backend. It
+exports an interface borrowing the most commonly-used symbols of FFTW_. hipFFTW does not require its
+computational input and output to be directly accessible by the GPU.
 
 For more information, see the :ref:`overview-of-hipfft-and-hipfftw`.
 
-.. _rocFFT: https://rocm.docs.amd.com/projects/rocFFT/en/latest/index.html
 .. _cuFFT: https://developer.nvidia.com/cufft
 .. _FFTW: https://www.fftw.org/
 

--- a/projects/hipfft/docs/index.rst
+++ b/projects/hipfft/docs/index.rst
@@ -1,23 +1,31 @@
 .. meta::
-  :description: hipFFT documentation and API reference library
-  :keywords: FFT, hipFFT, rocFFT, ROCm, API, documentation
+  :description: hipFFT documentation, hipFFTW documentation, and API reference library
+  :keywords: FFT, hipFFT, hipFFTW, rocFFT, ROCm, API, documentation
 
 .. _hipfft-docs-home:
 
 ********************************************************************
-hipFFT documentation
+hipFFT and hipFFTW documentation
 ********************************************************************
 
 hipFFT is an FFT (fast Fourier transform) marshalling library. It supports either :doc:`rocFFT <rocfft:index>` or
 NVIDIA CUDA cuFFT_ as the backend. hipFFT sits between the
 application and the backend FFT library, marshalling inputs into the
 backend and results back to the application.
-For more information, see the :ref:`hipfft-overview`.
+hipFFT requires its computational input and output data to be GPU-visible; data residing in device memory is
+recommended as it typically delivers best performance.
+
+hipFFTW is a GPU-aware library for fast Fourier transforms using rocFFT_ as backend. It exports an interface
+borrowing the most commonly-used symbols of FFTW_. hipFFTW does not require its computational input and output
+to be directly accessible by the GPU.
+
+For more information, see the :ref:`overview-of-hipfft-and-hipfftw`.
 
 .. _rocFFT: https://rocm.docs.amd.com/projects/rocFFT/en/latest/index.html
 .. _cuFFT: https://developer.nvidia.com/cufft
+.. _FFTW: https://www.fftw.org/
 
-The hipFFT public repository is located at `<https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipfft>`_.
+hipFFT and hipFFTW share the same public repository located at `<https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipfft>`_.
 
 .. note::
 
@@ -28,11 +36,11 @@ The hipFFT public repository is located at `<https://github.com/ROCm/rocm-librar
 
   .. grid-item-card:: Install
 
-    * :doc:`Installation guide <./install/building-installing-hipfft>`
+    * :doc:`Installation guide <./install/building-installing-hipfft-and-hipfftw>`
 
   .. grid-item-card:: Conceptual
 
-    * :doc:`hipFFT overview <./conceptual/overview>`
+    * :doc:`Overview of hipFFT and hipFFTW <./conceptual/overview>`
 
   .. grid-item-card:: Examples
 
@@ -40,7 +48,8 @@ The hipFFT public repository is located at `<https://github.com/ROCm/rocm-librar
 
   .. grid-item-card:: API Reference
 
-    * :doc:`API and usage notes <./reference/fft-api-usage>`
+    * :doc:`hipFFT API and usage notes <./reference/hipfft-api-usage>`
+    * :doc:`hipFFTW API and usage notes <./reference/hipfftw-api-usage>`
     * :ref:`API Index <genindex>`
 
 To contribute to the documentation, see `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.

--- a/projects/hipfft/docs/install/building-installing-hipfft-and-hipfftw.rst
+++ b/projects/hipfft/docs/install/building-installing-hipfft-and-hipfftw.rst
@@ -1,15 +1,15 @@
 .. meta::
-  :description: hipFFT documentation and API reference library
-  :keywords: FFT, hipFFT, rocFFT, ROCm, API, documentation, build from source, installing
+  :description: hipFFT documentation, hipFFTW documentation, and API reference library
+  :keywords: FFT, hipFFT, hipFFTW, rocFFT, ROCm, API, documentation, build from source, installing
 
-.. _building-installing-hipfft:
+.. _building-installing-hipfft-and-hipfftw:
 
 ********************************************************************
-Building and installing hipFFT
+Building and installing hipFFT and hipFFTW
 ********************************************************************
 
-This topic explains how to install hipFFT from the prebuilt packages or build it from the source code.
-hipFTT requires a ROCm-enabled platform. For more information,
+This topic explains how to install hipFFT and hipFFTW from the prebuilt packages or build it from the source code.
+hipFTT and hipFFTW require a ROCm-enabled platform. For more information,
 see the :doc:`Linux system requirements <rocm-install-on-linux:reference/system-requirements>`.
 
 Installing prebuilt packages
@@ -18,9 +18,9 @@ Installing prebuilt packages
 For information on downloading and installing ROCm, see the
 :doc:`ROCm installation guide <rocm-install-on-linux:install/quick-start>`.
 
-To install hipFFT, use the package manager for the Linux distribution, which
+To install hipFFT and hipFFTW, use the package manager for the Linux distribution, which
 handles all dependencies.
-This lets you run programs that use hipFFT, but not compile them.
+This lets you run programs that use hipFFT or hipFFTW, but not compile them.
 
 On the Ubuntu distribution, run the following command:
 
@@ -35,10 +35,10 @@ On the Ubuntu distribution, run the following command:
    This package is named ``hipfft-dev`` on Ubuntu/Debian systems and
    ``hipfft-devel`` on RHEL and related variants.
 
-Building hipFFT from source
-=============================
+Building hipFFT and hipFFTW from source
+=======================================
 
-To build hipFFT from source, follow these steps:
+To build hipFFT and hipFFTW from source, follow these steps:
 
 #. Install the library build dependencies:
 
@@ -49,10 +49,10 @@ To build hipFFT from source, follow these steps:
 
 #. Install the client build dependencies for the clients:
 
-   The clients that are included with the hipFFT source code, including samples and tests,
-   depend on :doc:`hipRAND <hiprand:index>`, `FFTW <https://fftw.org/>`_, and GoogleTest.
+   The clients that are included with the source code, including samples and tests,
+   depend on :doc:`hipRAND <hiprand:index>`, `FFTW <https://fftw.org/>`_, `boost <https://www.boost.org/>`_, and GoogleTest.
 
-#. Build hipFFT:
+#. Build hipFFT and hipFFTW:
 
    To show all build options, run these commands from the ``rocm-libraries/projects/hipfft`` directory:
 
@@ -63,13 +63,13 @@ To build hipFFT from source, follow these steps:
 
    Here are some CMake build examples for AMD GPUs:
 
-   *  Building a project using :doc:`HIP language <hip:index>` APIs and hipFFT with the standard host compiler:
+   *  Building a project using :doc:`HIP language <hip:index>` APIs and hipFFT (or hipFFTW) with the standard host compiler:
 
       .. code-block:: shell
 
          cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -L ..
 
-   *  Building a project using HIP language APIs, hipFFT, and device kernels with HIP-Clang:
+   *  Building a project using HIP language APIs, hipFFT (or hipFFTW), and device kernels with HIP-Clang:
 
       .. code-block:: shell
 

--- a/projects/hipfft/docs/reference/hipfft-api-usage.rst
+++ b/projects/hipfft/docs/reference/hipfft-api-usage.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipFFT documentation and API reference library
-  :keywords: FFT, hipFFT, rocFFT, ROCm, API, documentation
+  :description: hipFFT documentation, hipFFTW documentation, and API reference library
+  :keywords: FFT, hipFFT, hipFFTW, rocFFT, ROCm, API, documentation
 
 .. _hipfft-api-usage:
 

--- a/projects/hipfft/docs/reference/hipfftw-api-usage.rst
+++ b/projects/hipfft/docs/reference/hipfftw-api-usage.rst
@@ -125,7 +125,7 @@ Plans capture:
 - the length(s) and batch size(s) of the transform;
 - layout information for input and output data, for example, stride(s), distance(s);
 - pointers to buffers that it should consider as input and output data buffers when computing a transform via a :ref:`generic execution function <hipfftw-execute-with-creation-io>`;
-- its flag value(s) used at creation.
+- the flag value(s) to use at creation.
 
 A plan of interest can be created using more than one plan creation function. For instance, any plan created
 by ``fftw_plan_dft`` (resp. ``fftwf_plan_dft``) could be created by ``fftw_plan_many_dft``

--- a/projects/hipfft/docs/reference/hipfftw-api-usage.rst
+++ b/projects/hipfft/docs/reference/hipfftw-api-usage.rst
@@ -35,7 +35,7 @@ Flag values
 -----------
 
 All the hipFFTW :ref:`plan creation functions <hipfftw-plan-creation>` request an ``unsigned flags`` argument.
-The value of that argument conditions what hipFFTW may or may not consider when creating the requested plan. Valid
+The value of that argument conditions what hipFFTW will consider when creating the requested plan. Valid
 values are bitwise OR of zero of more of the following constant values.
 
 .. doxygendefine:: FFTW_MEASURE
@@ -57,7 +57,7 @@ values are bitwise OR of zero of more of the following constant values.
 .. doxygendefine:: FFTW_WISDOM_ONLY
 
 .. note::
-  Even if seemingly accepted, flag values are currently ignored by hipFFTW. In particular, note that
+  Even if seemingly accepted, flag values are currently ignored by hipFFTW. In particular, note that:
 
   - no measurement is ever done at plan creation (plan configurations are chosen based on heuristics);
   - preservation of input data is never guaranteed;
@@ -102,15 +102,15 @@ hipFFTW supports the following buffer-management functions.
 .. doxygenfunction:: fftwf_free
 
 The memory blocks allocated by any of the above ``{fftw,fftwf}_{malloc,alloc_real,alloc_complex}``
-are always directly accessible to the host, but not necessarily to GPU. hipFFTW decides on the type
-of memory being allocated following a ranked-choice strategy: it attempts to allocate
+are always directly accessible to the host, but not necessarily to the GPU. hipFFTW decides on the
+type of memory being allocated following a ranked-choice strategy. It attempts to allocate:
 
-1. pinned host memory, first;
-2. pageable host memory, if the latter failed (or if the request exceeds a :ref:`user-defined threshold <hipfftw-env-byte-size-host-alloc>`).
+1. pinned host memory (first);
+2. pageable host memory (if the latter failed or if the request exceeds a :ref:`user-defined threshold <hipfftw-env-byte-size-host-alloc>`).
 
 .. important::
   Every buffer allocated via ``fftw_malloc``, ``fftwf_malloc``, ``fftw_alloc_real``, ``fftwf_alloc_real``,
-  ``fftw_alloc_complex`` or ``fftwf_alloc_complex`` **must** be freed using ``fftw_free`` or ``fftwf_free``.
+  ``fftw_alloc_complex``, or ``fftwf_alloc_complex`` **must** be freed using ``fftw_free`` or ``fftwf_free``.
 
 .. _hipfftw-plan-creation:
 
@@ -119,25 +119,25 @@ Plan creation
 
 hipFFTW supports the creation of :ref:`basic <hipfftw-basic-plan-creation>`, :ref:`advanced <hipfftw-advanced-plan-creation>`,
 and :ref:`general <hipfftw-general-plan-creation>` plans, using interleaved formats for complex floating-point data.
-Plans capture
+Plans capture:
 
-- the type of transform, *i.e.*, complex or real, forward or backward (inverse) discrete Fourier transform;
+- the type of transform, namely, complex or real, forward or backward (inverse) discrete Fourier transform;
 - the length(s) and batch size(s) of the transform;
-- layout information for input and output data, *e.g.*, stride(s), distance(s);
+- layout information for input and output data, for example, stride(s), distance(s);
 - pointers to buffers that it should consider as input and output data buffers when computing a transform via a :ref:`generic execution function <hipfftw-execute-with-creation-io>`;
 - its flag value(s) used at creation.
 
-A plan of interest may be created via more than one plan creation function. For instance, any plan created
+A plan of interest can be created using more than one plan creation function. For instance, any plan created
 by ``fftw_plan_dft`` (resp. ``fftwf_plan_dft``) could be created by ``fftw_plan_many_dft``
 (resp. ``fftwf_plan_many_dft``) without any difference.
 
-For all plan creation functions, the requested plan is said to be configured for in-place (resp. out-of-place)
-operations if identical (resp. different) input and output buffers are used when the plan is created.
+For all plan creation functions, the requested plan is said to be configured for in-place operations if identical
+input and output buffers are used when the plan is created. The plan is configured for out-of-place operations otherwise.
 
 .. note::
   - hipFFTW does not support split complex formats, real-to-real transforms, nor distributed transforms;
-  - hipFFTW does not support transforms of more than 3 dimensions, *i.e.*, ``rank > 3`` is not supported;
-  - hipFFTW does not support transforms of more than 1 batch dimension, *i.e.*, ``batch_rank > 1`` is not supported.
+  - hipFFTW does not support transforms of more than 3 dimensions, that is, ``rank > 3`` is not supported;
+  - hipFFTW does not support transforms of more than 1 batch dimension, that is, ``batch_rank > 1`` is not supported.
 
 .. _hipfftw-basic-plan-creation:
 
@@ -155,7 +155,7 @@ default data layouts use strides :math:`s_i` along dimension :math:`i` where
     - :math:`n_{d-1}` otherwise.
 - if :math:`d > 2`, :math:`s_{i} = n_{i+1}s_{i+1}` for :math:`0 \leq i < d-2`.
 
-The following functions may be used for creating basic hipFFTW plans.
+The following functions can be used for creating basic hipFFTW plans.
 
 .. doxygenfunction:: fftw_plan_dft_1d
 .. doxygenfunction:: fftwf_plan_dft_1d
@@ -201,9 +201,9 @@ Arbitrary plans
 Plan execution
 ==============
 
-Once successfully created, hipFFTW plans may be executed, *i.e.*, used for computing the discrete Fourier transform that they capture.
+After they are successfully created, hipFFTW plans can be executed, that is, used for computing the discrete Fourier transform that they capture.
 The :ref:`generic execution functions <hipfftw-execute-with-creation-io>` implicitly reuse the input and output buffers that were set
-at :ref:`plan creation <hipfftw-plan-creation>`. If that is not possible or impractical, new input and output buffers may be communicated
+at :ref:`plan creation <hipfftw-plan-creation>`. If that is not possible or impractical, new input and output buffers can be communicated
 instead by using the :ref:`new-arrays execution functions <hipfftw-execute-with-new-io>`.
 
 .. _hipfftw-execute-with-creation-io:
@@ -247,8 +247,8 @@ matching the plan's precision.
 Other utility functions (existing yet non-functional)
 =====================================================
 
-The following functions exist in hipFFTW but are **not** functional in any way: they are effectively ignoring all
-arguments and made to systematically return ``0.0`` when a ``double`` value is to be returned.
+The following functions exist in hipFFTW but are **not** functional in any way. They effectively ignore all
+arguments and systematically return ``0.0`` when a ``double`` value needs to be returned.
 
 - ``fftw_print_plan`` and ``fftwf_print_plan``;
 - ``fftw_set_timelimit`` and ``fftwf_set_timelimit``;
@@ -271,22 +271,22 @@ By setting any of the environment variables
 - ``HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC``;
 - ``HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC``;
 
-to a non-negative integer value, users can instruct hipFFTW to observe the value set so as the maximal
-byte size that may be considered for the corresponding kind of host-accessible memory for any individual
+to a non-negative integer value, users can instruct hipFFTW to observe the value set for the maximal
+byte size that can be considered for the corresponding kind of host-accessible memory for any individual
 allocation requested via the :ref:`buffer allocation functions <hipfftw-buffer-management>`. Setting
 any of the above variables to ``0`` effectively prevents the corresponding kind of memory to be
-considered in user-requested buffer allocations altogether, for instance.
+considered in user-requested buffer allocations altogether.
 
 .. _hipfftw-env-verbose-exceptions:
 
-Turning hipFFTW verbose
------------------------
+Making hipFFTW verbose
+----------------------
 
-Debugging failures or errors suspected to be triggered by hipFFTW may turn challenging, particularly
-if the root-cause lies in any of the :ref:`execution functions <hipfftw-execution>` given
+Debugging failures or errors suspected to be triggered by hipFFTW can be challenging, particularly
+if the root cause lies in any of the :ref:`execution functions <hipfftw-execution>`, given
 that these functions' signatures make such errors silent by design. Setting the environment variable
 ``HIPFFTW_LOG_EXCEPTIONS`` to a strictly positive integer value effectively instructs hipFFTW to become
-verbose about internal exceptions it may encounter by reporting about them into the standard error stream.
+verbose about internal exceptions it might encounter by reporting them to the standard error stream.
 
 .. note::
   The hipFFTW interface is C-compatible, even when ``HIPFFTW_LOG_EXCEPTIONS`` is set as

--- a/projects/hipfft/docs/reference/hipfftw-api-usage.rst
+++ b/projects/hipfft/docs/reference/hipfftw-api-usage.rst
@@ -128,8 +128,8 @@ Plans capture:
 - the flag value(s) to use at creation.
 
 A plan of interest can be created using more than one plan creation function. For instance, any plan created
-by ``fftw_plan_dft`` (resp. ``fftwf_plan_dft``) could be created by ``fftw_plan_many_dft``
-(resp. ``fftwf_plan_many_dft``) without any difference.
+by ``fftw_plan_dft`` (or ``fftwf_plan_dft``) could be created by ``fftw_plan_many_dft``
+(or ``fftwf_plan_many_dft``) without any difference.
 
 For all plan creation functions, the requested plan is said to be configured for in-place operations if identical
 input and output buffers are used when the plan is created. The plan is configured for out-of-place operations otherwise.

--- a/projects/hipfft/docs/reference/hipfftw-api-usage.rst
+++ b/projects/hipfft/docs/reference/hipfftw-api-usage.rst
@@ -1,0 +1,294 @@
+.. meta::
+  :description: hipFFT documentation, hipFFTW documentation, and API reference library
+  :keywords: FFT, hipFFT, hipFFTW, rocFFT, ROCm, API, documentation
+
+.. _hipfftw-api-usage:
+
+********************************************************************
+hipFFTW API usage
+********************************************************************
+
+This section describes how to use the hipFFTW library API. The hipFFTW
+API is a partial reproduction of the FFTW_ API.
+
+.. _FFTW: https://www.fftw.org/
+
+Data types
+==========
+
+Similarly to FFTW_, hipFFTW uses the following specific types.
+
+.. doxygentypedef:: fftw_complex
+
+.. doxygentypedef:: fftwf_complex
+
+.. doxygentypedef:: fftw_plan
+
+.. doxygentypedef:: fftwf_plan
+
+Constant values
+===============
+
+.. _hipfftw-flag-values:
+
+Flag values
+-----------
+
+All the hipFFTW :ref:`plan creation functions <hipfftw-plan-creation>` request an ``unsigned flags`` argument.
+The value of that argument conditions what hipFFTW may or may not consider when creating the requested plan. Valid
+values are bitwise OR of zero of more of the following constant values.
+
+.. doxygendefine:: FFTW_MEASURE
+
+.. doxygendefine:: FFTW_DESTROY_INPUT
+
+.. doxygendefine:: FFTW_UNALIGNED
+
+.. doxygendefine:: FFTW_CONSERVE_MEMORY
+
+.. doxygendefine:: FFTW_EXHAUSTIVE
+
+.. doxygendefine:: FFTW_PRESERVE_INPUT
+
+.. doxygendefine:: FFTW_PATIENT
+
+.. doxygendefine:: FFTW_ESTIMATE
+
+.. doxygendefine:: FFTW_WISDOM_ONLY
+
+.. note::
+  Even if seemingly accepted, flag values are currently ignored by hipFFTW. In particular, note that
+
+  - no measurement is ever done at plan creation (plan configurations are chosen based on heuristics);
+  - preservation of input data is never guaranteed;
+  - requests for a minimized memory footprint are ignored;
+
+  with the current status of hipFFTW.
+
+.. _hipfftw-sign-values:
+
+Sign values
+-----------
+
+The hipFFTW :ref:`plan creation functions <hipfftw-plan-creation>` for complex transforms request an ``int sign``
+argument. This argument determines whether the plan being created is meant to compute forward or backward (inverse)
+discrete Fourier transforms. Valid values of that argument are either of the following constant values.
+
+.. doxygendefine:: FFTW_FORWARD
+
+.. doxygendefine:: FFTW_BACKWARD
+
+.. _hipfftw-buffer-management:
+
+Buffer management
+=================
+
+hipFFTW supports the following buffer-management functions.
+
+.. doxygenfunction:: fftw_malloc
+
+.. doxygenfunction:: fftwf_malloc
+
+.. doxygenfunction:: fftw_alloc_real
+
+.. doxygenfunction:: fftwf_alloc_real
+
+.. doxygenfunction:: fftw_alloc_complex
+
+.. doxygenfunction:: fftwf_alloc_complex
+
+.. doxygenfunction:: fftw_free
+
+.. doxygenfunction:: fftwf_free
+
+The memory blocks allocated by any of the above ``{fftw,fftwf}_{malloc,alloc_real,alloc_complex}``
+are always directly accessible to the host, but not necessarily to GPU. hipFFTW decides on the type
+of memory being allocated following a ranked-choice strategy: it attempts to allocate
+
+1. pinned host memory, first;
+2. pageable host memory, if the latter failed (or if the request exceeds a :ref:`user-defined threshold <hipfftw-env-byte-size-host-alloc>`).
+
+.. important::
+  Every buffer allocated via ``fftw_malloc``, ``fftwf_malloc``, ``fftw_alloc_real``, ``fftwf_alloc_real``,
+  ``fftw_alloc_complex`` or ``fftwf_alloc_complex`` **must** be freed using ``fftw_free`` or ``fftwf_free``.
+
+.. _hipfftw-plan-creation:
+
+Plan creation
+=============
+
+hipFFTW supports the creation of :ref:`basic <hipfftw-basic-plan-creation>`, :ref:`advanced <hipfftw-advanced-plan-creation>`,
+and :ref:`general <hipfftw-general-plan-creation>` plans, using interleaved formats for complex floating-point data.
+Plans capture
+
+- the type of transform, *i.e.*, complex or real, forward or backward (inverse) discrete Fourier transform;
+- the length(s) and batch size(s) of the transform;
+- layout information for input and output data, *e.g.*, stride(s), distance(s);
+- pointers to buffers that it should consider as input and output data buffers when computing a transform via a :ref:`generic execution function <hipfftw-execute-with-creation-io>`;
+- its flag value(s) used at creation.
+
+A plan of interest may be created via more than one plan creation function. For instance, any plan created
+by ``fftw_plan_dft`` (resp. ``fftwf_plan_dft``) could be created by ``fftw_plan_many_dft``
+(resp. ``fftwf_plan_many_dft``) without any difference.
+
+For all plan creation functions, the requested plan is said to be configured for in-place (resp. out-of-place)
+operations if identical (resp. different) input and output buffers are used when the plan is created.
+
+.. note::
+  - hipFFTW does not support split complex formats, real-to-real transforms, nor distributed transforms;
+  - hipFFTW does not support transforms of more than 3 dimensions, *i.e.*, ``rank > 3`` is not supported;
+  - hipFFTW does not support transforms of more than 1 batch dimension, *i.e.*, ``batch_rank > 1`` is not supported.
+
+.. _hipfftw-basic-plan-creation:
+
+Basic plans
+-----------
+
+Basic plans are implicitly configured for unbatched transforms with compact, default data layouts. For :math:`d`-dimensional (:math:`d > 0`)
+transforms of lengths :math:`n_0 \times n_1 \times \ldots \times n_{d-1}` (:math:`n_{i} > 0\, \forall i \in \lbrace 0, 1, \ldots, d-1\rbrace`),
+default data layouts use strides :math:`s_i` along dimension :math:`i` where
+
+- :math:`s_{d-1} = 1`;
+- if :math:`d > 1`,
+    - :math:`s_{d-2} = 2 \lfloor n_{d-1} / 2 + 1 \rfloor` on input (resp. output) and :math:`s_{d-2} = \lfloor n_{d-1} / 2 + 1 \rfloor` on output (resp. input) for forward (resp. backward) real in-place transforms;
+    - :math:`s_{d-2} = n_{d-1}` on input (resp. output) and :math:`s_{d-2} = \lfloor n_{d-1} / 2 + 1 \rfloor` on output (resp. input) for forward (resp. backward) real out-of-place transforms;
+    - :math:`n_{d-1}` otherwise.
+- if :math:`d > 2`, :math:`s_{i} = n_{i+1}s_{i+1}` for :math:`0 \leq i < d-2`.
+
+The following functions may be used for creating basic hipFFTW plans.
+
+.. doxygenfunction:: fftw_plan_dft_1d
+.. doxygenfunction:: fftwf_plan_dft_1d
+.. doxygenfunction:: fftw_plan_dft_2d
+.. doxygenfunction:: fftwf_plan_dft_2d
+.. doxygenfunction:: fftw_plan_dft_3d
+.. doxygenfunction:: fftwf_plan_dft_3d
+.. doxygenfunction:: fftw_plan_dft
+.. doxygenfunction:: fftwf_plan_dft
+.. doxygenfunction:: fftw_plan_dft_r2c_1d
+.. doxygenfunction:: fftwf_plan_dft_r2c_1d
+.. doxygenfunction:: fftw_plan_dft_r2c_2d
+.. doxygenfunction:: fftwf_plan_dft_r2c_2d
+.. doxygenfunction:: fftw_plan_dft_r2c_3d
+.. doxygenfunction:: fftwf_plan_dft_r2c_3d
+.. doxygenfunction:: fftw_plan_dft_r2c
+.. doxygenfunction:: fftwf_plan_dft_r2c
+.. doxygenfunction:: fftw_plan_dft_c2r_1d
+.. doxygenfunction:: fftwf_plan_dft_c2r_1d
+.. doxygenfunction:: fftw_plan_dft_c2r_2d
+.. doxygenfunction:: fftwf_plan_dft_c2r_2d
+.. doxygenfunction:: fftw_plan_dft_c2r_3d
+.. doxygenfunction:: fftwf_plan_dft_c2r_3d
+.. doxygenfunction:: fftw_plan_dft_c2r
+.. doxygenfunction:: fftwf_plan_dft_c2r
+
+.. _hipfftw-advanced-plan-creation:
+
+Advanced plans
+--------------
+
+.. TBD
+
+.. _hipfftw-general-plan-creation:
+
+Arbitrary plans
+---------------
+
+.. TBD
+
+.. _hipfftw-execution:
+
+Plan execution
+==============
+
+Once successfully created, hipFFTW plans may be executed, *i.e.*, used for computing the discrete Fourier transform that they capture.
+The :ref:`generic execution functions <hipfftw-execute-with-creation-io>` implicitly reuse the input and output buffers that were set
+at :ref:`plan creation <hipfftw-plan-creation>`. If that is not possible or impractical, new input and output buffers may be communicated
+instead by using the :ref:`new-arrays execution functions <hipfftw-execute-with-new-io>`.
+
+.. _hipfftw-execute-with-creation-io:
+
+Using buffers set at plan creation for computation
+--------------------------------------------------
+
+.. doxygenfunction:: fftw_execute
+.. doxygenfunction:: fftwf_execute
+
+.. _hipfftw-execute-with-new-io:
+
+Using new buffers for computation
+---------------------------------
+
+.. doxygenfunction:: fftw_execute_dft
+.. doxygenfunction:: fftwf_execute_dft
+.. doxygenfunction:: fftw_execute_dft_r2c
+.. doxygenfunction:: fftwf_execute_dft_r2c
+.. doxygenfunction:: fftw_execute_dft_c2r
+.. doxygenfunction:: fftwf_execute_dft_c2r
+
+.. note::
+  When new input and output buffers are used for execution, they must honor the placement that was set at plan creation.
+  In other words, the result of ``(void*)in == (void*)out`` must be unchanged between plan creation and plan execution.
+
+.. note::
+  If the type of memory for the output buffer is directly accessible by the host, hipFFTW enforces synchronization before
+  returning from any of the above :ref:`execution functions <hipfftw-execution>` to guarantee that the results are readily
+  available to the host upon completion of the execution function.
+
+Plan destruction
+================
+
+When no longer needed or going out of scope, hipFFTW plans must be destructed using either of the following functions
+matching the plan's precision.
+
+.. doxygenfunction:: fftw_destroy_plan
+.. doxygenfunction:: fftwf_destroy_plan
+
+Other utility functions (existing yet non-functional)
+=====================================================
+
+The following functions exist in hipFFTW but are **not** functional in any way: they are effectively ignoring all
+arguments and made to systematically return ``0.0`` when a ``double`` value is to be returned.
+
+- ``fftw_print_plan`` and ``fftwf_print_plan``;
+- ``fftw_set_timelimit`` and ``fftwf_set_timelimit``;
+- ``fftw_cost`` and ``fftwf_cost``;
+- ``fftw_flops`` and ``fftwf_flops``;
+- ``fftw_cleanup`` and ``fftwf_cleanup``.
+
+.. _hipfftw-env-vars:
+
+Environment variables specific to hipFFTW
+=========================================
+
+.. _hipfftw-env-byte-size-host-alloc:
+
+Enforcing size limits on types of memory for user-managed buffers
+-----------------------------------------------------------------
+
+By setting any of the environment variables
+
+- ``HIPFFTW_BYTE_SIZE_LIMIT_PINNED_HOST_ALLOC``;
+- ``HIPFFTW_BYTE_SIZE_LIMIT_PAGEABLE_HOST_ALLOC``;
+
+to a non-negative integer value, users can instruct hipFFTW to observe the value set so as the maximal
+byte size that may be considered for the corresponding kind of host-accessible memory for any individual
+allocation requested via the :ref:`buffer allocation functions <hipfftw-buffer-management>`. Setting
+any of the above variables to ``0`` effectively prevents the corresponding kind of memory to be
+considered in user-requested buffer allocations altogether, for instance.
+
+.. _hipfftw-env-verbose-exceptions:
+
+Turning hipFFTW verbose
+-----------------------
+
+Debugging failures or errors suspected to be triggered by hipFFTW may turn challenging, particularly
+if the root-cause lies in any of the :ref:`execution functions <hipfftw-execution>` given
+that these functions' signatures make such errors silent by design. Setting the environment variable
+``HIPFFTW_LOG_EXCEPTIONS`` to a strictly positive integer value effectively instructs hipFFTW to become
+verbose about internal exceptions it may encounter by reporting about them into the standard error stream.
+
+.. note::
+  The hipFFTW interface is C-compatible, even when ``HIPFFTW_LOG_EXCEPTIONS`` is set as
+  described above.
+

--- a/projects/hipfft/docs/sphinx/_toc.yml.in
+++ b/projects/hipfft/docs/sphinx/_toc.yml.in
@@ -5,13 +5,13 @@ subtrees:
 
 - caption: Install
   entries:
-  - file: install/building-installing-hipfft
+  - file: install/building-installing-hipfft-and-hipfftw
     title: Installation guide
 
 - caption: Conceptual
   entries:
   - file: conceptual/overview
-    title: hipFFT overview
+    title: Overview of hipFFT and hipFFTW
 
 - caption: Examples
   entries:
@@ -20,8 +20,10 @@ subtrees:
 
 - caption: API reference
   entries:
-  - file: reference/fft-api-usage
-    title: API and usage notes
+  - file: reference/hipfft-api-usage
+    title: hipFFT API and usage notes
+  - file: reference/hipfftw-api-usage
+    title: hipFFTW API and usage notes
 
 - caption: About
   entries:

--- a/projects/hipfft/library/include/hipfft/hipfftw.h
+++ b/projects/hipfft/library/include/hipfft/hipfftw.h
@@ -29,107 +29,413 @@
 extern "C" {
 #endif
 
-// FFTW can use standard complex type
+// Data types and constant values
+
+/**
+ * @brief Type for double-precision complex floating-point values.
+ * \note `fftw_complex` is defined equivalent to `double complex` in applications
+ * that include the standard `complex.h` prior to `hipfft/hipfftw.h`.
+ */
 #if defined(_Complex_I) && defined(complex) && defined(I)
 typedef double complex fftw_complex;
-typedef float complex  fftwf_complex;
 #else
 typedef double fftw_complex[2];
+#endif
+
+/**
+ * @brief Single-precision equivalent of \ref fftw_complex.
+ */
+#if defined(_Complex_I) && defined(complex) && defined(I)
+typedef float complex fftwf_complex;
+#else
 typedef float  fftwf_complex[2];
 #endif
 
-// Planning flags and constants
+/**
+ * @brief Type for double-precision hipFFTW plans.
+ */
+typedef struct fftw_plan_s* fftw_plan;
+
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan;
+ */
+typedef struct fftwf_plan_s* fftwf_plan;
+
+/**
+ * @brief Flag value allowing hipFFTW to compute (possibly many) FFTs at plan creation
+ * to find the optimal configuration, using the input and output data buffers set at plan
+ * creation (hence possibly overwriting data therein).
+ */
 #define FFTW_MEASURE (0U)
+
+/**
+ * @brief Flag value allowing an out-of-place hipFFTW plan to overwrite its input buffer
+ * data at execution.
+ */
 #define FFTW_DESTROY_INPUT (1U << 0)
+
+/**
+ * @brief Flag value ruling out any alignment assumption for the input and output buffers
+ * to be used at plan execution.
+ */
 #define FFTW_UNALIGNED (1U << 1)
+
+/**
+ * @brief Flag value instructing plans to prefer configurations minimizing their memory footprint.
+ */
 #define FFTW_CONSERVE_MEMORY (1U << 2)
+
+/**
+ * @brief Flag value equivalent to \ref FFTW_PATIENT, enabling the largest possible set of plan
+ * configurations to be considered in the measurements.
+ */
 #define FFTW_EXHAUSTIVE (1U << 3)
+
+/**
+ * @brief Flag value forbidding an out-of-place hipFFTW plan to overwrite its input buffer
+ * data at execution.
+ * \note This flag value is not supported for out-of-place multidimensional real inverse tranforms.
+ */
 #define FFTW_PRESERVE_INPUT (1U << 4)
+
+/**
+ * @brief Flag value equivalent to \ref FFTW_MEASURE, enabling a larger-than-default set of plan
+ * configurations to be considered in the measurements.
+ */
 #define FFTW_PATIENT (1U << 5)
+
+/**
+ * @brief Flag value enforcing hipFFTW to use a heuristric when selecting the plan configuration,
+ * thereby ruling out measurements and leaving input and output buffers untouched.
+ */
 #define FFTW_ESTIMATE (1U << 6)
+
+/**
+ * @brief Flag instructing hipFFTW to query the requested plan from an on-disk database file ("wisdom").
+ * If not found therein, no plan is created.
+ * \note This flag value is not supported by hipFFTW.
+ */
 #define FFTW_WISDOM_ONLY (1U << 21)
+
+/**
+ * @brief Exponent ``sign`` value to be used for forward discrete Fourier transforms.
+ */
 #define FFTW_FORWARD (-1)
+
+/**
+ * @brief Exponent ``sign`` value to be used for backward (inverse) discrete Fourier transforms.
+ */
 #define FFTW_BACKWARD (1)
 
 // Buffer management
-HIPFFT_EXPORT void*   fftw_malloc(size_t n);
-HIPFFT_EXPORT void*   fftwf_malloc(size_t n);
+/**
+ * @brief Allocates a data buffer accessible by the host.
+ * @param[in] n number of bytes desired for the buffer.
+ * @return a pointer to the base address of the allocated memory block upon success (``nullptr`` otherwise).
+ * 
+ * @remark The returned base address is at least 64-bit aligned.
+ */
+HIPFFT_EXPORT void* fftw_malloc(size_t n);
+/**
+ * @brief This function is strictly equivalent to \ref fftw_malloc
+ */
+HIPFFT_EXPORT void* fftwf_malloc(size_t n);
+/**
+ * @brief This function is strictly equivalent to ``(double*) fftw_malloc(n * sizeof(double))``
+ */
 HIPFFT_EXPORT double* fftw_alloc_real(size_t n);
-HIPFFT_EXPORT float*  fftwf_alloc_real(size_t n);
+/**
+ * @brief This function is strictly equivalent to ``(float*) fftw_malloc(n * sizeof(float))``
+ */
+HIPFFT_EXPORT float* fftwf_alloc_real(size_t n);
+/**
+ * @brief This function is strictly equivalent to ``(fftw_complex*) fftw_malloc(n * sizeof(fftw_complex))``
+ */
 HIPFFT_EXPORT fftw_complex* fftw_alloc_complex(size_t n);
+/**
+ * @brief This function is strictly equivalent to ``(fftwf_complex*) fftw_malloc(n * sizeof(fftwf_complex))``
+ */
 HIPFFT_EXPORT fftwf_complex* fftwf_alloc_complex(size_t n);
 
+/**
+ * @brief Frees a buffer previously allocated by any of the allocation functions above.
+ * 
+ * @param[in] p pointer to the base address of the buffer to be freed.
+ */
 HIPFFT_EXPORT void fftw_free(void* p);
+/**
+ * @brief This function is strictly equivalent to \ref fftw_free
+ */
 HIPFFT_EXPORT void fftwf_free(void* p);
 
-// Plan usage
-typedef struct fftw_plan_s*  fftw_plan;
-typedef struct fftwf_plan_s* fftwf_plan;
-
-HIPFFT_EXPORT void fftw_destroy_plan(fftw_plan plan);
-HIPFFT_EXPORT void fftwf_destroy_plan(fftwf_plan plan);
-HIPFFT_EXPORT void fftw_cleanup();
-HIPFFT_EXPORT void fftwf_cleanup();
-HIPFFT_EXPORT void fftw_execute(const fftw_plan plan);
-HIPFFT_EXPORT void fftwf_execute(const fftwf_plan plan);
-HIPFFT_EXPORT void fftw_execute_dft(const fftw_plan plan, fftw_complex* in, fftw_complex* out);
-HIPFFT_EXPORT void fftwf_execute_dft(const fftwf_plan plan, fftwf_complex* in, fftwf_complex* out);
-HIPFFT_EXPORT void fftw_execute_dft_r2c(const fftw_plan plan, double* in, fftw_complex* out);
-HIPFFT_EXPORT void fftwf_execute_dft_r2c(const fftwf_plan plan, float* in, fftwf_complex* out);
-HIPFFT_EXPORT void fftw_execute_dft_c2r(const fftw_plan plan, fftw_complex* in, double* out);
-HIPFFT_EXPORT void fftwf_execute_dft_c2r(const fftwf_plan plan, fftwf_complex* in, float* out);
+// Plan creation
 
 // Basic plans
+/**
+ * @brief Creates a basic plan for a one-dimensional, double-precision, complex discrete Fourier transform of length ``n``.
+ * 
+ * @param[in] n strictly positive length of the transform;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] sign exponent sign defining the desired complex transform (``FFTW_FORWARD`` or ``FFTW_BACKWARD``);
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan
     fftw_plan_dft_1d(int n, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_1d.
+ */
 HIPFFT_EXPORT fftwf_plan
     fftwf_plan_dft_1d(int n, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags);
+/**
+ * @brief Creates a basic plan for a two-dimensional, double-precision, complex discrete Fourier transform of lengths ``n0 x n1``.
+ * 
+ * @param[in] n0, n1 strictly positive lengths of the transform;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] sign exponent sign defining the desired complex transform (``FFTW_FORWARD`` or ``FFTW_BACKWARD``);
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan
     fftw_plan_dft_2d(int n0, int n1, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_2d.
+ */
 HIPFFT_EXPORT fftwf_plan fftwf_plan_dft_2d(
     int n0, int n1, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags);
+/**
+ * @brief Creates a basic plan for a three-dimensional, double-precision, complex discrete Fourier transform of lengths ``n0 x n1 x n2``.
+ * 
+ * @param[in] n0, n1,n2 strictly positive lengths of the transform;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] sign exponent sign defining the desired complex transform (``FFTW_FORWARD`` or ``FFTW_BACKWARD``);
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan fftw_plan_dft_3d(
     int n0, int n1, int n2, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_3d.
+ */
 HIPFFT_EXPORT fftwf_plan fftwf_plan_dft_3d(
     int n0, int n1, int n2, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags);
+/**
+ * @brief Creates a basic plan for a multidimensional, double-precision, complex discrete Fourier transform of lengths ``n[0] x n[1] x ... x n[rank-1]``.
+ * 
+ * @param[in] rank strictly positive rank of the transform;
+ * @param[in] n array of strictly positive lengths of the transform (must be of size ``rank``);
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] sign exponent sign defining the desired complex transform (``FFTW_FORWARD`` or ``FFTW_BACKWARD``);
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan fftw_plan_dft(
     int rank, const int* n, fftw_complex* in, fftw_complex* out, int sign, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft.
+ */
 HIPFFT_EXPORT fftwf_plan fftwf_plan_dft(
     int rank, const int* n, fftwf_complex* in, fftwf_complex* out, int sign, unsigned flags);
-HIPFFT_EXPORT fftw_plan  fftw_plan_dft_r2c_1d(int n, double* in, fftw_complex* out, unsigned flags);
+/**
+ * @brief Creates a basic plan for a one-dimensional, double-precision, real forward discrete Fourier transform of length ``n``.
+ * 
+ * @param[in] n strictly positive length of the transform;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
+HIPFFT_EXPORT fftw_plan fftw_plan_dft_r2c_1d(int n, double* in, fftw_complex* out, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_r2c_1d.
+ */
 HIPFFT_EXPORT fftwf_plan fftwf_plan_dft_r2c_1d(int            n,
                                                float*         in,
                                                fftwf_complex* out,
                                                unsigned       flags);
+/**
+ * @brief Creates a basic plan for a two-dimensional, double-precision, real forward discrete Fourier transform of lengths ``n0 x n1``.
+ * 
+ * @param[in] n0, n1 strictly positive lengths of the transform;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan
     fftw_plan_dft_r2c_2d(int n0, int n1, double* in, fftw_complex* out, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_r2c_2d. 
+ */
 HIPFFT_EXPORT fftwf_plan
     fftwf_plan_dft_r2c_2d(int n0, int n1, float* in, fftwf_complex* out, unsigned flags);
+/**
+ * @brief Creates a basic plan for a three-dimensional, double-precision, real forward discrete Fourier transform of lengths ``n0 x n1 x n2``.
+ * 
+ * @param[in] n0, n1, n2 strictly positive lengths of the transform;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan
     fftw_plan_dft_r2c_3d(int n0, int n1, int n2, double* in, fftw_complex* out, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_r2c_3d. 
+ */
 HIPFFT_EXPORT fftwf_plan
     fftwf_plan_dft_r2c_3d(int n0, int n1, int n2, float* in, fftwf_complex* out, unsigned flags);
+/**
+ * @brief Creates a basic plan for a multidimensional, double-precision, real forward discrete Fourier transform of lengths ``n[0] x n[1] x ... x n[rank-1]``.
+ * 
+ * @param[in] rank strictly positive rank of the transform;
+ * @param[in] n array of strictly positive lengths of the transform (must be of size ``rank``);
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan
     fftw_plan_dft_r2c(int rank, const int* n, double* in, fftw_complex* out, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_r2c. 
+ */
 HIPFFT_EXPORT fftwf_plan
     fftwf_plan_dft_r2c(int rank, const int* n, float* in, fftwf_complex* out, unsigned flags);
-HIPFFT_EXPORT fftw_plan  fftw_plan_dft_c2r_1d(int n, fftw_complex* in, double* out, unsigned flags);
+/**
+ * @brief Creates a basic plan for a one-dimensional, double-precision, real backward (inverse) discrete Fourier transform of length ``n``.
+ * 
+ * @param[in] n strictly positive length of the transform;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
+HIPFFT_EXPORT fftw_plan fftw_plan_dft_c2r_1d(int n, fftw_complex* in, double* out, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_c2r_1d.
+ */
 HIPFFT_EXPORT fftwf_plan fftwf_plan_dft_c2r_1d(int            n,
                                                fftwf_complex* in,
                                                float*         out,
                                                unsigned       flags);
+/**
+ * @brief Creates a basic plan for a two-dimensional, double-precision, real backward (inverse) discrete Fourier transform of lengths ``n0 x n1``.
+ * 
+ * @param[in] n0, n1 strictly positive lengths of the transform;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan
     fftw_plan_dft_c2r_2d(int n0, int n1, fftw_complex* in, double* out, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_c2r_2d.
+ */
 HIPFFT_EXPORT fftwf_plan
     fftwf_plan_dft_c2r_2d(int n0, int n1, fftwf_complex* in, float* out, unsigned flags);
+/**
+ * @brief Creates a basic plan for a three-dimensional, double-precision, real backward (inverse) discrete Fourier transform of lengths ``n0 x n1 x n2``.
+ * 
+ * @param[in] n0, n1, n2 strictly positive lengths of the transform;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan
     fftw_plan_dft_c2r_3d(int n0, int n1, int n2, fftw_complex* in, double* out, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_c2r_3d.
+ */
 HIPFFT_EXPORT fftwf_plan
     fftwf_plan_dft_c2r_3d(int n0, int n1, int n2, fftwf_complex* in, float* out, unsigned flags);
+/**
+ * @brief Creates a basic plan for a multidimensional, double-precision, real backward (inverse) discrete Fourier transform of lengths ``n[0] x n[1] x ... x n[rank-1]``.
+ * 
+ * @param[in] rank strictly positive rank of the transform;
+ * @param[in] n array of strictly positive lengths of the transform (must be of size ``rank``);
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
 HIPFFT_EXPORT fftw_plan
     fftw_plan_dft_c2r(int rank, const int* n, fftw_complex* in, double* out, unsigned flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_dft_c2r.
+ */
 HIPFFT_EXPORT fftwf_plan
     fftwf_plan_dft_c2r(int rank, const int* n, fftwf_complex* in, float* out, unsigned flags);
+
+// Plan execution
+/**
+ * @brief Computes the discrete Fourier transform that a double-precision plan captures using
+ * the input and output data buffers that were communicated at plan's creation.
+ * 
+ * @param[in] plan the double-precision plan capturing the transform to compute.
+ */
+HIPFFT_EXPORT void fftw_execute(const fftw_plan plan);
+/**
+ * @brief Single-precision equivalent of \ref fftw_execute 
+ */
+HIPFFT_EXPORT void fftwf_execute(const fftwf_plan plan);
+/**
+ * @brief Computes the discrete Fourier transform that a double-precision plan captures using new input and output data buffers.
+ * The plan must have been created for a complex transform.
+ * 
+ * @param[in] plan the double-precision plan capturing the complex transform to compute;
+ * @param[in] in pointer to a new input buffer for the transform;
+ * @param[out] out pointer to a new output buffer for the transform.
+ */
+HIPFFT_EXPORT void fftw_execute_dft(const fftw_plan plan, fftw_complex* in, fftw_complex* out);
+/**
+ * @brief Single-precision equivalent of \ref fftw_execute_dft. 
+ */
+HIPFFT_EXPORT void fftwf_execute_dft(const fftwf_plan plan, fftwf_complex* in, fftwf_complex* out);
+/**
+ * @brief Computes the discrete Fourier transform that a double-precision plan captures using new input and output data buffers.
+ * The plan must have been created for a real forward transform.
+ * 
+ * @param[in] plan the double-precision plan capturing the real forward transform to compute;
+ * @param[in] in pointer to a new input buffer for the transform;
+ * @param[out] out pointer to a new output buffer for the transform.
+ */
+HIPFFT_EXPORT void fftw_execute_dft_r2c(const fftw_plan plan, double* in, fftw_complex* out);
+/**
+ * @brief Single-precision equivalent of \ref fftw_execute_dft_r2c. 
+ */
+HIPFFT_EXPORT void fftwf_execute_dft_r2c(const fftwf_plan plan, float* in, fftwf_complex* out);
+/**
+ * @brief Computes the discrete Fourier transform that a double-precision plan captures using new input and output data buffers.
+ * The plan must have been created for a real backward (inverse) transform.
+ * 
+ * @param[in] plan the double-precision plan capturing the real backward (inverse) transform to compute;
+ * @param[in] in pointer to a new input buffer for the transform;
+ * @param[out] out pointer to a new output buffer for the transform.
+ */
+HIPFFT_EXPORT void fftw_execute_dft_c2r(const fftw_plan plan, fftw_complex* in, double* out);
+/**
+ * @brief Single-precision equivalent of \ref fftw_execute_dft_c2r. 
+ */
+HIPFFT_EXPORT void fftwf_execute_dft_c2r(const fftwf_plan plan, fftwf_complex* in, float* out);
+
+// Plan destruction
+/**
+ * @brief Deallocates a double-precision plan and frees all its resources.
+ * 
+ * @param[in] plan plan to be destroyed.
+ */
+HIPFFT_EXPORT void fftw_destroy_plan(fftw_plan plan);
+/**
+ * @brief Single-precision equivalent of \ref fftw_destroy_plan. 
+ */
+HIPFFT_EXPORT void fftwf_destroy_plan(fftwf_plan plan);
 
 // Non-functional utility APIs
 HIPFFT_EXPORT void   fftw_print_plan(const fftw_plan);
@@ -140,6 +446,8 @@ HIPFFT_EXPORT double fftw_cost(const fftw_plan);
 HIPFFT_EXPORT double fftwf_cost(const fftw_plan);
 HIPFFT_EXPORT void   fftw_flops(const fftw_plan, double*, double*, double*);
 HIPFFT_EXPORT void   fftwf_flops(const fftw_plan, double*, double*, double*);
+HIPFFT_EXPORT void   fftw_cleanup();
+HIPFFT_EXPORT void   fftwf_cleanup();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Motivation

The recent addition of hipFFTW requires documentation additions.

## Technical Details

The PR is self-explanatory and intends to document hipFFTW as needed.
Note: Advanced and guru plans will be documented when integrated in hipFFTW.

## Test Plan

N/A.

## Test Result

N/A.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
