### PR TITLE
[TheRock CI] Fixing CI nightly

### DIFF
--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -8,5 +8,90 @@ permissions:
   contents: read
 
 jobs:
-  therock_ci_nightly:
-    uses: './.github/workflows/therock-ci.yml'
+  setup:
+    name: "Setup"
+    runs-on: ubuntu-24.04
+    outputs:
+      projects: ${{ steps.projects.outputs.projects }}
+      test_type: ${{ steps.projects.outputs.test_type }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pydantic requests
+
+      - name: Determine projects to run
+        id: projects
+        env:
+          PROJECTS: ${{ inputs.projects }}
+        run: |
+          python .github/scripts/therock_configure_ci.py
+
+  therock-ci-linux:
+    name: Linux (${{ matrix.projects.project_to_test }})
+    permissions:
+      contents: read
+      id-token: write
+    needs: setup
+    if: ${{ needs.setup.outputs.projects != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        projects: ${{ fromJSON(needs.setup.outputs.projects) }}
+    uses: ./.github/workflows/therock-ci-linux.yml
+    secrets: inherit
+    with:
+      cmake_options: ${{ matrix.projects.cmake_options }}
+      project_to_test: ${{ matrix.projects.project_to_test }}
+      test_type: ${{ needs.setup.outputs.test_type }}
+
+  therock-ci-windows:
+    name: Windows (${{ matrix.projects.project_to_test }})
+    permissions:
+      contents: read
+      id-token: write
+    needs: setup
+    if: ${{ needs.setup.outputs.projects != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        projects: ${{ fromJSON(needs.setup.outputs.projects) }}
+    uses: ./.github/workflows/therock-ci-windows.yml
+    secrets: inherit
+    with:
+      cmake_options: ${{ matrix.projects.cmake_options }}
+      project_to_test: ${{ matrix.projects.project_to_test }}
+      test_type: ${{ needs.setup.outputs.test_type }}
+
+  therock_ci_nightly_summary:
+    name: TheRock CI Nightly Summary
+    if: always()
+    needs:
+      - setup
+      - therock-ci-linux
+      - therock-ci-windows
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Output failed jobs
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -3,6 +3,11 @@ name: TheRock CI Nightly
 on:
   schedule:
     - cron: "0 7 * * *" # Runs nightly at 7 AM UTC
+  workflow_dispatch:
+    inputs:
+      projects:
+        type: string
+        description: "Insert space-separated list of projects to test or 'all' to test all projects. ex: 'projects/rocprim projects/hipcub'"
 
 permissions:
   contents: read


### PR DESCRIPTION
Getting errors during CI nightly :(

```
[Invalid workflow file: .github/workflows/therock-ci-nightly.yml#L12](https://github.com/ROCm/rocm-libraries/actions/runs/18772362440/workflow)
error parsing called workflow
".github/workflows/therock-ci-nightly.yml"
-> "./.github/workflows/therock-ci.yml" (source branch with sha:ec1178a23231c0f09c4f091972d3e474419ed6f8)
--> "./.github/workflows/therock-ci-linux.yml" (source branch with sha:ec1178a23231c0f09c4f091972d3e474419ed6f8)
---> "./.github/workflows/therock-test-packages.yml" (source branch with sha:ec1178a23231c0f09c4f091972d3e474419ed6f8)
: job "test_components" calls workflow "./.github/workflows/therock-test-component.yml", but doing so would exceed the limit on called workflow depth of 3
```

I am now reverting to use original format to run nightlies correctly