### PR TITLE
Port back ordered block id feature to rocPRIM rocm 7.0.x

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -139,8 +139,121 @@
     #define ROCPRIM_TARGET_UNKNOWN 1
 #endif
 
+#if defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1
+    #define ROCPRIM_AMDGCN_CONSTEXPR
+#else
+    #define ROCPRIM_AMDGCN_CONSTEXPR constexpr
+#endif
+
+#if __has_builtin(__builtin_amdgcn_processor_is)
+    #if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS)
+        #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
+    #endif
+    #if !defined(ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS)
+        #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
+    #endif
+    #define IS_CDNA3()                                                                     \
+        __builtin_amdgcn_processor_is("gfx942") || __builtin_amdgcn_processor_is("gfx950") \
+            || __builtin_amdgcn_processor_is("gfx9-4-generic")
+    #define IS_CDNA2() __builtin_amdgcn_processor_is("gfx90a")
+    #define IS_CDNA1() __builtin_amdgcn_processor_is("gfx908")
+    #define IS_GCN5()                                                                             \
+        __builtin_amdgcn_processor_is("gfx900") || __builtin_amdgcn_processor_is("gfx902")        \
+            || __builtin_amdgcn_processor_is("gfx904") || __builtin_amdgcn_processor_is("gfx906") \
+            || __builtin_amdgcn_processor_is("gfx90c")                                            \
+            || __builtin_amdgcn_processor_is("gfx9-generic")
+    #define IS_RDNA4()                                                                       \
+        __builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201") \
+        // TODO: enable when these structures are supported
+            /*|| __builtin_amdgcn_processor_is("gfx1250")                                      \
+            || __builtin_amdgcn_processor_is("gfx12-generic")*/
+    #define IS_RDNA3()                                                                       \
+        __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \
+            || __builtin_amdgcn_processor_is("gfx1102")                                      \
+            || __builtin_amdgcn_processor_is("gfx1103")                                      \
+            || __builtin_amdgcn_processor_is("gfx11-generic")
+    #define IS_RDNA2()                                                                       \
+        __builtin_amdgcn_processor_is("gfx1030") || __builtin_amdgcn_processor_is("gfx1031") \
+            || __builtin_amdgcn_processor_is("gfx1032")                                      \
+            || __builtin_amdgcn_processor_is("gfx1033")                                      \
+            || __builtin_amdgcn_processor_is("gfx1034")                                      \
+            || __builtin_amdgcn_processor_is("gfx1035")                                      \
+            || __builtin_amdgcn_processor_is("gfx1036")                                      \
+            || __builtin_amdgcn_processor_is("gfx10-3-generic")
+    #define IS_RDNA1()                                                                       \
+        __builtin_amdgcn_processor_is("gfx1010") || __builtin_amdgcn_processor_is("gfx1011") \
+            || __builtin_amdgcn_processor_is("gfx1012")                                      \
+            || __builtin_amdgcn_processor_is("gfx1013")                                      \
+            || __builtin_amdgcn_processor_is("gfx10-1-generic")
+    #define IS_GCN3()                                                                             \
+        __builtin_amdgcn_processor_is("gfx801") || __builtin_amdgcn_processor_is("gfx802")        \
+            || __builtin_amdgcn_processor_is("gfx803") || __builtin_amdgcn_processor_is("gfx805") \
+            || __builtin_amdgcn_processor_is("gfx810")
+#else
+    #if defined(ROCPRIM_TARGET_CDNA3)
+        #define IS_CDNA3() 1
+    #else
+        #define IS_CDNA3() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_CDNA2)
+        #define IS_CDNA2() 1
+    #else
+        #define IS_CDNA2() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_CDNA1)
+        #define IS_CDNA1() 1
+    #else
+        #define IS_CDNA1() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_GCN5)
+        #define IS_GCN5() 1
+    #else
+        #define IS_GCN5() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_RDNA4)
+        #define IS_RDNA4() 1
+    #else
+        #define IS_RDNA4() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_RDNA3)
+        #define IS_RDNA3() 1
+    #else
+        #define IS_RDNA3() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_RDNA2)
+        #define IS_RDNA2() 1
+    #else
+        #define IS_RDNA2() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_RDNA1)
+        #define IS_RDNA1() 1
+    #else
+        #define IS_RDNA1() 0
+    #endif
+    #if defined(ROCPRIM_TARGET_GCN3)
+        #define IS_GCN3() 1
+    #else
+        #define IS_GCN3() 0
+    #endif
+
+    #if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS)
+        #if defined(ROCPRIM_TARGET_SPIRV)
+            #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 0
+        #else
+            #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
+        #endif
+    #endif
+    #if !defined(ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS)
+        #if defined(ROCPRIM_TARGET_SPIRV)
+            #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 0
+        #else
+            #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
+        #endif
+    #endif
+#endif
+
 // SPIR-V and unknown targets do not support 128-bit atomics.
-#if defined(ROCPRIM_TARGET_UKNOWN) || defined(ROCPRIM_TARGET_SPIRV)
+#if defined(ROCPRIM_TARGET_UNKNOWN) || defined(ROCPRIM_TARGET_SPIRV)
     #define ROCPRIM_MAX_ATOMIC_SIZE 8
 #else
     #define ROCPRIM_MAX_ATOMIC_SIZE 16
@@ -150,32 +263,15 @@
 // Only defined when support is present, in contrast to ROCPRIM_DETAIL_USE_DPP, which should be
 // always defined
 #if defined(__HIP_DEVICE_COMPILE__) && defined(__AMDGCN__) \
-    && (!defined(__GFX6__) && !defined(__GFX7__))          \
-    && !(defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1)
+    && (!defined(__GFX6__) && !defined(__GFX7__))
     #define ROCPRIM_DETAIL_HAS_DPP 1
 #endif
 
-#if(!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) \
+#if (!defined(ROCPRIM_DISABLE_DPP) || ROCPRIM_DISABLE_DPP == 0) \
     && (defined(ROCPRIM_DETAIL_HAS_DPP) && ROCPRIM_DETAIL_HAS_DPP == 1)
     #define ROCPRIM_DETAIL_USE_DPP 1
 #else
     #define ROCPRIM_DETAIL_USE_DPP 0
-#endif
-
-#if defined(ROCPRIM_DETAIL_HAS_DPP) && (defined(__GFX8__) || defined(__GFX9__))
-    #define ROCPRIM_DETAIL_HAS_DPP_BROADCAST 1
-#endif
-
-#if defined(ROCPRIM_DETAIL_HAS_DPP) && (defined(__GFX8__) || defined(__GFX9__))
-    #define ROCPRIM_DETAIL_HAS_DPP_WF 1
-#endif
-
-#if !defined(ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS) && !defined(ROCPRIM_TARGET_SPIRV)
-    #define ROCPRIM_THREAD_LOAD_USE_CACHE_MODIFIERS 1
-#endif
-
-#if !defined(ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS) && !defined(ROCPRIM_TARGET_SPIRV)
-    #define ROCPRIM_THREAD_STORE_USE_CACHE_MODIFIERS 1
 #endif
 
 #ifndef ROCPRIM_NAVI
@@ -196,7 +292,7 @@
 /// Quad size (group of 4 threads)
 #define ROCPRIM_QUAD_SIZE 4u
 
-#if(defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
+#if (defined(_MSC_VER) && !defined(__clang__)) || (defined(__GNUC__) && !defined(__clang__))
     #define ROCPRIM_UNROLL
     #define ROCPRIM_NO_UNROLL
 #else
@@ -273,6 +369,25 @@
     #define ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH \
         ROCPRIM_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
     #define ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_POP ROCPRIM_CLANG_SUPPRESS_WARNING_POP
+#endif
+
+#if __has_builtin(__builtin_amdgcn_is_invocable)
+    #define ROCPRIM_HAS_DPP() __builtin_amdgcn_is_invocable(__builtin_amdgcn_mov_dpp)
+    #define ROCPRIM_HAS_PERMLANE() __builtin_amdgcn_is_invocable(__builtin_amdgcn_permlane16)
+#elif defined(ROCPRIM_TARGET_SPIRV) && ROCPRIM_TARGET_SPIRV == 1
+    #define ROCPRIM_HAS_DPP() false
+    #define ROCPRIM_HAS_PERMLANE() false
+#else
+    #if defined(ROCPRIM_DETAIL_HAS_DPP) && ROCPRIM_DETAIL_HAS_DPP == 1
+        #define ROCPRIM_HAS_DPP() true
+    #else
+        #define ROCPRIM_HAS_DPP() false
+    #endif
+    #if defined(__GFX8__) || defined(__GFX9__)
+        #define ROCPRIM_HAS_PERMLANE() false
+    #else
+        #define ROCPRIM_HAS_PERMLANE() true
+    #endif
 #endif
 
 #endif // ROCPRIM_CONFIG_HPP_

--- a/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
@@ -33,6 +33,11 @@
 
 #include <hip/hip_runtime.h>
 
+#include <chrono>
+#include <iostream>
+#include <type_traits>
+#include <variant>
+
 // Check for c++ standard library features, in a backwards compatible manner
 #ifndef __has_include
     #define __has_include(x) 0
@@ -497,6 +502,70 @@ inline float update_time_point(std::chrono::high_resolution_clock::time_point& t
 
     return delta_time;
 }
+
+template<typename T, T... Vs>
+struct constexpr_value_variant
+{
+    using variant = std::variant<std::integral_constant<T, Vs>...>;
+
+    static variant create(T value)
+    {
+        variant var{};
+        // Unfold over variadic enum values. For each value
+        // create and run a small lambda that sets our variant.
+        (
+            [&]
+            {
+                if(value == Vs)
+                {
+                    var = std::integral_constant<T, Vs>{};
+                }
+            }(),
+            ...);
+        return var;
+    }
+};
+
+template<typename... T>
+struct constexpr_type_variant
+{
+    using variant = std::variant<T...>;
+
+    static variant create(int index, T... values)
+    {
+        variant var{};
+        update_variant(index, var, std::make_tuple(values...), std::index_sequence_for<T...>{});
+        return var;
+    }
+
+    static variant create(int index)
+    {
+        return create(index, (T{}, ...));
+    }
+
+    template<typename F>
+    static variant create_with(int index, F f)
+    {
+        auto var = create(index, (T{}, ...));
+        std::visit(f, var);
+    };
+
+    static variant create(bool select, T... values)
+    {
+        return create(select ? 1 /* true */ : 0 /* false */, values...);
+    }
+
+private:
+    template<std::size_t... I>
+    static void update_variant(std::size_t      index,
+                               variant&         var,
+                               std::tuple<T...> t,
+                               std::index_sequence<I...> /* */)
+    {
+        ((index == I ? var = std::get<I>(t), 0 : 0), ...);
+    }
+};
+
 
 } // end namespace detail
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -170,6 +170,7 @@ enum class target_arch : unsigned int
     gfx908  = 908,
     gfx90a  = 910,
     gfx942  = 942,
+    gfx950  = 950,
     gfx1030 = 1030,
     gfx1100 = 1100,
     gfx1102 = 1102,
@@ -212,6 +213,7 @@ constexpr target_arch get_target_arch_from_name(const char* const arch_name, con
                                                     "gfx908",
                                                     "gfx90a",
                                                     "gfx942",
+                                                    "gfx950",
                                                     "gfx1030",
                                                     "gfx1100",
                                                     "gfx1102",
@@ -224,6 +226,7 @@ constexpr target_arch get_target_arch_from_name(const char* const arch_name, con
         target_arch::gfx908,
         target_arch::gfx90a,
         target_arch::gfx942,
+        target_arch::gfx950,
         target_arch::gfx1030,
         target_arch::gfx1100,
         target_arch::gfx1102,
@@ -285,6 +288,8 @@ auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
             return Config::template architecture_config<target_arch::gfx90a>::params;
         case target_arch::gfx942:
             return Config::template architecture_config<target_arch::gfx942>::params;
+        case target_arch::gfx950: 
+            return Config::template architecture_config<target_arch::gfx950>::params;
         case target_arch::gfx1030:
             return Config::template architecture_config<target_arch::gfx1030>::params;
         case target_arch::gfx1100:

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -24,12 +24,14 @@
 #include <algorithm>
 #include <atomic>
 #include <limits>
+#include <optional>
 #include <type_traits>
 
 #include <cassert>
 
 #include "../config.hpp"
 #include "../detail/various.hpp"
+#include "../intrinsics/arch.hpp"
 
 /// \addtogroup primitivesmodule_deviceconfigs
 /// @{
@@ -153,11 +155,7 @@ struct fallback_block_size
 
 template<class Config, class Default>
 using default_or_custom_config =
-    typename std::conditional<
-        std::is_same<Config, default_config>::value,
-        Default,
-        Config
-    >::type;
+    typename std::conditional<std::is_same<Config, default_config>::value, Default, Config>::type;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 enum class target_arch : unsigned int
@@ -205,34 +203,36 @@ constexpr bool prefix_equals(const char* lhs, const char* rhs, std::size_t n)
     return i == n && *lhs == '\0';
 }
 
+constexpr const char* target_names[] = {"gfx803",
+                                        "gfx900",
+                                        "gfx906",
+                                        "gfx908",
+                                        "gfx90a",
+                                        "gfx942",
+                                        "gfx950",
+                                        "gfx1030",
+                                        "gfx1100",
+                                        "gfx1102",
+                                        "gfx1200",
+                                        "gfx1201"};
+
+constexpr target_arch target_architectures[] = {
+    target_arch::gfx803,
+    target_arch::gfx900,
+    target_arch::gfx906,
+    target_arch::gfx908,
+    target_arch::gfx90a,
+    target_arch::gfx942,
+    target_arch::gfx950,
+    target_arch::gfx1030,
+    target_arch::gfx1100,
+    target_arch::gfx1102,
+    target_arch::gfx1200,
+    target_arch::gfx1201,
+};
+
 constexpr target_arch get_target_arch_from_name(const char* const arch_name, const std::size_t n)
 {
-    constexpr const char* target_names[]         = {"gfx803",
-                                                    "gfx900",
-                                                    "gfx906",
-                                                    "gfx908",
-                                                    "gfx90a",
-                                                    "gfx942",
-                                                    "gfx950",
-                                                    "gfx1030",
-                                                    "gfx1100",
-                                                    "gfx1102",
-                                                    "gfx1200",
-                                                    "gfx1201"};
-    constexpr target_arch target_architectures[] = {
-        target_arch::gfx803,
-        target_arch::gfx900,
-        target_arch::gfx906,
-        target_arch::gfx908,
-        target_arch::gfx90a,
-        target_arch::gfx942,
-        target_arch::gfx950,
-        target_arch::gfx1030,
-        target_arch::gfx1100,
-        target_arch::gfx1102,
-        target_arch::gfx1200,
-        target_arch::gfx1201,
-    };
     static_assert(sizeof(target_names) / sizeof(target_names[0])
                       == sizeof(target_architectures) / sizeof(target_architectures[0]),
                   "target_names and target_architectures should have the same number of elements");
@@ -246,6 +246,42 @@ constexpr target_arch get_target_arch_from_name(const char* const arch_name, con
         }
     }
     return target_arch::unknown;
+}
+
+template<class F, std::size_t... Is>
+constexpr void for_each_arch_impl(F&& f, std::index_sequence<Is...>)
+{
+    (f(std::integral_constant<target_arch, target_architectures[Is]>{}), ...);
+}
+
+template<class F>
+constexpr void for_each_arch(F&& f)
+{
+    for_each_arch_impl(std::forward<F>(f),
+                       std::make_index_sequence<std::size(target_architectures)>{});
+}
+
+constexpr arch::wavefront::target arch_wavefront_size(const target_arch target_arch)
+{
+    switch(target_arch)
+    {
+        case target_arch::unknown: return arch::wavefront::get_target();
+        case target_arch::gfx803: return arch::wavefront::target::size64;
+        case target_arch::gfx900: return arch::wavefront::target::size64;
+        case target_arch::gfx906: return arch::wavefront::target::size64;
+        case target_arch::gfx908: return arch::wavefront::target::size64;
+        case target_arch::gfx90a: return arch::wavefront::target::size64;
+        case target_arch::gfx942: return arch::wavefront::target::size64;
+        case target_arch::gfx950: return arch::wavefront::target::size64;
+        case target_arch::gfx1030: return arch::wavefront::target::size32;
+        case target_arch::gfx1100: return arch::wavefront::target::size32;
+        case target_arch::gfx1102: return arch::wavefront::target::size32;
+        case target_arch::gfx1200: return arch::wavefront::target::size32;
+        case target_arch::gfx1201: return arch::wavefront::target::size32;
+
+        // Unreachable
+        case target_arch::invalid: return arch::wavefront::target::dynamic;
+    }
 }
 
 /**
@@ -267,43 +303,228 @@ constexpr target_arch device_target_arch()
 #endif
 }
 
-template<class Config>
+template<typename Config, target_arch Arch>
+struct default_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.kernel_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct non_blev_batch_memcpy_config_selector
+{
+    static constexpr unsigned int block_size = Config::template architecture_config<Arch>::params
+                                                   .non_blev_batch_memcpy_kernel_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct blev_batch_memcpy_config_selector
+{
+    static constexpr unsigned int block_size = Config::template architecture_config<Arch>::params
+                                                   .blev_batch_memcpy_kernel_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct histogram_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.histogram_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct histogram_global_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.histogram_global_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct merge_oddeven_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.merge_oddeven_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct merge_mergepath_partition_config_selector
+{
+    static constexpr unsigned int block_size = Config::template architecture_config<Arch>::params
+                                                   .merge_mergepath_partition_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct merge_mergepath_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.merge_mergepath_config.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct radix_sort_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct radix_sort_onesweep_histogram_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.histogram.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct radix_sort_onesweep_sort_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.sort.block_size;
+};
+
+template<typename Config, target_arch Arch>
+struct segmented_radix_sort_warp_sort_small_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.warp_sort_config.block_size_small;
+};
+
+template<typename Config, target_arch Arch>
+struct segmented_radix_sort_warp_sort_meduim_config_selector
+{
+    static constexpr unsigned int block_size
+        = Config::template architecture_config<Arch>::params.warp_sort_config.block_size_medium;
+};
+
+template<class Config, target_arch Arch>
+struct target_config
+{
+    constexpr static auto params    = Config::template architecture_config<Arch>::params;
+    constexpr static auto wavefront = arch_wavefront_size(Arch);
+    constexpr static auto arch      = Arch;
+};
+
+// trampoline_kernel that is fully specialized at compile-time for a single GPU architecture.
+// By instantiating this template once per supported `target_arch`,the correct tuned config
+// will be derived from the template
+template<typename Config,
+         target_arch Arch,
+         class Kernel,
+         template<typename, target_arch>
+         class LaunchSelector>
+ROCPRIM_KERNEL __launch_bounds__((LaunchSelector<Config, Arch>::block_size))
+void trampoline_kernel(Kernel kernel)
+{
+    using ArchConfig = target_config<Config, Arch>;
+
+#if !defined(ROCPRIM_TARGET_SPIRV) || ROCPRIM_TARGET_SPIRV == 0
+    if constexpr(Arch == device_target_arch())
+#endif
+    {
+        kernel(ArchConfig{});
+    }
+}
+
+template<typename Kernel>
+struct launch_plan
+{
+    using kernel_type = void (*)(Kernel);
+    kernel_type kernel;
+    Kernel      device_callback;
+
+    void launch(dim3 grid_size, dim3 block_size, size_t shared_mem, hipStream_t stream) const
+    {
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(kernel),
+                           grid_size,
+                           block_size,
+                           shared_mem,
+                           stream,
+                           device_callback);
+    }
+};
+
+template<class Config,
+         class Kernel,
+         template<typename, target_arch> class LaunchSelector = default_config_selector>
+auto make_launch_plan(target_arch arch, Kernel kernel) -> launch_plan<Kernel>
+{
+    std::optional<void (*)(Kernel)> tuned_kernel = std::nullopt;
+
+    for_each_arch(
+        [&](auto arch_tag)
+        {
+            constexpr target_arch Arch = decltype(arch_tag)::value;
+            if(Arch != arch || tuned_kernel)
+                return;
+
+            tuned_kernel = trampoline_kernel<Config, Arch, Kernel, LaunchSelector>;
+        });
+
+    if(!tuned_kernel)
+    {
+        tuned_kernel = trampoline_kernel<Config, target_arch::unknown, Kernel, LaunchSelector>;
+    }
+
+    return {tuned_kernel.value(), kernel};
+}
+
+// Host-side helper running at run-time, picking the trampoline_kernel whose template
+// argument `Arch` matches the actual GPU we are executing on.
+template<class Config,
+         class Kernel,
+         template<typename, target_arch> class LaunchSelector = default_config_selector>
+hipError_t execute_launch_plan(target_arch arch,
+                               Kernel      kernel,
+                               dim3        grid_size,
+                               dim3        block_size,
+                               size_t      shmem,
+                               hipStream_t stream)
+{
+    const auto launch_plan = make_launch_plan<Config, Kernel, LaunchSelector>(arch, kernel);
+    launch_plan.launch(grid_size, block_size, shmem, stream);
+    return hipGetLastError();
+}
+
+#ifdef ROCPRIM_EXPERIMENTAL_SPIRV
+template<class Config, bool ForceUnknownArch = true>
+#else
+template<class Config, bool ForceUnknownArch = false>
+#endif
 auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
 {
-#if !defined(ROCPRIM_EXPERIMENTAL_SPIRV)
-    switch(target_arch)
+    if constexpr(!ForceUnknownArch)
     {
+        switch(target_arch)
+        {
 
-        case target_arch::unknown:
-            return Config::template architecture_config<target_arch::unknown>::params;
-        case target_arch::gfx803:
-            return Config::template architecture_config<target_arch::gfx803>::params;
-        case target_arch::gfx900:
-            return Config::template architecture_config<target_arch::gfx900>::params;
-        case target_arch::gfx906:
-            return Config::template architecture_config<target_arch::gfx906>::params;
-        case target_arch::gfx908:
-            return Config::template architecture_config<target_arch::gfx908>::params;
-        case target_arch::gfx90a:
-            return Config::template architecture_config<target_arch::gfx90a>::params;
-        case target_arch::gfx942:
-            return Config::template architecture_config<target_arch::gfx942>::params;
-        case target_arch::gfx950: 
-            return Config::template architecture_config<target_arch::gfx950>::params;
-        case target_arch::gfx1030:
-            return Config::template architecture_config<target_arch::gfx1030>::params;
-        case target_arch::gfx1100:
-            return Config::template architecture_config<target_arch::gfx1100>::params;
-        case target_arch::gfx1102:
-            return Config::template architecture_config<target_arch::gfx1102>::params;
-        case target_arch::gfx1200:
-            return Config::template architecture_config<target_arch::gfx1200>::params;
-        case target_arch::gfx1201:
-            return Config::template architecture_config<target_arch::gfx1201>::params;
-        case target_arch::invalid:
-            assert(false && "Invalid target architecture selected at runtime.");
+            case target_arch::unknown:
+                return Config::template architecture_config<target_arch::unknown>::params;
+            case target_arch::gfx803:
+                return Config::template architecture_config<target_arch::gfx803>::params;
+            case target_arch::gfx900:
+                return Config::template architecture_config<target_arch::gfx900>::params;
+            case target_arch::gfx906:
+                return Config::template architecture_config<target_arch::gfx906>::params;
+            case target_arch::gfx908:
+                return Config::template architecture_config<target_arch::gfx908>::params;
+            case target_arch::gfx90a:
+                return Config::template architecture_config<target_arch::gfx90a>::params;
+            case target_arch::gfx942:
+                return Config::template architecture_config<target_arch::gfx942>::params;
+            case target_arch::gfx950:
+                return Config::template architecture_config<target_arch::gfx950>::params;
+            case target_arch::gfx1030:
+                return Config::template architecture_config<target_arch::gfx1030>::params;
+            case target_arch::gfx1100:
+                return Config::template architecture_config<target_arch::gfx1100>::params;
+            case target_arch::gfx1102:
+                return Config::template architecture_config<target_arch::gfx1102>::params;
+            case target_arch::gfx1200:
+                return Config::template architecture_config<target_arch::gfx1200>::params;
+            case target_arch::gfx1201:
+                return Config::template architecture_config<target_arch::gfx1201>::params;
+            case target_arch::invalid:
+                assert(false && "Invalid target architecture selected at runtime.");
+        }
     }
-#endif
     return Config::template architecture_config<target_arch::unknown>::params;
 }
 
@@ -366,7 +587,7 @@ inline hipError_t get_device_from_stream(const hipStream_t stream, int& device_i
     const bool is_legacy_stream = false;
 #endif
 
-    if (stream == default_stream || stream == hipStreamPerThread || is_legacy_stream)
+    if(stream == default_stream || stream == hipStreamPerThread || is_legacy_stream)
     {
         const hipError_t result = hipGetDevice(&device_id);
         if(result != hipSuccess)
@@ -431,7 +652,8 @@ inline hipError_t host_warp_size(const int device_id, unsigned int& warp_size)
 /// \return hipError_t any error that might occur.
 ///
 /// It is constant for a device.
-ROCPRIM_HOST inline hipError_t host_warp_size(const hipStream_t stream, unsigned int& warp_size)
+ROCPRIM_HOST
+inline hipError_t host_warp_size(const hipStream_t stream, unsigned int& warp_size)
 {
     int        hip_device;
     hipError_t success = detail::get_device_from_stream(stream, hip_device);

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_radix_sort_block_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_radix_sort_block_sort.hpp
@@ -4637,6 +4637,548 @@ struct default_radix_sort_block_sort_config<
     : kernel_config<512, 22>
 {};
 
+// Based on key_type = double, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = double, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = double, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = double, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = double, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = double, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = float, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = float, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = float, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<512, 16>
+{};
+
+// Based on key_type = float, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 32>
+{};
+
+// Based on key_type = float, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = float, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = rocprim::half, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8))>>
+    : kernel_config<256, 8>
+{};
+
+// Based on key_type = rocprim::half, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : kernel_config<512, 8>
+{};
+
+// Based on key_type = rocprim::half, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = rocprim::half, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : kernel_config<512, 18>
+{};
+
+// Based on key_type = rocprim::half, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = rocprim::half, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<512, 22>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 8>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 8>
+{};
+
+// Based on key_type = int64_t, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = int64_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = int64_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = int64_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = int64_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = int64_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 16>
+{};
+
+// Based on key_type = int, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = int, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 10>
+{};
+
+// Based on key_type = int, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 32>
+{};
+
+// Based on key_type = int, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<256, 32>
+{};
+
+// Based on key_type = int, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = int, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = short, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>> : kernel_config<256, 8>
+{};
+
+// Based on key_type = short, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>> : kernel_config<256, 16>
+{};
+
+// Based on key_type = short, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>> : kernel_config<256, 32>
+{};
+
+// Based on key_type = short, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>> : kernel_config<512, 19>
+{};
+
+// Based on key_type = short, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 32>
+{};
+
+// Based on key_type = short, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<512, 23>
+{};
+
+// Based on key_type = int8_t, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8))>>
+    : kernel_config<512, 7>
+{};
+
+// Based on key_type = int8_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : kernel_config<1024, 4>
+{};
+
+// Based on key_type = int8_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : kernel_config<256, 21>
+{};
+
+// Based on key_type = int8_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : kernel_config<256, 21>
+{};
+
+// Based on key_type = int8_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<256, 23>
+{};
+
+// Based on key_type = int8_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_block_sort_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : kernel_config<512, 22>
+{};
+
 } // end namespace detail
 
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_radix_sort_onesweep.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_radix_sort_onesweep.hpp
@@ -5019,6 +5019,715 @@ struct default_radix_sort_onesweep_config<
                                  block_radix_rank_algorithm::match>
 {};
 
+// Based on key_type = double, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<256, 32>,
+                                 kernel_config<256, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 12>,
+                                 6,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 22>,
+                                 6,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
 } // end namespace detail
 
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -32,6 +32,7 @@
 #include "rocprim/device/config_types.hpp"
 #include "rocprim/device/detail/device_scan_common.hpp"
 #include "rocprim/device/detail/lookback_scan_state.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 #include "rocprim/device/device_memcpy_config.hpp"
 #include "rocprim/device/device_scan.hpp"
 
@@ -82,17 +83,21 @@ private:
     BackingUnitType          data[num_items];
 
 public:
-    ROCPRIM_DEVICE ROCPRIM_INLINE uint32_t get(size_class index) const
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    uint32_t get(size_class index) const
     {
         return data[static_cast<uint32_t>(index)];
     }
 
-    ROCPRIM_DEVICE ROCPRIM_INLINE void add(size_class index, uint32_t value)
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    void add(size_class index, uint32_t value)
     {
         data[static_cast<uint32_t>(index)] += value;
     }
 
-    ROCPRIM_DEVICE counter operator+(const counter& other) const
+    ROCPRIM_DEVICE
+    counter
+        operator+(const counter& other) const
     {
         counter result{};
 
@@ -198,8 +203,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE static void vectorized_copy_bytes(const void
     using vector_type                      = uint4;
     constexpr uint32_t ints_in_vector_type = sizeof(uint4) / sizeof(uint32_t);
 
-    const auto     warp_size = ::rocprim::arch::wavefront::size();
-    const auto     rank      = ::rocprim::detail::block_thread_id<0>() % warp_size;
+    const auto warp_size = ::rocprim::arch::wavefront::size();
+    const auto rank      = ::rocprim::detail::block_thread_id<0>() % warp_size;
 
     const uint8_t* src = reinterpret_cast<const uint8_t*>(input_buffer) + offset;
     uint8_t*       dst = reinterpret_cast<uint8_t*>(output_buffer) + offset;
@@ -327,13 +332,15 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE static void
 // Use template specialization on IsMemCpy is done in order to avoid using std::conditional.
 // Using std::conditional can result in build errors because the compiler evaluates both sides
 // of the conditional.
-template <bool IsMemCpy, typename InputBufferItType>
-struct AliasType { };
+template<bool IsMemCpy, typename InputBufferItType>
+struct AliasType
+{};
 
 template<typename InputBufferItType>
 struct AliasType<false, InputBufferItType>
 {
-    using type = typename std::iterator_traits<typename std::iterator_traits<InputBufferItType>::value_type>::value_type;
+    using type = typename std::iterator_traits<
+        typename std::iterator_traits<InputBufferItType>::value_type>::value_type;
 };
 
 template<typename InputBufferItType>
@@ -342,7 +349,12 @@ struct AliasType<true, InputBufferItType>
     using type = unsigned char;
 };
 
-template<bool IsMemCpy, class InputBufferItType, class OutputBufferItType, class BufferSizeItType>
+// TODO: make UseOrderedBlockId dynamic
+template<bool IsMemCpy,
+         class InputBufferItType,
+         class OutputBufferItType,
+         class BufferSizeItType,
+         class WrappedBlockId>
 struct batch_memcpy_impl
 {
     using input_buffer_type  = typename std::iterator_traits<InputBufferItType>::value_type;
@@ -360,6 +372,8 @@ struct batch_memcpy_impl
 
     // The byte offset within a thread-level buffer. Must fit at least `wlev_size_threshold`.
     using tlev_byte_offset_type = uint16_t;
+
+    using ordered_bid_type = WrappedBlockId;
 
     struct copyable_buffers
     {
@@ -416,10 +430,10 @@ private:
                                                           blev_block_scan_state_type,
                                                           rocprim::plus<tile_offset_type>>;
 
-    template<class Config>
+    template<class ArchConfig>
     struct non_blev_memcpy
     {
-        ROCPRIM_DEVICE static constexpr batch_memcpy_config_params params = device_params<Config>();
+        ROCPRIM_DEVICE static constexpr batch_memcpy_config_params params = ArchConfig::params;
 
         ROCPRIM_DEVICE static constexpr uint32_t block_size
             = params.non_blev_batch_memcpy_kernel_config.block_size;
@@ -467,6 +481,8 @@ private:
 
             union shared_t
             {
+                typename ordered_bid_type::storage_type ordered_bid;
+
                 union analysis_t
                 {
                     typename buffer_load_type::storage_type     load_storage;
@@ -494,7 +510,8 @@ private:
 
         ROCPRIM_DEVICE ROCPRIM_INLINE non_blev_memcpy() {}
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE static size_class_counter get_buffer_size_class_histogram(
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        static size_class_counter get_buffer_size_class_histogram(
             const buffer_size_type (&buffer_sizes)[buffers_per_thread])
         {
             size_class_counter counters{};
@@ -502,16 +519,16 @@ private:
             ROCPRIM_UNROLL
             for(uint32_t i = 0; i < buffers_per_thread; ++i)
             {
-                auto size_class = get_size_class(buffer_sizes[i], device_params<Config>());
+                auto size_class = get_size_class(buffer_sizes[i], ArchConfig::params);
                 counters.add(size_class, buffer_sizes[i] > 0 ? 1 : 0);
             }
             return counters;
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void
-            partition_buffer_by_size(const buffer_size_type (&buffer_sizes)[buffers_per_thread],
-                                     size_class_counter counters,
-                                     buffer_tuple (&buffers_by_size_class)[buffers_per_block])
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void partition_buffer_by_size(const buffer_size_type (&buffer_sizes)[buffers_per_thread],
+                                      size_class_counter counters,
+                                      buffer_tuple (&buffers_by_size_class)[buffers_per_block])
         {
             const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
 
@@ -526,7 +543,7 @@ private:
                     continue;
                 }
 
-                const auto size_class = get_size_class(buffer_sizes[i], device_params<Config>());
+                const auto     size_class   = get_size_class(buffer_sizes[i], ArchConfig::params);
                 const uint32_t write_offset = counters.get(size_class);
                 buffers_by_size_class[write_offset]
                     = buffer_tuple{static_cast<tlev_byte_offset_type>(buffer_sizes[i]), buffer_id};
@@ -535,15 +552,15 @@ private:
             }
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void
-            prepare_blev_buffers(typename storage::shared_t::prepare_blev_t& blev_storage,
-                                 buffer_tuple*                               buffer_by_size_class,
-                                 copyable_buffers                            buffers,
-                                 buffer_offset_type                          num_blev_buffers,
-                                 copyable_blev_buffers                       blev_buffers,
-                                 buffer_offset_type                          tile_buffer_offset,
-                                 blev_block_scan_state_type                  blev_block_scan_state,
-                                 buffer_offset_type                          tile_id)
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void prepare_blev_buffers(typename storage::shared_t::prepare_blev_t& blev_storage,
+                                  buffer_tuple*                               buffer_by_size_class,
+                                  copyable_buffers                            buffers,
+                                  buffer_offset_type                          num_blev_buffers,
+                                  copyable_blev_buffers                       blev_buffers,
+                                  buffer_offset_type                          tile_buffer_offset,
+                                  blev_block_scan_state_type                  blev_block_scan_state,
+                                  buffer_offset_type                          tile_id)
         {
             const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
 
@@ -556,8 +573,15 @@ private:
                 if(blev_buffer_offset < num_blev_buffers)
                 {
                     auto tile_buffer_id = buffer_by_size_class[blev_buffer_offset].buffer_id;
+                    /* In the case that buffer_size_type is rocthrust::device_reference<T> a static cast to 
+                    / buffer_size_type is needed so that the type passed into ceiling_div is not 
+                    / rocthrust::device_reference<T>. This is possible since rocthrust::device_reference<T>
+                    / can be implicitly cast to type T.
+                    */
+                    buffer_size_type size
+                        = static_cast<buffer_size_type>(buffers.sizes[tile_buffer_id]);
                     tile_offsets[i]
-                        = rocprim::detail::ceiling_div(buffers.sizes[tile_buffer_id],
+                        = rocprim::detail::ceiling_div(size,
                                                        blev_block_size * blev_bytes_per_thread);
                 }
                 else
@@ -619,9 +643,10 @@ private:
             }
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void copy_wlev_buffers(buffer_tuple*    buffers_by_size_class,
-                                                             copyable_buffers tile_buffers,
-                                                             buffer_offset_type num_wlev_buffers)
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void copy_wlev_buffers(buffer_tuple*      buffers_by_size_class,
+                               copyable_buffers   tile_buffers,
+                               buffer_offset_type num_wlev_buffers)
         {
             const uint32_t warp_id = rocprim::warp_id();
             const uint32_t warps_per_block
@@ -631,18 +656,24 @@ private:
                 buffer_offset += warps_per_block)
             {
                 const auto buffer_id = buffers_by_size_class[buffer_offset].buffer_id;
-
+                /* In the case that buffer_size_type is rocthrust::device_reference<T> a static cast to 
+                / buffer_size_type is needed so that the type passed into copy_items is not 
+                / rocthrust::device_reference<T>. This is possible since rocthrust::device_reference<T>
+                / can be implicitly cast to type T.
+                */
+                buffer_size_type size
+                    = static_cast<buffer_size_type>(tile_buffers.sizes[buffer_id]);
                 batch_memcpy::copy_items<IsMemCpy>(tile_buffers.srcs[buffer_id],
                                                    tile_buffers.dsts[buffer_id],
-                                                   tile_buffers.sizes[buffer_id]);
+                                                   size);
             }
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void
-            copy_tlev_buffers(typename storage::shared_t::copy_tlev_t& tlev_storage,
-                              buffer_tuple*                            buffers_by_size_class,
-                              copyable_buffers                         tile_buffers,
-                              buffer_offset_type                       num_tlev_buffers)
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void copy_tlev_buffers(typename storage::shared_t::copy_tlev_t& tlev_storage,
+                               buffer_tuple*                            buffers_by_size_class,
+                               copyable_buffers                         tile_buffers,
+                               buffer_offset_type                       num_tlev_buffers)
         {
             const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
 
@@ -771,13 +802,14 @@ private:
             }
         }
 
-        ROCPRIM_DEVICE ROCPRIM_INLINE void copy(storage&                    temp_storage,
-                                                copyable_buffers            buffers,
-                                                uint32_t                    num_buffers,
-                                                copyable_blev_buffers       blev_buffers,
-                                                blev_buffer_scan_state_type blev_buffer_scan_state,
-                                                blev_block_scan_state_type  blev_block_scan_state,
-                                                const buffer_offset_type    tile_id)
+        ROCPRIM_DEVICE ROCPRIM_INLINE
+        void copy(storage&                    temp_storage,
+                  copyable_buffers            buffers,
+                  uint32_t                    num_buffers,
+                  copyable_blev_buffers       blev_buffers,
+                  blev_buffer_scan_state_type blev_buffer_scan_state,
+                  blev_block_scan_state_type  blev_block_scan_state,
+                  const buffer_offset_type    tile_id)
         {
             const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
 
@@ -918,7 +950,8 @@ public:
     static ROCPRIM_KERNEL
     void init_tile_state_kernel(blev_buffer_scan_state_type buffer_scan_state,
                                 blev_block_scan_state_type  block_scan_state,
-                                tile_offset_type            num_tiles)
+                                tile_offset_type            num_tiles,
+                                ordered_bid_type            ordered_bid)
     {
         const uint32_t block_id        = rocprim::detail::block_id<0>();
         const uint32_t block_size      = rocprim::detail::block_size<0>();
@@ -928,33 +961,43 @@ public:
         buffer_scan_state.initialize_prefix(flat_thread_id, num_tiles);
 
         block_scan_state.initialize_prefix(flat_thread_id, num_tiles);
+
+        if(flat_thread_id == 0)
+        {
+            ordered_bid.reset();
+        }
     }
 
