### PR TITLE
rocfft/hipfft: sync shared files

### DIFF
--- a/projects/hipfft/clients/hipfft_params.h
+++ b/projects/hipfft/clients/hipfft_params.h
@@ -924,9 +924,10 @@ public:
     }
 
     // call the hipFFT APIs to distribute data to multiple GPUs
-    void multi_gpu_prepare(std::vector<gpubuf>& ibuffer,
-                           std::vector<void*>&  pibuffer,
-                           std::vector<void*>&  pobuffer) override
+    void multi_gpu_prepare(std::vector<hostbuf>& cpu_input,
+                           std::vector<gpubuf>&  ibuffer,
+                           std::vector<void*>&   pibuffer,
+                           std::vector<void*>&   pobuffer) override
     {
         if(multiGPU <= 1)
             return;
@@ -1006,8 +1007,9 @@ public:
     }
 
     // call the hipFFT APIs to gather the data back from the multiple GPUs
-    virtual void multi_gpu_finalize(std::vector<gpubuf>& obuffer,
-                                    std::vector<void*>&  pobuffer) override
+    virtual void multi_gpu_finalize(std::vector<hostbuf>& gpu_output,
+                                    std::vector<gpubuf>&  obuffer,
+                                    std::vector<void*>&   pobuffer) override
     {
         if(multiGPU <= 1)
             return;

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -38,6 +38,9 @@
 #include <omp.h>
 #endif
 
+extern size_t max_length_for_hipfftw_test;
+extern size_t max_io_gb_for_hipfftw_test;
+
 // test details
 namespace
 {

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -352,41 +352,43 @@ inline void execute_gpu_fft(Tparams&              params,
     // Execute the transform:
     auto fft_status = params.execute(pibuffer.data(), pobuffer.data());
     if(fft_status != fft_status_success)
-        throw std::runtime_error("plan execution failure");
-    // work around potential problem of following hipMemcpy
-    // not properly waiting for rocFFT's kernels to finish
-    if(hipDeviceSynchronize() != hipSuccess)
-        throw std::runtime_error("hipDeviceSynchronize after execute failed");
+        throw std::runtime_error("rocFFT plan execution failure");
 
     // if not comparing, then just executing the GPU FFT is all we
     // need to do
     if(!fftw_compare)
         return;
 
-    // finalize a multi-GPU transform
-    params.multi_gpu_finalize(obuffer, pobuffer);
-
     ASSERT_TRUE(!gpu_output.empty()) << "no output buffers";
-    for(unsigned int idx = 0; idx < gpu_output.size(); ++idx)
+
+    // if output is in multiple bricks, collect it into the
+    // host buffer where the results need to go
+    params.multi_gpu_finalize(gpu_output, obuffer, pobuffer);
+
+    if(params.ofields.empty())
     {
-        ASSERT_TRUE(gpu_output[idx].data() != nullptr)
-            << "output buffer index " << idx << " is empty";
-        auto hip_status = hipMemcpy(gpu_output[idx].data(),
-                                    pobuffer.at(idx),
-                                    gpu_output[idx].size(),
-                                    hipMemcpyDeviceToHost);
-        if(hip_status != hipSuccess)
+        // otherwise, copy directly from the device
+        for(unsigned int idx = 0; idx < gpu_output.size(); ++idx)
         {
-            ++n_hip_failures;
-            std::stringstream ss;
-            ss << "hipMemcpy failure";
-            if(skip_runtime_fails)
+            ASSERT_TRUE(gpu_output[idx].data() != nullptr)
+                << "output buffer index " << idx << " is empty";
+            auto hip_status = hipMemcpy(gpu_output[idx].data(),
+                                        pobuffer.at(idx),
+                                        gpu_output[idx].size(),
+                                        hipMemcpyDeviceToHost);
+            if(hip_status != hipSuccess)
             {
-                throw ROCFFT_SKIP{ss.str()};
-            }
-            else
-            {
-                throw ROCFFT_FAIL{ss.str()};
+                ++n_hip_failures;
+                std::stringstream ss;
+                ss << "hipMemcpy failure";
+                if(skip_runtime_fails)
+                {
+                    throw ROCFFT_SKIP{ss.str()};
+                }
+                else
+                {
+                    throw ROCFFT_FAIL{ss.str()};
+                }
             }
         }
     }
@@ -547,7 +549,6 @@ void check_output_strides(const std::vector<hostbuf>& output, Tparams& params)
 // run rocFFT inverse transform
 template <class Tparams>
 inline void run_round_trip_inverse(Tparams&              params,
-                                   std::vector<gpubuf>&  ibuffer,
                                    std::vector<gpubuf>&  obuffer,
                                    std::vector<void*>&   pibuffer,
                                    std::vector<void*>&   pobuffer,
@@ -593,8 +594,7 @@ inline void run_round_trip_inverse(Tparams&              params,
             // shouldn't have been touched.
             if(params.check_output_strides)
             {
-                auto hip_status
-                    = hipMemset(obuffer[i].data(), OUTPUT_INIT_PATTERN, obuffer_sizes[i]);
+                auto hip_status = hipMemset(pobuffer[i], OUTPUT_INIT_PATTERN, obuffer_sizes[i]);
                 if(hip_status != hipSuccess)
                 {
                     ++n_hip_failures;
@@ -612,14 +612,17 @@ inline void run_round_trip_inverse(Tparams&              params,
             }
         }
     }
+
     if(params.multiGPU > 1)
     {
         if(verbose > 0)
         {
             std::cout << "scattering data for multi-GPU inverse" << std::endl;
         }
-        params.multi_gpu_prepare(ibuffer, pibuffer, pobuffer);
+        std::vector<hostbuf> cpu_input;
+        params.multi_gpu_prepare(cpu_input, obuffer, pibuffer, pobuffer);
     }
+
     // execute GPU transform
     execute_gpu_fft(params, pibuffer, pobuffer, obuffer, gpu_output, true);
 }
@@ -1273,6 +1276,9 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
         pobuffer[i] = obuffer->at(i).data();
     }
 
+    // scatter data out to multi-GPUs if this is a multi-GPU test
+    params.multi_gpu_prepare(cpu_input, ibuffer, pibuffer, pobuffer);
+
     // Run CPU transform
     //
     // NOTE: This must happen after input is copied to GPU and input
@@ -1310,9 +1316,6 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
                 std::cout << "CPU Output L2 norm:   " << cpu_output_norm.l_2 << "\n";
             }
         });
-
-    // scatter data out to multi-GPUs if this is a multi-GPU test
-    params.multi_gpu_prepare(ibuffer, pibuffer, pobuffer);
 
     // execute GPU transform
     std::vector<hostbuf> gpu_output
@@ -1414,7 +1417,7 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
         params_inverse.inverse_from_forward(params);
 
         run_round_trip_inverse<Tparams>(
-            params_inverse, *obuffer, ibuffer, pobuffer, pibuffer, gpu_input_data);
+            params_inverse, *obuffer, pobuffer, pibuffer, gpu_input_data);
     }
 
     if(fftw_compare)

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -352,7 +352,7 @@ inline void execute_gpu_fft(Tparams&              params,
     // Execute the transform:
     auto fft_status = params.execute(pibuffer.data(), pobuffer.data());
     if(fft_status != fft_status_success)
-        throw std::runtime_error("rocFFT plan execution failure");
+        throw std::runtime_error("FFT plan execution failure");
 
     // if not comparing, then just executing the GPU FFT is all we
     // need to do

--- a/projects/hipfft/shared/device_properties.h
+++ b/projects/hipfft/shared/device_properties.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <hip/hip_runtime_api.h>
 #include <stdexcept>
+#include <string>
 
 // get device properties
 static hipDeviceProp_t get_curr_device_prop()

--- a/projects/hipfft/shared/fft_hash.h
+++ b/projects/hipfft/shared/fft_hash.h
@@ -338,6 +338,23 @@ static inline void compute_buffer_hash(const std::vector<hostbuf>& ibuffer,
             hash_real,
             hash_imag);
         break;
+    case 4:
+    {
+        // treat 4D brick as 3D + batch, but this needs to be
+        // unbatched until we add 4D support for copy_buffers
+        if(nbatch != 1)
+            throw std::runtime_error("cannot copy batched 4D bricks");
+        compute_buffer_hash<Tfloat, std::tuple<size_t, size_t, size_t>, Tint>(
+            ibuffer,
+            itype,
+            std::make_tuple(ilength[1], ilength[2], ilength[3]),
+            std::make_tuple(istride[1], istride[2], istride[3]),
+            istride[0],
+            ilength[0],
+            hash_real,
+            hash_imag);
+        break;
+    }
     default:
         abort();
     }

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023 - 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -585,22 +585,37 @@ public:
         // location of the brick
         int rank   = 0;
         int device = 0;
+
+        bool operator==(const fft_brick& other) const
+        {
+            return this->lower == other.lower && this->upper == other.upper
+                   && this->stride == other.stride && this->rank == other.rank
+                   && this->device == other.device;
+        }
+        bool operator!=(const fft_brick& other) const
+        {
+            return !(*this == other);
+        }
     };
 
     struct fft_field
     {
         std::vector<fft_brick> bricks;
 
-        void sort_by_rank()
+        // Brick ordering is significant - a rank needs to pass
+        // pointers to execute() in the order that the bricks were
+        // added to the field.
+        //
+        // But we also want to sort the bricks by rank, so that we can
+        // efficiently find the bricks for a given rank.  So do a
+        // stable sort to preserve the relative order of bricks on any
+        // rank, even after they're sorted.
+        void stable_sort_by_rank()
         {
-            std::sort(bricks.begin(), bricks.end(), [](const fft_brick& a, const fft_brick& b) {
-                if(a.rank != b.rank)
+            std::stable_sort(
+                bricks.begin(), bricks.end(), [](const fft_brick& a, const fft_brick& b) {
                     return a.rank < b.rank;
-                if(a.device != b.device)
-                    return a.device < b.device;
-                return std::lexicographical_compare(
-                    a.lower.begin(), a.lower.end(), b.lower.begin(), b.lower.end());
-            });
+                });
         }
     };
 
@@ -688,7 +703,7 @@ public:
             }
         }
 
-        if(selected_grid[0] * selected_grid[1] == mp_ranks)
+        if(selected_grid[0] * selected_grid[1] != mp_ranks)
         {
             throw std::runtime_error("Grid dimensions do not multiply to mp_ranks.");
         }
@@ -732,9 +747,8 @@ public:
         }
 
         // sanity checks
