### PR TITLE
[HipDNN] Change epsilons for batchnorm

### DIFF
--- a/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormBwdPlan.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormBwdPlan.cpp
@@ -4,6 +4,7 @@
 #include "MiopenBatchnormBwdPlan.hpp"
 #include "HipdnnEnginePluginHandle.hpp"
 #include "MiopenUtils.hpp"
+
 #include <hipdnn_sdk/utilities/Constants.hpp>
 
 namespace miopen_legacy_plugin

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormBwdPlan.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormBwdPlan.cpp
@@ -95,7 +95,7 @@ void BatchnormBwdPlan::execute(const HipdnnEnginePluginHandle& handle,
     float betaDataDiff = 0.0f;
     float alphaParamDiff = 1.0f;
     float betaParamDiff = 0.0f;
-    double epsilon = 1e-3;
+    double epsilon = 1e-5;
 
     auto xBuffer
         = miopen_utils::findDeviceBuffer(_params.x().uid(), deviceBuffers, numDeviceBuffers);

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormBwdPlan.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormBwdPlan.cpp
@@ -4,6 +4,7 @@
 #include "MiopenBatchnormBwdPlan.hpp"
 #include "HipdnnEnginePluginHandle.hpp"
 #include "MiopenUtils.hpp"
+#include <hipdnn_sdk/utilities/Constants.hpp>
 
 namespace miopen_legacy_plugin
 {
@@ -95,7 +96,7 @@ void BatchnormBwdPlan::execute(const HipdnnEnginePluginHandle& handle,
     float betaDataDiff = 0.0f;
     float alphaParamDiff = 1.0f;
     float betaParamDiff = 0.0f;
-    double epsilon = 1e-5;
+    double epsilon = hipdnn_sdk::utilities::BATCHNORM_DEFAULT_EPSILON;
 
     auto xBuffer
         = miopen_utils::findDeviceBuffer(_params.x().uid(), deviceBuffers, numDeviceBuffers);

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
@@ -3,6 +3,7 @@
 
 #include "MiopenBatchnormFwdInferencePlan.hpp"
 #include "MiopenUtils.hpp"
+
 #include <hipdnn_sdk/utilities/Constants.hpp>
 
 namespace miopen_legacy_plugin

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
@@ -73,7 +73,7 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
     // Hardcoded values from bn_driver in miopen
     auto alpha = static_cast<float>(1);
     auto beta = static_cast<float>(0);
-    double epsilon = 1e-3;
+    double epsilon = 1e-5;
 
     auto xBuffer = miopen_utils::findDeviceBuffer(
         _inferenceParams.x().uid(), deviceBuffers, numDeviceBuffers);

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
@@ -3,6 +3,7 @@
 
 #include "MiopenBatchnormFwdInferencePlan.hpp"
 #include "MiopenUtils.hpp"
+#include <hipdnn_sdk/utilities/Constants.hpp>
 
 namespace miopen_legacy_plugin
 {
@@ -73,7 +74,7 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
     // Hardcoded values from bn_driver in miopen
     auto alpha = static_cast<float>(1);
     auto beta = static_cast<float>(0);
-    double epsilon = 1e-5;
+    double epsilon = hipdnn_sdk::utilities::BATCHNORM_DEFAULT_EPSILON;
 
     auto xBuffer = miopen_utils::findDeviceBuffer(
         _inferenceParams.x().uid(), deviceBuffers, numDeviceBuffers);

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -263,7 +263,7 @@ protected:
             cpuTensorBundle.meanTensor,
             cpuTensorBundle.varianceTensor,
             cpuTensorBundle.yTensor,
-            1e-3);
+            1e-5);
     }
 
     void runBatchnormTest(InputType tolerance, const TensorLayout& layout = TensorLayout::NCHW)

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -15,6 +15,7 @@
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/TestUtilities.hpp>
+#include <hipdnn_sdk/utilities/Constants.hpp>
 #include <hipdnn_sdk/utilities/MigratableMemory.hpp>
 #include <hipdnn_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
@@ -263,7 +264,7 @@ protected:
             cpuTensorBundle.meanTensor,
             cpuTensorBundle.varianceTensor,
             cpuTensorBundle.yTensor,
-            1e-5);
+            BATCHNORM_DEFAULT_EPSILON);
     }
 
     void runBatchnormTest(InputType tolerance, const TensorLayout& layout = TensorLayout::NCHW)

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenBatchnormFwdInferenceOperations.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenBatchnormFwdInferenceOperations.cpp
@@ -10,6 +10,7 @@
 #include <hipdnn_sdk/test_utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/TestUtilities.hpp>