-    template<class Config>
-    static ROCPRIM_KERNEL
-    void non_blev_memcpy_kernel(copyable_buffers            buffers,
-                                buffer_offset_type          num_buffers,
-                                copyable_blev_buffers       blev_buffers,
-                                blev_buffer_scan_state_type blev_buffer_scan_state,
-                                blev_block_scan_state_type  blev_block_scan_state)
+    template<class ArchConfig>
+    static ROCPRIM_DEVICE
+    void non_blev_memcpy_kernel_impl(copyable_buffers            buffers,
+                                     buffer_offset_type          num_buffers,
+                                     copyable_blev_buffers       blev_buffers,
+                                     blev_buffer_scan_state_type blev_buffer_scan_state,
+                                     blev_block_scan_state_type  blev_block_scan_state,
+                                     ordered_bid_type            ordered_bid)
     {
-        ROCPRIM_SHARED_MEMORY typename non_blev_memcpy<Config>::storage_type temp_storage;
-        non_blev_memcpy<Config>{}.copy(temp_storage.get(),
-                                       buffers,
-                                       num_buffers,
-                                       blev_buffers,
-                                       blev_buffer_scan_state,
-                                       blev_block_scan_state,
-                                       rocprim::flat_block_id());
+        ROCPRIM_SHARED_MEMORY typename non_blev_memcpy<ArchConfig>::storage_type temp_storage;
+
+        auto tile_id = ordered_bid.get(rocprim::flat_tile_thread_id(),
+                                       temp_storage.get().shared.ordered_bid);
+
+        non_blev_memcpy<ArchConfig>{}.copy(temp_storage.get(),
+                                           buffers,
+                                           num_buffers,
+                                           blev_buffers,
+                                           blev_buffer_scan_state,
+                                           blev_block_scan_state,
+                                           tile_id /* rocprim::flat_block_id() */);
     }
 
-    template<typename Config>
-    static ROCPRIM_KERNEL
-    void blev_memcpy_kernel(copyable_blev_buffers       blev_buffers,
-                            blev_buffer_scan_state_type buffer_offset_tile,
-                            tile_offset_type            last_tile_offset)
+    template<typename ArchConfig>
+    static ROCPRIM_DEVICE
+    void blev_memcpy_kernel_impl(copyable_blev_buffers       blev_buffers,
+                                 blev_buffer_scan_state_type buffer_offset_tile,
+                                 tile_offset_type            last_tile_offset)
     {
-        static constexpr batch_memcpy_config_params params = device_params<Config>();
+        static constexpr batch_memcpy_config_params params = ArchConfig::params;
         static constexpr uint32_t                   blev_block_size
             = params.blev_batch_memcpy_kernel_config.block_size;
         static constexpr uint32_t blev_bytes_per_thread
@@ -1037,213 +1080,267 @@ public:
     }
 };
 
-template<class Config_,
+template<class Config,
          class InputBufferItType,
          class OutputBufferItType,
          class BufferSizeItType,
          bool IsMemCpy>
-ROCPRIM_INLINE static hipError_t batch_memcpy_func(void*              temporary_storage,
-                                                   size_t&            storage_size,
-                                                   InputBufferItType  sources,
-                                                   OutputBufferItType destinations,
-                                                   BufferSizeItType   sizes,
-                                                   uint32_t           num_copies,
-                                                   hipStream_t        stream = hipStreamDefault,
-                                                   bool               debug_synchronous = false)
+ROCPRIM_INLINE
+static hipError_t batch_memcpy_func(void*              temporary_storage,
+                                    size_t&            storage_size,
+                                    InputBufferItType  sources,
+                                    OutputBufferItType destinations,
+                                    BufferSizeItType   sizes,
+                                    uint32_t           num_copies,
+                                    hipStream_t        stream            = hipStreamDefault,
+                                    bool               debug_synchronous = false)
 {
-    using config
-        = wrapped_batch_memcpy_config<Config_,
-                                      typename std::iterator_traits<InputBufferItType>::value_type,
-                                      IsMemCpy>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    detail::target_arch target_arch;
-    hipError_t          result = detail::host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    const detail::batch_memcpy_config_params params
-        = detail::dispatch_target_arch<config>(target_arch);
-
-    using BufferOffsetType = unsigned int;
-    using BlockOffsetType  = unsigned int;
-
-    using batch_memcpy_impl_type = detail::
-        batch_memcpy_impl<IsMemCpy, InputBufferItType, OutputBufferItType, BufferSizeItType>;
-
-    static const uint32_t non_blev_block_size
-        = params.non_blev_batch_memcpy_kernel_config.block_size;
-    static const uint32_t non_blev_items_per_thread
-        = params.non_blev_batch_memcpy_kernel_config.items_per_thread;
-    static const uint32_t blev_block_size = params.blev_batch_memcpy_kernel_config.block_size;
-
-    const uint32_t buffers_per_block = non_blev_block_size * non_blev_items_per_thread;
-    const uint32_t num_blocks        = rocprim::detail::ceiling_div(num_copies, buffers_per_block);
-
-    using scan_state_buffer_type = rocprim::detail::lookback_scan_state<BufferOffsetType>;
-    using scan_state_block_type  = rocprim::detail::lookback_scan_state<BlockOffsetType>;
-
-    // Pack buffers
-    typename batch_memcpy_impl_type::copyable_buffers const buffers{
-        sources,
-        destinations,
-        sizes,
-    };
-
-    detail::temp_storage::layout scan_state_buffer_layout{};
-    ROCPRIM_RETURN_ON_ERROR(
-        scan_state_buffer_type::get_temp_storage_layout(num_blocks,
-                                                        stream,
-                                                        scan_state_buffer_layout));
-
-    detail::temp_storage::layout blev_block_scan_state_layout{};
-    ROCPRIM_RETURN_ON_ERROR(
-        scan_state_block_type::get_temp_storage_layout(num_blocks,
-                                                       stream,
-                                                       blev_block_scan_state_layout));
-
-    uint8_t* blev_buffer_scan_data;
-    uint8_t* blev_block_scan_state_data;
-
-    // The non-blev kernel will prepare blev copy. Communication between the two
-    // kernels is done via `blev_buffers`.
-    typename batch_memcpy_impl_type::copyable_blev_buffers blev_buffers{};
-
-    // Partition `temporary_storage`.
-    // If `temporary_storage` is null, calculate the allocation size instead.
-    ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.srcs, num_copies),
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.dsts, num_copies),
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.sizes, num_copies),
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.offsets, num_copies),
-            detail::temp_storage::make_partition(&blev_buffer_scan_data, scan_state_buffer_layout),
-            detail::temp_storage::make_partition(&blev_block_scan_state_data,
-                                                 blev_block_scan_state_layout))));
-
-    // Return the storage size.
-    if(temporary_storage == nullptr)
-    {
-        return hipSuccess;
-    }
-
-    // Compute launch parameters.
-
-    int device_id;
-    ROCPRIM_RETURN_ON_ERROR(get_device_from_stream(stream, device_id));
-
-    // Get the number of multiprocessors
-    int multiprocessor_count{};
-    ROCPRIM_RETURN_ON_ERROR(hipDeviceGetAttribute(&multiprocessor_count,
-                                                  hipDeviceAttributeMultiprocessorCount,
-                                                  device_id));
-
-    // `hipOccupancyMaxActiveBlocksPerMultiprocessor` uses the default device.
-    // We need to perserve the current default device id while we change it temporarily
-    // to get the max occupancy on this stream.
-    int previous_device;
-    ROCPRIM_RETURN_ON_ERROR(hipGetDevice(&previous_device));
-
-    ROCPRIM_RETURN_ON_ERROR(hipSetDevice(device_id));
-
-    int blev_occupancy{};
-    hipError_t error = hipOccupancyMaxActiveBlocksPerMultiprocessor(
-        &blev_occupancy,
-        batch_memcpy_impl_type::template blev_memcpy_kernel<config>,
-        blev_block_size,
-        0 /* dynSharedMemPerBlk */);
-    if(error != hipSuccess)
-    {
-        // Attempt to reset the device.
-        static_cast<void>(hipSetDevice(previous_device));
-
-        return error;
-    }
-
-    // Restore the default device id to initial state
-    ROCPRIM_RETURN_ON_ERROR(hipSetDevice(previous_device));
-
-    constexpr BlockOffsetType init_kernel_threads = 128;
-    const BlockOffsetType     init_kernel_grid_size
-        = rocprim::detail::ceiling_div(num_blocks, init_kernel_threads);
-
-    auto batch_memcpy_blev_grid_size
-        = multiprocessor_count * blev_occupancy * 1 /* subscription factor */;
-
-    BlockOffsetType batch_memcpy_grid_size = num_blocks;
-
-    // Prepare init_scan_states_kernel.
-    scan_state_buffer_type scan_state_buffer{};
-    ROCPRIM_RETURN_ON_ERROR(scan_state_buffer_type::create(scan_state_buffer,
-                                                           blev_buffer_scan_data,
-                                                           num_blocks,
-                                                           stream));
-
-    scan_state_block_type scan_state_block{};
-    ROCPRIM_RETURN_ON_ERROR(scan_state_block_type::create(scan_state_block,
-                                                          blev_block_scan_state_data,
-                                                          num_blocks,
-                                                          stream));
-
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-
-    const auto start_timer = [&start, debug_synchronous]()
-    {
-        if(debug_synchronous)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_atomic_block_id)
         {
-            start = std::chrono::steady_clock::now();
-        }
-    };
+            using config = wrapped_batch_memcpy_config<
+                Config,
+                typename std::iterator_traits<InputBufferItType>::value_type,
+                IsMemCpy>;
 
-    if(debug_synchronous)
-    {
-        std::cout << "-----" << '\n'
-                  << "storage_size: " << storage_size << '\n'
-                  << "num_copies: " << num_copies << '\n'
-                  << "non_blev_block_size: " << non_blev_block_size << '\n'
-                  << "non_blev_buffers_per_thread: " << non_blev_items_per_thread << '\n'
-                  << "blev_block_size: " << blev_block_size << '\n'
-                  << "buffers_per_block: " << buffers_per_block << '\n'
-                  << "num_blocks: " << num_blocks << '\n'
-                  << "multiprocessor_count: " << multiprocessor_count << '\n'
-                  << "blev_occupancy: " << blev_occupancy << '\n'
-                  << "init_kernel_grid_size: " << init_kernel_grid_size << '\n'
-                  << "batch_memcpy_blev_grid_size: " << batch_memcpy_blev_grid_size << '\n';
-    }
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(detail::host_target_arch(stream, target_arch));
 
-    // Launch init_scan_states_kernel.
-    start_timer();
-    batch_memcpy_impl_type::
-        init_tile_state_kernel<<<init_kernel_grid_size, init_kernel_threads, 0, stream>>>(
-            scan_state_buffer,
-            scan_state_block,
-            num_blocks);
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_tile_state_kernel", num_blocks, start);
+            const detail::batch_memcpy_config_params params
+                = detail::dispatch_target_arch<config, false>(target_arch);
 
-    // Launch batch_memcpy_non_blev_kernel.
-    start_timer();
-    batch_memcpy_impl_type::template non_blev_memcpy_kernel<config>
-        <<<batch_memcpy_grid_size, non_blev_block_size, 0, stream>>>(buffers,
-                                                                     num_copies,
-                                                                     blev_buffers,
-                                                                     scan_state_buffer,
-                                                                     scan_state_block);
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("non_blev_memcpy_kernel", num_copies, start);
+            using BufferOffsetType = unsigned int;
+            using BlockOffsetType  = unsigned int;
 
-    // Launch batch_memcpy_blev_kernel.
-    start_timer();
-    batch_memcpy_impl_type::template blev_memcpy_kernel<config>
-        <<<batch_memcpy_blev_grid_size, blev_block_size, 0, stream>>>(blev_buffers,
-                                                                      scan_state_buffer,
-                                                                      batch_memcpy_grid_size - 1);
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("blev_memcpy_kernel",
-                                                batch_memcpy_grid_size - 1,
-                                                start);
+            // TODO: make dynamic
+            using WrappedBlockId = block_id_wrapper<unsigned int, use_atomic_block_id>;
 
+            using batch_memcpy_impl_type = detail::batch_memcpy_impl<IsMemCpy,
+                                                                     InputBufferItType,
+                                                                     OutputBufferItType,
+                                                                     BufferSizeItType,
+                                                                     WrappedBlockId>;
+
+            static const uint32_t non_blev_block_size
+                = params.non_blev_batch_memcpy_kernel_config.block_size;
+            static const uint32_t non_blev_items_per_thread
+                = params.non_blev_batch_memcpy_kernel_config.items_per_thread;
+            static const uint32_t blev_block_size
+                = params.blev_batch_memcpy_kernel_config.block_size;
+
+            const uint32_t buffers_per_block = non_blev_block_size * non_blev_items_per_thread;
+            const uint32_t num_blocks = rocprim::detail::ceiling_div(num_copies, buffers_per_block);
+
+            using scan_state_buffer_type = rocprim::detail::lookback_scan_state<BufferOffsetType>;
+            using scan_state_block_type  = rocprim::detail::lookback_scan_state<BlockOffsetType>;
+
+            // Pack buffers
+            typename batch_memcpy_impl_type::copyable_buffers const buffers{
+                sources,
+                destinations,
+                sizes,
+            };
+
+            detail::temp_storage::layout scan_state_buffer_layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_buffer_type::get_temp_storage_layout(num_blocks,
+                                                                stream,
+                                                                scan_state_buffer_layout));
+
+            detail::temp_storage::layout blev_block_scan_state_layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_block_type::get_temp_storage_layout(num_blocks,
+                                                               stream,
+                                                               blev_block_scan_state_layout));
+
+            uint8_t* blev_buffer_scan_data;
+            uint8_t* blev_block_scan_state_data;
+
+            typename WrappedBlockId::id_type* ordered_bid_storage;
+
+            // The non-blev kernel will prepare blev copy. Communication between the two
+            // kernels is done via `blev_buffers`.
+            typename batch_memcpy_impl_type::copyable_blev_buffers blev_buffers{};
+
+            // Partition `temporary_storage`.
+            // If `temporary_storage` is null, calculate the allocation size instead.
+            ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.srcs, num_copies),
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.dsts, num_copies),
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.sizes, num_copies),
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.offsets, num_copies),
+                    detail::temp_storage::make_partition(&blev_buffer_scan_data,
+                                                         scan_state_buffer_layout),
+                    detail::temp_storage::make_partition(&blev_block_scan_state_data,
+                                                         blev_block_scan_state_layout),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        WrappedBlockId::get_temp_storage_layout()))));
+
+            // Return the storage size.
+            if(temporary_storage == nullptr)
+            {
+                return hipSuccess;
+            }
+
+            // Compute launch parameters.
+
+            int device_id;
+            ROCPRIM_RETURN_ON_ERROR(get_device_from_stream(stream, device_id));
+
+            // Get the number of multiprocessors
+            int multiprocessor_count{};
+            ROCPRIM_RETURN_ON_ERROR(hipDeviceGetAttribute(&multiprocessor_count,
+                                                          hipDeviceAttributeMultiprocessorCount,
+                                                          device_id));
+
+            constexpr BlockOffsetType init_kernel_threads = 128;
+            const BlockOffsetType     init_kernel_grid_size
+                = rocprim::detail::ceiling_div(num_blocks, init_kernel_threads);
+
+            BlockOffsetType batch_memcpy_grid_size = num_blocks;
+
+            // Prepare init_scan_states_kernel.
+            scan_state_buffer_type scan_state_buffer{};
+            ROCPRIM_RETURN_ON_ERROR(scan_state_buffer_type::create(scan_state_buffer,
+                                                                   blev_buffer_scan_data,
+                                                                   num_blocks,
+                                                                   stream));
+
+            scan_state_block_type scan_state_block{};
+            ROCPRIM_RETURN_ON_ERROR(scan_state_block_type::create(scan_state_block,
+                                                                  blev_block_scan_state_data,
+                                                                  num_blocks,
+                                                                  stream));
+
+            auto ordered_bid = WrappedBlockId::create(ordered_bid_storage);
+
+            // `hipOccupancyMaxActiveBlocksPerMultiprocessor` uses the default device.
+            // We need to perserve the current default device id while we change it temporarily
+            // to get the max occupancy on this stream.
+            int previous_device;
+            ROCPRIM_RETURN_ON_ERROR(hipGetDevice(&previous_device));
+
+            ROCPRIM_RETURN_ON_ERROR(hipSetDevice(device_id));
+
+            auto blev_memcpy_kernel = [=](auto arch_config)
+            {
+                batch_memcpy_impl_type::template blev_memcpy_kernel_impl<decltype(arch_config)>(
+                    blev_buffers,
+                    scan_state_buffer,
+                    batch_memcpy_grid_size - 1);
+            };
+
+            auto blev_memcpy_launch_plan
+                = make_launch_plan<config,
+                                   decltype(blev_memcpy_kernel),
+                                   blev_batch_memcpy_config_selector>(target_arch,
+                                                                      blev_memcpy_kernel);
+
+            int        blev_occupancy{};
+            hipError_t error
+                = hipOccupancyMaxActiveBlocksPerMultiprocessor(&blev_occupancy,
+                                                               blev_memcpy_launch_plan.kernel,
+                                                               blev_block_size,
+                                                               0 /* dynSharedMemPerBlk */);
+            if(error != hipSuccess)
+            {
+                // Attempt to reset the device.
+                static_cast<void>(hipSetDevice(previous_device));
+
+                return error;
+
+                // Restore the default device id to initial state
+                ROCPRIM_RETURN_ON_ERROR(hipSetDevice(previous_device));
+            }
+
+            auto batch_memcpy_blev_grid_size
+                = multiprocessor_count * blev_occupancy * 1 /* subscription factor */;
+
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+
+            const auto start_timer = [&start, debug_synchronous]()
+            {
+                if(debug_synchronous)
+                {
+                    start = std::chrono::steady_clock::now();
+                }
+            };
+
+            if(debug_synchronous)
+            {
+                std::cout << "-----" << '\n'
+                          << "storage_size: " << storage_size << '\n'
+                          << "num_copies: " << num_copies << '\n'
+                          << "non_blev_block_size: " << non_blev_block_size << '\n'
+                          << "non_blev_buffers_per_thread: " << non_blev_items_per_thread << '\n'
+                          << "blev_block_size: " << blev_block_size << '\n'
+                          << "buffers_per_block: " << buffers_per_block << '\n'
+                          << "num_blocks: " << num_blocks << '\n'
+                          << "multiprocessor_count: " << multiprocessor_count << '\n'
+                          << "blev_occupancy: " << blev_occupancy << '\n'
+                          << "init_kernel_grid_size: " << init_kernel_grid_size << '\n'
+                          << "batch_memcpy_blev_grid_size: " << batch_memcpy_blev_grid_size << '\n';
+            }
+
+            // Launch init_scan_states_kernel.
+            start_timer();
+            batch_memcpy_impl_type::
+                init_tile_state_kernel<<<init_kernel_grid_size, init_kernel_threads, 0, stream>>>(
+                    scan_state_buffer,
+                    scan_state_block,
+                    num_blocks,
+                    ordered_bid);
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_tile_state_kernel",
+                                                        num_blocks,
+                                                        start);
+
+            auto non_blev_memcpy_kernel = [=](auto arch_config)
+            {
+                batch_memcpy_impl_type::template non_blev_memcpy_kernel_impl<decltype(arch_config)>(
+                    buffers,
+                    num_copies,
+                    blev_buffers,
+                    scan_state_buffer,
+                    scan_state_block,
+                    ordered_bid);
+            };
+
+            // Launch batch_memcpy_non_blev_kernel.
+            start_timer();
+
+            ROCPRIM_RETURN_ON_ERROR(
+                execute_launch_plan<config,
+                                    decltype(non_blev_memcpy_kernel),
+                                    non_blev_batch_memcpy_config_selector>(target_arch,
+                                                                           non_blev_memcpy_kernel,
+                                                                           batch_memcpy_grid_size,
+                                                                           non_blev_block_size,
+                                                                           0,
+                                                                           stream));
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("non_blev_memcpy_kernel",
+                                                        num_copies,
+                                                        start);
+
+            // Launch batch_memcpy_blev_kernel.
+            start_timer();
+            blev_memcpy_launch_plan.launch(batch_memcpy_blev_grid_size, blev_block_size, 0, stream);
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("blev_memcpy_kernel",
+                                                        batch_memcpy_grid_size - 1,
+                                                        start);
+            return hipSuccess;
+        },
+        use_atomic_block_id_variant));
     return hipSuccess;
 }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@
 #include "../../block/block_scan.hpp"
 #include "../../block/block_sort.hpp"
 #include "../../block/block_store.hpp"
+#include "../../intrinsics/thread.hpp"
 
 #include "../../common.hpp"
 #include "../../config.hpp"
@@ -35,9 +36,9 @@
 #include "../device_transform.hpp"
 
 #include "device_config_helper.hpp"
+#include "ordered_block_id.hpp"
 
 #include <cstdint>
-#include <hip/amd_detail/amd_hip_runtime.h>
 #include <hip/hip_runtime.h>
 
 #include <iostream>
@@ -120,11 +121,11 @@ struct n_th_element_iteration_data
     bool         equality_bucket;
 };
 
