### PR TITLE
[rocSOLVER] Optimize LARFB kernels

### DIFF
--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -54,13 +54,13 @@ ROCSOLVER_KERNEL void copymatA1(const rocblas_int ldw,
     const auto i = hipBlockIdx_y * blocksizey + hipThreadIdx_y;
     rocblas_stride strideW = rocblas_stride(ldw) * order;
 
-    if(i < ldw && j < order)
+    if(i < order && j < ldw)
     {
         T *Ap, *Wp;
         Wp = tmptr + b * strideW;
         Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
 
-        Wp[i + j * ldw] = Ap[i + j * lda];
+        Wp[j + i * ldw] = Ap[j + i * lda];
     }
 }
 
@@ -80,13 +80,13 @@ ROCSOLVER_KERNEL void addmatA1(const rocblas_int ldw,
     const auto i = hipBlockIdx_y * blocksizey + hipThreadIdx_y;
     rocblas_stride strideW = rocblas_stride(ldw) * order;
 
-    if(i < ldw && j < order)
+    if(i < order && j < ldw)
     {
         T *Ap, *Wp;
         Wp = tmptr + b * strideW;
         Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
 
-        Ap[i + j * lda] -= Wp[i + j * ldw];
+        Ap[j + i * lda] -= Wp[j + i * ldw];
     }
 }
 
@@ -313,8 +313,8 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    rocblas_int blocksx = (order - 1) / 32 + 1;
-    rocblas_int blocksy = (ldw - 1) / 32 + 1;
+    rocblas_int blocksy = (order - 1) / 32 + 1;
+    rocblas_int blocksx = (ldw - 1) / 32 + 1;
     ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 
