### PR TITLE
[rocBLAS] Revert "[rocBLAS] Stream Order Allocation as default (#1516)" due to rocHPL performance drop (multi-gpu)

### DIFF
--- a/projects/rocblas/clients/common/client_utility.cpp
+++ b/projects/rocblas/clients/common/client_utility.cpp
@@ -527,6 +527,8 @@ void rocblas_local_handle::rocblas_stream_begin_capture()
     CHECK_ROCBLAS_ERROR(rocblas_get_stream(m_handle, &m_old_stream));
     CHECK_HIP_ERROR(hipStreamSynchronize(m_old_stream));
 
+    m_handle->set_stream_order_memory_allocation(true);
+
     CHECK_HIP_ERROR(hipStreamCreate(&m_graph_stream));
     CHECK_ROCBLAS_ERROR(rocblas_set_stream(m_handle, m_graph_stream));
 
@@ -551,6 +553,8 @@ void rocblas_local_handle::rocblas_stream_end_capture()
     CHECK_ROCBLAS_ERROR(rocblas_set_stream(m_handle, m_old_stream));
     CHECK_HIP_ERROR(hipStreamDestroy(m_graph_stream));
     m_graph_stream = nullptr;
+
+    m_handle->set_stream_order_memory_allocation(false);
 }
 
 void rocblas_parallel_initialize_thread(int id, size_t& memory_used)

--- a/projects/rocblas/clients/include/blas2/testing_trsv.hpp
+++ b/projects/rocblas/clients/include/blas2/testing_trsv.hpp
@@ -155,6 +155,18 @@ void testing_trsv(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        CHECK_ALLOC_QUERY(rocblas_trsv_fn(handle, uplo, transA, diag, N, dA, lda, dx_or_b, incx));
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/projects/rocblas/clients/include/blas2/testing_trsv_batched.hpp
+++ b/projects/rocblas/clients/include/blas2/testing_trsv_batched.hpp
@@ -175,6 +175,28 @@ void testing_trsv_batched(const Arguments& arg)
     double error_eps_multiplier    = ERROR_EPS_MULTIPLIER;
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trsv_batched_fn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  diag,
+                                                  N,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dx_or_b.ptr_on_device(),
+                                                  incx,
+                                                  batch_count));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
 
     if(arg.unit_check || arg.norm_check)
     {

--- a/projects/rocblas/clients/include/blas2/testing_trsv_strided_batched.hpp
+++ b/projects/rocblas/clients/include/blas2/testing_trsv_strided_batched.hpp
@@ -189,6 +189,30 @@ void testing_trsv_strided_batched(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trsv_strided_batched_fn(handle,
+                                                          uplo,
+                                                          transA,
+                                                          diag,
+                                                          N,
+                                                          dA,
+                                                          lda,
+                                                          stride_a,
+                                                          dx_or_b,
+                                                          incx,
+                                                          stride_x,
+                                                          batch_count));
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/projects/rocblas/clients/include/blas3/testing_trsm.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_trsm.hpp
@@ -324,6 +324,21 @@ void testing_trsm(const Arguments& arg)
     double err_host                = 0.0;
     double err_device              = 0.0;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        DAPI_CHECK_ALLOC_QUERY(
+            rocblas_trsm_fn,
+            (handle, side, uplo, transA, diag, M, N, &alpha_h, dA, lda, dXorB, ldb));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/projects/rocblas/clients/include/blas3/testing_trsm_batched.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_trsm_batched.hpp
@@ -455,6 +455,31 @@ void testing_trsm_batched(const Arguments& arg)
     double err_host                = 0.0;
     double err_device              = 0.0;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+        DAPI_CHECK_ALLOC_QUERY(rocblas_trsm_batched_fn,
+                               (handle,
+                                side,
+                                uplo,
+                                transA,
+                                diag,
+                                M,
+                                N,
+                                &alpha_h,
+                                dA.ptr_on_device(),
+                                lda,
+                                dXorB.ptr_on_device(),
+                                ldb,
+                                batch_count));
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/projects/rocblas/clients/include/blas3/testing_trsm_strided_batched.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_trsm_strided_batched.hpp
@@ -522,6 +522,34 @@ void testing_trsm_strided_batched(const Arguments& arg)
     double err_host   = 0.0;
     double err_device = 0.0;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        DAPI_CHECK_ALLOC_QUERY(rocblas_trsm_strided_batched_fn,
+                               (handle,
+                                side,
+                                uplo,
+                                transA,
+                                diag,
+                                M,
+                                N,
+                                &alpha_h,
+                                dA,
+                                lda,
+                                stride_A,
+                                dXorB,
+                                ldb,
+                                stride_B,
+                                batch_count));
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         if(arg.pointer_mode_host)

--- a/projects/rocblas/clients/include/blas3/testing_trtri.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_trtri.hpp
@@ -163,6 +163,20 @@ void testing_trtri(const Arguments& arg)
     gpu_time_used = cpu_time_used = 0.0;
     double rocblas_error_out, rocblas_error_in;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trtri_fn(handle, uplo, diag, N, dA, lda, dinvA, ldinvA));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     /* =====================================================================
            ROCBLAS
     =================================================================== */