-template<class config, class KeysIterator, class BinaryFunction>
+template<class ArchConfig, class KeysIterator, class BinaryFunction>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_block_sort_impl(KeysIterator keys, const unsigned int size, BinaryFunction compare_function)
+    block_sort_kernel_impl(KeysIterator keys, const unsigned int size, BinaryFunction compare_function)
 {
-    constexpr nth_element_config_params params = device_params<config>();
+    constexpr nth_element_config_params params = ArchConfig::params;
 
     constexpr unsigned int stop_recursion_size = params.stop_recursion_size;
 
@@ -154,22 +155,31 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     block_store_key().store(keys, sample_buffer, size, storage.store);
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().stop_recursion_size) void
-    kernel_block_sort(KeysIterator keys, const unsigned int size, BinaryFunction compare_function)
+template<class Config, class KeysIterator, class BinaryFunction>
+inline hipError_t launch_block_sort(detail::target_arch arch,
+                                    KeysIterator        keys,
+                                    const unsigned int  size,
+                                    BinaryFunction      compare_function,
+                                    dim3                grid,
+                                    dim3                block,
+                                    size_t              shmem,
+                                    hipStream_t         stream)
 {
-    kernel_block_sort_impl<config>(keys, size, compare_function);
+    auto kernel = [=](auto arch_config)
+    { block_sort_kernel_impl<decltype(arch_config)>(keys, size, compare_function); };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
-ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_find_splitters_impl(KeysIterator                                             keys,
+template<class ArchConfig, class KeysIterator, class BinaryFunction>
+ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void find_splitters_kernel_impl(
+                               KeysIterator                                             keys,
                                typename std::iterator_traits<KeysIterator>::value_type* tree,
                                bool*          equality_buckets,
                                const unsigned int   size,
                                BinaryFunction compare_function)
 {
-    constexpr nth_element_config_params params        = device_params<config>();
+    constexpr nth_element_config_params params        = ArchConfig::params;
     constexpr unsigned int              num_splitters = params.number_of_buckets - 1;
 
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
@@ -203,27 +213,41 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     equality_buckets[idx] = equality_bucket;
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().number_of_buckets - 1) void
-    kernel_find_splitters(KeysIterator                                             keys,
+template<class Config, class KeysIterator, class BinaryFunction>
+inline hipError_t
+    launch_find_splitters(detail::target_arch                                      arch,
+                          KeysIterator                                             keys,
                           typename std::iterator_traits<KeysIterator>::value_type* tree,
                           bool*                                                    equality_buckets,
                           const unsigned int                                       size,
-                          BinaryFunction                                           compare_function)
+                          BinaryFunction                                           compare_function,
+                          dim3                                                     grid,
+                          dim3                                                     block,
+                          size_t                                                   shmem,
+                          hipStream_t                                              stream)
 {
-    kernel_find_splitters_impl<config>(keys, tree, equality_buckets, size, compare_function);
+    auto kernel = [=](auto arch_config)
+    {
+        find_splitters_kernel_impl<decltype(arch_config)>(keys,
+                                                          tree,
+                                                          equality_buckets,
+                                                          size,
+                                                          compare_function);
+    };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
+template<class ArchConfig, class KeysIterator, class BinaryFunction>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_count_bucket_sizes_impl(KeysIterator                                             keys,
+    count_bucket_sizes_kernel_impl(KeysIterator                                             keys,
                                    typename std::iterator_traits<KeysIterator>::value_type* tree,
                                    const unsigned int                                             size,
                                    unsigned int*                                                  buckets,
                                    bool*          equality_buckets,
                                    BinaryFunction compare_function)
 {
-    constexpr nth_element_config_params params = device_params<config>();
+    constexpr nth_element_config_params params = ArchConfig::params;
 
     constexpr unsigned int num_buckets           = params.number_of_buckets;
     constexpr unsigned int num_threads_per_block = params.kernel_config.block_size;
@@ -318,32 +342,42 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     }
 }
 
-template<class config, class KeysIterator, class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().kernel_config.block_size) void
-    kernel_count_bucket_sizes(KeysIterator                                             keys,
+template<class Config, class KeysIterator, class BinaryFunction>
+inline hipError_t
+    launch_count_bucket_sizes(detail::target_arch                                      arch,
+                              KeysIterator                                             keys,
                               typename std::iterator_traits<KeysIterator>::value_type* tree,
                               const unsigned int                                       size,
                               unsigned int*                                            buckets,
                               bool*          equality_buckets,
-                              BinaryFunction compare_function)
+                              BinaryFunction compare_function,
+                              dim3           grid,
+                              dim3           block,
+                              size_t         shmem,
+                              hipStream_t    stream)
 {
-    kernel_count_bucket_sizes_impl<config>(keys,
-                                           tree,
-                                           size,
-                                           buckets,
-                                           equality_buckets,
-                                           compare_function);
+    auto kernel = [=](auto arch_config)
+    {
+        count_bucket_sizes_kernel_impl<decltype(arch_config)>(keys,
+                                                              tree,
+                                                              size,
+                                                              buckets,
+                                                              equality_buckets,
+                                                              compare_function);
+    };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config>
+template<class ArchConfig>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_find_nth_element_bucket_impl(unsigned int*                      buckets,
+    find_nth_element_bucket_kernel_impl(unsigned int*                      buckets,
                                         n_th_element_iteration_data* nth_element_data,
                                         bool*                        equality_buckets,
                                         const unsigned int           rank)
 
 {
-    constexpr nth_element_config_params params = device_params<config>();
+    constexpr nth_element_config_params params = ArchConfig::params;
 
     constexpr unsigned int num_buckets = params.number_of_buckets;
 
@@ -381,32 +415,45 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     }
 }
 
-template<class config>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().number_of_buckets) void
-    kernel_find_nth_element_bucket(unsigned int*                buckets,
-                                   n_th_element_iteration_data* nth_element_data,
-                                   bool*                        equality_buckets,
-                                   const unsigned int           rank)
+template<class Config>
+inline hipError_t launch_find_nth_element_bucket(detail::target_arch          arch,
+                                                 unsigned int*                buckets,
+                                                 n_th_element_iteration_data* nth_element_data,
+                                                 bool*                        equality_buckets,
+                                                 const unsigned int           rank,
+                                                 dim3                         grid,
+                                                 dim3                         block,
+                                                 size_t                       shmem,
+                                                 hipStream_t                  stream)
 
 {
-    kernel_find_nth_element_bucket_impl<config>(buckets, nth_element_data, equality_buckets, rank);
+    auto kernel = [=](auto arch_config)
+    {
+        find_nth_element_bucket_kernel_impl<decltype(arch_config)>(buckets,
+                                                                   nth_element_data,
+                                                                   equality_buckets,
+                                                                   rank);
+    };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+template<class ArchConfig, unsigned int NumPartitions, class KeysIterator, class BinaryFunction, class WrappedBlockId>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
-    kernel_copy_buckets_impl(KeysIterator                                             keys,
+    copy_buckets_kernel_impl(KeysIterator                                             keys,
                              typename std::iterator_traits<KeysIterator>::value_type* tree,
                              const unsigned int                                       size,
                              nth_element_onesweep_lookback_state* lookback_states,
                              n_th_element_iteration_data*         nth_element_data,
                              typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
-                             bool*          equality_buckets,
-                             BinaryFunction compare_function)
+                             bool*              equality_buckets,
+                             BinaryFunction     compare_function,
+                             WrappedBlockId     ordered_bid)
 {
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
     using state    = nth_element_onesweep_lookback_state;
 
-    constexpr nth_element_config_params params = device_params<config>();
+    constexpr nth_element_config_params params = ArchConfig::params;
 
     constexpr unsigned int num_buckets           = params.number_of_buckets;
     constexpr unsigned int num_splitters         = num_buckets - 1;
@@ -415,9 +462,10 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     constexpr unsigned int num_items_per_block   = num_threads_per_block * num_items_per_thread;
     constexpr unsigned int num_partitions        = NumPartitions;
 
-    using block_rank         = rocprim::block_radix_rank<num_threads_per_block,
+    using block_rank = rocprim::block_radix_rank<num_threads_per_block,
                                                  Log2<static_cast<int>(num_partitions + 1)>::VALUE,
                                                  params.radix_rank_algorithm>;
+
     using block_load_element = block_load<key_type, num_threads_per_block, num_items_per_thread>;
 
     static_assert(block_rank::digits_per_thread == 1,
@@ -428,7 +476,10 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
         typename block_rank::storage_type         rank;
         typename block_load_element::storage_type load_element;
         size_t                                    buckets_block_offsets_shared[num_partitions];
+        typename WrappedBlockId::storage_type     ordered_bid;
     } storage;
+
+    auto block_id = ordered_bid.get(threadIdx.x, storage.ordered_bid);
 
     uint8_t buckets[num_items_per_thread];
 
@@ -438,7 +489,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     const bool         equality_bucket = nth_element_data->equality_bucket;
     const bool equality_bucket_before  = nth_element > 0 && equality_buckets[nth_element - 1];
 
-    const unsigned int offset            = blockIdx.x * num_items_per_block;
+    const unsigned int offset            = block_id * num_items_per_block;
     const bool         is_complete_block = offset + num_items_per_block <= size;
 
     key_type elements[num_items_per_thread];
@@ -514,11 +565,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     const unsigned int partition = threadIdx.x;
     if(partition < num_partitions)
     {
-        state* block_state = &lookback_states[blockIdx.x * num_partitions + partition];
+        state* block_state = &lookback_states[block_id * num_partitions + partition];
         state(state::PARTIAL, partition_counts[0]).store(block_state);
 
         unsigned int exclusive_prefix  = 0;
-        unsigned int lookback_block_id = blockIdx.x;
+        unsigned int lookback_block_id = block_id;
         // The main back tracking loop.
         while(lookback_block_id > 0)
         {
@@ -581,31 +632,52 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     }
 }
 
-template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<config>().kernel_config.block_size) void
-    kernel_copy_buckets(KeysIterator                                             keys,
+template<class Config,
+         unsigned int NumPartitions,
+         class KeysIterator,
+         class BinaryFunction,
+         class WrappedBlockId>
+inline hipError_t
+    launch_copy_buckets(detail::target_arch                                      arch,
+                        KeysIterator                                             keys,
                         typename std::iterator_traits<KeysIterator>::value_type* tree,
                         const unsigned int                                       size,
                         nth_element_onesweep_lookback_state*                     lookback_states,
                         n_th_element_iteration_data*                             nth_element_data,
                         typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
                         bool*                                                    equality_buckets,
-                        BinaryFunction                                           compare_function)
+                        BinaryFunction                                           compare_function,
+                        WrappedBlockId                                           ordered_bid,
+                        dim3                                                     grid,
+                        dim3                                                     block,
+                        size_t                                                   shmem,
+                        hipStream_t                                              stream)
 {
-    kernel_copy_buckets_impl<config, NumPartitions>(keys,
-                                                    tree,
-                                                    size,
-                                                    lookback_states,
-                                                    nth_element_data,
-                                                    keys_buffer,
-                                                    equality_buckets,
-                                                    compare_function);
+    auto kernel = [=](auto arch_config)
+    {
+        copy_buckets_kernel_impl<decltype(arch_config), NumPartitions>(keys,
+                                                                       tree,
+                                                                       size,
+                                                                       lookback_states,
+                                                                       nth_element_data,
+                                                                       keys_buffer,
+                                                                       equality_buckets,
+                                                                       compare_function,
+                                                                       ordered_bid);
+    };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+template<class Config,
+         unsigned int NumPartitions,
+         class KeysIterator,
+         class BinaryFunction,
+         class WrappedBlockId>
 ROCPRIM_INLINE
 hipError_t
-    nth_element_keys_impl(KeysIterator                                             keys,
+    nth_element_keys_impl(detail::target_arch                                      arch,
+                          KeysIterator                                             keys,
                           typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
                           typename std::iterator_traits<KeysIterator>::value_type* tree,
                           unsigned int                                             rank,
@@ -620,7 +692,8 @@ hipError_t
                           n_th_element_iteration_data* nth_element_data,
                           BinaryFunction               compare_function,
                           hipStream_t                  stream,
-                          bool                         debug_synchronous)
+                          bool                         debug_synchronous,
+                          WrappedBlockId               ordered_bid)
 {
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
 
@@ -663,37 +736,64 @@ hipError_t
                                                        num_partitions * num_blocks,
                                                        stream));
 
-        start_timer();
-        kernel_find_splitters<config>
-            <<<1, num_splitters, 0, stream>>>(keys, tree, equality_buckets, size, compare_function);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_find_splitters", size, start);
+        // Reset ordered block id.
+        ROCPRIM_RETURN_ON_ERROR(ordered_bid.reset_from_host(stream));
 
         start_timer();
-        kernel_count_bucket_sizes<config>
-            <<<num_blocks, num_threads_per_block, 0, stream>>>(keys,
-                                                               tree,
-                                                               size,
-                                                               buckets,
-                                                               equality_buckets,
-                                                               compare_function);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_count_bucket_sizes", size, start);
+        ROCPRIM_RETURN_ON_ERROR(launch_find_splitters<Config>(arch,
+                                                              keys,
+                                                              tree,
+                                                              equality_buckets,
+                                                              size,
+                                                              compare_function,
+                                                              1,
+                                                              num_splitters,
+                                                              0,
+                                                              stream));
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("find_splitters_kernel", size, start);
 
         start_timer();
-        kernel_find_nth_element_bucket<config>
-            <<<1, num_buckets, 0, stream>>>(buckets, nth_element_data, equality_buckets, rank);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_find_nth_element_bucket", size, start);
+        ROCPRIM_RETURN_ON_ERROR(launch_count_bucket_sizes<Config>(arch,
+                                                                  keys,
+                                                                  tree,
+                                                                  size,
+                                                                  buckets,
+                                                                  equality_buckets,
+                                                                  compare_function,
+                                                                  num_blocks,
+                                                                  num_threads_per_block,
+                                                                  0,
+                                                                  stream));
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("count_bucket_sizes_kernel", size, start);
 
         start_timer();
-        kernel_copy_buckets<config, num_partitions>
-            <<<num_blocks, num_threads_per_block, 0, stream>>>(keys,
-                                                               tree,
-                                                               size,
-                                                               lookback_states,
-                                                               nth_element_data,
-                                                               keys_buffer,
-                                                               equality_buckets,
-                                                               compare_function);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_copy_buckets", size, start);
+        ROCPRIM_RETURN_ON_ERROR(launch_find_nth_element_bucket<Config>(arch,
+                                                                       buckets,
+                                                                       nth_element_data,
+                                                                       equality_buckets,
+                                                                       rank,
+                                                                       1,
+                                                                       num_buckets,
+                                                                       0,
+                                                                       stream));
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("find_nth_element_bucket_kernel", size, start);
+
+        start_timer();
+        ROCPRIM_RETURN_ON_ERROR(launch_copy_buckets<Config, num_partitions>(arch,
+                                                                            keys,
+                                                                            tree,
+                                                                            size,
+                                                                            lookback_states,
+                                                                            nth_element_data,
+                                                                            keys_buffer,
+                                                                            equality_buckets,
+                                                                            compare_function,
+                                                                            ordered_bid,
+                                                                            num_blocks,
+                                                                            num_threads_per_block,
+                                                                            0,
+                                                                            stream));
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("copy_buckets_kernel", size, start);
 
         // Copy the results in keys_buffer back to the keys
         ROCPRIM_RETURN_ON_ERROR(transform(keys_buffer,
@@ -729,7 +829,14 @@ hipError_t
     }
 
     start_timer();
-    kernel_block_sort<config><<<1, stop_recursion_size, 0, stream>>>(keys, size, compare_function);
+    ROCPRIM_RETURN_ON_ERROR(launch_block_sort<Config>(arch,
+                                                      keys,
+                                                      size,
+                                                      compare_function,
+                                                      1,
+                                                      stop_recursion_size,
+                                                      0,
+                                                      stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("kernel_block_sort", size, start);
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
@@ -1027,15 +1027,12 @@ struct partition_kernel_impl_
                                  bool[items_per_thread],
                                  bool[sizeof...(UnaryPredicates)][items_per_thread]>;
 
+        const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
+        const uint32_t flat_block_id        = block_id.get(flat_block_thread_id, storage.block_id);
+        
         size_t prev_selected_count_values[sizeof...(UnaryPredicates)]{};
         load_selected_count(prev_selected_count, prev_selected_count_values);
-
-        const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
-        const auto flat_block_id = block_id.get(flat_block_thread_id, storage.block_id);
-        ::rocprim::syncthreads(); // sync threads to reuse shared memory
-        
-        // const auto flat_block_id = ::rocprim::detail::block_id<0>();
-
+             
         const auto         block_offset = flat_block_id * items_per_block;
         const unsigned int valid_in_global_last_block
             = total_size - prev_processed - items_per_block * (number_of_blocks - 1);

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
@@ -21,18 +21,18 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_PARTITION_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_PARTITION_HPP_
 
-#include <type_traits>
 #include <iterator>
+#include <type_traits>
 
 #include "../../detail/various.hpp"
-#include "../../intrinsics.hpp"
 #include "../../functional.hpp"
+#include "../../intrinsics.hpp"
 #include "../../types.hpp"
 
-#include "../../block/block_load.hpp"
-#include "../../block/block_store.hpp"
-#include "../../block/block_scan.hpp"
 #include "../../block/block_discontinuity.hpp"
+#include "../../block/block_load.hpp"
+#include "../../block/block_scan.hpp"
+#include "../../block/block_store.hpp"
 #include "ordered_block_id.hpp"
 
 #include "../config_types.hpp"
@@ -84,18 +84,18 @@ template<select_method SelectMethod,
          class UnaryPredicate,
          class InequalityOp,
          class StorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_block_load_flags(InputIterator /* block_predecessor */,
-                               FlagIterator block_flags,
-                               ValueType (&/* values */)[ItemsPerThread],
-                               bool (&is_selected)[ItemsPerThread],
-                               UnaryPredicate /* predicate */,
-                               InequalityOp /* inequality_op */,
-                               StorageType& storage,
-                               const bool /* is_first_block */,
-                               const unsigned int /* block_thread_id */,
-                               const bool         is_global_last_block,
-                               const unsigned int valid_in_global_last_block) ->
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_block_load_flags(InputIterator /* block_predecessor */,
+                                FlagIterator block_flags,
+                                ValueType (& /* values */)[ItemsPerThread],
+                                bool (&is_selected)[ItemsPerThread],
+                                UnaryPredicate /* predicate */,
+                                InequalityOp /* inequality_op */,
+                                StorageType& storage,
+                                const bool /* is_first_block */,
+                                const unsigned int /* block_thread_id */,
+                                const bool         is_global_last_block,
+                                const unsigned int valid_in_global_last_block) ->
     typename std::enable_if<SelectMethod == select_method::flag>::type
 {
     if(is_global_last_block) // last block
@@ -108,12 +108,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE auto
     }
     else
     {
-        BlockLoadFlagsType()
-            .load(
-                block_flags,
-                is_selected,
-                storage.load_flags
-            );
+        BlockLoadFlagsType().load(block_flags, is_selected, storage.load_flags);
     }
     ::rocprim::syncthreads(); // sync threads to reuse shared memory
 }
@@ -183,18 +178,18 @@ template<select_method SelectMethod,
          class UnaryPredicate,
          class InequalityOp,
          class StorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_block_load_flags(InputIterator /* block_predecessor */,
-                               FlagIterator /* block_flags */,
-                               ValueType (&values)[ItemsPerThread],
-                               bool (&is_selected)[ItemsPerThread],
-                               UnaryPredicate predicate,
-                               InequalityOp /* inequality_op */,
-                               StorageType& /* storage */,
-                               const bool /* is_first_block */,
-                               const unsigned int block_thread_id,
-                               const bool         is_global_last_block,
-                               const unsigned int valid_in_global_last_block) ->
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_block_load_flags(InputIterator /* block_predecessor */,
+                                FlagIterator /* block_flags */,
+                                ValueType (&values)[ItemsPerThread],
+                                bool (&is_selected)[ItemsPerThread],
+                                UnaryPredicate predicate,
+                                InequalityOp /* inequality_op */,
+                                StorageType& /* storage */,
+                                const bool /* is_first_block */,
+                                const unsigned int block_thread_id,
+                                const bool         is_global_last_block,
+                                const unsigned int valid_in_global_last_block) ->
     typename std::enable_if<SelectMethod == select_method::predicate>::type
 {
     if(is_global_last_block) // last block
@@ -255,18 +250,18 @@ template<select_method SelectMethod,
          class UnaryPredicate,
          class InequalityOp,
          class StorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_block_load_flags(InputIterator block_predecessor,
-                               FlagIterator /* block_flags */,
-                               ValueType (&values)[ItemsPerThread],
-                               bool (&is_selected)[ItemsPerThread],
-                               UnaryPredicate /* predicate */,
-                               InequalityOp       inequality_op,
-                               StorageType&       storage,
-                               const bool         is_first_block,
-                               const unsigned int block_thread_id,
-                               const bool         is_global_last_block,
-                               const unsigned int valid_in_global_last_block) ->
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_block_load_flags(InputIterator block_predecessor,
+                                FlagIterator /* block_flags */,
+                                ValueType (&values)[ItemsPerThread],
+                                bool (&is_selected)[ItemsPerThread],
+                                UnaryPredicate /* predicate */,
+                                InequalityOp       inequality_op,
+                                StorageType&       storage,
+                                const bool         is_first_block,
+                                const unsigned int block_thread_id,
+                                const bool         is_global_last_block,
+                                const unsigned int valid_in_global_last_block) ->
     typename std::enable_if<SelectMethod == select_method::unique>::type
 {
     if(is_first_block)
@@ -309,7 +304,6 @@ ROCPRIM_DEVICE ROCPRIM_INLINE auto
         }
     }
 
-
     // Set is_selected for invalid items to false
     if(is_global_last_block)
     {
@@ -338,19 +332,19 @@ template<select_method SelectMethod,
          class SecondUnaryPredicate,
          class InequalityOp,
          class StorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE void
-    partition_block_load_flags(InputIterator /*block_predecessor*/,
-                               FlagIterator /* block_flags */,
-                               ValueType (&values)[ItemsPerThread],
-                               bool (&is_selected)[2][ItemsPerThread],
-                               FirstUnaryPredicate  select_first_part_op,
-                               SecondUnaryPredicate select_second_part_op,
-                               InequalityOp /*inequality_op*/,
-                               StorageType& /*storage*/,
-                               const unsigned int /*block_id*/,
-                               const unsigned int block_thread_id,
-                               const bool         is_global_last_block,
-                               const unsigned int valid_in_global_last_block)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void partition_block_load_flags(InputIterator /*block_predecessor*/,
+                                FlagIterator /* block_flags */,
+                                ValueType (&values)[ItemsPerThread],
+                                bool (&is_selected)[2][ItemsPerThread],
+                                FirstUnaryPredicate  select_first_part_op,
+                                SecondUnaryPredicate select_second_part_op,
+                                InequalityOp /*inequality_op*/,
+                                StorageType& /*storage*/,
+                                const unsigned int /*block_id*/,
+                                const unsigned int block_thread_id,
+                                const bool         is_global_last_block,
+                                const unsigned int valid_in_global_last_block)
 {
     if(is_global_last_block)
     {
@@ -389,21 +383,21 @@ template<bool         OnlySelected,
          class OffsetType,
          class SelectType,
          class ScatterStorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_scatter(ValueType (&values)[ItemsPerThread],
-                      bool (&is_selected)[ItemsPerThread],
-                      OffsetType (&output_indices)[ItemsPerThread],
-                      tuple<SelectType, ::rocprim::empty_type*> output,
-                      const size_t                              total_size,
-                      const OffsetType                          selected_prefix,
-                      const OffsetType                          selected_in_block,
-                      ScatterStorageType&                       storage,
-                      const unsigned int                        flat_block_id,
-                      const unsigned int                        flat_block_thread_id,
-                      const bool                                is_global_last_block,
-                      const unsigned int                        valid_in_global_last_block,
-                      size_t (&prev_selected_count_values)[1],
-                      size_t prev_processed) -> typename std::enable_if<!OnlySelected>::type
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_scatter(ValueType (&values)[ItemsPerThread],
+                       bool (&is_selected)[ItemsPerThread],
+                       OffsetType (&output_indices)[ItemsPerThread],
+                       tuple<SelectType, ::rocprim::empty_type*> output,
+                       const size_t                              total_size,
+                       const OffsetType                          selected_prefix,
+                       const OffsetType                          selected_in_block,
+                       ScatterStorageType&                       storage,
+                       const unsigned int                        flat_block_id,
+                       const unsigned int                        flat_block_thread_id,
+                       const bool                                is_global_last_block,
+                       const unsigned int                        valid_in_global_last_block,
+                       size_t (&prev_selected_count_values)[1],
+                       size_t prev_processed) -> typename std::enable_if<!OnlySelected>::type
 {
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
@@ -467,21 +461,21 @@ template<bool         OnlySelected,
          class SelectType,
          class RejectType,
          class ScatterStorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto partition_scatter(ValueType (&values)[ItemsPerThread],
-                                                     bool (&is_selected)[ItemsPerThread],
-                                                     OffsetType (&output_indices)[ItemsPerThread],
-                                                     tuple<SelectType, RejectType> output,
-                                                     const size_t /*total_size*/,
-                                                     const OffsetType    selected_prefix,
-                                                     const OffsetType    selected_in_block,
-                                                     ScatterStorageType& storage,
-                                                     const unsigned int  flat_block_id,
-                                                     const unsigned int  flat_block_thread_id,
-                                                     const bool          is_global_last_block,
-                                                     const unsigned int  valid_in_global_last_block,
-                                                     size_t (&prev_selected_count_values)[1],
-                                                     size_t prev_processed) ->
-    typename std::enable_if<!OnlySelected>::type
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_scatter(ValueType (&values)[ItemsPerThread],
+                       bool (&is_selected)[ItemsPerThread],
+                       OffsetType (&output_indices)[ItemsPerThread],
+                       tuple<SelectType, RejectType> output,
+                       const size_t /*total_size*/,
+                       const OffsetType    selected_prefix,
+                       const OffsetType    selected_in_block,
+                       ScatterStorageType& storage,
+                       const unsigned int  flat_block_id,
+                       const unsigned int  flat_block_thread_id,
+                       const bool          is_global_last_block,
+                       const unsigned int  valid_in_global_last_block,
+                       size_t (&prev_selected_count_values)[1],
+                       size_t prev_processed) -> typename std::enable_if<!OnlySelected>::type
 {
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
 
@@ -552,21 +546,21 @@ template<bool         OnlySelected,
          class SelectType,
          class RejectType,
          class ScatterStorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE auto
-    partition_scatter(ValueType (&values)[ItemsPerThread],
-                      bool (&is_selected)[ItemsPerThread],
-                      OffsetType (&output_indices)[ItemsPerThread],
-                      tuple<SelectType, RejectType> output,
-                      const size_t /*total_size*/,
-                      const OffsetType    selected_prefix,
-                      const OffsetType    selected_in_block,
-                      ScatterStorageType& storage,
-                      const unsigned int /*flat_block_id*/,
-                      const unsigned int flat_block_thread_id,
-                      const bool         is_global_last_block,
-                      const unsigned int /*valid_in_global_last_block*/,
-                      size_t (&prev_selected_count_values)[1],
-                      size_t /*prev_processed*/) -> typename std::enable_if<OnlySelected>::type
+ROCPRIM_DEVICE ROCPRIM_INLINE
+auto partition_scatter(ValueType (&values)[ItemsPerThread],
+                       bool (&is_selected)[ItemsPerThread],
+                       OffsetType (&output_indices)[ItemsPerThread],
+                       tuple<SelectType, RejectType> output,
+                       const size_t /*total_size*/,
+                       const OffsetType    selected_prefix,
+                       const OffsetType    selected_in_block,
+                       ScatterStorageType& storage,
+                       const unsigned int /*flat_block_id*/,
+                       const unsigned int flat_block_thread_id,
+                       const bool         is_global_last_block,
+                       const unsigned int /*valid_in_global_last_block*/,
+                       size_t (&prev_selected_count_values)[1],
+                       size_t /*prev_processed*/) -> typename std::enable_if<OnlySelected>::type
 {
     if(selected_in_block > BlockSize)
     {
@@ -614,20 +608,21 @@ template<bool         OnlySelected,
          class OffsetType,
          class OutputType,
          class ScatterStorageType>
-ROCPRIM_DEVICE ROCPRIM_INLINE void partition_scatter(ValueType (&values)[ItemsPerThread],
-                                                     bool (&is_selected)[2][ItemsPerThread],
-                                                     OffsetType (&output_indices)[ItemsPerThread],
-                                                     OutputType output,
-                                                     const size_t /*total_size*/,
-                                                     const OffsetType    selected_prefix,
-                                                     const OffsetType    selected_in_block,
-                                                     ScatterStorageType& storage,
-                                                     const unsigned int  flat_block_id,
-                                                     const unsigned int  flat_block_thread_id,
-                                                     const bool          is_global_last_block,
-                                                     const unsigned int  valid_in_global_last_block,
-                                                     size_t (&prev_selected_count_values)[2],
-                                                     size_t prev_processed)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void partition_scatter(ValueType (&values)[ItemsPerThread],
+                       bool (&is_selected)[2][ItemsPerThread],
+                       OffsetType (&output_indices)[ItemsPerThread],
+                       OutputType output,
+                       const size_t /*total_size*/,
+                       const OffsetType    selected_prefix,
+                       const OffsetType    selected_in_block,
+                       ScatterStorageType& storage,
+                       const unsigned int  flat_block_id,
+                       const unsigned int  flat_block_thread_id,
+                       const bool          is_global_last_block,
+                       const unsigned int  valid_in_global_last_block,
+                       size_t (&prev_selected_count_values)[2],
+                       size_t prev_processed)
 {
     constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
     auto                   scatter_storage = storage.get();
@@ -642,8 +637,8 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void partition_scatter(ValueType (&values)[ItemsPe
     for(unsigned int i = 0; i < ItemsPerThread; i++)
     {
         const unsigned int first_selected_item_index = output_indices[i].x - selected_prefix.x;
-        const unsigned int second_selected_item_index = output_indices[i].y - selected_prefix.y
-            + selected_in_block.x;
+        const unsigned int second_selected_item_index
+            = output_indices[i].y - selected_prefix.y + selected_in_block.x;
         unsigned int scatter_index{};
 
         if(is_selected[0][i])
@@ -657,8 +652,9 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void partition_scatter(ValueType (&values)[ItemsPe
         else
         {
             const unsigned int item_index = (flat_block_thread_id * ItemsPerThread) + i;
-            const unsigned int unselected_item_index = (item_index - first_selected_item_index - second_selected_item_index)
-                + 2*selected_in_block.x + selected_in_block.y;
+            const unsigned int unselected_item_index
+                = (item_index - first_selected_item_index - second_selected_item_index)
+                  + 2 * selected_in_block.x + selected_in_block.y;
             scatter_index = unselected_item_index;
         }
         scatter_storage[scatter_index] = values[i];
@@ -705,10 +701,7 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void partition_scatter(ValueType (&values)[ItemsPe
     }
 }
 
-template<
-    unsigned int items_per_thread,
-    class offset_type
->
+template<unsigned int items_per_thread, class offset_type>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void convert_selected_to_indices(offset_type (&output_indices)[items_per_thread],
                                  bool (&is_selected)[items_per_thread])
@@ -720,9 +713,7 @@ void convert_selected_to_indices(offset_type (&output_indices)[items_per_thread]
     }
 }
 
-template<
-    unsigned int items_per_thread
->
+template<unsigned int items_per_thread>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 void convert_selected_to_indices(uint2 (&output_indices)[items_per_thread],
                                  bool (&is_selected)[2][items_per_thread])
@@ -736,26 +727,28 @@ void convert_selected_to_indices(uint2 (&output_indices)[items_per_thread],
 }
 
 template<class OffsetT>
-ROCPRIM_DEVICE ROCPRIM_INLINE void store_selected_count(size_t* selected_count,
-                                                        size_t (&prev_selected_count_values)[1],
-                                                        const OffsetT selected_prefix,
-                                                        const OffsetT selected_in_block)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void store_selected_count(size_t* selected_count,
+                          size_t (&prev_selected_count_values)[1],
+                          const OffsetT selected_prefix,
+                          const OffsetT selected_in_block)
 {
     selected_count[0] = prev_selected_count_values[0] + selected_prefix + selected_in_block;
 }
 
-ROCPRIM_DEVICE ROCPRIM_INLINE void store_selected_count(size_t* selected_count,
-                                                        size_t (&prev_selected_count_values)[2],
-                                                        const uint2 selected_prefix,
-                                                        const uint2 selected_in_block)
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void store_selected_count(size_t* selected_count,
+                          size_t (&prev_selected_count_values)[2],
+                          const uint2 selected_prefix,
+                          const uint2 selected_in_block)
 {
     selected_count[0] = prev_selected_count_values[0] + selected_prefix.x + selected_in_block.x;
     selected_count[1] = prev_selected_count_values[1] + selected_prefix.y + selected_in_block.y;
 }
 
 template<unsigned int Size>
-ROCPRIM_DEVICE void load_selected_count(const size_t* const prev_selected_count,
-                                        size_t (&loaded_values)[Size])
+ROCPRIM_DEVICE
+void load_selected_count(const size_t* const prev_selected_count, size_t (&loaded_values)[Size])
 {
     for(unsigned int i = 0; i < Size; ++i)
     {
@@ -776,10 +769,11 @@ private:
     ValueType values[ItemsPerThread];
 
 public:
-    ROCPRIM_DEVICE void load(ValueIterator                              values_input,
-                             unsigned int                               valid,
-                             unsigned int                               is_global_last_block,
-                             typename BlockLoadValueType::storage_type& load_values)
+    ROCPRIM_DEVICE
+    void load(ValueIterator                              values_input,
+              unsigned int                               valid,
+              unsigned int                               is_global_last_block,
+              typename BlockLoadValueType::storage_type& load_values)
     {
         // Load values and sync threads
         if(is_global_last_block)
@@ -794,19 +788,20 @@ public:
     }
 
     template<class OffsetType, class OutputType, class ScatterStorageType>
-    ROCPRIM_DEVICE void store(bool (&is_selected)[ItemsPerThread],
-                              OffsetType (&output_indices)[ItemsPerThread],
-                              OutputType          values_output,
-                              const size_t        total_size,
-                              const OffsetType    selected_prefix,
-                              const OffsetType    selected_in_block,
-                              ScatterStorageType& storage,
-                              const unsigned int  flat_block_id,
-                              const unsigned int  flat_block_thread_id,
-                              const bool          is_global_last_block,
-                              const unsigned int  valid_in_global_last_block,
-                              size_t (&prev_selected_count_values)[1],
-                              size_t prev_processed)
+    ROCPRIM_DEVICE
+    void store(bool (&is_selected)[ItemsPerThread],
+               OffsetType (&output_indices)[ItemsPerThread],
+               OutputType          values_output,
+               const size_t        total_size,
+               const OffsetType    selected_prefix,
+               const OffsetType    selected_in_block,
+               ScatterStorageType& storage,
+               const unsigned int  flat_block_id,
+               const unsigned int  flat_block_thread_id,
+               const bool          is_global_last_block,
+               const unsigned int  valid_in_global_last_block,
+               size_t (&prev_selected_count_values)[1],
+               size_t prev_processed)
     {
         // Sync threads and store values
         ::rocprim::syncthreads();
@@ -827,19 +822,20 @@ public:
     }
 
     template<class OffsetType, class OutputType, class ScatterStorageType>
-    ROCPRIM_DEVICE void store(bool (&is_selected)[2][ItemsPerThread],
-                              OffsetType (&output_indices)[ItemsPerThread],
-                              OutputType          values_output,
-                              const size_t        total_size,
-                              const OffsetType    selected_prefix,
-                              const OffsetType    selected_in_block,
-                              ScatterStorageType& storage,
-                              const unsigned int  flat_block_id,
-                              const unsigned int  flat_block_thread_id,
-                              const bool          is_global_last_block,
-                              const unsigned int  valid_in_global_last_block,
-                              size_t (&prev_selected_count_values)[2],
-                              size_t prev_processed)
+    ROCPRIM_DEVICE
+    void store(bool (&is_selected)[2][ItemsPerThread],
+               OffsetType (&output_indices)[ItemsPerThread],
+               OutputType          values_output,
+               const size_t        total_size,
+               const OffsetType    selected_prefix,
+               const OffsetType    selected_in_block,
+               ScatterStorageType& storage,
+               const unsigned int  flat_block_id,
+               const unsigned int  flat_block_thread_id,
+               const bool          is_global_last_block,
+               const unsigned int  valid_in_global_last_block,
+               size_t (&prev_selected_count_values)[2],
+               size_t prev_processed)
     {
         // Sync threads and store values
         ::rocprim::syncthreads();
@@ -873,46 +869,48 @@ class partition_values_helper<ItemsPerThread,
                               rocprim::empty_type>
 {
 public:
-    ROCPRIM_DEVICE void
-        load(ValueIterator, unsigned int, unsigned int, typename BlockLoadValueType::storage_type&)
+    ROCPRIM_DEVICE
+    void load(ValueIterator, unsigned int, unsigned int, typename BlockLoadValueType::storage_type&)
     {}
 
     template<class OffsetType, class OutputType, class ScatterStorageType>
-    ROCPRIM_DEVICE void store(bool[ItemsPerThread],
-                              OffsetType[ItemsPerThread],
-                              OutputType,
-                              const size_t,
-                              const OffsetType,
-                              const OffsetType,
-                              ScatterStorageType&,
-                              const unsigned int,
-                              const unsigned int,
-                              const bool,
-                              const unsigned int,
-                              size_t[ItemsPerThread],
-                              size_t)
+    ROCPRIM_DEVICE
+    void store(bool[ItemsPerThread],
+               OffsetType[ItemsPerThread],
+               OutputType,
+               const size_t,
+               const OffsetType,
+               const OffsetType,
+               ScatterStorageType&,
+               const unsigned int,
+               const unsigned int,
+               const bool,
+               const unsigned int,
+               size_t[ItemsPerThread],
+               size_t)
     {}
 
     template<class OffsetType, class OutputType, class ScatterStorageType>
-    ROCPRIM_DEVICE void store(bool[2][ItemsPerThread],
-                              OffsetType[ItemsPerThread],
-                              OutputType,
-                              const size_t,
-                              const OffsetType,
-                              const OffsetType,
-                              ScatterStorageType&,
-                              const unsigned int,
-                              const unsigned int,
-                              const bool,
-                              const unsigned int,
-                              size_t[ItemsPerThread],
-                              size_t)
+    ROCPRIM_DEVICE
+    void store(bool[2][ItemsPerThread],
+               OffsetType[ItemsPerThread],
+               OutputType,
+               const size_t,
+               const OffsetType,
+               const OffsetType,
+               ScatterStorageType&,
+               const unsigned int,
+               const unsigned int,
+               const bool,
+               const unsigned int,
+               size_t[ItemsPerThread],
+               size_t)
     {}
 };
 
-template<select_method SelectMethod,
+template<class ArchConfig,
+         select_method SelectMethod,
          bool          OnlySelected,
-         class Config,
          class Key,
          class Value,
          class FlagType,
@@ -921,7 +919,7 @@ template<select_method SelectMethod,
 struct partition_kernel_impl_
 {
 
-    static constexpr partition_config_params params = device_params<Config>();
+    static constexpr partition_config_params params = ArchConfig::params;
 
     static constexpr auto         block_size       = params.kernel_config.block_size;
     static constexpr auto         items_per_thread = params.kernel_config.items_per_thread;
@@ -937,14 +935,15 @@ struct partition_kernel_impl_
     using block_scan_offset_type
         = ::rocprim::block_scan<OffsetType, block_size, params.block_scan_method>;
     using block_discontinuity_key_type = ::rocprim::block_discontinuity<Key, block_size>;
-    using ordered_block_id = BlockIdWrapper;
+    using ordered_block_id             = BlockIdWrapper;
 
     // Memory required for 2-phase scatter
     using exchange_keys_storage_type   = Key[items_per_block];
     using exchange_values_storage_type = Value[items_per_block];
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH
     using raw_exchange_keys_storage_type = typename detail::raw_storage<exchange_keys_storage_type>;
-    using raw_exchange_values_storage_type = typename detail::raw_storage<exchange_values_storage_type>;
+    using raw_exchange_values_storage_type =
+        typename detail::raw_storage<exchange_values_storage_type>;
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_POP
 
     union storage_type
@@ -1029,10 +1028,10 @@ struct partition_kernel_impl_
 
         const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
         const uint32_t flat_block_id        = block_id.get(flat_block_thread_id, storage.block_id);
-        
+
         size_t prev_selected_count_values[sizeof...(UnaryPredicates)]{};
         load_selected_count(prev_selected_count, prev_selected_count_values);
-             
+
         const auto         block_offset = flat_block_id * items_per_block;
         const unsigned int valid_in_global_last_block
             = total_size - prev_processed - items_per_block * (number_of_blocks - 1);
@@ -1172,7 +1171,7 @@ struct partition_kernel_impl_
     }
 };
 
-} // end of detail namespace
+} // namespace detail
 
 END_ROCPRIM_NAMESPACE
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -40,6 +40,8 @@
 #include "../../block/block_scan.hpp"
 #include "../../block/block_store_func.hpp"
 
+#include "ordered_block_id.hpp"
+
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
@@ -1052,7 +1054,8 @@ template<class Key,
          unsigned int               RadixBits,
          bool                       Descending,
          block_radix_rank_algorithm RadixRankAlgorithm,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 struct onesweep_iteration_helper
 {
     static constexpr unsigned int radix_size      = 1u << RadixBits;
@@ -1068,7 +1071,7 @@ struct onesweep_iteration_helper
 
     static constexpr unsigned int digits_per_thread = radix_rank_type::digits_per_thread;
 
-    union storage_type_
+    union data_storage
     {
         typename radix_rank_type::storage_type rank;
         struct
@@ -1080,6 +1083,12 @@ struct onesweep_iteration_helper
                 Value ordered_block_values[items_per_block];
             };
         };
+    };
+
+    struct storage_type_
+    {
+        data_storage                          data;
+        typename BlockIdWrapper::storage_type ordered_bid;
     };
 
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH
@@ -1103,10 +1112,11 @@ struct onesweep_iteration_helper
                   const unsigned int       bit,
                   const unsigned int       current_radix_bits,
                   const unsigned int       valid_items,
-                  storage_type_&           storage)
+                  data_storage&            storage,
+                  unsigned int             ordered_bid)
     {
         const unsigned int flat_id      = ::rocprim::detail::block_thread_id<0>();
-        const unsigned int block_id     = ::rocprim::detail::block_id<0>();
+        const unsigned int block_id     = ordered_bid;
         const unsigned int block_offset = block_id * items_per_block;
 
         // Load keys into private memory, and encode them to unsigned integers.
@@ -1348,7 +1358,8 @@ template<unsigned int               BlockSize,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Offset,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     onesweep_iteration(KeysInputIterator        keys_input,
                        KeysOutputIterator       keys_output,
@@ -1361,7 +1372,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                        Decomposer               decomposer,
                        const unsigned int       bit,
                        const unsigned int       current_radix_bits,
-                       const unsigned int       full_blocks)
+                       const unsigned int       full_blocks,
+                       BlockIdWrapper           ordered_bid)
 {
     using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
     using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
@@ -1374,12 +1386,14 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                      RadixBits,
                                                                      Descending,
                                                                      RadixRankAlgorithm,
-                                                                     Decomposer>;
-
-    constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
-    const unsigned int block_id = ::rocprim::detail::block_id<0>();
+                                                                     Decomposer,
+                                                                     BlockIdWrapper>;
 
     ROCPRIM_SHARED_MEMORY typename onesweep_iteration_helper_type::storage_type storage;
+
+    constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
+    const unsigned int     thread_id       = ::rocprim::detail::block_thread_id<0>();
+    const unsigned int     block_id        = ordered_bid.get(thread_id, storage.get().ordered_bid);
 
     if(block_id < full_blocks)
     {
@@ -1394,7 +1408,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                  bit,
                                                                  current_radix_bits,
                                                                  items_per_block,
-                                                                 storage.get());
+                                                                 storage.get().data,
+                                                                 block_id);
     }
     else
     {
@@ -1410,7 +1425,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                   bit,
                                                                   current_radix_bits,
                                                                   valid_in_last_block,
-                                                                  storage.get());
+                                                                  storage.get().data,
+                                                                  block_id);
     }
 }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
@@ -34,6 +34,7 @@
 
 #include "../../config.hpp"
 #include "../../type_traits.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 
 #include <iterator>
 #include <type_traits>
@@ -515,8 +516,8 @@ public:
     }
 };
 
-template<lookback_scan_determinism Determinism,
-         typename Config,
+template<typename ArchConfig,
+         lookback_scan_determinism Determinism,
          typename AccumulatorType,
          typename KeyIterator,
          typename ValueIterator,
@@ -525,7 +526,8 @@ template<lookback_scan_determinism Determinism,
          typename UniqueCountIterator,
          typename CompareFunction,
          typename BinaryOp,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto kernel_impl(KeyIterator,
                                                      ValueIterator,
                                                      const UniqueIterator,
@@ -538,14 +540,15 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto kernel_impl(KeyIterator,
                                                      const std::size_t,
                                                      const std::size_t,
                                                      const std::size_t* const,
-                                                     const AccumulatorType* const)
+                                                     const AccumulatorType* const,
+                                                     BlockIdWrapper)
     -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
 {
     // No need to build the kernel with sleep on a device that does not require it
 }
 
-template<lookback_scan_determinism Determinism,
-         typename Config,
+template<typename ArchConfig,
+         lookback_scan_determinism Determinism,
          typename AccumulatorType,
          typename KeyIterator,
          typename ValueIterator,
@@ -554,7 +557,8 @@ template<lookback_scan_determinism Determinism,
          typename UniqueCountIterator,
          typename CompareFunction,
          typename BinaryOp,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     kernel_impl(KeyIterator                    keys_input,
                 ValueIterator                  values_input,
@@ -568,10 +572,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                 const std::size_t              total_number_of_blocks,
                 const std::size_t              size,
                 const std::size_t* const       global_head_count,
-                const AccumulatorType* const   previous_accumulated)
+                const AccumulatorType* const   previous_accumulated,
+                BlockIdWrapper                 ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
-    static constexpr reduce_by_key_config_params params = device_params<Config>();
+    static constexpr reduce_by_key_config_params params = ArchConfig::params;
 
     static constexpr unsigned int         block_size       = params.kernel_config.block_size;
     static constexpr unsigned int         items_per_thread = params.kernel_config.items_per_thread;
@@ -593,10 +598,13 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
 
     ROCPRIM_SHARED_MEMORY union
     {
+        typename BlockIdWrapper::storage_type ordered_bid;
         typename tile_processor::storage_type tile;
     } storage;
 
-    const unsigned int  block_id     = rocprim::flat_block_id<block_size, 1, 1>();
+    const unsigned int block_id
+        = ordered_bid.get(threadIdx.x,
+                          storage.ordered_bid); // rocprim::flat_block_id<block_size, 1, 1>();
     const unsigned int  block_offset = block_id * items_per_block;
     const KeyIterator   block_keys   = keys_input + block_offset;
     const ValueIterator block_values = values_input + block_offset;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan.hpp
@@ -21,23 +21,17 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_LOOKBACK_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_LOOKBACK_HPP_
 
-#include <iterator>
-#include <type_traits>
-
-#include "../../detail/various.hpp"
-#include "../../functional.hpp"
-#include "../../intrinsics.hpp"
-#include "../../types.hpp"
+#include "device_config_helper.hpp"
+#include "device_scan_common.hpp"
+#include "lookback_scan_state.hpp"
+#include "ordered_block_id.hpp"
 
 #include "../../block/block_load.hpp"
 #include "../../block/block_scan.hpp"
 #include "../../block/block_store.hpp"
+#include "../../intrinsics/thread.hpp"
 
-#include "../../device/device_scan_config.hpp"
-
-#include "device_scan_common.hpp"
-#include "lookback_scan_state.hpp"
-#include "ordered_block_id.hpp"
+#include <type_traits>
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -100,15 +94,16 @@ auto single_scan_block_scan(T (&input)[ItemsPerThread],
     }
 }
 
-template<lookback_scan_determinism Determinism,
+template<class ArchConfig,
+         lookback_scan_determinism Determinism,
          bool                      Exclusive,
          bool UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
          class AccType,
-         class LookbackScanState>
+         class LookbackScanState,
+         class BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto lookback_scan_kernel_impl(InputIterator,
                                                                    OutputIterator,
                                                                    const size_t,
@@ -116,24 +111,26 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto lookback_scan_kernel_impl(InputIterator
                                                                    BinaryFunction,
                                                                    LookbackScanState,
                                                                    const unsigned int,
-                                                                   AccType* = nullptr,
-                                                                   AccType* = nullptr,
-                                                                   bool     = false,
-                                                                   bool     = false)
+                                                                   AccType*,
+                                                                   AccType*,
+                                                                   bool,
+                                                                   bool,
+                                                                   BlockIdWrapper)
     -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
 {
     // No need to build the kernel with sleep on a device that does not require it
 }
 
-template<lookback_scan_determinism Determinism,
+template<class ArchConfig,
+         lookback_scan_determinism Determinism,
          bool                      Exclusive,
          bool UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
          class AccType,
-         class LookbackScanState>
+         class LookbackScanState,
+         class BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     lookback_scan_kernel_impl(InputIterator      input,
                               OutputIterator     output,
@@ -142,15 +139,16 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                               BinaryFunction     scan_op,
                               LookbackScanState  scan_state,
                               const unsigned int number_of_blocks,
-                              AccType*           previous_last_element = nullptr,
-                              AccType*           new_last_element      = nullptr,
-                              bool               override_first_value  = false,
-                              bool               save_last_value       = false)
+                              AccType*           previous_last_element,
+                              AccType*           new_last_element,
+                              bool               override_first_value,
+                              bool               save_last_value,
+                              BlockIdWrapper     ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
     static_assert(std::is_same<AccType, typename LookbackScanState::value_type>::value,
                   "value_type of LookbackScanState must be result_type");
-    static constexpr scan_config_params params = device_params<Config>();
+    static constexpr scan_config_params params = ArchConfig::params;
 
     constexpr auto         block_size       = params.kernel_config.block_size;
     constexpr auto         items_per_thread = params.kernel_config.items_per_thread;
@@ -167,13 +165,16 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
 
     ROCPRIM_SHARED_MEMORY union
     {
+        typename BlockIdWrapper::storage_type   ordered_bid;
         typename block_load_type::storage_type  load;
         typename block_store_type::storage_type store;
         typename block_scan_type::storage_type  scan;
     } storage;
 
     const auto         flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
-    const auto         flat_block_id        = ::rocprim::detail::block_id<0>();
+    const size_t       flat_block_id
+        = ordered_bid.get(flat_block_thread_id,
+                          storage.ordered_bid); // ::rocprim::detail::block_id<0>();
     const unsigned int block_offset         = flat_block_id * items_per_block;
     const auto         valid_in_last_block  = size - items_per_block * (number_of_blocks - 1);
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -21,6 +21,7 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_BY_KEY_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_BY_KEY_HPP_
 
+#include "device_config_helper.hpp"
 #include "device_scan_common.hpp"
 #include "lookback_scan_state.hpp"
 
@@ -32,7 +33,7 @@
 #include "../../detail/binary_op_wrappers.hpp"
 #include "../../intrinsics/thread.hpp"
 #include "../../types/tuple.hpp"
-#include "device_config_helper.hpp"
+#include "../detail/ordered_block_id.hpp"
 
 #include <type_traits>
 
@@ -40,220 +41,230 @@ BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
-    template <bool Exclusive,
-              unsigned int block_size,
-              unsigned int items_per_thread,
-              typename key_type,
-              typename result_type,
-              ::rocprim::block_load_method load_keys_method,
-              ::rocprim::block_load_method load_values_method>
-    struct load_values_flagged
+template<bool         Exclusive,
+         unsigned int block_size,
+         unsigned int items_per_thread,
+         typename key_type,
+         typename result_type,
+         ::rocprim::block_load_method load_keys_method,
+         ::rocprim::block_load_method load_values_method>
+struct load_values_flagged
+{
+    using block_load_keys
+        = ::rocprim::block_load<key_type, block_size, items_per_thread, load_keys_method>;
+
+    using block_discontinuity = ::rocprim::block_discontinuity<key_type, block_size>;
+
+    using block_load_values
+        = ::rocprim::block_load<result_type, block_size, items_per_thread, load_keys_method>;
+
+    union storage_type
     {
-        using block_load_keys
-            = ::rocprim::block_load<key_type, block_size, items_per_thread, load_keys_method>;
+        struct
+        {
+            typename block_load_keys::storage_type     load;
+            typename block_discontinuity::storage_type flag;
+        } keys;
+        typename block_load_values::storage_type load_values;
+    };
 
-        using block_discontinuity = ::rocprim::block_discontinuity<key_type, block_size>;
+    // Load flagged values
+    // - if the scan is exclusive, the last item of each segment (range where the keys compare equal)
+    //   is flagged and reset to the initial value. Adding the last item of the range to the
+    //   second to last using `headflag_scan_op_wrapper` will return the initial_value,
+    //   which is exactly what should be saved at the start of the next range.
+    // - if the scan is inclusive, then the first item of each segment is marked, and it will
+    //   restart the scan from that value
+    template<typename KeyIterator, typename ValueIterator, typename CompareFunction>
+    ROCPRIM_DEVICE
+    void load(
+        KeyIterator        keys_input,
+        ValueIterator      values_input,
+        CompareFunction    compare,
+        const result_type  initial_value,
+        const unsigned int flat_block_id,
+        const size_t       starting_block,
+        const size_t       number_of_blocks,
+        const unsigned int flat_thread_id,
+        const size_t       size,
+        bool               use_last_keys,
+        const typename std::iterator_traits<KeyIterator>::value_type* const __restrict__ last_keys,
+        rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
+        storage_type& storage)
+    {
+        constexpr static unsigned int items_per_block = items_per_thread * block_size;
+        const unsigned int            block_offset    = flat_block_id * items_per_block;
+        KeyIterator                   block_keys      = keys_input + block_offset;
+        ValueIterator                 block_values    = values_input + block_offset;
 
-        using block_load_values
-            = ::rocprim::block_load<result_type, block_size, items_per_thread, load_keys_method>;
+        key_type    keys[items_per_thread];
+        result_type values[items_per_thread];
+        bool        flags[items_per_thread];
 
-        union storage_type {
-            struct {
-                typename block_load_keys::storage_type     load;
-                typename block_discontinuity::storage_type flag;
-            } keys;
-            typename block_load_values::storage_type load_values;
+        auto not_equal = [compare](const auto& a, const auto& b) mutable { return !compare(a, b); };
+        const auto global_block_id = starting_block + flat_block_id;
+
+        const auto flag_segment_boundaries = [&]()
+        {
+            if constexpr(Exclusive)
+            {
+                const key_type tile_successor
+                    = global_block_id < number_of_blocks - 1
+                          ? static_cast<key_type>(block_keys[items_per_block])
+                          : static_cast<key_type>(*block_keys);
+                block_discontinuity{}.flag_tails(flags,
+                                                 tile_successor,
+                                                 keys,
+                                                 not_equal,
+                                                 storage.keys.flag);
+            }
+            else
+            { // Inclusive
+                const key_type tile_predecessor
+                    = global_block_id > 0
+                          ? (use_last_keys ? static_cast<key_type>(last_keys[global_block_id - 1])
+                                           : static_cast<key_type>(block_keys[-1]))
+                          : static_cast<key_type>(*block_keys);
+                block_discontinuity{}.flag_heads(flags,
+                                                 tile_predecessor,
+                                                 keys,
+                                                 not_equal,
+                                                 storage.keys.flag);
+            }
         };
 
-        // Load flagged values
-        // - if the scan is exclusive, the last item of each segment (range where the keys compare equal)
-        //   is flagged and reset to the initial value. Adding the last item of the range to the
-        //   second to last using `headflag_scan_op_wrapper` will return the initial_value,
-        //   which is exactly what should be saved at the start of the next range.
-        // - if the scan is inclusive, then the first item of each segment is marked, and it will
-        //   restart the scan from that value
-        template <typename KeyIterator, typename ValueIterator, typename CompareFunction>
-        ROCPRIM_DEVICE void
-            load(KeyIterator        keys_input,
-                 ValueIterator      values_input,
-                 CompareFunction    compare,
-                 const result_type  initial_value,
-                 const unsigned int flat_block_id,
-                 const size_t       starting_block,
-                 const size_t       number_of_blocks,
-                 const unsigned int flat_thread_id,
-                 const size_t       size,
-                 rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
-                 storage_type& storage)
+        if(global_block_id < number_of_blocks - 1)
         {
-            constexpr static unsigned int items_per_block = items_per_thread * block_size;
-            const unsigned int            block_offset    = flat_block_id * items_per_block;
-            KeyIterator                   block_keys      = keys_input + block_offset;
-            ValueIterator                 block_values    = values_input + block_offset;
+            block_load_keys{}.load(block_keys, keys, storage.keys.load);
 
-            key_type    keys[items_per_thread];
-            result_type values[items_per_thread];
-            bool        flags[items_per_thread];
+            flag_segment_boundaries();
+            // Reusing shared memory for loading values
+            ::rocprim::syncthreads();
 
-            auto not_equal
-                = [compare](const auto& a, const auto& b) mutable { return !compare(a, b); };
+            block_load_values{}.load(block_values, values, storage.load_values);
 
-            const auto flag_segment_boundaries = [&]() {
-                if(Exclusive)
-                {
-                    const key_type tile_successor
-                        = starting_block + flat_block_id < number_of_blocks - 1
-                              ? block_keys[items_per_block]
-                              : *block_keys;
-                    block_discontinuity {}.flag_tails(
-                        flags, tile_successor, keys, not_equal, storage.keys.flag);
-                }
-                else
-                {
-                    const key_type tile_predecessor = starting_block + flat_block_id > 0
-                                                          ? block_keys[-1]
-                                                          : *block_keys;
-                    block_discontinuity {}.flag_heads(
-                        flags, tile_predecessor, keys, not_equal, storage.keys.flag);
-                }
-            };
-
-            if(starting_block + flat_block_id < number_of_blocks - 1)
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < items_per_thread; ++i)
             {
-                block_load_keys{}.load(
-                    block_keys,
-                    keys,
-                    storage.keys.load
-                );
-
-                flag_segment_boundaries();
-                // Reusing shared memory for loading values
-                ::rocprim::syncthreads();
-
-                block_load_values{}.load(
-                    block_values,
-                    values,
-                    storage.load_values
-                );
-
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i) {
-                    rocprim::get<0>(wrapped_values[i])
-                        = (Exclusive && flags[i]) ? initial_value : values[i];
-                    rocprim::get<1>(wrapped_values[i]) = flags[i];
-                }
-            }
-            else
-            {
-                const unsigned int valid_in_last_block
-                    = static_cast<unsigned int>(size - items_per_block * (number_of_blocks - 1));
-
-                block_load_keys {}.load(
-                    block_keys,
-                    keys,
-                    valid_in_last_block,
-                    *block_keys, // Any value is okay, so discontinuity doesn't access undefined items
-                    storage.keys.load);
-
-                flag_segment_boundaries();
-                // Reusing shared memory for loading values
-                ::rocprim::syncthreads();
-
-                block_load_values{}.load(
-                    block_values,
-                    values,
-                    valid_in_last_block,
-                    storage.load_values
-                );
-
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i) {
-                    if(flat_thread_id * items_per_thread + i >= valid_in_last_block) {
-                        break;
-                    }
-
-                    rocprim::get<0>(wrapped_values[i])
-                        = (Exclusive && flags[i]) ? initial_value : values[i];
-                    rocprim::get<1>(wrapped_values[i]) = flags[i];
-                }
+                rocprim::get<0>(wrapped_values[i])
+                    = (Exclusive && flags[i]) ? initial_value : values[i];
+                rocprim::get<1>(wrapped_values[i]) = flags[i];
             }
         }
-    };
+        else
+        {
+            const unsigned int valid_in_last_block
+                = static_cast<unsigned int>(size - items_per_block * (number_of_blocks - 1));
 
-    template <unsigned int block_size,
-              unsigned int items_per_thread,
-              typename result_type,
-              ::rocprim::block_store_method store_method>
-    struct unwrap_store
+            block_load_keys{}.load(
+                block_keys,
+                keys,
+                valid_in_last_block,
+                *block_keys, // Any value is okay, so discontinuity doesn't access undefined items
+                storage.keys.load);
+
+            flag_segment_boundaries();
+            // Reusing shared memory for loading values
+            ::rocprim::syncthreads();
+
+            block_load_values{}.load(block_values,
+                                     values,
+                                     valid_in_last_block,
+                                     storage.load_values);
+
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < items_per_thread; ++i)
+            {
+                if(flat_thread_id * items_per_thread + i >= valid_in_last_block)
+                {
+                    break;
+                }
+
+                rocprim::get<0>(wrapped_values[i])
+                    = (Exclusive && flags[i]) ? initial_value : values[i];
+                rocprim::get<1>(wrapped_values[i]) = flags[i];
+            }
+        }
+    }
+};
+
+template<unsigned int block_size,
+         unsigned int items_per_thread,
+         typename result_type,
+         ::rocprim::block_store_method store_method>
+struct unwrap_store
+{
+    using block_store_values
+        = ::rocprim::block_store<result_type, block_size, items_per_thread, store_method>;
+
+    using storage_type = typename block_store_values::storage_type;
+
+    template<typename OutputIterator>
+    ROCPRIM_DEVICE
+    void store(OutputIterator     output,
+               const unsigned int flat_block_id,
+               const size_t       starting_block,
+               const size_t       number_of_blocks,
+               const unsigned int flat_thread_id,
+               const size_t       size,
+               const rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
+               storage_type& storage)
     {
-        using block_store_values
-            = ::rocprim::block_store<result_type, block_size, items_per_thread, store_method>;
+        constexpr static unsigned int items_per_block = items_per_thread * block_size;
+        const unsigned int            block_offset    = flat_block_id * items_per_block;
+        OutputIterator                block_output    = output + block_offset;
 
-        using storage_type = typename block_store_values::storage_type;
+        result_type thread_values[items_per_thread];
 
-        template <typename OutputIterator>
-        ROCPRIM_DEVICE void
-            store(OutputIterator     output,
-                  const unsigned int flat_block_id,
-                  const size_t       starting_block,
-                  const size_t       number_of_blocks,
-                  const unsigned int flat_thread_id,
-                  const size_t       size,
-                  const rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
-                  storage_type& storage)
+        if(starting_block + flat_block_id < number_of_blocks - 1)
         {
-            constexpr static unsigned int items_per_block = items_per_thread * block_size;
-            const unsigned int block_offset = flat_block_id * items_per_block;
-            OutputIterator block_output = output + block_offset;
-
-            result_type thread_values[items_per_thread];
-
-            if(starting_block + flat_block_id < number_of_blocks - 1)
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < items_per_thread; ++i)
             {
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i) {
-                    thread_values[i] = rocprim::get<0>(wrapped_values[i]);
-                }
-
-                // Reusing shared memory from scan to perform store
-                rocprim::syncthreads();
-
-                block_store_values {}.store(block_output, thread_values, storage);
+                thread_values[i] = rocprim::get<0>(wrapped_values[i]);
             }
-            else
-            {
-                const unsigned int valid_in_last_block
-                    = static_cast<unsigned int>(size - items_per_block * (number_of_blocks - 1));
 
-                ROCPRIM_UNROLL
-                for(unsigned int i = 0; i < items_per_thread; ++i) {
-                    if(flat_thread_id * items_per_thread + i >= valid_in_last_block) {
-                        break;
-                    }
+            // Reusing shared memory from scan to perform store
+            rocprim::syncthreads();
 
-                    thread_values[i] = rocprim::get<0>(wrapped_values[i]);
-                }
-
-                // Reusing shared memory from scan to perform store
-                rocprim::syncthreads();
-
-                block_store_values {}.store(
-                    block_output, thread_values, valid_in_last_block, storage);
-            }
+            block_store_values{}.store(block_output, thread_values, storage);
         }
-    };
+        else
+        {
+            const unsigned int valid_in_last_block
+                = static_cast<unsigned int>(size - items_per_block * (number_of_blocks - 1));
 
-    template<lookback_scan_determinism Determinism,
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < items_per_thread; ++i)
+            {
+                if(flat_thread_id * items_per_thread + i >= valid_in_last_block)
+                {
+                    break;
+                }
+
+                thread_values[i] = rocprim::get<0>(wrapped_values[i]);
+            }
+
+            // Reusing shared memory from scan to perform store
+            rocprim::syncthreads();
+
+            block_store_values{}.store(block_output, thread_values, valid_in_last_block, storage);
+        }
+    }
+};
+
+    template<typename ArchConfig,
+             lookback_scan_determinism Determinism,
              bool                      Exclusive,
