### PR TITLE
[superbuild] Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@
 cmake_minimum_required(VERSION 3.25.2)
 project(rocm-libraries LANGUAGES C CXX Fortran ASM)
 
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW) # FetchContent timestamp handling
+endif()
+if(POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW) # option() honors normal variables
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 include(CMakeDependentOption)
@@ -94,7 +101,8 @@ if("hipblas-common" IN_LIST ROCM_LIBS_ENABLE_COMPONENTS)
 endif()
 
 if("rocroller" IN_LIST ROCM_LIBS_ENABLE_COMPONENTS)
-    # required deps: pip install pytest-cmake
+    # pip packages:
+    #   pip install pytest-cmake
     set(ROCROLLER_ENABLE_FETCH ON)
     add_subdirectory_with_message(
         COMPONENT rocroller

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,10 +31,17 @@
             }
         },
         {
+            "name": "origami",
+            "inherits": ["default:release"],
+            "cacheVariables": {
+                "ROCM_LIBS_ENABLE_COMPONENTS": "origami"
+            }
+        },
+        {
             "name": "hipblaslt",
             "inherits": ["default:release"],
             "cacheVariables": {
-                "ROCM_LIBS_ENABLE_COMPONENTS": "mxdatagenerator;rocroller;hipblas-common;hipblaslt"
+                "ROCM_LIBS_ENABLE_COMPONENTS": "mxdatagenerator;rocroller;origami;hipblas-common;hipblaslt"
             }
         },
         {

--- a/cmake/modules/fetch_rocm_cmake.cmake
+++ b/cmake/modules/fetch_rocm_cmake.cmake
@@ -1,3 +1,6 @@
+# Copyright Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
 find_package(ROCmCMakeBuildTools QUIET CONFIG)
 
 if(NOT ROCmCMakeBuildTools_FOUND)

--- a/cmake/toolchains/linux-amdclang.cmake
+++ b/cmake/toolchains/linux-amdclang.cmake
@@ -1,9 +1,6 @@
 # Copyright Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier: MIT
 
-set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR x86_64)
-
 set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to ROCm installation")
 set(CMAKE_PREFIX_PATH "${ROCM_PATH}" CACHE PATH "Search path for ROCm packages")
 

--- a/projects/hipblas-common/cmake/dependencies.cmake
+++ b/projects/hipblas-common/cmake/dependencies.cmake
@@ -26,22 +26,25 @@
 
 include(FetchContent)
 
-find_package(ROCM 0.11.0 CONFIG QUIET PATHS "${ROCM_PATH}") # First version with Sphinx doc gen improvement
-if(NOT ROCM_FOUND)
-  message(STATUS "ROCm CMake not found. Fetching...")
-  set(rocm_cmake_tag
-    "c044bb52ba85058d28afe2313be98d9fed02e293" # develop@2023.09.12. (move to 6.0 tag when released)
-    CACHE STRING "rocm-cmake tag to download")
-  FetchContent_Declare(
-    rocm-cmake
-    GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git
-    GIT_TAG        ${rocm_cmake_tag}
-    SOURCE_SUBDIR "DISABLE ADDING TO BUILD" # We don't really want to consume the build and test targets of ROCm CMake.
-  )
-  FetchContent_MakeAvailable(rocm-cmake)
-  find_package(ROCM CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
-else()
-  find_package(ROCM 0.11.0 CONFIG REQUIRED PATHS "${ROCM_PATH}")
+find_package(ROCmCMakeBuildTools QUIET CONFIG)
+
+if(NOT ROCmCMakeBuildTools_FOUND)
+    message(STATUS "ROCmCMakeBuildTools not found. Fetching from source...")
+    include(FetchContent)
+    FetchContent_Declare(
+        rocm-cmake GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git GIT_TAG rocm-6.4.3
+        GIT_SHALLOW TRUE
+    )
+
+    FetchContent_GetProperties(rocm-cmake)
+    if(NOT rocm-cmake_POPULATED)
+        FetchContent_Populate(rocm-cmake)
+        message(
+            STATUS
+                "Added ROCm CMake modules path: ${rocm-cmake_SOURCE_DIR}/share/rocmcmakebuildtools/cmake"
+        )
+        list(APPEND CMAKE_MODULE_PATH ${rocm-cmake_SOURCE_DIR}/share/rocmcmakebuildtools/cmake)
+    endif()
 endif()
 
 include(ROCMSetupVersion)

--- a/shared/origami/CMakeLists.txt
+++ b/shared/origami/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+# Set cpack license file here to avoid rocm-cmake warning
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md")
+
 include(dependencies)
 
 rocm_setup_version(VERSION ${PROJECT_VERSION})

--- a/shared/origami/LICENSE.md
+++ b/shared/origami/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (C) Advanced Micro Devices, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/shared/origami/cmake/dependencies.cmake
+++ b/shared/origami/cmake/dependencies.cmake
@@ -10,34 +10,25 @@ find_package(Git REQUIRED)
 # (Thanks to rocBLAS devs for finding workaround for this problem!)
 list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hip /opt/rocm)
 
-# ROCm cmake package
-find_package(ROCmCMakeBuildTools 0.11.0 CONFIG QUIET) # First version with Sphinx doc gen improvement
-if(NOT ROCM_FOUND)
-  set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
-  set(rocm_cmake_tag "rocm-6.4.1" CACHE STRING "rocm-cmake tag to download")
-  file(DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
-       ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
+find_package(ROCmCMakeBuildTools QUIET CONFIG)
 
-  list(GET status 0 status_code)
-  list(GET status 1 status_string)
+if(NOT ROCmCMakeBuildTools_FOUND)
+    message(STATUS "ROCmCMakeBuildTools not found. Fetching from source...")
+    include(FetchContent)
+    FetchContent_Declare(
+        rocm-cmake GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git GIT_TAG rocm-6.4.3
+        GIT_SHALLOW TRUE
+    )
 
-  if(NOT status_code EQUAL 0)
-    message(FATAL_ERROR "error: downloading
-    'https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
-    status_code: ${status_code}
-    status_string: ${status_string}
-    log: ${log}
-    ")
-  endif()
-
-  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
-  execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag})
-  execute_process(COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
-
-  find_package( ROCmCMakeBuildTools 0.6 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )
+    FetchContent_GetProperties(rocm-cmake)
+    if(NOT rocm-cmake_POPULATED)
+        FetchContent_Populate(rocm-cmake)
+        message(
+            STATUS
+                "Added ROCm CMake modules path: ${rocm-cmake_SOURCE_DIR}/share/rocmcmakebuildtools/cmake"
+        )
+        list(APPEND CMAKE_MODULE_PATH ${rocm-cmake_SOURCE_DIR}/share/rocmcmakebuildtools/cmake)
+    endif()
 endif()
 
 include(ROCMSetupVersion)


### PR DESCRIPTION
## Motivation

Origami needs a build preset, plus, many warnings are emitted because rocm-cmake is using a deprecated name (ROCM instead of ROCmCMakeBuildTools).

## Technical Details

1. Add origami to the build preset and resolve the license error emitted by rocm-cmake
2. Update the origami and hipblas-common rocm-cmake fetch file

## Test Plan

Superbuild CI testing

## Test Result

See CI results

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
