### PR TITLE
[MIOpen][CI] Move gfx908 to Nightlies

### DIFF
--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -75,7 +75,7 @@ def runBuildAndSingleGtestJob(def utils, def flags, def build_timeout_minutes=42
 }
 
 //launch develop branch nightly jobs
-CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 0 * * * % RUN_NIGHTLY_TESTS=true;BUILD_PACKAGE_AND_CHECKS=false;BUILD_FULL_TESTS=false;TARGET_GFX908=true;TARGET_GFX90A=true;TARGET_GFX942=true''' : ""
+CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 0 * * * % RUN_NIGHTLY_TESTS=true;RUN_GFX908_DBSYNC_AND_FULL_TESTS_NIGHTLY=true;BUILD_PACKAGE_AND_CHECKS=false;BUILD_FULL_TESTS=false;TARGET_GFX908=true;TARGET_GFX90A=true;TARGET_GFX942=true''' : ""
 
 pipeline {
     agent none
@@ -119,7 +119,7 @@ pipeline {
             description: "")
         booleanParam(
             name: "TARGET_GFX908",
-            defaultValue: env.BRANCH_NAME == "develop" ? true : false,
+            defaultValue: false,
             description: "")
         booleanParam(
             name: "TARGET_GFX90A",
@@ -180,6 +180,10 @@ pipeline {
             name: "RUN_NIGHTLY_TESTS",
             defaultValue: false,
             description: "Run the nightly tests (default: OFF)")
+        booleanParam(
+            name: "RUN_GFX908_DBSYNC_AND_FULL_TESTS_NIGHTLY",
+            defaultValue: false,
+            description: "Run the gfx908 DBSync + full tests in nightly (default: OFF)")
     }
 
     environment{
@@ -894,6 +898,78 @@ pipeline {
                                 utils.buildHipClangJob(build_type: 'debug', make_targets: Smoke_targets, build_install: true)
                             }
                         }
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+                stage('Dbsync gfx908') {
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 && params.RUN_GFX908_DBSYNC_AND_FULL_TESTS_NIGHTLY }
+                    }
+                    options {
+                        retry(2)
+                    }
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        runDbSyncJob(utils)
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+                stage('Bf16 Hip Install All gfx908') {
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 && params.RUN_GFX908_DBSYNC_AND_FULL_TESTS_NIGHTLY }
+                    }
+                    options {
+                        retry(2)
+                    }
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        runBuildAndSingleGtestJob(utils, Full_test + Bf16_flags, Build_timeout_minutes)
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+                stage('Fp16 Hip All Install gfx908') {
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 && params.RUN_GFX908_DBSYNC_AND_FULL_TESTS_NIGHTLY }
+                    }
+                    options {
+                        retry(2)
+                    }
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        runBuildAndSingleGtestJob(utils, Full_test + Fp16_flags, Build_timeout_minutes)
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+                stage('Fp32 Hip All gfx908') {
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 && params.RUN_GFX908_DBSYNC_AND_FULL_TESTS_NIGHTLY }
+                    }
+                    options {
+                        retry(2)
+                    }
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        runBuildAndSingleGtestJob(utils, Full_test, Build_timeout_minutes)
                     }
                     post {
                         always {


### PR DESCRIPTION
## Motivation
MI100 is lower priority than other architectures (MI200, MI300, etc.), and we don't have a lot of MI100 CI machines. This often becomes a bottleneck on the develop post-checkin CI. To alleviate this, we want to move the MI100 testing to a nightly CI run off of the develop branch.

## Technical Details
Currently, we have the following CI processes:

- Pre-checkin CI: Runs on gfx90a and gfx942.
- Post-checkin CI (develop branch): Runs on gfx908, gfx90a, gfx942, and NAVI35.
- Debug nightlies (develop branch): Runs on gfx908, gfx90a, and gfx942 at 12:00 am.

## Changes implemented:

- Removed gfx908 from the post-checkin CI (develop branch) and added it to the debug nightlies.
- The DB sync and full tests for gfx908 will now run as part of the nightly CI.
- Developers can still trigger gfx908 full tests manually if necessary, but they are disabled by default.
- Introduced a flag `RUN_GFX908_DBSYNC_AND_FULL_TESTS_NIGHTLY` to enable or disable these tests. This flag is disabled by default but enabled as part of the nightly `cron` job.

## Test Plan

- Ensure that the gfx908 DB sync and full tests run successfully as part of the nightly CI.
- Verify that the flag RUN_GFX908_DBSYNC_AND_FULL_TESTS_NIGHTLY correctly enables or disables the tests.

## Test Result

- The gfx908 DB sync and full tests were successfully integrated into the nightly CI.
- The flag RUN_GFX908_DBSYNC_AND_FULL_TESTS_NIGHTLY was tested and works as expected.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
