### PR TITLE
Update rocfft slurm test to remove hard-coded gpus per node

### DIFF
--- a/projects/rocfft/scripts/rocfftslurmtest.py
+++ b/projects/rocfft/scripts/rocfftslurmtest.py
@@ -177,15 +177,19 @@ def main():
 
         buildcmd = ""
 
-        # If we need a new cmake, get it.
-        buildcmd += "TEMP_DIR=$(mktemp -d) && cd ${TEMP_DIR}\n"
-        buildcmd += "wget -q https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7.tar.gz -O cmake-3.31.7.tar.gz\n"
-        buildcmd += "tar -xf cmake-3.31.7.tar.gz && cd cmake-3.31.7\n"
-        buildcmd += "mkdir build && cd build\n"
-        buildcmd += "cmake -DCMAKE_INSTALL_PREFIX=${TEMP_DIR}/cmake .. && make && make install\n"
-        buildcmd += "export PATH=${TEMP_DIR}/cmake/bin:$PATH\n"
+        # # If we need a new cmake, get it.
+        # buildcmd += "TEMP_DIR=$(mktemp -d) && cd ${TEMP_DIR}\n"
+        # buildcmd += "wget -q https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7.tar.gz -O cmake-3.31.7.tar.gz\n"
+        # buildcmd += "tar -xf cmake-3.31.7.tar.gz && cd cmake-3.31.7\n"
+        # buildcmd += "mkdir build && cd build\n"
+        # buildcmd += "cmake -DCMAKE_INSTALL_PREFIX=${TEMP_DIR}/cmake .. &&  make -j && make install\n"
+        # buildcmd += "export PATH=${TEMP_DIR}/cmake/bin:$PATH\n"
+
+        buildcmd += "which cmake\n"
+        buildcmd += "cmake --version\n"
 
         # Run a compile job first.
+        buildcmd += "cd " + args.builddir + "\n"
         buildcmd += "cmake"
         buildcmd += " -DCMAKE_CXX_COMPILER=amdclang++"
         buildcmd += " -DCMAKE_C_COMPILER=amdclang"
@@ -198,7 +202,7 @@ def main():
         if args.buildcraympi:
             buildcmd += " -DROCFFT_CRAY_MPI_ENABLE=on"
         buildcmd += " " + args.srcdir
-        buildcmd += " && make"
+        buildcmd += " && make -j"
 
         # Set up the basic slurm parameters:
         buildparams = rocslurm.sbatchparams()
@@ -216,7 +220,7 @@ def main():
         buildjob = rocslurm.sbatch("build",
                                    buildparams,
                                    args.logdir,
-                                   args.builddir,
+                                   args.srcdir,
                                    buildcmd,
                                    verbose=args.verbose)
 

--- a/projects/rocfft/scripts/rocfftslurmtest.py
+++ b/projects/rocfft/scripts/rocfftslurmtest.py
@@ -123,7 +123,6 @@ def main():
                                             ("yes", "true", "t", "1")),
                         default=False,
                         help='Do not exit until the report job has completed')
-    
 
     if args.config_file:
         for k, v in config.items("Defaults"):

--- a/projects/rocfft/scripts/rocfftslurmtest.py
+++ b/projects/rocfft/scripts/rocfftslurmtest.py
@@ -72,6 +72,10 @@ def main():
                         type=str,
                         default=None,
                         help='build directory')
