### PR TITLE
[hipDNN] Fix cmake test inclusion and possible nullptr dereference

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/ConvolutionWgradNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/ConvolutionWgradNode.hpp
@@ -31,17 +31,6 @@ public:
         auto dy = attributes.get_dy();
         auto dw = attributes.get_dw();
 
-        auto& xDims = x->get_dim();
-        auto& dyDims = dy->get_dim();
-        auto& dwDims = dw->get_dim();
-        auto& dwStrides = dw->get_stride();
-
-        auto spatialDims = dyDims.size() - 2; // N & C dimensions aren't spatial
-        auto& prePadding = attributes.get_pre_padding();
-        auto& postPadding = attributes.get_post_padding();
-        auto& stride = attributes.get_stride();
-        auto& dilation = attributes.get_dilation();
-
         HIPDNN_RETURN_IF_FALSE(x,
                                ErrorCode::ATTRIBUTE_NOT_SET,
                                "ConvolutionWgradNode missing x (input) for pre-validation");
@@ -55,6 +44,17 @@ public:
             dw,
             ErrorCode::ATTRIBUTE_NOT_SET,
             "ConvolutionWgradNode missing dw (gradient of weights) for pre-validation");
+
+        auto& xDims = x->get_dim();
+        auto& dyDims = dy->get_dim();
+        auto& dwDims = dw->get_dim();
+        auto& dwStrides = dw->get_stride();
+
+        auto spatialDims = dyDims.size() - 2; // N & C dimensions aren't spatial
+        auto& prePadding = attributes.get_pre_padding();
+        auto& postPadding = attributes.get_post_padding();
+        auto& stride = attributes.get_stride();
+        auto& dilation = attributes.get_dilation();
 
         HIPDNN_RETURN_IF_TRUE(attributes.get_pre_padding().empty(),
                               ErrorCode::ATTRIBUTE_NOT_SET,

--- a/projects/hipdnn/frontend/tests/CMakeLists.txt
+++ b/projects/hipdnn/frontend/tests/CMakeLists.txt
@@ -11,7 +11,8 @@ endif()
 find_package(hip REQUIRED)
 find_package(Threads REQUIRED)
 
-add_executable(hipdnn_frontend_tests 
+add_executable(
+    hipdnn_frontend_tests
     main.cpp
     TestBackendLoggingHelpers.cpp
     TestBatchnormAttributes.cpp
@@ -24,6 +25,8 @@ add_executable(hipdnn_frontend_tests
     TestConvolutionFwdAttributes.cpp
     TestConvolutionDgradNode.cpp
     TestConvolutionNode.cpp
+    TestConvolutionWgradAttributes.cpp
+    TestConvolutionWgradNode.cpp
     TestError.cpp
     TestGraph.cpp
     TestGraphAttributes.cpp
@@ -40,12 +43,13 @@ add_executable(hipdnn_frontend_tests
 
 target_compile_options(hipdnn_frontend_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 
-target_link_libraries(hipdnn_frontend_tests 
-    GTest::gtest 
+target_link_libraries(
+    hipdnn_frontend_tests
+    GTest::gtest
     GTest::gmock
     hip::host
-    Threads::Threads 
-    hipdnn_sdk 
+    Threads::Threads
+    hipdnn_sdk
     hipdnn_frontend
 )
 clang_tidy_check(hipdnn_frontend_tests)


### PR DESCRIPTION
## Motivation

We forgot to add a couple tests to the CMakeLists.txt.

## Technical Details

Adds the tests, and fixes a test failure.

## Test Plan

Run gtest.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