--- a/projects/rocblas/clients/include/blas3/testing_trtri_batched.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_trtri_batched.hpp
@@ -234,6 +234,32 @@ void testing_trtri_batched(const Arguments& arg)
     gpu_time_used = cpu_time_used = 0.0;
     double rocblas_error_out, rocblas_error_in;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trtri_batched_fn(handle,
+                                                   uplo,
+                                                   diag,
+                                                   N,
+                                                   dA.ptr_on_device(),
+                                                   lda,
+                                                   dinvA.ptr_on_device(),
+                                                   lda,
+                                                   batch_count));
+
+        // Test in place
+        CHECK_ALLOC_QUERY(rocblas_trtri_batched_fn(
+            handle, uplo, diag, N, dA.ptr_on_device(), lda, dA.ptr_on_device(), lda, batch_count));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     /* =====================================================================
            ROCBLAS
     =================================================================== */

--- a/projects/rocblas/clients/include/blas3/testing_trtri_strided_batched.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_trtri_strided_batched.hpp
@@ -214,6 +214,25 @@ void testing_trtri_strided_batched(const Arguments& arg)
     gpu_time_used = cpu_time_used = 0.0;
     double rocblas_error_out, rocblas_error_in;
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched_fn(
+            handle, uplo, diag, N, dA, lda, stride_A, dinvA, lda, stride_A, batch_count));
+
+        // Test in place
+        CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched_fn(
+            handle, uplo, diag, N, dA, lda, stride_A, dA, lda, stride_A, batch_count));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     /* =====================================================================
            ROCBLAS
     =================================================================== */

--- a/projects/rocblas/clients/include/blas_ex/testing_trsm_batched_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_trsm_batched_ex.hpp
@@ -365,6 +365,72 @@ void testing_trsm_batched_ex(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        if(arg.unit_check || arg.norm_check)
+        {
+            for(int b = 0; b < batch_count; b++)
+            {
+                if(blocks > 0)
+                {
+                    CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(handle,
+                                                                       uplo,
+                                                                       diag,
+                                                                       TRSM_BLOCK,
+                                                                       dA[b],
+                                                                       lda,
+                                                                       stride_A,
+                                                                       dinvA[b],
+                                                                       TRSM_BLOCK,
+                                                                       stride_invA,
+                                                                       blocks));
+                }
+
+                if(K % TRSM_BLOCK != 0 || blocks == 0)
+                {
+                    CHECK_ALLOC_QUERY(
+                        rocblas_trtri_strided_batched<T>(handle,
+                                                         uplo,
+                                                         diag,
+                                                         K - TRSM_BLOCK * blocks,
+                                                         dA[b] + stride_A * blocks,
+                                                         lda,
+                                                         stride_A,
+                                                         dinvA[b] + stride_invA * blocks,
+                                                         TRSM_BLOCK,
+                                                         stride_invA,
+                                                         1));
+                }
+            }
+        }
+
+        CHECK_ALLOC_QUERY(rocblas_trsm_batched_ex_fn(handle,
+                                                     side,
+                                                     uplo,
+                                                     transA,
+                                                     diag,
+                                                     M,
+                                                     N,
+                                                     &alpha_h,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     dXorB.ptr_on_device(),
+                                                     ldb,
+                                                     batch_count,
+                                                     dinvA.ptr_on_device(),
+                                                     TRSM_BLOCK * K,
+                                                     arg.compute_type));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         // calculate dXorB <- A^(-1) B   rocblas_device_pointer_host

--- a/projects/rocblas/clients/include/blas_ex/testing_trsm_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_trsm_ex.hpp
@@ -339,6 +339,64 @@ void testing_trsm_ex(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        if(blocks > 0)
+        {
+            CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(handle,
+                                                               uplo,
+                                                               diag,
+                                                               TRSM_BLOCK,
+                                                               dA,
+                                                               lda,
+                                                               stride_A,
+                                                               dinvA,
+                                                               TRSM_BLOCK,
+                                                               stride_invA,
+                                                               blocks));
+        }
+
+        if(K % TRSM_BLOCK != 0 || blocks == 0)
+        {
+            CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(handle,
+                                                               uplo,
+                                                               diag,
+                                                               K - TRSM_BLOCK * blocks,
+                                                               dA + stride_A * blocks,
+                                                               lda,
+                                                               stride_A,
+                                                               dinvA + stride_invA * blocks,
+                                                               TRSM_BLOCK,
+                                                               stride_invA,
+                                                               1));
+        }
+
+        CHECK_ALLOC_QUERY(rocblas_trsm_ex_fn(handle,
+                                             side,
+                                             uplo,
+                                             transA,
+                                             diag,
+                                             M,
+                                             N,
+                                             &alpha_h,
+                                             dA,
+                                             lda,
+                                             dXorB,
+                                             ldb,
+                                             dinvA,
+                                             TRSM_BLOCK * K,
+                                             arg.compute_type));
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
         // calculate dXorB <- A^(-1) B   rocblas_device_pointer_host

--- a/projects/rocblas/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
@@ -415,6 +415,75 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
     double residual_eps_multiplier = RESIDUAL_EPS_MULTIPLIER;
     double eps                     = std::numeric_limits<real_t<T>>::epsilon();
 