+#include <hipdnn_sdk/utilities/Constants.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_sdk/utilities/Tensor.hpp>
 
@@ -21,6 +22,7 @@
 #include "common/Helpers.hpp"
 
 using namespace hipdnn_sdk::test_utilities;
+using namespace hipdnn_sdk::utilities;
 using namespace test_bn_common;
 using namespace test_helpers;
 
@@ -154,7 +156,7 @@ protected:
             meanTensorCpu,
             varianceTensorCpu,
             yTensorCpu,
-            1e-5);
+            BATCHNORM_DEFAULT_EPSILON);
 
         CpuFpReferenceValidation<InputType> cpuRefValidation(tolerance, tolerance);
         EXPECT_TRUE(cpuRefValidation.allClose(yTensorCpu.memory(), yTensor.memory()));

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenBatchnormFwdInferenceOperations.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenBatchnormFwdInferenceOperations.cpp
@@ -154,7 +154,7 @@ protected:
             meanTensorCpu,
             varianceTensorCpu,
             yTensorCpu,
-            1e-3);
+            1e-5);
 
         CpuFpReferenceValidation<InputType> cpuRefValidation(tolerance, tolerance);
         EXPECT_TRUE(cpuRefValidation.allClose(yTensorCpu.memory(), yTensor.memory()));

--- a/projects/hipdnn/samples/batchnorm/BnInference.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInference.cpp
@@ -9,6 +9,7 @@
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
+#include <hipdnn_sdk/utilities/Constants.hpp>
 #include <hipdnn_sdk/utilities/Tensor.hpp>
 
 #include "../utils/Helpers.hpp"
@@ -111,7 +112,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
         }
 
         auto tolerance = test_utilities::batchnorm::getToleranceInference<InputType>();
-        double epsilon = 1e-5;
+        double epsilon = utilities::BATCHNORM_DEFAULT_EPSILON;
 
         test_utilities::CpuFpReferenceBatchnormImpl<InputType, IntermediateType>::
             batchnormFwdInference(

--- a/projects/hipdnn/samples/batchnorm/BnInference.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInference.cpp
@@ -111,7 +111,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
         }
 
         auto tolerance = test_utilities::batchnorm::getToleranceInference<InputType>();
-        double epsilon = 1e-3;
+        double epsilon = 1e-5;
 
         test_utilities::CpuFpReferenceBatchnormImpl<InputType, IntermediateType>::
             batchnormFwdInference(

--- a/projects/hipdnn/samples/batchnorm/BnTraining.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnTraining.cpp
@@ -8,6 +8,7 @@
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
+#include <hipdnn_sdk/utilities/Constants.hpp>
 #include <hipdnn_sdk/utilities/Tensor.hpp>
 
 #include "../utils/Helpers.hpp"
@@ -97,7 +98,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
                                        static_cast<IntermediateType>(1.0f));
 
     momentumTensor.memory().hostData()[0] = 0.1f;
-    epsilonTensor.memory().hostData()[0] = 1e-5f;
+    epsilonTensor.memory().hostData()[0] = utilities::BATCHNORM_DEFAULT_EPSILON;
 
     std::unordered_map<int64_t, void*> variantPack;
 

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/cpu_graph_executor/BatchnormFwdInferencePlan.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/cpu_graph_executor/BatchnormFwdInferencePlan.hpp
@@ -148,7 +148,7 @@ public:
                                            *tensorMap.at(nodeAttributes->bias_tensor_uid()),
                                            *tensorMap.at(nodeAttributes->mean_tensor_uid()),
                                            *tensorMap.at(nodeAttributes->inv_variance_tensor_uid()),
