### PR TITLE
[hipDNN] Remove test_utilities exclusion from code coverage

### DIFF
--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -101,12 +101,12 @@ include(cmake/Tests.cmake)
 set(EXTRA_COMPILE_OPTIONS)
 set(EXTRA_LINK_OPTIONS)
 if(CODE_COVERAGE)
-    list(PREPEND EXTRA_COMPILE_OPTIONS 
+    list(PREPEND EXTRA_COMPILE_OPTIONS
         -fprofile-instr-generate
         -fcoverage-mapping
     )
-    list(PREPEND EXTRA_LINK_OPTIONS 
-        -fprofile-instr-generate 
+    list(PREPEND EXTRA_LINK_OPTIONS
+        -fprofile-instr-generate
         -fcoverage-mapping)
 endif()
 
@@ -167,12 +167,12 @@ endif()
 
 if(CODE_COVERAGE)
     findAndCheckLlvmTools()
-    
+
     if(HIP_DNN_BUILD_PLUGINS)
         set(MIOPEN_PLUGIN_CODE_COVERAGE_OBJECT -object ${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}/libmiopen_legacy_plugin.so -object ./${CMAKE_INSTALL_BINDIR}/miopen_legacy_plugin_tests)
     endif()
 
-    set(CODE_COVERAGE_IGNORE_REGEX "\(.*deps.*\)|\(.*tests.*\)|\(.*sdk/include/hipdnn_sdk/data_objects.*\)|\(.*sdk/include/hipdnn_sdk/test_utilities.*\)|\(.*sdk/include/hipdnn_sdk/plugin/test_utils.*\)")
+    set(CODE_COVERAGE_IGNORE_REGEX "\(.*deps.*\)|\(.*tests.*\)|\(.*sdk/include/hipdnn_sdk/data_objects.*\)|\(.*sdk/include/hipdnn_sdk/plugin/test_utils.*\)")
     set(CODE_COVERAGE_OBJECTS -object ./${CMAKE_INSTALL_LIBDIR}/libhipdnn_backend.so -object ./${CMAKE_INSTALL_BINDIR}/hipdnn_backend_tests -object ./${CMAKE_INSTALL_BINDIR}/hipdnn_frontend_tests -object ./${CMAKE_INSTALL_BINDIR}/public_hipdnn_backend_tests -object ./${CMAKE_INSTALL_BINDIR}/hipdnn_sdk_tests ${MIOPEN_PLUGIN_CODE_COVERAGE_OBJECT})
 
     add_custom_target(


### PR DESCRIPTION
## Motivation

Include test_utilities in code coverage report.

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