-        int ingrid_size = std::accumulate(ingrid.begin(), ingrid.end(), 1, std::multiplies<int>());
-        int outgrid_size
-            = std::accumulate(outgrid.begin(), outgrid.end(), 1, std::multiplies<int>());
+        int ingrid_size  = product(ingrid.begin(), ingrid.end());
+        int outgrid_size = product(outgrid.begin(), outgrid.end());
 
         if((ingrid.size() != length.size()) || (outgrid.size() != length.size()))
         {
@@ -2053,19 +2067,19 @@ public:
             case fft_precision_half:
             {
                 buffer_printer<rocfft_complex<rocfft_fp16>> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_half(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             case fft_precision_single:
             {
                 buffer_printer<rocfft_complex<float>> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_single(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             case fft_precision_double:
             {
                 buffer_printer<rocfft_complex<double>> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_double(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             }
@@ -2080,19 +2094,19 @@ public:
             case fft_precision_half:
             {
                 buffer_printer<rocfft_fp16> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_half(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             case fft_precision_single:
             {
                 buffer_printer<float> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_single(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             case fft_precision_double:
             {
                 buffer_printer<double> s;
-                s.print_buffer(buf, ilength(), istride, nbatch, idist, ioffset);
+                s.print_buffer_double(buf, ilength(), istride, nbatch, idist, ioffset);
                 break;
             }
             }
@@ -2116,18 +2130,18 @@ public:
             case fft_precision_half:
             {
                 buffer_printer<rocfft_complex<rocfft_fp16>> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_half(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             case fft_precision_single:
             {
                 buffer_printer<rocfft_complex<float>> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_single(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             case fft_precision_double:
                 buffer_printer<rocfft_complex<double>> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_double(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             break;
@@ -2141,19 +2155,19 @@ public:
             case fft_precision_half:
             {
                 buffer_printer<rocfft_fp16> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_half(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             case fft_precision_single:
             {
                 buffer_printer<float> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_single(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             case fft_precision_double:
             {
                 buffer_printer<double> s;
-                s.print_buffer(buf, olength(), ostride, nbatch, odist, ooffset);
+                s.print_buffer_double(buf, olength(), ostride, nbatch, odist, ooffset);
                 break;
             }
             }
@@ -2309,11 +2323,11 @@ public:
     virtual size_t vram_footprint()
     {
         const auto ibuf_size = ibuffer_sizes();
-        size_t     val       = std::accumulate(ibuf_size.begin(), ibuf_size.end(), (size_t)1);
+        size_t val = std::accumulate(ibuf_size.begin(), ibuf_size.end(), static_cast<size_t>(1));
         if(placement == fft_placement_notinplace)
         {
             const auto obuf_size = obuffer_sizes();
-            val += std::accumulate(obuf_size.begin(), obuf_size.end(), (size_t)1);
+            val += std::accumulate(obuf_size.begin(), obuf_size.end(), static_cast<size_t>(1));
         }
         return val;
     }
@@ -2381,29 +2395,43 @@ public:
         scale_factor = 1 / params_forward.scale_factor;
     }
 
-    // prepare for multi-GPU transform.  Generated input is in ibuffer.
-    // pibuffer, pobuffer are the pointers that will be passed to the
-    // FFT library's "execute" API.
-    virtual void multi_gpu_prepare(std::vector<gpubuf>& ibuffer,
-                                   std::vector<void*>&  pibuffer,
-                                   std::vector<void*>&  pobuffer)
+    // prepare for multi-GPU transform.  cpu_input has contiguous
+    // input on the host, ibuffer has device input, which can be
+    // discarded if it's turned into multi-GPU bricks.  pibuffer,
+    // pobuffer are the pointers that will be passed to the FFT
+    // library's "execute" API.
+    virtual void multi_gpu_prepare(std::vector<hostbuf>& cpu_input,
+                                   std::vector<gpubuf>&  ibuffer,
+                                   std::vector<void*>&   pibuffer,
+                                   std::vector<void*>&   pobuffer)
     {
     }
 
     // finalize multi-GPU transform.  pobuffers are the pointers
     // provided to the FFT library's "execute" API.  obuffer is the
-    // buffer where transform output needs to go for validation
-    virtual void multi_gpu_finalize(std::vector<gpubuf>& obuffer, std::vector<void*>& pobuffer) {}
+    // normal GPU buffer that is used for single-device FFTs.
+    // gpu_output is the host buffer where transform output needs to
+    // go for validation
+    // Field is distributed among ranks and then among the number
+    // of GPUs per rank (which defaults to 1).
+    virtual void multi_gpu_finalize(std::vector<hostbuf>& gpu_output,
+                                    std::vector<gpubuf>&  obuffer,
+                                    std::vector<void*>&   pobuffer)
+    {
+    }
 
     // Create bricks in the specified field.  brick_grid has an
     // integer per dimension (batch and FFT dimensions), with the
     // number of bricks to split that dimension on.  Field length
     // starts with batch dimension, followed by FFT dimensions
     // slowest to fastest.
-    void distribute_field(int                              localDeviceCount,
+    // num_ranks represents the number of ranks used in the parallel
+    // computer, which are assumed to have at least gpusperrank each
+    void distribute_field(int                              gpusperrank,
                           const std::vector<unsigned int>& brick_grid,
                           std::vector<fft_field>&          fields,
-                          const std::vector<size_t>&       field_length)
+                          const std::vector<size_t>&       field_length,
+                          int                              num_ranks)
     {
         if(brick_grid.size() != field_length.size())
             throw std::runtime_error(
@@ -2418,11 +2446,11 @@ public:
 
         auto& field = fields.emplace_back();
 
-        // start with empty brick in field
+        // Start with empty brick in field
         field.bricks.reserve(total_bricks);
         field.bricks.emplace_back();
 
-        // go over the grid
+        // Go over the grid
         for(size_t i = 0; i < brick_grid.size(); ++i)
         {
             std::vector<fft_brick> cur_bricks;
@@ -2442,21 +2470,25 @@ public:
                     new_brick.lower.push_back(cur_length / brick_count * ibrick);
                     // last brick needs to include the whole split len
                     if(ibrick == brick_count - 1)
+                    {
                         new_brick.upper.push_back(cur_length);
+                    }
                     else
+                    {
                         new_brick.upper.push_back(std::min(
                             cur_length, new_brick.lower.back() + cur_length / brick_count));
+                    }
                 }
             }
         }
 
-        // give all bricks contiguous strides
+        // Give all bricks contiguous strides
         int brickIdx = 0;
         for(auto& b : field.bricks)
         {
             b.stride.resize(b.upper.size());
 
-            // fill strides from fastest to slowest
+            // Fill strides from fastest to slowest
             size_t brick_dist = 1;
             for(size_t distIdx = 0; distIdx < b.upper.size(); ++distIdx)
             {
@@ -2464,41 +2496,49 @@ public:
                 brick_dist *= *(b.upper.rbegin() + distIdx) - *(b.lower.rbegin() + distIdx);
             }
 
-            // split across ranks for a multi-process transform,
+            // Split across ranks for a multi-process transform,
             // otherwise split across bricks.  assume there's one
             // rank/device per brick
             if(mp_lib == fft_mp_lib_none)
-                b.device = brickIdx++;
+            {
+                b.device = brickIdx;
+            }
             else
             {
-                b.rank = brickIdx++;
+                int rank = brickIdx / gpusperrank; // determine MPI rank
+                int gpu  = brickIdx % gpusperrank; // determine GPU within rank
 
-                // if there are at least as many devices as bricks,
-                // give each rank a separate device
-                if(localDeviceCount >= static_cast<int>(field.bricks.size()))
-                    b.device = b.rank;
+                b.rank   = rank;
+                b.device = gpu;
             }
+            brickIdx++;
         }
     }
 
     // Distribute problem input among specified grid of devices/processors.
     // Grid specifies number of bricks per dimension, starting with batch
-    // and ending with fastest FFT dimension.
-    void distribute_input(int localDeviceCount, const std::vector<unsigned int>& brick_grid)
+    // and ending with fastest FFT dimension. For single-proc single-proc
+    // multi-gpu, gpusperrank represents the number of GPUs to use;
+    // while for multi-proc it represents the number of GPUs on each rank.
+    void distribute_input(int                              gpusperrank,
+                          const std::vector<unsigned int>& brick_grid,
+                          int                              num_ranks = 1)
     {
         auto len = length;
         len.insert(len.begin(), nbatch);
-        distribute_field(localDeviceCount, brick_grid, ifields, len);
+        distribute_field(gpusperrank, brick_grid, ifields, len, num_ranks);
     }
 
     // Distribute problem output among specified grid of devices/processors.
     // Grid specifies number of bricks per dimension, starting with batch
     // and ending with fastest FFT dimension.
-    void distribute_output(int localDeviceCount, const std::vector<unsigned int>& brick_grid)
+    void distribute_output(int                              gpusperrank,
+                           const std::vector<unsigned int>& brick_grid,
+                           int                              num_ranks = 1)
     {
         auto len = olength();
         len.insert(len.begin(), nbatch);
-        distribute_field(localDeviceCount, brick_grid, ofields, len);
+        distribute_field(gpusperrank, brick_grid, ofields, len, num_ranks);
     }
 };
 
@@ -2973,6 +3013,26 @@ inline void copy_buffers(const std::vector<hostbuf>& input,
                             odist,
                             ioffset,
                             ooffset);
+    case 4:
+    {
+        // treat 4D brick as 3D + batch, but this needs to be
+        // unbatched until we add 4D support for copy_buffers
+        if(nbatch != 1)
+            throw std::runtime_error("cannot copy batched 4D bricks");
+        return copy_buffers(input,
+                            output,
+                            std::make_tuple(length[1], length[2], length[3]),
+                            length[0],
+                            precision,
+                            itype,
+                            std::make_tuple(istride[1], istride[2], istride[3]),
+                            istride[0],
+                            otype,
+                            std::make_tuple(ostride[1], ostride[2], istride[3]),
+                            ostride[0],
+                            ioffset,
+                            ooffset);
+    }
     default:
         abort();
     }
@@ -3015,7 +3075,8 @@ inline VectorNorms distance_1to1_complex(const Tcomplex*                        
     for(size_t b = 0; b < nbatch; b++, idx_base += idist, odx_base += odist)
     {
 #ifdef _OPENMP
-#pragma omp parallel for reduction(max : linf) reduction(+ : l2) num_threads(partitions.size()) private(linf_failures_private)
+#pragma omp parallel for reduction(max : linf) reduction(+ : l2) \
+    num_threads(partitions.size()) private(linf_failures_private)
 #endif
         for(size_t part = 0; part < partitions.size(); ++part)
         {
@@ -3100,7 +3161,8 @@ inline VectorNorms distance_1to1_real(const Tfloat*                           in
     for(size_t b = 0; b < nbatch; b++, idx_base += idist, odx_base += odist)
     {
 #ifdef _OPENMP
-#pragma omp parallel for reduction(max : linf) reduction(+ : l2) num_threads(partitions.size()) private(linf_failures_private)
+#pragma omp parallel for reduction(max : linf) reduction(+ : l2) \
+    num_threads(partitions.size()) private(linf_failures_private)
 #endif
         for(size_t part = 0; part < partitions.size(); ++part)
         {
@@ -3173,7 +3235,8 @@ inline VectorNorms distance_1to2(const rocfft_complex<Tval>*             input,
     for(size_t b = 0; b < nbatch; b++, idx_base += idist, odx_base += odist)
     {
 #ifdef _OPENMP
-#pragma omp parallel for reduction(max : linf) reduction(+ : l2) num_threads(partitions.size()) private(linf_failures_private)
+#pragma omp parallel for reduction(max : linf) reduction(+ : l2) \
+    num_threads(partitions.size()) private(linf_failures_private)
 #endif
         for(size_t part = 0; part < partitions.size(); ++part)
         {
@@ -3872,6 +3935,118 @@ inline size_t twiddle_table_vram_footprint(const fft_params& params)
     }
 
     return vram_footprint;
+}
+
+// set input for a brick in a field
+// functor to search for bricks on a rank, in a container of bricks
+// sorted by rank
+struct match_rank
+{
+    bool operator()(const fft_params::fft_brick& b, int rank) const
+    {
+        return b.rank < rank;
+    }
+    bool operator()(int rank, const fft_params::fft_brick& b) const
+    {
+        return rank < b.rank;
+    }
+};
+
+// Initialize input for the bricks on the specified comm rank
+// (assumed to be the local rank)
+template <typename Tparams, typename Tbuff>
+void init_local_input(int                                       comm_rank,
+                      const Tparams&                            params,
+                      const std::vector<fft_params::fft_brick>& bricks,
+                      size_t                                    elem_size,
+                      const std::vector<void*>&                 input_ptrs)
+{
+    // get bricks for this rank
+    auto range = std::equal_range(bricks.begin(), bricks.end(), comm_rank, match_rank());
+
+    const bool is_planar = params.itype == fft_array_type_complex_planar
+                           || params.itype == fft_array_type_hermitian_planar;
+
+    size_t ptr_idx = 0;
+    for(auto brick = range.first; brick != range.second; ++brick, ++ptr_idx)
+    {
+        rocfft_scoped_device dev(brick->device);
+
+        // some utility code below needs batch separated from brick lengths
+        std::vector<size_t> brick_len_nobatch = brick->length();
+        auto                brick_batch       = brick_len_nobatch.front();
+        brick_len_nobatch.erase(brick_len_nobatch.begin());
+        std::vector<size_t> brick_stride_nobatch = brick->stride;
+        auto                brick_dist           = brick_stride_nobatch.front();
+        brick_stride_nobatch.erase(brick_stride_nobatch.begin());
+        std::vector<size_t> brick_lower_nobatch = brick->lower;
+        auto                brick_lower_batch   = brick_lower_nobatch.front();
+        brick_lower_nobatch.erase(brick_lower_nobatch.begin());
+
+        auto contiguous_stride = params.compute_stride(params.ilength());
+        auto contiguous_dist   = params.compute_idist();
+
+        std::vector<Tbuff> bufvec(1);
+        size_t brick_size_bytes = compute_ptrdiff(brick->length(), brick->stride, 0, 0) * elem_size
+                                  / (is_planar ? 2 : 1);
+        bufvec.back() = Tbuff::make_nonowned(input_ptrs[ptr_idx], brick_size_bytes);
+        // grab a second pointer for planar
+        if(is_planar)
+        {
+            ++ptr_idx;
+            bufvec.push_back(Tbuff::make_nonowned(input_ptrs[ptr_idx], brick_size_bytes));
+        }
+
+        // generate data (in device mem)
+        switch(params.precision)
+        {
+        case fft_precision_half:
+            set_input<Tbuff, rocfft_fp16>(bufvec,
+                                          params.igen,
+                                          params.itype,
+                                          brick_len_nobatch,
+                                          brick_len_nobatch,
+                                          brick_stride_nobatch,
+                                          brick_dist,
+                                          brick_batch,
+                                          get_curr_device_prop(),
+                                          brick_lower_nobatch,
+                                          brick_lower_batch,
+                                          contiguous_stride,
+                                          contiguous_dist);
+            break;
+        case fft_precision_single:
+            set_input<Tbuff, float>(bufvec,
+                                    params.igen,
+                                    params.itype,
+                                    brick_len_nobatch,
+                                    brick_len_nobatch,
+                                    brick_stride_nobatch,
+                                    brick_dist,
+                                    brick_batch,
+                                    get_curr_device_prop(),
+                                    brick_lower_nobatch,
+                                    brick_lower_batch,
+                                    contiguous_stride,
+                                    contiguous_dist);
+            break;
+        case fft_precision_double:
+            set_input<Tbuff, double>(bufvec,
+                                     params.igen,
+                                     params.itype,
+                                     brick_len_nobatch,
+                                     brick_len_nobatch,
+                                     brick_stride_nobatch,
+                                     brick_dist,
+                                     brick_batch,
+                                     get_curr_device_prop(),
+                                     brick_lower_nobatch,
+                                     brick_lower_batch,
+                                     contiguous_stride,
+                                     contiguous_dist);
+            break;
+        }
+    }
 }
 
 #endif

--- a/projects/hipfft/shared/mpi_worker.h
+++ b/projects/hipfft/shared/mpi_worker.h
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+* Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -30,109 +30,6 @@
 #include "rocfft_hip.h"
 #include <chrono>
 #include <mpi.h>
-
-// functor to search for bricks on a rank, in a container of bricks
-// sorted by rank
-struct match_rank
-{
-    bool operator()(const fft_params::fft_brick& b, int rank) const
-    {
-        return b.rank < rank;
-    }
-    bool operator()(int rank, const fft_params::fft_brick& b) const
-    {
-        return rank < b.rank;
-    }
-};
-
-// Initialize input for the bricks on the current rank.
-template <typename Tparams>
-void init_local_input(MPI_Comm                  mpi_comm,
-                      const Tparams&            params,
-                      size_t                    elem_size,
-                      const std::vector<void*>& input_ptrs)
-{
-    int mpi_rank = 0;
-    MPI_Comm_rank(mpi_comm, &mpi_rank);
-
-    // get bricks for this rank
-    auto range = std::equal_range(params.ifields.front().bricks.begin(),
-                                  params.ifields.front().bricks.end(),
-                                  mpi_rank,
-                                  match_rank());
-
-    size_t ptr_idx = 0;
-    for(auto brick = range.first; brick != range.second; ++brick, ++ptr_idx)
-    {
-        // some utility code below needs batch separated from brick lengths
-        std::vector<size_t> brick_len_nobatch = brick->length();
-        auto                brick_batch       = brick_len_nobatch.front();
-        brick_len_nobatch.erase(brick_len_nobatch.begin());
-        std::vector<size_t> brick_stride_nobatch = brick->stride;
-        auto                brick_dist           = brick_stride_nobatch.front();
-        brick_stride_nobatch.erase(brick_stride_nobatch.begin());
-        std::vector<size_t> brick_lower_nobatch = brick->lower;
-        auto                brick_lower_batch   = brick_lower_nobatch.front();
-        brick_lower_nobatch.erase(brick_lower_nobatch.begin());
-
-        auto contiguous_stride = params.compute_stride(params.ilength());
-        auto contiguous_dist   = params.compute_idist();
-
-        std::vector<gpubuf> bufvec(1);
-        bufvec.back() = gpubuf::make_nonowned(
-            input_ptrs[ptr_idx], compute_ptrdiff(brick->length(), brick->stride, 0, 0) * elem_size);
-
-        // generate data (in device mem)
-        switch(params.precision)
-        {
-        case fft_precision_half:
-            set_input<gpubuf, rocfft_fp16>(bufvec,
-                                           fft_input_random_generator_device,
-                                           params.itype,
-                                           brick_len_nobatch,
-                                           brick_len_nobatch,
-                                           brick_stride_nobatch,
-                                           brick_dist,
-                                           brick_batch,
-                                           get_curr_device_prop(),
-                                           brick_lower_nobatch,
-                                           brick_lower_batch,
-                                           contiguous_stride,
-                                           contiguous_dist);
-            break;
-        case fft_precision_single:
-            set_input<gpubuf, float>(bufvec,
-                                     fft_input_random_generator_device,
-                                     params.itype,
-                                     brick_len_nobatch,
-                                     brick_len_nobatch,
-                                     brick_stride_nobatch,
-                                     brick_dist,
-                                     brick_batch,
-                                     get_curr_device_prop(),
-                                     brick_lower_nobatch,
-                                     brick_lower_batch,
-                                     contiguous_stride,
-                                     contiguous_dist);
-            break;
-        case fft_precision_double:
-            set_input<gpubuf, double>(bufvec,
-                                      fft_input_random_generator_device,
-                                      params.itype,
-                                      brick_len_nobatch,
-                                      brick_len_nobatch,
-                                      brick_stride_nobatch,
-                                      brick_dist,
-                                      brick_batch,
-                                      get_curr_device_prop(),
-                                      brick_lower_nobatch,
-                                      brick_lower_batch,
-                                      contiguous_stride,
-                                      contiguous_dist);
-            break;
-        }
-    }
-}
 
 static MPI_Datatype get_mpi_type(size_t elem_size)
 {
@@ -166,20 +63,46 @@ static size_t add_brick_elems(size_t val, const fft_params::fft_brick& b)
     return val + compute_ptrdiff(b.length(), b.stride, 0, 0);
 }
 
-// Gather a whole field to a host buffer on rank 0.  local_bricks is
-// the contiguous buffer allocated by alloc_local_bricks with all of
-// the current rank's bricks.
-static void gather_field(MPI_Comm                                  mpi_comm,
-                         const std::vector<fft_params::fft_brick>& bricks,
-                         const std::vector<size_t>&                field_stride,
-                         size_t                                    field_dist,
-                         const fft_precision                       precision,
-                         const fft_array_type                      array_type,
-                         gpubuf&                                   local_bricks,
-                         hostbuf&                                  output)
+// Test if any rank uses multiple devices.
+static bool multiple_devices_on_rank(const std::vector<fft_params::fft_brick>& bricks)
+{
+    // Go over each rank's bricks
+    for(auto range
+        = std::equal_range(bricks.begin(), bricks.end(), bricks.front().rank, match_rank());
+        range.first != range.second;
+        range = std::equal_range(range.second, bricks.end(), range.second->rank, match_rank()))
+    {
+        // If we find a device on this rank that has a different device
+        // from the first, then that means this rank is using multiple
+        // devices.
+        int first_device = range.first->device;
+        if(std::any_of(
+               range.first, range.second, [first_device](const fft_params::fft_brick& brick) {
+                   return brick.device != first_device;
+               }))
+            return true;
+    }
+    // No rank had multiple devices
+    return false;
+}
+
+// Gather a whole field to a host buffer on rank 0, using MPI_Gatherv.
+// This is only possible if each rank's bricks are on a single device.
+// local_bricks is the contiguous buffer allocated by
+// alloc_local_bricks with all of the current rank's bricks.
+static void gather_field_v(MPI_Comm                                  mpi_comm,
+                           const std::vector<fft_params::fft_brick>& bricks,
+                           const std::vector<size_t>&                field_stride,
+                           size_t                                    field_dist,
+                           const fft_precision                       precision,
+                           const fft_array_type                      array_type,
+                           std::map<int, gpubuf>&                    local_bricks,
+                           hostbuf&                                  output)
 {
     int mpi_rank = 0;
     MPI_Comm_rank(mpi_comm, &mpi_rank);
+    int mpi_size = 0;
+    MPI_Comm_size(mpi_comm, &mpi_size);
 
     auto elem_size = var_size<size_t>(precision, array_type);
 
@@ -188,13 +111,14 @@ static void gather_field(MPI_Comm                                  mpi_comm,
     // allocate buffer for rank 0 to run fftw
     if(mpi_rank == 0)
     {
-        size_t field_elems = std::accumulate(bricks.begin(), bricks.end(), 0UL, add_brick_elems);
+        size_t field_elems = std::accumulate(
+            bricks.begin(), bricks.end(), static_cast<size_t>(0), add_brick_elems);
         recvbuf.alloc(field_elems * elem_size);
     }
 
     // work out how much to receive from each rank and where
-    std::vector<int> recvcounts;
-    std::vector<int> displs;
+    std::vector<int> recvcounts(static_cast<size_t>(mpi_size));
+    std::vector<int> displs(static_cast<size_t>(mpi_size));
     // loop over each rank's bricks
     size_t elem_total = 0;
     for(auto range
@@ -202,17 +126,19 @@ static void gather_field(MPI_Comm                                  mpi_comm,
         range.first != range.second;
         range = std::equal_range(range.second, bricks.end(), range.second->rank, match_rank()))
     {
-        size_t rank_elems = std::accumulate(range.first, range.second, 0UL, add_brick_elems);
-        recvcounts.push_back(rank_elems);
-        displs.push_back(elem_total);
+        size_t current_rank = range.first->rank;
+        size_t rank_elems
+            = std::accumulate(range.first, range.second, static_cast<size_t>(0), add_brick_elems);
+        recvcounts[current_rank] = rank_elems;
+        displs[current_rank]     = elem_total;
         elem_total += rank_elems;
     }
 
     // gather brick(s) to rank 0 (to host memory)
     auto mpi_type = get_mpi_type(elem_size);
 
-    MPI_Gatherv(local_bricks.data(),
-                local_bricks.size() / elem_size,
+    MPI_Gatherv(local_bricks.empty() ? nullptr : local_bricks.begin()->second.data(),
+                local_bricks.empty() ? 0 : local_bricks.begin()->second.size() / elem_size,
                 mpi_type,
                 recvbuf.data(),
                 recvcounts.data(),
@@ -277,37 +203,209 @@ static void gather_field(MPI_Comm                                  mpi_comm,
     }
 }
 
-// Allocate a device buffer to hold all of the bricks for this rank.
-// A rank can have N bricks on it but this will allocate one
-// contiguous buffer and return pointers to each of the N bricks.
-static void alloc_local_bricks(MPI_Comm                                  mpi_comm,
-                               const std::vector<fft_params::fft_brick>& bricks,
-                               size_t                                    elem_size,
-                               gpubuf&                                   buffer,
-                               std::vector<void*>&                       buffer_ptrs)
+// Gather a whole field to a host buffer on rank 0, using MPI
+// point-to-point operations.  local_bricks is the contiguous buffer
+// allocated by alloc_local_bricks with all of the current rank's
+// bricks.
+static void gather_field_p2p(MPI_Comm                                  mpi_comm,
+                             const std::vector<fft_params::fft_brick>& bricks,
+                             const std::vector<size_t>&                field_stride,
+                             size_t                                    field_dist,
+                             const fft_precision                       precision,
+                             const fft_array_type                      array_type,
+                             std::map<int, gpubuf>&                    local_bricks,
+                             hostbuf&                                  output)
 {
     int mpi_rank = 0;
     MPI_Comm_rank(mpi_comm, &mpi_rank);
 
-    auto range = std::equal_range(bricks.begin(), bricks.end(), mpi_rank, match_rank());
+    auto elem_size = var_size<size_t>(precision, array_type);
+    auto mpi_type  = get_mpi_type(elem_size);
 
-    // get ptrdiff (i.e. length to alloc) of all bricks on this rank
-    std::vector<size_t> brick_ptrdiffs_bytes;
-    for(auto b = range.first; b != range.second; ++b)
-        brick_ptrdiffs_bytes.push_back(compute_ptrdiff(b->length(), b->stride, 0, 0) * elem_size);
+    // map device -> offset, to keep track of the offset of each
+    // brick in the per-device buffers
+    std::map<int, size_t> offsets;
 
-    size_t alloc_length_bytes
-        = std::accumulate(brick_ptrdiffs_bytes.begin(), brick_ptrdiffs_bytes.end(), 0);
-
-    if(buffer.alloc(alloc_length_bytes) != hipSuccess)
-        throw std::runtime_error("failed to alloc brick");
-
-    // return pointers to the bricks
-    size_t cur_offset_bytes = 0;
-    for(auto len : brick_ptrdiffs_bytes)
+    for(unsigned int i = 0; i < bricks.size(); ++i)
     {
-        buffer_ptrs.push_back(buffer.data_offset(cur_offset_bytes));
-        cur_offset_bytes += len;
+        const auto& brick       = bricks[i];
+        size_t      brick_elems = compute_ptrdiff(brick.length(), brick.stride, 0, 0);
+
+        // The rank that this brick is on needs to send to rank 0,
+        // and rank 0 needs to receive all bricks
+        if(brick.rank != mpi_rank && mpi_rank != 0)
+            continue;
+
+        void* brick_ptr   = nullptr;
+        auto  local_brick = local_bricks.find(brick.device);
+        if(local_brick != local_bricks.end())
+        {
+            // get pointer to this brick in the per-device buffer
+            auto& cur_offset = offsets.emplace(brick.device, static_cast<size_t>(0)).first->second;
+            brick_ptr        = local_brick->second.data_offset(cur_offset);
+            cur_offset += brick_elems * elem_size;
+        }
+
+        // rank 0 needs to receive the data
+        hostbuf recvbuf;
+        if(mpi_rank == 0)
+            recvbuf.alloc(brick_elems * elem_size);
+
+        if(brick.rank == 0)
+        {
+            if(mpi_rank == 0)
+            {
+                rocfft_scoped_device dev(brick.device);
+                // Data is already on a rank-0 local device, just memcpy it
+                //
+                // Ignore error as we don't want to hang collective
+                // operations, but we will notice accuracy test
+                // problems if this fails.
+                (void)hipMemcpy(
+                    recvbuf.data(), brick_ptr, brick_elems * elem_size, hipMemcpyDeviceToHost);
+            }
+        }
+        else
+        {
+            // otherwise, brick is on another rank and needs to be
+            // communicated via Send/Recv
+
+            if(mpi_rank == 0)
+            {
+                // Receive this brick to rank 0
+                MPI_Recv(recvbuf.data(),
+                         static_cast<int>(brick_elems),
+                         mpi_type,
+                         brick.rank,
+                         i,
+                         mpi_comm,
+                         MPI_STATUS_IGNORE);
+            }
+            else if(mpi_rank == brick.rank)
+            {
+                // Send this brick to rank 0
+                rocfft_scoped_device dev(brick.device);
+                MPI_Send(brick_ptr, static_cast<int>(brick_elems), mpi_type, 0, i, mpi_comm);
+            }
+        }
+
+        if(mpi_rank == 0)
+        {
+            // Brick is now local, transpose to the output buf
+            void* brick_write_ptr = output.data_offset(
+                brick.lower_field_offset(field_stride, field_dist) * elem_size);
+
+            std::vector<hostbuf> copy_in(1);
+            std::vector<hostbuf> copy_out(1);
+            copy_in.front()  = hostbuf::make_nonowned(recvbuf.data());
+            copy_out.front() = hostbuf::make_nonowned(brick_write_ptr);
+
+            // separate batch length + stride for the sake of copy_buffers
+            std::vector<size_t> brick_len_nobatch = brick.length();
+            auto                brick_batch       = brick_len_nobatch.front();
+            brick_len_nobatch.erase(brick_len_nobatch.begin());
+            std::vector<size_t> brick_stride_nobatch = brick.stride;
+            auto                brick_dist           = brick_stride_nobatch.front();
+            brick_stride_nobatch.erase(brick_stride_nobatch.begin());
+
+            copy_buffers(copy_in,
+                         copy_out,
+                         brick_len_nobatch,
+                         brick_batch,
+                         precision,
+                         array_type,
+                         brick_stride_nobatch,
+                         brick_dist,
+                         array_type,
+                         field_stride,
+                         field_dist,
+                         {0},
+                         {0});
+        }
+    }
+}
+
+// Gather a whole field to a host buffer on rank 0.
+static void gather_field(MPI_Comm                                  mpi_comm,
+                         const std::vector<fft_params::fft_brick>& bricks,
+                         const std::vector<size_t>&                field_stride,
+                         size_t                                    field_dist,
+                         const fft_precision                       precision,
+                         const fft_array_type                      array_type,
+                         std::map<int, gpubuf>&                    local_bricks,
+                         hostbuf&                                  output)
+{
+    if(multiple_devices_on_rank(bricks))
+    {
+        // Can't do MPI_Gather, as MPI assumes we only have one pointer per rank
+        gather_field_p2p(mpi_comm,
+                         bricks,
+                         field_stride,
+                         field_dist,
+                         precision,
+                         array_type,
+                         local_bricks,
+                         output);
+    }
+    else
+    {
+        // Do gather, which is more efficient
+        gather_field_v(mpi_comm,
+                       bricks,
+                       field_stride,
+                       field_dist,
+                       precision,
+                       array_type,
+                       local_bricks,
+                       output);
+    }
+}
+
+// Allocate device buffer(s) to hold all of the bricks for this rank.
+// A rank can have N bricks on it but this will allocate one
+// contiguous buffer per device and return pointers to each of the N bricks.
+static void alloc_local_bricks(int                                       mpi_rank,
+                               const std::vector<fft_params::fft_brick>& bricks,
+                               size_t                                    elem_size,
+                               std::map<int, gpubuf>&                    buffers,
+                               std::vector<void*>&                       buffer_ptrs)
+{
+    // Get bricks that are local to this rank
+    auto local_range = std::equal_range(bricks.begin(), bricks.end(), mpi_rank, match_rank());
+
+    // Do one pass over these bricks to work out how big of a buffer
+    // we need to allocate on each device
+    std::map<int, size_t> buffer_sizes;
+    for(auto brick = local_range.first; brick != local_range.second; ++brick)
+    {
+        buffer_sizes.insert({brick->device, static_cast<size_t>(0)}).first->second
+            += compute_ptrdiff(brick->length(), brick->stride, 0, 0);
+    }
+
+    // Alloc buffers for each device
+    for(const auto buffer_size : buffer_sizes)
+    {
+        rocfft_scoped_device dev(buffer_size.first);
+        if(buffers.emplace(buffer_size.first, gpubuf{})
+               .first->second.alloc(buffer_size.second * elem_size)
+           != hipSuccess)
+        {
+            throw std::runtime_error("Failed to allocate buffer on device "
+                                     + std::to_string(buffer_size.first));
+        }
+    }
+
+    // Return pointers for each brick
+    for(auto brick = local_range.first; brick != local_range.second; ++brick)
+    {
+        auto& buf = buffers[brick->device];
+
+        // Use buffer_sizes to count down bricks for each device
+        auto& remaining_size = buffer_sizes[brick->device];
+        auto  offset_elems   = (buf.size() / elem_size) - remaining_size;
+        remaining_size -= compute_ptrdiff(brick->length(), brick->stride, 0, 0);
+
+        buffer_ptrs.push_back(buf.data_offset(offset_elems * elem_size));
     }
 }
 
@@ -334,32 +432,6 @@ double half_epsilon    = default_half_epsilon();
 double single_epsilon  = default_single_epsilon();
 double double_epsilon  = default_double_epsilon();
 
-// get the device that the field's bricks are on, for this rank.
-// throws std::runtime_error if bricks for this rank are on multiple
-// devices since that's not something we currently handle.
-static int get_field_device(int mpi_rank, const fft_params::fft_field& field)
-{
-    // get first brick on this rank
-    auto first
-        = std::find_if(field.bricks.begin(),
-                       field.bricks.end(),
-                       [mpi_rank](const fft_params::fft_brick& b) { return b.rank == mpi_rank; });
-
-    if(first == field.bricks.end())
-        return true;
-
-    int first_device = first->device;
-
-    // check if remaining bricks are either not on this rank or on
-    // the same device
-    if(std::all_of(
-           first, field.bricks.end(), [mpi_rank, first_device](const fft_params::fft_brick& b) {
-               return b.rank != mpi_rank || b.device == first_device;
-           }))
-        return first_device;
-    throw std::runtime_error("field spans multiple devices");
-}
-
 // execute the specific number of trials on a vec of libraries
 template <typename AllParams>
 void exec_testcases(std::function<AllParams(const std::vector<std::string>&)> make_params,
@@ -371,9 +443,9 @@ void exec_testcases(std::function<AllParams(const std::vector<std::string>&)> ma
                     const std::string&                                        token,
                     const std::vector<std::string>&                           lib_strings,
                     std::vector<std::vector<double>>&                         gpu_time,
-                    gpubuf&                                                   local_input,
+                    std::map<int, gpubuf>&                                    local_inputs,
                     std::vector<void*>&                                       local_input_ptrs,
-                    gpubuf&                                                   local_output,
+                    std::map<int, gpubuf>&                                    local_outputs,
                     std::vector<void*>&                                       local_output_ptrs,
                     size_t                                                    ntrial)
 {
@@ -385,8 +457,8 @@ void exec_testcases(std::function<AllParams(const std::vector<std::string>&)> ma
 
         p.from_token(token);
         p.validate();
-        p.ifields.front().sort_by_rank();
-        p.ofields.front().sort_by_rank();
+        p.ifields.front().stable_sort_by_rank();
+        p.ofields.front().stable_sort_by_rank();
 
         p.mp_lib  = fft_params::fft_mp_lib_mpi;
         p.mp_comm = &mpi_comm;
@@ -396,6 +468,7 @@ void exec_testcases(std::function<AllParams(const std::vector<std::string>&)> ma
     // it to all ranks
     std::vector<size_t> testcases;
     testcases.reserve(ntrial * lib_strings.size());
+
     if(mpi_rank == 0)
     {
         switch(test_sequence)
@@ -442,140 +515,81 @@ void exec_testcases(std::function<AllParams(const std::vector<std::string>&)> ma
     const auto  in_elem_size  = var_size<size_t>(params.precision, params.itype);
     const auto  out_elem_size = var_size<size_t>(params.precision, params.otype);
 
-    // currently, MPI worker requires that any rank only uses a
-    // single device
-    int input_device  = get_field_device(mpi_rank, params.ifields.front());
-    int output_device = get_field_device(mpi_rank, params.ifields.front());
-    if(input_device != output_device)
-        throw std::runtime_error("input field uses different device from output field");
+    // allocate and initialize input buffers
+    alloc_local_bricks(
+        mpi_rank, params.ifields.back().bricks, in_elem_size, local_inputs, local_input_ptrs);
 
-    rocfft_scoped_device dev(input_device);
+    init_local_input<decltype(params), gpubuf>(
+        mpi_rank, params, params.ifields.back().bricks, in_elem_size, local_input_ptrs);
 
-    // check accuracy vs. FFTW - we only do this if FFTW actually ran
-    // on this iteration
-    bool                 check_fftw = false;
+    // gather input for FFTW before we transform, in case we're doing an in-place FFT
     std::vector<hostbuf> cpu_data(1);
-    VectorNorms          cpu_output_norm;
-
-    // allocate input/output if it hasn't been allocated already
-    if(local_input_ptrs.empty())
+    if(run_fftw)
     {
-        alloc_local_bricks(
-            mpi_comm, params.ifields.back().bricks, in_elem_size, local_input, local_input_ptrs);
-        init_local_input(mpi_comm, params, in_elem_size, local_input_ptrs);
+        if(mpi_rank == 0)
+            cpu_data.front().alloc(std::max(params.isize.front() * in_elem_size,
+                                            params.osize.front() * out_elem_size));
 
-        // allocate local output bricks
-        if(params.placement == fft_placement_inplace)
-        {
-            local_output_ptrs = local_input_ptrs;
-        }
-        else
-        {
-            alloc_local_bricks(mpi_comm,
-                               params.ofields.back().bricks,
-                               out_elem_size,
-                               local_output,
-                               local_output_ptrs);
-        }
-
-        if(run_fftw)
-        {
-            check_fftw = true;
-            if(mpi_rank == 0)
-                cpu_data.front().alloc(std::max(params.isize.front() * in_elem_size,
-                                                params.osize.front() * out_elem_size));
-
-            gather_field(mpi_comm,
-                         params.ifields.front().bricks,
-                         params.istride,
-                         params.idist,
-                         params.precision,
-                         params.itype,
-                         local_input,
-                         cpu_data.front());
-
-            if(mpi_rank == 0)
-            {
-                fft_params params_inplace = params;
-                params_inplace.placement  = fft_placement_inplace;
-
-                // create fftw plan and run it
-                switch(params_inplace.precision)
-                {
-                case fft_precision_half:
-                {
-                    execute_reference_fft<rocfft_fp16>(params_inplace, cpu_data);
-                    break;
-                }
-                case fft_precision_single:
-                {
-                    execute_reference_fft<float>(params_inplace, cpu_data);
-                    break;
-                }
-                case fft_precision_double:
-                {
-                    execute_reference_fft<double>(params_inplace, cpu_data);
-                    break;
-                }
-                }
-
-                cpu_output_norm = norm(cpu_data,
-                                       params_inplace.ilength(),
-                                       params_inplace.nbatch,
-                                       params_inplace.precision,
-                                       params_inplace.itype,
-                                       params_inplace.istride,
-                                       params_inplace.idist,
-                                       params_inplace.ioffset);
-            }
-        }
+        gather_field(mpi_comm,
+                     params.ifields.front().bricks,
+                     params.istride,
+                     params.idist,
+                     params.precision,
+                     params.itype,
+                     local_inputs,
+                     cpu_data.front());
     }
 
-    // now all ranks are ready to start FFT
+    // if this is not an in-place transform, then allocate output buffers
+    if(params.placement == fft_placement_inplace)
+    {
+        local_output_ptrs = local_input_ptrs;
+    }
+    else
+    {
+        alloc_local_bricks(mpi_rank,
+                           params.ofields.back().bricks,
+                           out_elem_size,
+                           local_outputs,
+                           local_output_ptrs);
+    }
+
+    // execute FFTs
+    std::chrono::time_point<std::chrono::steady_clock> start, stop;
 
     // call rocfft_plan_create
     for(auto& p : all_params)
         p.create_plan();
 
-    std::chrono::time_point<std::chrono::steady_clock> start, stop;
     for(size_t i = 0; i < testcases.size(); ++i)
     {
         size_t testcase = testcases[i];
+
         if(run_bench)
         {
-            // reinit input for tests after the first one
             if(i > 0)
-                init_local_input(mpi_comm, params, in_elem_size, local_input_ptrs);
+            {
+                init_local_input<decltype(params), gpubuf>(
+                    mpi_rank, params, params.ifields.back().bricks, in_elem_size, local_input_ptrs);
+            }
 
-            // ensure plan is finished building, synchronize all devices
-            // in the input bricks
             (void)hipDeviceSynchronize();
-
             MPI_Barrier(mpi_comm);
 
-            // start timer
             start = std::chrono::steady_clock::now();
         }
 
-        all_params[testcase].execute(local_input_ptrs.data(), local_output_ptrs.data());
+        all_params[testcase].execute(reinterpret_cast<void**>(local_input_ptrs.data()),
+                                     reinterpret_cast<void**>(local_output_ptrs.data()));
 
         if(run_bench)
         {
-            // ensure FFT is finished executing - synchronize all devices
-            // on output bricks
-            {
-                rocfft_scoped_device dev(output_device);
-                (void)hipDeviceSynchronize();
-            }
-
-            stop = std::chrono::steady_clock::now();
-
-            std::chrono::duration<double, std::milli> diff = stop - start;
-
-            double diff_ms = diff.count();
+            (void)hipDeviceSynchronize();
+            stop                                              = std::chrono::steady_clock::now();
+            std::chrono::duration<double, std::milli> diff    = stop - start;
+            double                                    diff_ms = diff.count();
 
             double max_diff_ms = 0.0;
-            // reduce max runtime to root
             MPI_Reduce(&diff_ms, &max_diff_ms, 1, MPI_DOUBLE, MPI_MAX, 0, mpi_comm);
 
             if(mpi_rank == 0)
@@ -583,24 +597,55 @@ void exec_testcases(std::function<AllParams(const std::vector<std::string>&)> ma
         }
     }
 
-    if(check_fftw)
+    // FFTW Validation
+    if(run_fftw)
     {
-        // gather output
         std::vector<hostbuf> gpu_output(1);
+        VectorNorms          cpu_output_norm;
+
+        if(mpi_rank == 0)
+        {
+            fft_params params_inplace = params;
+            params_inplace.placement  = fft_placement_inplace;
+
+            switch(params_inplace.precision)
+            {
+            case fft_precision_half:
+                execute_reference_fft<rocfft_fp16>(params_inplace, cpu_data);
+                break;
+            case fft_precision_single:
+                execute_reference_fft<float>(params_inplace, cpu_data);
+                break;
+            case fft_precision_double:
+                execute_reference_fft<double>(params_inplace, cpu_data);
+                break;
+            }
+
+            cpu_output_norm = norm(cpu_data,
+                                   params_inplace.ilength(),
+                                   params_inplace.nbatch,
+                                   params_inplace.precision,
+                                   params_inplace.itype,
+                                   params_inplace.istride,
+                                   params_inplace.idist,
+                                   params_inplace.ioffset);
+        }
+
         if(mpi_rank == 0)
             gpu_output.front().alloc(params.osize.front() * out_elem_size);
+
         gather_field(mpi_comm,
                      params.ofields.front().bricks,
                      params.ostride,
                      params.odist,
                      params.precision,
                      params.otype,
-                     params.placement == fft_placement_inplace ? local_input : local_output,
+                     params.placement == fft_placement_inplace ? local_inputs : local_outputs,
                      gpu_output.front());
 
         if(mpi_rank == 0)
         {
-            // compare data to reference implementation
+            // Compare data to reference implementation
             const double linf_cutoff = type_epsilon(params.precision) * cpu_output_norm.l_inf
                                        * log(product(params.length.begin(), params.length.end()));
 
@@ -621,6 +666,7 @@ void exec_testcases(std::function<AllParams(const std::vector<std::string>&)> ma
                                  linf_cutoff,
                                  params.ooffset,
                                  params.ooffset);
+
             if(diff.l_inf > linf_cutoff)
             {
                 std::stringstream msg;
@@ -641,6 +687,18 @@ void exec_testcases(std::function<AllParams(const std::vector<std::string>&)> ma
         p.free();
         p.cleanup();
     }
+}
+
+// returns final grid integrating inter-process and intra-process grids
+std::vector<unsigned int> compute_final_grid(const std::vector<unsigned int>& mpi_grid,
+                                             const std::vector<unsigned int>& intra_grid)
+{
+    std::vector<unsigned int> final_grid(mpi_grid.size());
+    for(size_t i = 0; i < mpi_grid.size(); ++i)
+    {
+        final_grid[i] = mpi_grid[i] * intra_grid[i];
+    }
+    return final_grid;
 }
 
 // AllParams is a callable that returns a container of fft_params
@@ -721,6 +779,13 @@ int mpi_worker_main(const char*                                               de
     std::vector<unsigned int> imgrid;
     std::vector<unsigned int> omgrid;
 
+    // input/output GPU grids per process
+    std::vector<unsigned int> ingrid;
+    std::vector<unsigned int> outgrid;
+
+    // number of GPUs to use per rank
+    int ngpus{};
+
     auto* non_token = app.add_option_group("Token Conflict", "Options excluded by --token");
     non_token
         ->add_flag("--double", "Double precision transform (deprecated: use --precision double)")
@@ -771,6 +836,20 @@ int mpi_worker_main(const char*                                               de
                      "If this value is greater than one, arrays will be used")
         ->default_val(1);
 
+    // set number of GPUs to user per MPI rank
+    non_token->add_option("--ngpus", ngpus, "Number of GPUs to use per rank")
+        ->default_val(1)
+        ->check(CLI::NonNegativeNumber);
+
+    // define multi-GPU grids per process
+    non_token->add_option("--ingrid", ingrid, "Single-process grid of GPUs at input")
+        ->expected(1, 3)
+        ->needs("--ngpus");
+
+    non_token->add_option("--outgrid", outgrid, "Single-process grid of GPUs at output")
+        ->expected(1, 3)
+        ->needs("--ngpus");
+
     CLI::Option* opt_istride = non_token->add_option("--istride", params.istride, "Input strides");
     CLI::Option* opt_ostride = non_token->add_option("--ostride", params.ostride, "Output strides");
 
@@ -810,25 +889,28 @@ int mpi_worker_main(const char*                                               de
 
     if(token.empty())
     {
-
-        int localDeviceCount = 0;
-        (void)hipGetDeviceCount(&localDeviceCount);
-
         // set default multi-process grids in case none were given
         params.set_default_grid(mp_size, imgrid, omgrid);
+
+        // set default GPU grids per process
+        params.set_default_grid(ngpus, ingrid, outgrid);
 
         // start with all-ones in grids
         std::vector<unsigned int> input_grid(params.length.size() + 1, 1);
         std::vector<unsigned int> output_grid(params.length.size() + 1, 1);
 
         // sanity checks
-        int imgrid_size = std::accumulate(imgrid.begin(), imgrid.end(), 1, std::multiplies<int>());
-        int omgrid_size = std::accumulate(omgrid.begin(), omgrid.end(), 1, std::multiplies<int>());
+        int imgrid_size = product(imgrid.begin(), imgrid.end());
+        int omgrid_size = product(omgrid.begin(), omgrid.end());
 
-        if((imgrid.size() != params.length.size()) || (omgrid.size() != params.length.size()))
+        int ingrid_size  = product(ingrid.begin(), ingrid.end());
+        int outgrid_size = product(outgrid.begin(), outgrid.end());
+
+        if((imgrid.size() != params.length.size()) || (omgrid.size() != params.length.size())
+           || (ingrid.size() != params.length.size()) || (outgrid.size() != params.length.size()))
         {
             throw std::runtime_error(
-                "grid of processors must be of the same size as the problem dimension!");
+                "grid of processors and GPUs must be of the same size as the problem dimension!");
         }
 
         if((imgrid_size != mp_size) || (omgrid_size != mp_size))
@@ -837,12 +919,25 @@ int mpi_worker_main(const char*                                               de
                 "size of grid of processors must be equal to the number of MPI resources!");
         }
 
-        // create input and output grids and distribute it according to user requirements
-        std::copy(imgrid.begin(), imgrid.end(), input_grid.begin() + 1);
-        std::copy(omgrid.begin(), omgrid.end(), output_grid.begin() + 1);
+        if((ingrid_size != ngpus) || (outgrid_size != ngpus))
+        {
+            throw std::runtime_error("size of grid of GPUs per process must be equal to ngpus!");
+        }
 
-        params.distribute_input(localDeviceCount, input_grid);
-        params.distribute_output(localDeviceCount, output_grid);
+        // create input and output grids and distribute it according to user requirements
+        std::vector<unsigned int> final_input_grid, final_output_grid;
+        final_input_grid  = compute_final_grid(imgrid, ingrid);
+        final_output_grid = compute_final_grid(omgrid, outgrid);
+
+        std::copy(final_input_grid.begin(), final_input_grid.end(), input_grid.begin() + 1);
+        std::copy(final_output_grid.begin(), final_output_grid.end(), output_grid.begin() + 1);
+
+        // get number of nodes to asign local GPU indexing, since within
+        // each node, GPUs are indexed 0,1,...,N
+
+        // distribute input and output among the available number of ranks and GPUs per rank
+        params.distribute_input(ngpus, input_grid, mp_size);
+        params.distribute_output(ngpus, output_grid, mp_size);
 
         params.validate();
         token = params.token();
@@ -902,11 +997,32 @@ int mpi_worker_main(const char*                                               de
                 std::cout << " " << i;
             std::cout << "\n";
 
+            if(!ingrid.empty())
+            {
+                std::cout << "\tGPU grid:";
+                for(auto& i : ingrid)
+                    std::cout << " " << i;
+                std::cout << "\n";
+            }
+
             std::cout << "output grid:";
             for(auto& i : omgrid)
                 std::cout << " " << i;
             std::cout << "\n";
 
+            if(!outgrid.empty())
+            {
+                std::cout << "\tGPU grid:";
+                for(auto& i : outgrid)
+                    std::cout << " " << i;
+                std::cout << "\n";
+            }
+
+            std::cout << "\n";
+        }
+
+        if(mpi_rank == 0)
+        {
             std::cout << "Token: " << token << std::endl;
             std::cout << "\n";
 
@@ -914,10 +1030,11 @@ int mpi_worker_main(const char*                                               de
         }
     }
 
-    gpubuf             local_input;
-    std::vector<void*> local_input_ptrs;
-    gpubuf             local_output;
-    std::vector<void*> local_output_ptrs;
+    // Resize buffers based on the number of GPUs assigned
+    std::map<int, gpubuf> local_inputs;
+    std::vector<void*>    local_input_ptrs;
+    std::map<int, gpubuf> local_outputs;
+    std::vector<void*>    local_output_ptrs;
 
     // timing results - for each lib, store a vector of measured
     // times
@@ -935,9 +1052,9 @@ int mpi_worker_main(const char*                                               de
                    token,
                    lib_strings,
                    gpu_time,
-                   local_input,
+                   local_inputs,
                    local_input_ptrs,
-                   local_output,
+                   local_outputs,
                    local_output_ptrs,
                    ntrial_pass1);
     if(reverse)
@@ -956,9 +1073,9 @@ int mpi_worker_main(const char*                                               de
                        token,
                        lib_strings,
                        gpu_time,
-                       local_input,
+                       local_inputs,
                        local_input_ptrs,
-                       local_output,
+                       local_outputs,
                        local_output_ptrs,
                        ntrial_pass2);
         // put back to normal order
@@ -978,7 +1095,8 @@ int mpi_worker_main(const char*                                               de
             std::sort(times.begin(), times.end());
             // print median
             double median;
-            if(ntrial % 2)
+            // average the two times around the middle
+            if(ntrial % 2 && ntrial > 1)
                 median = (times[ntrial / 2] + times[(ntrial + 1) / 2]) / 2;
             else
                 median = times[ntrial / 2];

--- a/projects/hipfft/shared/params_gen.h
+++ b/projects/hipfft/shared/params_gen.h
@@ -36,13 +36,13 @@ const static std::vector<fft_precision> precision_range_sp_dp
 
 const static std::vector<fft_result_placement> place_range
     = {fft_placement_inplace, fft_placement_notinplace};
+const static std::vector<fft_transform_type> trans_type_range
+    = {fft_transform_type_complex_forward, fft_transform_type_real_forward};
 const static std::vector<fft_transform_type> trans_type_range_full
     = {fft_transform_type_complex_forward,
        fft_transform_type_real_forward,
        fft_transform_type_complex_inverse,
        fft_transform_type_real_inverse};
-const static std::vector<fft_transform_type> trans_type_range
-    = {fft_transform_type_complex_forward, fft_transform_type_real_forward};
 const static std::vector<fft_transform_type> trans_type_range_complex
     = {fft_transform_type_complex_forward};
 const static std::vector<fft_transform_type> trans_type_range_real

--- a/projects/hipfft/shared/printbuffer.h
+++ b/projects/hipfft/shared/printbuffer.h
@@ -24,12 +24,14 @@
 #include "hostbuf.h"
 #include "increment.h"
 #include <algorithm>
+#include <iomanip>
 #include <vector>
 
 // Output a formatted general-dimensional array with given length and stride in batches
 // separated by dist.
 template <typename Toutput, typename T1, typename T2, typename Tsize, typename Tstream>
-inline void printbuffer(const Toutput*         output,
+inline void printbuffer(const size_t&          num_decimals,
+                        const Toutput*         output,
                         const std::vector<T1>& length,
                         const std::vector<T2>& stride,
                         const Tsize            nbatch,
@@ -46,7 +48,8 @@ inline void printbuffer(const Toutput*         output,
         {
             const int i
                 = std::inner_product(index.begin(), index.end(), stride.begin(), i_base + offset);
-            stream << output[i] << " ";
+
+            stream << std::fixed << std::setprecision(num_decimals) << output[i] << " ";
             for(int li = index.size(); li-- > 0;)
             {
                 if(index[li] == (length[li] - 1))
@@ -69,24 +72,40 @@ class buffer_printer
     // The scalar versions might be part of a planar format.
 public:
     template <typename Tint1, typename Tint2, typename Tsize, typename Tstream = std::ostream>
-    static void print_buffer(const std::vector<hostbuf>& buf,
-                             const std::vector<Tint1>&   length,
-                             const std::vector<Tint2>&   stride,
-                             const Tsize                 nbatch,
-                             const Tsize                 dist,
-                             const std::vector<size_t>&  offset,
-                             Tstream&                    stream = std::cout)
+    static void print_buffer_half(const std::vector<hostbuf>& buf,
+                                  const std::vector<Tint1>&   length,
+                                  const std::vector<Tint2>&   stride,
+                                  const Tsize                 nbatch,
+                                  const Tsize                 dist,
+                                  const std::vector<size_t>&  offset,
+                                  Tstream&                    stream = std::cout)
     {
-        for(const auto& vec : buf)
-        {
-            printbuffer(reinterpret_cast<const Telem*>(vec.data()),
-                        length,
-                        stride,
-                        nbatch,
-                        dist,
-                        offset[0],
-                        stream);
-        }
+        auto num_decimals = 3;
+        print_buffer(num_decimals, buf, length, stride, nbatch, dist, offset, stream);
+    };
+    template <typename Tint1, typename Tint2, typename Tsize, typename Tstream = std::ostream>
+    static void print_buffer_single(const std::vector<hostbuf>& buf,
+                                    const std::vector<Tint1>&   length,
+                                    const std::vector<Tint2>&   stride,
+                                    const Tsize                 nbatch,
+                                    const Tsize                 dist,
+                                    const std::vector<size_t>&  offset,
+                                    Tstream&                    stream = std::cout)
+    {
+        auto num_decimals = 6;
+        print_buffer(num_decimals, buf, length, stride, nbatch, dist, offset, stream);
+    };
+    template <typename Tint1, typename Tint2, typename Tsize, typename Tstream = std::ostream>
+    static void print_buffer_double(const std::vector<hostbuf>& buf,
+                                    const std::vector<Tint1>&   length,
+                                    const std::vector<Tint2>&   stride,
+                                    const Tsize                 nbatch,
+                                    const Tsize                 dist,
+                                    const std::vector<size_t>&  offset,
+                                    Tstream&                    stream = std::cout)
+    {
+        auto num_decimals = 15;
+        print_buffer(num_decimals, buf, length, stride, nbatch, dist, offset, stream);
     };
     template <typename Tstream = std::ostream>
     static void print_buffer_flat(const std::vector<hostbuf>& buf,
@@ -101,6 +120,30 @@ public:
             for(size_t i = 0; i < size[0]; ++i)
                 stream << " " << data[i];
             stream << std::endl;
+        }
+    };
+
+private:
+    template <typename Tint1, typename Tint2, typename Tsize, typename Tstream = std::ostream>
+    static void print_buffer(const size_t&               num_decimals,
+                             const std::vector<hostbuf>& buf,
+                             const std::vector<Tint1>&   length,
+                             const std::vector<Tint2>&   stride,
+                             const Tsize                 nbatch,
+                             const Tsize                 dist,
+                             const std::vector<size_t>&  offset,
+                             Tstream&                    stream)
+    {
+        for(const auto& vec : buf)
+        {
+            printbuffer(num_decimals,
+                        reinterpret_cast<const Telem*>(vec.data()),
+                        length,
+                        stride,
+                        nbatch,
+                        dist,
+                        offset[0],
+                        stream);
         }
     };
 };

--- a/projects/hipfft/shared/rocfft_params.h
+++ b/projects/hipfft/shared/rocfft_params.h
@@ -109,6 +109,21 @@ inline rocfft_precision rocfft_precision_from_fftparams(const fft_precision val)
     }
 }
 
+inline fft_precision fft_precision_from_rocfft_precision(const rocfft_precision val)
+{
+    switch(val)
+    {
+    case rocfft_precision_single:
+        return fft_precision_single;
+    case rocfft_precision_double:
+        return fft_precision_double;
+    case rocfft_precision_half:
+        return fft_precision_half;
+    default:
+        throw std::runtime_error("Invalid precision");
+    }
+}
+
 inline rocfft_array_type rocfft_array_type_from_fftparams(const fft_array_type val)
 {
     switch(val)
@@ -129,6 +144,26 @@ inline rocfft_array_type rocfft_array_type_from_fftparams(const fft_array_type v
     return rocfft_array_type_unset;
 }
 
+inline fft_array_type fft_array_type_from_rocfft_array_type(const rocfft_array_type val)
+{
+    switch(val)
+    {
+    case rocfft_array_type_complex_interleaved:
+        return fft_array_type_complex_interleaved;
+    case rocfft_array_type_complex_planar:
+        return fft_array_type_complex_planar;
+    case rocfft_array_type_real:
+        return fft_array_type_real;
+    case rocfft_array_type_hermitian_interleaved:
+        return fft_array_type_hermitian_interleaved;
+    case rocfft_array_type_hermitian_planar:
+        return fft_array_type_hermitian_planar;
+    case rocfft_array_type_unset:
+        return fft_array_type_unset;
+    }
+    return fft_array_type_unset;
+}
+
 inline rocfft_transform_type rocfft_transform_type_from_fftparams(const fft_transform_type val)
 {
     switch(val)
@@ -146,6 +181,24 @@ inline rocfft_transform_type rocfft_transform_type_from_fftparams(const fft_tran
     }
 }
 
+inline fft_transform_type
+    fft_transform_type_from_rocfft_transform_type(const rocfft_transform_type val)
+{
+    switch(val)
+    {
+    case rocfft_transform_type_complex_forward:
+        return fft_transform_type_complex_forward;
+    case rocfft_transform_type_complex_inverse:
+        return fft_transform_type_complex_inverse;
+    case rocfft_transform_type_real_forward:
+        return fft_transform_type_real_forward;
+    case rocfft_transform_type_real_inverse:
+        return fft_transform_type_real_inverse;
+    default:
+        throw std::runtime_error("Invalid transform type");
+    }
+}
+
 inline rocfft_result_placement
     rocfft_result_placement_from_fftparams(const fft_result_placement val)
 {
@@ -155,6 +208,20 @@ inline rocfft_result_placement
         return rocfft_placement_inplace;
     case fft_placement_notinplace:
         return rocfft_placement_notinplace;
+    default:
+        throw std::runtime_error("Invalid result placement");
+    }
+}
+
+inline fft_result_placement
+    fft_result_placement_from_rocfft_result_placement(const rocfft_result_placement val)
+{
+    switch(val)
+    {
+    case rocfft_placement_inplace:
+        return fft_placement_inplace;
+    case rocfft_placement_notinplace:
+        return fft_placement_notinplace;
     default:
         throw std::runtime_error("Invalid result placement");
     }
@@ -474,9 +541,10 @@ public:
     }
 
     // scatter data to multiple GPUs and adjust I/O buffers to match
-    void multi_gpu_prepare(std::vector<gpubuf>& ibuffer,
-                           std::vector<void*>&  pibuffer,
-                           std::vector<void*>&  pobuffer) override
+    virtual void multi_gpu_prepare(std::vector<hostbuf>& cpu_input,
+                                   std::vector<gpubuf>&  ibuffer,
+                                   std::vector<void*>&   pibuffer,
+                                   std::vector<void*>&   pobuffer) override
     {
         auto alloc_fields = [&](const fft_params::fft_field& field,
                                 fft_array_type               array_type,
@@ -489,17 +557,11 @@ public:
             // we'll be allocating new ones for each brick
             pbuffer.clear();
 
-            auto length_with_batch = copy_input ? length : olength();
-            length_with_batch.insert(length_with_batch.begin(), nbatch);
-            const auto   splitDims       = get_split_dimensions(field, length_with_batch);
-            const auto   splitDimIdx     = splitDims.back();
             const size_t elem_size_bytes = var_size<size_t>(precision, array_type);
 
-            for(auto b : field.bricks)
+            for(const auto& b : field.bricks)
             {
-                const auto   whole_brick_len = b.length();
-                const size_t brick_size_elems
-                    = product(whole_brick_len.begin(), whole_brick_len.end());
+                const size_t brick_size_elems = compute_ptrdiff(b.length(), b.stride, 0, 0);
                 const size_t brick_size_bytes = brick_size_elems * elem_size_bytes;
 
                 // set device for the alloc, but we want to return to the
@@ -512,48 +574,44 @@ public:
                     pbuffer.push_back(multi_gpu_data.back().data());
                 }
 
-                const auto   batch_increment  = splitDims.size() == 1 ? b.upper[0] - b.lower[0] : 1;
-                const size_t batch_upper_orig = b.upper[0];
-
-                for(auto batchIdx = b.lower[0]; batchIdx < batch_upper_orig;
-                    batchIdx += batch_increment)
+                if(copy_input)
                 {
-                    b.lower[0] = batchIdx;
-                    b.upper[0] = b.lower[0] + batch_increment;
+                    // get this brick's starting offset in the field
+                    const size_t brick_offset_elems = b.lower_field_offset(istride, idist);
 
-                    // get brick's length now - might be just a single batch's worth
-                    const auto brick_len    = b.length();
-                    const auto brick_stride = b.stride;
+                    // transpose input data to the brick's shape in
+                    // host memory, then memcpy
 
-                    if(copy_input)
+                    // alloc a host-side brick that's the right shape
+                    std::vector<hostbuf> host_brick(1);
+                    host_brick.front().alloc(brick_size_bytes);
+
+                    std::vector<size_t> istride_with_batch{idist};
+                    std::copy(
+                        istride.begin(), istride.end(), std::back_inserter(istride_with_batch));
+
+                    copy_buffers(cpu_input,
+                                 host_brick,
+                                 b.length(),
+                                 1,
+                                 precision,
+                                 array_type,
+                                 istride_with_batch,
+                                 0,
+                                 array_type,
+                                 b.stride,
+                                 0,
+                                 {brick_offset_elems},
+                                 {0});
+
+                    // memcpy the transposed brick to the device
+                    if(hipMemcpy(pbuffer.back(),
+                                 host_brick.front().data(),
+                                 brick_size_bytes,
+                                 hipMemcpyHostToDevice)
+                       != hipSuccess)
                     {
-                        // get contiguous elems before and after the split
-                        const auto brick_length_before_split
-                            = product(brick_len.begin() + splitDimIdx, brick_len.end());
-                        const auto fft_length_with_split = product(
-                            length_with_batch.begin() + splitDimIdx, length_with_batch.end());
-                        const auto length_after_split
-                            = product(brick_len.begin(), brick_len.begin() + splitDimIdx);
-
-                        // get this brick's starting offset in the field
-                        const size_t brick_offset
-                            = b.lower_field_offset(istride, idist) * elem_size_bytes;
-
-                        // copy from original input - note that we're
-                        // assuming interleaved data so ibuffer has only one
-                        // gpubuf
-                        if(hipMemcpy2D(ptr_offset(pbuffer.back(),
-                                                  batchIdx * b.stride[0],
-                                                  rocfft_precision_from_fftparams(precision),
-                                                  rocfft_array_type_from_fftparams(array_type)),
-                                       brick_length_before_split * elem_size_bytes,
-                                       ibuffer.front().data_offset(brick_offset),
-                                       fft_length_with_split * elem_size_bytes,
-                                       brick_length_before_split * elem_size_bytes,
-                                       length_after_split,
-                                       hipMemcpyHostToDevice)
-                           != hipSuccess)
-                            throw std::runtime_error("hipMemcpy failure");
+                        throw std::runtime_error("hipMemcpy failure");
                     }
                 }
             }
@@ -582,68 +640,56 @@ public:
     std::vector<gpubuf> multi_gpu_data;
 
     // gather data after multi-GPU FFT for verification
-    void multi_gpu_finalize(std::vector<gpubuf>& obuffer, std::vector<void*>& pobuffer) override
+    void multi_gpu_finalize(std::vector<hostbuf>& gpu_output,
+                            std::vector<gpubuf>&  obuffer,
+                            std::vector<void*>&   pobuffer) override
     {
         if(ofields.empty())
             return;
 
-        auto length_with_batch = olength();
-        length_with_batch.insert(length_with_batch.begin(), nbatch);
-        const auto   splitDims       = get_split_dimensions(ofields.front(), length_with_batch);
-        const auto   splitDimIdx     = splitDims.back();
         const size_t elem_size_bytes = var_size<size_t>(precision, otype);
 
-        for(size_t i = 0; i < ofields.front().bricks.size(); ++i)
+        for(size_t i = 0; i < pobuffer.size(); ++i)
         {
-            auto b = ofields.front().bricks[i];
+            const auto& b = ofields.front().bricks[i];
 
-            const auto   batch_increment  = splitDims.size() == 1 ? b.upper[0] - b.lower[0] : 1;
-            const size_t batch_upper_orig = b.upper[0];
+            const size_t brick_size_elems = compute_ptrdiff(b.length(), b.stride, 0, 0);
+            const size_t brick_size_bytes = brick_size_elems * elem_size_bytes;
 
-            for(auto batchIdx = b.lower[0]; batchIdx < batch_upper_orig;
-                batchIdx += batch_increment)
+            // get this brick's starting offset in the field
+            const size_t brick_offset_elems = b.lower_field_offset(ostride, odist);
+
+            // switch device to where we're copying from
+            rocfft_scoped_device dev(b.device);
+
+            // copy the brick to host, then copy to output
+            std::vector<hostbuf> host_brick(1);
+            host_brick.front().alloc(brick_size_bytes);
+            if(hipMemcpy(
+                   host_brick.front().data(), pobuffer[i], brick_size_bytes, hipMemcpyDeviceToHost)
+               != hipSuccess)
             {
-                b.lower[0] = batchIdx;
-                b.upper[0] = b.lower[0] + batch_increment;
-
-                const auto& brick_ptr = pobuffer[i];
-                const auto  brick_len = b.length();
-
-                // get contiguous elems before and after the split
-                const auto brick_length_before_split
-                    = product(brick_len.begin() + splitDimIdx, brick_len.end());
-                const auto fft_length_with_split
-                    = product(length_with_batch.begin() + splitDimIdx, length_with_batch.end());
-                const auto length_after_split
-                    = product(brick_len.begin(), brick_len.begin() + splitDimIdx);
-
-                // get this brick's starting offset in the field
-                const size_t brick_offset = b.lower_field_offset(ostride, odist) * elem_size_bytes;
-
-                // switch device to where we're copying from
-                rocfft_scoped_device dev(b.device);
-
-                // copy to original output buffer - note that
-                // we're assuming interleaved data so obuffer
-                // has only one gpubuf
-                if(hipMemcpy2D(obuffer.front().data_offset(brick_offset),
-                               fft_length_with_split * elem_size_bytes,
-                               ptr_offset(brick_ptr,
-                                          batchIdx * b.stride[0],
-                                          rocfft_precision_from_fftparams(precision),
-                                          rocfft_array_type_from_fftparams(otype)),
-                               brick_length_before_split * elem_size_bytes,
-                               brick_length_before_split * elem_size_bytes,
-                               length_after_split,
-                               hipMemcpyDeviceToDevice)
-                   != hipSuccess)
-                    throw std::runtime_error("hipMemcpy failure");
-
-                // device-to-device transfers don't synchronize with the
-                // host, add explicit sync
-                (void)hipDeviceSynchronize();
+                throw std::runtime_error("hipMemcpy failed");
             }
+
+            std::vector<size_t> ostride_with_batch{odist};
+            std::copy(ostride.begin(), ostride.end(), std::back_inserter(ostride_with_batch));
+
+            copy_buffers(host_brick,
+                         gpu_output,
+                         b.length(),
+                         1,
+                         precision,
+                         otype,
+                         b.stride,
+                         0,
+                         otype,
+                         ostride_with_batch,
+                         0,
+                         {0},
+                         {brick_offset_elems});
         }
+        // set pobuffer back to a single-device transform
         pobuffer.clear();
         pobuffer.push_back(obuffer.front().data());
     }

--- a/projects/hipfft/shared/sys_mem.h
+++ b/projects/hipfft/shared/sys_mem.h
@@ -107,11 +107,11 @@ private:
 
     host_memory()
     {
-        update();
         // Note: passing (reading) a member variable as argument to a member routine that
         // requires a unique lock. This constructor is only possibly invoked at initialization
         // of the local static variable in the "singleton" public member function though, and
         // that initialization is guaranteed to be thread-safe in C++11.
+        update();
         set_limit_bytes(total_bytes);
     }
 

--- a/projects/hipfft/shared/test_params.h
+++ b/projects/hipfft/shared/test_params.h
@@ -27,18 +27,18 @@
 extern int    verbose;
 extern size_t ramgb;
 extern size_t vramgb;
+extern int    ngpus;
 
 extern size_t n_random_tests;
 
 extern size_t random_seed;
 extern double test_prob;
+extern double unittest_prob;
 extern double emulation_prob;
 extern double complex_interleaved_prob_factor;
 extern double real_prob_factor;
 extern double complex_planar_prob_factor;
 extern double callback_prob_factor;
-extern size_t max_length_for_hipfftw_test;
-extern size_t max_io_gb_for_hipfftw_test;
 
 extern double half_epsilon;
 extern double single_epsilon;

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -363,9 +363,9 @@ inline void execute_gpu_fft(Tparams&              params,
 
     // if output is in multiple bricks, collect it into the
     // host buffer where the results need to go
-    if(!params.ofields.empty())
-        params.multi_gpu_finalize(gpu_output, obuffer, pobuffer);
-    else
+    params.multi_gpu_finalize(gpu_output, obuffer, pobuffer);
+
+    if(params.ofields.empty())
     {
         // otherwise, copy directly from the device
         for(unsigned int idx = 0; idx < gpu_output.size(); ++idx)
@@ -594,8 +594,7 @@ inline void run_round_trip_inverse(Tparams&              params,
             // shouldn't have been touched.
             if(params.check_output_strides)
             {
-                auto hip_status
-                    = hipMemset(obuffer[i].data(), OUTPUT_INIT_PATTERN, obuffer_sizes[i]);
+                auto hip_status = hipMemset(pobuffer[i], OUTPUT_INIT_PATTERN, obuffer_sizes[i]);
                 if(hip_status != hipSuccess)
                 {
                     ++n_hip_failures;
@@ -612,6 +611,16 @@ inline void run_round_trip_inverse(Tparams&              params,
                 }
             }
         }
+    }
+
+    if(params.multiGPU > 1)
+    {
+        if(verbose > 0)
+        {
+            std::cout << "scattering data for multi-GPU inverse" << std::endl;
+        }
+        std::vector<hostbuf> cpu_input;
+        params.multi_gpu_prepare(cpu_input, obuffer, pibuffer, pobuffer);
     }
 
     // execute GPU transform
@@ -1408,7 +1417,7 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
         params_inverse.inverse_from_forward(params);
 
         run_round_trip_inverse<Tparams>(
-            params_inverse, ibuffer, pobuffer, pibuffer, gpu_input_data);
+            params_inverse, *obuffer, pobuffer, pibuffer, gpu_input_data);
     }
 
     if(fftw_compare)

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -352,7 +352,7 @@ inline void execute_gpu_fft(Tparams&              params,
     // Execute the transform:
     auto fft_status = params.execute(pibuffer.data(), pobuffer.data());
     if(fft_status != fft_status_success)
-        throw std::runtime_error("rocFFT plan execution failure");
+        throw std::runtime_error("FFT plan execution failure");
 
     // if not comparing, then just executing the GPU FFT is all we
     // need to do

--- a/projects/rocfft/shared/gpubuf.h
+++ b/projects/rocfft/shared/gpubuf.h
@@ -58,7 +58,7 @@ public:
         ret.owned             = false;
         ret.buf               = p;
         ret.bsize             = size_bytes;
-        ret.is_managed_memory = false;
+        ret.is_managed_memory = false; // irrelevant if not owned
         return ret;
     }
 


### PR DESCRIPTION
## Motivation

Synchronize shared files between rocFFT and hipFFT

## Technical Details

rocFFT and hipFFT have shared files that are meant to be kept in sync, but they've diverged over time.  Synchronize them again.

## Test Plan

Manually ran rocFFT and hipFFT single-device, single-proc multi-GPU, and MPI test cases.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