-                                           1e-3);
+                                           1e-5);
 
         return std::make_unique<
             BatchnormFwdPlan<InputDataType, ScaleBiasDataType, MeanVarianceDataType>>(

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/cpu_graph_executor/BatchnormFwdInferencePlan.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/test_utilities/cpu_graph_executor/BatchnormFwdInferencePlan.hpp
@@ -14,6 +14,7 @@
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/IGraphNodePlanBuilder.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/IGraphNodePlanExecutor.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/PlanUtils.hpp>
+#include <hipdnn_sdk/utilities/Constants.hpp>
 
 namespace hipdnn_sdk::test_utilities
 {
@@ -148,12 +149,11 @@ public:
                                            *tensorMap.at(nodeAttributes->bias_tensor_uid()),
                                            *tensorMap.at(nodeAttributes->mean_tensor_uid()),
                                            *tensorMap.at(nodeAttributes->inv_variance_tensor_uid()),
-                                           1e-5);
+                                           utilities::BATCHNORM_DEFAULT_EPSILON);
 
         return std::make_unique<
             BatchnormFwdPlan<InputDataType, ScaleBiasDataType, MeanVarianceDataType>>(
             std::move(params));
     }
 };
-
 }

--- a/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/Constants.hpp
+++ b/projects/hipdnn/sdk/include/hipdnn_sdk/utilities/Constants.hpp
@@ -1,0 +1,9 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+namespace hipdnn_sdk::utilities
+{
+constexpr double BATCHNORM_DEFAULT_EPSILON = 1e-5;
+} // namespace hipdnn_sdk::utilities

--- a/projects/hipdnn/sdk/tests/test_utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <hipdnn_sdk/test_utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_sdk/test_utilities/TestUtilities.hpp>
+#include <hipdnn_sdk/utilities/Constants.hpp>
 #include <hipdnn_sdk/utilities/Tensor.hpp>
 #include <hipdnn_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_sdk/utilities/UtilsFp16.hpp>
@@ -23,8 +24,13 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInferenceNchw)
     Tensor<float> meanTensor({1, 3});
     Tensor<float> varianceTensor({1, 3});
 
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(inputTensor,
+                                                                     scaleTensor,
+                                                                     biasTensor,
+                                                                     meanTensor,
+                                                                     varianceTensor,
+                                                                     outputTensor,
+                                                                     BATCHNORM_DEFAULT_EPSILON);
 }
 
 TEST(TestCpuFpReferenceBatchnormBfp16, BatchnormFwdInferenceNchw)
@@ -37,7 +43,13 @@ TEST(TestCpuFpReferenceBatchnormBfp16, BatchnormFwdInferenceNchw)
     Tensor<float> varianceTensor({1, 3});
 
     CpuFpReferenceBatchnormImpl<hip_bfloat16, float>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        meanTensor,
+        varianceTensor,
+        outputTensor,
+        BATCHNORM_DEFAULT_EPSILON);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp16, BatchnormFwdInferenceNchw)
@@ -49,8 +61,13 @@ TEST(TestCpuFpReferenceBatchnormFp16, BatchnormFwdInferenceNchw)
     Tensor<float> meanTensor({1, 3});
     Tensor<float> varianceTensor({1, 3});
 
-    CpuFpReferenceBatchnormImpl<half, float>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+    CpuFpReferenceBatchnormImpl<half, float>::batchnormFwdInference(inputTensor,
+                                                                    scaleTensor,
+                                                                    biasTensor,
+                                                                    meanTensor,
+                                                                    varianceTensor,
+                                                                    outputTensor,
+                                                                    BATCHNORM_DEFAULT_EPSILON);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdInferenceNchw)
@@ -62,8 +79,13 @@ TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdInferenceNchw)
     Tensor<double> meanTensor({1, 3});
     Tensor<double> varianceTensor({1, 3});
 
-    CpuFpReferenceBatchnormImpl<double, double>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+    CpuFpReferenceBatchnormImpl<double, double>::batchnormFwdInference(inputTensor,
+                                                                       scaleTensor,
+                                                                       biasTensor,
+                                                                       meanTensor,
+                                                                       varianceTensor,
+                                                                       outputTensor,
+                                                                       BATCHNORM_DEFAULT_EPSILON);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInferenceNhwc)
@@ -75,8 +97,13 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInferenceNhwc)
     Tensor<float> meanTensor({1, 3});
     Tensor<float> varianceTensor({1, 3});
 
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(inputTensor,
+                                                                     scaleTensor,
+                                                                     biasTensor,
+                                                                     meanTensor,
+                                                                     varianceTensor,
+                                                                     outputTensor,
+                                                                     BATCHNORM_DEFAULT_EPSILON);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdInferenceSanityValidationNchw)
@@ -112,8 +139,13 @@ TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdInferenceSanityValidationNchw)
     // where inv_variance (named by convention) = 1 / sqrt(1.25 + 1e-5) = 0.894423613312618
     const std::vector<double> expectedOutput = {-2.18327084, -0.39442361, 1.39442361, 3.18327084};
 
