### PR TITLE
[FusilliPlugin] Re-Enable build and CI and add `CODEOWNERS` etc.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,7 @@
 
 # Project-specific ownership
 /projects/composablekernel/                         @illsilin @carlushuang @qianfengz @aosewski @poyenc @geyyer @bartekxk @andriy-ca @afagaj @asleepzzz @tenpercent @ThomasNing @coderfeli
+/projects/fusilli-plugin                            @ROCm/fusilli-plugin-reviewers
 /projects/hipblas/                                  @ROCm/hipblas-reviewers
 /projects/hipblas-common/                           @ROCm/hipblas-common-reviewers
 /projects/hipblaslt/                                @ROCm/hipblaslt-reviewers

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,6 +2,10 @@
 - changed-files:
   - any-glob-to-any-file: 'projects/composablekernel/**/*'
 
+"project: fusilli-plugin":
+- changed-files:
+  - any-glob-to-any-file: 'projects/fusilli-plugin/**/*'
+
 "project: hipblas":
 - changed-files:
   - any-glob-to-any-file: 'projects/hipblas/**/*'

--- a/.github/workflows/fusilli-plugin-ci.yml
+++ b/.github/workflows/fusilli-plugin-ci.yml
@@ -1,0 +1,107 @@
+# Copyright 2025 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: fusilli-plugin CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/fusilli-plugin-ci.yml'
+      - 'projects/fusilli-plugin/**'
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  FUSILLI_PLUGIN_DIR: ${{ github.workspace }}/projects/fusilli-plugin
+
+jobs:
+  build-and-test:
+    name: "Build & Test :: ${{ matrix.name }}"
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        # --noprofile skips loading ~/.bash_profile
+        # --norc      skips loading ~/.bashrc
+        # -exo pipefail:
+        #   -e exit immediately if any command fails
+        #   -x print each command before executing
+        #   -o pipefail ensure pipeline fails if any command in it fails
+        # {0} github actions placeholder for the command to run
+        shell: bash --noprofile --norc -exo pipefail {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: ["gfx942_clang20_debug"]
+        include:
+          - name: gfx942_clang20_debug
+            runs-on: linux-mi325-1gpu-ossci-rocm
+            fusilli-plugin-cmake-options:
+              -DCMAKE_C_COMPILER=clang-20
+              -DCMAKE_CXX_COMPILER=clang++-20
+              -DCMAKE_BUILD_TYPE=Debug
+              -DIREERuntime_DIR=/workspace/.cache/docker/iree/build/lib/cmake/IREE
+
+    steps:
+    - name: checkout fusilli-plugin
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        sparse-checkout: |
+          projects/fusilli-plugin
+          projects/hipdnn
+        sparse-checkout-cone-mode: true
+
+    - name: build fusilli-plugin
+      # The docker container mounts the working directory as a volume, so we
+      # must run from github.workspace to ensure fusilli-plugin can reach into
+      # ../sharkfuser for its fusilli dependency.
+      working-directory: ${{ github.workspace }}
+      run: |
+        ${{ env.FUSILLI_PLUGIN_DIR }}/build_tools/docker/exec_docker_ci.sh \
+        bash -c "cd projects/fusilli-plugin && \
+                 cmake -GNinja -S. -Bbuild \
+                   ${{ matrix.fusilli-plugin-cmake-options }} && \
+                 cmake --build build --target all"
+
+    - name: Test fusilli-plugin
+      working-directory: ${{ github.workspace }}
+      run: |
+        ${{ env.FUSILLI_PLUGIN_DIR }}/build_tools/docker/exec_docker_ci.sh \
+        bash -c "cd projects/fusilli-plugin && \
+                 ctest --test-dir build --output-on-failure --extra-verbose --timeout 120 -j \$(nproc)"
+
+  # Depends on all other jobs to provide an aggregate job status.
+  ci_fusilli_plugin_summary:
+    if: always()
+    runs-on: ubuntu-24.04
+    needs:
+      - build-and-test
+    steps:
+      - name: Getting failed jobs
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi

--- a/projects/fusilli-plugin/CMakeLists.txt
+++ b/projects/fusilli-plugin/CMakeLists.txt
@@ -26,17 +26,26 @@ include(FusilliPluginDependencyUtils)
 # Global constants
 set(FUSILLI_PLUGIN_NAME fusilli_plugin)
 set(FUSILLI_PLUGIN_ENGINE_ID 1001)
-
-# Options
-option(FUSILLI_PLUGIN_USE_LOCAL_FUSILLI "Use local Fusilli build from ../sharkfuser" ON)
+set(FUSILLI_HASH "5970f13835942213c7d4fd6171b936ee9fe9be73" CACHE STRING "Git hash for Fusilli")
+set(HIP_DNN_HASH "4e0a0452cfcb8fdb86e9c40a6e43debab4d4ecbc" CACHE STRING "Git hash for hipDNN")
 
 # Dependencies
 set(HIP_PLATFORM "amd")
 find_package(hip REQUIRED)
 fusilli_plugin_dependency(GTest GTEST_VERSION 1.16.0)
 fusilli_plugin_dependency(IREERuntime)
-fusilli_plugin_dependency(hipdnn_frontend HIP_DNN_HASH 4e0a0452cfcb8fdb86e9c40a6e43debab4d4ecbc)
-fusilli_plugin_dependency(Fusilli USE_LOCAL ${FUSILLI_PLUGIN_USE_LOCAL_FUSILLI})
+# Use local path if user set -DHIPDNN_LOCAL_PATH otherwise hash.
+if(HIPDNN_LOCAL_PATH)
+    fusilli_plugin_dependency(hipdnn_frontend LOCAL_PATH ${HIPDNN_LOCAL_PATH})
+else()
+    fusilli_plugin_dependency(hipdnn_frontend HIP_DNN_HASH ${HIP_DNN_HASH})
+endif()
+# Use local path if user set -DFUSILLI_LOCAL_PATH otherwise hash.
+if(FUSILLI_LOCAL_PATH)
+    fusilli_plugin_dependency(Fusilli LOCAL_PATH ${FUSILLI_LOCAL_PATH})
+else()
+    fusilli_plugin_dependency(Fusilli FUSILLI_HASH ${FUSILLI_HASH})
+endif()
 
 # Includes
 include_directories(include)

--- a/projects/fusilli-plugin/CMakeLists.txt
+++ b/projects/fusilli-plugin/CMakeLists.txt
@@ -26,25 +26,25 @@ include(FusilliPluginDependencyUtils)
 # Global constants
 set(FUSILLI_PLUGIN_NAME fusilli_plugin)
 set(FUSILLI_PLUGIN_ENGINE_ID 1001)
-set(FUSILLI_HASH "5970f13835942213c7d4fd6171b936ee9fe9be73" CACHE STRING "Git hash for Fusilli")
-set(HIP_DNN_HASH "4e0a0452cfcb8fdb86e9c40a6e43debab4d4ecbc" CACHE STRING "Git hash for hipDNN")
 
 # Dependencies
 set(HIP_PLATFORM "amd")
 find_package(hip REQUIRED)
+find_package(IREERuntime CONFIG REQUIRED)
+find_package(hipdnn_sdk CONFIG REQUIRED)
+find_package(Fusilli CONFIG REQUIRED)
+
+# GTest is still fetched since TheRock doesn't provide it
 fusilli_plugin_dependency(GTest GTEST_VERSION 1.16.0)
-fusilli_plugin_dependency(IREERuntime)
-# Use local path if user set -DHIPDNN_LOCAL_PATH otherwise hash.
-if(HIPDNN_LOCAL_PATH)
-    fusilli_plugin_dependency(hipdnn_frontend LOCAL_PATH ${HIPDNN_LOCAL_PATH})
-else()
-    fusilli_plugin_dependency(hipdnn_frontend HIP_DNN_HASH ${HIP_DNN_HASH})
+
+# Define hipDNN variables that were previously provided by building hipDNN
+# These are needed since hipdnn_sdk config doesn't export them
+if(NOT DEFINED HIPDNN_PLUGIN_ENGINE_SUBDIR)
+    set(HIPDNN_PLUGIN_ENGINE_SUBDIR "hipdnn_plugins/engines")
 endif()
-# Use local path if user set -DFUSILLI_LOCAL_PATH otherwise hash.
-if(FUSILLI_LOCAL_PATH)
-    fusilli_plugin_dependency(Fusilli LOCAL_PATH ${FUSILLI_LOCAL_PATH})
-else()
-    fusilli_plugin_dependency(Fusilli FUSILLI_HASH ${FUSILLI_HASH})
+if(NOT DEFINED HIPDNN_BUILD_PLUGIN_ENGINE_DIR)
+    set(HIPDNN_BUILD_PLUGIN_ENGINE_DIR
+        "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/${HIPDNN_PLUGIN_ENGINE_SUBDIR}")
 endif()
 
 # Includes
@@ -54,7 +54,6 @@ include_directories(include)
 add_library(${FUSILLI_PLUGIN_NAME} SHARED
     src/fusilli_plugin.cpp
 )
-target_compile_options(${FUSILLI_PLUGIN_NAME} PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 target_link_libraries(${FUSILLI_PLUGIN_NAME} PRIVATE hipdnn_sdk hip::host fusilli::fusilli)
 target_compile_definitions(${FUSILLI_PLUGIN_NAME} PRIVATE
   FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"

--- a/projects/fusilli-plugin/CMakeLists.txt
+++ b/projects/fusilli-plugin/CMakeLists.txt
@@ -32,6 +32,7 @@ set(HIP_PLATFORM "amd")
 find_package(hip REQUIRED)
 find_package(IREERuntime CONFIG REQUIRED)
 find_package(hipdnn_sdk CONFIG REQUIRED)
+find_package(hipdnn_frontend CONFIG REQUIRED)
 find_package(Fusilli CONFIG REQUIRED)
 
 # GTest is still fetched since TheRock doesn't provide it

--- a/projects/fusilli-plugin/LICENCE.md
+++ b/projects/fusilli-plugin/LICENCE.md
@@ -1,0 +1,218 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.

--- a/projects/fusilli-plugin/build_tools/cmake/FusilliPluginDependencyUtils.cmake
+++ b/projects/fusilli-plugin/build_tools/cmake/FusilliPluginDependencyUtils.cmake
@@ -12,11 +12,9 @@
 #   fusilli_plugin_dependency(DEP_NAME [args...])
 #
 # `fusilli_plugin_dependency` routes to lower level `_fetch_X` macros to
-# actually fetch dependency `X`. Each `_fetch_X` macro preferentially
-# `find_package`s installed/system versions of packages and falls back to
-# vendoring dependencies in the build tree with `FetchContent`.
+# actually fetch dependency `X` using FetchContent.
 #
-# Supported dependencies: GTest, hipdnn_frontend, Fusilli, IREERuntime
+# Supported dependencies: GTest
 #
 #===------------------------------------------------------------------------===#
 
@@ -25,9 +23,8 @@ cmake_minimum_required(VERSION 3.25.2)
 include(FetchContent)
 
 # Provide a fusilli plugin dependency. `fusilli_plugin_dependency` will
-# preferentially use system version (available through `find_package`) of a
-# dependency, and fall back to building local copy with `FetchContent` +
-# configuration.
+# fetch the dependency using FetchContent for dependencies not available
+# as system packages.
 #
 #  fusilli_plugin_dependency(
 #    DEP_NAME
@@ -36,14 +33,11 @@ include(FetchContent)
 #
 # DEP_NAME
 #   Supported dependencies:
-#     GTest
-#     hipdnn_frontend
-#     Fusilli
-#     IREERuntime
+#     GTest - Fetched via FetchContent (not provided by TheRock)
 #
 # <dependency-specific args>
 #   The `_fetch_X` macro for dependency X defines the available options.
-#   Examples: GTEST_VERSION for GTest, HIP_DNN_HASH for hipdnn_frontend
+#   Example: GTEST_VERSION for GTest
 #
 function(fusilli_plugin_dependency DEP_NAME)
     # Set indent for logging, any logs from dep "X" will be prefixed with [X].
@@ -107,124 +101,9 @@ macro(_fetch_GTest)
     FetchContent_Declare(
         GTest
         URL https://github.com/google/googletest/archive/refs/tags/v${ARG_GTEST_VERSION}.zip
+        FIND_PACKAGE_ARGS # When FIND_PACKAGE_ARGS is passed CMake first tries find_package before downloading.
     )
     set(INSTALL_GTEST OFF)
     set(BUILD_GMOCK OFF)
     FetchContent_MakeAvailable(GTest)
-endmacro()
-
-# hipdnn_frontend
-#
-# NOTE: we currently build hipDNN as a CMake source dependency (via
-# FetchContent) rather than using find_package() to locate an installed version.
-# The hipDNN build automatically handles transitive dependencies, which is
-# quite convenient.
-#
-# HIP_DNN_HASH
-#   Git commit hash or tag to fetch
-macro(_fetch_hipdnn_frontend)
-    cmake_parse_arguments(
-        ARG                        # prefix for parsed variables
-        ""                         # options (flags)
-        "HIP_DNN_HASH;LOCAL_PATH"  # single-value arguments
-        ""                         # multi-value arguments
-        ${ARGN}
-    )
-    if(NOT DEFINED ARG_LOCAL_PATH AND NOT DEFINED ARG_HIP_DNN_HASH)
-        message(FATAL_ERROR "Required argument: one of LOCAL_PATH or HIP_DNN_HASH")
-    endif()
-
-    if(DEFINED ARG_LOCAL_PATH AND DEFINED ARG_HIP_DNN_HASH)
-        message(FATAL_ERROR "Argument error: passing both LOCAL_PATH and HIP_DNN_HASH is ambiguous.")
-    endif()
-
-    if (DEFINED ARG_HIP_DNN_HASH)
-        FetchContent_Declare(
-            hipdnn_frontend
-            # location of hipdnn CMakeLists.txt in rocm-libraries
-            SOURCE_SUBDIR  projects/hipdnn
-            # rocm-libraries takes 10+ min to fetch  without sparse checkout
-            # (even with a shallow clone). We provide a custom
-            # DOWNLOAD_COMMAND until such time as CMAKE natively supports
-            # sparse checkouts.
-            DOWNLOAD_COMMAND
-                git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-libraries.git <SOURCE_DIR> &&
-                cd <SOURCE_DIR> &&
-                git sparse-checkout init --cone &&
-                git sparse-checkout set projects/hipdnn &&
-                git checkout ${ARG_HIP_DNN_HASH}
-        )
-    else()
-        FetchContent_Declare(
-            hipdnn_frontend
-            SOURCE_DIR ${ARG_LOCAL_PATH}
-        )
-    endif()
-
-    set(HIP_DNN_BUILD_BACKEND ON)
-    set(HIP_DNN_BUILD_FRONTEND ON)
-    set(HIP_DNN_SKIP_TESTS ON)
-    set(HIP_DNN_BUILD_PLUGINS OFF)
-    set(ENABLE_CLANG_TIDY OFF)
-    # PIC required to link static library into shared object.
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-    FetchContent_MakeAvailable(hipdnn_frontend)
-endmacro()
-
-# IREERuntime
-#
-# NOTE: For now, we're not providing a FetchContent fallback for IREERuntime.
-#       Fusilli expects that the system provides this dependency, and we're
-#       keeping the projects in sync as much as possible for now. If you're
-#       running in the fusilli docker container (described in sharkfuser README)
-#       passing -DIREERuntime_DIR=/workspace/.cache/docker/iree/build/lib/cmake/IREE
-#       should be enough.
-macro(_fetch_IREERuntime)
-    find_package(IREERuntime CONFIG REQUIRED)
-endmacro()
-
-# Fusilli
-#
-# FUSILLI_HASH
-#   Git commit hash or tag to fetch from https://github.com/nod-ai/shark-ai
-# LOCAL_PATH
-#   If set, uses local source directory instead of fetching from GitHub
-macro(_fetch_Fusilli)
-    cmake_parse_arguments(
-        ARG                           # prefix for parsed variables
-        ""                            # options (flags)
-        "FUSILLI_HASH;LOCAL_PATH"     # single-value arguments
-        ""                            # multi-value arguments
-        ${ARGN}
-    )
-
-    if(NOT DEFINED ARG_LOCAL_PATH AND NOT DEFINED ARG_FUSILLI_HASH)
-        message(FATAL_ERROR "Required argument: one of LOCAL_PATH or FUSILLI_HASH")
-    endif()
-
-    if(DEFINED ARG_LOCAL_PATH AND DEFINED ARG_FUSILLI_HASH)
-        message(FATAL_ERROR "Argument error: passing both LOCAL_PATH and FUSILLI_HASH is ambiguous.")
-    endif()
-
-    if(DEFINED ARG_FUSILLI_HASH)
-        FetchContent_Declare(
-            Fusilli
-            GIT_REPOSITORY https://github.com/nod-ai/shark-ai.git
-            GIT_TAG ${ARG_FUSILLI_HASH}
-            # Location of fusilli's CMakeLists.txt in shark-ai
-            SOURCE_SUBDIR sharkfuser
-            # Preferentially use `find_package` based install if available.
-            FIND_PACKAGE_ARGS NAMES Fusilli
-        )
-    else()
-        FetchContent_Declare(
-            Fusilli
-            SOURCE_DIR ${ARG_LOCAL_PATH}
-        )
-    endif()
-
-    set(FUSILLI_BUILD_TESTS OFF)
-    set(FUSILLI_BUILD_BENCHMARKS OFF)
-    set(FUSILLI_SYSTEMS_AMDGPU ON)
-    FetchContent_MakeAvailable(Fusilli)
 endmacro()

--- a/projects/fusilli-plugin/build_tools/cmake/FusilliPluginDependencyUtils.cmake
+++ b/projects/fusilli-plugin/build_tools/cmake/FusilliPluginDependencyUtils.cmake
@@ -185,33 +185,44 @@ endmacro()
 
 # Fusilli
 #
-# USE_LOCAL
-#   If set, uses local source from ../sharkfuser directory. Without USE_LOCAL,
-#   requires system installation via find_package.
+# FUSILLI_HASH
+#   Git commit hash or tag to fetch from https://github.com/nod-ai/shark-ai
+# LOCAL_PATH
+#   If set, uses local source directory instead of fetching from GitHub
 macro(_fetch_Fusilli)
     cmake_parse_arguments(
-        ARG          # prefix for parsed variables
-        ""           # options (flags)
-        "USE_LOCAL"  # single-value arguments
-        ""           # multi-value arguments
+        ARG                           # prefix for parsed variables
+        ""                            # options (flags)
+        "FUSILLI_HASH;LOCAL_PATH"     # single-value arguments
+        ""                            # multi-value arguments
         ${ARGN}
     )
 
-    if(NOT DEFINED ARG_USE_LOCAL)
-        message(FATAL_ERROR "USE_LOCAL argument is required")
+    if(NOT DEFINED ARG_LOCAL_PATH AND NOT DEFINED ARG_FUSILLI_HASH)
+        message(FATAL_ERROR "Required argument: one of LOCAL_PATH or FUSILLI_HASH")
     endif()
 
-    if(NOT ARG_USE_LOCAL)
-        # For the time being we're keeping fusilli-plugin setup as in sync as
-        # possible with fusilli.
-        message(FATAL_ERROR "Only LOCAL builds are supported currently")
+    if(DEFINED ARG_LOCAL_PATH AND DEFINED ARG_FUSILLI_HASH)
+        message(FATAL_ERROR "Argument error: passing both LOCAL_PATH and FUSILLI_HASH is ambiguous.")
     endif()
 
-    message(STATUS "Using local Fusilli build from ../sharkfuser")
-    FetchContent_Declare(
-        Fusilli
-        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../sharkfuser
-    )
+    if(DEFINED ARG_FUSILLI_HASH)
+        FetchContent_Declare(
+            Fusilli
+            GIT_REPOSITORY https://github.com/nod-ai/shark-ai.git
+            GIT_TAG ${ARG_FUSILLI_HASH}
+            # Location of fusilli's CMakeLists.txt in shark-ai
+            SOURCE_SUBDIR sharkfuser
+            # Preferentially use `find_package` based install if available.
+            FIND_PACKAGE_ARGS NAMES Fusilli
+        )
+    else()
+        FetchContent_Declare(
+            Fusilli
+            SOURCE_DIR ${ARG_LOCAL_PATH}
+        )
+    endif()
+
     set(FUSILLI_BUILD_TESTS OFF)
     set(FUSILLI_BUILD_BENCHMARKS OFF)
     set(FUSILLI_SYSTEMS_AMDGPU ON)

--- a/projects/fusilli-plugin/build_tools/docker/exec_docker_ci.sh
+++ b/projects/fusilli-plugin/build_tools/docker/exec_docker_ci.sh
@@ -4,7 +4,7 @@
 #
 # This script is copied from fusilli:
 # https://github.com/nod-ai/shark-ai/blob/52e12fe6bd76b8fad83687d48be1ca067120c310/sharkfuser/build_tools/docker/exec_docker_ci.sh
-# It's used to run fusilli-plugin CI in a docker container: https://github.com/sjain-stanford/docker/tree/main
+# It's used to run fusilli-plugin CI in a docker container: https://github.com/sjain-stanford/docker/pkgs/container/compiler-dev-ubuntu-24.04
 #
 # Once fusilli-plugin has been moved to TheRock CI this script (and the
 # standalone github actions based CI) should be removed.

--- a/projects/fusilli-plugin/build_tools/docker/exec_docker_ci.sh
+++ b/projects/fusilli-plugin/build_tools/docker/exec_docker_ci.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#===----------------------------------------------------------------------===#
+#
+# This script is copied from fusilli:
+# https://github.com/nod-ai/shark-ai/blob/52e12fe6bd76b8fad83687d48be1ca067120c310/sharkfuser/build_tools/docker/exec_docker_ci.sh
+# It's used to run fusilli-plugin CI in a docker container: https://github.com/sjain-stanford/docker/tree/main
+#
+# Once fusilli-plugin has been moved to TheRock CI this script (and the
+# standalone github actions based CI) should be removed.
+#
+#===----------------------------------------------------------------------===#
+
+
+# ROCm requires accesses to the host's /dev/kfd and /dev/dri/* device nodes, typically
+# owned by the `render` and `video` groups. The groups' GIDs in the container must
+# match the host's to access the resources. Sometimes the device nodes may be owned by
+# dynamic GIDs (that don't belong to the `render` or `video` groups). So instead of
+# adding user to the GIDs of named groups (obtained from `getent group render` or
+# `getent group video`), we simply check the owning GID of the device nodes on the host
+# and pass it to `docker run` with `--group-add=<GID>`.
+for DEV in /dev/kfd /dev/dri/*; do
+  # Skip if not a character device
+  # /dev/dri/by-path/ symlinks are ignored
+  [[ -c "${DEV}" ]] || continue
+  DOCKER_RUN_DEVICE_OPTS+=" --device=${DEV} --group-add=$(stat -c '%g' ${DEV})"
+done
+
+# Bind mounts for the following:
+# - current directory to /workspace in the container
+docker run --rm \
+           -v "${PWD}":/workspace \
+           ${DOCKER_RUN_DEVICE_OPTS} \
+           --security-opt seccomp=unconfined \
+           ghcr.io/sjain-stanford/compiler-dev-ubuntu-24.04:main@sha256:d52a5eb21ce21509f5fd1064074ba34f7ad8810c5d5c6caff9790149c8e05b3c \
+           "$@"

--- a/projects/fusilli-plugin/include/graph_import.h
+++ b/projects/fusilli-plugin/include/graph_import.h
@@ -95,11 +95,11 @@ private:
     // Import graph level properties.
     fusilliGraph.setName(hipDnnGraph.name()->str())
         .setIODataType(
-            FUSILLI_TRY(hipDnnDataTypeToFusilliDataType(hipDnnGraph.io_type())))
+            FUSILLI_TRY(hipDnnDataTypeToFusilliDataType(hipDnnGraph.io_data_type())))
         .setIntermediateDataType(FUSILLI_TRY(
-            hipDnnDataTypeToFusilliDataType(hipDnnGraph.intermediate_type())))
+            hipDnnDataTypeToFusilliDataType(hipDnnGraph.intermediate_data_type())))
         .setComputeDataType(FUSILLI_TRY(
-            hipDnnDataTypeToFusilliDataType(hipDnnGraph.compute_type())));
+            hipDnnDataTypeToFusilliDataType(hipDnnGraph.compute_data_type())));
 
     return importNodes();
   }

--- a/projects/fusilli-plugin/src/fusilli_plugin.cpp
+++ b/projects/fusilli-plugin/src/fusilli_plugin.cpp
@@ -222,7 +222,31 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetApplicableEngineIds(
   }
 
   // Check for single conv_fprop node graph
+  HIPDNN_LOG_INFO("Creating GraphWrapper: opGraph ptr={:p}, size={}",
+                  static_cast<const void*>(opGraph->ptr), opGraph->size);
+
+  // Log buffer header for debugging
+  if (opGraph->ptr != nullptr && opGraph->size >= 16) {
+    const uint8_t* bytes = static_cast<const uint8_t*>(opGraph->ptr);
+    HIPDNN_LOG_INFO("Buffer header (first 16 bytes): "
+                    "{:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} "
+                    "{:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x}",
+                    bytes[0], bytes[1], bytes[2], bytes[3],
+                    bytes[4], bytes[5], bytes[6], bytes[7],
+                    bytes[8], bytes[9], bytes[10], bytes[11],
+                    bytes[12], bytes[13], bytes[14], bytes[15]);
+  }
+
   GraphWrapper opGraphWrapper(opGraph->ptr, opGraph->size);
+
+  // Validate flatbuffer verification succeeded
+  if (!opGraphWrapper.isValid()) {
+    HIPDNN_LOG_INFO("Graph validation failed - flatbuffer verification error. "
+                    "Buffer ptr={:p}, size={}.",
+                    static_cast<const void*>(opGraph->ptr), opGraph->size);
+    return HIPDNN_PLUGIN_STATUS_SUCCESS;
+  }
+
   if (opGraphWrapper.nodeCount() != 1) {
     HIPDNN_LOG_INFO("Fusilli plan builder is (currently) only applicable only "
                     "for single node conv_fprop graphs.",

--- a/projects/fusilli-plugin/src/fusilli_plugin.cpp
+++ b/projects/fusilli-plugin/src/fusilli_plugin.cpp
@@ -441,6 +441,28 @@ hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContext(
   return HIPDNN_PLUGIN_STATUS_SUCCESS;
 }
 
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContext(
+    hipdnnEnginePluginHandle_t handle,
+    hipdnnEnginePluginExecutionContext_t executionContext,
+    size_t *workspaceSize) {
+  LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspaceSize={:p}",
+                static_cast<void *>(handle),
+                static_cast<void *>(executionContext),
+                static_cast<void *>(workspaceSize));
+  FUSILLI_PLUGIN_CHECK_NULL(handle);
+  FUSILLI_PLUGIN_CHECK_NULL(executionContext);
+  FUSILLI_PLUGIN_CHECK_NULL(workspaceSize);
+
+  // TODO(#2309): for now we're focusing on kernels that don't require scratch
+  // buffer space. Eventually we will need to teach IREE to report what scratch
+  // buffer space required, and how to use a passed in pre-allocated scratch
+  // space rather than a runtime allocated scratch space.
+  *workspaceSize = 0;
+
+  LOG_API_SUCCESS_AUTO("workspaceSize={}", *workspaceSize);
+  return HIPDNN_PLUGIN_STATUS_SUCCESS;
+}
+
 hipdnnPluginStatus_t hipdnnEnginePluginExecuteOpGraph(
     hipdnnEnginePluginHandle_t handle,
     hipdnnEnginePluginExecutionContext_t executionContext, void *workspace,

--- a/projects/fusilli-plugin/test/CMakeLists.txt
+++ b/projects/fusilli-plugin/test/CMakeLists.txt
@@ -25,7 +25,13 @@ target_compile_definitions(test_fusilli_plugin_api PRIVATE
   FUSILLI_PLUGIN_NAME="${FUSILLI_PLUGIN_NAME}"
   FUSILLI_PLUGIN_ENGINE_ID=${FUSILLI_PLUGIN_ENGINE_ID}
 )
-gtest_discover_tests(test_fusilli_plugin_api)
+# Register with CTest
+gtest_discover_tests(test_fusilli_plugin_api
+    PROPERTIES
+      ENVIRONMENT "HIPDNN_LOG_LEVEL=info"
+      ENVIRONMENT "FUSILLI_LOG_INFO=1"
+      ENVIRONMENT "FUSILLI_LOG_FILE=stdout"
+)
 
 # Graph import tests
 add_executable(test_graph_import
@@ -38,7 +44,13 @@ target_link_libraries(test_graph_import PRIVATE
     GTest::gtest_main
     hipdnn_sdk
 )
-gtest_discover_tests(test_graph_import)
+# Register with CTest
+gtest_discover_tests(test_graph_import
+    PROPERTIES
+      ENVIRONMENT "HIPDNN_LOG_LEVEL=info"
+      ENVIRONMENT "FUSILLI_LOG_INFO=1"
+      ENVIRONMENT "FUSILLI_LOG_FILE=stdout"
+)
 
 # Integration tests
 add_subdirectory(integration)

--- a/projects/fusilli-plugin/test/integration/CMakeLists.txt
+++ b/projects/fusilli-plugin/test/integration/CMakeLists.txt
@@ -27,5 +27,8 @@ target_compile_definitions(fusilli_plugin_integration_tests PRIVATE
 )
 # Register with CTest
 gtest_discover_tests(fusilli_plugin_integration_tests
-    PROPERTIES ENVIRONMENT "HIPDNN_LOG_LEVEL=info"
+    PROPERTIES
+      ENVIRONMENT "HIPDNN_LOG_LEVEL=info"
+      ENVIRONMENT "FUSILLI_LOG_INFO=1"
+      ENVIRONMENT "FUSILLI_LOG_FILE=stdout"
 )

--- a/projects/fusilli-plugin/test/integration/CMakeLists.txt
+++ b/projects/fusilli-plugin/test/integration/CMakeLists.txt
@@ -27,7 +27,5 @@ target_compile_definitions(fusilli_plugin_integration_tests PRIVATE
 )
 # Register with CTest
 gtest_discover_tests(fusilli_plugin_integration_tests
-    # Ensure that tests pick up libhipdnn_backend.so in build directory, not
-    # from the global TheRock install.
-    PROPERTIES ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+    PROPERTIES ENVIRONMENT "HIPDNN_LOG_LEVEL=info"
 )

--- a/projects/fusilli-plugin/test/integration/test_convfprop.cpp
+++ b/projects/fusilli-plugin/test/integration/test_convfprop.cpp
@@ -154,7 +154,7 @@ TEST_P(ConvFpropIntegrationTest, Basic1x1Convolution) {
 
   // Check results.
   CpuFpReferenceValidation<float> validator(1e-6f, 1e-6f);
-  EXPECT_TRUE(validator.allClose(expectedOutput.memory(), yTensor.memory()));
+  EXPECT_TRUE(validator.allClose(expectedOutput, yTensor));
 
   // Clean up.
   if (params.shouldSetStream) {

--- a/projects/fusilli-plugin/test/test_fusilli_plugin_api.cpp
+++ b/projects/fusilli-plugin/test/test_fusilli_plugin_api.cpp
@@ -26,7 +26,6 @@
 #include <unistd.h>
 #include <vector>
 
-#include "fusilli/attributes/tensor_attributes.h"
 #include "graph_import.h"
 #include "hipdnn_engine_plugin_execution_context.h"
 #include "utils.h"

--- a/projects/fusilli-plugin/test/test_fusilli_plugin_api.cpp
+++ b/projects/fusilli-plugin/test/test_fusilli_plugin_api.cpp
@@ -211,6 +211,7 @@ createValidConvFwdGraph(int64_t xUID = 0, int64_t wUID = 1, int64_t yUID = 2,
   std::vector<::flatbuffers::Offset<hipdnn_sdk::data_objects::Node>> nodes;
   auto node = CreateNodeDirect(
       builder, "conv_fwd",
+      dataType,
       hipdnn_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes,
       convAttributes.Union());
   nodes.push_back(node);


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

As part of the effort to create IREE/Fusilli based hipDNN plugin in TheRock, this PR enables github action based CI for `fusilli-plugin`, adds a `CODEOWNERS` section, and updates the label mapping for the PR labeling bot.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

This PR is part of a series that will move the initial efforts toward bringing and IREE/Fusilli based hipDNN plugin into TheRock  (see [`RFC0004-Fusilli-IREE-Kernel-Provider-hipDNN.md`](https://github.com/ROCm/TheRock/blob/main/docs/rfcs/RFC0004-Fusilli-IREE-Kernel-Provider-hipDNN.md)):

- PR 1 Directly move existing code from [nod-ai/shark-ai](https://github.com/nod-ai/shark-ai) without any edits. At this point, the plugin will not build, and will not be running in rocm-libraries CI through TheRock or an individual GitHub actions runner.
  - https://github.com/ROCm/rocm-libraries/pull/2252
- PR 2 Follow up with changes to update and re-enable the build, enable CI, and set up fusilli-plugin as a proper rocm-libraries project. At this point fusilli-plugin CI should run in individual GitHub actions runner CI. Note: TheRock CI will still not be enabled. TheRock CI is the main CI platform for rocm-libraries, but a project must build as part of TheRock to participate.
  - https://github.com/ROCm/rocm-libraries/pull/2269 (this PR)
- PR 3 Remove fusilli-plugin from shark-ai.
- PR 4/N Enable building fusilli plugin optionally in TheRock and enable TheRock CI.
- PR N+1 Remove CI added in PR 2 as things will now be tested through TheRock CI.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

CI now runs `fusilli-plugin` CI.

## Test Result

<!-- Briefly summarize test outcomes. -->

CI looks green!

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
