### PR TITLE
[hipDNN] Add MiopenActivationDescriptor & tests

### DIFF
--- a/projects/hipdnn/plugins/miopen_legacy_plugin/CMakeLists.txt
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(miopen_legacy_plugin_private
     engines/plans/MiopenConvWrwPlan.cpp
     engines/plans/MiopenConvPlanBuilder.cpp
     EngineManager.cpp
+    MiopenActivationDescriptor.cpp
     MiopenHandleFactory.cpp
     MiopenContainer.cpp
     MiopenConvDescriptor.cpp

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenActivationDescriptor.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenActivationDescriptor.cpp
@@ -1,0 +1,142 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "MiopenActivationDescriptor.hpp"
+#include "MiopenUtils.hpp"
+
+#include <hipdnn_sdk/plugin/PluginException.hpp>
+#include <optional>
+
+namespace miopen_legacy_plugin
+{
+
+namespace
+{
+
+struct ActivationParams
+{
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+};
+
+std::optional<ActivationParams>
+    mapPointwiseModeToMiopenActivation(const hipdnn_sdk::data_objects::PointwiseAttributes& attrs)
+{
+    using PM = hipdnn_sdk::data_objects::PointwiseMode;
+
+    switch(attrs.operation())
+    {
+    case PM::RELU_FWD:
+    case PM::RELU_BWD:
+    {
+        if(attrs.relu_lower_clip() && attrs.relu_upper_clip())
+        {
+            // CLAMP
+            return ActivationParams{miopenActivationCLAMP,
+                                    static_cast<double>(*attrs.relu_lower_clip()),
+                                    static_cast<double>(*attrs.relu_upper_clip()),
+                                    0.0};
+        }
+        if(attrs.relu_upper_clip())
+        {
+            // Clipped ReLU
+            return ActivationParams{miopenActivationCLIPPEDRELU,
+                                    static_cast<double>(*attrs.relu_upper_clip()),
+                                    0.0,
+                                    0.0};
+        }
+        if(attrs.relu_lower_clip_slope())
+        {
+            // Leaky ReLU
+            return ActivationParams{miopenActivationLEAKYRELU,
+                                    static_cast<double>(*attrs.relu_lower_clip_slope()),
+                                    0.0,
+                                    0.0};
+        }
+        // Standard ReLU
+        return ActivationParams{miopenActivationRELU, 0.0, 0.0, 0.0};
+    }
+    case PM::SIGMOID_FWD:
+    case PM::SIGMOID_BWD:
+        return ActivationParams{miopenActivationLOGISTIC, 0.0, 0.0, 0.0};
+    case PM::TANH_FWD:
+    case PM::TANH_BWD:
+        return ActivationParams{miopenActivationTANH, 1.0, 1.0, 0.0};
+    case PM::ELU_FWD:
+    case PM::ELU_BWD:
+    {
+        double alpha = attrs.elu_alpha() ? static_cast<double>(*attrs.elu_alpha()) : 1.0;
+        return ActivationParams{miopenActivationELU, alpha, 0.0, 0.0};
+    }
+    case PM::SOFTPLUS_FWD:
+    case PM::SOFTPLUS_BWD:
+        return ActivationParams{miopenActivationSOFTRELU, 0.0, 0.0, 0.0};
+    case PM::ABS:
+        return ActivationParams{miopenActivationABS, 0.0, 0.0, 0.0};
+    case PM::IDENTITY:
+        return ActivationParams{miopenActivationPASTHRU, 0.0, 0.0, 0.0};
+    default:
+        return std::nullopt;
+    }
+}
+
+} // namespace
+
+MiopenActivationDescriptor::MiopenActivationDescriptor(
+    const hipdnn_sdk::data_objects::PointwiseAttributes& pointwiseAttrs)
+{
+    const auto params = mapPointwiseModeToMiopenActivation(pointwiseAttrs);
+    if(!params.has_value())
+    {
+        // TODO: make a common pointwise mode to string function
+        throw hipdnn_plugin::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Unsupported pointwise mode for activation descriptor: "
+                + std::to_string(static_cast<int>(pointwiseAttrs.operation())));
+    }
+
+    THROW_ON_MIOPEN_FAILURE(miopenCreateActivationDescriptor(&_descriptor));
+    THROW_ON_MIOPEN_FAILURE(miopenSetActivationDescriptor(
+        _descriptor, params->mode, params->alpha, params->beta, params->gamma));
+}
+
+MiopenActivationDescriptor::MiopenActivationDescriptor(MiopenActivationDescriptor&& other) noexcept
+    : _descriptor(other._descriptor)
+{
+    other._descriptor = nullptr;
+}
+
+MiopenActivationDescriptor&
+    MiopenActivationDescriptor::operator=(MiopenActivationDescriptor&& other) noexcept
+{
+    if(this == &other)
+    {
+        return *this;
+    }
+
+    if(_descriptor != nullptr)
+    {
+        LOG_ON_MIOPEN_FAILURE(miopenDestroyActivationDescriptor(_descriptor));
+    }
+
+    _descriptor = other._descriptor;
+    other._descriptor = nullptr;
+    return *this;
+}
+
+MiopenActivationDescriptor::~MiopenActivationDescriptor()
+{
+    if(_descriptor != nullptr)
+    {
+        LOG_ON_MIOPEN_FAILURE(miopenDestroyActivationDescriptor(_descriptor));
+    }
+}
+
+miopenActivationDescriptor_t MiopenActivationDescriptor::activationDescriptor() const
+{
+    return _descriptor;
+}
+
+} // namespace miopen_legacy_plugin

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenActivationDescriptor.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenActivationDescriptor.cpp
@@ -15,7 +15,6 @@ MiopenActivationDescriptor::MiopenActivationDescriptor(
     const auto params = miopen_utils::mapPointwiseModeToMiopenActivation(pointwiseAttrs);
     if(!params.has_value())
     {
-        // TODO: make a common pointwise mode to string function
         throw hipdnn_plugin::HipdnnPluginException(
             HIPDNN_PLUGIN_STATUS_BAD_PARAM,
             "Unsupported pointwise mode for activation descriptor: "

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenActivationDescriptor.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenActivationDescriptor.cpp
@@ -5,89 +5,14 @@
 #include "MiopenUtils.hpp"
 
 #include <hipdnn_sdk/plugin/PluginException.hpp>
-#include <optional>
 
 namespace miopen_legacy_plugin
 {
 
-namespace
-{
-
-struct ActivationParams
-{
-    miopenActivationMode_t mode;
-    double alpha;
-    double beta;
-    double gamma;
-};
-
-std::optional<ActivationParams>
-    mapPointwiseModeToMiopenActivation(const hipdnn_sdk::data_objects::PointwiseAttributes& attrs)
-{
-    using PM = hipdnn_sdk::data_objects::PointwiseMode;
-
-    switch(attrs.operation())
-    {
-    case PM::RELU_FWD:
-    case PM::RELU_BWD:
-    {
-        if(attrs.relu_lower_clip() && attrs.relu_upper_clip())
-        {
-            // CLAMP
-            return ActivationParams{miopenActivationCLAMP,
-                                    static_cast<double>(*attrs.relu_lower_clip()),
-                                    static_cast<double>(*attrs.relu_upper_clip()),
-                                    0.0};
-        }
-        if(attrs.relu_upper_clip())
-        {
-            // Clipped ReLU
-            return ActivationParams{miopenActivationCLIPPEDRELU,
-                                    static_cast<double>(*attrs.relu_upper_clip()),
-                                    0.0,
-                                    0.0};
-        }
-        if(attrs.relu_lower_clip_slope())
-        {
-            // Leaky ReLU
-            return ActivationParams{miopenActivationLEAKYRELU,
-                                    static_cast<double>(*attrs.relu_lower_clip_slope()),
-                                    0.0,
-                                    0.0};
-        }
-        // Standard ReLU
-        return ActivationParams{miopenActivationRELU, 0.0, 0.0, 0.0};
-    }
-    case PM::SIGMOID_FWD:
-    case PM::SIGMOID_BWD:
-        return ActivationParams{miopenActivationLOGISTIC, 0.0, 0.0, 0.0};
-    case PM::TANH_FWD:
-    case PM::TANH_BWD:
-        return ActivationParams{miopenActivationTANH, 1.0, 1.0, 0.0};
-    case PM::ELU_FWD:
-    case PM::ELU_BWD:
-    {
-        double alpha = attrs.elu_alpha() ? static_cast<double>(*attrs.elu_alpha()) : 1.0;
-        return ActivationParams{miopenActivationELU, alpha, 0.0, 0.0};
-    }
-    case PM::SOFTPLUS_FWD:
-    case PM::SOFTPLUS_BWD:
-        return ActivationParams{miopenActivationSOFTRELU, 0.0, 0.0, 0.0};
-    case PM::ABS:
-        return ActivationParams{miopenActivationABS, 0.0, 0.0, 0.0};
-    case PM::IDENTITY:
-        return ActivationParams{miopenActivationPASTHRU, 0.0, 0.0, 0.0};
-    default:
-        return std::nullopt;
-    }
-}
-
-} // namespace
-
 MiopenActivationDescriptor::MiopenActivationDescriptor(
     const hipdnn_sdk::data_objects::PointwiseAttributes& pointwiseAttrs)
 {
-    const auto params = mapPointwiseModeToMiopenActivation(pointwiseAttrs);
+    const auto params = miopen_utils::mapPointwiseModeToMiopenActivation(pointwiseAttrs);
     if(!params.has_value())
     {
         // TODO: make a common pointwise mode to string function

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenActivationDescriptor.hpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenActivationDescriptor.hpp
@@ -1,0 +1,32 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipdnn_sdk/data_objects/pointwise_attributes_generated.h>
+#include <miopen/miopen.h>
+
+namespace miopen_legacy_plugin
+{
+
+class MiopenActivationDescriptor
+{
+public:
+    explicit MiopenActivationDescriptor(
+        const hipdnn_sdk::data_objects::PointwiseAttributes& pointwiseAttrs);
+
+    MiopenActivationDescriptor(const MiopenActivationDescriptor&) = delete;
+    MiopenActivationDescriptor& operator=(const MiopenActivationDescriptor&) = delete;
+
+    MiopenActivationDescriptor(MiopenActivationDescriptor&& other) noexcept;
+    MiopenActivationDescriptor& operator=(MiopenActivationDescriptor&& other) noexcept;
+
+    ~MiopenActivationDescriptor();
+
+    miopenActivationDescriptor_t activationDescriptor() const;
+
+private:
+    miopenActivationDescriptor_t _descriptor{nullptr};
+};
+
+} // namespace miopen_legacy_plugin

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenUtils.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenUtils.cpp
@@ -79,6 +79,67 @@ size_t getSpatialDimCount(const hipdnn_sdk::data_objects::TensorAttributes& attr
     return attr.dims()->size() - 2;
 }
 
+std::optional<ActivationParams>
+    mapPointwiseModeToMiopenActivation(const hipdnn_sdk::data_objects::PointwiseAttributes& attrs)
+{
+    using PM = hipdnn_sdk::data_objects::PointwiseMode;
+
+    switch(attrs.operation())
+    {
+    case PM::RELU_FWD:
+    case PM::RELU_BWD:
+    {
+        if(attrs.relu_lower_clip() && attrs.relu_upper_clip())
+        {
+            // CLAMP
+            return ActivationParams{miopenActivationCLAMP,
+                                    static_cast<double>(*attrs.relu_lower_clip()),
+                                    static_cast<double>(*attrs.relu_upper_clip()),
+                                    0.0};
+        }
+        if(attrs.relu_upper_clip())
+        {
+            // Clipped ReLU
+            return ActivationParams{miopenActivationCLIPPEDRELU,
+                                    static_cast<double>(*attrs.relu_upper_clip()),
+                                    0.0,
+                                    0.0};
+        }
+        if(attrs.relu_lower_clip_slope())
+        {
+            // Leaky ReLU
+            return ActivationParams{miopenActivationLEAKYRELU,
+                                    static_cast<double>(*attrs.relu_lower_clip_slope()),
+                                    0.0,
+                                    0.0};
+        }
+        // Standard ReLU
+        return ActivationParams{miopenActivationRELU, 0.0, 0.0, 0.0};
+    }
+    case PM::SIGMOID_FWD:
+    case PM::SIGMOID_BWD:
+        return ActivationParams{miopenActivationLOGISTIC, 0.0, 0.0, 0.0};
+    case PM::TANH_FWD:
+    case PM::TANH_BWD:
+        return ActivationParams{miopenActivationTANH, 1.0, 1.0, 0.0};
+    case PM::ELU_FWD:
+    case PM::ELU_BWD:
+    {
+        double alpha = attrs.elu_alpha() ? static_cast<double>(*attrs.elu_alpha()) : 1.0;
+        return ActivationParams{miopenActivationELU, alpha, 0.0, 0.0};
+    }
+    case PM::SOFTPLUS_FWD:
+    case PM::SOFTPLUS_BWD:
+        return ActivationParams{miopenActivationSOFTRELU, 0.0, 0.0, 0.0};
+    case PM::ABS:
+        return ActivationParams{miopenActivationABS, 0.0, 0.0, 0.0};
+    case PM::IDENTITY:
+        return ActivationParams{miopenActivationPASTHRU, 0.0, 0.0, 0.0};
+    default:
+        return std::nullopt;
+    }
+}
+
 }
 
 }

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenUtils.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenUtils.cpp
@@ -130,6 +130,18 @@ std::optional<ActivationParams>
     }
     case PM::SOFTPLUS_FWD:
     case PM::SOFTPLUS_BWD:
+        // Softplus is (1/beta) * log(1 + e^(beta*x))
+        // However, MIOpen uses:
+        // log(1 + e^x)
+        // This is valid Softplus only when beta=1
+        if(attrs.softplus_beta())
+        {
+            // Only support beta=1
+            if(static_cast<double>(*attrs.softplus_beta()) != 1.0)
+            {
+                return std::nullopt;
+            }
+        }
         return ActivationParams{miopenActivationSOFTRELU, 0.0, 0.0, 0.0};
     case PM::ABS:
         return ActivationParams{miopenActivationABS, 0.0, 0.0, 0.0};

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenUtils.hpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/MiopenUtils.hpp
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include <optional>
+#include <unordered_map>
+
+#include <hipdnn_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_sdk/plugin/PluginException.hpp>
 #include <hipdnn_sdk/plugin/PluginFlatbufferTypeHelpers.hpp>
 #include <miopen/miopen.h>
-#include <unordered_map>
 
 #include "MiopenTensor.hpp"
 
@@ -36,6 +39,17 @@ namespace miopen_legacy_plugin
 
 namespace miopen_utils
 {
+
+struct ActivationParams
+{
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+};
+
+std::optional<ActivationParams>
+    mapPointwiseModeToMiopenActivation(const hipdnn_sdk::data_objects::PointwiseAttributes& attrs);
 
 hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
                                             const hipdnnPluginDeviceBuffer_t* deviceBuffers,

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(miopen_legacy_plugin_tests
     engines/plans/TestMiopenConvPlanBuilder.cpp
     engines/TestMiopenEngine.cpp
     main.cpp
+    TestMiopenActivationDescriptor.cpp
     TestMiopenBatchnormFwdInferenceOperations.cpp
     TestMiopenBatchnormBwdOperations.cpp
     TestMiopenConvFwdOperations.cpp

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenActivationDescriptor.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenActivationDescriptor.cpp
@@ -275,7 +275,7 @@ TEST(TestMiopenActivationDescriptor, CreatesEluWithDefaultAlpha)
     EXPECT_DOUBLE_EQ(alpha, 1.0);
 }
 
-TEST(TestMiopenActivationDescriptor, CreatesSoftplusFwd)
+TEST(TestMiopenActivationDescriptor, CreatesSoftplusFwdWithoutBeta)
 {
     auto builder
         = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD);
@@ -294,7 +294,7 @@ TEST(TestMiopenActivationDescriptor, CreatesSoftplusFwd)
     EXPECT_EQ(mode, miopenActivationSOFTRELU);
 }
 
-TEST(TestMiopenActivationDescriptor, CreatesSoftplusBwd)
+TEST(TestMiopenActivationDescriptor, CreatesSoftplusBwdWithoutBeta)
 {
     auto builder
         = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD);
@@ -311,6 +311,47 @@ TEST(TestMiopenActivationDescriptor, CreatesSoftplusBwd)
                   activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
               miopenStatusSuccess);
     EXPECT_EQ(mode, miopenActivationSOFTRELU);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesSoftplusWithBetaOne)
+{
+    const float softplusBeta = 1.0f;
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
+                                           flatbuffers::nullopt,
+                                           flatbuffers::nullopt,
+                                           flatbuffers::nullopt,
+                                           flatbuffers::nullopt,
+                                           softplusBeta);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationSOFTRELU);
+}
+
+TEST(TestMiopenActivationDescriptor, ThrowsOnSoftplusWithInvalidBeta)
+{
+    const float softplusBeta = 2.0f;
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD,
+                                           flatbuffers::nullopt,
+                                           flatbuffers::nullopt,
+                                           flatbuffers::nullopt,
+                                           flatbuffers::nullopt,
+                                           softplusBeta);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    EXPECT_THROW(MiopenActivationDescriptor activDesc(*attr), hipdnn_plugin::HipdnnPluginException);
 }
 
 TEST(TestMiopenActivationDescriptor, CreatesAbs)

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenActivationDescriptor.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenActivationDescriptor.cpp
@@ -1,0 +1,406 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <hipdnn_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_sdk/plugin/PluginException.hpp>
+#include <miopen/miopen.h>
+
+#include "MiopenActivationDescriptor.hpp"
+
+using namespace miopen_legacy_plugin;
+
+namespace
+{
+
+// Helper function to create PointwiseAttributes flatbuffer
+flatbuffers::FlatBufferBuilder createPointwiseAttributesBuilder(
+    hipdnn_sdk::data_objects::PointwiseMode mode,
+    flatbuffers::Optional<float> reluLowerClip = flatbuffers::nullopt,
+    flatbuffers::Optional<float> reluUpperClip = flatbuffers::nullopt,
+    flatbuffers::Optional<float> reluLowerClipSlope = flatbuffers::nullopt,
+    flatbuffers::Optional<float> eluAlpha = flatbuffers::nullopt,
+    flatbuffers::Optional<float> softplusBeta = flatbuffers::nullopt)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        mode,
+        reluLowerClip,
+        reluUpperClip,
+        reluLowerClipSlope,
+        flatbuffers::nullopt, // axis
+        0, // in_0_tensor_uid
+        flatbuffers::nullopt, // in_1_tensor_uid
+        flatbuffers::nullopt, // in_2_tensor_uid
+        1, // out_0_tensor_uid
+        flatbuffers::nullopt, // swish_beta
+        eluAlpha,
+        softplusBeta);
+    builder.Finish(attrOffset);
+    return builder;
+}
+
+} // namespace
+
+TEST(TestMiopenActivationDescriptor, CreatesStandardRelu)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::RELU_FWD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationRELU);
+    EXPECT_DOUBLE_EQ(alpha, 0.0);
+    EXPECT_DOUBLE_EQ(beta, 0.0);
+    EXPECT_DOUBLE_EQ(gamma, 0.0);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesStandardReluBwd)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::RELU_BWD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationRELU);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesClippedRelu)
+{
+    const float upperClip = 6.0f;
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_sdk::data_objects::PointwiseMode::RELU_FWD, flatbuffers::nullopt, upperClip);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationCLIPPEDRELU);
+    EXPECT_DOUBLE_EQ(alpha, static_cast<double>(upperClip));
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesLeakyRelu)
+{
+    const float slope = 0.01f;
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::RELU_BWD,
+                                           flatbuffers::nullopt,
+                                           flatbuffers::nullopt,
+                                           slope);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationLEAKYRELU);
+    EXPECT_DOUBLE_EQ(alpha, static_cast<double>(slope));
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesClamp)
+{
+    const float lowerClip = 1.0f;
+    const float upperClip = 6.0f;
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_sdk::data_objects::PointwiseMode::RELU_FWD, lowerClip, upperClip);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationCLAMP);
+    EXPECT_DOUBLE_EQ(alpha, static_cast<double>(lowerClip));
+    EXPECT_DOUBLE_EQ(beta, static_cast<double>(upperClip));
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesSigmoidFwd)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationLOGISTIC);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesSigmoidBwd)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::SIGMOID_BWD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationLOGISTIC);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesTanhFwd)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::TANH_FWD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationTANH);
+    EXPECT_DOUBLE_EQ(alpha, 1.0);
+    EXPECT_DOUBLE_EQ(beta, 1.0);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesTanhBwd)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::TANH_BWD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationTANH);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesEluWithCustomAlpha)
+{
+    const float eluAlpha = 2.0f;
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::ELU_FWD,
+                                           flatbuffers::nullopt,
+                                           flatbuffers::nullopt,
+                                           flatbuffers::nullopt,
+                                           eluAlpha);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationELU);
+    EXPECT_DOUBLE_EQ(alpha, static_cast<double>(eluAlpha));
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesEluWithDefaultAlpha)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::ELU_BWD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationELU);
+    EXPECT_DOUBLE_EQ(alpha, 1.0);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesSoftplusFwd)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationSOFTRELU);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesSoftplusBwd)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationSOFTRELU);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesAbs)
+{
+    auto builder = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::ABS);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationABS);
+}
+
+TEST(TestMiopenActivationDescriptor, CreatesIdentity)
+{
+    auto builder
+        = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::IDENTITY);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationPASTHRU);
+}
+
+TEST(TestMiopenActivationDescriptor, ThrowsOnUnsupportedMode)
+{
+    auto builder = createPointwiseAttributesBuilder(hipdnn_sdk::data_objects::PointwiseMode::ADD);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    EXPECT_THROW(MiopenActivationDescriptor activDesc(*attr), hipdnn_plugin::HipdnnPluginException);
+}
+
+TEST(TestMiopenActivationDescriptor, ClampTakesPrecedenceOverClippedRelu)
+{
+    // When both lower and upper clips are present, should use CLAMP, not CLIPPED_RELU
+    const float lowerClip = -1.0f;
+    const float upperClip = 6.0f;
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_sdk::data_objects::PointwiseMode::RELU_BWD, lowerClip, upperClip);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationCLAMP);
+    EXPECT_DOUBLE_EQ(alpha, static_cast<double>(lowerClip));
+    EXPECT_DOUBLE_EQ(beta, static_cast<double>(upperClip));
+}
+
+TEST(TestMiopenActivationDescriptor, UpperClipWithoutLowerUsesClippedRelu)
+{
+    // Only upper clip present should use CLIPPED_RELU, not CLAMP
+    const float upperClip = 6.0f;
+    auto builder = createPointwiseAttributesBuilder(
+        hipdnn_sdk::data_objects::PointwiseMode::RELU_FWD, flatbuffers::nullopt, upperClip);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    MiopenActivationDescriptor activDesc(*attr);
+
+    miopenActivationMode_t mode;
+    double alpha;
+    double beta;
+    double gamma;
+    EXPECT_EQ(miopenGetActivationDescriptor(
+                  activDesc.activationDescriptor(), &mode, &alpha, &beta, &gamma),
+              miopenStatusSuccess);
+    EXPECT_EQ(mode, miopenActivationCLIPPEDRELU);
+    EXPECT_DOUBLE_EQ(alpha, static_cast<double>(upperClip));
+}

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenUtils.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenUtils.cpp
@@ -249,7 +249,7 @@ TEST(TestMiopenUtils, MapPointwiseModeEluWithDefaultAlpha)
     EXPECT_DOUBLE_EQ(result->alpha, 1.0);
 }
 