-    CpuFpReferenceBatchnormImpl<double, double>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+    CpuFpReferenceBatchnormImpl<double, double>::batchnormFwdInference(inputTensor,
+                                                                       scaleTensor,
+                                                                       biasTensor,
+                                                                       meanTensor,
+                                                                       varianceTensor,
+                                                                       outputTensor,
+                                                                       BATCHNORM_DEFAULT_EPSILON);
 
     auto tolerance = 1e-6;
 
@@ -142,8 +174,13 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInference2D)
         varianceTensor.setHostValue(0.0f, 0, i);
     }
 
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(inputTensor,
+                                                                     scaleTensor,
+                                                                     biasTensor,
+                                                                     meanTensor,
+                                                                     varianceTensor,
+                                                                     outputTensor,
+                                                                     BATCHNORM_DEFAULT_EPSILON);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInference3D)
@@ -166,8 +203,13 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInference3D)
         varianceTensor.setHostValue(1.0f, 0, i);
     }
 
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(inputTensor,
+                                                                     scaleTensor,
+                                                                     biasTensor,
+                                                                     meanTensor,
+                                                                     varianceTensor,
+                                                                     outputTensor,
+                                                                     BATCHNORM_DEFAULT_EPSILON);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInferenceNcdhw)
@@ -189,8 +231,13 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInferenceNcdhw)
         varianceTensor.setHostValue(0.5f, 0, i);
     }
 
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(inputTensor,
+                                                                     scaleTensor,
+                                                                     biasTensor,
+                                                                     meanTensor,
+                                                                     varianceTensor,
+                                                                     outputTensor,
+                                                                     BATCHNORM_DEFAULT_EPSILON);
 }
 
 TEST(TestCpuFpReferenceBatchnormBfp16, BatchnormFwdInferenceNdhwc)
@@ -211,8 +258,13 @@ TEST(TestCpuFpReferenceBatchnormBfp16, BatchnormFwdInferenceNdhwc)
         varianceTensor.setHostValue(1.0f, 0, i);
     }
 
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(
-        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor, 1e-5);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdInference(inputTensor,
+                                                                     scaleTensor,
+                                                                     biasTensor,
+                                                                     meanTensor,
+                                                                     varianceTensor,
+                                                                     outputTensor,
+                                                                     BATCHNORM_DEFAULT_EPSILON);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormBackwardNchw)
@@ -525,7 +577,7 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwBasic)
 
     // Call without optional tensors
     CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
-        inputTensor, scaleTensor, biasTensor, outputTensor, 1e-5f, 0.1f);
+        inputTensor, scaleTensor, biasTensor, outputTensor, BATCHNORM_DEFAULT_EPSILON, 0.1f);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwWithSavedStats)
@@ -549,7 +601,7 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwWithSavedStats)
                                                                     scaleTensor,
                                                                     biasTensor,
                                                                     outputTensor,
-                                                                    1e-5f,
+                                                                    BATCHNORM_DEFAULT_EPSILON,
                                                                     0.1f,
                                                                     &savedMean,
                                                                     &savedInvVariance);
@@ -589,7 +641,7 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwWithRunningStats)
                                                                     scaleTensor,
                                                                     biasTensor,
                                                                     outputTensor,
-                                                                    1e-5f,
+                                                                    BATCHNORM_DEFAULT_EPSILON,
                                                                     momentum,
                                                                     nullptr,
                                                                     nullptr,
@@ -650,7 +702,7 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwFullFeatures)
                                                                     scaleTensor,
                                                                     biasTensor,
                                                                     outputTensor,
-                                                                    1e-5f,
+                                                                    BATCHNORM_DEFAULT_EPSILON,
                                                                     0.1f,
                                                                     &savedMean,
                                                                     &savedInvVariance,
@@ -698,14 +750,15 @@ TEST(TestCpuFpReferenceBatchnormBfp16, BatchnormFwdTrainingNchw)
         biasTensor.setHostValue(0.0f, 0, i);
     }
 