-             typename Config,
              typename KeyInputIterator,
              typename InputIterator,
              typename OutputIterator,
              typename ResultType,
              typename CompareFunction,
              typename BinaryFunction,
-             typename LookbackScanState>
-    ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
+             typename LookbackScanState,
+             typename WrappedBlockId>
+ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
         device_scan_by_key_kernel_impl(KeyInputIterator,
                                        InputIterator,
                                        OutputIterator,
@@ -264,22 +275,26 @@ namespace detail
                                        const size_t,
                                        const size_t,
                                        const size_t,
-                                       const rocprim::tuple<ResultType, bool>* const)
+                                       const rocprim::tuple<ResultType, bool>* const,
+                                       bool,
+                                       const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__,
+                                       WrappedBlockId)
             -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
     {
         // No need to build the kernel with sleep on a device that does not require it
     }
 
-    template<lookback_scan_determinism Determinism,
+    template<typename ArchConfig,
+             lookback_scan_determinism Determinism,
              bool                      Exclusive,
-             typename Config,
              typename KeyInputIterator,
              typename InputIterator,
              typename OutputIterator,
              typename ResultType,
              typename CompareFunction,
              typename BinaryFunction,
-             typename LookbackScanState>
+             typename LookbackScanState,
+             typename WrappedBlockId>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto device_scan_by_key_kernel_impl(
         KeyInputIterator                              keys,
         InputIterator                                 values,
@@ -291,21 +306,24 @@ namespace detail
         const size_t                                  size,
         const size_t                                  starting_block,
         const size_t                                  number_of_blocks,
-        const rocprim::tuple<ResultType, bool>* const previous_last_value)
+        const rocprim::tuple<ResultType, bool>* const previous_last_value,
+        bool use_last_keys,
+        const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__ last_keys,
+        WrappedBlockId ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
     {
         using result_type = ResultType;
         static_assert(std::is_same<rocprim::tuple<ResultType, bool>,
                                    typename LookbackScanState::value_type>::value,
                       "value_type of LookbackScanState must be tuple of result type and flag");
-        static constexpr scan_by_key_config_params params = device_params<Config>();
+        static constexpr scan_by_key_config_params params = ArchConfig::params;
 
         constexpr auto block_size         = params.kernel_config.block_size;
         constexpr auto items_per_thread   = params.kernel_config.items_per_thread;
         constexpr auto load_keys_method   = params.block_load_method;
         constexpr auto load_values_method = load_keys_method;
 
-        using key_type = typename std::iterator_traits<KeyInputIterator>::value_type;
+        using key_type     = typename std::iterator_traits<KeyInputIterator>::value_type;
         using load_flagged = load_values_flagged<Exclusive,
                                                  block_size,
                                                  items_per_thread,
@@ -314,7 +332,7 @@ namespace detail
                                                  load_keys_method,
                                                  load_values_method>;
 
-        auto wrapped_op = headflag_scan_op_wrapper<result_type, bool, BinaryFunction>{scan_op};
+        auto wrapped_op    = headflag_scan_op_wrapper<result_type, bool, BinaryFunction>{scan_op};
         using wrapped_type = rocprim::tuple<result_type, bool>;
 
         using block_scan_type
@@ -325,27 +343,34 @@ namespace detail
 
         ROCPRIM_SHARED_MEMORY union
         {
+            typename WrappedBlockId::storage_type  ordered_bid;
             typename load_flagged::storage_type    load;
             typename block_scan_type::storage_type scan;
             typename store_unwrap::storage_type    store;
         } storage;
 
         const auto flat_thread_id = ::rocprim::detail::block_thread_id<0>();
-        const auto flat_block_id  = ::rocprim::detail::block_id<0>();
+        const auto flat_block_id
+            = ordered_bid.get(flat_thread_id,
+                              storage.ordered_bid); // ::rocprim::detail::block_id<0>();
+
+        ::rocprim::syncthreads();
 
         // Load input
         wrapped_type wrapped_values[items_per_thread];
-        load_flagged {}.load(keys,
-                             values,
-                             compare,
-                             initial_value,
-                             flat_block_id,
-                             starting_block,
-                             number_of_blocks,
-                             flat_thread_id,
-                             size,
-                             wrapped_values,
-                             storage.load);
+        load_flagged{}.load(keys,
+                            values,
+                            compare,
+                            initial_value,
+                            flat_block_id,
+                            starting_block,
+                            number_of_blocks,
+                            flat_thread_id,
+                            size,
+                            use_last_keys,
+                            last_keys,
+                            wrapped_values,
+                            storage.load);
 
         // Reusing the storage from load to perform the scan
         ::rocprim::syncthreads();
@@ -359,9 +384,12 @@ namespace detail
             // multi grid launch
             if(previous_last_value != nullptr)
             {
-                if(Exclusive) {
+                if constexpr(Exclusive)
+                {
                     rocprim::get<0>(wrapped_initial_value) = rocprim::get<0>(*previous_last_value);
-                } else if (flat_thread_id == 0) {
+                }
+                else if(flat_thread_id == 0)
+                {
                     wrapped_values[0] = wrapped_op(*previous_last_value, wrapped_values[0]);
                 }
             }
@@ -397,26 +425,25 @@ namespace detail
                                           Determinism>{flat_block_id, wrapped_op, scan_state};
 
             // Scan of block values
-            lookback_block_scan<Exclusive, block_scan_type>(
-                wrapped_values,
-                storage.scan,
-                prefix_op,
-                wrapped_op);
+            lookback_block_scan<Exclusive, block_scan_type>(wrapped_values,
+                                                            storage.scan,
+                                                            prefix_op,
+                                                            wrapped_op);
         }
 
         // Store output
         // synchronization is inside the function after unwrapping
-        store_unwrap {}.store(output,
-                              flat_block_id,
-                              starting_block,
-                              number_of_blocks,
-                              flat_thread_id,
-                              size,
-                              wrapped_values,
-                              storage.store);
+        store_unwrap{}.store(output,
+                             flat_block_id,
+                             starting_block,
+                             number_of_blocks,
+                             flat_thread_id,
+                             size,
+                             wrapped_values,
+                             storage.store);
     }
-} // namespace detail
+    } // namespace detail
 
-END_ROCPRIM_NAMESPACE
+    END_ROCPRIM_NAMESPACE
 
 #endif // ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_BY_KEY_HPP_

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_common.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_common.hpp
@@ -25,7 +25,6 @@
 #include "../../intrinsics/thread.hpp"
 
 #include "lookback_scan_state.hpp"
-#include "ordered_block_id.hpp"
 
 #include <hip/hip_runtime.h>
 
@@ -54,12 +53,12 @@ void access_indexed_lookback_value(LookBackScanState  lookback_scan_state,
     }
 }
 
-template<typename LookBackScanState>
-ROCPRIM_DEVICE ROCPRIM_INLINE void
-    init_lookback_scan_state(LookBackScanState              lookback_scan_state,
-                             const unsigned int             number_of_blocks,
-                             ordered_block_id<unsigned int> ordered_bid,
-                             unsigned int                   flat_thread_id)
+template<class LookBackScanState, class BlockIdWrapper>
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void init_lookback_scan_state(LookBackScanState  lookback_scan_state,
+                              const unsigned int number_of_blocks,
+                              BlockIdWrapper     ordered_bid,
+                              unsigned int       flat_thread_id)
 {
     // Reset ordered_block_id.
     if(flat_thread_id == 0)
@@ -71,25 +70,24 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void
     lookback_scan_state.initialize_prefix(flat_thread_id, number_of_blocks);
 }
 
-template<typename LookBackScanState>
-ROCPRIM_DEVICE ROCPRIM_INLINE void init_lookback_scan_state(LookBackScanState  lookback_scan_state,
-                                                            const unsigned int number_of_blocks,
-                                                            unsigned int       flat_thread_id)
+template<class LookBackScanState>
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void init_lookback_scan_state(LookBackScanState  lookback_scan_state,
+                              const unsigned int number_of_blocks,
+                              unsigned int       flat_thread_id)
 {
 
     // Initialize lookback scan status.
     lookback_scan_state.initialize_prefix(flat_thread_id, number_of_blocks);
 }
 
-template<typename LookBackScanState>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
-    init_lookback_scan_state_kernel(LookBackScanState              lookback_scan_state,
-                                    const unsigned int             number_of_blocks,
-                                    ordered_block_id<unsigned int> ordered_bid,
-                                    unsigned int                   save_index = 0,
-                                    typename LookBackScanState::value_type* const save_dest
-                                    = nullptr)
+template<class LookBackScanState, class WrappedBlockId>
+ROCPRIM_FORCE_INLINE ROCPRIM_DEVICE 
+void init_lookback_scan_state_kernel_impl(LookBackScanState              lookback_scan_state,
+                                          const unsigned int             number_of_blocks,
+                                          WrappedBlockId ordered_bid, // ordered block id is passed by value, so no need to call its constructor
+                                          unsigned int                   save_index,
+                                          typename LookBackScanState::value_type* const save_dest)
 {
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();
@@ -111,13 +109,11 @@ ROCPRIM_KERNEL
 }
 
 template<typename LookBackScanState>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
-    init_lookback_scan_state_kernel(LookBackScanState  lookback_scan_state,
+ROCPRIM_FORCE_INLINE ROCPRIM_DEVICE 
+void init_lookback_scan_state_kernel_impl(LookBackScanState  lookback_scan_state,
                                     const unsigned int number_of_blocks,
-                                    unsigned int       save_index = 0,
-                                    typename LookBackScanState::value_type* const save_dest
-                                    = nullptr)
+                                    unsigned int       save_index,
+                                    typename LookBackScanState::value_type* const save_dest)
 {
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();
@@ -136,6 +132,38 @@ ROCPRIM_KERNEL
     }
 
     init_lookback_scan_state(lookback_scan_state, number_of_blocks, flat_thread_id);
+}
+
+template<class LookBackScanState, class WrappedBlockId>
+ROCPRIM_KERNEL
+    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
+    init_lookback_scan_state_kernel(LookBackScanState  lookback_scan_state,
+                                    const unsigned int number_of_blocks,
+                                    WrappedBlockId     ordered_bid,
+                                    unsigned int       save_index = 0,
+                                    typename LookBackScanState::value_type* const save_dest
+                                    = nullptr)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         ordered_bid,
+                                         save_index,
+                                         save_dest);
+}
+
+template<typename LookBackScanState>
+ROCPRIM_KERNEL
+    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
+    init_lookback_scan_state_kernel(LookBackScanState  lookback_scan_state,
+                                    const unsigned int number_of_blocks,
+                                    unsigned int       save_index = 0,
+                                    typename LookBackScanState::value_type* const save_dest
+                                    = nullptr)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         save_index,
+                                         save_dest);
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -116,8 +116,8 @@ constexpr const int MAX_PAYLOAD_SIZE = ROCPRIM_MAX_ATOMIC_SIZE - 1;
 ///
 /// \tparam T The accumulator type of the scan operation.
 /// \tparam UseSleep [optional] If true, the execution of a wavefront is paused for a short duration, allowing other threads or processes to execute during idle periods.
-/// \tparam IsSmall [optional] Dependent on the size of `T`. If it's smaller than 16 bytes, it's set to true.
-template<class T, bool UseSleep = false, bool IsSmall = (sizeof(T) <= 15)>
+/// \tparam IsSmall [optional] Dependent on the size of `T`. If it's smaller than 16 bytes (8 bytes if 16 byte atomics are possibly not supported), it's by default set to true.
+template<class T, bool UseSleep = false, bool IsSmall = (sizeof(T) <= MAX_PAYLOAD_SIZE)>
 struct lookback_scan_state;
 
 /// Reduce lanes `0-valid_items` and return the result in lane 0.
@@ -128,11 +128,22 @@ T lookback_reduce_forward_init(F scan_op, T block_prefix, unsigned int valid_ite
     T prefix = block_prefix;
     for(unsigned int i = 0; i < valid_items; ++i)
     {
-#ifdef ROCPRIM_DETAIL_HAS_DPP_WF
-        prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
-#else
-        prefix = warp_shuffle_down(prefix, 1, ::rocprim::arch::wavefront::size());
-#endif
+        // If ROCPRIM_HAS_PERMLANE() is true, DPP_WF_RL1 is not available.
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
+        {
+            prefix = warp_shuffle_down(prefix, 1, ::rocprim::arch::wavefront::size());
+        }
+        else
+        {
+            if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP())
+            {
+                prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
+            }
+            else
+            {
+                prefix = warp_shuffle_down(prefix, 1, ::rocprim::arch::wavefront::size());
+            }
+        }
         prefix = scan_op(prefix, block_prefix);
     }
     return prefix;
@@ -144,39 +155,61 @@ template<typename F, typename T>
 ROCPRIM_DEVICE ROCPRIM_INLINE
 T lookback_reduce_forward(F scan_op, T prefix, T block_prefix)
 {
-#ifdef ROCPRIM_DETAIL_HAS_DPP_WF
-    for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+    // If ROCPRIM_HAS_PERMLANE() is true, DPP_WF_RL1 is not available.
+    if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
     {
-        prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
-        prefix = scan_op(prefix, block_prefix);
-    }
-#elif ROCPRIM_DETAIL_USE_DPP == 1
-    // If we can't rotate or shift the entire wavefront in one instruction,
-    // iterate over rows of 16 lanes and use warp_readlane to communicate across rows.
-    constexpr const int row_size = 16;
-
-    for(int j = ::rocprim::arch::wavefront::size(); j > 0; j -= row_size)
-    {
-        prefix = warp_readlane(
-            prefix,
-            j /* automatically taken modulo ::rocprim::arch::wavefront::size(), first read is lane 0 */);
-        prefix = scan_op(prefix, block_prefix);
-
-        ROCPRIM_UNROLL
-        for(int i = 0; i < row_size - 1; ++i)
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP())
         {
-            prefix = warp_move_dpp<T, 0x101 /* DPP_ROW_SL1 */>(prefix);
-            prefix = scan_op(prefix, block_prefix);
+            // If we can't rotate or shift the entire wavefront in one instruction,
+            // iterate over rows of 16 lanes and use warp_readlane to communicate across rows.
+            constexpr const int row_size = 16;
+
+            for(int j = ::rocprim::arch::wavefront::size(); j > 0; j -= row_size)
+            {
+                prefix = warp_readlane(
+                    prefix,
+                    j /* automatically taken modulo ::rocprim::arch::wavefront::size(), first read is lane 0 */);
+                prefix = scan_op(prefix, block_prefix);
+
+                ROCPRIM_UNROLL
+                for(int i = 0; i < row_size - 1; ++i)
+                {
+                    prefix = warp_move_dpp<T, 0x101 /* DPP_ROW_SL1 */>(prefix);
+                    prefix = scan_op(prefix, block_prefix);
+                }
+            }
+        }
+        else
+        {
+            // If no DPP available at all, fall back to shuffles.
+            for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+            {
+                prefix = warp_shuffle(prefix, lane_id() + 1, ::rocprim::arch::wavefront::size());
+                prefix = scan_op(prefix, block_prefix);
+            }
         }
     }
-#else
-    // If no DPP available at all, fall back to shuffles.
-    for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+    else
     {
-        prefix = warp_shuffle(prefix, lane_id() + 1, ::rocprim::arch::wavefront::size());
-        prefix = scan_op(prefix, block_prefix);
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_DPP())
+        {
+            for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+            {
+                prefix = warp_move_dpp<T, 0x134 /* DPP_WF_RL1 */>(prefix);
+                prefix = scan_op(prefix, block_prefix);
+            }
+        }
+        else
+        {
+            // If no DPP available at all, fall back to shuffles.
+            for(unsigned int i = 0; i < ::rocprim::arch::wavefront::size(); ++i)
+            {
+                prefix = warp_shuffle(prefix, lane_id() + 1, ::rocprim::arch::wavefront::size());
+                prefix = scan_op(prefix, block_prefix);
+            }
+        }
     }
-#endif
+
     return prefix;
 }
 
@@ -625,7 +658,7 @@ public:
         {
             v.words[i] = ::rocprim::detail::atomic_load(&values[padding + block_id].words[i]);
         }
-        __builtin_memcpy(&value, &v, sizeof(value));
+        __builtin_memcpy(reinterpret_cast<void*>(&value), &v, sizeof(value));
 #else
         ::rocprim::detail::memory_fence_device();
 
@@ -654,7 +687,7 @@ public:
         {
             v.words[i] = ::rocprim::detail::atomic_load(&values[padding + block_id].words[i]);
         }
-        __builtin_memcpy(&value, &v, sizeof(value));
+        __builtin_memcpy(reinterpret_cast<void*>(&value), &v, sizeof(value));
         return value;
 #else
         const auto* values = static_cast<const T*>(prefixes_complete_values);
@@ -675,7 +708,7 @@ public:
         {
             v.words[i] = ::rocprim::detail::atomic_load(&values[padding + block_id].words[i]);
         }
-        __builtin_memcpy(&value, &v, sizeof(value));
+        __builtin_memcpy(reinterpret_cast<void*>(&value), &v, sizeof(value));
         return value;
 #else
         const auto* values = static_cast<const T*>(prefixes_partial_values);
@@ -796,7 +829,7 @@ private:
             flag == lookback_scan_prefix_flag::partial ? prefixes_partial_values
                                                        : prefixes_complete_values);
         value_underlying_type v;
-        __builtin_memcpy(&v, &value, sizeof(value));
+        __builtin_memcpy(&v, reinterpret_cast<const void*>(&value), sizeof(value));
         for(unsigned int i = 0; i < value_underlying_type::words_no; ++i)
         {
             ::rocprim::detail::atomic_store(&values[padding + block_id].words[i], v.words[i]);
@@ -1018,6 +1051,7 @@ hipError_t is_sleep_scan_state_used(const hipStream_t stream, bool& use_sleep)
 template<typename LookbackScanState>
 constexpr bool is_lookback_kernel_runnable()
 {
+#if !defined(ROCPRIM_TARGET_SPIRV) || ROCPRIM_TARGET_SPIRV == 0
     if(device_target_arch() == target_arch::gfx908)
     {
         // For gfx908 kernels with both version of lookback_scan_state can run: with and without
@@ -1026,6 +1060,9 @@ constexpr bool is_lookback_kernel_runnable()
     }
     // For other GPUs only a kernel without sleep can run
     return !LookbackScanState::use_sleep;
+#else
+    return true;
+#endif
 }
 
 template<typename T>

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -1002,7 +1002,7 @@ hipError_t is_sleep_scan_state_used(const hipStream_t stream, bool& use_sleep)
     {
         return error;
     }
-    else if(const hipError_t error = hipGetDeviceProperties(&prop, device_id))
+    if(const hipError_t error = hipGetDeviceProperties(&prop, device_id))
     {
         return error;
     }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
@@ -26,40 +26,71 @@
 #include "../../detail/temp_storage.hpp"
 #include "../../intrinsics/atomic.hpp"
 #include "../../intrinsics/thread.hpp"
+#include "../config_types.hpp"
+
+#include <atomic>
+#include <exception>
+#include <type_traits>
 
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
 
-// Helper struct for generating ordered unique ids for blocks in a grid.
+/// Helper struct for generating ordered unique ids for blocks in a grid.
 template<class T /* id type */ = unsigned int>
 struct ordered_block_id
 {
+    // It's a bit confusing on how this API *should* be used. So here is how it should be initialized:
+    //   using ordered_bid_type = ordered_block_id<>;
+    //   ordered_bid_type::id_type* ordered_bid_storage;
+    //
+    //   detail::temp_storage::make_linear_partition(
+    //     detail::temp_storage::make_partition(&ordered_bid_storage, ordered_bid_type::get_temp_storage_layout())
+    //   );
+    //
+    //   auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+    //
+    //   my_kernel<<<x, y>>>(ordered_bid);
+    //
+    // On the kernel side it should be:
+    //   __globbal__ my_kernel(ordered_block_id<> ordered_bid)
+    //   {
+    //     __shared__ ordered_block_id<>::storage ordered_bid_storage;
+    //
+    //     auto tid      = threadIdx.x;
+    //     auto block_id = ordered_bid.get(tid, ordered_bid_storage);
+    //   }    
     static_assert(std::is_integral<T>::value, "T must be integer");
     using id_type = T;
 
-    // shared memory temporary storage type
+    /// Pointer to global memory that contains the atomic counter for block id.
+    id_type* id;
+
+    /// Shared memory for sharing the received block id to other threads in the block.
+    
     struct storage_type
     {
         id_type id;
     };
 
     ROCPRIM_HOST static inline
-    ordered_block_id create(id_type * id)
+    ordered_block_id create(id_type* ordered_bid_storage)
     {
         ordered_block_id ordered_id;
-        ordered_id.id = id;
+        ordered_id.id = ordered_bid_storage;;
         return ordered_id;
     }
 
-    ROCPRIM_HOST static inline
+    ROCPRIM_HOST 
+    static inline
     size_t get_storage_size()
     {
         return sizeof(id_type);
     }
 
-    ROCPRIM_HOST static inline detail::temp_storage::layout get_temp_storage_layout()
+    ROCPRIM_HOST 
+    static inline detail::temp_storage::layout get_temp_storage_layout()
     {
         return detail::temp_storage::layout{get_storage_size(), alignof(id_type)};
     }
@@ -81,7 +112,13 @@ struct ordered_block_id
         return storage.id;
     }
 
-    id_type* id;
+    /// Resets the ordered block id from host. Don't use this if we have an init kernel!
+    /// Call `ordered_block_id::reset()` from that kernel instead.
+    ROCPRIM_HOST ROCPRIM_INLINE
+    hipError_t reset_from_host(const hipStream_t = hipStreamDefault)
+    {
+        return hipMemset(id, 0, sizeof(id_type));
+    }
 };
 
 template<class T = unsigned int, bool UsingOrderedBlockId = false>
@@ -97,7 +134,7 @@ struct block_id_wrapper<T, false>
     {};
 
     ROCPRIM_HOST
-    static inline block_id_wrapper create(id_type* /*id*/)
+    static inline block_id_wrapper create(void* /*id*/)
     {
         block_id_wrapper ordered_id;
         return ordered_id;
@@ -140,10 +177,11 @@ struct block_id_wrapper<T, true>
     using storage_type = typename ::rocprim::detail::ordered_block_id<id_type>::storage_type;
 
     ROCPRIM_HOST
-    static inline block_id_wrapper create(id_type* id)
+    static inline block_id_wrapper create(void* id)
     {
         block_id_wrapper id_wrapper;
-        id_wrapper.ordered_id = detail::ordered_block_id<id_type>::create(id);
+        id_wrapper.ordered_id
+            = detail::ordered_block_id<id_type>::create(static_cast<id_type*>(id));
         return id_wrapper;
     }
 
@@ -181,6 +219,88 @@ struct block_id_wrapper<T, true>
 
     ::rocprim::detail::ordered_block_id<id_type> ordered_id;
 };
+
+ROCPRIM_INLINE ROCPRIM_HOST
+hipError_t check_if_using_atomic_block_id(hipStream_t stream, bool& enable)
+{
+    // Define possible options
+    enum class use_atomic_block_id : int
+    {
+        never  = 0,
+        hotfix = 1,
+        always = 2,
+
+        default_option = use_atomic_block_id::hotfix,
+    };
+
+    struct data_t
+    {
+        bool                valid  = false;
+        use_atomic_block_id option = use_atomic_block_id::hotfix;
+    };
+
+    static_assert(std::is_trivially_copyable_v<data_t>);
+
+    // Store our data in a static atomic.
+    static std::atomic<data_t> cache{data_t{}};
+
+    // First load the atomic, if it's invalid, we need to check the env vars.
+    data_t data = cache.load(std::memory_order_acquire);
+    if(!data.valid)
+    {
+        // Try to parse the env var, if it fails fall back to the default option.
+        auto* env = std::getenv("ROCPRIM_USE_ATOMIC_BLOCK_ID");
+
+        data.option = use_atomic_block_id::default_option;
+        try
+        {
+            if(env != nullptr)
+            {
+                data.option = use_atomic_block_id{std::stoi(env)};
+            }
+        }
+        catch(std::exception)
+        {
+            data.option = use_atomic_block_id::default_option;
+        }
+
+        data.valid = true;
+        // Now finally update our static atomic.
+        cache.store(data, std::memory_order_release);
+    }
+
+    // Now we have our data, we need to check what the behaviour is.
+    bool needs_hotfix = false;
+    if(data.option == use_atomic_block_id::hotfix)
+    {
+        // First get the device ID.
+        int device_id;
+        ROCPRIM_RETURN_ON_ERROR(::rocprim::detail::get_device_from_stream(stream, device_id));
+
+        // Then we get the arch. This property is cached.
+        target_arch arch;
+        ROCPRIM_RETURN_ON_ERROR(rocprim::detail::get_device_arch(device_id, arch));
+
+        needs_hotfix = (arch == target_arch::gfx942) || (arch == target_arch::gfx950);
+    }
+
+    switch(data.option)
+    {
+            // clang-format off
+        case use_atomic_block_id::never:
+            enable = false;
+            break;
+        case use_atomic_block_id::always:
+            enable = true;
+            break;
+        case use_atomic_block_id::hotfix:
+        default:
+            enable = needs_hotfix;
+        //clang-format on
+    }
+
+    return hipSuccess;
+}
 
 } // end of detail namespace
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_nth_element.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_nth_element.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@
 #define ROCPRIM_DEVICE_DEVICE_NTH_ELEMENT_HPP_
 
 #include "detail/device_nth_element.hpp"
+#include "detail/ordered_block_id.hpp"
 
 #include "../detail/temp_storage.hpp"
 
@@ -59,104 +60,130 @@ hipError_t
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
     using config   = wrapped_nth_element_config<Config, key_type>;
 
-    target_arch target_arch;
-    hipError_t  result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const nth_element_config_params params = dispatch_target_arch<config>(target_arch);
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    constexpr unsigned int num_partitions        = 3;
-    const unsigned int     num_buckets           = params.number_of_buckets;
-    const unsigned int     num_splitters         = num_buckets - 1;
-    const unsigned int     stop_recursion_size   = params.stop_recursion_size;
-    const unsigned int     num_items_per_threads = params.kernel_config.items_per_thread;
-    const unsigned int     num_threads_per_block = params.kernel_config.block_size;
-    const unsigned int     num_items_per_block   = num_threads_per_block * num_items_per_threads;
-    const unsigned int     num_blocks            = ceiling_div(size, num_items_per_block);
-
-    key_type*                            tree             = nullptr;
-    unsigned int*                        buckets          = nullptr;
-    n_th_element_iteration_data*         nth_element_data = nullptr;
-    bool*                                equality_buckets = nullptr;
-    nth_element_onesweep_lookback_state* lookback_states  = nullptr;
-
-    key_type* keys_buffer = nullptr;
-
-    {
-        using namespace temp_storage;
-
-        hipError_t partition_result;
-        if(keys_double_buffer == nullptr)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_atomic_block_id)
         {
-            partition_result
-                = partition(temporary_storage,
-                            storage_size,
-                            make_linear_partition(
-                                ptr_aligned_array(&tree, num_splitters),
-                                ptr_aligned_array(&equality_buckets, num_buckets),
-                                ptr_aligned_array(&buckets, num_buckets),
-                                ptr_aligned_array(&keys_buffer, size),
-                                ptr_aligned_array(&nth_element_data, 1),
-                                ptr_aligned_array(&lookback_states, num_partitions * num_blocks)));
-        }
-        else
-        {
-            partition_result
-                = partition(temporary_storage,
-                            storage_size,
-                            make_linear_partition(
-                                ptr_aligned_array(&tree, num_splitters),
-                                ptr_aligned_array(&equality_buckets, num_buckets),
-                                ptr_aligned_array(&buckets, num_buckets),
-                                ptr_aligned_array(&nth_element_data, 1),
-                                ptr_aligned_array(&lookback_states, num_partitions * num_blocks)));
-            keys_buffer = keys_double_buffer;
-        }
+            target_arch target_arch;
+            hipError_t  result = host_target_arch(stream, target_arch);
+            if(result != hipSuccess)
+            {
+                return result;
+            }
+            const nth_element_config_params params
+                = dispatch_target_arch<config, false>(target_arch);
 
-        if(partition_result != hipSuccess || temporary_storage == nullptr)
-        {
-            return partition_result;
-        }
-    }
+            constexpr unsigned int num_partitions        = 3;
+            const unsigned int     num_buckets           = params.number_of_buckets;
+            const unsigned int     num_splitters         = num_buckets - 1;
+            const unsigned int     stop_recursion_size   = params.stop_recursion_size;
+            const unsigned int     num_items_per_threads = params.kernel_config.items_per_thread;
+            const unsigned int     num_threads_per_block = params.kernel_config.block_size;
+            const unsigned int num_items_per_block = num_threads_per_block * num_items_per_threads;
+            const unsigned int num_blocks          = ceiling_div(size, num_items_per_block);
 
-    if((size == 0) || (size == 1 && nth == 0))
-    {
-        return hipSuccess;
-    }
+            key_type*                            tree             = nullptr;
+            unsigned int*                        buckets          = nullptr;
+            n_th_element_iteration_data*         nth_element_data = nullptr;
+            bool*                                equality_buckets = nullptr;
+            nth_element_onesweep_lookback_state* lookback_states  = nullptr;
 
-    if(nth >= size)
-    {
-        return hipErrorInvalidValue;
-    }
+            key_type* keys_buffer = nullptr;
 
-    if(debug_synchronous)
-    {
-        std::cout << "-----" << '\n';
-        std::cout << "size: " << size << '\n';
-        std::cout << "num_buckets: " << num_buckets << '\n';
-        std::cout << "num_threads_per_block: " << num_threads_per_block << '\n';
-        std::cout << "num_blocks: " << num_blocks << '\n';
-        std::cout << "storage_size: " << storage_size << '\n';
-    }
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
+            typename ordered_bid_type::id_type* ordered_bid_storage;
 