+    parser.add_argument('--srcdir',
+                        type=str,
+                        default=None,
+                        help='source directory')
     parser.add_argument('--build',
                         type=lambda x: bool(x.lower() in
                                             ("yes", "true", "t", "1")),
@@ -164,6 +168,14 @@ def main():
 
     buildjob = None
     if args.build:
+        if args.srcdir == None:
+            print("You must specify source dir if you are going to build")
+            sys.exit(1)
+        if not os.path.exists(args.srcdir):
+            print("Source dir " + args.srcdir + " does not exist")
+            sys.exit(1)
+        
+        
         # Run a compile job first.
         buildcmd = "cmake"
         buildcmd += " -DCMAKE_CXX_COMPILER=amdclang++"
@@ -176,7 +188,7 @@ def main():
         buildcmd += " -DROCFFT_MPI_ENABLE=on "
         if args.buildcraympi:
             buildcmd += " -DROCFFT_CRAY_MPI_ENABLE=on"
-        buildcmd += " .."
+        buildcmd += " " + args.srcdir
         buildcmd += " && make"
 
         # Set up the basic slurm parameters:

--- a/projects/rocfft/scripts/rocfftslurmtest.py
+++ b/projects/rocfft/scripts/rocfftslurmtest.py
@@ -174,10 +174,19 @@ def main():
         if not os.path.exists(args.srcdir):
             print("Source dir " + args.srcdir + " does not exist")
             sys.exit(1)
-        
-        
+
+        buildcmd = ""
+
+        # If we need a new cmake, get it.
+        buildcmd += "TEMP_DIR=$(mktemp -d) && cd ${TEMP_DIR}\n"
+        buildcmd += "wget -q https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7.tar.gz -O cmake-3.31.7.tar.gz\n"
+        buildcmd += "tar -xf cmake-3.31.7.tar.gz && cd cmake-3.31.7\n"
+        buildcmd += "mkdir build && cd build\n"
+        buildcmd += "cmake -DCMAKE_INSTALL_PREFIX=${TEMP_DIR}/cmake .. && make && make install\n"
+        buildcmd += "export PATH=${TEMP_DIR}/cmake/bin:$PATH\n"
+
         # Run a compile job first.
-        buildcmd = "cmake"
+        buildcmd += "cmake"
         buildcmd += " -DCMAKE_CXX_COMPILER=amdclang++"
         buildcmd += " -DCMAKE_C_COMPILER=amdclang"
         if args.ccache:

--- a/projects/rocfft/scripts/rocfftslurmtest.py
+++ b/projects/rocfft/scripts/rocfftslurmtest.py
@@ -118,6 +118,12 @@ def main():
                         type=int,
                         default=1,
                         help='Maximum number of nodes to use')
+    parser.add_argument('--reportwait',
+                        type=lambda x: bool(x.lower() in
+                                            ("yes", "true", "t", "1")),
+                        default=False,
+                        help='Do not exit until the report job has completed')
+    
 
     if args.config_file:
         for k, v in config.items("Defaults"):
@@ -272,6 +278,8 @@ def main():
     # Report on job status
     jobparams.ntaskspernode = 1
     jobparams.nnodes = 1
+    if args.reportwait == True:
+        jobparams.wait = True
     rocslurm.reportonjobs(jobparams, args.logdir, jobs, verbose=args.verbose)
 
 

--- a/projects/rocfft/scripts/rocfftslurmtest.py
+++ b/projects/rocfft/scripts/rocfftslurmtest.py
@@ -189,9 +189,8 @@ def main():
         buildparams.modules = args.modules
         buildparams.exports = args.exports
         buildparams.ntaskspernode = 1
-        buildparams.gpuspernode = 1
+        buildparams.gpuspernode = None
         buildparams.timelimit = datetime.timedelta(hours=2)