-TEST(TestMiopenUtils, MapPointwiseModeSoftplus)
+TEST(TestMiopenUtils, MapPointwiseModeSoftplusWithoutBeta)
 {
     flatbuffers::FlatBufferBuilder builder;
     auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
@@ -261,6 +261,59 @@ TEST(TestMiopenUtils, MapPointwiseModeSoftplus)
     auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result->mode, miopenActivationSOFTRELU);
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeSoftplusWithBetaOne)
+{
+    const float beta = 1.0f;
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_sdk::data_objects::PointwiseMode::SOFTPLUS_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        0,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        1,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        beta);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationSOFTRELU);
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeSoftplusWithInvalidBeta)
+{
+    const float beta = 2.0f;
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        0,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        1,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        beta);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    EXPECT_FALSE(result.has_value());
 }
 
 TEST(TestMiopenUtils, MapPointwiseModeAbs)

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenUtils.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenUtils.cpp
@@ -104,3 +104,202 @@ TEST(TestMiopenUtils, GetSpatialDimCountThrowsOnInvalidDims)
 
     EXPECT_THROW(miopen_utils::getSpatialDimCount(*attrPtr1), hipdnn_plugin::HipdnnPluginException);
 }
+
+TEST(TestMiopenUtils, MapPointwiseModeStandardRelu)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_sdk::data_objects::PointwiseMode::RELU_FWD);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationRELU);
+    EXPECT_DOUBLE_EQ(result->alpha, 0.0);
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeClippedRelu)
+{
+    const float upperClip = 6.0f;
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        upperClip);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationCLIPPEDRELU);
+    EXPECT_DOUBLE_EQ(result->alpha, static_cast<double>(upperClip));
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeLeakyRelu)
+{
+    const float slope = 0.01f;
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        slope);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationLEAKYRELU);
+    EXPECT_DOUBLE_EQ(result->alpha, static_cast<double>(slope));
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeClamp)
+{
+    const float lowerClip = -1.0f;
+    const float upperClip = 6.0f;
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_sdk::data_objects::PointwiseMode::RELU_BWD, lowerClip, upperClip);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationCLAMP);
+    EXPECT_DOUBLE_EQ(result->alpha, static_cast<double>(lowerClip));
+    EXPECT_DOUBLE_EQ(result->beta, static_cast<double>(upperClip));
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeSigmoid)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_sdk::data_objects::PointwiseMode::SIGMOID_FWD);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationLOGISTIC);
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeTanh)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_sdk::data_objects::PointwiseMode::TANH_BWD);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationTANH);
+    EXPECT_DOUBLE_EQ(result->alpha, 1.0);
+    EXPECT_DOUBLE_EQ(result->beta, 1.0);
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeEluWithCustomAlpha)
+{
+    const float eluAlpha = 2.0f;
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_sdk::data_objects::PointwiseMode::ELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        0,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        1,
+        flatbuffers::nullopt,
+        eluAlpha);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationELU);
+    EXPECT_DOUBLE_EQ(result->alpha, static_cast<double>(eluAlpha));
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeEluWithDefaultAlpha)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_sdk::data_objects::PointwiseMode::ELU_BWD);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationELU);
+    EXPECT_DOUBLE_EQ(result->alpha, 1.0);
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeSoftplus)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_sdk::data_objects::PointwiseMode::SOFTPLUS_FWD);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationSOFTRELU);
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeAbs)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_sdk::data_objects::PointwiseMode::ABS);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationABS);
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeIdentity)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_sdk::data_objects::PointwiseMode::IDENTITY);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->mode, miopenActivationPASTHRU);
+}
+
+TEST(TestMiopenUtils, MapPointwiseModeUnsupported)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_sdk::data_objects::CreatePointwiseAttributes(
+        builder, hipdnn_sdk::data_objects::PointwiseMode::ADD);
+    builder.Finish(attrOffset);
+    const auto* attr = flatbuffers::GetRoot<hipdnn_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    auto result = miopen_utils::mapPointwiseModeToMiopenActivation(*attr);
+    EXPECT_FALSE(result.has_value());
+}


### PR DESCRIPTION
## Motivation

Adds MiopenActivationDescriptor to convert pointwiseAttrs to MIOpen activation descriptors.

## Technical Details

See above.

## Test Plan

Unit tests for the MiopenActivationDescriptor class and for the new utility.

## Test Result

Test suite passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