-    return nth_element_keys_impl<config, num_partitions>(keys,
-                                                         keys_buffer,
-                                                         tree,
-                                                         nth,
-                                                         size,
-                                                         buckets,
-                                                         equality_buckets,
-                                                         lookback_states,
-                                                         num_buckets,
-                                                         stop_recursion_size,
-                                                         num_threads_per_block,
-                                                         num_items_per_threads,
-                                                         nth_element_data,
-                                                         compare_function,
-                                                         stream,
-                                                         debug_synchronous);
+            {
+                using namespace temp_storage;
+
+                hipError_t partition_result;
+                if(keys_double_buffer == nullptr)
+                {
+                    partition_result = partition(
+                        temporary_storage,
+                        storage_size,
+                        make_linear_partition(
+                            ptr_aligned_array(&tree, num_splitters),
+                            ptr_aligned_array(&equality_buckets, num_buckets),
+                            ptr_aligned_array(&buckets, num_buckets),
+                            ptr_aligned_array(&keys_buffer, size),
+                            ptr_aligned_array(&nth_element_data, 1),
+                            ptr_aligned_array(&lookback_states, num_partitions * num_blocks),
+                            detail::temp_storage::make_partition(
+                                &ordered_bid_storage,
+                                ordered_bid_type::get_temp_storage_layout())));
+                }
+                else
+                {
+                    partition_result = partition(
+                        temporary_storage,
+                        storage_size,
+                        make_linear_partition(
+                            ptr_aligned_array(&tree, num_splitters),
+                            ptr_aligned_array(&equality_buckets, num_buckets),
+                            ptr_aligned_array(&buckets, num_buckets),
+                            ptr_aligned_array(&nth_element_data, 1),
+                            ptr_aligned_array(&lookback_states, num_partitions * num_blocks),
+                            detail::temp_storage::make_partition(
+                                &ordered_bid_storage,
+                                ordered_bid_type::get_temp_storage_layout())));
+                    keys_buffer = keys_double_buffer;
+                }
+
+                if(partition_result != hipSuccess || temporary_storage == nullptr)
+                {
+                    return partition_result;
+                }
+            }
+
+            if((size == 0) || (size == 1 && nth == 0))
+            {
+                return hipSuccess;
+            }
+
+            if(nth >= size)
+            {
+                return hipErrorInvalidValue;
+            }
+
+            if(debug_synchronous)
+            {
+                std::cout << "-----" << '\n';
+                std::cout << "size: " << size << '\n';
+                std::cout << "num_buckets: " << num_buckets << '\n';
+                std::cout << "num_threads_per_block: " << num_threads_per_block << '\n';
+                std::cout << "num_blocks: " << num_blocks << '\n';
+                std::cout << "storage_size: " << storage_size << '\n';
+            }
+
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            return nth_element_keys_impl<config, num_partitions>(target_arch,
+                                                                 keys,
+                                                                 keys_buffer,
+                                                                 tree,
+                                                                 nth,
+                                                                 size,
+                                                                 buckets,
+                                                                 equality_buckets,
+                                                                 lookback_states,
+                                                                 num_buckets,
+                                                                 stop_recursion_size,
+                                                                 num_threads_per_block,
+                                                                 num_items_per_threads,
+                                                                 nth_element_data,
+                                                                 compare_function,
+                                                                 stream,
+                                                                 debug_synchronous,
+                                                                 ordered_bid);
+        },
+        use_atomic_block_id_variant));
+    return hipSuccess;
 }
 
 } // namespace detail

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
@@ -41,6 +41,7 @@
 #include "device_transform.hpp"
 #include "rocprim/detail/virtual_shared_memory.hpp"
 #include "rocprim/device/config_types.hpp"
+#include "rocprim/device/detail/lookback_scan_state.hpp"
 #include "rocprim/device/detail/ordered_block_id.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
@@ -174,268 +175,226 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     using key_type = typename std::iterator_traits<KeyIterator>::value_type;
     using value_type = typename std::iterator_traits<ValueIterator>::value_type;
 
-    using config = wrapped_partition_config<Config, SubAlgo, key_type, value_type>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
+            
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
+    ;
+    const auto use_sleepy_scan_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(use_sleepy_scan);
 
-    constexpr bool write_only_selected = SubAlgo == partition_subalgo::select_flag
-                                         || SubAlgo == partition_subalgo::select_predicate
-                                         || SubAlgo == partition_subalgo::select_predicated_flag
-                                         || SubAlgo == partition_subalgo::select_unique
-                                         || SubAlgo == partition_subalgo::select_unique_by_key;
-
-    constexpr bool is_unique = SubAlgo == partition_subalgo::select_unique
-                               || SubAlgo == partition_subalgo::select_unique_by_key;
-    constexpr bool is_flag = SubAlgo == partition_subalgo::partition_two_way_flag
-                             || SubAlgo == partition_subalgo::partition_flag
-                             || SubAlgo == partition_subalgo::select_flag;
-    constexpr bool is_predicated_flag = SubAlgo == partition_subalgo::select_predicated_flag;
-    constexpr select_method method
-        = is_unique
-              ? select_method::unique
-              : (is_predicated_flag ? select_method::predicated_flag
-                                    : (is_flag ? select_method::flag : select_method::predicate));
-
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const partition_config_params params = dispatch_target_arch<config>(target_arch);
-
-    using offset_scan_state_type = detail::lookback_scan_state<offset_type>;
-    using offset_scan_state_with_sleep_type = detail::lookback_scan_state<offset_type, true>;
-
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const auto         items_per_block  = block_size * items_per_thread;
-
-    static constexpr bool is_three_way = sizeof...(UnaryPredicates) == 2;
-    static constexpr const size_t selected_count_size = is_three_way ? 2 : 1;
-
-    const size_t size_limit = params.kernel_config.size_limit;
-    const size_t aligned_size_limit
-        = ::rocprim::max<size_t>(size_limit - (size_limit % items_per_block), items_per_block);
-    const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
-    const bool   use_limited_size = limited_size == aligned_size_limit;
-
-    const unsigned int number_of_blocks
-        = static_cast<unsigned int>(::rocprim::detail::ceiling_div(limited_size, items_per_block));
-
-    // Calculate required temporary storage
-    void*                           offset_scan_state_storage;
-    size_t*                         selected_count;
-    size_t*                         prev_selected_count;
-
-    detail::temp_storage::layout layout{};
-    result = offset_scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    using block_id_wrapper_type = block_id_wrapper<uint32_t, UsingOrderedBlockId>;
-
-    typename block_id_wrapper_type::id_type* block_id_pool = nullptr;
-
-    bool use_sleep;
-    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleep));
-
-    // vsmem size
-    void*  vsmem                      = nullptr;
-    size_t virtual_shared_memory_size = 0;
-    using flag_type =
-        typename std::conditional<method == select_method::predicated_flag,
-                                  typename std::iterator_traits<FlagIterator>::value_type,
-                                  bool>::type;
-    if(use_sleep)
-    {
-        virtual_shared_memory_size
-            = get_partition_vsmem_size_per_block<method,
-                                                 write_only_selected,
-                                                 config,
-                                                 key_type,
-                                                 value_type,
-                                                 flag_type,
-                                                 offset_scan_state_with_sleep_type,
-                                                 block_id_wrapper_type>();
-    }
-    else
-    {
-        virtual_shared_memory_size = get_partition_vsmem_size_per_block<method,
-                                                                        write_only_selected,
-                                                                        config,
-                                                                        key_type,
-                                                                        value_type,
-                                                                        flag_type,
-                                                                        offset_scan_state_type,
-                                                                        block_id_wrapper_type>();
-    }
-    virtual_shared_memory_size *= number_of_blocks;
-
-    // temporary storage partition
-
-    result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with offset_scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&offset_scan_state_storage, layout),
-            // Note: the following two are to be allocated continuously, so that they can be initialized
-            // simultaneously.
-            // They have the same base type, so there is no padding between the types.
-            detail::temp_storage::ptr_aligned_array(&selected_count, selected_count_size),
-            detail::temp_storage::ptr_aligned_array(&prev_selected_count, selected_count_size),
-            detail::temp_storage::ptr_aligned_array(&block_id_pool, block_id_wrapper_type::get_storage_size()),
-            // vsmem
-            detail::temp_storage::make_partition(&vsmem,
-                                                 virtual_shared_memory_size,
-                                                 cache_line_size)));
-
-    if(result != hipSuccess || temporary_storage == nullptr)
-    {
-        return result;
-    }
-
-    auto block_id = block_id_wrapper_type::create(block_id_pool);
-
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-
-    // Create and initialize lookback_scan_state obj
-    offset_scan_state_type offset_scan_state{};
-    result = offset_scan_state_type::create(offset_scan_state,
-                                            offset_scan_state_storage,
-                                            number_of_blocks,
-                                            stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    offset_scan_state_with_sleep_type offset_scan_state_with_sleep{};
-    result = offset_scan_state_with_sleep_type::create(offset_scan_state_with_sleep,
-                                                       offset_scan_state_storage,
-                                                       number_of_blocks,
-                                                       stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    // Call the provided function with either offset_scan_state or offset_scan_state_with_sleep based on
-    // the value of use_sleep
-    auto with_scan_state = [use_sleep, offset_scan_state, offset_scan_state_with_sleep](
-                               auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(offset_scan_state_with_sleep);
-        }
-        else
-        {
-            return func(offset_scan_state);
-        }
-    };
+            using scan_state_type = detail::lookback_scan_state<offset_type, use_sleepy_scan>;
+            using block_id_type   = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
+            
+            using config = wrapped_partition_config<Config, SubAlgo, key_type, value_type>;
 
-    // Memset selected_count and prev_selected_count at once
-    result = hipMemsetAsync(selected_count,
-                            0,
-                            sizeof(*selected_count) * 2 * selected_count_size,
-                            stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+            constexpr bool write_only_selected = SubAlgo == partition_subalgo::select_flag
+                                                 || SubAlgo == partition_subalgo::select_predicate
+                                                 || SubAlgo == partition_subalgo::select_predicated_flag
+                                                 || SubAlgo == partition_subalgo::select_unique
+                                                 || SubAlgo == partition_subalgo::select_unique_by_key;
 
-    const size_t number_of_launches = ::rocprim::detail::ceiling_div(size, aligned_size_limit);
+            constexpr bool is_unique = SubAlgo == partition_subalgo::select_unique
+                                       || SubAlgo == partition_subalgo::select_unique_by_key;
+            constexpr bool is_flag = SubAlgo == partition_subalgo::partition_two_way_flag
+                                     || SubAlgo == partition_subalgo::partition_flag
+                                     || SubAlgo == partition_subalgo::select_flag;
+            constexpr bool is_predicated_flag = SubAlgo == partition_subalgo::select_predicated_flag;
+            constexpr select_method method
+                = is_unique
+                      ? select_method::unique
+                      : (is_predicated_flag ? select_method::predicated_flag
+                                            : (is_flag ? select_method::flag : select_method::predicate));
 
-    if(debug_synchronous)
-    {
-        std::cout << "use_limited_size " << use_limited_size << '\n';
-        std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
-        std::cout << "number_of_launches " << number_of_launches << '\n';
-        std::cout << "size " << size << '\n';
-        std::cout << "block_size " << block_size << '\n';
-        std::cout << "number of blocks " << number_of_blocks << '\n';
-        std::cout << "items_per_block " << items_per_block << '\n';
-    }
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+            const partition_config_params params = dispatch_target_arch<config, false>(target_arch);
 
-    for(size_t i = 0, prev_processed = 0; i < number_of_launches;
-        i++, prev_processed += limited_size)
-    {
-        const unsigned int current_size
-            = static_cast<unsigned int>(std::min<size_t>(size - prev_processed, limited_size));
+            const unsigned int block_size       = params.kernel_config.block_size;
+            const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+            const auto         items_per_block  = block_size * items_per_thread;
 
-        const unsigned int current_number_of_blocks = ::rocprim::detail::ceiling_div(current_size, items_per_block);
+            static constexpr bool is_three_way = sizeof...(UnaryPredicates) == 2;
+            static constexpr const size_t selected_count_size = is_three_way ? 2 : 1;
 
-        if(debug_synchronous)
-        {
-            std::cout << "current size " << current_size << '\n';
-            std::cout << "current number of blocks " << current_number_of_blocks << '\n';
+            const size_t size_limit = params.kernel_config.size_limit;
+            const size_t aligned_size_limit
+                = ::rocprim::max<size_t>(size_limit - (size_limit % items_per_block), items_per_block);
+            const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
+            const bool   use_limited_size = limited_size == aligned_size_limit;
 
-            start = std::chrono::steady_clock::now();
-        }
+            const unsigned int number_of_blocks
+                = static_cast<unsigned int>(::rocprim::detail::ceiling_div(limited_size, items_per_block));
 
-        with_scan_state(
-            [&](const auto scan_state)
+            // Calculate required temporary storage
+            void*                           offset_scan_state_storage;
+            size_t*                         selected_count;
+            size_t*                         prev_selected_count;
+
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
+
+            typename block_id_type::id_type* block_id_pool = nullptr;
+
+            // vsmem size
+            void*  vsmem                      = nullptr;
+            size_t virtual_shared_memory_size = 0;
+            using flag_type =
+                typename std::conditional<method == select_method::predicated_flag,
+                                          typename std::iterator_traits<FlagIterator>::value_type,
+                                          bool>::type;
+            // vsmem size
+            void*  vsmem                      = nullptr;
+            size_t virtual_shared_memory_size = 0;
+            using flag_type =
+                typename std::conditional<method == select_method::predicated_flag,
+                                          typename std::iterator_traits<FlagIterator>::value_type,
+                                          bool>::type;
+
+            virtual_shared_memory_size
+                = get_partition_vsmem_size_per_block<config,
+                                                     method,
+                                                     write_only_selected,
+                                                     key_type,
+                                                     value_type,
+                                                     flag_type,
+                                                     scan_state_type,
+                                                     block_id_type>(target_arch);
+            virtual_shared_memory_size *= number_of_blocks;
+
+            // temporary storage partition
+            ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    // Note: the following two are to be allocated continuously, so that they can be initialized
+                    // simultaneously.
+                    // They have the same base type, so there is no padding between the types.
+                    detail::temp_storage::ptr_aligned_array(&selected_count, selected_count_size),
+                    detail::temp_storage::ptr_aligned_array(&prev_selected_count,
+                                                            selected_count_size),
+                    detail::temp_storage::ptr_aligned_array(&block_id_pool,
+                                                            block_id_type::get_storage_size()),
+                    // vsmem
+                    detail::temp_storage::make_partition(&vsmem,
+                                                         virtual_shared_memory_size,
+                                                         cache_line_size))));
+
+            if(temporary_storage == nullptr)
             {
-                const unsigned int block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
-                const unsigned int grid_size
-                    = ::rocprim::detail::ceiling_div(current_number_of_blocks, block_size);
-                init_lookback_scan_state_kernel<decltype(scan_state)>
-                    <<<dim3(grid_size), dim3(block_size), 0, stream>>>(scan_state,
-                                                                       current_number_of_blocks);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_offset_scan_state_kernel",
-                                                    current_number_of_blocks,
-                                                    start);
-
-        if (UsingOrderedBlockId)
-        {
-            result = hipMemsetAsync(block_id_pool, 0, sizeof(unsigned int), stream);
-            if (result != hipSuccess)
-            {
-                return result;
+                return hipSuccess;
             }
-        }
 
-        if(debug_synchronous) start = std::chrono::steady_clock::now();
+            block_id_type block_id = block_id_type::create(block_id_pool);
 
-        with_scan_state(
-            [&](const auto scan_state)
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+
+            // Create and initialize lookback_scan_state obj
+            scan_state_type scan_state{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream));
+
+// Memset selected_count and prev_selected_count at once
+            ROCPRIM_RETURN_ON_ERROR(
+                hipMemsetAsync(selected_count,
+                               0,
+                               sizeof(*selected_count) * 2 * selected_count_size,
+                               stream));
+
+            const size_t number_of_launches
+                = ::rocprim::detail::ceiling_div(size, aligned_size_limit);
+
+            if(debug_synchronous)
             {
-                partition_kernel<method, write_only_selected, config>
-                    <<<dim3(current_number_of_blocks), dim3(block_size), 0, stream>>>(
-                        keys_input + prev_processed,
-                        values_input + prev_processed,
-                        flags + prev_processed,
-                        keys_output,
-                        values_output,
-                        selected_count,
-                        prev_selected_count,
-                        prev_processed,
-                        size,
-                        inequality_op,
-                        scan_state,
-                        current_number_of_blocks,
-                        detail::vsmem_t{vsmem},
-                        block_id,
-                        predicates...);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", size, start);
+                std::cout << "use_limited_size " << use_limited_size << '\n';
+                std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
+                std::cout << "number_of_launches " << number_of_launches << '\n';
+                std::cout << "size " << size << '\n';
+                std::cout << "block_size " << block_size << '\n';
+                std::cout << "number of blocks " << number_of_blocks << '\n';
+                std::cout << "items_per_block " << items_per_block << '\n';
+            }
 
-        std::swap(selected_count, prev_selected_count);
-    }
+            for(size_t i = 0, prev_processed = 0; i < number_of_launches;
+                i++, prev_processed += limited_size)
+            {
+                const unsigned int current_size = static_cast<unsigned int>(
+                    std::min<size_t>(size - prev_processed, limited_size));
 
-    result = ::rocprim::transform(prev_selected_count,
-                                  selected_count_output,
-                                  (is_three_way ? 2 : 1),
-                                  ::rocprim::identity<>{},
-                                  stream,
-                                  debug_synchronous);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+                const unsigned int current_number_of_blocks
+                    = ::rocprim::detail::ceiling_div(current_size, items_per_block);
+
+                if(debug_synchronous)
+                {
+                    std::cout << "current size " << current_size << '\n';
+                    std::cout << "current number of blocks " << current_number_of_blocks << '\n';
+
+                    start = std::chrono::steady_clock::now();
+                }
+
+                // Define block and grid sizes for init kernel.
+                const size_t init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
+                const size_t init_grid_size
+                    = ::rocprim::detail::ceiling_div(current_number_of_blocks, init_block_size);
+                init_lookback_scan_state_kernel<<<init_grid_size, init_block_size, 0, stream>>>(
+                    scan_state,
+                    current_number_of_blocks,
+                    block_id);
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_offset_scan_state_kernel",
+                                                            current_number_of_blocks,
+                                                            start);
+                if(debug_synchronous)
+                {
+                    start = std::chrono::steady_clock::now();
+                }
+
+                ROCPRIM_RETURN_ON_ERROR(launch_partition<config, method, write_only_selected>(
+                    target_arch,
+                    keys_input + prev_processed,
+                    values_input + prev_processed,
+                    flags + prev_processed,
+                    keys_output,
+                    values_output,
+                    selected_count,
+                    prev_selected_count,
+                    prev_processed,
+                    size,
+                    inequality_op,
+                    scan_state,
+                    current_number_of_blocks,
+                    detail::vsmem_t{vsmem},
+                    block_id,
+                    dim3(current_number_of_blocks),
+                    dim3(block_size),
+                    0,
+                    stream,
+                    predicates...));
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", size, start);
+
+                std::swap(selected_count, prev_selected_count);
+            }
+
+            ROCPRIM_RETURN_ON_ERROR(::rocprim::transform(prev_selected_count,
+                                                         selected_count_output,
+                                                         (is_three_way ? 2 : 1),
+                                                         ::rocprim::identity<>{},
+                                                         stream,
+                                                         debug_synchronous));
+
+            return hipSuccess;
+        },
+        use_sleepy_scan_variant,
+        use_atomic_block_id_variant));
 
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
@@ -24,15 +24,14 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
+#include <optional>
 #include <type_traits>
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/temp_storage.hpp"
 #include "../detail/various.hpp"
 #include "../functional.hpp"
-#include "../iterator/reverse_iterator.hpp"
-#include "../type_traits.hpp"
 #include "../types.hpp"
 
 #include "detail/device_partition.hpp"
@@ -52,9 +51,9 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<select_method SelectMethod,
+template<class Config,
+         select_method SelectMethod,
          bool          OnlySelected,
-         class Config,
          class KeyIterator,
          class ValueIterator,
          class FlagIterator,
