### PR TITLE
[hipDNN] Fix template alias deduction usage in C++17

### DIFF
--- a/projects/hipdnn/backend/tests/TestEnginePlugin.cpp
+++ b/projects/hipdnn/backend/tests/TestEnginePlugin.cpp
@@ -14,9 +14,8 @@
 #include "plugin/EnginePlugin.hpp"
 
 using namespace hipdnn_backend;
+using namespace hipdnn_sdk::utilities;
 
-template <typename T>
-using ScopedResource = hipdnn_sdk::utilities::ScopedResource<T>;
 class SimpleEnginePluginManager : public plugin::PluginManagerBase<plugin::EnginePlugin>
 {
 public:


### PR DESCRIPTION
## Motivation

Alias template deduction isn't supported in C++17, and is being used in this file.
This issue is blocking compiler promotion [PR](https://github.com/ROCm/TheRock/pull/1774).


## Technical Details

Swap from alias template to using namespace directly in test file.

## Test Plan

Compilation is successful, and tests pass.

## Test Result

Compilation successful, and tests are passing.