### PR TITLE
[hipblaslt] Add alignment support for labels

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -5430,7 +5430,7 @@ class KernelWriterAssembly(KernelWriter):
         kernel["ProblemType"]["IndicesSummation"][loopIdx]]
     if not tailLoop and not noLabelGen:
       module.add(Label("openLoop%s"%loopChar, ""))
-    loopLabelBegin = Label("%sLoopBegin%s"%("Tail" if tailLoop else "", loopChar), "" )
+    loopLabelBegin = Label("%sLoopBegin%s"%("Tail" if tailLoop else "", loopChar), "", alignment=16 )
     loopLabelEnd = Label("%sLoopEnd%s"%("Tail" if tailLoop else "", loopChar), "" )
 
     if beginLabelOnly:
@@ -13888,7 +13888,7 @@ class KernelWriterAssembly(KernelWriter):
     module.addComment0("SIMD specialized dispatch")
 
     for l in range(numCodePath):
-      loopLabelBegin.append(Label("LoopBegin%s_%u"%(loopChar, l), "" ))
+      loopLabelBegin.append(Label("LoopBegin%s_%u"%(loopChar, l), "", alignment=16))
       loopLabelSkipBegin.append(Label("LoopSkipBegin%s_%u"%(loopChar, l), "" ))
     loopLabelEnd = Label("LoopEnd%s"%(loopChar), "" )
 

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/code.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/code.hpp
@@ -43,25 +43,31 @@ namespace rocisa
     {
         std::variant<std::string, int> label;
         std::string                    comment;
+        int                            alignment;
 
-        Label(int label, const std::string& comment)
+        Label(int label, const std::string& comment, int alignment = 1)
             : Item("")
             , label(label)
             , comment(comment)
+            , alignment(alignment)
         {
         }
 
-        Label(const std::string& label, const std::string& comment)
+        Label(const std::string& label, const std::string& comment, int alignment = 1)
             : Item("")
             , label(label)
             , comment(comment)
+            , alignment(alignment)
         {
         }
 
-        Label(const std::variant<std::string, int>& label, const std::string& comment)
+        Label(const std::variant<std::string, int>& label,
+              const std::string&                    comment,
+              int                                   alignment = 1)
             : Item("")
             , label(label)
             , comment(comment)
+            , alignment(alignment)
         {
         }
 
@@ -69,6 +75,7 @@ namespace rocisa
             : Item(other)
             , label(other.label)
             , comment(other.comment)
+            , alignment(other.alignment)
         {
         }
 
@@ -103,6 +110,10 @@ namespace rocisa
         std::string toString() const override
         {
             std::string t = getLabelName() + ":";
+            if(alignment > 1)
+            {
+                t = ".align " + std::to_string(alignment) + "\n" + t;
+            }
             if(!comment.empty() && !rocIsa::getInstance().getOutputOptions().outputNoComment)
             {
                 t += "  /// " + comment;

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/code.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/code.cpp
@@ -101,13 +101,18 @@ void init_code(nb::module_ m)
     auto m_code = m.def_submodule("code", "rocIsa code submodule.");
 
     nb::class_<rocisa::Label, rocisa::Item>(m_code, "Label")
-        .def(nb::init<int, const std::string&>(), nb::arg("label"), nb::arg("comment"))
-        .def(nb::init<const std::string&, const std::string&>(),
+        .def(nb::init<int, const std::string&, int>(),
              nb::arg("label"),
-             nb::arg("comment"))
+             nb::arg("comment"),
+             nb::arg("alignment") = 1)
+        .def(nb::init<const std::string&, const std::string&, int>(),
+             nb::arg("label"),
+             nb::arg("comment"),
+             nb::arg("alignment") = 1)
         .def_static("getFormatting", &rocisa::Label::getFormatting)
         .def_rw("label", &rocisa::Label::label)
         .def_rw("comment", &rocisa::Label::comment)
+        .def_rw("alignment", &rocisa::Label::alignment)
         .def("getLabelName", &rocisa::Label::getLabelName)
         .def("__str__", &rocisa::Label::toString)
         .def("__deepcopy__",
@@ -117,12 +122,13 @@ void init_code(nb::module_ m)
              })
         .def("__getstate__",
              [](const rocisa::Label& self) {
-                 return std::make_tuple(self.name, self.label, self.comment);
+                 return std::make_tuple(self.name, self.label, self.comment, self.alignment);
              })
         .def("__setstate__",
-             [](rocisa::Label&                                                       self,
-                std::tuple<std::string, std::variant<std::string, int>, std::string> state) {
-                 new(&self) rocisa::Label(std::get<1>(state), std::get<2>(state));
+             [](rocisa::Label&                                                            self,
+                std::tuple<std::string, std::variant<std::string, int>, std::string, int> state) {
+                 new(&self)
+                     rocisa::Label(std::get<1>(state), std::get<2>(state), std::get<3>(state));
                  self.name = std::get<0>(state);
              });
 


### PR DESCRIPTION
## Motivation

For often used branch targets we want to have proper alignment to avoid additional branch overheads. 

## Technical Details

Add alignment support for labels. Alignment is done using the `.align` directive. Default alignment is 1 which skips generating `.align` before the label.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
