### PR TITLE
[hipblaslt] Add missing copyright headers for hipBLASLt files.

### DIFF
--- a/projects/hipblaslt/tensilelite/tasks.py
+++ b/projects/hipblaslt/tensilelite/tasks.py
@@ -1,3 +1,6 @@
+# Copyright (C) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 from invoke.tasks import task
 import os
 

--- a/projects/hipblaslt/utilities/QuickTune/gemm_tuning.py
+++ b/projects/hipblaslt/utilities/QuickTune/gemm_tuning.py
@@ -1,3 +1,6 @@
+# Copyright (C) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 import os
 import argparse
 import subprocess

--- a/projects/hipblaslt/utilities/QuickTune/remove_duplicate.py
+++ b/projects/hipblaslt/utilities/QuickTune/remove_duplicate.py
@@ -1,3 +1,6 @@
+# Copyright (C) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 import re
 import argparse
 import time

--- a/projects/hipblaslt/utilities/QuickTune/tuning.sh
+++ b/projects/hipblaslt/utilities/QuickTune/tuning.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+# Copyright (C) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 nohup python gemm_tuning.py --input_file example/Qwen3-32B_hipblaslt.log --output_path test_tuning --requested_solution 128 > output.log 2>&1 &

--- a/projects/hipblaslt/utilities/QuickTune/tuning_analysis.py
+++ b/projects/hipblaslt/utilities/QuickTune/tuning_analysis.py
@@ -1,3 +1,6 @@
+# Copyright (C) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 import argparse
 import re
 import csv

--- a/projects/hipblaslt/utilities/QuickTune/utils.py
+++ b/projects/hipblaslt/utilities/QuickTune/utils.py
@@ -1,3 +1,6 @@
+# Copyright (C) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
 import os
 import re
 import csv


### PR DESCRIPTION
## Motivation
This PR adds missing copyright and SPDX license headers to various hipblaslt open source files, including Python, and shell scripts. The update ensures compliance with open source licensing requirements.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- Added or updated copyright and SPDX headers in:


  - Python scripts
  - Shell scripts

- No functional code changes; only header/license updates.
- Relevant links:
    - [[SWDEV-562323] Palamida scan remediation [ROCM 7.2] - hipblaslt - [copyright]](https://ontrack-internal.amd.com/browse/SWDEV-562323)

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