+    if(!ROCBLAS_REALLOC_ON_DEMAND)
+    {
+        // Compute size
+        CHECK_ROCBLAS_ERROR(rocblas_start_device_memory_size_query(handle));
+
+        if(arg.unit_check || arg.norm_check)
+        {
+            for(int b = 0; b < batch_count; b++)
+            {
+                if(blocks > 0)
+                {
+                    CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(handle,
+                                                                       uplo,
+                                                                       diag,
+                                                                       TRSM_BLOCK,
+                                                                       dA[b],
+                                                                       lda,
+                                                                       sub_stride_A,
+                                                                       dinvA[b],
+                                                                       TRSM_BLOCK,
+                                                                       sub_stride_invA,
+                                                                       blocks));
+                }
+
+                if(K % TRSM_BLOCK != 0 || blocks == 0)
+                {
+                    CHECK_ALLOC_QUERY(rocblas_trtri_strided_batched<T>(
+                        handle,
+                        uplo,
+                        diag,
+                        K - TRSM_BLOCK * blocks,
+                        (T*)dA + sub_stride_A * blocks + b * stride_A,
+                        lda,
+                        sub_stride_A,
+                        (T*)dinvA + sub_stride_invA * blocks + b * stride_invA,
+                        TRSM_BLOCK,
+                        sub_stride_invA,
+                        1));
+                }
+            }
+
+            CHECK_ALLOC_QUERY(rocblas_trsm_strided_batched_ex_fn(handle,
+                                                                 side,
+                                                                 uplo,
+                                                                 transA,
+                                                                 diag,
+                                                                 M,
+                                                                 N,
+                                                                 &alpha_h,
+                                                                 dA,
+                                                                 lda,
+                                                                 stride_A,
+                                                                 dXorB,
+                                                                 ldb,
+                                                                 stride_B,
+                                                                 batch_count,
+                                                                 dinvA,
+                                                                 size_invA,
+                                                                 stride_invA,
+                                                                 arg.compute_type));
+        }
+
+        size_t size;
+        CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &size));
+
+        // Allocate memory
+        CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, size));
+    }
+
     if(arg.unit_check || arg.norm_check)
     {
 

--- a/projects/rocblas/clients/samples/example_solver_rocblas.cpp
+++ b/projects/rocblas/clients/samples/example_solver_rocblas.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,9 @@ int main()
     rocblas_handle handle;
     CHECK_ROCBLAS_ERROR(rocblas_create_handle(&handle));
 
+    // Free all memory in the handle
+    CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, 0));
+
     size_t sizes[] = {512, 1025, 10 * 1024 * 1024};
 
     if(rocblas_is_device_memory_size_query(handle))
@@ -47,6 +50,11 @@ int main()
     }
 
     CHECK_ALLOC_QUERY(rocblas_set_optimal_device_memory_size(handle, sizes[0], sizes[1], sizes[2]));