-    CpuFpReferenceBatchnormImpl<hip_bfloat16, float>::batchnormFwdTraining(inputTensor,
-                                                                           scaleTensor,
-                                                                           biasTensor,
-                                                                           outputTensor,
-                                                                           1e-5f,
-                                                                           0.1f,
-                                                                           &savedMean,
-                                                                           &savedInvVariance);
+    CpuFpReferenceBatchnormImpl<hip_bfloat16, float>::batchnormFwdTraining(
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        BATCHNORM_DEFAULT_EPSILON,
+        0.1f,
+        &savedMean,
+        &savedInvVariance);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp16, BatchnormFwdTrainingNchw)
@@ -728,7 +781,7 @@ TEST(TestCpuFpReferenceBatchnormFp16, BatchnormFwdTrainingNchw)
                                                                    scaleTensor,
                                                                    biasTensor,
                                                                    outputTensor,
-                                                                   1e-5f,
+                                                                   BATCHNORM_DEFAULT_EPSILON,
                                                                    0.1f,
                                                                    &savedMean,
                                                                    &savedInvVariance);
@@ -754,7 +807,7 @@ TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdTrainingNchw)
                                                                       scaleTensor,
                                                                       biasTensor,
                                                                       outputTensor,
-                                                                      1e-5,
+                                                                      BATCHNORM_DEFAULT_EPSILON,
                                                                       0.1,
                                                                       &savedMean,
                                                                       &savedInvVariance);
@@ -789,7 +842,7 @@ TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdTrainingSanityValidationNchw)
     prevRunningMean.setHostValue(0.0, 0, 0);
     prevRunningVariance.setHostValue(1.0, 0, 0);
 
-    double epsilon = 1e-5;
+    double epsilon = BATCHNORM_DEFAULT_EPSILON;
     double momentum = 0.1;
 
     // During training, batch statistics are calculated:
@@ -849,7 +902,7 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTraining2D)
     }
 
     CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
-        inputTensor, scaleTensor, biasTensor, outputTensor, 1e-5f, 0.1f);
+        inputTensor, scaleTensor, biasTensor, outputTensor, BATCHNORM_DEFAULT_EPSILON, 0.1f);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTraining3D)
@@ -868,7 +921,7 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTraining3D)
     }
 
     CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
-        inputTensor, scaleTensor, biasTensor, outputTensor, 1e-5f, 0.1f);
+        inputTensor, scaleTensor, biasTensor, outputTensor, BATCHNORM_DEFAULT_EPSILON, 0.1f);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNcdhw)
@@ -892,7 +945,7 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNcdhw)
                                                                     scaleTensor,
                                                                     biasTensor,
                                                                     outputTensor,
-                                                                    1e-5f,
+                                                                    BATCHNORM_DEFAULT_EPSILON,
                                                                     0.1f,
                                                                     &savedMean,
                                                                     &savedInvVariance);
@@ -919,7 +972,7 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNdhwc)
                                                                     scaleTensor,
                                                                     biasTensor,
                                                                     outputTensor,
-                                                                    1e-5f,
+                                                                    BATCHNORM_DEFAULT_EPSILON,
                                                                     0.1f,
                                                                     &savedMean,
                                                                     &savedInvVariance);

--- a/projects/hipdnn/sdk/tests/test_utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -577,7 +577,12 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwBasic)
 
     // Call without optional tensors
     CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
-        inputTensor, scaleTensor, biasTensor, outputTensor, BATCHNORM_DEFAULT_EPSILON, 0.1f);
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
+        0.1f);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwWithSavedStats)
@@ -597,14 +602,15 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwWithSavedStats)
     }
 
     // Call with saved statistics for backward pass
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(inputTensor,
-                                                                    scaleTensor,
-                                                                    biasTensor,
-                                                                    outputTensor,
-                                                                    BATCHNORM_DEFAULT_EPSILON,
-                                                                    0.1f,
-                                                                    &savedMean,
-                                                                    &savedInvVariance);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
+        0.1f,
+        &savedMean,
+        &savedInvVariance);
 
     // Verify saved statistics were populated
     for(int i = 0; i < 3; i++)
@@ -637,18 +643,19 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwWithRunningStats)
     float momentum = 0.1f;
 
     // Call with running statistics
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(inputTensor,
-                                                                    scaleTensor,
-                                                                    biasTensor,
-                                                                    outputTensor,
-                                                                    BATCHNORM_DEFAULT_EPSILON,
-                                                                    momentum,
-                                                                    nullptr,
-                                                                    nullptr,
-                                                                    &prevRunningMean,
-                                                                    &prevRunningVariance,
-                                                                    &nextRunningMean,
-                                                                    &nextRunningVariance);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
+        momentum,
+        nullptr,
+        nullptr,
+        &prevRunningMean,
+        &prevRunningVariance,
+        &nextRunningMean,
+        &nextRunningVariance);
 
     // Verify running statistics were updated
     for(int i = 0; i < 3; i++)