-        buildparams.ntaskspernode = 1
 
         buildjob = rocslurm.sbatch("build",
                                    buildparams,
@@ -211,10 +210,10 @@ def main():
         jobparams.acct = args.acct
     jobparams.modules = args.modules
     jobparams.exports = args.exports
-    jobparams.ntaskspernode = 1
-    jobparams.gpuspernode = args.gpuspernode
+    #jobparams.gpuspernode = args.gpuspernode
     jobparams.timelimit = datetime.timedelta(hours=2)
-    jobparams.ntaskspernode = jobparams.gpuspernode
+    #jobparams.ntaskspernode = jobparams.gpuspernode
+    jobparams.ntasks = jobparams.gpuspernode
     if buildjob != None:
         jobparams.afterok = [buildjob.jobid]
 
@@ -233,11 +232,10 @@ def main():
         mpigpucmd += " --launcher srun"
         if args.gpuidvar != None:
             mpigpucmd += " --gpuidvar " + args.gpuidvar
-        mpigpucmd += " --nranks " + str(
-            jobparams.ntaskspernode * jobparams.nnodes)
+        mpigpucmd += " --nranks " + str(args.gpuspernode * jobparams.nnodes)
         mpigpucmd += " --gpusperrank " + str(1)  #args.gpuspernode
 
-        jobparams.ntaskspernode = 8
+        #jobparams.ntaskspernode = args.gpuspernode
         mpijob = rocslurm.sbatch("mpi" + str(nodes),
                                  jobparams,
                                  args.logdir,

--- a/projects/rocfft/scripts/rocslurm/__init__.py
+++ b/projects/rocfft/scripts/rocslurm/__init__.py
@@ -22,7 +22,6 @@ import subprocess, os, sys, datetime
 
 
 class sbatchparams:
-
     def __init__(self):
         self.partition = None
         self.acct = None
@@ -35,15 +34,13 @@ class sbatchparams:
         self.afterok = []
         self.afterany = []
         self.timelimit = None
-
+        self.wait = False
 
 class sbatchjob:
-
     def __init__(self, jobid, outfilename, errfilename):
         self.jobid = jobid
         self.outfilename = outfilename
         self.errfilename = errfilename
-
 
 def sbatch(jobname, params, logdir, workdir, jobcmd, verbose=0):
     sbatchcmd = []
@@ -156,6 +153,9 @@ def reportonjobs(params, logdir, jobs, verbose=0):
         batchscript += "#SBATCH --partition=" + params.partition + "\n"
     if params.timelimit != None:
         batchscript += "#SBATCH --time=0:5:00\n"
+    if params.wait:
+        batchscript += "#SBATCH --wait\n"
+        
     # TODO: copy out and err log files to the report working dir.
     # TODO: out and err files, and job name.
     if len(jobids) > 0:

--- a/projects/rocfft/scripts/rocslurm/__init__.py
+++ b/projects/rocfft/scripts/rocslurm/__init__.py
@@ -80,6 +80,9 @@ def sbatch(jobname, params, logdir, workdir, jobcmd, verbose=0):
             str(x) for x in params.afterok) + "\n"
     if len(params.afterany) > 0 or len(params.afterok) > 0:
         batchscript += "#SBATCH --kill-on-invalid-dep=yes\n"
+
+    batchscript += "#SBATCH --exclusive\n"
+        
         
     for module in params.modules:
         batchscript += "module load " + module + "\n"
@@ -164,8 +167,9 @@ def reportonjobs(params, logdir, jobs, verbose=0):
     for job in jobs:
         joblogdir = os.path.dirname(os.path.realpath(job.outfilename))
         #print(joblogdir)
+        reportcmd += "if [ -e " + joblogdir + " ]; then\n" 
         reportcmd += "cp -r " + joblogdir + " " + logdir + "/$SLURM_JOB_ID\n"
-
+        reportcmd += "fi\n" 
 
     reportcmd += "sacct -X -j " + ",".join(str(x) for x in jobids) \
         + " -o JobName,JobID,state,Elapsed,ExitCode\n"
@@ -185,8 +189,6 @@ def reportonjobs(params, logdir, jobs, verbose=0):
         byteline = str.encode(line + "\n")
         p.stdin.write(byteline)
     p.stdin.close()
-
-    #sacct -X -j 9628127,9628128 -o JobID,state,ExitCode
 
     #reportjob = sbatch("finalreport", params, logdir, workdir, jobcmd, verbose=False):
 

--- a/projects/rocfft/scripts/rocslurm/__init__.py
+++ b/projects/rocfft/scripts/rocslurm/__init__.py
@@ -30,6 +30,7 @@ class sbatchparams:
         self.modules = []
         self.exports = []
         self.ntaskspernode = None
+        self.ntasks = None
         self.gpuspernode = None
         self.afterok = []
         self.afterany = []
@@ -61,6 +62,9 @@ def sbatch(jobname, params, logdir, workdir, jobcmd, verbose=0):
     if params.ntaskspernode != None:
         batchscript += "#SBATCH --ntasks-per-node=" + str(
             params.ntaskspernode) + "\n"
+    if params.ntasks != None:
+        batchscript += "#SBATCH --ntasks=" + str(params.ntasks) + "\n"
+
     if params.gpuspernode != None:
         batchscript += "#SBATCH --gpus-per-node=" + str(
             params.gpuspernode) + "\n"

--- a/projects/rocfft/scripts/rocslurm/__init__.py
+++ b/projects/rocfft/scripts/rocslurm/__init__.py
@@ -22,6 +22,7 @@ import subprocess, os, sys, datetime
 
 
 class sbatchparams:
+
     def __init__(self):
         self.partition = None
         self.acct = None
@@ -36,11 +37,14 @@ class sbatchparams:
         self.timelimit = None
         self.wait = False
 
+
 class sbatchjob:
+
     def __init__(self, jobid, outfilename, errfilename):
         self.jobid = jobid
         self.outfilename = outfilename
         self.errfilename = errfilename
+
 
 def sbatch(jobname, params, logdir, workdir, jobcmd, verbose=0):
     sbatchcmd = []
@@ -79,8 +83,7 @@ def sbatch(jobname, params, logdir, workdir, jobcmd, verbose=0):
         batchscript += "#SBATCH --kill-on-invalid-dep=yes\n"
 
     batchscript += "#SBATCH --exclusive\n"
-        
-        
+
     for module in params.modules:
         batchscript += "module load " + module + "\n"
     for export in params.exports:
@@ -155,7 +158,7 @@ def reportonjobs(params, logdir, jobs, verbose=0):
         batchscript += "#SBATCH --time=0:5:00\n"
     if params.wait:
         batchscript += "#SBATCH --wait\n"
-        
+
     # TODO: copy out and err log files to the report working dir.
     # TODO: out and err files, and job name.
     if len(jobids) > 0:
@@ -167,9 +170,9 @@ def reportonjobs(params, logdir, jobs, verbose=0):
     for job in jobs:
         joblogdir = os.path.dirname(os.path.realpath(job.outfilename))
         #print(joblogdir)
-        reportcmd += "if [ -e " + joblogdir + " ]; then\n" 
+        reportcmd += "if [ -e " + joblogdir + " ]; then\n"
         reportcmd += "cp -r " + joblogdir + " " + logdir + "/$SLURM_JOB_ID\n"
-        reportcmd += "fi\n" 
+        reportcmd += "fi\n"
 
     reportcmd += "sacct -X -j " + ",".join(str(x) for x in jobids) \
         + " -o JobName,JobID,state,Elapsed,ExitCode\n"

--- a/projects/rocfft/scripts/rocslurm/__init__.py
+++ b/projects/rocfft/scripts/rocslurm/__init__.py
@@ -78,7 +78,9 @@ def sbatch(jobname, params, logdir, workdir, jobcmd, verbose=0):
     if len(params.afterok) > 0:
         batchscript += "#SBATCH --dependency=afterok:" + ",".join(
             str(x) for x in params.afterok) + "\n"
-
+    if len(params.afterany) > 0 or len(params.afterok) > 0:
+        batchscript += "#SBATCH --kill-on-invalid-dep=yes\n"
+        
     for module in params.modules:
         batchscript += "module load " + module + "\n"
     for export in params.exports:


### PR DESCRIPTION
## Motivation

The original script erroneously hard-coded gpus per node.  Also, move to tasks per node, which slurm seems to like better.

## Technical Details

Slurm has multiple ways of specifying resources, and it seems that it prefers ranks and gpusperrank.

## Test Plan

This is new test infra, so no CI yet; manual testing.

## Test Result

Works on my machine.