@@ -64,85 +63,122 @@ template<select_method SelectMethod,
          class OffsetLookbackScanState,
          class BlockIdWrapper,
          class... UnaryPredicates>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    partition_kernel(KeyIterator                        keys_input,
-                     ValueIterator                      values_input,
-                     FlagIterator                       flags,
-                     OutputKeyIterator                  keys_output,
-                     OutputValueIterator                values_output,
-                     size_t*                            selected_count,
-                     size_t*                            prev_selected_count,
-                     size_t                             prev_processed,
-                     const size_t                       total_size,
-                     InequalityOp                       inequality_op,
-                     OffsetLookbackScanState            offset_scan_state,
-                     const unsigned int                 number_of_blocks,
-                     detail::vsmem_t                    vsmem,
-                     BlockIdWrapper                     block_id,
-                     UnaryPredicates... predicates)
+inline hipError_t launch_partition(detail::target_arch     arch,
+                                   KeyIterator             keys_input,
+                                   ValueIterator           values_input,
+                                   FlagIterator            flags,
+                                   OutputKeyIterator       keys_output,
+                                   OutputValueIterator     values_output,
+                                   size_t*                 selected_count,
+                                   size_t*                 prev_selected_count,
+                                   size_t                  prev_processed,
+                                   const size_t            total_size,
+                                   InequalityOp            inequality_op,
+                                   OffsetLookbackScanState offset_scan_state,
+                                   const unsigned int      number_of_blocks,
+                                   detail::vsmem_t         vsmem,
+                                   BlockIdWrapper          block_id,
+                                   dim3                    grid,
+                                   dim3                    block,
+                                   size_t                  shmem,
+                                   hipStream_t             stream,
+                                   UnaryPredicates... predicates)
 {
-    using offset_type = typename OffsetLookbackScanState::value_type;
-    using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
-    using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
-    using flag_type =
-        typename std::conditional<SelectMethod == select_method::predicated_flag,
-                                  typename std::iterator_traits<FlagIterator>::value_type,
-                                  bool>::type;
+    auto kernel = [=](auto arch_config) mutable
+    {
+        using offset_type = typename OffsetLookbackScanState::value_type;
+        using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
+        using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
+        using flag_type =
+            typename std::conditional<SelectMethod == select_method::predicated_flag,
+                                      typename std::iterator_traits<FlagIterator>::value_type,
+                                      bool>::type;
 
-    using partition_kernel_impl_t = partition_kernel_impl_<SelectMethod,
-                                                           OnlySelected,
-                                                           Config,
-                                                           key_type,
-                                                           value_type,
-                                                           flag_type,
-                                                           offset_type,
-                                                           BlockIdWrapper>;
+        using partition_kernel_impl_t = partition_kernel_impl_<decltype(arch_config),
+                                                               SelectMethod,
+                                                               OnlySelected,
+                                                               key_type,
+                                                               value_type,
+                                                               flag_type,
+                                                               offset_type,
+                                                               BlockIdWrapper>;
 
-    using VSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
-    ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
-    // Get temporary storage
-    typename partition_kernel_impl_t::storage_type& storage
-        = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
+        using VSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
+        ROCPRIM_SHARED_MEMORY typename VSmemHelperT::static_temp_storage_t static_temp_storage;
+        // Get temporary storage
+        typename partition_kernel_impl_t::storage_type& storage
+            = VSmemHelperT::get_temp_storage(static_temp_storage, vsmem);
 
-    partition_kernel_impl_t().partition(keys_input,
-                                        values_input,
-                                        flags,
-                                        keys_output,
-                                        values_output,
-                                        selected_count,
-                                        prev_selected_count,
-                                        prev_processed,
-                                        total_size,
-                                        inequality_op,
-                                        offset_scan_state,
-                                        number_of_blocks,
-                                        block_id,
-                                        storage,
-                                        predicates...);
+        partition_kernel_impl_t().partition(keys_input,
+                                            values_input,
+                                            flags,
+                                            keys_output,
+                                            values_output,
+                                            selected_count,
+                                            prev_selected_count,
+                                            prev_processed,
+                                            total_size,
+                                            inequality_op,
+                                            offset_scan_state,
+                                            number_of_blocks,
+                                            block_id,
+                                            storage,
+                                            predicates...);
+    };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<select_method SelectMethod,
+template<class Config,
+         select_method SelectMethod,
          bool          OnlySelected,
-         class Config,
          class Key,
          class Value,
          class FlagType,
          class OffsetLookbackScanState,
          class BlockIdWrapper>
-inline size_t get_partition_vsmem_size_per_block()
+inline size_t get_partition_vsmem_size_per_block(detail::target_arch arch)
 {
-    using offset_type             = typename OffsetLookbackScanState::value_type;
-    using partition_kernel_impl_t = partition_kernel_impl_<SelectMethod,
-                                                           OnlySelected,
-                                                           Config,
-                                                           Key,
-                                                           Value,
-                                                           FlagType,
-                                                           offset_type,
-                                                           BlockIdWrapper>;
+    using offset_type = typename OffsetLookbackScanState::value_type;
+    std::optional<size_t> vsmem_per_block;
+    for_each_arch(
+        [&](auto arch_tag)
+        {
+            constexpr target_arch Arch = decltype(arch_tag)::value;
+            if(Arch != arch || vsmem_per_block)
+            {
+                return;
+            }
 
-    using PartitionVSmemHelperT = detail::vsmem_helper_impl<partition_kernel_impl_t>;
-    return PartitionVSmemHelperT::vsmem_per_block;
+            using ArchConfig               = typename Config::template architecture_config<Arch>;
+            using partition_kernel_impl_t  = partition_kernel_impl_<ArchConfig,
+                                                                   SelectMethod,
+                                                                   OnlySelected,
+                                                                   Key,
+                                                                   Value,
+                                                                   FlagType,
+                                                                   offset_type,
+                                                                   BlockIdWrapper>;
+            using partition_vsmem_helper_t = detail::vsmem_helper_impl<partition_kernel_impl_t>;
+
+            vsmem_per_block = partition_vsmem_helper_t::vsmem_per_block;
+        });
+    if(!vsmem_per_block)
+    {
+        using ArchConfig = typename Config::template architecture_config<target_arch::unknown>;
+        using partition_kernel_impl_t  = partition_kernel_impl_<ArchConfig,
+                                                               SelectMethod,
+                                                               OnlySelected,
+                                                               Key,
+                                                               Value,
+                                                               FlagType,
+                                                               offset_type,
+                                                               BlockIdWrapper>;
+        using partition_vsmem_helper_t = detail::vsmem_helper_impl<partition_kernel_impl_t>;
+
+        vsmem_per_block = partition_vsmem_helper_t::vsmem_per_block;
+    }
+    return vsmem_per_block.value();
 }
 
 template<partition_subalgo SubAlgo,
@@ -172,15 +208,15 @@ inline hipError_t partition_impl(void*                       temporary_storage,
                                  UnaryPredicates... predicates)
 {
     using offset_type = OffsetT;
-    using key_type = typename std::iterator_traits<KeyIterator>::value_type;
-    using value_type = typename std::iterator_traits<ValueIterator>::value_type;
+    using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
+    using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
 
     bool use_atomic_block_id;
     ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
     const auto use_atomic_block_id_variant
         = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
             use_atomic_block_id);
-            
+
     bool use_sleepy_scan;
     ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
     ;
@@ -192,26 +228,28 @@ inline hipError_t partition_impl(void*                       temporary_storage,
         {
             using scan_state_type = detail::lookback_scan_state<offset_type, use_sleepy_scan>;
             using block_id_type   = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
-            
+
             using config = wrapped_partition_config<Config, SubAlgo, key_type, value_type>;
 
-            constexpr bool write_only_selected = SubAlgo == partition_subalgo::select_flag
-                                                 || SubAlgo == partition_subalgo::select_predicate
-                                                 || SubAlgo == partition_subalgo::select_predicated_flag
-                                                 || SubAlgo == partition_subalgo::select_unique
-                                                 || SubAlgo == partition_subalgo::select_unique_by_key;
+            constexpr bool write_only_selected
+                = SubAlgo == partition_subalgo::select_flag
+                  || SubAlgo == partition_subalgo::select_predicate
+                  || SubAlgo == partition_subalgo::select_predicated_flag
+                  || SubAlgo == partition_subalgo::select_unique
+                  || SubAlgo == partition_subalgo::select_unique_by_key;
 
             constexpr bool is_unique = SubAlgo == partition_subalgo::select_unique
                                        || SubAlgo == partition_subalgo::select_unique_by_key;
             constexpr bool is_flag = SubAlgo == partition_subalgo::partition_two_way_flag
                                      || SubAlgo == partition_subalgo::partition_flag
                                      || SubAlgo == partition_subalgo::select_flag;
-            constexpr bool is_predicated_flag = SubAlgo == partition_subalgo::select_predicated_flag;
+            constexpr bool is_predicated_flag
+                = SubAlgo == partition_subalgo::select_predicated_flag;
             constexpr select_method method
-                = is_unique
-                      ? select_method::unique
-                      : (is_predicated_flag ? select_method::predicated_flag
-                                            : (is_flag ? select_method::flag : select_method::predicate));
+                = is_unique ? select_method::unique
+                            : (is_predicated_flag
+                                   ? select_method::predicated_flag
+                                   : (is_flag ? select_method::flag : select_method::predicate));
 
             detail::target_arch target_arch;
             ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
@@ -221,22 +259,23 @@ inline hipError_t partition_impl(void*                       temporary_storage,
             const unsigned int items_per_thread = params.kernel_config.items_per_thread;
             const auto         items_per_block  = block_size * items_per_thread;
 
-            static constexpr bool is_three_way = sizeof...(UnaryPredicates) == 2;
+            static constexpr bool         is_three_way        = sizeof...(UnaryPredicates) == 2;
             static constexpr const size_t selected_count_size = is_three_way ? 2 : 1;
 
-            const size_t size_limit = params.kernel_config.size_limit;
-            const size_t aligned_size_limit
-                = ::rocprim::max<size_t>(size_limit - (size_limit % items_per_block), items_per_block);
+            const size_t size_limit         = params.kernel_config.size_limit;
+            const size_t aligned_size_limit = ::rocprim::max<size_t>(
+                size_limit - (size_limit % static_cast<size_t>(items_per_block)),
+                items_per_block);
             const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
             const bool   use_limited_size = limited_size == aligned_size_limit;
 
-            const unsigned int number_of_blocks
-                = static_cast<unsigned int>(::rocprim::detail::ceiling_div(limited_size, items_per_block));
+            const unsigned int number_of_blocks = static_cast<unsigned int>(
+                ::rocprim::detail::ceiling_div(limited_size, items_per_block));
 
             // Calculate required temporary storage
-            void*                           offset_scan_state_storage;
-            size_t*                         selected_count;
-            size_t*                         prev_selected_count;
+            void*   scan_state_storage;
+            size_t* selected_count;
+            size_t* prev_selected_count;
 
             detail::temp_storage::layout layout{};
             ROCPRIM_RETURN_ON_ERROR(
@@ -244,13 +283,6 @@ inline hipError_t partition_impl(void*                       temporary_storage,
 
             typename block_id_type::id_type* block_id_pool = nullptr;
 
-            // vsmem size
-            void*  vsmem                      = nullptr;
-            size_t virtual_shared_memory_size = 0;
-            using flag_type =
-                typename std::conditional<method == select_method::predicated_flag,
-                                          typename std::iterator_traits<FlagIterator>::value_type,
-                                          bool>::type;
             // vsmem size
             void*  vsmem                      = nullptr;
             size_t virtual_shared_memory_size = 0;
@@ -304,7 +336,7 @@ inline hipError_t partition_impl(void*                       temporary_storage,
             ROCPRIM_RETURN_ON_ERROR(
                 scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream));
 
-// Memset selected_count and prev_selected_count at once
+            // Memset selected_count and prev_selected_count at once
             ROCPRIM_RETURN_ON_ERROR(
                 hipMemsetAsync(selected_count,
                                0,
@@ -399,7 +431,7 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     return hipSuccess;
 }
 
-} // end of detail namespace
+} // namespace detail
 
 /// \brief Two-way parallel select primitive for device level using selection predicate.
 ///
@@ -457,7 +489,7 @@ inline hipError_t partition_impl(void*                       temporary_storage,
 /// #include <rocprim/rocprim.hpp>///
 ///
 /// auto predicate =
-///     [] __device__ (int a) -> bool
+///     [] (int a) -> bool
 ///     {
 ///         return (a%2) == 0;
 ///     };
@@ -506,7 +538,7 @@ template<class Config = default_config,
          class RejectedOutputIterator,
          class SelectedCountOutputIterator,
          class Predicate,
-         bool  UsingOrderedBlockId = false>
+         bool UsingOrderedBlockId = false>
 inline hipError_t partition_two_way(void*                       temporary_storage,
                                     size_t&                     storage_size,
                                     InputIterator               input,
@@ -651,7 +683,7 @@ template<class Config = default_config,
          typename SelectedOutputIterator,
          typename RejectedOutputIterator,
          typename SelectedCountOutputIterator,
-         bool     UsingOrderedBlockId = false>
+         bool UsingOrderedBlockId = false>
 inline hipError_t partition_two_way(void*                       temporary_storage,
                                     size_t&                     storage_size,
                                     InputIterator               input,
@@ -774,23 +806,21 @@ inline hipError_t partition_two_way(void*                       temporary_storag
 /// // output_count: 4
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class FlagIterator,
-    class OutputIterator,
-    class SelectedCountOutputIterator,
-    bool  UsingOrderedBlockId = false>
-inline
-hipError_t partition(void * temporary_storage,
-                     size_t& storage_size,
-                     InputIterator input,
-                     FlagIterator flags,
-                     OutputIterator output,
-                     SelectedCountOutputIterator selected_count_output,
-                     const size_t size,
-                     const hipStream_t stream = 0,
-                     const bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class FlagIterator,
+         class OutputIterator,
+         class SelectedCountOutputIterator,
+         bool UsingOrderedBlockId = false>
+inline hipError_t partition(void*                       temporary_storage,
+                            size_t&                     storage_size,
+                            InputIterator               input,
+                            FlagIterator                flags,
+                            OutputIterator              output,
+                            SelectedCountOutputIterator selected_count_output,
+                            const size_t                size,
+                            const hipStream_t           stream            = 0,
+                            const bool                  debug_synchronous = false)
 {
     using unary_predicate_type = ::rocprim::empty_type; // dummy
     using inequality_op_type   = ::rocprim::empty_type; // dummy
@@ -873,7 +903,7 @@ hipError_t partition(void * temporary_storage,
 /// #include <rocprim/rocprim.hpp>///
 ///
 /// auto predicate =
-///     [] __device__ (int a) -> bool
+///     [] (int a) -> bool
 ///     {
 ///         return (a%2) == 0;
 ///     };
@@ -910,23 +940,21 @@ hipError_t partition(void * temporary_storage,
 /// // output_count: 4
 /// \endcode
 /// \endparblock
-template<
-    class Config = default_config,
-    class InputIterator,
-    class OutputIterator,
-    class SelectedCountOutputIterator,
-    class UnaryPredicate,
-    bool  UsingOrderedBlockId = false>
-inline
-hipError_t partition(void * temporary_storage,
-                     size_t& storage_size,
-                     InputIterator input,
-                     OutputIterator output,
-                     SelectedCountOutputIterator selected_count_output,
-                     const size_t size,
-                     UnaryPredicate predicate,
-                     const hipStream_t stream = 0,
-                     const bool debug_synchronous = false)
+template<class Config = default_config,
+         class InputIterator,
+         class OutputIterator,
+         class SelectedCountOutputIterator,
+         class UnaryPredicate,
+         bool UsingOrderedBlockId = false>
+inline hipError_t partition(void*                       temporary_storage,
+                            size_t&                     storage_size,
+                            InputIterator               input,
+                            OutputIterator              output,
+                            SelectedCountOutputIterator selected_count_output,
+                            const size_t                size,
+                            UnaryPredicate              predicate,
+                            const hipStream_t           stream            = 0,
+                            const bool                  debug_synchronous = false)
 {
     using flag_type          = ::rocprim::empty_type; //dummy
     using inequality_op_type = ::rocprim::empty_type; //dummy
@@ -1037,12 +1065,12 @@ hipError_t partition(void * temporary_storage,
 /// #include <rocprim/rocprim.hpp>
 ///
 /// auto first_predicate =
-///     [] __device__ (int a) -> bool
+///     [] (int a) -> bool
 ///     {
 ///         return (a%2) == 0;
 ///     };
 /// auto second_predicate =
-///     [] __device__ (int a) -> bool
+///     [] (int a) -> bool
 ///     {
 ///         return (a%3) == 0;
 ///     };
@@ -1088,46 +1116,42 @@ hipError_t partition(void * temporary_storage,
 /// // output_count:       [4, 1]
 /// \endcode
 /// \endparblock
-template <
-    class Config = default_config,
-    typename InputIterator,
-    typename FirstOutputIterator,
-    typename SecondOutputIterator,
-    typename UnselectedOutputIterator,
-    typename SelectedCountOutputIterator,
-    typename FirstUnaryPredicate,
-    typename SecondUnaryPredicate,
-    bool     UsingOrderedBlockId = false>
-inline
-hipError_t partition_three_way(void * temporary_storage,
-                               size_t& storage_size,
-                               InputIterator input,
-                               FirstOutputIterator output_first_part,
-                               SecondOutputIterator output_second_part,
-                               UnselectedOutputIterator output_unselected,
-                               SelectedCountOutputIterator selected_count_output,
-                               const size_t size,
-                               FirstUnaryPredicate select_first_part_op,
-                               SecondUnaryPredicate select_second_part_op,
-                               const hipStream_t stream = 0,
-                               const bool debug_synchronous = false)
+template<class Config = default_config,
+         typename InputIterator,
+         typename FirstOutputIterator,
+         typename SecondOutputIterator,
+         typename UnselectedOutputIterator,
+         typename SelectedCountOutputIterator,
+         typename FirstUnaryPredicate,
+         typename SecondUnaryPredicate,
+         bool UsingOrderedBlockId = false>
+inline hipError_t partition_three_way(void*                       temporary_storage,
+                                      size_t&                     storage_size,
+                                      InputIterator               input,
+                                      FirstOutputIterator         output_first_part,
+                                      SecondOutputIterator        output_second_part,
+                                      UnselectedOutputIterator    output_unselected,
+                                      SelectedCountOutputIterator selected_count_output,
+                                      const size_t                size,
+                                      FirstUnaryPredicate         select_first_part_op,
+                                      SecondUnaryPredicate        select_second_part_op,
+                                      const hipStream_t           stream            = 0,
+                                      const bool                  debug_synchronous = false)
 {
     // Dummy flag type
-    using flag_type = ::rocprim::empty_type;
-    flag_type * flags = nullptr;
+    using flag_type  = ::rocprim::empty_type;
+    flag_type* flags = nullptr;
     // Dummy inequality operation
     using inequality_op_type = ::rocprim::empty_type;
-    using offset_type = uint2;
-    using output_key_iterator_tuple = tuple<
-        FirstOutputIterator,
-        SecondOutputIterator,
-        UnselectedOutputIterator>;
+    using offset_type        = uint2;
+    using output_key_iterator_tuple
+        = tuple<FirstOutputIterator, SecondOutputIterator, UnselectedOutputIterator>;
     using output_value_iterator_tuple
         = tuple<::rocprim::empty_type*, ::rocprim::empty_type*, ::rocprim::empty_type*>;
-    rocprim::empty_type* const no_input_values = nullptr; // key only
-    const output_value_iterator_tuple no_output_values {nullptr, nullptr, nullptr}; // key only
+    rocprim::empty_type* const        no_input_values = nullptr; // key only
+    const output_value_iterator_tuple no_output_values{nullptr, nullptr, nullptr}; // key only
 
-    output_key_iterator_tuple output{ output_first_part, output_second_part, output_unselected };
+    output_key_iterator_tuple output{output_first_part, output_second_part, output_unselected};
 
     return detail::partition_impl<detail::partition_subalgo::partition_three_way,
                                   UsingOrderedBlockId,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,19 +26,20 @@
 #include <type_traits>
 #include <utility>
 
-#include "../config.hpp"
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/temp_storage.hpp"
 #include "../detail/various.hpp"
 
-#include "../intrinsics.hpp"
 #include "../functional.hpp"
+#include "../intrinsics.hpp"
 #include "../types.hpp"
 
 #include "../type_traits.hpp"
 #include "detail/config/device_radix_sort_onesweep.hpp"
 #include "detail/device_radix_sort.hpp"
 #include "device_transform.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 #include "specialization/device_radix_block_sort.hpp"
 #include "specialization/device_radix_merge_sort.hpp"
 
@@ -75,43 +76,70 @@ struct decomposer_max_bits
 {};
 
 template<class Size>
-using offset_type_t = std::conditional_t<
-    sizeof(Size) <= 4,
-    unsigned int,
-    size_t
->;
+using offset_type_t = std::conditional_t<sizeof(Size) <= 4, unsigned int, size_t>;
 
 template<class Config, bool Descending, class KeysInputIterator, class Offset, class Decomposer>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram.block_size) void
-    onesweep_histograms_kernel(KeysInputIterator  keys_input,
-                               Offset*            global_digit_counts,
-                               const Offset       size,
-                               const Offset       full_blocks,
-                               Decomposer         decomposer,
-                               const unsigned int begin_bit,
-                               const unsigned int end_bit)
+inline hipError_t launch_onesweep_histograms(detail::target_arch arch,
+                                             KeysInputIterator   keys_input,
+                                             Offset*             global_digit_counts,
+                                             const Offset        size,
+                                             const Offset        full_blocks,
+                                             Decomposer          decomposer,
+                                             const unsigned int  begin_bit,
+                                             const unsigned int  end_bit,
+                                             dim3                grid,
+                                             dim3                block,
+                                             size_t              shmem,
+                                             hipStream_t         stream)
 {
-    static constexpr radix_sort_onesweep_config_params params = device_params<Config>();
-    onesweep_histograms<params.histogram.block_size,
-                        params.histogram.items_per_thread,
-                        params.radix_bits_per_place,
-                        Descending>(keys_input,
-                                    global_digit_counts,
-                                    size,
-                                    full_blocks,
-                                    decomposer,
-                                    begin_bit,
-                                    end_bit);
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr radix_sort_onesweep_config_params params = decltype(arch_config)::params;
+        onesweep_histograms<params.histogram.block_size,
+                            params.histogram.items_per_thread,
+                            params.radix_bits_per_place,
+                            Descending>(keys_input,
+                                        global_digit_counts,
+                                        size,
+                                        full_blocks,
+                                        decomposer,
+                                        begin_bit,
+                                        end_bit);
+    };
+
+    return execute_launch_plan<Config,
+                               decltype(kernel),
+                               radix_sort_onesweep_histogram_config_selector>(arch,
+                                                                              kernel,
+                                                                              grid,
+                                                                              block,
+                                                                              shmem,
+                                                                              stream);
 }
 
 template<class Config, class Offset>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().histogram.block_size) void
-    onesweep_scan_histograms_kernel(Offset* global_digit_offsets)
+inline hipError_t launch_onesweep_scan_histograms(detail::target_arch arch,
+                                                  Offset*             global_digit_offsets,
+                                                  dim3                grid,
+                                                  dim3                block,
+                                                  size_t              shmem,
+                                                  hipStream_t         stream)
 {
-    static constexpr radix_sort_onesweep_config_params params = device_params<Config>();
-    onesweep_scan_histograms<params.histogram.block_size, params.radix_bits_per_place>(
-        global_digit_offsets);
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr radix_sort_onesweep_config_params params = decltype(arch_config)::params;
+        onesweep_scan_histograms<params.histogram.block_size, params.radix_bits_per_place>(
+            global_digit_offsets);
+    };
+
+    return execute_launch_plan<Config,
+                               decltype(kernel),
+                               radix_sort_onesweep_histogram_config_selector>(arch,
+                                                                              kernel,
+                                                                              grid,
+                                                                              block,
+                                                                              shmem,
+                                                                              stream);
 }
 
 template<class Config,
@@ -141,7 +169,8 @@ hipError_t radix_sort_onesweep_global_offsets(KeysInputIterator keys_input,
     {
         return result;
     }
-    const radix_sort_onesweep_config_params params = dispatch_target_arch<config>(target_arch);
+    const radix_sort_onesweep_config_params params
+        = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int items_per_block
         = params.histogram.block_size * params.histogram.items_per_thread;
@@ -168,18 +197,19 @@ hipError_t radix_sort_onesweep_global_offsets(KeysInputIterator keys_input,
     }
 
     // Compute a histogram for each digit.
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_histograms_kernel<config, Descending>),
-                       dim3(blocks),
-                       dim3(params.histogram.block_size),
-                       0,
-                       stream,
-                       keys_input,
-                       global_digit_offsets,
-                       size,
-                       full_blocks,
-                       decomposer,
-                       begin_bit,
-                       end_bit);
+    ROCPRIM_RETURN_ON_ERROR(
+        launch_onesweep_histograms<config, Descending>(target_arch,
+                                                       keys_input,
+                                                       global_digit_offsets,
+                                                       size,
+                                                       full_blocks,
+                                                       decomposer,
+                                                       begin_bit,
+                                                       end_bit,
+                                                       dim3(blocks),
+                                                       dim3(params.histogram.block_size),
+                                                       0,
+                                                       stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("compute_global_digit_histograms", size, start);
 
     // Scan each histogram separately to get the final offsets.
@@ -188,13 +218,13 @@ hipError_t radix_sort_onesweep_global_offsets(KeysInputIterator keys_input,
         start = std::chrono::steady_clock::now();
     }
 
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_scan_histograms_kernel<config>),
-                       dim3(digit_places), // One block for every digit place.
-                       dim3(params.histogram.block_size),
-                       0,
-                       stream,
-                       global_digit_offsets);
-
+    ROCPRIM_RETURN_ON_ERROR(launch_onesweep_scan_histograms<config>(
+        target_arch,
+        global_digit_offsets,
+        dim3(digit_places), // One block for every digit place.
+        dim3(params.histogram.block_size),
+        0,
+        stream));
     ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("scan_global_digit_histograms", bins, start);
     return hipSuccess;
 }
@@ -206,38 +236,57 @@ template<class Config,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Offset,
-         class Decomposer>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().sort.block_size) void
-    onesweep_iteration_kernel(KeysInputIterator        keys_input,
-                              KeysOutputIterator       keys_output,
-                              ValuesInputIterator      values_input,
-                              ValuesOutputIterator     values_output,
-                              const unsigned int       size,
-                              Offset*                  global_digit_offsets_in,
-                              Offset*                  global_digit_offsets_out,
-                              onesweep_lookback_state* lookback_states,
-                              Decomposer               decomposer,
-                              const unsigned int       bit,
-                              const unsigned int       current_radix_bits,
-                              const unsigned int       full_blocks)
+         class Decomposer,
+         class BlockIdWrapper>
+inline hipError_t launch_onesweep_iteration(detail::target_arch      arch,
+                                            KeysInputIterator        keys_input,
+                                            KeysOutputIterator       keys_output,
+                                            ValuesInputIterator      values_input,
+                                            ValuesOutputIterator     values_output,
+                                            const unsigned int       size,
+                                            Offset*                  global_digit_offsets_in,
+                                            Offset*                  global_digit_offsets_out,
+                                            onesweep_lookback_state* lookback_states,
+                                            Decomposer               decomposer,
+                                            const unsigned int       bit,
+                                            const unsigned int       current_radix_bits,
+                                            const unsigned int       full_blocks,
+                                            BlockIdWrapper           ordered_bid,
+                                            dim3                     grid,
+                                            dim3                     block,
+                                            size_t                   shmem,
+                                            hipStream_t              stream)
 {
-    static constexpr radix_sort_onesweep_config_params params = device_params<Config>();
-    onesweep_iteration<params.sort.block_size,
-                       params.sort.items_per_thread,
-                       params.radix_bits_per_place,
-                       Descending,
-                       params.radix_rank_algorithm>(keys_input,
-                                                    keys_output,
-                                                    values_input,
-                                                    values_output,
-                                                    size,
-                                                    global_digit_offsets_in,
-                                                    global_digit_offsets_out,
-                                                    lookback_states,
-                                                    decomposer,
-                                                    bit,
-                                                    current_radix_bits,
-                                                    full_blocks);
+    auto kernel = [=](auto arch_config)
+    {
+        static constexpr auto params = decltype(arch_config)::params;
+
+        onesweep_iteration<params.sort.block_size,
+                           params.sort.items_per_thread,
+                           params.radix_bits_per_place,
+                           Descending,
+                           params.radix_rank_algorithm>(keys_input,
+                                                        keys_output,
+                                                        values_input,
+                                                        values_output,
+                                                        size,
+                                                        global_digit_offsets_in,
+                                                        global_digit_offsets_out,
+                                                        lookback_states,
+                                                        decomposer,
+                                                        bit,
+                                                        current_radix_bits,
+                                                        full_blocks,
+                                                        ordered_bid);
+    };
+
+    return execute_launch_plan<Config, decltype(kernel), radix_sort_onesweep_sort_config_selector>(
+        arch,
+        kernel,
+        grid,
+        block,
+        shmem,
+        stream);
 }
 
 template<class Config,
@@ -247,7 +296,8 @@ template<class Config,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Offset,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 hipError_t radix_sort_onesweep_iteration(
     KeysInputIterator                                               keys_input,
     typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
@@ -264,6 +314,7 @@ hipError_t radix_sort_onesweep_iteration(
     Decomposer                                                      decomposer,
     const unsigned int                                              bit,
     const unsigned int                                              end_bit,
+    BlockIdWrapper                                                  ordered_bid,
     const hipStream_t                                               stream,
     const bool                                                      debug_synchronous)
 {
@@ -272,12 +323,9 @@ hipError_t radix_sort_onesweep_iteration(
     using config     = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
 
     detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const radix_sort_onesweep_config_params params = dispatch_target_arch<config>(target_arch);
+    ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+    const radix_sort_onesweep_config_params params
+        = dispatch_target_arch<config, false>(target_arch);
 
     const unsigned int items_per_block = params.sort.block_size * params.sort.items_per_thread;
     const unsigned int current_radix_bits
@@ -294,8 +342,8 @@ hipError_t radix_sort_onesweep_iteration(
 
     for(Offset batch = 0; batch < batches; ++batch)
     {
-        const Offset       offset             = batch * items_per_batch;
-        const Offset       items_left         = size - offset;
+        const Offset       offset     = batch * items_per_batch;
+        const Offset       items_left = size - offset;
         const unsigned int current_batch_size
             = static_cast<unsigned int>(::rocprim::min<Offset>(items_left, items_per_batch));
         const unsigned int blocks
@@ -305,12 +353,11 @@ hipError_t radix_sort_onesweep_iteration(
         const unsigned int num_lookback_states = radix_size_per_place * blocks;
 
         // Reset lookback scan states to zero, indicating empty prefix.
-        hipError_t error = hipMemsetAsync(lookback_states,
-                                          0,
-                                          sizeof(onesweep_lookback_state) * num_lookback_states,
-                                          stream);
-        if(error != hipSuccess)
-            return error;
+        ROCPRIM_RETURN_ON_ERROR(
+            hipMemsetAsync(lookback_states,
+                           0,
+                           sizeof(onesweep_lookback_state) * num_lookback_states,
+                           stream));
 
         std::chrono::steady_clock::time_point start;
         if(debug_synchronous)
@@ -330,87 +377,96 @@ hipError_t radix_sort_onesweep_iteration(
             start = std::chrono::steady_clock::now();
         }
 
+        ROCPRIM_RETURN_ON_ERROR(ordered_bid.reset_from_host(stream));
+
         if(from_input && to_output)
         {
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_iteration_kernel<config, Descending>),
-                               dim3(blocks),
-                               dim3(params.sort.block_size),
-                               0,
-                               stream,
-                               keys_input + offset,
-                               keys_output,
-                               values_input + offset,
-                               values_output,
-                               current_batch_size,
-                               global_digit_offsets_in,
-                               global_digit_offsets_out,
-                               lookback_states,
-                               decomposer,
-                               bit,
-                               current_radix_bits,
-                               full_blocks);
+            ROCPRIM_RETURN_ON_ERROR(
+                launch_onesweep_iteration<config, Descending>(target_arch,
+                                                              keys_input + offset,
+                                                              keys_output,
+                                                              values_input + offset,
+                                                              values_output,
+                                                              current_batch_size,
+                                                              global_digit_offsets_in,
+                                                              global_digit_offsets_out,
+                                                              lookback_states,
+                                                              decomposer,
+                                                              bit,
+                                                              current_radix_bits,
+                                                              full_blocks,
+                                                              ordered_bid,
+                                                              dim3(blocks),
+                                                              dim3(params.sort.block_size),
+                                                              0,
+                                                              stream));
         }
         else if(from_input)
         {
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_iteration_kernel<config, Descending>),
-                               dim3(blocks),
-                               dim3(params.sort.block_size),
-                               0,
-                               stream,
-                               keys_input + offset,
-                               keys_tmp,
-                               values_input + offset,
-                               values_tmp,
-                               current_batch_size,
-                               global_digit_offsets_in,
-                               global_digit_offsets_out,
-                               lookback_states,
-                               decomposer,
-                               bit,
-                               current_radix_bits,
-                               full_blocks);
+            ROCPRIM_RETURN_ON_ERROR(
+                launch_onesweep_iteration<config, Descending>(target_arch,
+                                                              keys_input + offset,
+                                                              keys_tmp,
+                                                              values_input + offset,
+                                                              values_tmp,
+                                                              current_batch_size,
+                                                              global_digit_offsets_in,
+                                                              global_digit_offsets_out,
+                                                              lookback_states,
+                                                              decomposer,
+                                                              bit,
+                                                              current_radix_bits,
+                                                              full_blocks,
+                                                              ordered_bid,
+                                                              dim3(blocks),
+                                                              dim3(params.sort.block_size),
+                                                              0,
+                                                              stream));
         }
         else if(to_output)
         {
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_iteration_kernel<config, Descending>),
-                               dim3(blocks),
-                               dim3(params.sort.block_size),
-                               0,
-                               stream,
-                               keys_tmp + offset,
-                               keys_output,
-                               values_tmp + offset,
-                               values_output,
-                               current_batch_size,
-                               global_digit_offsets_in,
-                               global_digit_offsets_out,
-                               lookback_states,
-                               decomposer,
-                               bit,
-                               current_radix_bits,
-                               full_blocks);
+            ROCPRIM_RETURN_ON_ERROR(
+                launch_onesweep_iteration<config, Descending>(target_arch,
+                                                              keys_tmp + offset,
+                                                              keys_output,
+                                                              values_tmp + offset,
+                                                              values_output,
+                                                              current_batch_size,
+                                                              global_digit_offsets_in,
+                                                              global_digit_offsets_out,
+                                                              lookback_states,
+                                                              decomposer,
+                                                              bit,
+                                                              current_radix_bits,
+                                                              full_blocks,
+                                                              ordered_bid,
+                                                              dim3(blocks),
+                                                              dim3(params.sort.block_size),
+                                                              0,
+                                                              stream));
         }
         else
         {
-            hipLaunchKernelGGL(HIP_KERNEL_NAME(onesweep_iteration_kernel<config, Descending>),
-                               dim3(blocks),
-                               dim3(params.sort.block_size),
-                               0,
-                               stream,
-                               keys_output + offset,
-                               keys_tmp,
-                               values_output + offset,
-                               values_tmp,
-                               current_batch_size,
-                               global_digit_offsets_in,
-                               global_digit_offsets_out,
-                               lookback_states,
-                               decomposer,
-                               bit,
-                               current_radix_bits,
-                               full_blocks);
+            ROCPRIM_RETURN_ON_ERROR(
+                launch_onesweep_iteration<config, Descending>(target_arch,
+                                                              keys_output + offset,
+                                                              keys_tmp,
+                                                              values_output + offset,
+                                                              values_tmp,
+                                                              current_batch_size,
+                                                              global_digit_offsets_in,
+                                                              global_digit_offsets_out,
+                                                              lookback_states,
+                                                              decomposer,
+                                                              bit,
+                                                              current_radix_bits,
+                                                              full_blocks,
+                                                              ordered_bid,
+                                                              dim3(blocks),
+                                                              dim3(params.sort.block_size),
+                                                              0,
+                                                              stream));
         }
-
         ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("onesweep_iteration", size, start);
 
         std::swap(global_digit_offsets_in, global_digit_offsets_out);
@@ -448,159 +504,169 @@ hipError_t radix_sort_onesweep_impl(
     using value_type  = typename std::iterator_traits<ValuesInputIterator>::value_type;
     using offset_type = offset_type_t<Size>;
 
-    using config = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const radix_sort_onesweep_config_params params = dispatch_target_arch<config>(target_arch);
-
-    const unsigned int sort_items_per_block = params.sort.block_size * params.sort.items_per_thread;
-    const unsigned int radix_size_per_place = 1u << params.radix_bits_per_place;
-    const unsigned int max_items_per_full_batch = 1u << 30;
-    const unsigned int items_per_full_batch
-        = max_items_per_full_batch - max_items_per_full_batch % sort_items_per_block;
-
-    const unsigned int places = ceiling_div(end_bit - begin_bit, params.radix_bits_per_place);
-    const unsigned int bins   = radix_size_per_place * places;
-    const unsigned int items_per_batch
-        = static_cast<unsigned int>(::rocprim::min<size_t>(size, items_per_full_batch));
-    const unsigned int num_lookback_states
-        = radix_size_per_place * ceiling_div(items_per_batch, sort_items_per_block);
-
-    constexpr bool with_values = !std::is_same<value_type, ::rocprim::empty_type>::value;
-
-    offset_type*             global_digit_offsets;
-    offset_type*             global_digit_offsets_tmp;
-    onesweep_lookback_state* lookback_states;
-    key_type*                keys_tmp_storage;
-    value_type*              values_tmp_storage;
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            detail::temp_storage::ptr_aligned_array(&global_digit_offsets, bins),
-            detail::temp_storage::ptr_aligned_array(&global_digit_offsets_tmp,
-                                                    radix_size_per_place),
-            detail::temp_storage::ptr_aligned_array(&lookback_states, num_lookback_states),
-            detail::temp_storage::ptr_aligned_array(&keys_tmp_storage,
-                                                    !no_allocate_tmp_buffer ? size : 0),
-            detail::temp_storage::ptr_aligned_array(&values_tmp_storage,
-                                                    !no_allocate_tmp_buffer && with_values ? size
-                                                                                           : 0)));
-
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return partition_result;
-    }
-
-    if(size == 0)
-        return hipSuccess;
-
-    if(debug_synchronous)
-    {
-        std::cout << "radix_size " << radix_size_per_place << '\n';
-        std::cout << "digit_places " << places << '\n';
-        std::cout << "histograms_size " << bins << '\n';
-        std::cout << "num_lookback_states " << num_lookback_states << '\n';
-        hipError_t error = hipStreamSynchronize(stream);
-        if(error != hipSuccess)
-            return error;
-    }
-
-    // Compute the global digit offset, for each digit and for each digit place.
-    {
-        hipError_t error
-            = radix_sort_onesweep_global_offsets<Config, Descending>(keys_input,
-                                                                     values_input,
-                                                                     global_digit_offsets,
-                                                                     static_cast<offset_type>(size),
-                                                                     places,
-                                                                     decomposer,
-                                                                     begin_bit,
-                                                                     end_bit,
-                                                                     stream,
-                                                                     debug_synchronous);
-        if(error != hipSuccess)
-            return error;
-    }
-
-    if(!no_allocate_tmp_buffer)
-    {
-        keys_tmp   = keys_tmp_storage;
-        values_tmp = values_tmp_storage;
-    }
-
-    // Copy input keys and values if necessary (in-place sorting: input and output iterators are equal).
-    bool to_output  = no_allocate_tmp_buffer || (places - 1) % 2 == 0;
-    bool from_input = true;
-    if(!no_allocate_tmp_buffer && to_output)
-    {
-        const bool keys_alias
-            = ::rocprim::detail::can_iterators_alias(keys_input, keys_output, size);
-        const bool values_alias
-            = with_values
-              && ::rocprim::detail::can_iterators_alias(values_input, values_output, size);
-        if(keys_alias || values_alias)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_atomic_block_id)
         {
-            hipError_t error = ::rocprim::transform(keys_input,
-                                                    keys_tmp,
-                                                    size,
-                                                    ::rocprim::identity<key_type>(),
-                                                    stream,
-                                                    debug_synchronous);
-            if(error != hipSuccess)
-                return error;
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
+            using config = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
 
-            if(with_values)
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+
+            const radix_sort_onesweep_config_params params
+                = dispatch_target_arch<config, false>(target_arch);
+
+            const unsigned int sort_items_per_block
+                = params.sort.block_size * params.sort.items_per_thread;
+            const unsigned int radix_size_per_place     = 1u << params.radix_bits_per_place;
+            const unsigned int max_items_per_full_batch = 1u << 30;
+            const unsigned int items_per_full_batch
+                = max_items_per_full_batch - (max_items_per_full_batch % sort_items_per_block);
+
+            const unsigned int places
+                = ceiling_div(end_bit - begin_bit, params.radix_bits_per_place);
+            const unsigned int bins = radix_size_per_place * places;
+            const unsigned int items_per_batch
+                = static_cast<unsigned int>(::rocprim::min<size_t>(size, items_per_full_batch));
+            const unsigned int num_lookback_states
+                = radix_size_per_place * ceiling_div(items_per_batch, sort_items_per_block);
+
+            constexpr bool with_values = !std::is_same<value_type, ::rocprim::empty_type>::value;
+
+            offset_type*                        global_digit_offsets;
+            offset_type*                        global_digit_offsets_tmp;
+            onesweep_lookback_state*            lookback_states;
+            key_type*                           keys_tmp_storage;
+            value_type*                         values_tmp_storage;
+            typename ordered_bid_type::id_type* ordered_bid_storage;
+
+            ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::ptr_aligned_array(&global_digit_offsets, bins),
+                    detail::temp_storage::ptr_aligned_array(&global_digit_offsets_tmp,
+                                                            radix_size_per_place),
+                    detail::temp_storage::ptr_aligned_array(&lookback_states, num_lookback_states),
+                    detail::temp_storage::ptr_aligned_array(&keys_tmp_storage,
+                                                            !no_allocate_tmp_buffer ? size : 0),
+                    detail::temp_storage::ptr_aligned_array(
+                        &values_tmp_storage,
+                        !no_allocate_tmp_buffer && with_values ? size : 0),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        ordered_bid_type::get_temp_storage_layout()))));
+
+            if(temporary_storage == nullptr || size == 0)
             {
-                hipError_t error = ::rocprim::transform(values_input,
-                                                        values_tmp,
-                                                        size,
-                                                        ::rocprim::identity<value_type>(),
-                                                        stream,
-                                                        debug_synchronous);
+                return hipSuccess;
+            }
+
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            if(debug_synchronous)
+            {
+                std::cout << "radix_size " << radix_size_per_place << '\n';
+                std::cout << "digit_places " << places << '\n';
+                std::cout << "histograms_size " << bins << '\n';
+                std::cout << "num_lookback_states " << num_lookback_states << '\n';
+                hipError_t error = hipStreamSynchronize(stream);
                 if(error != hipSuccess)
                     return error;
             }
 
-            from_input = false;
-        }
-    }
+            // Compute the global digit offset, for each digit and for each digit place.
+            {
+                ROCPRIM_RETURN_ON_ERROR(radix_sort_onesweep_global_offsets<Config, Descending>(
+                    keys_input,
+                    values_input,
+                    global_digit_offsets,
+                    static_cast<offset_type>(size),
+                    places,
+                    decomposer,
+                    begin_bit,
+                    end_bit,
+                    stream,
+                    debug_synchronous));
+            }
 
-    // Sort each digit place iteratively.
-    for(unsigned bit = begin_bit, place = 0; bit < end_bit;
-        bit += params.radix_bits_per_place, ++place)
-    {
-        hipError_t error = radix_sort_onesweep_iteration<Config, Descending>(
-            keys_input,
-            keys_tmp,
-            keys_output,
-            values_input,
-            values_tmp,
-            values_output,
-            static_cast<offset_type>(size),
-            global_digit_offsets + place * radix_size_per_place,
-            global_digit_offsets_tmp,
-            lookback_states,
-            from_input,
-            to_output,
-            decomposer,
-            bit,
-            end_bit,
-            stream,
-            debug_synchronous);
-        if(error != hipSuccess)
-            return error;
+            if(!no_allocate_tmp_buffer)
+            {
+                keys_tmp   = keys_tmp_storage;
+                values_tmp = values_tmp_storage;
+            }
 
-        is_result_in_output = to_output;
-        from_input          = false;
-        to_output           = !to_output;
-    }
+            // Copy input keys and values if necessary (in-place sorting: input and output iterators are equal).
+            bool to_output  = no_allocate_tmp_buffer || (places - 1) % 2 == 0;
+            bool from_input = true;
+            if(!no_allocate_tmp_buffer && to_output)
+            {
+                const bool keys_alias
+                    = ::rocprim::detail::can_iterators_alias(keys_input, keys_output, size);
+                const bool values_alias
+                    = with_values
+                      && ::rocprim::detail::can_iterators_alias(values_input, values_output, size);
+                if(keys_alias || values_alias)
+                {
+                    ROCPRIM_RETURN_ON_ERROR(::rocprim::transform(keys_input,
+                                                                 keys_tmp,
+                                                                 size,
+                                                                 ::rocprim::identity<key_type>(),
+                                                                 stream,
+                                                                 debug_synchronous));
+
+                    if(with_values)
+                    {
+                        ROCPRIM_RETURN_ON_ERROR(
+                            ::rocprim::transform(values_input,
+                                                 values_tmp,
+                                                 size,
+                                                 ::rocprim::identity<value_type>(),
+                                                 stream,
+                                                 debug_synchronous));
+                    }
+
+                    from_input = false;
+                }
+            }
+
+            // Sort each digit place iteratively.
+            for(unsigned bit = begin_bit, place = 0; bit < end_bit;
+                bit += params.radix_bits_per_place, ++place)
+            {
+                ROCPRIM_RETURN_ON_ERROR(radix_sort_onesweep_iteration<Config, Descending>(
+                    keys_input,
+                    keys_tmp,
+                    keys_output,
+                    values_input,
+                    values_tmp,
+                    values_output,
+                    static_cast<offset_type>(size),
+                    global_digit_offsets + place * radix_size_per_place,
+                    global_digit_offsets_tmp,
+                    lookback_states,
+                    from_input,
+                    to_output,
+                    decomposer,
+                    bit,
+                    end_bit,
+                    ordered_bid,
+                    stream,
+                    debug_synchronous));
+
+                is_result_in_output = to_output;
+                from_input          = false;
+                to_output           = !to_output;
+            }
+            return hipSuccess;
+        },
+        use_atomic_block_id_variant));
 
     return hipSuccess;
 }
@@ -666,7 +732,10 @@ hipError_t
     using block_sort_config = typename std::conditional<use_default_small_block_sort,
                                                         default_block_sort_config,
                                                         typename Config::single_sort_config>::type;
-
+    bool using_spirv        = false;
+#if defined(ROCPRIM_TARGET_SPIRV)
+    using_spirv = true;
+#endif
     if(::rocprim::is_floating_point<key_type>::value
        && ((begin_bit != 0) || (end_bit != sizeof(key_type) * 8)))
     {
@@ -674,7 +743,7 @@ hipError_t
     }
     unsigned int single_sort_items_per_block
         = block_sort_config::block_size * block_sort_config::items_per_thread;
-    if(size <= single_sort_items_per_block)
+    if(size <= static_cast<decltype(size)>(single_sort_items_per_block))
     {
         if(temporary_storage == nullptr)
         {
@@ -703,8 +772,8 @@ hipError_t
     }
     // For sizeof(key_type) <= 2, onesweep is 2x/3x faster (also with values) when
     // input_size > 100K, so don't use radix_sort_merge_sort then.
-    else if(static_cast<size_t>(size) <= merge_sort_limit
-            && (sizeof(key_type) > 2 || size < 100000))
+    else if(static_cast<size_t>(size) <= merge_sort_limit && (sizeof(key_type) > 2 || size < 100000)
+            && !using_spirv)
     {
         is_result_in_output = true;
         // note: Config::merge_sort_config may be default_config
@@ -747,8 +816,6 @@ hipError_t
                                                                      debug_synchronous);
     }
 }
-
-
 
 } // end namespace detail
 
@@ -850,8 +917,8 @@ hipError_t radix_sort_keys(void*              temporary_storage,
                            bool               debug_synchronous = false)
 {
     static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
-    empty_type * values = nullptr;
-    bool ignored;
+    empty_type* values = nullptr;
+    bool        ignored;
     return detail::radix_sort_impl<Config, false>(temporary_storage,
                                                   storage_size,
                                                   keys_input,
@@ -967,9 +1034,9 @@ hipError_t radix_sort_keys(void*               temporary_storage,
                            bool                debug_synchronous = false)
 {
     static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
-    empty_type * values = nullptr;
-    bool         is_result_in_output;
-    hipError_t   error = detail::radix_sort_impl<Config, false>(temporary_storage,
+    empty_type* values = nullptr;
+    bool        is_result_in_output;
+    hipError_t  error = detail::radix_sort_impl<Config, false>(temporary_storage,
                                                               storage_size,
                                                               keys.current(),
                                                               keys.current(),

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -38,6 +38,7 @@
 #include "../intrinsics/thread.hpp"
 #include "../iterator/constant_iterator.hpp"
 #include "../type_traits.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 
 #include <chrono>
 #include <iostream>
@@ -51,15 +52,18 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<typename LookBackScanState, typename AccumulatorType>
+template<typename LookBackScanState, typename AccumulatorType, typename BlockIdWrapper>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
     reduce_by_key_init_kernel(LookBackScanState      lookback_scan_state,
                               const unsigned int     number_of_blocks,
                               const bool             is_first_launch,
                               const unsigned int     block_save_idx,
                               std::size_t* const     global_head_count,
-                              AccumulatorType* const previous_accumulated)
+                              AccumulatorType* const previous_accumulated,
+                              BlockIdWrapper         ordered_bid)
 {
+    // 'ordered_bid' gets reset by 'init_lookback_scan_state'.
+
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();
     const unsigned int block_thread_id = ::rocprim::detail::block_thread_id<0>();
@@ -89,11 +93,11 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
                                       update_func);
     }
 
-    init_lookback_scan_state(lookback_scan_state, number_of_blocks, flat_thread_id);
+    init_lookback_scan_state(lookback_scan_state, number_of_blocks, ordered_bid, flat_thread_id);
 }
 
-template<lookback_scan_determinism Determinism,
-         typename Config,
+template<typename Config,
+         lookback_scan_determinism Determinism,
          typename AccumulatorType,
          typename KeyIterator,
          typename ValueIterator,
@@ -102,35 +106,47 @@ template<lookback_scan_determinism Determinism,
          typename UniqueCountIterator,
          typename CompareFunction,
          typename BinaryOp,
-         typename LookbackScanState>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    reduce_by_key_kernel(const KeyIterator            keys_input,
-                         const ValueIterator          values_input,
-                         const UniqueIterator         unique_keys,
-                         const ReductionIterator      reductions,
-                         const UniqueCountIterator    unique_count,
-                         const BinaryOp               reduce_op,
-                         const CompareFunction        compare,
-                         const LookbackScanState      scan_state,
-                         const std::size_t            starting_block,
-                         const std::size_t            total_number_of_blocks,
-                         const std::size_t            size,
-                         const std::size_t* const     global_head_count,
-                         const AccumulatorType* const previous_accumulated)
+         typename LookbackScanState,
+         typename BlockIdWrapper>
+inline hipError_t launch_reduce_by_key(detail::target_arch          arch,
+                                       const KeyIterator            keys_input,
+                                       const ValueIterator          values_input,
+                                       const UniqueIterator         unique_keys,
+                                       const ReductionIterator      reductions,
+                                       const UniqueCountIterator    unique_count,
+                                       const BinaryOp               reduce_op,
+                                       const CompareFunction        compare,
+                                       const LookbackScanState      scan_state,
+                                       const std::size_t            starting_block,
+                                       const std::size_t            total_number_of_blocks,
+                                       const std::size_t            size,
+                                       const std::size_t* const     global_head_count,
+                                       const AccumulatorType* const previous_accumulated,
+                                       BlockIdWrapper               ordered_bid,
+                                       dim3                         grid,
+                                       dim3                         block,
+                                       size_t                       shmem,
+                                       hipStream_t                  stream)
 {
-    reduce_by_key::kernel_impl<Determinism, Config>(keys_input,
-                                                    values_input,
-                                                    unique_keys,
-                                                    reductions,
-                                                    unique_count,
-                                                    reduce_op,
-                                                    compare,
-                                                    scan_state,
-                                                    starting_block,
-                                                    total_number_of_blocks,
-                                                    size,
-                                                    global_head_count,
-                                                    previous_accumulated);
+    auto kernel = [=](auto arch_config)
+    {
+        reduce_by_key::kernel_impl<decltype(arch_config), Determinism>(keys_input,
+                                                                       values_input,
+                                                                       unique_keys,
+                                                                       reductions,
+                                                                       unique_count,
+                                                                       reduce_op,
+                                                                       compare,
+                                                                       scan_state,
+                                                                       starting_block,
+                                                                       total_number_of_blocks,
+                                                                       size,
+                                                                       global_head_count,
+                                                                       previous_accumulated,
+                                                                       ordered_bid);
+    };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<lookback_scan_determinism Determinism,
@@ -156,177 +172,166 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
                                              const bool                debug_synchronous)
 {
     using accumulator_type = reduce_by_key::accumulator_type_t<ValuesInputIterator, BinaryFunction>;
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const reduce_by_key_config_params params = dispatch_target_arch<config>(target_arch);
 
-    using scan_state_type
-        = reduce_by_key::lookback_scan_state_t<accumulator_type, /*UseSleep=*/false>;
-    using scan_state_with_sleep_type
-        = reduce_by_key::lookback_scan_state_t<accumulator_type, /*UseSleep=*/true>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    const unsigned int block_size      = params.kernel_config.block_size;
-    const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
+    const auto use_sleepy_scan_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(use_sleepy_scan);
 
-    const size_t size_limit = params.kernel_config.size_limit;
-    const size_t aligned_size_limit
-        = ::rocprim::max<size_t>(size_limit - size_limit % items_per_block, items_per_block);
-
-    const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
-    const bool   use_limited_size = limited_size == aligned_size_limit;
-
-    // Number of blocks in a single launch (or the only launch if it fits)
-    const std::size_t number_of_blocks = detail::ceiling_div(limited_size, items_per_block);
-
-    // Calculate required temporary storage
-    void* scan_state_storage;
-    // The number of segment heads in previous launches.
-    std::size_t* d_global_head_count = nullptr;
-    // The running accumulation across the launch boundary.
-    accumulator_type* d_previous_accumulated = nullptr;
-
-    detail::temp_storage::layout layout{};
-    result = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&d_global_head_count, use_limited_size ? 1 : 0),
-            detail::temp_storage::ptr_aligned_array(&d_previous_accumulated,
-                                                    use_limited_size ? 1 : 0)));
-    if(result != hipSuccess || temporary_storage == nullptr)
-    {
-        return result;
-    }
-
-    bool use_sleep;
-    result = detail::is_sleep_scan_state_used(stream, use_sleep);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    scan_state_type scan_state{};
-    result = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    scan_state_with_sleep_type scan_state_with_sleep{};
-    result = scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                scan_state_storage,
-                                                number_of_blocks,
-                                                stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    auto with_scan_state
-        = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(scan_state_with_sleep);
-        }
-        else
-        {
-            return func(scan_state);
-        }
-    };
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+            const reduce_by_key_config_params params
+                = dispatch_target_arch<config, false>(target_arch);
 
-    if(size == 0)
-    {
-        // Fill out unique_count_output with zero
-        return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
-                                  unique_count_output,
-                                  1,
-                                  rocprim::identity<std::size_t>{},
-                                  stream,
-                                  debug_synchronous);
-    }
+            using scan_state_type
+                = reduce_by_key::lookback_scan_state_t<accumulator_type, use_sleepy_scan>;
+            const unsigned int block_size      = params.kernel_config.block_size;
+            const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
 
-    // Total number of blocks in all launches
-    const std::size_t total_number_of_blocks = ceiling_div(size, items_per_block);
-    const std::size_t number_of_launch       = ceiling_div(size, limited_size);
+            const size_t size_limit         = params.kernel_config.size_limit;
+            const size_t aligned_size_limit = ::rocprim::max<size_t>(
+                size_limit - (size_limit % static_cast<std::size_t>(items_per_block)),
+                items_per_block);
 
-    if(debug_synchronous)
-    {
-        std::cout << "size:               " << size << '\n';
-        std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
-        std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
-        std::cout << "number_of_launch:   " << number_of_launch << '\n';
-        std::cout << "block_size:         " << block_size << '\n';
-        std::cout << "number_of_blocks:   " << number_of_blocks << '\n';
-        std::cout << "items_per_block:    " << items_per_block << '\n';
-    }
+            const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
+            const bool   use_limited_size = limited_size == aligned_size_limit;
 