@@ -698,18 +705,19 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNchwFullFeatures)
     }
 
     // Call with all optional parameters
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(inputTensor,
-                                                                    scaleTensor,
-                                                                    biasTensor,
-                                                                    outputTensor,
-                                                                    BATCHNORM_DEFAULT_EPSILON,
-                                                                    0.1f,
-                                                                    &savedMean,
-                                                                    &savedInvVariance,
-                                                                    &prevRunningMean,
-                                                                    &prevRunningVariance,
-                                                                    &nextRunningMean,
-                                                                    &nextRunningVariance);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
+        0.1f,
+        &savedMean,
+        &savedInvVariance,
+        &prevRunningMean,
+        &prevRunningVariance,
+        &nextRunningMean,
+        &nextRunningVariance);
 
     // Verify all outputs were populated
     for(int i = 0; i < 3; i++)
@@ -755,7 +763,7 @@ TEST(TestCpuFpReferenceBatchnormBfp16, BatchnormFwdTrainingNchw)
         scaleTensor,
         biasTensor,
         outputTensor,
-        BATCHNORM_DEFAULT_EPSILON,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
         0.1f,
         &savedMean,
         &savedInvVariance);
@@ -777,14 +785,15 @@ TEST(TestCpuFpReferenceBatchnormFp16, BatchnormFwdTrainingNchw)
         biasTensor.setHostValue(0.0f, 0, i);
     }
 
-    CpuFpReferenceBatchnormImpl<half, float>::batchnormFwdTraining(inputTensor,
-                                                                   scaleTensor,
-                                                                   biasTensor,
-                                                                   outputTensor,
-                                                                   BATCHNORM_DEFAULT_EPSILON,
-                                                                   0.1f,
-                                                                   &savedMean,
-                                                                   &savedInvVariance);
+    CpuFpReferenceBatchnormImpl<half, float>::batchnormFwdTraining(
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
+        0.1f,
+        &savedMean,
+        &savedInvVariance);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdTrainingNchw)
@@ -902,7 +911,12 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTraining2D)
     }
 
     CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
-        inputTensor, scaleTensor, biasTensor, outputTensor, BATCHNORM_DEFAULT_EPSILON, 0.1f);
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
+        0.1f);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTraining3D)
@@ -921,7 +935,12 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTraining3D)
     }
 
     CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
-        inputTensor, scaleTensor, biasTensor, outputTensor, BATCHNORM_DEFAULT_EPSILON, 0.1f);
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
+        0.1f);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNcdhw)
@@ -941,14 +960,15 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNcdhw)
         biasTensor.setHostValue(0.0f, 0, i);
     }
 
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(inputTensor,
-                                                                    scaleTensor,
-                                                                    biasTensor,
-                                                                    outputTensor,
-                                                                    BATCHNORM_DEFAULT_EPSILON,
-                                                                    0.1f,
-                                                                    &savedMean,
-                                                                    &savedInvVariance);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
+        0.1f,
+        &savedMean,
+        &savedInvVariance);
 }
 
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNdhwc)
@@ -968,12 +988,13 @@ TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdTrainingNdhwc)
         biasTensor.setHostValue(0.0f, 0, i);
     }
 
-    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(inputTensor,
-                                                                    scaleTensor,
-                                                                    biasTensor,
-                                                                    outputTensor,
-                                                                    BATCHNORM_DEFAULT_EPSILON,
-                                                                    0.1f,
-                                                                    &savedMean,
-                                                                    &savedInvVariance);
+    CpuFpReferenceBatchnormImpl<float, float>::batchnormFwdTraining(
+        inputTensor,
+        scaleTensor,
+        biasTensor,
+        outputTensor,
+        static_cast<float>(BATCHNORM_DEFAULT_EPSILON),
+        0.1f,
+        &savedMean,
+        &savedInvVariance);
 }

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/BatchnormTensorBundles.hpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/BatchnormTensorBundles.hpp
@@ -8,6 +8,7 @@
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 #include <hipdnn_sdk/plugin/flatbuffer_utilities/NodeWrapper.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/GraphTensorBundle.hpp>
+#include <hipdnn_sdk/utilities/Constants.hpp>
 #include <hipdnn_sdk/utilities/Tensor.hpp>
 
 using namespace hipdnn_sdk::utilities;
