### PR TITLE
Fix type_traits.hpp rocprim::half float_bit_mask definition

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/type_traits.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/type_traits.hpp
@@ -1290,7 +1290,7 @@ struct traits::define<rocprim::half>
     using number_format
         = traits::number_format::values<traits::number_format::kind::floating_point_type>;
     /// \brief Trait `float_bit_mask` for this type
-    using float_bit_mask = traits::float_bit_mask::values<uint16_t, 0x8000, 0x7F80, 0x007F>;
+    using float_bit_mask = traits::float_bit_mask::values<uint16_t, 0x8000, 0x7C00, 0x03FF>;
 };
 
 // Type traits like std::is_integral and std::is_arithmetic may be defined for 128-bit integral


### PR DESCRIPTION
## Motivation
Fixes: https://github.com/ROCm/rocm-libraries/issues/2212
## Technical Details

`float_bit_mask` for `rocprim::half` is currently incorrect and a duplicate of `rocprim::bfloat16` `float_bit_mask`.

This PR updates the values to match [previously correct definition](https://github.com/ROCm/rocPRIM/blob/rocm-6.3.2/rocprim/include/rocprim/type_traits.hpp#L338-L345).

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