-    for(size_t i = 0, offset = 0; i < number_of_launch; ++i, offset += limited_size)
-    {
-        const std::size_t current_size = std::min<std::size_t>(size - offset, limited_size);
-        const std::size_t number_of_blocks_launch = ceiling_div(current_size, items_per_block);
+            // Number of blocks in a single launch (or the only launch if it fits)
+            const std::size_t number_of_blocks = detail::ceiling_div(limited_size, items_per_block);
 
-        // Start point for time measurements
-        std::chrono::steady_clock::time_point start;
-        if(debug_synchronous)
-        {
-            std::cout << "index:            " << i << '\n';
-            std::cout << "current_size:     " << current_size << '\n';
-            std::cout << "number of blocks: " << number_of_blocks_launch << '\n';
+            // Calculate required temporary storage
+            void* scan_state_storage;
+            // The number of segment heads in previous launches.
+            std::size_t* d_global_head_count = nullptr;
+            // The running accumulation across the launch boundary.
+            accumulator_type* d_previous_accumulated = nullptr;
 
-            start = std::chrono::steady_clock::now();
-        }
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
 
-        with_scan_state(
-            [&](const auto scan_state)
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
+            typename ordered_bid_type::id_type* ordered_bid_storage;
+
+            auto result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::ptr_aligned_array(&d_global_head_count,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::ptr_aligned_array(&d_previous_accumulated,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        ordered_bid_type::get_temp_storage_layout())));
+            if(result != hipSuccess || temporary_storage == nullptr)
             {
-                const unsigned int block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
-                const std::size_t  grid_size
-                    = detail::ceiling_div(number_of_blocks_launch, block_size);
+                return result;
+            }
 
-                reduce_by_key_init_kernel<<<dim3(grid_size), dim3(block_size), 0, stream>>>(
+            scan_state_type scan_state{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream));
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            if(size == 0)
+            {
+                // Fill out unique_count_output with zero
+                return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
+                                          unique_count_output,
+                                          1,
+                                          rocprim::identity<std::size_t>{},
+                                          stream,
+                                          debug_synchronous);
+            }
+
+            // Total number of blocks in all launches
+            const std::size_t total_number_of_blocks = ceiling_div(size, items_per_block);
+            const std::size_t number_of_launch       = ceiling_div(size, limited_size);
+
+            if(debug_synchronous)
+            {
+                std::cout << "size:               " << size << '\n';
+                std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
+                std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
+                std::cout << "number_of_launch:   " << number_of_launch << '\n';
+                std::cout << "block_size:         " << block_size << '\n';
+                std::cout << "number_of_blocks:   " << number_of_blocks << '\n';
+                std::cout << "items_per_block:    " << items_per_block << '\n';
+            }
+
+            for(size_t i = 0, offset = 0; i < number_of_launch; ++i, offset += limited_size)
+            {
+                const std::size_t current_size = std::min<std::size_t>(size - offset, limited_size);
+                const std::size_t number_of_blocks_launch
+                    = ceiling_div(current_size, items_per_block);
+
+                // Start point for time measurements
+                std::chrono::steady_clock::time_point start;
+                if(debug_synchronous)
+                {
+                    std::cout << "index:            " << i << '\n';
+                    std::cout << "current_size:     " << current_size << '\n';
+                    std::cout << "number of blocks: " << number_of_blocks_launch << '\n';
+
+                    start = std::chrono::steady_clock::now();
+                }
+
+                // Define block and grid sizes for init kernel.
+                const size_t init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
+                const size_t init_grid_size
+                    = detail::ceiling_div(number_of_blocks_launch, init_block_size);
+                reduce_by_key_init_kernel<<<init_grid_size, init_block_size, 0, stream>>>(
                     scan_state,
                     number_of_blocks_launch,
                     i == 0,
                     number_of_blocks - 1,
                     d_global_head_count,
-                    d_previous_accumulated);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_init_kernel",
-                                                    number_of_blocks_launch,
-                                                    start);
+                    d_previous_accumulated,
+                    ordered_bid);
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_init_kernel",
+                                                            number_of_blocks_launch,
+                                                            start);
 
-        with_scan_state(
-            [&](const auto scan_state)
-            {
-                reduce_by_key_kernel<Determinism, config>
-                    <<<dim3(number_of_blocks_launch), dim3(block_size), 0, stream>>>(
-                        keys_input + offset,
-                        values_input + offset,
-                        unique_output,
-                        aggregates_output,
-                        unique_count_output,
-                        reduce_op,
-                        key_compare_op,
-                        scan_state,
-                        i * number_of_blocks,
-                        total_number_of_blocks,
-                        size,
-                        i > 0 ? d_global_head_count : nullptr,
-                        i > 0 ? d_previous_accumulated : nullptr);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_kernel", current_size, start);
-    }
+                ROCPRIM_RETURN_ON_ERROR(launch_reduce_by_key<config, Determinism>(
+                    target_arch,
+                    keys_input + offset,
+                    values_input + offset,
+                    unique_output,
+                    aggregates_output,
+                    unique_count_output,
+                    reduce_op,
+                    key_compare_op,
+                    scan_state,
+                    i * number_of_blocks,
+                    total_number_of_blocks,
+                    size,
+                    i > 0 ? d_global_head_count : nullptr,
+                    i > 0 ? d_previous_accumulated : nullptr,
+                    ordered_bid,
+                    dim3(number_of_blocks_launch),
+                    dim3(block_size),
+                    0,
+                    stream));
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_kernel",
+                                                            current_size,
+                                                            start);
+            }
+            return hipSuccess;
+        },
+        use_sleepy_scan_variant,
+        use_atomic_block_id_variant));
 
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <iterator>
 #include <type_traits>
+#include <variant>
 
 #include "../common.hpp"
 #include "../config.hpp"
@@ -37,6 +38,7 @@
 #include "detail/device_scan_common.hpp"
 #include "device_scan_config.hpp"
 #include "device_transform.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -47,9 +49,9 @@ namespace detail
 {
 
 // Single kernel scan (performs scan on one thread block only)
-template<bool Exclusive,
+template<class ArchConfig,
+         bool Exclusive,
          bool UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
@@ -60,7 +62,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void single_scan_kernel_impl(InputIterator  
                                                                  OutputIterator output,
                                                                  BinaryFunction scan_op)
 {
-    static constexpr scan_config_params params = device_params<Config>();
+    static constexpr scan_config_params params = ArchConfig::params;
 
     constexpr unsigned int block_size       = params.kernel_config.block_size;
     constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
@@ -94,66 +96,86 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void single_scan_kernel_impl(InputIterator  
     block_store_type().store(output, values, input_size, storage.store);
 }
 
-template<bool Exclusive,
+template<class Config,
+         bool Exclusive,
          bool UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
          class InitValueType,
          class AccType>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    single_scan_kernel(InputIterator       input,
-                       const size_t        size,
-                       const InitValueType initial_value,
-                       OutputIterator      output,
-                       BinaryFunction      scan_op)
+inline hipError_t launch_single_scan(detail::target_arch arch,
+                                     InputIterator       input,
+                                     const size_t        size,
+                                     const InitValueType initial_value,
+                                     OutputIterator      output,
+                                     BinaryFunction      scan_op,
+                                     dim3                grid,
+                                     dim3                block,
+                                     size_t              shmem,
+                                     hipStream_t         stream)
 {
-    single_scan_kernel_impl<Exclusive, UseInitialValue, Config>(
-        input,
-        size,
-        static_cast<AccType>(get_input_value(initial_value)),
-        output,
-        scan_op);
+    auto kernel = [=](auto arch_config)
+    {
+        single_scan_kernel_impl<decltype(arch_config), Exclusive, UseInitialValue>(
+            input,
+            size,
+            static_cast<AccType>(get_input_value(initial_value)),
+            output,
+            scan_op);
+    };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 // Single pass (look-back kernels)
-
-template<lookback_scan_determinism Determinism,
+template<class Config,
+         lookback_scan_determinism Determinism,
          bool                      Exclusive,
          bool                      UseInitialValue,
-         class Config,
          class InputIterator,
          class OutputIterator,
          class BinaryFunction,
          class InitValueType,
          class AccType,
-         class LookBackScanState>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    lookback_scan_kernel(InputIterator      input,
-                         OutputIterator     output,
-                         const size_t       size,
-                         InitValueType      initial_value,
-                         BinaryFunction     scan_op,
-                         LookBackScanState  lookback_scan_state,
-                         const unsigned int number_of_blocks,
-                         AccType*           previous_last_element = nullptr,
-                         AccType*           new_last_element      = nullptr,
-                         bool               override_first_value  = false,
-                         bool               save_last_value       = false)
+         class LookBackScanState,
+         class BlockIdWrapper>
+inline hipError_t launch_lookback_scan(detail::target_arch arch,
+                                       InputIterator       input,
+                                       OutputIterator      output,
+                                       const size_t        size,
+                                       InitValueType       initial_value,
+                                       BinaryFunction      scan_op,
+                                       LookBackScanState   lookback_scan_state,
+                                       const unsigned int  number_of_blocks,
+                                       dim3                grid,
+                                       dim3                block,
+                                       size_t              shmem,
+                                       hipStream_t         stream,
+                                       AccType*            previous_last_element,
+                                       AccType*            new_last_element,
+                                       bool                override_first_value,
+                                       bool                save_last_value,
+                                       BlockIdWrapper      ordered_bid)
 {
-    lookback_scan_kernel_impl<Determinism, Exclusive, UseInitialValue, Config>(
-        input,
-        output,
-        size,
-        static_cast<AccType>(get_input_value(initial_value)),
-        scan_op,
-        lookback_scan_state,
-        number_of_blocks,
-        previous_last_element,
-        new_last_element,
-        override_first_value,
-        save_last_value);
+    auto kernel = [=](auto arch_config)
+    {
+        lookback_scan_kernel_impl<decltype(arch_config), Determinism, Exclusive, UseInitialValue>(
+            input,
+            output,
+            size,
+            static_cast<AccType>(get_input_value(initial_value)),
+            scan_op,
+            lookback_scan_state,
+            number_of_blocks,
+            previous_last_element,
+            new_last_element,
+            override_first_value,
+            save_last_value,
+            ordered_bid);
+    };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
 template<lookback_scan_determinism Determinism,
@@ -175,213 +197,210 @@ inline auto scan_impl(void*               temporary_storage,
                       const hipStream_t   stream,
                       bool                debug_synchronous)
 {
-    using config = wrapped_scan_config<Config, AccType>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const scan_config_params params = dispatch_target_arch<config>(target_arch);
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
+    const auto use_sleepy_scan_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(use_sleepy_scan);
 
-    using scan_state_type            = detail::lookback_scan_state<AccType>;
-    using scan_state_with_sleep_type = detail::lookback_scan_state<AccType, true>;
-
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const auto         items_per_block  = block_size * items_per_thread;
-
-    const size_t size_limit = params.kernel_config.size_limit;
-    const size_t aligned_size_limit
-        = ::rocprim::max<size_t>(size_limit - size_limit % items_per_block, items_per_block);
-    size_t     limited_size     = std::min<size_t>(size, aligned_size_limit);
-    const bool use_limited_size = limited_size == aligned_size_limit;
-
-    unsigned int number_of_blocks = (limited_size + items_per_block - 1) / items_per_block;
-
-    // Pointer to array with block_prefixes
-    void*    scan_state_storage;
-    AccType* previous_last_element;
-    AccType* new_last_element;
-
-    detail::temp_storage::layout layout{};
-    hipError_t                   layout_result
-        = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(layout_result != hipSuccess)
-    {
-        return layout_result;
-    }
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with offset_scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&previous_last_element,
-                                                    use_limited_size ? 1 : 0),
-            detail::temp_storage::ptr_aligned_array(&new_last_element, use_limited_size ? 1 : 0)));
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return partition_result;
-    }
-
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-
-    if(number_of_blocks == 0u)
-        return hipSuccess;
-
-    if(number_of_blocks > 1 || use_limited_size)
-    {
-        bool use_sleep;
-        if(const hipError_t error = is_sleep_scan_state_used(stream, use_sleep))
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return error;
-        }
+            using scan_state_type = detail::lookback_scan_state<AccType, use_sleepy_scan>;
+            using block_id_type   = detail::block_id_wrapper<unsigned int, use_atomic_block_id>;
+            scan_state_type scan_state;
+            block_id_type   block_id;
 
-        // Create and initialize lookback_scan_state obj
-        scan_state_type scan_state{};
-        hipError_t      result
-            = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
-        scan_state_with_sleep_type scan_state_with_sleep{};
-        result = scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                    scan_state_storage,
-                                                    number_of_blocks,
-                                                    stream);
-        if(result != hipSuccess)
-        {
-            return result;
-        }
+            using config = wrapped_scan_config<Config, AccType>;
 
-        // Call the provided function with either scan_state or scan_state_with_sleep based on
-        // the value of use_sleep
-        auto with_scan_state
-            = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-        {
-            if(use_sleep)
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+
+            const auto         params           = dispatch_target_arch<config, false>(target_arch);
+            const unsigned int block_size       = params.kernel_config.block_size;
+            const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+            const unsigned int items_per_block  = block_size * items_per_thread;
+
+            const size_t size_limit         = params.kernel_config.size_limit;
+            const size_t aligned_size_limit = ::rocprim::max<size_t>(
+                size_limit - (size_limit % static_cast<size_t>(items_per_block)),
+                items_per_block);
+            size_t     limited_size     = std::min<size_t>(size, aligned_size_limit);
+            const bool use_limited_size = limited_size == aligned_size_limit;
+
+            unsigned int number_of_blocks = (limited_size + items_per_block - 1) / items_per_block;
+
+            // Pointer to array with block_prefixes
+            void*    scan_state_storage;
+            AccType* previous_last_element;
+            AccType* new_last_element;
+
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
+
+            void* block_id_storage;
+
+            ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with offset_scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::ptr_aligned_array(&previous_last_element,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::ptr_aligned_array(&new_last_element,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::make_partition(
+                        &block_id_storage,
+                        block_id_type::get_temp_storage_layout()))));
+
+            if(temporary_storage == nullptr || number_of_blocks == 0u)
             {
-                return func(scan_state_with_sleep);
-            }
-            else
-            {
-                return func(scan_state);
-            }
-        };
-
-        if(debug_synchronous)
-            start = std::chrono::steady_clock::now();
-
-        size_t number_of_launch = (size + limited_size - 1) / limited_size;
-        for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
-        {
-            size_t current_size = std::min<size_t>(size - offset, limited_size);
-            number_of_blocks    = (current_size + items_per_block - 1) / items_per_block;
-            auto grid_size      = (number_of_blocks + block_size - 1) / block_size;
-
-            if(debug_synchronous)
-            {
-                std::cout << "use_limited_size " << use_limited_size << '\n';
-                std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
-                std::cout << "number_of_launch " << number_of_launch << '\n';
-                std::cout << "index " << i << '\n';
-                std::cout << "size " << current_size << '\n';
-                std::cout << "block_size " << block_size << '\n';
-                std::cout << "number of blocks " << number_of_blocks << '\n';
-                std::cout << "items_per_block " << items_per_block << '\n';
+                return hipSuccess;
             }
 
-            with_scan_state(
-                [&](const auto scan_state)
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+
+            if(number_of_blocks > 1 || use_limited_size)
+            {
+                // Create and initialize lookback_scan_state obj
+                ROCPRIM_RETURN_ON_ERROR(
+                    scan_state.create(scan_state, scan_state_storage, number_of_blocks, stream));
+                block_id = block_id.create(block_id_storage);
+                if(debug_synchronous)
                 {
+                    start = std::chrono::steady_clock::now();
+                }
+
+                const size_t number_of_launch = (size + limited_size - 1) / limited_size;
+                for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
+                {
+                    size_t current_size = std::min<size_t>(size - offset, limited_size);
+                    number_of_blocks    = (current_size + items_per_block - 1) / items_per_block;
+                    auto grid_size      = (number_of_blocks + block_size - 1) / block_size;
+
+                    if(debug_synchronous)
+                    {
+                        std::cout << "use_limited_size " << use_limited_size << '\n';
+                        std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
+                        std::cout << "number_of_launch " << number_of_launch << '\n';
+                        std::cout << "index " << i << '\n';
+                        std::cout << "size " << current_size << '\n';
+                        std::cout << "block_size " << block_size << '\n';
+                        std::cout << "number of blocks " << number_of_blocks << '\n';
+                        std::cout << "items_per_block " << items_per_block << '\n';
+                    }
+
                     init_lookback_scan_state_kernel<<<dim3(grid_size),
                                                       dim3(block_size),
                                                       0,
-                                                      stream>>>(scan_state, number_of_blocks);
-                });
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                        number_of_blocks,
-                                                        start);
+                                                      stream>>>(scan_state,
+                                                                number_of_blocks,
+                                                                block_id);
+                    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
+                                                                number_of_blocks,
+                                                                start);
 
-            if(debug_synchronous)
-                start = std::chrono::steady_clock::now();
-            grid_size = number_of_blocks;
+                    if(debug_synchronous)
+                    {
+                        start = std::chrono::steady_clock::now();
+                    }
+                    grid_size = number_of_blocks;
 
-            if(debug_synchronous)
-            {
-                std::cout << "use_limited_size " << use_limited_size << '\n';
-                std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
-                std::cout << "size " << current_size << '\n';
-                std::cout << "block_size " << block_size << '\n';
-                std::cout << "number of blocks " << number_of_blocks << '\n';
-                std::cout << "items_per_block " << items_per_block << '\n';
+                    if(debug_synchronous)
+                    {
+                        std::cout << "use_limited_size " << use_limited_size << '\n';
+                        std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
+                        std::cout << "size " << current_size << '\n';
+                        std::cout << "block_size " << block_size << '\n';
+                        std::cout << "number of blocks " << number_of_blocks << '\n';
+                        std::cout << "items_per_block " << items_per_block << '\n';
+                    }
+
+                    ROCPRIM_RETURN_ON_ERROR(launch_lookback_scan<config,
+                                                                 Determinism,
+                                                                 Exclusive,
+                                                                 UseInitialValue,
+                                                                 InputIterator,
+                                                                 OutputIterator,
+                                                                 BinaryFunction,
+                                                                 InitValueType,
+                                                                 AccType>(target_arch,
+                                                                          input + offset,
+                                                                          output + offset,
+                                                                          current_size,
+                                                                          initial_value,
+                                                                          scan_op,
+                                                                          scan_state,
+                                                                          number_of_blocks,
+                                                                          dim3(grid_size),
+                                                                          dim3(block_size),
+                                                                          0,
+                                                                          stream,
+                                                                          previous_last_element,
+                                                                          new_last_element,
+                                                                          i != size_t(0),
+                                                                          number_of_launch > 1,
+                                                                          block_id));
+                    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("lookback_scan_kernel",
+                                                                current_size,
+                                                                start);
+
+                    // Swap the last_elements
+                    if(number_of_launch > 1)
+                    {
+                        ROCPRIM_RETURN_ON_ERROR(::rocprim::transform(new_last_element,
+                                                                     previous_last_element,
+                                                                     1,
+                                                                     ::rocprim::identity<AccType>(),
+                                                                     stream,
+                                                                     debug_synchronous));
+                    }
+                }
             }
-
-            with_scan_state(
-                [&](const auto scan_state)
+            else
+            {
+                if(debug_synchronous)
                 {
-                    lookback_scan_kernel<Determinism,
-                                         Exclusive,
-                                         UseInitialValue,
-                                         config,
-                                         InputIterator,
-                                         OutputIterator,
-                                         BinaryFunction,
-                                         InitValueType,
-                                         AccType>
-                        <<<dim3(grid_size), dim3(block_size), 0, stream>>>(input + offset,
-                                                                           output + offset,
-                                                                           current_size,
-                                                                           initial_value,
-                                                                           scan_op,
-                                                                           scan_state,
-                                                                           number_of_blocks,
-                                                                           previous_last_element,
-                                                                           new_last_element,
-                                                                           i != size_t(0),
-                                                                           number_of_launch > 1);
-                });
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("lookback_scan_kernel",
-                                                        current_size,
-                                                        start);
+                    std::cout << "size " << size << '\n';
+                    std::cout << "block_size " << block_size << '\n';
+                    std::cout << "number of blocks " << number_of_blocks << '\n';
+                    std::cout << "items_per_block " << items_per_block << '\n';
+                    start = std::chrono::steady_clock::now();
+                }
 
-            // Swap the last_elements
-            if(number_of_launch > 1)
-            {
-                hipError_t error = ::rocprim::transform(new_last_element,
-                                                        previous_last_element,
-                                                        1,
-                                                        ::rocprim::identity<AccType>(),
-                                                        stream,
-                                                        debug_synchronous);
-                if(error != hipSuccess)
-                    return error;
+                ROCPRIM_RETURN_ON_ERROR(
+                    launch_single_scan<config,
+                                       Exclusive, // flag for exclusive scan operation
+                                       UseInitialValue,
+                                       InputIterator,
+                                       OutputIterator,
+                                       BinaryFunction,
+                                       InitValueType,
+                                       AccType>(target_arch,
+                                                input,
+                                                size,
+                                                initial_value,
+                                                output,
+                                                scan_op,
+                                                dim3(1),
+                                                dim3(block_size),
+                                                0,
+                                                stream));
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("single_scan_kernel", size, start);
             }
-        }
-    }
-    else
-    {
-        if(debug_synchronous)
-        {
-            std::cout << "size " << size << '\n';
-            std::cout << "block_size " << block_size << '\n';
-            std::cout << "number of blocks " << number_of_blocks << '\n';
-            std::cout << "items_per_block " << items_per_block << '\n';
-            start = std::chrono::steady_clock::now();
-        }
+            return hipSuccess;
+        },
+        use_sleepy_scan_variant,
+        use_atomic_block_id_variant));
 
-        single_scan_kernel<Exclusive, // flag for exclusive scan operation
-                           UseInitialValue,
-                           config,
-                           InputIterator,
-                           OutputIterator,
-                           BinaryFunction,
-                           InitValueType,
-                           AccType>
-            <<<dim3(1), dim3(block_size), 0, stream>>>(input, size, initial_value, output, scan_op);
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("single_scan_kernel", size, start);
-    }
     return hipSuccess;
 }
 
@@ -520,7 +539,8 @@ inline hipError_t inclusive_scan(void*             temporary_storage,
 {
     // AccType may be const or a reference. Get the non-const, non-reference type.
     // This is necessary because we may need to assign to instances of this type or create pointers to it.
-    using safe_acc_type = typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
+    using safe_acc_type =
+        typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
 
     // input_type() is a dummy initial value (not used)
     return detail::scan_impl<detail::lookback_scan_determinism::default_determinism,
@@ -727,7 +747,8 @@ inline hipError_t deterministic_inclusive_scan(void*             temporary_stora
 {
     // AccType may be const or a reference. Get the non-const, non-reference type.
     // This is necessary because we may need to assign to instances of this type or create pointers to it.
-    using safe_acc_type = typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
+    using safe_acc_type =
+        typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
 
     return detail::scan_impl<detail::lookback_scan_determinism::deterministic,
                              false,
@@ -855,7 +876,7 @@ inline hipError_t deterministic_inclusive_scan(void*             temporary_stora
 ///
 /// // custom scan function
 /// auto min_op =
-///     [] __device__ (int a, int b) -> int
+///     [] (int a, int b) -> int
 ///     {
 ///         return a < b ? a : b;
 ///     };
@@ -905,7 +926,8 @@ inline hipError_t exclusive_scan(void*               temporary_storage,
 {
     // AccType may be const or a reference. Get the non-const, non-reference type.
     // This is necessary because we may need to assign to instances of this type or create pointers to it.
-    using safe_acc_type = typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
+    using safe_acc_type =
+        typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
 
     return detail::scan_impl<detail::lookback_scan_determinism::default_determinism,
                              true,
@@ -953,7 +975,8 @@ inline hipError_t deterministic_exclusive_scan(void*               temporary_sto
 {
     // AccType may be const or a reference. Get the non-const, non-reference type.
     // This is necessary because we may need to assign to instances of this type or create pointers to it.
-    using safe_acc_type = typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
+    using safe_acc_type =
+        typename std::remove_const<typename std::remove_reference<AccType>::type>::type;
 
     return detail::scan_impl<detail::lookback_scan_determinism::deterministic,
                              true,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -21,34 +21,85 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_SCAN_BY_KEY_HPP_
 #define ROCPRIM_DEVICE_DEVICE_SCAN_BY_KEY_HPP_
 
-#include "../config.hpp"
+#include "config_types.hpp"
+#include "detail/device_config_helper.hpp"
+#include "detail/device_scan_by_key.hpp"
+#include "detail/lookback_scan_state.hpp"
+#include "detail/ordered_block_id.hpp"
+#include "device_scan_by_key_config.hpp"
+
 #include "../common.hpp"
+#include "../config.hpp"
 #include "../detail/temp_storage.hpp"
 #include "../detail/various.hpp"
 #include "../functional.hpp"
 #include "../types/future_value.hpp"
 #include "../types/tuple.hpp"
-#include "config_types.hpp"
-#include "detail/config/device_scan_by_key.hpp"
-#include "detail/device_config_helper.hpp"
-#include "detail/device_scan_by_key.hpp"
-#include "detail/lookback_scan_state.hpp"
-#include "device_scan_by_key_config.hpp"
 
 #include <hip/hip_runtime.h>
 
 #include <iostream>
 #include <iterator>
-#include <type_traits>
 
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
 
-template<lookback_scan_determinism Determinism,
+template<typename LookBackScanState, class BlockIdWrapper>
+ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
+    init_device_scan_by_key_kernel(LookBackScanState  lookback_scan_state,
+                                   const unsigned int number_of_blocks,
+                                   unsigned int       save_index,
+                                   typename LookBackScanState::value_type* const save_dest,
+                                   BlockIdWrapper                                block_id)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         block_id,
+                                         save_index,
+                                         save_dest);
+}
+
+template<typename LookBackScanState,
+         class KeysInputIterator,
+         class ItemPerBlockType,
+         class BlockIdWrapper>
+ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void init_device_scan_by_key_kernel(
+    LookBackScanState                             lookback_scan_state,
+    const unsigned int                            number_of_blocks,
+    unsigned int                                  save_index,
+    typename LookBackScanState::value_type* const save_dest,
+    KeysInputIterator                             keys, // keys from the 0 without any offsets
+    typename std::iterator_traits<
+        KeysInputIterator>::value_type* __restrict__ last_keys_of_each_block,
+    size_t                 num_last_keys_of_each_block,
+    const ItemPerBlockType items_per_block,
+    BlockIdWrapper block_id)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         block_id,
+                                         save_index,
+                                         save_dest);
+
+    // Initialize the last_keys_of_each_block
+    const auto block_size = ::rocprim::detail::block_size<0>();
+    const auto global_tid
+        = (::rocprim::detail::block_id<0>() * block_size) + ::rocprim::detail::block_thread_id<0>();
+    const auto total_threads = ::rocprim::detail::grid_size<0>() * block_size;
+    using common_size_t      = typename std::common_type<decltype(num_last_keys_of_each_block),
+                                                    decltype(total_threads)>::type;
+    for(common_size_t i = global_tid; i < static_cast<common_size_t>(num_last_keys_of_each_block);
+        i += static_cast<common_size_t>(total_threads))
+    {
+        last_keys_of_each_block[i] = keys[(i * items_per_block) + (items_per_block - 1)];
+    }
+}
+
+template<typename Config,
+         lookback_scan_determinism Determinism,
          bool                      Exclusive,
-         typename Config,
          typename KeyInputIterator,
          typename InputIterator,
          typename OutputIterator,
@@ -56,34 +107,87 @@ template<lookback_scan_determinism Determinism,
          typename CompareFunction,
          typename BinaryFunction,
          typename LookbackScanState,
-         typename AccType>
-ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(device_params<Config>().kernel_config.block_size) void
-    device_scan_by_key_kernel(const KeyInputIterator                       keys,
-                              const InputIterator                          values,
-                              const OutputIterator                         output,
-                              const InitialValueType                       initial_value,
-                              const CompareFunction                        compare,
-                              const BinaryFunction                         scan_op,
-                              const LookbackScanState                      scan_state,
-                              const size_t                                 size,
-                              const size_t                                 starting_block,
-                              const size_t                                 number_of_blocks,
-                              const ::rocprim::tuple<AccType, bool>* const previous_last_value)
+         typename AccType,
+         typename WrappedBlockId>
+inline hipError_t launch_device_scan_by_key(
+    detail::target_arch                          arch,
+    const KeyInputIterator                       keys,
+    const InputIterator                          values,
+    const OutputIterator                         output,
+    const InitialValueType                       initial_value,
+    const CompareFunction                        compare,
+    const BinaryFunction                         scan_op,
+    const LookbackScanState                      scan_state,
+    const size_t                                 size,
+    const size_t                                 starting_block,
+    const size_t                                 number_of_blocks,
+    const ::rocprim::tuple<AccType, bool>* const previous_last_value,
+    bool                                         use_last_keys,
+    const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__ last_keys,
+    WrappedBlockId ordered_bid,
+    dim3                           grid,
+    dim3                           block,
+    size_t                         shmem,
+    hipStream_t                    stream)
 {
-    device_scan_by_key_kernel_impl<Determinism, Exclusive, Config>(
-        keys,
-        values,
-        output,
-        static_cast<AccType>(get_input_value(initial_value)),
-        compare,
-        scan_op,
-        scan_state,
-        size,
-        starting_block,
-        number_of_blocks,
-        previous_last_value);
+
+    auto kernel = [=](auto arch_config)
+    {
+        device_scan_by_key_kernel_impl<decltype(arch_config), Determinism, Exclusive>(
+            keys,
+            values,
+            output,
+            static_cast<AccType>(get_input_value(initial_value)),
+            compare,
+            scan_op,
+            scan_state,
+            size,
+            starting_block,
+            number_of_blocks,
+            previous_last_value,
+            use_last_keys,
+            last_keys,
+            ordered_bid);
+    };
+
+    return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
+/// \return 0 if in-place is not detected
+template<bool Exclusive,
+         typename KeysInputIterator,
+         typename OutputIterator,
+         typename SizeType,
+         typename NumBlockType>
+ROCPRIM_FORCE_INLINE ROCPRIM_HOST size_t detect_reusing_keys(
+    KeysInputIterator keys,
+    OutputIterator output,
+    SizeType size,
+    NumBlockType number_of_blocks)
+{
+    using key_type    = typename std::iterator_traits<KeysInputIterator>::value_type;
+    using output_type = typename std::iterator_traits<OutputIterator>::value_type;
+    if constexpr(std::is_same<KeysInputIterator, OutputIterator>::value)
+    {
+        if(static_cast<SizeType>(std::distance(keys, output)) < size)
+        {
+            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
+            return sizeof(key_type) * (number_of_blocks - 1);
+        }
+    }
+    else if constexpr(std::is_pointer<KeysInputIterator>::value
+                      && std::is_pointer<OutputIterator>::value
+                      && std::is_convertible<key_type, output_type>::value)
+    {
+        if(static_cast<SizeType>(std::distance(keys, reinterpret_cast<KeysInputIterator>(output)))
+           < size)
+        {
+            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
+            return sizeof(key_type) * (number_of_blocks - 1);
+        }
+    }
+    return 0;
+}
 
 template<lookback_scan_determinism Determinism,
          bool                      Exclusive,
@@ -109,166 +213,169 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
 {
     using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;
 
-    using config = wrapped_scan_by_key_config<Config, key_type, AccType>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const scan_by_key_config_params params = dispatch_target_arch<config>(target_arch);
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
+    const auto use_sleepy_scan_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(use_sleepy_scan);
 
-    using wrapped_type = ::rocprim::tuple<AccType, bool>;
-
-    using scan_state_type            = detail::lookback_scan_state<wrapped_type>;
-    using scan_state_with_sleep_type = detail::lookback_scan_state<wrapped_type, true>;
-
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const unsigned int items_per_block  = block_size * items_per_thread;
-
-    const unsigned int size_limit = params.kernel_config.size_limit;
-    const unsigned int aligned_size_limit
-        = std::max(size_limit - size_limit % items_per_block, items_per_block);
-
-    const unsigned int limited_size
-        = static_cast<unsigned int>(std::min<size_t>(size, aligned_size_limit));
-    const bool use_limited_size = limited_size == aligned_size_limit;
-
-    // Number of blocks in a single launch (or the only launch if it fits)
-    const unsigned int number_of_blocks = ceiling_div(limited_size, items_per_block);
-
-    void*         scan_state_storage;
-    wrapped_type* previous_last_value;
-
-    detail::temp_storage::layout layout{};
-    const hipError_t             layout_result
-        = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(layout_result != hipSuccess)
-    {
-        return layout_result;
-    }
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with offset_scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&previous_last_value,
-                                                    use_limited_size ? 1 : 0)));
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return partition_result;
-    }
-
-    if(number_of_blocks == 0u)
-    {
-        return hipSuccess;
-    }
-
-    bool use_sleep;
-    if(const hipError_t error = is_sleep_scan_state_used(stream, use_sleep))
-    {
-        return error;
-    }
-
-    scan_state_type scan_state{};
-    hipError_t      scan_state_result
-        = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
-    scan_state_with_sleep_type scan_state_with_sleep{};
-    scan_state_result = scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                           scan_state_storage,
-                                                           number_of_blocks,
-                                                           stream);
-    if(scan_state_result != hipSuccess)
-    {
-        return scan_state_result;
-    }
-
-    // Call the provided function with either scan_state or scan_state_with_sleep based on
-    // the value of use_sleep
-    auto with_scan_state
-        = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(scan_state_with_sleep);
-        }
-        else
-        {
-            return func(scan_state);
-        }
-    };
+            using config = wrapped_scan_by_key_config<Config, key_type, AccType>;
 
-    // Total number of blocks in all launches
-    const auto   total_number_of_blocks = ceiling_div(size, items_per_block);
-    const size_t number_of_launch       = ceiling_div(size, limited_size);
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+            const scan_by_key_config_params params
+                = dispatch_target_arch<config, false>(target_arch);
 
-    if(debug_synchronous)
-    {
-        std::cout << "----------------------------------\n";
-        std::cout << "size:               " << size << '\n';
-        std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
-        std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
-        std::cout << "number_of_launch:   " << number_of_launch << '\n';
-        std::cout << "block_size:         " << block_size << '\n';
-        std::cout << "items_per_block:    " << items_per_block << '\n';
-        std::cout << "----------------------------------\n";
-    }
+            using wrapped_type     = ::rocprim::tuple<AccType, bool>;
+            using scan_state_type  = detail::lookback_scan_state<wrapped_type, use_sleepy_scan>;
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
 
-    for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
-    {
-        // limited_size is of type unsigned int, so current_size also fits in an unsigned int
-        // size_t is necessary as type of std::min because 'size - offset' can exceed the
-        // upper limit of unsigned int and converting it can lead to wrong results
-        const unsigned int current_size
-            = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
-        const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
-        const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
+            const unsigned int block_size       = params.kernel_config.block_size;
+            const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+            const unsigned int items_per_block  = block_size * items_per_thread;
 
-        // Start point for time measurements
-        std::chrono::steady_clock::time_point start;
-        if(debug_synchronous)
-        {
-            std::cout << "index:            " << i << '\n';
-            std::cout << "current_size:     " << current_size << '\n';
-            std::cout << "number of blocks: " << scan_blocks << '\n';
+            const unsigned int size_limit = params.kernel_config.size_limit;
+            const unsigned int aligned_size_limit
+                = std::max<size_t>(size_limit - (size_limit % static_cast<size_t>(items_per_block)),
+                                   items_per_block);
 
-            start = std::chrono::steady_clock::now();
-        }
+            const unsigned int limited_size
+                = static_cast<unsigned int>(std::min<size_t>(size, aligned_size_limit));
+            const bool use_limited_size = limited_size == aligned_size_limit;
 
-        with_scan_state(
-            [&](const auto scan_state)
+            // Number of blocks in a single launch (or the only launch if it fits)
+            const unsigned int number_of_blocks = ceiling_div(limited_size, items_per_block);
+
+            void*         scan_state_storage;
+            wrapped_type* previous_last_value;
+
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
+
+            typename ordered_bid_type::id_type* ordered_bid_storage;
+
+            key_type*  last_keys_of_each_block;
+            const auto last_keys_of_each_block_size_byte
+                = items_per_thread
+                      ? detect_reusing_keys<Exclusive>(keys,
+                                                       output,
+                                                       size,
+                                                       ceiling_div(size, items_per_block))
+                      : 0;
+
+            const hipError_t partition_result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with offset_scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::ptr_aligned_array(&previous_last_value,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::ptr_aligned_array(&last_keys_of_each_block,
+                                                            last_keys_of_each_block_size_byte),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        ordered_bid_type::get_temp_storage_layout())));
+            if(partition_result != hipSuccess || temporary_storage == nullptr)
             {
-                hipLaunchKernelGGL(init_lookback_scan_state_kernel,
-                                   dim3(init_grid_size),
-                                   dim3(block_size),
-                                   0,
-                                   stream,
-                                   scan_state,
-                                   scan_blocks,
-                                   number_of_blocks - 1,
-                                   i > 0 ? previous_last_value : nullptr);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                    scan_blocks,
-                                                    start);
+                return partition_result;
+            }
 
-        if(debug_synchronous)
-        {
-            start = std::chrono::steady_clock::now();
-        }
-        with_scan_state(
-            [&](auto& scan_state)
+            if(number_of_blocks == 0u)
             {
-                hipLaunchKernelGGL(
-                    HIP_KERNEL_NAME(device_scan_by_key_kernel<Determinism, Exclusive, config>),
-                    dim3(scan_blocks),
-                    dim3(block_size),
-                    0,
-                    stream,
+                return hipSuccess;
+            }
+
+            scan_state_type scan_state{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream));
+
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            // Total number of blocks in all launches
+            const auto   total_number_of_blocks = ceiling_div(size, items_per_block);
+            const size_t number_of_launch       = ceiling_div(size, limited_size);
+
+            if(debug_synchronous)
+            {
+                std::cout << "----------------------------------\n";
+                std::cout << "size:               " << size << '\n';
+                std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
+                std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
+                std::cout << "number_of_launch:   " << number_of_launch << '\n';
+                std::cout << "block_size:         " << block_size << '\n';
+                std::cout << "items_per_block:    " << items_per_block << '\n';
+                std::cout << "----------------------------------\n";
+            }
+
+            for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
+            {
+                // limited_size is of type unsigned int, so current_size also fits in an unsigned int
+                // size_t is necessary as type of std::min because 'size - offset' can exceed the
+                // upper limit of unsigned int and converting it can lead to wrong results
+                const unsigned int current_size
+                    = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
+                const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
+                const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
+
+                // Start point for time measurements
+                std::chrono::steady_clock::time_point start;
+                if(debug_synchronous)
+                {
+                    std::cout << "index:            " << i << '\n';
+                    std::cout << "current_size:     " << current_size << '\n';
+                    std::cout << "number of blocks: " << scan_blocks << '\n';
+
+                    start = std::chrono::steady_clock::now();
+                }
+                if (!Exclusive && last_keys_of_each_block_size_byte != 0 && i == 0)
+                {
+                    init_device_scan_by_key_kernel<<<dim3(init_grid_size),
+                                                     dim3(block_size),
+                                                     0,
+                                                     stream>>>(
+                        scan_state,
+                        scan_blocks,
+                        number_of_blocks - 1,
+                        i > 0 ? previous_last_value : nullptr,
+                        keys,
+                        last_keys_of_each_block,
+                        last_keys_of_each_block_size_byte
+                            / sizeof(decltype(*last_keys_of_each_block)),
+                        items_per_block,
+                        ordered_bid);
+                }
+                else
+                {
+                    init_device_scan_by_key_kernel<<<dim3(init_grid_size),
+                                                     dim3(block_size),
+                                                     0,
+                                                     stream>>>(scan_state,
+                                                               scan_blocks,
+                                                               number_of_blocks - 1,
+                                                               i > 0 ? previous_last_value
+                                                                     : nullptr,
+                                                               ordered_bid);
+                }
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
+                                                            scan_blocks,
+                                                            start);
+
+                if(debug_synchronous)
+                {
+                    start = std::chrono::steady_clock::now();
+                }
+                ROCPRIM_RETURN_ON_ERROR(launch_device_scan_by_key<config, Determinism, Exclusive>(
+                    target_arch,
                     keys + offset,
                     input + offset,
                     output + offset,
@@ -279,17 +386,26 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                     size,
                     i * number_of_blocks,
                     total_number_of_blocks,
-                    i > 0 ? as_const_ptr(previous_last_value) : nullptr);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
-                                                    current_size,
-                                                    start);
-    }
+                    i > 0 ? as_const_ptr(previous_last_value) : nullptr,
+                    last_keys_of_each_block_size_byte != 0,
+                    last_keys_of_each_block,
+                    ordered_bid,
+                    dim3(scan_blocks),
+                    dim3(block_size),
+                    0,
+                    stream));
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
+                                                            current_size,
+                                                            start);
+            }
+            return hipSuccess;
+        },
+        use_sleepy_scan_variant,
+        use_atomic_block_id_variant));
     return hipSuccess;
 }
 
