### PR TITLE
[rocFFT] Add wait option to slurm script

### DIFF
--- a/projects/rocfft/scripts/rocfftslurmtest.py
+++ b/projects/rocfft/scripts/rocfftslurmtest.py
@@ -114,6 +114,10 @@ def main():
                         type=int,
                         default=1,
                         help='Maximum number of nodes to use')
+    parser.add_argument('--wait',
+                        type=boolean,
+                        default=False,
+                        help='Wait for job to complete')
 
     if args.config_file:
         for k, v in config.items("Defaults"):
@@ -215,6 +219,8 @@ def main():
     jobparams.gpuspernode = args.gpuspernode
     jobparams.timelimit = datetime.timedelta(hours=2)
     jobparams.ntaskspernode = jobparams.gpuspernode
+    if args.wait:
+        jobparams.wait = True
     if buildjob != None:
         jobparams.afterok = [buildjob.jobid]
 

--- a/projects/rocfft/scripts/rocfftslurmtest.py
+++ b/projects/rocfft/scripts/rocfftslurmtest.py
@@ -115,7 +115,7 @@ def main():
                         default=1,
                         help='Maximum number of nodes to use')
     parser.add_argument('--wait',
-                        type=boolean,
+                        type=bool,
                         default=False,
                         help='Wait for job to complete')
 

--- a/projects/rocfft/scripts/rocfftslurmtest.py
+++ b/projects/rocfft/scripts/rocfftslurmtest.py
@@ -115,9 +115,8 @@ def main():
                         default=1,
                         help='Maximum number of nodes to use')
     parser.add_argument('--wait',
-                        type=bool,
-                        default=False,
-                        help='Wait for job to complete')
+                        action='store_true',
+                        help='Wait for job to complete. Default is off')
 
     if args.config_file:
         for k, v in config.items("Defaults"):

--- a/projects/rocfft/scripts/rocslurm/__init__.py
+++ b/projects/rocfft/scripts/rocslurm/__init__.py
@@ -34,6 +34,7 @@ class sbatchparams:
         self.afterok = []
         self.afterany = []
         self.timelimit = None
+        self.wait = False
 
 
 class sbatchjob:
@@ -74,6 +75,8 @@ def sbatch(jobname, params, logdir, workdir, jobcmd, verbose=0):
     if len(params.afterok) > 0:
         batchscript += "#SBATCH --dependency=afterok:" + ",".join(
             str(x) for x in params.afterok) + "\n"
+    if params.wait:
+        batchscript += "#SBATCH --wait\n"
 
     for module in params.modules:
         batchscript += "module load " + module + "\n"


### PR DESCRIPTION
## Motivation

Add wait option to allow automation to wait for completion before attempting to read logs

## Technical Details

sbatch takes `--wait`. Add `--wait` to rocfftslurmtest.py

## Test Plan

To be tested on math-ci

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
