### PR TITLE
Set random seeds to a fixed value to resolve flaky tests

### DIFF
--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
@@ -389,7 +389,9 @@ class IntegrationGpuBatchnormBackwardNdhwcFp16
 
 std::vector<Batchnorm2dTestCase> getBnBwdTestCases()
 {
-    unsigned int seed = std::random_device{}();
+    // Fixing seeds for now to ensure consistent runs
+    // unsigned seed = std::random_device{}();
+    unsigned seed = 1337;
 
     return std::vector<Batchnorm2dTestCase>{
         {1, 3, 14, 14, seed},
@@ -407,7 +409,9 @@ std::vector<Batchnorm2dTestCase> getBnBwdTestCases()
 
 std::vector<Batchnorm3dTestCase> getBnBwd3dTestCases()
 {
-    unsigned int seed = std::random_device{}();
+    // Fixing seeds for now to ensure consistent runs
+    // unsigned seed = std::random_device{}();
+    unsigned seed = 1337;
 
     return std::vector<Batchnorm3dTestCase>{
         {2, 3, 3, 1, 1, seed},

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
@@ -391,7 +391,7 @@ std::vector<Batchnorm2dTestCase> getBnBwdTestCases()
 {
     // Fixing seeds for now to ensure consistent runs
     // unsigned seed = std::random_device{}();
-    unsigned seed = 1337;
+    unsigned seed = 1;
 
     return std::vector<Batchnorm2dTestCase>{
         {1, 3, 14, 14, seed},
@@ -411,7 +411,7 @@ std::vector<Batchnorm3dTestCase> getBnBwd3dTestCases()
 {
     // Fixing seeds for now to ensure consistent runs
     // unsigned seed = std::random_device{}();
-    unsigned seed = 1337;
+    unsigned seed = 1;
 
     return std::vector<Batchnorm3dTestCase>{
         {2, 3, 3, 1, 1, seed},

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -358,7 +358,9 @@ class IntegrationGpuBatchnormForwardInferenceNdhwcFp16
 
 std::vector<Batchnorm2dTestCase> getBnFwdInferenceTestCases()
 {
-    unsigned int seed = std::random_device{}();
+    // Fixing seeds for now to ensure consistent runs
+    // unsigned seed = std::random_device{}();
+    unsigned seed = 1337;
 
     return {
         {1, 3, 14, 14, seed},
@@ -374,7 +376,9 @@ std::vector<Batchnorm2dTestCase> getBnFwdInferenceTestCases()
 
 std::vector<Batchnorm3dTestCase> getBnFwdInference3dTestCases()
 {
-    unsigned int seed = std::random_device{}();
+    // Fixing seeds for now to ensure consistent runs
+    // unsigned seed = std::random_device{}();
+    unsigned seed = 1337;
 
     return {
         {2, 3, 3, 1, 1, seed},

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -360,7 +360,7 @@ std::vector<Batchnorm2dTestCase> getBnFwdInferenceTestCases()
 {
     // Fixing seeds for now to ensure consistent runs
     // unsigned seed = std::random_device{}();
-    unsigned seed = 1337;
+    unsigned seed = 1;
 
     return {
         {1, 3, 14, 14, seed},
@@ -378,7 +378,7 @@ std::vector<Batchnorm3dTestCase> getBnFwdInference3dTestCases()
 {
     // Fixing seeds for now to ensure consistent runs
     // unsigned seed = std::random_device{}();
-    unsigned seed = 1337;
+    unsigned seed = 1;
 
     return {
         {2, 3, 3, 1, 1, seed},

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenConvFwdOperations.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenConvFwdOperations.cpp
@@ -140,7 +140,7 @@ std::vector<ConvTestCase> getTestCases()
 {
     // Fixing seeds for now to ensure consistent runs
     // unsigned seed = std::random_device{}();
-    unsigned seed = 1337;
+    unsigned seed = 1;
 
     return {
         {{1, 16, 16, 16}, {1, 16, 1, 1}, {0, 0}, {0, 0}, {1, 1}, {1, 1}, seed},

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenConvFwdOperations.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/TestMiopenConvFwdOperations.cpp
@@ -138,7 +138,9 @@ protected:
 
 std::vector<ConvTestCase> getTestCases()
 {
-    unsigned seed = std::random_device{}();
+    // Fixing seeds for now to ensure consistent runs
+    // unsigned seed = std::random_device{}();
+    unsigned seed = 1337;
 
     return {
         {{1, 16, 16, 16}, {1, 16, 1, 1}, {0, 0}, {0, 0}, {1, 1}, {1, 1}, seed},

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/BatchnormCommon.hpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/BatchnormCommon.hpp
@@ -33,7 +33,9 @@ struct Batchnorm2dTestCase
 
 inline std::vector<Batchnorm2dTestCase> getBatchnorm2dTestCases()
 {
-    unsigned int seed = std::random_device{}();
+    // Fixing seeds for now to ensure consistent runs
+    // unsigned seed = std::random_device{}();
+    unsigned seed = 1337;
 
     return {
         {1, 3, 14, 14, seed},

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/BatchnormCommon.hpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/BatchnormCommon.hpp
@@ -35,7 +35,7 @@ inline std::vector<Batchnorm2dTestCase> getBatchnorm2dTestCases()
 {
     // Fixing seeds for now to ensure consistent runs
     // unsigned seed = std::random_device{}();
-    unsigned seed = 1337;
+    unsigned seed = 1;
 
     return {
         {1, 3, 14, 14, seed},

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/ConvolutionCommon.hpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/ConvolutionCommon.hpp
@@ -112,7 +112,9 @@ struct ConvTestCase
 
 inline std::vector<ConvTestCase> getConvTestCases4D()
 {
-    unsigned seed = std::random_device{}();
+    // Fixing seeds for now to ensure consistent runs
+    // unsigned seed = std::random_device{}();
+    unsigned seed = 1337;
 
     return {
         // Filter 1x1
@@ -139,7 +141,9 @@ inline std::vector<ConvTestCase> getConvTestCases4D()
 
 inline std::vector<ConvTestCase> getConvTestCases5D()
 {
-    unsigned seed = std::random_device{}();
+    // Fixing seeds for now to ensure consistent runs
+    // unsigned seed = std::random_device{}();
+    unsigned seed = 1337;
 
     return {
         // Filter 1x1

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/ConvolutionCommon.hpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/ConvolutionCommon.hpp
@@ -114,7 +114,7 @@ inline std::vector<ConvTestCase> getConvTestCases4D()
 {
     // Fixing seeds for now to ensure consistent runs
     // unsigned seed = std::random_device{}();
-    unsigned seed = 1337;
+    unsigned seed = 1;
 
     return {
         // Filter 1x1
@@ -143,7 +143,7 @@ inline std::vector<ConvTestCase> getConvTestCases5D()
 {
     // Fixing seeds for now to ensure consistent runs
     // unsigned seed = std::random_device{}();
-    unsigned seed = 1337;
+    unsigned seed = 1;
 
     return {
         // Filter 1x1

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
@@ -37,7 +37,10 @@ public:
                                     hipdnn_sdk::data_objects::DataType scaleBiasDataType,
                                     hipdnn_sdk::data_objects::DataType meanVarianceDataType)
     {
-        unsigned int seed = std::random_device{}();
+        // Fixing seeds for now to ensure consistent runs
+        // unsigned seed = std::random_device{}();
+        unsigned seed = 1337;
+
         std::vector<int64_t> dims = {1, 3, 14, 14};
         auto graph = buildBatchnormFwdInferenceGraph(
             inputDataType, scaleBiasDataType, meanVarianceDataType, dims, TensorLayout::NCHW, true);

--- a/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
+++ b/projects/hipdnn/sdk/tests/test_utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
@@ -39,7 +39,7 @@ public:
     {
         // Fixing seeds for now to ensure consistent runs
         // unsigned seed = std::random_device{}();
-        unsigned seed = 1337;
+        unsigned seed = 1;
 
         std::vector<int64_t> dims = {1, 3, 14, 14};
         auto graph = buildBatchnormFwdInferenceGraph(


### PR DESCRIPTION
## Motivation

With adding hipDNN to TheRock we are seeing infrequent tolerance issues in the integration tests due to randomized seeds.
This PR locks the random seeds to ensure tests are stable. 
This matches with how MIOpen is currently testing as well.

## Technical Details

Since we are validating at an integration level, we cannot validate too strictly when comparing the results to a reference implementation. There is various factors that impact the final results (atomics leading to non-deterministic behavior, algorithm choices etc). The integration tests are meant to give us confidence that the integration is still working and not broken, but it cannot provide very strict tolerance ranges due to this variability, and lack of detail.

We plan to improve on this in the future, and provide more details about the selected implementation to allow more tight tolerance checks.

## Test Plan

Run existing tests on multiple architectures to ensure they are validating.

## Test Result

Tests passing.