-
-}
+} // namespace detail
 
 /// \addtogroup devicemodule
 /// @{
@@ -312,6 +428,13 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
 /// if \p temporary_storage in a null pointer.
 /// * Ranges specified by \p keys_input, \p values_input, and \p values_output must have
 /// at least \p size elements.
+///
+/// \note In-place inclusive_scan_by_key
+/// In these situations, in-place inclusive_scan_by_key is supported:
+/// - The buffers in `keys_input` and `values_output` are overlaped to each other, and `KeysInputIterator` and `ValuesOutputIterator` are the same.
+/// - The buffers in `keys_input` and `values_output` are overlaped to each other, `KeysInputIterator` and `ValuesOutputIterator` are the different,
+///   but they are both pointer types, and their "std::iterator_traits<KeysInputIterator>::value_type" is convertible to
+///   "std::iterator_traits<ValuesOutputIterator>::value_type"
 ///
 /// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `scan_by_key_config`.
 /// \tparam KeysInputIterator random-access iterator type of the input range. It can be
@@ -504,6 +627,9 @@ inline hipError_t deterministic_inclusive_scan_by_key(void* const               
 /// if \p temporary_storage in a null pointer.
 /// * Ranges specified by \p keys_input, \p values_input, and \p values_output must have
 /// at least \p size elements.
+///
+/// \note In-place exclusive_scan_by_key
+/// In-place exclusive_scan_by_key is supported.
 ///
 /// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `scan_by_key_config`.
 /// \tparam KeysInputIterator random-access iterator type of the input range. It can be

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -73,27 +73,52 @@ public:
             // registers (asume warp size of at least hardware warp-size)
             output = reduce_op(warp_move_dpp<T, 0x128>(output), output);
         }
-#ifdef ROCPRIM_DETAIL_HAS_DPP_BROADCAST
-        if(VirtualWaveSize > 16)
+
+        // Check for __builtin_amdgcn_permlane16; if it exists, the DPP equivalent is not available.
+        // Swizzle is kept instead of __builtin_amdgcn_permlanex16, as the latter can be slower in some cases.
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
-            // row_bcast:15
-            output = reduce_op(warp_move_dpp<T, 0x142>(output), output);
-        }
-        if(VirtualWaveSize > 32)
-        {
-            // row_bcast:31
-            output = reduce_op(warp_move_dpp<T, 0x143>(output), output);
-        }
-        static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
+            if(VirtualWaveSize > 16)
+            {
+                // row_bcast:15
+                output = reduce_op(warp_swizzle<T, 0x1e0>(output), output);
+            }
+
+#if !ROCPRIM_TARGET_SPIRV
+            static_assert(VirtualWaveSize <= 32,
+                          "VirtualWaveSize > 32 is not supported without DPP broadcasts");
 #else
-        if(VirtualWaveSize > 16)
-        {
-            // row_bcast:15
-            output = reduce_op(warp_swizzle<T, 0x1e0>(output), output);
-        }
-        static_assert(VirtualWaveSize <= 32,
-                      "VirtualWaveSize > 32 is not supported without DPP broadcasts");
+            if constexpr(VirtualWaveSize > 32)
+            {
+                ROCPRIM_PRINT_ERROR_ONCE(
+                    "VirtualWaveSize > 32 is not supported without DPP broadcasts");
+                return;
+            }
 #endif
+        }
+        else
+        {
+            if(VirtualWaveSize > 16)
+            {
+                // row_bcast:15
+                output = reduce_op(warp_move_dpp<T, 0x142>(output), output);
+            }
+            if(VirtualWaveSize > 32)
+            {
+                // row_bcast:31
+                output = reduce_op(warp_move_dpp<T, 0x143>(output), output);
+            }
+
+#if !ROCPRIM_TARGET_SPIRV
+            static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
+#else
+            if constexpr(VirtualWaveSize > 64)
+            {
+                ROCPRIM_PRINT_ERROR_ONCE("VirtualWaveSize > 64 is not supported");
+                return;
+            }
+#endif
+        }
         // Read the result from the last lane of the logical warp
         output = warp_shuffle(output, VirtualWaveSize - 1, VirtualWaveSize);
     }

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -75,30 +75,54 @@ public:
             if(row_lane_id >= 8)
                 output = scan_op(t, output);
         }
-#ifdef ROCPRIM_DETAIL_HAS_DPP_BROADCAST
-        if(VirtualWaveSize > 16)
+
+        // Check for __builtin_amdgcn_permlane16; if it exists, the DPP equivalent is not available.
+        // Swizzle is kept instead of __builtin_amdgcn_permlanex16, as the latter can be slower in some cases.
+        if ROCPRIM_AMDGCN_CONSTEXPR(ROCPRIM_HAS_PERMLANE())
         {
-            T t = warp_move_dpp<T, 0x142>(output); // row_bcast:15
-            if(lane_id % 32 >= 16)
-                output = scan_op(t, output);
-        }
-        if(VirtualWaveSize > 32)
-        {
-            T t = warp_move_dpp<T, 0x143>(output); // row_bcast:31
-            if(lane_id >= 32)
-                output = scan_op(t, output);
-        }
-        static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
+            if(VirtualWaveSize > 16)
+            {
+                T t = warp_swizzle<T, 0x1e0>(output); // row_bcast:15
+                if(lane_id % 32 >= 16)
+                    output = scan_op(t, output);
+            }
+
+#if !ROCPRIM_TARGET_SPIRV
+            static_assert(VirtualWaveSize <= 32,
+                          "VirtualWaveSize > 32 is not supported without DPP broadcasts");
 #else
-        if(VirtualWaveSize > 16)
-        {
-            T t = warp_swizzle<T, 0x1e0>(output); // row_bcast:15
-            if(lane_id % 32 >= 16)
-                output = scan_op(t, output);
-        }
-        static_assert(VirtualWaveSize <= 32,
-                      "VirtualWaveSize > 32 is not supported without DPP broadcasts");
+            if constexpr(VirtualWaveSize > 32)
+            {
+                ROCPRIM_PRINT_ERROR_ONCE(
+                    "VirtualWaveSize > 32 is not supported without DPP broadcasts");
+                return;
+            }
 #endif
+        }
+        else
+        {
+            if(VirtualWaveSize > 16)
+            {
+                T t = warp_move_dpp<T, 0x142>(output); // row_bcast:15
+                if(lane_id % 32 >= 16)
+                    output = scan_op(t, output);
+            }
+            if(VirtualWaveSize > 32)
+            {
+                T t = warp_move_dpp<T, 0x143>(output); // row_bcast:31
+                if(lane_id >= 32)
+                    output = scan_op(t, output);
+            }
+#if !ROCPRIM_TARGET_SPIRV
+            static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
+#else
+            if constexpr(VirtualWaveSize > 64)
+            {
+                ROCPRIM_PRINT_ERROR_ONCE("VirtualWaveSize > 64 is not supported");
+                return;
+            }
+#endif
+        }
     }
 
     template<class BinaryFunction>

--- a/projects/rocprim/test/rocprim/test_device_scan.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan.cpp
@@ -28,6 +28,7 @@
 // Required test headers
 #include "bounds_checking_iterator.hpp"
 #include "identity_iterator.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 #include "test_utils.hpp"
 #include "test_utils_assertions.hpp"
 #include "test_utils_custom_test_types.hpp"
@@ -66,31 +67,13 @@
 #include <utility>
 #include <vector>
 
-struct default_config_helper
-{
-    template<bool /* ByKey */>
-    using type = ::rocprim::default_config;
-};
-
 template<unsigned int SizeLimit>
-struct size_limit_config_helper
-{
-    template<bool ByKey>
-    using type = std::conditional_t<
-        ByKey,
-        rocprim::scan_by_key_config<256,
-                                    16,
-                                    rocprim::block_load_method::block_load_transpose,
-                                    rocprim::block_store_method::block_store_transpose,
-                                    rocprim::block_scan_algorithm::using_warp_scan,
-                                    SizeLimit>,
-        rocprim::scan_config<256,
-                             16,
-                             rocprim::block_load_method::block_load_transpose,
-                             rocprim::block_store_method::block_store_transpose,
-                             rocprim::block_scan_algorithm::using_warp_scan,
-                             SizeLimit>>;
-};
+using size_limit_config = rocprim::scan_config<256,
+                                               16,
+                                               rocprim::block_load_method::block_load_transpose,
+                                               rocprim::block_store_method::block_store_transpose,
+                                               rocprim::block_scan_algorithm::using_warp_scan,
+                                               SizeLimit>;
 
 // Params for tests
 template<class InputType,
@@ -99,7 +82,7 @@ template<class InputType,
          // Tests output iterator with void value_type (OutputIterator concept)
          // scan-by-key primitives don't support output iterator with void value_type
          bool UseIdentityIteratorIfSupported = false,
-         typename ConfigHelper               = default_config_helper,
+         typename ConfigHelper               = rocprim::default_config,
          bool UseGraphs                      = false,
          bool Deterministic                  = false,
          bool UseInitialValue                = false>
@@ -141,32 +124,6 @@ constexpr hipError_t invoke_exclusive_scan(Args&&... args)
     }
 }
 
-template<bool Deterministic, typename Config = rocprim::default_config, typename... Args>
-constexpr hipError_t invoke_inclusive_scan_by_key(Args&&... args)
-{
-    if(Deterministic)
-    {
-        return rocprim::deterministic_inclusive_scan_by_key<Config>(std::forward<Args>(args)...);
-    }
-    else
-    {
-        return rocprim::inclusive_scan_by_key<Config>(std::forward<Args>(args)...);
-    }
-}
-
-template<bool Deterministic, typename Config = rocprim::default_config, typename... Args>
-constexpr hipError_t invoke_exclusive_scan_by_key(Args&&... args)
-{
-    if(Deterministic)
-    {
-        return rocprim::deterministic_exclusive_scan_by_key<Config>(std::forward<Args>(args)...);
-    }
-    else
-    {
-        return rocprim::exclusive_scan_by_key<Config>(std::forward<Args>(args)...);
-    }
-}
-
 // ---------------------------------------------------------
 // Test for scan ops taking single input value
 // ---------------------------------------------------------
@@ -192,18 +149,18 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
     DeviceScanParams<unsigned short>,
     DeviceScanParams<short, int>,
     DeviceScanParams<int>,
-    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config_helper<512>>,
+    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config<512>>,
     DeviceScanParams<float, float, rocprim::maximum<float>>,
-    DeviceScanParams<float, float, rocprim::plus<float>, false, size_limit_config_helper<1024>>,
+    DeviceScanParams<float, float, rocprim::plus<float>, false, size_limit_config<1024>>,
     DeviceScanParams<float,
                      float,
                      rocprim::plus<float>,
                      false,
-                     size_limit_config_helper<1024>,
+                     size_limit_config<1024>,
                      false,
                      true>,
-    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config_helper<524288>>,
-    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config_helper<1048576>>,
+    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config<524288>>,
+    DeviceScanParams<int, int, rocprim::plus<int>, false, size_limit_config<1048576>>,
     DeviceScanParams<int8_t, int8_t, rocprim::maximum<int8_t>>,
     DeviceScanParams<uint8_t, uint8_t, rocprim::maximum<uint8_t>, false>,
     DeviceScanParams<rocprim::half, rocprim::half, rocprim::maximum<rocprim::half>>,
@@ -211,7 +168,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     default_config_helper,
+                     rocprim::default_config,
                      false,
                      true>,
     DeviceScanParams<rocprim::bfloat16, rocprim::bfloat16, rocprim::maximum<rocprim::bfloat16>>,
@@ -219,7 +176,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     default_config_helper,
+                     rocprim::default_config,
                      false,
                      true>,
     // Large
@@ -233,7 +190,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      double,
                      rocprim::plus<double>,
                      false,
-                     default_config_helper,
+                     rocprim::default_config,
                      true,
                      true>,
     DeviceScanParams<signed char, long, rocprim::plus<long>>,
@@ -247,19 +204,19 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      common::custom_type<double, double, true>,
                      rocprim::plus<common::custom_type<double, double, true>>,
                      false,
-                     default_config_helper,
+                     rocprim::default_config,
                      true>,
     DeviceScanParams<common::custom_type<int, int, true>>,
     DeviceScanParams<test_utils::custom_test_array_type<long long, 5>>,
     DeviceScanParams<test_utils::custom_test_array_type<int, 10>>,
     // With graphs
-    DeviceScanParams<int, int, rocprim::plus<int>, false, default_config_helper, true>,
+    DeviceScanParams<int, int, rocprim::plus<int>, false, rocprim::default_config, true>,
     // With initial values
     DeviceScanParams<int,
                      int,
                      rocprim::plus<int>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -267,7 +224,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      int,
                      rocprim::maximum<int>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -275,7 +232,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      int,
                      rocprim::minimum<int>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -283,7 +240,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -291,7 +248,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      rocprim::half,
                      rocprim::minimum<rocprim::half>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -299,7 +256,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -307,7 +264,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      rocprim::bfloat16,
                      rocprim::minimum<rocprim::bfloat16>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>,
@@ -315,7 +272,7 @@ using RocprimDeviceScanTestsParams = ::testing::Types<
                      float,
                      rocprim::plus<float>,
                      false,
-                     size_limit_config_helper<524288>,
+                     size_limit_config<524288>,
                      false,
                      true,
                      true>>;
@@ -348,7 +305,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
     const bool deterministic     = TestFixture::deterministic;
     const bool use_initial_value = TestFixture::use_initial_value;
 
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config = typename TestFixture::config_helper;
     using config = rocprim::detail::wrapped_scan_config<Config, acc_type>;
 
     hipStream_t stream = hipStreamDefault;
@@ -356,7 +313,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
     rocprim::detail::target_arch target_arch;
     HIP_CHECK(host_target_arch(stream, target_arch));
     const rocprim::detail::scan_config_params params
-        = rocprim::detail::dispatch_target_arch<config>(target_arch);
+        = rocprim::detail::dispatch_target_arch<config, false>(target_arch);
 
     // For non-associative operations in inclusive scan
     // intermediate results use the type of input iterator, then
@@ -469,10 +426,16 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
                                                          number_of_blocks,
                                                          stream));
 
+            // Create ordered block id.
+            using block_id_type = rocprim::detail::block_id_wrapper<unsigned int>;
+            common::device_ptr<void> ordered_bid_storage(sizeof(block_id_type::id_type));
+            auto ordered_bid = block_id_type::create(ordered_bid_storage.get());
+            HIP_CHECK(ordered_bid.reset_from_host(stream));
+
             // Call the provided function with either scan_state or scan_state_with_sleep based on
             // the value of use_sleep
             bool use_sleep;
-            HIP_CHECK(rocprim::detail::is_sleep_scan_state_used(stream, use_sleep))
+            HIP_CHECK(rocprim::detail::is_sleep_scan_state_used(stream, use_sleep));
             auto with_scan_state = [use_sleep, scan_state, scan_state_with_sleep](
                                        auto&& func) mutable -> decltype(auto)
             {
@@ -493,7 +456,8 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
                                                                        dim3(block_size),
                                                                        0,
                                                                        stream>>>(scan_state,
-                                                                                 number_of_blocks);
+                                                                                 number_of_blocks,
+                                                                                 ordered_bid);
                 });
 
             HIP_CHECK(hipGetLastError());
@@ -509,33 +473,35 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
 
             grid_size = number_of_blocks;
 
-            with_scan_state(
+            const auto launch_err = with_scan_state(
                 [&](const auto scan_state)
                 {
-                    rocprim::detail::lookback_scan_kernel<
-                        deterministic
-                            ? rocprim::detail::lookback_scan_determinism::deterministic
-                            : rocprim::detail::lookback_scan_determinism::nondeterministic,
-                        Exclusive,
-                        use_initial_value,
-                        config,
-                        decltype(input_iterator),
-                        U*,
-                        scan_op_type,
-                        acc_type,
-                        acc_type>
-                        <<<dim3(grid_size), dim3(block_size), 0, stream>>>(input_iterator,
-                                                                           d_output.get(),
-                                                                           size,
-                                                                           initial_value,
-                                                                           scan_op,
-                                                                           scan_state,
-                                                                           number_of_blocks,
-                                                                           previous_last_element,
-                                                                           new_last_element,
-                                                                           false,
-                                                                           false);
+                    return rocprim::detail::launch_lookback_scan < config,
+                           deterministic
+                               ? rocprim::detail::lookback_scan_determinism::deterministic
+                               : rocprim::detail::lookback_scan_determinism::nondeterministic,
+                           Exclusive, use_initial_value, decltype(input_iterator), U*, scan_op_type,
+                           acc_type,
+                           acc_type > (target_arch,
+                                       input_iterator,
+                                       d_output.get(),
+                                       size,
+                                       initial_value,
+                                       scan_op,
+                                       scan_state,
+                                       number_of_blocks,
+                                       dim3(grid_size),
+                                       dim3(block_size),
+                                       0,
+                                       stream,
+                                       previous_last_element,
+                                       new_last_element,
+                                       false,
+                                       false,
+                                       ordered_bid);
                 });
+
+            ASSERT_EQ(hipSuccess, launch_err);
 
             if(TestFixture::use_graphs)
             {
@@ -583,7 +549,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
     const bool deterministic     = TestFixture::deterministic;
     const bool use_initial_value = TestFixture::use_initial_value;
 
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config = typename TestFixture::config_helper;
     using config = rocprim::detail::wrapped_scan_config<Config, acc_type>;
 
     hipStream_t stream = hipStreamDefault;
@@ -591,7 +557,7 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
     rocprim::detail::target_arch target_arch;
     HIP_CHECK(host_target_arch(stream, target_arch));
     const rocprim::detail::scan_config_params params
-        = rocprim::detail::dispatch_target_arch<config>(target_arch);
+        = rocprim::detail::dispatch_target_arch<config, false>(target_arch);
 
     // For non-associative operations in inclusive scan
     // intermediate results use the type of input iterator, then
@@ -695,10 +661,15 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
                                                      number_of_blocks,
                                                      stream));
 
+        // Create ordered block id.
+        common::device_ptr<unsigned int> ordered_bid_storage(1);
+        auto                             ordered_bid
+            = rocprim::detail::ordered_block_id<unsigned int>::create(ordered_bid_storage.get());
+
         // Call the provided function with either scan_state or scan_state_with_sleep based on
         // the value of use_sleep
         bool use_sleep;
-        HIP_CHECK(rocprim::detail::is_sleep_scan_state_used(stream, use_sleep))
+        HIP_CHECK(rocprim::detail::is_sleep_scan_state_used(stream, use_sleep));
         auto with_scan_state
             = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
         {
@@ -719,7 +690,8 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
                                                                    dim3(block_size),
                                                                    0,
                                                                    stream>>>(scan_state,
-                                                                             number_of_blocks);
+                                                                             number_of_blocks,
+                                                                             ordered_bid);
             });
 
         HIP_CHECK(hipGetLastError());
@@ -735,32 +707,34 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
 
         grid_size = number_of_blocks;
 
-        with_scan_state(
+        const auto launch_err = with_scan_state(
             [&](const auto scan_state)
             {
-                rocprim::detail::lookback_scan_kernel<
-                    deterministic ? rocprim::detail::lookback_scan_determinism::deterministic
-                                  : rocprim::detail::lookback_scan_determinism::nondeterministic,
-                    Exclusive,
-                    use_initial_value,
-                    config,
-                    decltype(input_iterator),
-                    U*,
-                    scan_op_type,
-                    acc_type,
-                    acc_type>
-                    <<<dim3(grid_size), dim3(block_size), 0, stream>>>(input_iterator,
-                                                                       d_output.get(),
-                                                                       size,
-                                                                       initial_value,
-                                                                       scan_op,
-                                                                       scan_state,
-                                                                       number_of_blocks,
-                                                                       previous_last_element,
-                                                                       new_last_element,
-                                                                       false,
-                                                                       false);
+                return rocprim::detail::launch_lookback_scan < config,
+                       deterministic ? rocprim::detail::lookback_scan_determinism::deterministic
+                                     : rocprim::detail::lookback_scan_determinism::nondeterministic,
+                       Exclusive, use_initial_value, decltype(input_iterator), U*, scan_op_type,
+                       acc_type,
+                       acc_type > (target_arch,
+                                   input_iterator,
+                                   d_output.get(),
+                                   size,
+                                   initial_value,
+                                   scan_op,
+                                   scan_state,
+                                   number_of_blocks,
+                                   dim3(grid_size),
+                                   dim3(block_size),
+                                   0,
+                                   stream,
+                                   previous_last_element,
+                                   new_last_element,
+                                   false,
+                                   false,
+                                   ordered_bid);
             });
+
+        ASSERT_EQ(hipSuccess, launch_err);
 
         if(TestFixture::use_graphs)
         {
@@ -815,7 +789,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScanEmptyInput)
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
-    
+
     // Default
     hipStream_t stream = 0;
     if(TestFixture::use_graphs)
@@ -885,7 +859,7 @@ TYPED_TEST(RocprimDeviceScanTests, InclusiveScan)
     static constexpr bool deterministic         = TestFixture::deterministic;
     static constexpr bool use_initial_value     = TestFixture::use_initial_value;
 
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config = typename TestFixture::config_helper;
 
     // Default
     hipStream_t stream = 0;
@@ -1034,7 +1008,7 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
     static constexpr bool use_identity_iterator = TestFixture::use_identity_iterator;
     static constexpr bool deterministic         = TestFixture::deterministic;
 
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config = typename TestFixture::config_helper;
 
     // Default
     hipStream_t stream = 0;
@@ -1128,253 +1102,10 @@ TYPED_TEST(RocprimDeviceScanTests, ExclusiveScan)
     }
 }
 
-TYPED_TEST(RocprimDeviceScanTests, InclusiveScanByKey)
-{
-    // scan-by-key does not support output iterator with void value_type
-    using T = typename TestFixture::input_type;
-    using K = unsigned int; // Key type
-    using U = typename TestFixture::output_type;
-
-    using scan_op_type = typename TestFixture::scan_op_type;
-    // If scan_op_type is rocprim::plus and input_type is bfloat16 or half,
-    // use float as device-side accumulator and double as host-side accumulator
-    using is_plus_op = test_utils::is_plus_operator<scan_op_type>;
-    using acc_type   = typename accum_type<T, scan_op_type>::type;
-
-    constexpr float single_op_precision = is_plus_op::value ? test_utils::precision<acc_type> : 0;
-
-    const bool debug_synchronous = TestFixture::debug_synchronous;
-    const bool deterministic     = TestFixture::deterministic;
-    using Config                 = typename TestFixture::config_helper::template type<true>;
-
-    // Default
-    hipStream_t stream = 0;
-    if(TestFixture::use_graphs)
-    {
-        // Default stream does not support hipGraph stream capture, so create one
-        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-    }
-
-    int device_id = test_common_utils::obtain_device_from_ctest();
-    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
-    HIP_CHECK(hipSetDevice(device_id));
-
-    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
-    {
-        unsigned int seed_value
-            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
-        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
-
-        for(auto size : test_utils::get_sizes(seed_value))
-        {
-            if(single_op_precision * (size - 1) > 0.5)
-            {
-                std::cout << "Test is skipped from size " << size
-                          << " on, potential error of summation is more than 0.5 of the result "
-                             "with current or larger size"
-                          << std::endl;
-                break;
-            }
-
-            SCOPED_TRACE(testing::Message() << "with size = " << size);
-
-            const bool use_unique_keys = bool(test_utils::get_random_value<int>(0, 1, seed_value));
-
-            // Generate data
-            std::vector<T> input = test_utils::get_random_data<T>(size, 0, 9, seed_value);
-            std::vector<K> keys;
-            if(use_unique_keys)
-            {
-                keys = test_utils::get_random_data<K>(size, 0, 16, seed_value);
-                std::sort(keys.begin(), keys.end());
-            }
-            else
-            {
-                keys = test_utils::get_random_data<K>(size, 0, 3, seed_value);
-            }
-
-            common::device_ptr<T> d_input(input);
-            common::device_ptr<K> d_keys(keys);
-            common::device_ptr<U> d_output(input.size());
-
-            // Scan function
-            scan_op_type scan_op;
-            // Key compare function
-            rocprim::equal_to<K> keys_compare_op;
-
-            // Calculate expected results on host
-            std::vector<U> expected(input.size());
-            test_utils::host_inclusive_scan_by_key(input.begin(),
-                                                   input.end(),
-                                                   keys.begin(),
-                                                   expected.begin(),
-                                                   scan_op,
-                                                   keys_compare_op);
-
-            auto input_iterator
-                = rocprim::make_transform_iterator(d_input.get(),
-                                                   [](T in) { return static_cast<acc_type>(in); });
-
-            test_utils::test_kernel_wrapper(
-                [&](void* temp_storage, size_t& storage_bytes)
-                {
-                    return invoke_inclusive_scan_by_key<deterministic, Config>(temp_storage,
-                                                                               storage_bytes,
-                                                                               d_keys.get(),
-                                                                               input_iterator,
-                                                                               d_output.get(),
-                                                                               input.size(),
-                                                                               scan_op,
-                                                                               keys_compare_op,
-                                                                               stream,
-                                                                               debug_synchronous);
-                },
-                stream,
-                TestFixture::use_graphs);
-
-            // Copy output to host
-            const auto output = d_output.load();
-
-            // Check if output values are as expected
-            ASSERT_NO_FATAL_FAILURE(
-                test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
-        }
-    }
-
-    if(TestFixture::use_graphs)
-    {
-        HIP_CHECK(hipStreamDestroy(stream));
-    }
-}
-
-TYPED_TEST(RocprimDeviceScanTests, ExclusiveScanByKey)
-{
-    // scan-by-key does not support output iterator with void value_type
-    using T = typename TestFixture::input_type;
-    using K = unsigned int; // Key type
-    using U = typename TestFixture::output_type;
-
-    using scan_op_type = typename TestFixture::scan_op_type;
-    // If scan_op_type is rocprim::plus and input_type is bfloat16 or half,
-    // use float as device-side accumulator and double as host-side accumulator
-    using is_plus_op = test_utils::is_plus_operator<scan_op_type>;
-    using acc_type   = typename accum_type<T, scan_op_type>::type;
-
-    acc_type        initial_value;
-    constexpr float single_op_precision = is_plus_op::value ? test_utils::precision<acc_type> : 0;
-
-    const bool debug_synchronous = TestFixture::debug_synchronous;
-    const bool deterministic     = TestFixture::deterministic;
-    using Config                 = typename TestFixture::config_helper::template type<true>;
-
-    // Default
-    hipStream_t stream = 0;
-    if(TestFixture::use_graphs)
-    {
-        // Default stream does not support hipGraph stream capture, so create one
-        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-    }
-
-    int device_id = test_common_utils::obtain_device_from_ctest();
-    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
-    HIP_CHECK(hipSetDevice(device_id));
-
-    for(size_t seed_index = 0; seed_index < number_of_runs; seed_index++)
-    {
-        unsigned int seed_value
-            = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
-        SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
-
-        for(auto size : test_utils::get_sizes(seed_value))
-        {
-            if(single_op_precision * (size - 1) > 0.5)
-            {
-                std::cout << "Test is skipped from size " << size
-                          << " on, potential error of summation is more than 0.5 of the result "
-                             "with current or larger size"
-                          << std::endl;
-                break;
-            }
-
-            SCOPED_TRACE(testing::Message() << "with size = " << size);
-
-            const bool use_unique_keys = bool(test_utils::get_random_value<int>(0, 1, seed_value));
-
-            // Generate data
-            initial_value        = test_utils::get_random_value<acc_type>(1, 100, seed_value);
-            std::vector<T> input = test_utils::get_random_data<T>(size, 0, 9, seed_value);
-            std::vector<K> keys;
-            if(use_unique_keys)
-            {
-                keys = test_utils::get_random_data<K>(size, 0, 16, seed_value);
-                std::sort(keys.begin(), keys.end());
-            }
-            else
-            {
-                keys = test_utils::get_random_data<K>(size, 0, 3, seed_value);
-            }
-
-            common::device_ptr<T> d_input(input);
-            common::device_ptr<K> d_keys(keys);
-            common::device_ptr<U> d_output(input.size());
-
-            // Scan function
-            scan_op_type scan_op;
-
-            // Key compare function
-            rocprim::equal_to<K> keys_compare_op;
-
-            // Calculate expected results on host
-            std::vector<U> expected(input.size());
-            test_utils::host_exclusive_scan_by_key(input.begin(),
-                                                   input.end(),
-                                                   keys.begin(),
-                                                   initial_value,
-                                                   expected.begin(),
-                                                   scan_op,
-                                                   keys_compare_op);
-
-            auto input_iterator
-                = rocprim::make_transform_iterator(d_input.get(),
-                                                   [](T in) { return static_cast<acc_type>(in); });
-
-            test_utils::test_kernel_wrapper(
-                [&](void* temp_storage, size_t& storage_bytes)
-                {
-                    return invoke_exclusive_scan_by_key<deterministic, Config>(temp_storage,
-                                                                               storage_bytes,
-                                                                               d_keys.get(),
-                                                                               input_iterator,
-                                                                               d_output.get(),
-                                                                               initial_value,
-                                                                               input.size(),
-                                                                               scan_op,
-                                                                               keys_compare_op,
-                                                                               stream,
-                                                                               debug_synchronous);
-                },
-                stream,
-                TestFixture::use_graphs);
-
-            // Copy output to host
-            const auto output = d_output.load();
-
-            // Check if output values are as expected
-            ASSERT_NO_FATAL_FAILURE(
-                test_utils::assert_near(output, expected, single_op_precision * (size - 1)));
-        }
-    }
-
-    if(TestFixture::use_graphs)
-    {
-        HIP_CHECK(hipStreamDestroy(stream));
-    }
-}
-
 template<typename T>
 class single_index_iterator
 {
-private:
+public:
     class conditional_discard_value
     {
     public:
@@ -1803,157 +1534,6 @@ struct check_value_exclusive
     }
 };
 
-using check_run_inclusive_iterator
-    = check_run_iterator<check_value_inclusive, size_t, unsigned int*>;
-using check_run_exclusive_iterator
-    = check_run_iterator<check_value_exclusive, size_t, size_t, unsigned int*>;
-
-/// \p brief Provides a skeleton to both the inclusive and exclusive scan large indices tests.
-/// The call to the appropriate scan function must be implemented in \p scan_by_key_fun.
-template<class ScanByKeyFun, bool UseGraphs = false>
-void large_indices_scan_by_key_test(ScanByKeyFun scan_by_key_fun)
-{
-    const int device_id = test_common_utils::obtain_device_from_ctest();
-    SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);
-    HIP_CHECK(hipSetDevice(device_id));
-
-    constexpr bool debug_synchronous = false;
-    hipStream_t    stream            = 0;
-    if(UseGraphs)
-    {
-        // Default stream does not support hipGraph stream capture, so create one
-        HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-    }
-
-    const int seed_value = rand();
-    SCOPED_TRACE(testing::Message() << "with seed = " << seed_value);
-
-    const auto size = test_utils::get_large_sizes(seed_value).back();
-    SCOPED_TRACE(testing::Message() << "with size = " << size);
-
-    common::device_ptr<unsigned int> d_incorrect_flag(1);
-    HIP_CHECK(hipMemset(d_incorrect_flag.get(), 0, sizeof(unsigned int)));
-
-    const size_t run_length = test_utils::get_random_value<size_t>(1, 10000, seed_value);
-    SCOPED_TRACE(testing::Message() << "with run_length = " << run_length);
-
-    const auto keys_input = rocprim::make_transform_iterator(rocprim::counting_iterator<size_t>(0),
-                                                             [run_length](const auto value)
-                                                             { return value / run_length; });
-    const auto values_input = rocprim::counting_iterator<size_t>(0);
-
-    test_utils::test_kernel_wrapper(
-        [&](void* temp_storage, size_t& storage_bytes)
-        {
-            return scan_by_key_fun(temp_storage,
-                                   storage_bytes,
-                                   keys_input,
-                                   values_input,
-                                   run_length,
-                                   d_incorrect_flag.get(),
-                                   size,
-                                   stream,
-                                   debug_synchronous,
-                                   seed_value);
-        },
-        stream,
-        UseGraphs);
-
-    const auto incorrect_flag = d_incorrect_flag.load()[0];
-
-    ASSERT_EQ(0, incorrect_flag);
-
-    if(UseGraphs)
-    {
-        HIP_CHECK(hipStreamDestroy(stream));
-    }
-}
-
-template<bool UseGraphs = false>
-void testLargeIndicesInclusiveScanByKey()
-{
-    auto inclusive_scan_by_key = [](void*         d_temp_storage,
-                                    size_t&       temp_storage_size_bytes,
-                                    auto          keys_input,
-                                    auto          values_input,
-                                    size_t        run_length,
-                                    unsigned int* d_incorrect_flag,
-                                    size_t        size,
-                                    hipStream_t   stream,
-                                    bool          debug_synchronous,
-                                    int /*seed_value*/) -> hipError_t
-    {
-        const check_run_inclusive_iterator output_it(
-            rocprim::make_tuple(run_length, d_incorrect_flag));
-
-        return rocprim::inclusive_scan_by_key(d_temp_storage,
-                                              temp_storage_size_bytes,
-                                              keys_input,
-                                              values_input,
-                                              output_it,
-                                              size,
-                                              rocprim::plus<size_t>{},
-                                              rocprim::equal_to<size_t>{},
-                                              stream,
-                                              debug_synchronous);
-    };
-    large_indices_scan_by_key_test<decltype(inclusive_scan_by_key), UseGraphs>(
-        inclusive_scan_by_key);
-}
-
-TEST(RocprimDeviceScanTests, LargeIndicesInclusiveScanByKey)
-{
-    testLargeIndicesInclusiveScanByKey();
-}
-
-TEST(RocprimDeviceScanTests, LargeIndicesInclusiveScanByKeyWithGraphs)
-{
-    testLargeIndicesInclusiveScanByKey<true>();
-}
-
-template<bool UseGraphs = false>
-void testLargeIndicesExclusiveScanByKey()
-{
-    auto exclusive_scan_by_key = [](void*         d_temp_storage,
-                                    size_t&       temp_storage_size_bytes,
-                                    auto          keys_input,
-                                    auto          values_input,
-                                    size_t        run_length,
-                                    unsigned int* d_incorrect_flag,
-                                    size_t        size,
-                                    hipStream_t   stream,
-                                    bool          debug_synchronous,
-                                    int           seed_value) -> hipError_t
-    {
-        const size_t initial_value = test_utils::get_random_value<size_t>(0, 10000, seed_value);
-        const check_run_exclusive_iterator output_it(
-            rocprim::make_tuple(run_length, initial_value, d_incorrect_flag));
-        return rocprim::exclusive_scan_by_key(d_temp_storage,
-                                              temp_storage_size_bytes,
-                                              keys_input,
-                                              values_input,
-                                              output_it,
-                                              initial_value,
-                                              size,
-                                              rocprim::plus<size_t>{},
-                                              rocprim::equal_to<size_t>{},
-                                              stream,
-                                              debug_synchronous);
-    };
-    large_indices_scan_by_key_test<decltype(exclusive_scan_by_key), UseGraphs>(
-        exclusive_scan_by_key);
-}
-
-TEST(RocprimDeviceScanTests, LargeIndicesExclusiveScanByKey)
-{
-    testLargeIndicesExclusiveScanByKey();
-}
-
-TEST(RocprimDeviceScanTests, LargeIndicesExclusiveScanByKeyWithGraphs)
-{
-    testLargeIndicesExclusiveScanByKey<true>();
-}
-
 using RocprimDeviceScanFutureTestsParams = ::testing::Types<
     DeviceScanParams<char>,
     DeviceScanParams<int>,
@@ -1961,7 +1541,7 @@ using RocprimDeviceScanFutureTestsParams = ::testing::Types<
     DeviceScanParams<double, double, rocprim::plus<double>, true>,
     DeviceScanParams<common::custom_type<int, int, true>>,
     DeviceScanParams<test_utils::custom_test_array_type<long long, 5>>,
-    DeviceScanParams<int, int, ::rocprim::plus<int>, false, default_config_helper, true>>;
+    DeviceScanParams<int, int, ::rocprim::plus<int>, false, rocprim::default_config, true>>;
 
 template<typename Params>
 class RocprimDeviceScanFutureTests : public RocprimDeviceScanTests<Params>
@@ -1981,7 +1561,7 @@ TYPED_TEST(RocprimDeviceScanFutureTests, ExclusiveScan)
     const bool            debug_synchronous     = TestFixture::debug_synchronous;
     static constexpr bool use_identity_iterator = TestFixture::use_identity_iterator;
     const bool            deterministic         = TestFixture::deterministic;
-    using Config = typename TestFixture::config_helper::template type<false>;
+    using Config                                = typename TestFixture::config_helper;
 
     const int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id = " << device_id);


### PR DESCRIPTION
DO NOT MERGE UNTIL PM APPROVAL GIVEN.

## Motivation

See #1981 for full explanation.  This feature/fix needs to be ported back to ROCm 7.0.x

## Technical Details

Porting back 7.1 ordered block id changes to 7.0 codebase

## Test Plan

Running CI.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
