### PR TITLE
[hipfft][sample] do not use runtime-defined array sizes

### DIFF
--- a/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
+++ b/projects/hipfft/clients/samples/hipfft_multigpu_2d_z2z.cpp
@@ -94,8 +94,8 @@ int main()
         throw std::runtime_error("hipfftXtSetGPUs failed.");
 
     // Make the 2D plan
-    size_t workSize[gpus.size()];
-    hipfft_rt = hipfftMakePlan2d(plan, Nx, Ny, HIPFFT_Z2Z, workSize);
+    std::vector<size_t> workSize(gpus.size());
+    hipfft_rt = hipfftMakePlan2d(plan, Nx, Ny, HIPFFT_Z2Z, workSize.data());
     if(hipfft_rt != HIPFFT_SUCCESS)
         throw std::runtime_error("hipfftMakePlan2d failed.");
 

--- a/projects/hipfft/docs/conceptual/overview.rst
+++ b/projects/hipfft/docs/conceptual/overview.rst
@@ -533,8 +533,8 @@ For detailed API usage, see :ref:`hipfft-api-usage`.
          throw std::runtime_error("hipfftXtSetGPUs failed.");
 
       // Make the 2D plan for FFT (this defines the 2D FFT using the specified dimensions)
-      size_t workSize[gpus.size()];
-      hipfft_rt = hipfftMakePlan2d(plan, Nx, Ny, HIPFFT_Z2Z, workSize);
+      std::vector<size_t> workSize(gpus.size());
+      hipfft_rt = hipfftMakePlan2d(plan, Nx, Ny, HIPFFT_Z2Z, workSize.data());
       if(hipfft_rt != HIPFFT_SUCCESS)
          throw std::runtime_error("hipfftMakePlan2d failed.");
 


### PR DESCRIPTION
## Motivation

This was omitted in the changes from https://github.com/ROCm/rocm-libraries/pull/2165. With those changes, `gpus.size()` is no longer known at compilation, and the `size_t workSize[gpus.size()];` declaration emits "warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]".

## Technical Details

See motivation.

## Test Plan and Result

The sample was built, compilation warnings are gone and the sample runs successfully.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