+
+    size_t max;
+    CHECK_ROCBLAS_ERROR(rocblas_stop_device_memory_size_query(handle, &max));
+
+    CHECK_ROCBLAS_ERROR(rocblas_set_device_memory_size(handle, max));
 
     for(size_t size : sizes)
     {

--- a/projects/rocblas/docs/how-to/Programmers_Guide.rst
+++ b/projects/rocblas/docs/how-to/Programmers_Guide.rst
@@ -225,7 +225,7 @@ the ``hipStreamSynchronize(old_stream)`` API before setting the new stream.
 
 .. code-block:: cpp
 
-    // Synchronize the old stream (optional)
+    // Synchronize the old stream
     if(hipStreamSynchronize(old_stream) != hipSuccess) return EXIT_FAILURE;
 
     // Create a new stream (this step can be done before the steps above)
@@ -237,8 +237,8 @@ the ``hipStreamSynchronize(old_stream)`` API before setting the new stream.
     // Destroy the old stream (this step is optional but must come after synchronization)
     if(hipStreamDestroy(old_stream) != hipSuccess) return EXIT_FAILURE;
 
-The call to ``hipStreamSynchronize`` above is necessary for the ``user_owned`` allocation scheme because the ``rocBLAS_handle`` contains allocated device
-memory provided by the user that must not be shared by multiple asynchronous streams at the same time.
+The call to ``hipStreamSynchronize`` above is necessary because the ``rocBLAS_handle`` contains allocated device
+memory that must not be shared by multiple asynchronous streams at the same time.
 
 If either the old or new stream is the default or ``NULL`` stream, it is not necessary to
 synchronize the old stream before destroying it, or before setting the new stream,
@@ -246,8 +246,8 @@ because the synchronization is implicit.
 
 .. note::
 
-   You can switch from one non-default stream to another without calling ``hipStreamSynchronize()`` as the default memory allocation scheme (``rocBLAS_managed``) uses stream order allocation.
-   For more information, see :ref:`Device Memory Allocation Usage`.
+   You can switch from one non-default stream to another without calling ``hipStreamSynchronize()`` by enabling stream-order memory allocation.
+   For more information, see :ref:`stream order alloc`.
 
 Creating the handle incurs a startup cost. There is an additional startup cost for
 GEMM functions to load GEMM kernels for a specific device. You can shift the

--- a/projects/rocblas/docs/reference/beta-features.rst
+++ b/projects/rocblas/docs/reference/beta-features.rst
@@ -46,8 +46,8 @@ The captured graph can be launched as shown below:
       CHECK_HIP_ERROR(hipGraphInstantiate(&instance, graph, NULL, NULL, 0));
       CHECK_HIP_ERROR(hipGraphLaunch(instance, stream));
 
-Graph support requires asynchronous HIP APIs, so users must use the ``rocBLAS_managed`` (default) memory allocation scheme which uses stream-order memory allocation.
-For more details, see :ref:`Device Memory Allocation Usage`.
+Graph support requires asynchronous HIP APIs, so users must enable stream-order memory allocation.
+For more details, see :ref:`stream order alloc`.
 
 During stream capture, rocBLAS stores the allocated host and device memory in the handle.
 The allocated memory is freed when the handle is destroyed.

--- a/projects/rocblas/docs/reference/memory-alloc.rst
+++ b/projects/rocblas/docs/reference/memory-alloc.rst
@@ -8,15 +8,9 @@
 ********************************************************************
 Device memory allocation in rocBLAS
 ********************************************************************
-rocBLAS uses per-handle device memory allocation to manage temporary memory efficiently. Each handle maintains its own memory and executes kernels sequentially in a single stream, allowing memory reuse across kernels.
 
-There are two memory allocation schemes:
-
-*  **rocBLAS_managed(default)**:  By default, rocBLAS internally manages memory, allocating more if needed. Allocated memory persists with the handle for reuse.
-
-*  **user_owned**: Users allocate memory and provide it to rocBLAS via ``rocblas_set_workspace``.
-
-``rocBLAS_managed`` is the default scheme. This scheme uses ``hipMallocAsync`` and ``hipFreeAsync`` (stream-order allocation) to allocate and free memory in stream order, avoiding global synchronization. This enables seamless stream switching without needing ``hipStreamSynchronize()``.
+For temporary device memory, rocBLAS uses a per-handle memory allocation with out-of-band management.
+For more information, see the device memory allocation section of the :ref:programmers-guide.
 
 The following computational functions use temporary device memory.
 
@@ -117,10 +111,27 @@ The following computational functions use temporary device memory.
 | - rocblas_Xtrtri_strided_batched               |                                                      |
 +------------------------------------------------+------------------------------------------------------+
 
+.. _rocblas_device_memory_size:
+
+Environment variable for preallocating memory
+=============================================
+
+The environment variable ``ROCBLAS_DEVICE_MEMORY_SIZE`` is used to set how much memory to preallocate:
+
+*  If it is greater than 0, it sets the default handle device memory size to the specified size (in bytes).
+*  If it is equal to 0 or unset, it lets rocBLAS manage the device memory. It uses a default size, like 32MiB or 128MiB, and expands it when necessary.
+
 Memory allocation functions
 ==============================================
 
 rocBLAS includes functions for manually setting the memory size and determining the memory requirements.
+
+Functions for manually setting the memory size
+----------------------------------------------
+
+*  ``rocblas_set_device_memory_size``
+*  ``rocblas_get_device_memory_size``
+*  ``rocblas_is_user_managing_device_memory``
 
 Function for setting a user-owned workspace
 ----------------------------------------------
@@ -139,11 +150,32 @@ See the API section for information about these functions.
 rocBLAS function return values for insufficient device memory
 =============================================================
 
-If the user manually allocates (user-owned scheme) using ``rocblas_set_workspace(rocblas_handle handle, void* addr, size_t size)``, that size is used as the limit and no resizing or synchronizing ever occurs.
+If the user preallocates or manually allocates, that size is used as the limit and no resizing or synchronizing ever occurs.
 The following two function return values indicate insufficient memory:
 
 *  ``rocblas_status == rocblas_status_memory_error`` : indicates there is insufficient device memory for a rocBLAS function.
 *  ``rocblas_status == rocblas_status_perf_degraded`` : indicates that a slower algorithm was used because of insufficient device memory for the optimal algorithm.
+
+.. _stream order alloc:
+
+Stream-ordered memory allocation
+========================================
+
+Stream-ordered device memory allocation is added to rocBLAS. The asynchronous allocators
+``hipMallocAsync()`` and ``hipFreeAsync()`` are used to allow allocation and deallocation to happen in stream order.
+
+This is a non-default beta option that can be enabled by setting the environment variable ``ROCBLAS_STREAM_ORDER_ALLOC``.
+
+To check whether the device supports stream-order allocation, call ``hipDeviceGetAttribute()`` with the
+device attribute ``hipDeviceAttributeMemoryPoolsSupported``.
+
+Enabling stream-ordered memory allocation
+----------------------------------------------
+
+On supported platforms, the environment variable ``ROCBLAS_STREAM_ORDER_ALLOC`` is used to enable stream-ordered memory allocation.
+
+*  If it is greater than 0 (``> 0``), it sets the allocation to be stream-ordered and uses ``hipMallocAsync/hipFreeAsync`` to manage device memory.
+*  If it is equal to zero (``= 0``) or unset, it uses ``hipMalloc`` and ``hipFree`` to manage device memory.
 
 Switching streams without synchronization
 ----------------------------------------------

--- a/projects/rocblas/library/include/internal/rocblas-functions.h
+++ b/projects/rocblas/library/include/internal/rocblas-functions.h
@@ -25026,12 +25026,12 @@ ROCBLAS_EXPORT rocblas_status rocblas_get_device_memory_size(rocblas_handle hand
     size            size of allocated device memory
  ******************************************************************************/
 ROCBLAS_DEPRECATED_MSG("rocblas_set_device_memory_size will be removed in a future release and "
-                       "supported modes will be rocblas_managed & user_owned [Do not use]")
+                       "supported modes will be rocblas_managed & user_owned")
 ROCBLAS_EXPORT rocblas_status rocblas_set_device_memory_size(rocblas_handle handle, size_t size);
 
 /*! \brief
     \details
-    Allows user to set the device memory for the handle to use as a workspace (user-owned scheme).
+    Sets the device workspace for the handle to use.
 
     Any previously allocated device memory managed by the handle is freed.
 
@@ -25061,7 +25061,7 @@ ROCBLAS_EXPORT bool rocblas_is_managing_device_memory(rocblas_handle handle);
     handle          rocblas handle
  ******************************************************************************/
 ROCBLAS_DEPRECATED_MSG("rocblas_is_user_managing_device_memory will be removed in a future release "
-                       "and supported modes will be rocblas_managed and user_owned [Do not use]")
+                       "and supported modes will be rocblas_managed and user_owned")
 ROCBLAS_EXPORT bool rocblas_is_user_managing_device_memory(rocblas_handle handle);
 
 /*! \brief

--- a/projects/rocblas/library/src/blas2/rocblas_trsv_imp.hpp
+++ b/projects/rocblas/library/src/blas2/rocblas_trsv_imp.hpp
@@ -143,6 +143,7 @@ namespace
             if(trsv_check_numerics_status != rocblas_status_success)
                 return trsv_check_numerics_status;
         }
+
         rocblas_status status
             = ROCBLAS_API(rocblas_internal_trsv_template)(handle,
                                                           uplo,

--- a/projects/rocblas/library/src/handle.cpp
+++ b/projects/rocblas/library/src/handle.cpp
@@ -82,6 +82,15 @@ _rocblas_handle::_rocblas_handle()
     archMajor      = arch / 100; // this may need to switch to string handling in the future
     archMajorMinor = arch / 10;
 
+    //ROCBLAS_STREAM_ORDER_ALLOC
+    const char* stream_order_alloc_env = read_env("ROCBLAS_STREAM_ORDER_ALLOC");
+
+    if(stream_order_alloc_env)
+    {
+        int stream_order_alloc_env_val = strtoul(stream_order_alloc_env, nullptr, 0);
+        stream_order_alloc             = stream_order_alloc_env_val ? true : false;
+    }
+
     //ROCBLAS_DEFAULT_ATOMICS_MODE
     const char* atomics_mode_env = read_env("ROCBLAS_DEFAULT_ATOMICS_MODE");
     if(atomics_mode_env)
@@ -89,28 +98,60 @@ _rocblas_handle::_rocblas_handle()
         atomics_mode = strtoul(atomics_mode_env, nullptr, 0) ? rocblas_atomics_allowed
                                                              : rocblas_atomics_not_allowed;
     }
+
     // Device memory size
     const char* env = read_env("ROCBLAS_DEVICE_MEMORY_SIZE");
     if(env)
         device_memory_size = strtoul(env, nullptr, 0);
 
-    // The following allocation & free of device memory using hipMallocAsync/hipFreeAsync will allocate memory from
-    // the OS and release it to default memory pool. Further allocation of memory using hipMallocAsync
-    // will be from the memory pool and it will be faster.
     if(env && device_memory_size)
     {
+        device_memory_owner = rocblas_device_memory_ownership::user_managed;
+    }
+    else
+    {
+        device_memory_owner = rocblas_device_memory_ownership::rocblas_managed;
+
+        if(!env)
+        {
+            if(t_rocblas_device_malloc_default_memory_size)
+            {
+                device_memory_size = t_rocblas_device_malloc_default_memory_size;
+                t_rocblas_device_malloc_default_memory_size = 0;
+            }
+            else
+            {
+
+                device_memory_size = getDefaultDeviceMemorySize();
+            }
+        }
+    }
+
+    if(!stream_order_alloc)
+    { // Allocate device memory
+        if(device_memory_size)
+            THROW_IF_HIP_ERROR((hipMalloc)(&device_memory, device_memory_size));
+    }
+    else
+    {
+// hipMallocAsync and hipFreeAsync are defined in hip version 5.2.0
+// Support for default stream added in hip version 5.3.0
+#if HIP_VERSION >= 50300000
+        // The following allocation & free of device memory using hipMallocAsync/hipFreeAsync will allocate memory from
+        // the OS and release it to default memory pool. Further allocation of memory using hipMallocAsync
+        // will be from the memory pool and it will be faster.
         THROW_IF_HIP_ERROR((hipMallocAsync)(&device_memory, device_memory_size, stream));
 
         THROW_IF_HIP_ERROR((hipFreeAsync)(device_memory, stream));
-    }
-    else //uses default memory size
-    {
-        THROW_IF_HIP_ERROR((hipMallocAsync)(&device_memory, getDefaultDeviceMemorySize(), stream));
 
-        THROW_IF_HIP_ERROR((hipFreeAsync)(device_memory, stream));
+        device_memory = nullptr;
+#else
+        rocblas_cerr
+            << "rocBLAS internal error: Stream order allocation is supported on ROCm 5.3 and above."
+            << std::endl;
+        rocblas_abort();
+#endif
     }
-
-    device_memory = nullptr;
 
     // Initialize logging
     init_logging();
@@ -163,46 +204,64 @@ _rocblas_handle::~_rocblas_handle()
             << std::endl;
         rocblas_abort();
     }
-
     // Free device memory unless it's user-owned
     if(device_memory_owner != rocblas_device_memory_ownership::user_owned)
     {
         hipError_t hipStatus;
-
-        hipStatus = (device_memory) ? (hipFreeAsync)(device_memory, stream) : hipSuccess;
-        if(hipStatus != hipSuccess)
+        if(!stream_order_alloc)
         {
-            rocblas_cerr << "rocBLAS error during freeing of allocated memory in handle "
-                            "destructor (stream order allocation): "
-                         << rocblas_status_to_string(
-                                rocblas_internal_convert_hip_to_rocblas_status(hipStatus))
-                         << std::endl;
-            rocblas_abort();
-        };
-
-        hipMemPool_t mem_pool;
-        int          device;
-        hipStatus = hipGetDevice(&device);
-        if(hipStatus != hipSuccess)
-        {
-            rocblas_cerr << "rocBLAS error retreiving the device (deviceID: " << device << ")"
-                         << std::endl;
-            rocblas_abort();
+            hipStatus = (hipFree)(device_memory);
+            if(hipStatus != hipSuccess)
+            {
+                rocblas_cerr
+                    << "rocBLAS error during freeing of allocated memory in handle destructor: "
+                    << rocblas_status_to_string(
+                           rocblas_internal_convert_hip_to_rocblas_status(hipStatus))
+                    << std::endl;
+                rocblas_abort();
+            };
         }
-        hipStatus = hipDeviceGetDefaultMemPool(&mem_pool, device);
-        if(hipStatus != hipSuccess)
+        else
         {
-            rocblas_cerr << "rocBLAS error retreiving the device's memory pool (deviceID: "
-                         << device << ")" << std::endl;
-            rocblas_abort();
-        }
-        //Releases device memory back to OS
-        hipStatus = hipMemPoolTrimTo(mem_pool, 0);
-        if(hipStatus != hipSuccess)
-        {
-            rocblas_cerr << "rocBLAS error releasing the device's memory pool (deviceID: " << device
-                         << ")" << std::endl;
-            rocblas_abort();
+// hipMallocAsync and hipFreeAsync are defined in hip version 5.2.0
+// Support for default stream added in hip version 5.3.0
+#if HIP_VERSION >= 50300000
+            hipStatus = (device_memory) ? (hipFreeAsync)(device_memory, stream) : hipSuccess;
+            if(hipStatus != hipSuccess)
+            {
+                rocblas_cerr << "rocBLAS error during freeing of allocated memory in handle "
+                                "destructor (stream order allocation): "
+                             << rocblas_status_to_string(
+                                    rocblas_internal_convert_hip_to_rocblas_status(hipStatus))
+                             << std::endl;
+                rocblas_abort();
+            };
+
+            hipMemPool_t mem_pool;
+            int          device;
+            hipStatus = hipGetDevice(&device);
+            if(hipStatus != hipSuccess)
+            {
+                rocblas_cerr << "rocBLAS error retreiving the device (deviceID: " << device << ")"
+                             << std::endl;
+                rocblas_abort();
+            }
+            hipStatus = hipDeviceGetDefaultMemPool(&mem_pool, device);
+            if(hipStatus != hipSuccess)
+            {
+                rocblas_cerr << "rocBLAS error retreiving the device's memory pool (deviceID: "
+                             << device << ")" << std::endl;
+                rocblas_abort();
+            }
+            //Releases device memory back to OS
+            hipStatus = hipMemPoolTrimTo(mem_pool, 0);
+            if(hipStatus != hipSuccess)
+            {
+                rocblas_cerr << "rocBLAS error releasing the device's memory pool (deviceID: "
+                             << device << ")" << std::endl;
+                rocblas_abort();
+            }
+#endif
         }
     }
 
@@ -220,6 +279,46 @@ _rocblas_handle::~_rocblas_handle()
     }
 #endif
 }
+
+/*******************************************************************************
+ * helper for allocating device memory
+ ******************************************************************************/
+#if ROCBLAS_REALLOC_ON_DEMAND
+bool _rocblas_handle::device_allocator(size_t size)
+{
+    bool success = size <= device_memory_size - device_memory_in_use;
+    if(!success && device_memory_owner == rocblas_device_memory_ownership::rocblas_managed)
+    {
+        if(device_memory_in_use)
+        {
+            rocblas_cerr << "rocBLAS internal error: Cannot reallocate device memory while it is "
+                            "already in use."
+                         << std::endl;
+            rocblas_abort();
+        }
+
+        // Temporarily change the thread's default device ID to the handle's device ID
+        // cppcheck-suppress unreadVariable
+        auto saved_device_id = push_device_id();
+
+        device_memory_size = 0;
+
+        //Add an additional device memory on top of default size.
+        //This is to support kernels requiring large workspace with numerical checking enabled.
+        size_t total_size = size + getDefaultDeviceMemorySize();
+
+        if(!device_memory || (hipFree)(device_memory) == hipSuccess)
+        {
+            success = (hipMalloc)(&device_memory, total_size) == hipSuccess;
+            if(success)
+                device_memory_size = total_size;
+            else
+                device_memory = nullptr;
+        }
+    }
+    return success;
+}
+#endif
 
 int _rocblas_handle::getActiveDevice()
 {
@@ -452,7 +551,14 @@ static rocblas_status free_existing_device_memory(rocblas_handle handle)
     if(handle->device_memory
        && handle->device_memory_owner != rocblas_device_memory_ownership::user_owned)
     {
-        RETURN_IF_HIP_ERROR((hipFreeAsync)(handle->device_memory, handle->stream));
+        if(!handle->stream_order_alloc)
+            RETURN_IF_HIP_ERROR((hipFree)(handle->device_memory));
+// hipMallocAsync and hipFreeAsync are defined in hip version 5.2.0
+// Support for default stream added in hip version 5.3.0
+#if HIP_VERSION >= 50300000
+        else
+            RETURN_IF_HIP_ERROR((hipFreeAsync)(handle->device_memory, handle->stream));
+#endif
     }
 
     // Clear the memory size and address, and set the memory to be rocBLAS-managed
@@ -472,7 +578,46 @@ try
     if(!handle)
         return rocblas_status_invalid_handle;
 
-    return rocblas_status_success;
+    // Temporarily change the thread's default device ID to the handle's device ID
+    auto saved_device_id = handle->push_device_id();
+
+    // Free any allocated memory unless owned by user, and set device memory to
+    // the default of being rocBLAS-managed
+    rocblas_status status = free_existing_device_memory(handle);
+    if(status != rocblas_status_success)
+        return status;
+
+    // A zero specified size makes it rocBLAS-managed, and defers allocation
+    if(!size)
+        return rocblas_status_success;
+
+    // Allocate size rounded up to MIN_CHUNK_SIZE
+    size = roundup_device_memory_size(size);
+
+    hipError_t hipStatus;
+    if(!handle->stream_order_alloc)
+        hipStatus = (hipMalloc)(&handle->device_memory, size);
+// hipMallocAsync and hipFreeAsync are defined in hip version 5.2.0
+// Support for default stream added in hip version 5.3.0
+#if HIP_VERSION >= 50300000
+    else
+        hipStatus = (hipMallocAsync)(&handle->device_memory, size, handle->stream);
+#endif
+
+    if(hipStatus != hipSuccess)
+    {
+        // If allocation fails, nullify device memory address and return error
+        // Leave the memory under rocBLAS management for future calls
+        handle->device_memory = nullptr;
+        return rocblas_internal_convert_hip_to_rocblas_status(hipStatus);
+    }
+    else
+    {
+        // If allocation succeeds, set size, mark it under user-management, and return success
+        handle->device_memory_size  = size;
+        handle->device_memory_owner = rocblas_device_memory_ownership::user_managed;
+        return rocblas_status_success;
+    }
 }
 catch(...)
 {
@@ -518,8 +663,12 @@ catch(...)
  ******************************************************************************/
 extern "C" bool rocblas_is_managing_device_memory(rocblas_handle handle)
 {
+#if ROCBLAS_REALLOC_ON_DEMAND
     return handle
            && handle->device_memory_owner == rocblas_device_memory_ownership::rocblas_managed;
+#else
+    return false;
+#endif
 }
 
 /*******************************************************************************
@@ -527,7 +676,7 @@ extern "C" bool rocblas_is_managing_device_memory(rocblas_handle handle)
  ******************************************************************************/
 extern "C" bool rocblas_is_user_managing_device_memory(rocblas_handle handle)
 {
-    return false;
+    return handle && handle->device_memory_owner == rocblas_device_memory_ownership::user_managed;
 }
 
 /* \brief

--- a/projects/rocblas/library/src/include/handle.hpp
+++ b/projects/rocblas/library/src/include/handle.hpp
@@ -47,6 +47,12 @@ typedef void* hipblasLtHandle_t;
 // forcing early cleanup
 extern "C" ROCBLAS_EXPORT void rocblas_shutdown();
 
+// Whether rocBLAS can reallocate device memory on demand, at the cost of only
+// allowing one allocation at a time, and at the cost of potential synchronization.
+// If this is 0, then stack-like allocation is allowed, but reallocation on demand
+// does not occur.
+#define ROCBLAS_REALLOC_ON_DEMAND 1
+
 // Round up size to the nearest MIN_CHUNK_SIZE
 constexpr size_t roundup_device_memory_size(size_t size)
 {
@@ -63,6 +69,7 @@ struct rocblas_device_malloc_base
 enum class rocblas_device_memory_ownership
 {
     rocblas_managed,
+    user_managed,
     user_owned,
 };
 
@@ -427,9 +434,11 @@ public:
     friend rocblas_status(::rocblas_start_device_memory_size_query)(_rocblas_handle*);
     friend rocblas_status(::rocblas_stop_device_memory_size_query)(_rocblas_handle*, size_t*);
     friend rocblas_status(::rocblas_get_device_memory_size)(_rocblas_handle*, size_t*);
+    friend rocblas_status(::rocblas_set_device_memory_size)(_rocblas_handle*, size_t);
     friend rocblas_status(::free_existing_device_memory)(rocblas_handle);
     friend rocblas_status(::rocblas_set_workspace)(_rocblas_handle*, void*, size_t);
     friend bool(::rocblas_is_managing_device_memory)(_rocblas_handle*);
+    friend bool(::rocblas_is_user_managing_device_memory)(_rocblas_handle*);
     friend rocblas_status(::rocblas_set_stream)(_rocblas_handle*, hipStream_t);
 
     // C interfaces that interact with the solution selection process
@@ -542,9 +551,8 @@ private:
     size_t                          device_memory_in_use       = 0;
     bool                            device_memory_size_query   = false;
     bool                            alpha_beta_memcpy_complete = false;
-    rocblas_device_memory_ownership device_memory_owner
-        = rocblas_device_memory_ownership::rocblas_managed;
-    size_t device_memory_query_size;
+    rocblas_device_memory_ownership device_memory_owner;
+    size_t                          device_memory_query_size;
 
     bool stream_order_alloc = false;
 
@@ -553,6 +561,11 @@ private:
 
     // rocblas by default take the system default stream 0 users cannot create
     hipStream_t stream = 0;
+
+#if ROCBLAS_REALLOC_ON_DEMAND
+    // Helper for device memory allocator
+    bool ROCBLAS_EXPORT device_allocator(size_t size);
+#endif
 
 public:
     hipDeviceProp_t device_properties;
@@ -604,13 +617,16 @@ private:
             const size_t offsets[] = {(old = size, size += roundup_device_memory_size(sizes), old)...};
             char* addr = nullptr;
 
-            if( handle->device_memory_owner == rocblas_device_memory_ownership::rocblas_managed)
+            if(handle->stream_order_alloc &&
+                handle->device_memory_owner == rocblas_device_memory_ownership::rocblas_managed)
             {
+// hipMallocAsync and hipFreeAsync are defined in hip version 5.2.0
+// Support for default stream added in hip version 5.3.0
+#if HIP_VERSION >= 50300000
                 if(!size)
                     return decltype(pointers)(sizeof...(sizes));
 
                 hipError_t hipStatus = hipMallocAsync(&dev_mem, size, stream_in_use);
-
                 if(hipStatus != hipSuccess)
                 {
                     success = false;
@@ -618,11 +634,15 @@ private:
                     return decltype(pointers)(sizeof...(sizes));
                 }
                 addr = static_cast<char*>(dev_mem);
+#endif
             }
-            else if (handle->device_memory_owner == rocblas_device_memory_ownership::user_owned)
+            else
             {
+#if ROCBLAS_REALLOC_ON_DEMAND
+                success = handle->device_allocator(size);
+#else
                 success = size <= handle->device_memory_size - handle->device_memory_in_use;
-
+#endif
                 // If allocation failed, return an array of nullptr's
                 // If total size is 0, return an array of nullptr's, but leave it marked as successful
                 if(!success || !size)
@@ -632,7 +652,6 @@ private:
                 addr = static_cast<char*>(handle->device_memory) + handle->device_memory_in_use;
                 handle->device_memory_in_use += size;
             }
-
             // An array of pointers to all of the allocated arrays is formed.
             // If a size is 0, the corresponding pointer is nullptr
             size_t i = 0;
@@ -662,26 +681,33 @@ private:
             , stream_in_use(handle->stream)
             , success(true)
         {
-            if( handle->device_memory_owner == rocblas_device_memory_ownership::rocblas_managed)
+            if(handle->stream_order_alloc &&
+                handle->device_memory_owner == rocblas_device_memory_ownership::rocblas_managed)
             {
+// hipMallocAsync and hipFreeAsync are defined in hip version 5.2.0
+// Support for default stream added in hip version 5.3.0
+#if HIP_VERSION >= 50300000
                 bool status = hipMallocAsync(&dev_mem, size, stream_in_use) == hipSuccess ;
 
                 for(auto i= 0 ; i < count ; i++)
                     pointers.push_back(status ? dev_mem : nullptr);
+#endif
             }
-             else if (handle->device_memory_owner == rocblas_device_memory_ownership::user_owned)
+            else
             {
-
-                success = size <= handle->device_memory_size - handle->device_memory_in_use;
-                for(auto i= 0 ; i < count ; i++)
-                {    pointers.push_back(success ? static_cast<char*>(handle->device_memory)
-                                            + handle->device_memory_in_use : nullptr);
-                }
-
-                if(success)
-                    handle->device_memory_in_use += size;
+#if ROCBLAS_REALLOC_ON_DEMAND
+            success = handle->device_allocator(size);
+#else
+            success = size <= handle->device_memory_size - handle->device_memory_in_use;
+#endif
+            for(auto i= 0 ; i < count ; i++)
+            {    pointers.push_back(success ? static_cast<char*>(handle->device_memory)
+                                         + handle->device_memory_in_use : nullptr);
             }
 
+            if(success)
+                handle->device_memory_in_use += size;
+            }
         }
 
         // Move constructor
@@ -721,10 +747,15 @@ private:
             // If success == false or size == 0, the destructor is a no-op
             if(success && size)
             {
-                if( handle->device_memory_owner == rocblas_device_memory_ownership::rocblas_managed)
+                if(handle->stream_order_alloc &&
+                    handle->device_memory_owner == rocblas_device_memory_ownership::rocblas_managed)
                 {
+// hipMallocAsync and hipFreeAsync are defined in hip version 5.2.0
+// Support for default stream added in hip version 5.3.0
+#if HIP_VERSION >= 50300000
                         if(dev_mem)
                         {
+
                             bool status = hipFreeAsync(dev_mem, stream_in_use) == hipSuccess ;
                             if(!status)
                             {
@@ -734,9 +765,9 @@ private:
                             }
                             dev_mem = nullptr;
                         }
-
+#endif
                 }
-                else if (handle->device_memory_owner == rocblas_device_memory_ownership::user_owned)
+                else
                 {
                     // Subtract size from the handle's device_memory_in_use, making sure
                     // it matches the device_memory_in_use when this object was created.
@@ -754,7 +785,6 @@ private:
                         rocblas_abort();
                     }
                 }
-
 
                 handle->gsu_workspace_size = 0;
                 handle->gsu_workspace      = nullptr;


### PR DESCRIPTION
This reverts commit a2553f85ccdd7f60fa3aaf9c9aff026800083093.

## Motivation
[https://ontrack-internal.amd.com/browse/SWDEV-558744](url) ~15% to ~47% drops in rochpl-Mxp 2, 4 and 8GPUs

## Technical Details

Fixed the rocHPL performance drop in a multi-gpu setup. 

## Test Plan

**rocBLAS test:** 
Validate rocBLAS build using the './install.sh -dc -a auto' command
Run pre_checkin tests

> ./rocblas-test --gtest_filter=*pre_checkin*

**rocHPL test:** To benchmark performance, run the following commands:

>        cd rocHPL-MxP/
>        ./install.sh
>        
>        cd build/
>        
>        ./mpirun_rochplmxp -P 2 -Q 1 -N 179200 --NB 2560 -->For 2 GPU
>        
>        ./mpirun_rochplmxp -P 2 -Q 2 -N 250880 --NB 2560 -->For 4 GPU
>       
>        ./mpirun_rochplmxp -P 2 -Q 4 -N 358400 --NB 2560 -->For 8GPU

## Test Result

- rocBLAS Build successful
- rocblas-test pre_checkin passed
- rocHPL performance improved


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
