### PR TITLE
[hipBLAS] avoid clang static analysis false failure

### DIFF
--- a/projects/hipblas/clients/common/host_alloc.cpp
+++ b/projects/hipblas/clients/common/host_alloc.cpp
@@ -60,6 +60,7 @@ inline void free_ptr_use(void* ptr)
         mem_used -= mem_allocated[ptr];
         mem_allocated.erase(ptr);
     }
+    free(ptr);
 }
 
 size_t host_bytes_allocated()
@@ -224,6 +225,5 @@ void* host_calloc(size_t nmemb, size_t size)
 
 void host_free(void* ptr)
 {
-    free(ptr);
     free_ptr_use(ptr);
 }


### PR DESCRIPTION
* move free inside lock to release counters before free and thus avoids clang warning