@@ -586,8 +586,8 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    rocblas_int blocksx = (order - 1) / 32 + 1;
-    rocblas_int blocksy = (ldw - 1) / 32 + 1;
+    rocblas_int blocksy = (order - 1) / 32 + 1;
+    rocblas_int blocksx = (ldw - 1) / 32 + 1;
     ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -55,7 +55,7 @@ ROCSOLVER_KERNEL void copymatA1(const rocblas_int ldw,
     const auto j = hipBlockIdx_y * blocksizey + hipThreadIdx_y;
     rocblas_stride strideW = rocblas_stride(ldw) * order;
 
-    if(i < order && j < ldw)
+    if(i < ldw && j < order)
     {
         T const* __restrict const Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
         T* __restrict const Wp = tmptr + b * strideW;
@@ -80,7 +80,7 @@ ROCSOLVER_KERNEL void addmatA1(const rocblas_int ldw,
     const auto j = hipBlockIdx_y * blocksizey + hipThreadIdx_y;
     rocblas_stride strideW = rocblas_stride(ldw) * order;
 
-    if(i < order && j < ldw)
+    if(i < ldw && j < order)
     {
         T* __restrict const Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
         T const* __restrict const Wp = tmptr + b * strideW;

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -313,8 +313,8 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    const rocblas int nx = 32;
-    const rocblas int ny = 32;
+    const rocblas_int nx = 32;
+    const rocblas_int ny = 32;
     rocblas_int blocksx = (ldw - 1) / nx + 1;
     rocblas_int blocksy = (order - 1) / ny + 1;
     ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(nx, ny), 0, stream,
@@ -588,8 +588,8 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    const rocblas int nx = 32;
-    const rocblas int ny = 32;
+    const rocblas_int nx = 32;
+    const rocblas_int ny = 32;
     rocblas_int blocksx = (ldw - 1) / nx + 1;
     rocblas_int blocksy = (order - 1) / ny + 1;
     ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(nx, ny), 0, stream,

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -314,8 +314,11 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    rocblas_int blocksx = (ldw - 1) / BS2 + 1;
-    rocblas_int blocksy = (order - 1) / BS2 + 1;
+
+    auto ceil = [](auto n, auto base) { return( (n-1)/base + 1 ); };
+
+    auto const blocksx = ceil(ldw, BS2);
+    auto const blocksy = ceil(order, BS2);
     ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 
@@ -587,8 +590,10 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    rocblas_int blocksx = (ldw - 1) / BS2 + 1;
-    rocblas_int blocksy = (order - 1) / BS2 + 1;
+    auto ceil = [](auto n, auto base) { return( (n-1)/base + 1 ); };
+
+    auto const blocksx = ceil(ldw, BS2);
+    auto const blocksy = ceil(order, BS2);
     ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -313,9 +313,11 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    rocblas_int blocksy = (order - 1) / 32 + 1;
-    rocblas_int blocksx = (ldw - 1) / 32 + 1;
-    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
+    const rocblas int nx = 32;
+    const rocblas int ny = 32;
+    rocblas_int blocksx = (ldw - 1) / nx + 1;
+    rocblas_int blocksy = (order - 1) / ny + 1;
+    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(nx, ny), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     // compute: V1' * A1
@@ -586,9 +588,11 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    rocblas_int blocksy = (order - 1) / 32 + 1;
-    rocblas_int blocksx = (ldw - 1) / 32 + 1;
-    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
+    const rocblas int nx = 32;
+    const rocblas int ny = 32;
+    rocblas_int blocksx = (ldw - 1) / nx + 1;
+    rocblas_int blocksy = (order - 1) / ny + 1;
+    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(nx, ny), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     // compute: V1' * A1

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -35,6 +35,7 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 #include "rocsolver_run_specialized_kernels.hpp"
+#include "ideal_sizes.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 
@@ -313,11 +314,9 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    const rocblas_int nx = 32;
-    const rocblas_int ny = 32;
-    rocblas_int blocksx = (ldw - 1) / nx + 1;
-    rocblas_int blocksy = (order - 1) / ny + 1;
-    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(nx, ny), 0, stream,
+    rocblas_int blocksx = (ldw - 1) / BS2 + 1;
+    rocblas_int blocksy = (order - 1) / BS2 + 1;
+    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     // compute: V1' * A1
@@ -370,7 +369,7 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
 
     // compute: A1 - V1 * trans(T) * (V1' * A1 + V2' * A2)
     //    or    A1 - (A1 * V1 + A2 * V2) * trans(T) * V1'
-    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
+    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     rocblas_set_pointer_mode(handle, old_mode);
@@ -588,11 +587,9 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    const rocblas_int nx = 32;
-    const rocblas_int ny = 32;
-    rocblas_int blocksx = (ldw - 1) / nx + 1;
-    rocblas_int blocksy = (order - 1) / ny + 1;
-    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(nx, ny), 0, stream,
+    rocblas_int blocksx = (ldw - 1) / BS2 + 1;
+    rocblas_int blocksy = (order - 1) / BS2 + 1;
+    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     // compute: V1' * A1
@@ -651,7 +648,7 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
 
     // compute: A1 - V1 * trans(T) * (V1' * A1 + V2' * A2)
     //    or    A1 - (A1 * V1 + A2 * V2) * trans(T) * V1'
-    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(32, 32), 0, stream,
+    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
                             ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     rocblas_set_pointer_mode(handle, old_mode);

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -57,9 +57,8 @@ ROCSOLVER_KERNEL void copymatA1(const rocblas_int ldw,
 
     if(i < order && j < ldw)
     {
-        T *Ap, *Wp;
-        Wp = tmptr + b * strideW;
-        Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+        T const* __restrict const Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+        T* __restrict const Wp = tmptr + b * strideW;
 
         Wp[i + j * ldw] = Ap[i + j * lda];
     }
@@ -83,9 +82,8 @@ ROCSOLVER_KERNEL void addmatA1(const rocblas_int ldw,
 
     if(i < order && j < ldw)
     {
-        T *Ap, *Wp;
-        Wp = tmptr + b * strideW;
-        Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+        T* __restrict const Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
+        T const* __restrict const Wp = tmptr + b * strideW;
 
         Ap[i + j * lda] -= Wp[i + j * ldw];
     }

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -32,10 +32,10 @@
 
 #pragma once
 
+#include "ideal_sizes.hpp"
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 #include "rocsolver_run_specialized_kernels.hpp"
-#include "ideal_sizes.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 
@@ -313,12 +313,12 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
 
     // copy A1 to tmptr
 
-    auto ceil = [](auto n, auto base) { return( (n-1)/base + 1 ); };
+    auto ceil = [](auto n, auto base) { return ((n - 1) / base + 1); };
 
     auto const blocksx = ceil(ldw, BS2);
     auto const blocksy = ceil(order, BS2);
-    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
-                            ldw, order, A, offsetA1, lda, strideA, tmptr);
+    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0,
+                            stream, ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     // compute: V1' * A1
     //   or    A1 * V1
@@ -370,8 +370,8 @@ rocblas_status rocsolver_larfb_template(rocblas_handle handle,
 
     // compute: A1 - V1 * trans(T) * (V1' * A1 + V2' * A2)
     //    or    A1 - (A1 * V1 + A2 * V2) * trans(T) * V1'
-    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
-                            ldw, order, A, offsetA1, lda, strideA, tmptr);
+    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0,
+                            stream, ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
@@ -588,12 +588,12 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
     uploT = (forward ? rocblas_fill_upper : rocblas_fill_lower);
 
     // copy A1 to tmptr
-    auto ceil = [](auto n, auto base) { return( (n-1)/base + 1 ); };
+    auto ceil = [](auto n, auto base) { return ((n - 1) / base + 1); };
 
     auto const blocksx = ceil(ldw, BS2);
     auto const blocksy = ceil(order, BS2);
-    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
-                            ldw, order, A, offsetA1, lda, strideA, tmptr);
+    ROCSOLVER_LAUNCH_KERNEL(copymatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0,
+                            stream, ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     // compute: V1' * A1
     //   or    A1 * V1
@@ -651,8 +651,8 @@ rocblas_status rocsolver_larfb_inverse_template(rocblas_handle handle,
 
     // compute: A1 - V1 * trans(T) * (V1' * A1 + V2' * A2)
     //    or    A1 - (A1 * V1 + A2 * V2) * trans(T) * V1'
-    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0, stream,
-                            ldw, order, A, offsetA1, lda, strideA, tmptr);
+    ROCSOLVER_LAUNCH_KERNEL(addmatA1, dim3(blocksx, blocksy, batch_count), dim3(BS2, BS2), 0,
+                            stream, ldw, order, A, offsetA1, lda, strideA, tmptr);
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_larfb.hpp
@@ -51,8 +51,8 @@ ROCSOLVER_KERNEL void copymatA1(const rocblas_int ldw,
     const auto blocksizex = hipBlockDim_x;
     const auto blocksizey = hipBlockDim_y;
     const auto b = hipBlockIdx_z;
-    const auto j = hipBlockIdx_x * blocksizex + hipThreadIdx_x;
-    const auto i = hipBlockIdx_y * blocksizey + hipThreadIdx_y;
+    const auto i = hipBlockIdx_x * blocksizex + hipThreadIdx_x;
+    const auto j = hipBlockIdx_y * blocksizey + hipThreadIdx_y;
     rocblas_stride strideW = rocblas_stride(ldw) * order;
 
     if(i < order && j < ldw)
@@ -61,7 +61,7 @@ ROCSOLVER_KERNEL void copymatA1(const rocblas_int ldw,
         Wp = tmptr + b * strideW;
         Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
 
-        Wp[j + i * ldw] = Ap[j + i * lda];
+        Wp[i + j * ldw] = Ap[i + j * lda];
     }
 }
 
@@ -77,8 +77,8 @@ ROCSOLVER_KERNEL void addmatA1(const rocblas_int ldw,
     const auto blocksizex = hipBlockDim_x;
     const auto blocksizey = hipBlockDim_y;
     const auto b = hipBlockIdx_z;
-    const auto j = hipBlockIdx_x * blocksizex + hipThreadIdx_x;
-    const auto i = hipBlockIdx_y * blocksizey + hipThreadIdx_y;
+    const auto i = hipBlockIdx_x * blocksizex + hipThreadIdx_x;
+    const auto j = hipBlockIdx_y * blocksizey + hipThreadIdx_y;
     rocblas_stride strideW = rocblas_stride(ldw) * order;
 
     if(i < order && j < ldw)
@@ -87,7 +87,7 @@ ROCSOLVER_KERNEL void addmatA1(const rocblas_int ldw,
         Wp = tmptr + b * strideW;
         Ap = load_ptr_batch<T>(A, b, shiftA, strideA);
 
-        Ap[j + i * lda] -= Wp[j + i * ldw];
+        Ap[i + j * lda] -= Wp[i + j * ldw];
     }
 }
 


### PR DESCRIPTION
## Motivation

Optimize the kernels `addmatA1` and `copymatA1` in the LARFB routine to read data in a coalesced fashion.

## Technical Details

I reorganized data access to occur in a coalesced fashion.

## Test Plan

Run GTest Suite.

## Test Result

GTest Suite Passes. Kernels appear ~10x faster on gfx1030.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