@@ -68,7 +69,7 @@ struct BatchnormTrainTensorBundle
         invVarianceTensor.fillWithRandomValues(
             static_cast<MeanVarianceDataType>(1.9f), static_cast<MeanVarianceDataType>(2.0f), seed);
 
-        epsilonTensor.fillWithValue(static_cast<MeanVarianceDataType>(1e-5f));
+        epsilonTensor.fillWithValue(static_cast<MeanVarianceDataType>(BATCHNORM_DEFAULT_EPSILON));
 
         if(useOptionalTensors)
         {

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/BatchnormTensorBundles.hpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/BatchnormTensorBundles.hpp
@@ -69,7 +69,8 @@ struct BatchnormTrainTensorBundle
         invVarianceTensor.fillWithRandomValues(
             static_cast<MeanVarianceDataType>(1.9f), static_cast<MeanVarianceDataType>(2.0f), seed);
 
-        epsilonTensor.fillWithValue(static_cast<MeanVarianceDataType>(BATCHNORM_DEFAULT_EPSILON));
+        epsilonTensor.fillWithValue(
+            static_cast<MeanVarianceDataType>(static_cast<float>(BATCHNORM_DEFAULT_EPSILON)));
 
         if(useOptionalTensors)
         {

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestBatchnormBwdPlan.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestBatchnormBwdPlan.cpp
@@ -9,6 +9,7 @@
 #include <hipdnn_sdk/plugin/test_utils/MockGraph.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/BatchnormBwdPlan.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
 
@@ -77,8 +78,8 @@ TEST_F(TestBatchnormBwdPlan, ExecutePlan)
 
     bwdPlan.execute(variantPack);
 
-    CpuFpReferenceValidation<float> cpuRefOutputValidation(static_cast<float>(1e-3),
-                                                           static_cast<float>(1e-3));
+    CpuFpReferenceValidation<float> cpuRefOutputValidation(
+        batchnorm::getToleranceBackward<float>(), batchnorm::getToleranceBackward<float>());
 
     EXPECT_TRUE(cpuRefOutputValidation.allClose(directTensorBundle.dxTensor.memory(),
                                                 planTensorBundle.dxTensor.memory()));

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestBatchnormFwdInferencePlan.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestBatchnormFwdInferencePlan.cpp
@@ -39,7 +39,7 @@ protected:
 TEST_F(TestBatchnormFwdPlan, ExecutePlan)
 {
     auto tolerance = batchnorm::getToleranceInference<float>();
-    double epsilon = 1e-3;
+    double epsilon = 1e-5;
     std::vector<int64_t> dims = {6, 3, 32, 32};
     unsigned int seed = 1;
     auto graph = buildBatchnormFwdInferenceGraph(

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestBatchnormFwdInferencePlan.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestBatchnormFwdInferencePlan.cpp
@@ -11,6 +11,7 @@
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/BatchnormFwdInferencePlan.hpp>
+#include <hipdnn_sdk/utilities/Constants.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
 
 using namespace hipdnn_sdk::test_utilities;
@@ -39,7 +40,7 @@ protected:
 TEST_F(TestBatchnormFwdPlan, ExecutePlan)
 {
     auto tolerance = batchnorm::getToleranceInference<float>();
-    double epsilon = 1e-5;
+    double epsilon = BATCHNORM_DEFAULT_EPSILON;
     std::vector<int64_t> dims = {6, 3, 32, 32};
     unsigned int seed = 1;
     auto graph = buildBatchnormFwdInferenceGraph(

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestBatchnormTrainPlan.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestBatchnormTrainPlan.cpp
@@ -10,6 +10,7 @@
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/BatchnormTrainPlan.hpp>
+#include <hipdnn_sdk/utilities/Constants.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
 
 using namespace hipdnn_sdk::test_utilities;
@@ -36,7 +37,7 @@ protected:
 
 TEST_F(TestBatchnormTrainPlan, ExecutePlan)
 {
-    double epsilon = 1e-5;
+    double epsilon = BATCHNORM_DEFAULT_EPSILON;
     double momentum = 0.1;
     std::vector<int64_t> dims = {6, 3, 32, 32};
     unsigned int seed = 1;

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestConvolutionBwdPlan.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestConvolutionBwdPlan.cpp
@@ -9,6 +9,7 @@
 #include <hipdnn_sdk/plugin/test_utils/MockGraph.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/ConvolutionBwdPlan.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
 
@@ -36,7 +37,6 @@ protected:
 
 TEST_F(TestConvolutionBwdPlan, ExecutePlan)
 {
-    double epsilon = 1e-3;
     std::vector<int64_t> dxDims = {1, 1, 2, 2};
     std::vector<int64_t> wDims = {1, 1, 1, 1};
     std::vector<int64_t> dyDims = {1, 1, 2, 2};
@@ -76,8 +76,8 @@ TEST_F(TestConvolutionBwdPlan, ExecutePlan)
 
     patient.execute(variantPack);
 
-    CpuFpReferenceValidation<float> cpuRefOutputValidation(static_cast<float>(epsilon),
-                                                           static_cast<float>(epsilon));
+    CpuFpReferenceValidation<float> cpuRefOutputValidation(conv::getToleranceBwd<float>(),
+                                                           conv::getToleranceBwd<float>());
 
     EXPECT_TRUE(cpuRefOutputValidation.allClose(directTensorBundle.dxTensor.memory(),
                                                 planTensorBundle.dxTensor.memory()));

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestConvolutionFwdPlan.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestConvolutionFwdPlan.cpp
@@ -9,6 +9,7 @@
 #include <hipdnn_sdk/plugin/test_utils/MockGraph.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/ConvolutionFwdPlan.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
 
@@ -36,7 +37,6 @@ protected:
 
 TEST_F(TestConvolutionFwdPlan, ExecutePlan)
 {
-    double epsilon = 1e-3;
     std::vector<int64_t> xDims = {1, 1, 2, 2};
     std::vector<int64_t> wDims = {1, 1, 1, 1};
     std::vector<int64_t> yDims = {1, 1, 2, 2};
@@ -76,8 +76,8 @@ TEST_F(TestConvolutionFwdPlan, ExecutePlan)
 
     patient.execute(variantPack);
 
-    CpuFpReferenceValidation<float> cpuRefOutputValidation(static_cast<float>(epsilon),
-                                                           static_cast<float>(epsilon));
+    CpuFpReferenceValidation<float> cpuRefOutputValidation(conv::getToleranceFwd<float>(),
+                                                           conv::getToleranceFwd<float>());
 
     EXPECT_TRUE(cpuRefOutputValidation.allClose(directTensorBundle.yTensor.memory(),
                                                 planTensorBundle.yTensor.memory()));

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
@@ -12,6 +12,7 @@
 #include "ConvolutionGraphUtils.hpp"
 #include "PointwiseGraphUtils.hpp"
 #include "PointwiseTensorBundles.hpp"
+
 #include <hipdnn_sdk/plugin/EnginePluginApi.h>
 #include <hipdnn_sdk/plugin/PluginApiDataTypes.h>
 #include <hipdnn_sdk/plugin/flatbuffer_utilities/GraphWrapper.hpp>

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestFusedOperationsCpuGraphExecutor.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestFusedOperationsCpuGraphExecutor.cpp
@@ -8,6 +8,7 @@
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_sdk/test_utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_sdk/test_utilities/TestTolerances.hpp>
 #include <hipdnn_sdk/test_utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp>
 #include <hipdnn_sdk/test_utilities/pointwise/BinaryOperationFunctors.hpp>
 #include <hipdnn_sdk/utilities/ShapeUtilities.hpp>
@@ -24,7 +25,7 @@ class TestFusedOperationsCpuGraphExecutor : public ::testing::Test
 
 TEST_F(TestFusedOperationsCpuGraphExecutor, ConvAddMulFusedGraph)
 {
-    double epsilon = 1e-3;
+    auto tolerance = pointwise::getTolerance<float>();
     std::vector<int64_t> xDims = {1, 1, 2, 2};
     std::vector<int64_t> wDims = {1, 1, 1, 1};
     std::vector<int64_t> yDims = {1, 1, 2, 2};
@@ -184,8 +185,7 @@ TEST_F(TestFusedOperationsCpuGraphExecutor, ConvAddMulFusedGraph)
     }
 
     // Validate results
-    CpuFpReferenceValidation<float> cpuRefOutputValidation(static_cast<float>(epsilon),
-                                                           static_cast<float>(epsilon));
+    CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
 
     EXPECT_TRUE(cpuRefOutputValidation.allClose(refYTensor.memory(), yTensor.memory()));
 }


### PR DESCRIPTION
## Motivation

Decrease the size of epsilon used for batchnorm operations to 1e-5.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
