### PR TITLE
cherry-pick to 7.1.1: feat(rocprim): add environment variable switch to enable atomic block id

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -54,6 +54,7 @@ jobs:
           repository: "ROCm/TheRock"
           sparse-checkout: build_tools
           path: "prejob"
+          ref: c2921b151b8285a1d29942aceb33cfe0fea77ac9 # 10-15-2025 commit  
 
       - name: Pre-job cleanup processes on Windows
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
+          ref: c2921b151b8285a1d29942aceb33cfe0fea77ac9 # 10-15-2025 commit  
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/projects/rocprim/rocprim/include/rocprim/common.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/common.hpp
@@ -50,15 +50,15 @@ namespace detail
 #endif // ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR
 
 #ifndef ROCPRIM_RETURN_ON_ERROR
-    #define ROCPRIM_RETURN_ON_ERROR(...)      \
-        do                                    \
-        {                                     \
-            hipError_t error = (__VA_ARGS__); \
-            if(error != hipSuccess)           \
-            {                                 \
-                return error;                 \
-            }                                 \
-        }                                     \
+    #define ROCPRIM_RETURN_ON_ERROR(...)                                        \
+        do                                                                      \
+        {                                                                       \
+            hipError_t error = (__VA_ARGS__);                                   \
+            if(error != hipSuccess)                                             \
+            {                                                                   \
+                return error;                                                   \
+            }                                                                   \
+        }                                                                       \
         while(0)
 #endif // ROCPRIM_RETURN_ON_ERROR
 

--- a/projects/rocprim/rocprim/include/rocprim/detail/temp_storage.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/detail/temp_storage.hpp
@@ -24,7 +24,6 @@
 #include <cstddef>
 
 #include "../config.hpp"
-#include "../types.hpp"
 #include "various.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/detail/various.hpp
@@ -21,17 +21,17 @@
 #ifndef ROCPRIM_DETAIL_VARIOUS_HPP_
 #define ROCPRIM_DETAIL_VARIOUS_HPP_
 
-#include <chrono>
-#include <iostream>
-#include <type_traits>
-
 #include "../common.hpp"
 #include "../config.hpp"
-#include "../functional.hpp"
 #include "../type_traits.hpp"
 #include "../types.hpp"
 
 #include <hip/hip_runtime.h>
+
+#include <chrono>
+#include <iostream>
+#include <type_traits>
+#include <variant>
 
 // Check for c++ standard library features, in a backwards compatible manner
 #ifndef __has_include
@@ -497,6 +497,69 @@ inline float update_time_point(std::chrono::high_resolution_clock::time_point& t
 
     return delta_time;
 }
+
+template<typename T, T... Vs>
+struct constexpr_value_variant
+{
+    using variant = std::variant<std::integral_constant<T, Vs>...>;
+
+    static variant create(T value)
+    {
+        variant var{};
+        // Unfold over variadic enum values. For each value
+        // create and run a small lambda that sets our variant.
+        (
+            [&]
+            {
+                if(value == Vs)
+                {
+                    var = std::integral_constant<T, Vs>{};
+                }
+            }(),
+            ...);
+        return var;
+    }
+};
+
+template<typename... T>
+struct constexpr_type_variant
+{
+    using variant = std::variant<T...>;
+
+    static variant create(int index, T... values)
+    {
+        variant var{};
+        update_variant(index, var, std::make_tuple(values...), std::index_sequence_for<T...>{});
+        return var;
+    }
+
+    static variant create(int index)
+    {
+        return create(index, (T{}, ...));
+    }
+
+    template<typename F>
+    static variant create_with(int index, F f)
+    {
+        auto var = create(index, (T{}, ...));
+        std::visit(f, var);
+    };
+
+    static variant create(bool select, T... values)
+    {
+        return create(select ? 1 /* true */ : 0 /* false */, values...);
+    }
+
+private:
+    template<std::size_t... I>
+    static void update_variant(std::size_t      index,
+                               variant&         var,
+                               std::tuple<T...> t,
+                               std::index_sequence<I...> /* */)
+    {
+        ((index == I ? var = std::get<I>(t), 0 : 0), ...);
+    }
+};
 
 } // end namespace detail
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -168,6 +168,7 @@ enum class target_arch : unsigned int
     gfx908  = 908,
     gfx90a  = 910,
     gfx942  = 942,
+    gfx950  = 950,
     gfx1030 = 1030,
     gfx1100 = 1100,
     gfx1102 = 1102,
@@ -208,6 +209,7 @@ constexpr const char* target_names[] = {"gfx803",
                                         "gfx908",
                                         "gfx90a",
                                         "gfx942",
+                                        "gfx950",
                                         "gfx1030",
                                         "gfx1100",
                                         "gfx1102",
@@ -221,6 +223,7 @@ constexpr target_arch target_architectures[] = {
     target_arch::gfx908,
     target_arch::gfx90a,
     target_arch::gfx942,
+    target_arch::gfx950,
     target_arch::gfx1030,
     target_arch::gfx1100,
     target_arch::gfx1102,
@@ -269,6 +272,7 @@ constexpr arch::wavefront::target arch_wavefront_size(const target_arch target_a
         case target_arch::gfx908: return arch::wavefront::target::size64;
         case target_arch::gfx90a: return arch::wavefront::target::size64;
         case target_arch::gfx942: return arch::wavefront::target::size64;
+        case target_arch::gfx950: return arch::wavefront::target::size64;
         case target_arch::gfx1030: return arch::wavefront::target::size32;
         case target_arch::gfx1100: return arch::wavefront::target::size32;
         case target_arch::gfx1102: return arch::wavefront::target::size32;
@@ -505,6 +509,8 @@ auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
                 return Config::template architecture_config<target_arch::gfx90a>::params;
             case target_arch::gfx942:
                 return Config::template architecture_config<target_arch::gfx942>::params;
+            case target_arch::gfx950:
+                return Config::template architecture_config<target_arch::gfx950>::params;
             case target_arch::gfx1030:
                 return Config::template architecture_config<target_arch::gfx1030>::params;
             case target_arch::gfx1100:

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_radix_sort_onesweep.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/config/device_radix_sort_onesweep.hpp
@@ -5729,6 +5729,716 @@ struct default_radix_sort_onesweep_config<
                                  block_radix_rank_algorithm::match>
 {};
 
+// Based on key_type = double, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = double, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = float, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::half, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<256, 32>,
+                                 kernel_config<256, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = rocprim::int128_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 16)
+                      && (sizeof(key_type) > 8)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int64_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 8)
+                      && (sizeof(key_type) > 4)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 4)
+                      && (sizeof(key_type) > 2)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 16)
+                      && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 8)
+                      && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 4)
+                      && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 12>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 2)
+                      && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 22>,
+                                 6,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1) && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 22>,
+                                 kernel_config<1024, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = short, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 2)
+                      && (sizeof(key_type) > 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = rocprim::int128_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 16) && (sizeof(value_type) > 8))>>
+    : radix_sort_onesweep_config<kernel_config<512, 32>,
+                                 kernel_config<512, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = int64_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 8) && (sizeof(value_type) > 4))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 6>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = int
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 4) && (sizeof(value_type) > 2))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = short
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 2) && (sizeof(value_type) > 1))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 22>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
+// Based on key_type = int8_t, value_type = int8_t
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (sizeof(value_type) <= 1)
+                      && (!std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 22>,
+                                 kernel_config<1024, 22>,
+                                 4,
+                                 block_radix_rank_algorithm::basic>
+{};
+
+// Based on key_type = int8_t, value_type = empty_type
+template<class key_type, class value_type>
+struct default_radix_sort_onesweep_config<
+    static_cast<unsigned int>(target_arch::gfx950),
+    key_type,
+    value_type,
+    std::enable_if_t<(!bool(rocprim::is_floating_point<key_type>::value) && (sizeof(key_type) <= 1)
+                      && (std::is_same<value_type, rocprim::empty_type>::value))>>
+    : radix_sort_onesweep_config<kernel_config<1024, 32>,
+                                 kernel_config<1024, 12>,
+                                 8,
+                                 block_radix_rank_algorithm::match>
+{};
+
 } // end namespace detail
 
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -32,6 +32,7 @@
 #include "rocprim/device/config_types.hpp"
 #include "rocprim/device/detail/device_scan_common.hpp"
 #include "rocprim/device/detail/lookback_scan_state.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 #include "rocprim/device/device_memcpy_config.hpp"
 #include "rocprim/device/device_scan.hpp"
 
@@ -348,7 +349,12 @@ struct AliasType<true, InputBufferItType>
     using type = unsigned char;
 };
 
-template<bool IsMemCpy, class InputBufferItType, class OutputBufferItType, class BufferSizeItType>
+// TODO: make UseOrderedBlockId dynamic
+template<bool IsMemCpy,
+         class InputBufferItType,
+         class OutputBufferItType,
+         class BufferSizeItType,
+         class WrappedBlockId>
 struct batch_memcpy_impl
 {
     using input_buffer_type  = typename std::iterator_traits<InputBufferItType>::value_type;
@@ -366,6 +372,8 @@ struct batch_memcpy_impl
 
     // The byte offset within a thread-level buffer. Must fit at least `wlev_size_threshold`.
     using tlev_byte_offset_type = uint16_t;
+
+    using ordered_bid_type = WrappedBlockId;
 
     struct copyable_buffers
     {
@@ -473,6 +481,8 @@ private:
 
             union shared_t
             {
+                typename ordered_bid_type::storage_type ordered_bid;
+
                 union analysis_t
                 {
                     typename buffer_load_type::storage_type     load_storage;
@@ -940,7 +950,8 @@ public:
     static ROCPRIM_KERNEL
     void init_tile_state_kernel(blev_buffer_scan_state_type buffer_scan_state,
                                 blev_block_scan_state_type  block_scan_state,
-                                tile_offset_type            num_tiles)
+                                tile_offset_type            num_tiles,
+                                ordered_bid_type            ordered_bid)
     {
         const uint32_t block_id        = rocprim::detail::block_id<0>();
         const uint32_t block_size      = rocprim::detail::block_size<0>();
@@ -950,6 +961,11 @@ public:
         buffer_scan_state.initialize_prefix(flat_thread_id, num_tiles);
 
         block_scan_state.initialize_prefix(flat_thread_id, num_tiles);
+
+        if(flat_thread_id == 0)
+        {
+            ordered_bid.reset();
+        }
     }
 
     template<class ArchConfig>
@@ -958,16 +974,21 @@ public:
                                      buffer_offset_type          num_buffers,
                                      copyable_blev_buffers       blev_buffers,
                                      blev_buffer_scan_state_type blev_buffer_scan_state,
-                                     blev_block_scan_state_type  blev_block_scan_state)
+                                     blev_block_scan_state_type  blev_block_scan_state,
+                                     ordered_bid_type            ordered_bid)
     {
         ROCPRIM_SHARED_MEMORY typename non_blev_memcpy<ArchConfig>::storage_type temp_storage;
+
+        auto tile_id = ordered_bid.get(rocprim::flat_tile_thread_id(),
+                                       temp_storage.get().shared.ordered_bid);
+
         non_blev_memcpy<ArchConfig>{}.copy(temp_storage.get(),
                                            buffers,
                                            num_buffers,
                                            blev_buffers,
                                            blev_buffer_scan_state,
                                            blev_block_scan_state,
-                                           rocprim::flat_block_id());
+                                           tile_id /* rocprim::flat_block_id() */);
     }
 
     template<typename ArchConfig>
@@ -1074,222 +1095,252 @@ static hipError_t batch_memcpy_func(void*              temporary_storage,
                                     hipStream_t        stream            = hipStreamDefault,
                                     bool               debug_synchronous = false)
 {
-    using config
-        = wrapped_batch_memcpy_config<Config,
-                                      typename std::iterator_traits<InputBufferItType>::value_type,
-                                      IsMemCpy>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    detail::target_arch target_arch;
-    hipError_t          result = detail::host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    const detail::batch_memcpy_config_params params
-        = detail::dispatch_target_arch<config, false>(target_arch);
-
-    using BufferOffsetType = unsigned int;
-    using BlockOffsetType  = unsigned int;
-
-    using batch_memcpy_impl_type = detail::
-        batch_memcpy_impl<IsMemCpy, InputBufferItType, OutputBufferItType, BufferSizeItType>;
-
-    static const uint32_t non_blev_block_size
-        = params.non_blev_batch_memcpy_kernel_config.block_size;
-    static const uint32_t non_blev_items_per_thread
-        = params.non_blev_batch_memcpy_kernel_config.items_per_thread;
-    static const uint32_t blev_block_size = params.blev_batch_memcpy_kernel_config.block_size;
-
-    const uint32_t buffers_per_block = non_blev_block_size * non_blev_items_per_thread;
-    const uint32_t num_blocks        = rocprim::detail::ceiling_div(num_copies, buffers_per_block);
-
-    using scan_state_buffer_type = rocprim::detail::lookback_scan_state<BufferOffsetType>;
-    using scan_state_block_type  = rocprim::detail::lookback_scan_state<BlockOffsetType>;
-
-    // Pack buffers
-    typename batch_memcpy_impl_type::copyable_buffers const buffers{
-        sources,
-        destinations,
-        sizes,
-    };
-
-    detail::temp_storage::layout scan_state_buffer_layout{};
-    ROCPRIM_RETURN_ON_ERROR(
-        scan_state_buffer_type::get_temp_storage_layout(num_blocks,
-                                                        stream,
-                                                        scan_state_buffer_layout));
-
-    detail::temp_storage::layout blev_block_scan_state_layout{};
-    ROCPRIM_RETURN_ON_ERROR(
-        scan_state_block_type::get_temp_storage_layout(num_blocks,
-                                                       stream,
-                                                       blev_block_scan_state_layout));
-
-    uint8_t* blev_buffer_scan_data;
-    uint8_t* blev_block_scan_state_data;
-
-    // The non-blev kernel will prepare blev copy. Communication between the two
-    // kernels is done via `blev_buffers`.
-    typename batch_memcpy_impl_type::copyable_blev_buffers blev_buffers{};
-
-    // Partition `temporary_storage`.
-    // If `temporary_storage` is null, calculate the allocation size instead.
-    ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.srcs, num_copies),
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.dsts, num_copies),
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.sizes, num_copies),
-            detail::temp_storage::ptr_aligned_array(&blev_buffers.offsets, num_copies),
-            detail::temp_storage::make_partition(&blev_buffer_scan_data, scan_state_buffer_layout),
-            detail::temp_storage::make_partition(&blev_block_scan_state_data,
-                                                 blev_block_scan_state_layout))));
-
-    // Return the storage size.
-    if(temporary_storage == nullptr)
-    {
-        return hipSuccess;
-    }
-
-    // Compute launch parameters.
-
-    int device_id;
-    ROCPRIM_RETURN_ON_ERROR(get_device_from_stream(stream, device_id));
-
-    // Get the number of multiprocessors
-    int multiprocessor_count{};
-    ROCPRIM_RETURN_ON_ERROR(hipDeviceGetAttribute(&multiprocessor_count,
-                                                  hipDeviceAttributeMultiprocessorCount,
-                                                  device_id));
-
-    constexpr BlockOffsetType init_kernel_threads = 128;
-    const BlockOffsetType     init_kernel_grid_size
-        = rocprim::detail::ceiling_div(num_blocks, init_kernel_threads);
-
-    BlockOffsetType batch_memcpy_grid_size = num_blocks;
-
-    // Prepare init_scan_states_kernel.
-    scan_state_buffer_type scan_state_buffer{};
-    ROCPRIM_RETURN_ON_ERROR(scan_state_buffer_type::create(scan_state_buffer,
-                                                           blev_buffer_scan_data,
-                                                           num_blocks,
-                                                           stream));
-
-    scan_state_block_type scan_state_block{};
-    ROCPRIM_RETURN_ON_ERROR(scan_state_block_type::create(scan_state_block,
-                                                          blev_block_scan_state_data,
-                                                          num_blocks,
-                                                          stream));
-
-    // `hipOccupancyMaxActiveBlocksPerMultiprocessor` uses the default device.
-    // We need to perserve the current default device id while we change it temporarily
-    // to get the max occupancy on this stream.
-    int previous_device;
-    ROCPRIM_RETURN_ON_ERROR(hipGetDevice(&previous_device));
-
-    ROCPRIM_RETURN_ON_ERROR(hipSetDevice(device_id));
-
-    auto blev_memcpy_kernel = [=](auto arch_config)
-    {
-        batch_memcpy_impl_type::template blev_memcpy_kernel_impl<decltype(arch_config)>(
-            blev_buffers,
-            scan_state_buffer,
-            batch_memcpy_grid_size - 1);
-    };
-
-    auto blev_memcpy_launch_plan
-        = make_launch_plan<config, decltype(blev_memcpy_kernel), blev_batch_memcpy_config_selector>(
-            target_arch,
-            blev_memcpy_kernel);
-
-    int        blev_occupancy{};
-    hipError_t error = hipOccupancyMaxActiveBlocksPerMultiprocessor(&blev_occupancy,
-                                                                    blev_memcpy_launch_plan.kernel,
-                                                                    blev_block_size,
-                                                                    0 /* dynSharedMemPerBlk */);
-    if(error != hipSuccess)
-    {
-        // Attempt to reset the device.
-        static_cast<void>(hipSetDevice(previous_device));
-
-        return error;
-
-        // Restore the default device id to initial state
-        ROCPRIM_RETURN_ON_ERROR(hipSetDevice(previous_device));
-    }
-
-    auto batch_memcpy_blev_grid_size
-        = multiprocessor_count * blev_occupancy * 1 /* subscription factor */;
-
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-
-    const auto start_timer = [&start, debug_synchronous]()
-    {
-        if(debug_synchronous)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_atomic_block_id)
         {
-            start = std::chrono::steady_clock::now();
-        }
-    };
+            using config = wrapped_batch_memcpy_config<
+                Config,
+                typename std::iterator_traits<InputBufferItType>::value_type,
+                IsMemCpy>;
 
-    if(debug_synchronous)
-    {
-        std::cout << "-----" << '\n'
-                  << "storage_size: " << storage_size << '\n'
-                  << "num_copies: " << num_copies << '\n'
-                  << "non_blev_block_size: " << non_blev_block_size << '\n'
-                  << "non_blev_buffers_per_thread: " << non_blev_items_per_thread << '\n'
-                  << "blev_block_size: " << blev_block_size << '\n'
-                  << "buffers_per_block: " << buffers_per_block << '\n'
-                  << "num_blocks: " << num_blocks << '\n'
-                  << "multiprocessor_count: " << multiprocessor_count << '\n'
-                  << "blev_occupancy: " << blev_occupancy << '\n'
-                  << "init_kernel_grid_size: " << init_kernel_grid_size << '\n'
-                  << "batch_memcpy_blev_grid_size: " << batch_memcpy_blev_grid_size << '\n';
-    }
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(detail::host_target_arch(stream, target_arch));
 
-    // Launch init_scan_states_kernel.
-    start_timer();
-    batch_memcpy_impl_type::
-        init_tile_state_kernel<<<init_kernel_grid_size, init_kernel_threads, 0, stream>>>(
-            scan_state_buffer,
-            scan_state_block,
-            num_blocks);
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_tile_state_kernel", num_blocks, start);
+            const detail::batch_memcpy_config_params params
+                = detail::dispatch_target_arch<config, false>(target_arch);
 
-    auto non_blev_memcpy_kernel = [=](auto arch_config)
-    {
-        batch_memcpy_impl_type::template non_blev_memcpy_kernel_impl<decltype(arch_config)>(
-            buffers,
-            num_copies,
-            blev_buffers,
-            scan_state_buffer,
-            scan_state_block);
-    };
+            using BufferOffsetType = unsigned int;
+            using BlockOffsetType  = unsigned int;
 
-    // Launch batch_memcpy_non_blev_kernel.
-    start_timer();
+            // TODO: make dynamic
+            using WrappedBlockId = block_id_wrapper<unsigned int, use_atomic_block_id>;
 
-    ROCPRIM_RETURN_ON_ERROR(
-        execute_launch_plan<config,
-                            decltype(non_blev_memcpy_kernel),
-                            non_blev_batch_memcpy_config_selector>(target_arch,
-                                                                   non_blev_memcpy_kernel,
-                                                                   batch_memcpy_grid_size,
-                                                                   non_blev_block_size,
-                                                                   0,
+            using batch_memcpy_impl_type = detail::batch_memcpy_impl<IsMemCpy,
+                                                                     InputBufferItType,
+                                                                     OutputBufferItType,
+                                                                     BufferSizeItType,
+                                                                     WrappedBlockId>;
+
+            static const uint32_t non_blev_block_size
+                = params.non_blev_batch_memcpy_kernel_config.block_size;
+            static const uint32_t non_blev_items_per_thread
+                = params.non_blev_batch_memcpy_kernel_config.items_per_thread;
+            static const uint32_t blev_block_size
+                = params.blev_batch_memcpy_kernel_config.block_size;
+
+            const uint32_t buffers_per_block = non_blev_block_size * non_blev_items_per_thread;
+            const uint32_t num_blocks = rocprim::detail::ceiling_div(num_copies, buffers_per_block);
+
+            using scan_state_buffer_type = rocprim::detail::lookback_scan_state<BufferOffsetType>;
+            using scan_state_block_type  = rocprim::detail::lookback_scan_state<BlockOffsetType>;
+
+            // Pack buffers
+            typename batch_memcpy_impl_type::copyable_buffers const buffers{
+                sources,
+                destinations,
+                sizes,
+            };
+
+            detail::temp_storage::layout scan_state_buffer_layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_buffer_type::get_temp_storage_layout(num_blocks,
+                                                                stream,
+                                                                scan_state_buffer_layout));
+
+            detail::temp_storage::layout blev_block_scan_state_layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_block_type::get_temp_storage_layout(num_blocks,
+                                                               stream,
+                                                               blev_block_scan_state_layout));
+
+            uint8_t* blev_buffer_scan_data;
+            uint8_t* blev_block_scan_state_data;
+
+            typename WrappedBlockId::id_type* ordered_bid_storage;
+
+            // The non-blev kernel will prepare blev copy. Communication between the two
+            // kernels is done via `blev_buffers`.
+            typename batch_memcpy_impl_type::copyable_blev_buffers blev_buffers{};
+
+            // Partition `temporary_storage`.
+            // If `temporary_storage` is null, calculate the allocation size instead.
+            ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.srcs, num_copies),
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.dsts, num_copies),
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.sizes, num_copies),
+                    detail::temp_storage::ptr_aligned_array(&blev_buffers.offsets, num_copies),
+                    detail::temp_storage::make_partition(&blev_buffer_scan_data,
+                                                         scan_state_buffer_layout),
+                    detail::temp_storage::make_partition(&blev_block_scan_state_data,
+                                                         blev_block_scan_state_layout),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        WrappedBlockId::get_temp_storage_layout()))));
+
+            // Return the storage size.
+            if(temporary_storage == nullptr)
+            {
+                return hipSuccess;
+            }
+
+            // Compute launch parameters.
+
+            int device_id;
+            ROCPRIM_RETURN_ON_ERROR(get_device_from_stream(stream, device_id));
+
+            // Get the number of multiprocessors
+            int multiprocessor_count{};
+            ROCPRIM_RETURN_ON_ERROR(hipDeviceGetAttribute(&multiprocessor_count,
+                                                          hipDeviceAttributeMultiprocessorCount,
+                                                          device_id));
+
+            constexpr BlockOffsetType init_kernel_threads = 128;
+            const BlockOffsetType     init_kernel_grid_size
+                = rocprim::detail::ceiling_div(num_blocks, init_kernel_threads);
+
+            BlockOffsetType batch_memcpy_grid_size = num_blocks;
+
+            // Prepare init_scan_states_kernel.
+            scan_state_buffer_type scan_state_buffer{};
+            ROCPRIM_RETURN_ON_ERROR(scan_state_buffer_type::create(scan_state_buffer,
+                                                                   blev_buffer_scan_data,
+                                                                   num_blocks,
                                                                    stream));
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("non_blev_memcpy_kernel", num_copies, start);
 
-    // Launch batch_memcpy_blev_kernel.
-    start_timer();
-    blev_memcpy_launch_plan.launch(batch_memcpy_blev_grid_size, blev_block_size, 0, stream);
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("blev_memcpy_kernel",
-                                                batch_memcpy_grid_size - 1,
-                                                start);
+            scan_state_block_type scan_state_block{};
+            ROCPRIM_RETURN_ON_ERROR(scan_state_block_type::create(scan_state_block,
+                                                                  blev_block_scan_state_data,
+                                                                  num_blocks,
+                                                                  stream));
 
+            auto ordered_bid = WrappedBlockId::create(ordered_bid_storage);
+
+            // `hipOccupancyMaxActiveBlocksPerMultiprocessor` uses the default device.
+            // We need to perserve the current default device id while we change it temporarily
+            // to get the max occupancy on this stream.
+            int previous_device;
+            ROCPRIM_RETURN_ON_ERROR(hipGetDevice(&previous_device));
+
+            ROCPRIM_RETURN_ON_ERROR(hipSetDevice(device_id));
+
+            auto blev_memcpy_kernel = [=](auto arch_config)
+            {
+                batch_memcpy_impl_type::template blev_memcpy_kernel_impl<decltype(arch_config)>(
+                    blev_buffers,
+                    scan_state_buffer,
+                    batch_memcpy_grid_size - 1);
+            };
+
+            auto blev_memcpy_launch_plan
+                = make_launch_plan<config,
+                                   decltype(blev_memcpy_kernel),
+                                   blev_batch_memcpy_config_selector>(target_arch,
+                                                                      blev_memcpy_kernel);
+
+            int        blev_occupancy{};
+            hipError_t error
+                = hipOccupancyMaxActiveBlocksPerMultiprocessor(&blev_occupancy,
+                                                               blev_memcpy_launch_plan.kernel,
+                                                               blev_block_size,
+                                                               0 /* dynSharedMemPerBlk */);
+            if(error != hipSuccess)
+            {
+                // Attempt to reset the device.
+                static_cast<void>(hipSetDevice(previous_device));
+
+                return error;
+
+                // Restore the default device id to initial state
+                ROCPRIM_RETURN_ON_ERROR(hipSetDevice(previous_device));
+            }
+
+            auto batch_memcpy_blev_grid_size
+                = multiprocessor_count * blev_occupancy * 1 /* subscription factor */;
+
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+
+            const auto start_timer = [&start, debug_synchronous]()
+            {
+                if(debug_synchronous)
+                {
+                    start = std::chrono::steady_clock::now();
+                }
+            };
+
+            if(debug_synchronous)
+            {
+                std::cout << "-----" << '\n'
+                          << "storage_size: " << storage_size << '\n'
+                          << "num_copies: " << num_copies << '\n'
+                          << "non_blev_block_size: " << non_blev_block_size << '\n'
+                          << "non_blev_buffers_per_thread: " << non_blev_items_per_thread << '\n'
+                          << "blev_block_size: " << blev_block_size << '\n'
+                          << "buffers_per_block: " << buffers_per_block << '\n'
+                          << "num_blocks: " << num_blocks << '\n'
+                          << "multiprocessor_count: " << multiprocessor_count << '\n'
+                          << "blev_occupancy: " << blev_occupancy << '\n'
+                          << "init_kernel_grid_size: " << init_kernel_grid_size << '\n'
+                          << "batch_memcpy_blev_grid_size: " << batch_memcpy_blev_grid_size << '\n';
+            }
+
+            // Launch init_scan_states_kernel.
+            start_timer();
+            batch_memcpy_impl_type::
+                init_tile_state_kernel<<<init_kernel_grid_size, init_kernel_threads, 0, stream>>>(
+                    scan_state_buffer,
+                    scan_state_block,
+                    num_blocks,
+                    ordered_bid);
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_tile_state_kernel",
+                                                        num_blocks,
+                                                        start);
+
+            auto non_blev_memcpy_kernel = [=](auto arch_config)
+            {
+                batch_memcpy_impl_type::template non_blev_memcpy_kernel_impl<decltype(arch_config)>(
+                    buffers,
+                    num_copies,
+                    blev_buffers,
+                    scan_state_buffer,
+                    scan_state_block,
+                    ordered_bid);
+            };
+
+            // Launch batch_memcpy_non_blev_kernel.
+            start_timer();
+
+            ROCPRIM_RETURN_ON_ERROR(
+                execute_launch_plan<config,
+                                    decltype(non_blev_memcpy_kernel),
+                                    non_blev_batch_memcpy_config_selector>(target_arch,
+                                                                           non_blev_memcpy_kernel,
+                                                                           batch_memcpy_grid_size,
+                                                                           non_blev_block_size,
+                                                                           0,
+                                                                           stream));
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("non_blev_memcpy_kernel",
+                                                        num_copies,
+                                                        start);
+
+            // Launch batch_memcpy_blev_kernel.
+            start_timer();
+            blev_memcpy_launch_plan.launch(batch_memcpy_blev_grid_size, blev_block_size, 0, stream);
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("blev_memcpy_kernel",
+                                                        batch_memcpy_grid_size - 1,
+                                                        start);
+            return hipSuccess;
+        },
+        use_atomic_block_id_variant));
     return hipSuccess;
 }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_nth_element.hpp
@@ -26,6 +26,7 @@
 #include "../../block/block_scan.hpp"
 #include "../../block/block_sort.hpp"
 #include "../../block/block_store.hpp"
+#include "../../intrinsics/thread.hpp"
 
 #include "../../common.hpp"
 #include "../../config.hpp"
@@ -35,9 +36,9 @@
 #include "../device_transform.hpp"
 
 #include "device_config_helper.hpp"
+#include "ordered_block_id.hpp"
 
 #include <cstdint>
-#include <hip/amd_detail/amd_hip_runtime.h>
 #include <hip/hip_runtime.h>
 
 #include <iostream>
@@ -437,7 +438,7 @@ inline hipError_t launch_find_nth_element_bucket(detail::target_arch          ar
     return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class ArchConfig, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+template<class ArchConfig, unsigned int NumPartitions, class KeysIterator, class BinaryFunction, class WrappedBlockId>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     copy_buckets_kernel_impl(KeysIterator                                             keys,
                              typename std::iterator_traits<KeysIterator>::value_type* tree,
@@ -445,8 +446,9 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                              nth_element_onesweep_lookback_state* lookback_states,
                              n_th_element_iteration_data*         nth_element_data,
                              typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
-                             bool*          equality_buckets,
-                             BinaryFunction compare_function)
+                             bool*              equality_buckets,
+                             BinaryFunction     compare_function,
+                             WrappedBlockId     ordered_bid)
 {
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
     using state    = nth_element_onesweep_lookback_state;
@@ -474,7 +476,10 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
         typename block_rank::storage_type         rank;
         typename block_load_element::storage_type load_element;
         size_t                                    buckets_block_offsets_shared[num_partitions];
+        typename WrappedBlockId::storage_type     ordered_bid;
     } storage;
+
+    auto block_id = ordered_bid.get(threadIdx.x, storage.ordered_bid);
 
     uint8_t buckets[num_items_per_thread];
 
@@ -484,7 +489,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     const bool         equality_bucket = nth_element_data->equality_bucket;
     const bool equality_bucket_before  = nth_element > 0 && equality_buckets[nth_element - 1];
 
-    const unsigned int offset            = blockIdx.x * num_items_per_block;
+    const unsigned int offset            = block_id * num_items_per_block;
     const bool         is_complete_block = offset + num_items_per_block <= size;
 
     key_type elements[num_items_per_thread];
@@ -560,11 +565,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     const unsigned int partition = threadIdx.x;
     if(partition < num_partitions)
     {
-        state* block_state = &lookback_states[blockIdx.x * num_partitions + partition];
+        state* block_state = &lookback_states[block_id * num_partitions + partition];
         state(state::PARTIAL, partition_counts[0]).store(block_state);
 
         unsigned int exclusive_prefix  = 0;
-        unsigned int lookback_block_id = blockIdx.x;
+        unsigned int lookback_block_id = block_id;
         // The main back tracking loop.
         while(lookback_block_id > 0)
         {
@@ -627,7 +632,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     }
 }
 
-template<class Config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+template<class Config,
+         unsigned int NumPartitions,
+         class KeysIterator,
+         class BinaryFunction,
+         class WrappedBlockId>
 inline hipError_t
     launch_copy_buckets(detail::target_arch                                      arch,
                         KeysIterator                                             keys,
@@ -638,6 +647,7 @@ inline hipError_t
                         typename std::iterator_traits<KeysIterator>::value_type* keys_buffer,
                         bool*                                                    equality_buckets,
                         BinaryFunction                                           compare_function,
+                        WrappedBlockId                                           ordered_bid,
                         dim3                                                     grid,
                         dim3                                                     block,
                         size_t                                                   shmem,
@@ -652,13 +662,18 @@ inline hipError_t
                                                                        nth_element_data,
                                                                        keys_buffer,
                                                                        equality_buckets,
-                                                                       compare_function);
+                                                                       compare_function,
+                                                                       ordered_bid);
     };
 
     return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
 }
 
-template<class Config, unsigned int NumPartitions, class KeysIterator, class BinaryFunction>
+template<class Config,
+         unsigned int NumPartitions,
+         class KeysIterator,
+         class BinaryFunction,
+         class WrappedBlockId>
 ROCPRIM_INLINE
 hipError_t
     nth_element_keys_impl(detail::target_arch                                      arch,
@@ -677,7 +692,8 @@ hipError_t
                           n_th_element_iteration_data* nth_element_data,
                           BinaryFunction               compare_function,
                           hipStream_t                  stream,
-                          bool                         debug_synchronous)
+                          bool                         debug_synchronous,
+                          WrappedBlockId               ordered_bid)
 {
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
 
@@ -719,6 +735,9 @@ hipError_t
             nth_element_onesweep_lookback_state::reset(lookback_states,
                                                        num_partitions * num_blocks,
                                                        stream));
+
+        // Reset ordered block id.
+        ROCPRIM_RETURN_ON_ERROR(ordered_bid.reset_from_host(stream));
 
         start_timer();
         ROCPRIM_RETURN_ON_ERROR(launch_find_splitters<Config>(arch,
@@ -769,6 +788,7 @@ hipError_t
                                                                             keys_buffer,
                                                                             equality_buckets,
                                                                             compare_function,
+                                                                            ordered_bid,
                                                                             num_blocks,
                                                                             num_threads_per_block,
                                                                             0,

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_partition.hpp
@@ -1026,14 +1026,11 @@ struct partition_kernel_impl_
                                  bool[items_per_thread],
                                  bool[sizeof...(UnaryPredicates)][items_per_thread]>;
 
+        const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
+        const uint32_t flat_block_id        = block_id.get(flat_block_thread_id, storage.block_id);
+
         size_t prev_selected_count_values[sizeof...(UnaryPredicates)]{};
         load_selected_count(prev_selected_count, prev_selected_count_values);
-
-        const auto flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
-        const auto flat_block_id        = block_id.get(flat_block_thread_id, storage.block_id);
-        ::rocprim::syncthreads(); // sync threads to reuse shared memory
-
-        // const auto flat_block_id = ::rocprim::detail::block_id<0>();
 
         const auto         block_offset = flat_block_id * items_per_block;
         const unsigned int valid_in_global_last_block

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -40,6 +40,8 @@
 #include "../../block/block_scan.hpp"
 #include "../../block/block_store_func.hpp"
 
+#include "ordered_block_id.hpp"
+
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
@@ -1052,7 +1054,8 @@ template<class Key,
          unsigned int               RadixBits,
          bool                       Descending,
          block_radix_rank_algorithm RadixRankAlgorithm,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 struct onesweep_iteration_helper
 {
     static constexpr unsigned int radix_size      = 1u << RadixBits;
@@ -1068,7 +1071,7 @@ struct onesweep_iteration_helper
 
     static constexpr unsigned int digits_per_thread = radix_rank_type::digits_per_thread;
 
-    union storage_type_
+    union data_storage
     {
         typename radix_rank_type::storage_type rank;
         struct
@@ -1080,6 +1083,12 @@ struct onesweep_iteration_helper
                 Value ordered_block_values[items_per_block];
             };
         };
+    };
+
+    struct storage_type_
+    {
+        data_storage                          data;
+        typename BlockIdWrapper::storage_type ordered_bid;
     };
 
     ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH
@@ -1103,10 +1112,11 @@ struct onesweep_iteration_helper
                   const unsigned int       bit,
                   const unsigned int       current_radix_bits,
                   const unsigned int       valid_items,
-                  storage_type_&           storage)
+                  data_storage&            storage,
+                  unsigned int             ordered_bid)
     {
         const unsigned int flat_id      = ::rocprim::detail::block_thread_id<0>();
-        const unsigned int block_id     = ::rocprim::detail::block_id<0>();
+        const unsigned int block_id     = ordered_bid;
         const unsigned int block_offset = block_id * items_per_block;
 
         // Load keys into private memory, and encode them to unsigned integers.
@@ -1348,7 +1358,8 @@ template<unsigned int               BlockSize,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Offset,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
     onesweep_iteration(KeysInputIterator        keys_input,
                        KeysOutputIterator       keys_output,
@@ -1361,7 +1372,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                        Decomposer               decomposer,
                        const unsigned int       bit,
                        const unsigned int       current_radix_bits,
-                       const unsigned int       full_blocks)
+                       const unsigned int       full_blocks,
+                       BlockIdWrapper           ordered_bid)
 {
     using key_type   = typename std::iterator_traits<KeysInputIterator>::value_type;
     using value_type = typename std::iterator_traits<ValuesInputIterator>::value_type;
@@ -1374,12 +1386,14 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                      RadixBits,
                                                                      Descending,
                                                                      RadixRankAlgorithm,
-                                                                     Decomposer>;
-
-    constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
-    const unsigned int block_id = ::rocprim::detail::block_id<0>();
+                                                                     Decomposer,
+                                                                     BlockIdWrapper>;
 
     ROCPRIM_SHARED_MEMORY typename onesweep_iteration_helper_type::storage_type storage;
+
+    constexpr unsigned int items_per_block = BlockSize * ItemsPerThread;
+    const unsigned int     thread_id       = ::rocprim::detail::block_thread_id<0>();
+    const unsigned int     block_id        = ordered_bid.get(thread_id, storage.get().ordered_bid);
 
     if(block_id < full_blocks)
     {
@@ -1394,7 +1408,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                  bit,
                                                                  current_radix_bits,
                                                                  items_per_block,
-                                                                 storage.get());
+                                                                 storage.get().data,
+                                                                 block_id);
     }
     else
     {
@@ -1410,7 +1425,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE void
                                                                   bit,
                                                                   current_radix_bits,
                                                                   valid_in_last_block,
-                                                                  storage.get());
+                                                                  storage.get().data,
+                                                                  block_id);
     }
 }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce_by_key.hpp
@@ -34,6 +34,7 @@
 
 #include "../../config.hpp"
 #include "../../type_traits.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 
 #include <iterator>
 #include <type_traits>
@@ -525,7 +526,8 @@ template<typename ArchConfig,
          typename UniqueCountIterator,
          typename CompareFunction,
          typename BinaryOp,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto kernel_impl(KeyIterator,
                                                      ValueIterator,
                                                      const UniqueIterator,
@@ -538,7 +540,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto kernel_impl(KeyIterator,
                                                      const std::size_t,
                                                      const std::size_t,
                                                      const std::size_t* const,
-                                                     const AccumulatorType* const)
+                                                     const AccumulatorType* const,
+                                                     BlockIdWrapper)
     -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
 {
     // No need to build the kernel with sleep on a device that does not require it
@@ -554,7 +557,8 @@ template<typename ArchConfig,
          typename UniqueCountIterator,
          typename CompareFunction,
          typename BinaryOp,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     kernel_impl(KeyIterator                    keys_input,
                 ValueIterator                  values_input,
@@ -568,7 +572,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                 const std::size_t              total_number_of_blocks,
                 const std::size_t              size,
                 const std::size_t* const       global_head_count,
-                const AccumulatorType* const   previous_accumulated)
+                const AccumulatorType* const   previous_accumulated,
+                BlockIdWrapper                 ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
     static constexpr reduce_by_key_config_params params = ArchConfig::params;
@@ -593,10 +598,13 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
 
     ROCPRIM_SHARED_MEMORY union
     {
+        typename BlockIdWrapper::storage_type ordered_bid;
         typename tile_processor::storage_type tile;
     } storage;
 
-    const unsigned int  block_id     = rocprim::flat_block_id<block_size, 1, 1>();
+    const unsigned int block_id
+        = ordered_bid.get(threadIdx.x,
+                          storage.ordered_bid); // rocprim::flat_block_id<block_size, 1, 1>();
     const unsigned int  block_offset = block_id * items_per_block;
     const KeyIterator   block_keys   = keys_input + block_offset;
     const ValueIterator block_values = values_input + block_offset;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
@@ -23,16 +23,18 @@
 
 #include "device_partition.hpp"
 #include "lookback_scan_state.hpp"
+#include "ordered_block_id.hpp"
 
+#include "../../config.hpp"
 #include "../../detail/binary_op_wrappers.hpp"
 #include "../../detail/various.hpp"
 #include "../../functional.hpp"
+#include "../../intrinsics/arch.hpp"
 #include "../../intrinsics/thread.hpp"
 #include "../../thread/thread_reduce.hpp"
 #include "../../thread/thread_scan.hpp"
 #include "../../type_traits.hpp"
 #include "../../warp/warp_scan.hpp"
-#include "rocprim/intrinsics/arch.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -823,7 +825,8 @@ template<typename ArchConfig,
          typename OffsetsOutputIterator,
          typename CountsOutputIterator,
          typename RunsCountOutputIterator,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     non_trivial_kernel_impl(InputIterator,
                             const OffsetsOutputIterator,
@@ -831,7 +834,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                             const RunsCountOutputIterator,
                             const LookbackScanState,
                             const size_t,
-                            const size_t)
+                            const size_t,
+                            BlockIdWrapper)
         -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
 {
     // No need to build the kernel with sleep on a device that does not require it
@@ -843,15 +847,17 @@ template<typename ArchConfig,
          typename OffsetsOutputIterator,
          typename CountsOutputIterator,
          typename RunsCountOutputIterator,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
-    non_trivial_kernel_impl(InputIterator                  input,
-                            const OffsetsOutputIterator    offsets_output,
-                            const CountsOutputIterator     counts_output,
-                            const RunsCountOutputIterator  runs_count_output,
-                            const LookbackScanState        scan_state,
-                            const size_t              grid_size,
-                            const size_t              size)
+    non_trivial_kernel_impl(InputIterator                 input,
+                            const OffsetsOutputIterator   offsets_output,
+                            const CountsOutputIterator    counts_output,
+                            const RunsCountOutputIterator runs_count_output,
+                            const LookbackScanState       scan_state,
+                            const size_t                  grid_size,
+                            const size_t                  size,
+                            BlockIdWrapper                ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
     static constexpr non_trivial_runs_config_params params     = ArchConfig::params;
@@ -874,12 +880,16 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                                          load_input_method,
                                          scan_algorithm>;
 
-    ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH ROCPRIM_SHARED_MEMORY
-    typename detail::raw_storage<typename block_processor::storage_type>
-        storage;
-    ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_POP
+    ROCPRIM_SHARED_MEMORY union
+    {
+        ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_WITH_PUSH
+        typename detail::raw_storage<typename block_processor::storage_type>
+            block_processor_storage;
+        ROCPRIM_DETAIL_SUPPRESS_DEPRECATION_POP
+        typename BlockIdWrapper::storage_type ordered_bid_storage;
+    } storage;
 
-    const size_t block_id = flat_block_id<block_size, 1, 1>();
+    const size_t block_id = ordered_bid.get(rocprim::flat_tile_thread_id(), storage.ordered_bid_storage);
 
     const size_t        block_offset = block_id * items_per_block;
     const InputIterator block_input  = input + block_offset;
@@ -896,18 +906,19 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                                         block_id,
                                         grid_size,
                                         size,
-                                        storage.get());
+                                        storage.block_processor_storage.get());
     }
     else if(valid_in_last_block > 0)
     {
-        OffsetCountPairType total = block_processor{}.process_block(block_input,
-                                                                    offsets_output,
-                                                                    counts_output,
-                                                                    scan_state,
-                                                                    block_id,
-                                                                    grid_size,
-                                                                    size,
-                                                                    storage.get());
+        OffsetCountPairType total
+            = block_processor{}.process_block(block_input,
+                                              offsets_output,
+                                              counts_output,
+                                              scan_state,
+                                              block_id,
+                                              grid_size,
+                                              size,
+                                              storage.block_processor_storage.get());
         // First thread of last block sets the total number of non-trivial runs found and updates
         // the counts with the last run's length if necessary.
         if(threadIdx.x == 0)

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan.hpp
@@ -21,23 +21,17 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_LOOKBACK_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_LOOKBACK_HPP_
 
-#include <iterator>
-#include <type_traits>
-
-#include "../../detail/various.hpp"
-#include "../../functional.hpp"
-#include "../../intrinsics.hpp"
-#include "../../types.hpp"
+#include "device_config_helper.hpp"
+#include "device_scan_common.hpp"
+#include "lookback_scan_state.hpp"
+#include "ordered_block_id.hpp"
 
 #include "../../block/block_load.hpp"
 #include "../../block/block_scan.hpp"
 #include "../../block/block_store.hpp"
+#include "../../intrinsics/thread.hpp"
 
-#include "../../device/device_scan_config.hpp"
-
-#include "device_scan_common.hpp"
-#include "lookback_scan_state.hpp"
-#include "ordered_block_id.hpp"
+#include <type_traits>
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -108,7 +102,8 @@ template<class ArchConfig,
          class OutputIterator,
          class BinaryFunction,
          class AccType,
-         class LookbackScanState>
+         class LookbackScanState,
+         class BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto lookback_scan_kernel_impl(InputIterator,
                                                                    OutputIterator,
                                                                    const size_t,
@@ -116,10 +111,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto lookback_scan_kernel_impl(InputIterator
                                                                    BinaryFunction,
                                                                    LookbackScanState,
                                                                    const unsigned int,
-                                                                   AccType* = nullptr,
-                                                                   AccType* = nullptr,
-                                                                   bool     = false,
-                                                                   bool     = false)
+                                                                   AccType*,
+                                                                   AccType*,
+                                                                   bool,
+                                                                   bool,
+                                                                   BlockIdWrapper)
     -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
 {
     // No need to build the kernel with sleep on a device that does not require it
@@ -133,7 +129,8 @@ template<class ArchConfig,
          class OutputIterator,
          class BinaryFunction,
          class AccType,
-         class LookbackScanState>
+         class LookbackScanState,
+         class BlockIdWrapper>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
     lookback_scan_kernel_impl(InputIterator      input,
                               OutputIterator     output,
@@ -142,10 +139,11 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                               BinaryFunction     scan_op,
                               LookbackScanState  scan_state,
                               const unsigned int number_of_blocks,
-                              AccType*           previous_last_element = nullptr,
-                              AccType*           new_last_element      = nullptr,
-                              bool               override_first_value  = false,
-                              bool               save_last_value       = false)
+                              AccType*           previous_last_element,
+                              AccType*           new_last_element,
+                              bool               override_first_value,
+                              bool               save_last_value,
+                              BlockIdWrapper     ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
 {
     static_assert(std::is_same<AccType, typename LookbackScanState::value_type>::value,
@@ -167,13 +165,16 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
 
     ROCPRIM_SHARED_MEMORY union
     {
+        typename BlockIdWrapper::storage_type   ordered_bid;
         typename block_load_type::storage_type  load;
         typename block_store_type::storage_type store;
         typename block_scan_type::storage_type  scan;
     } storage;
 
     const auto         flat_block_thread_id = ::rocprim::detail::block_thread_id<0>();
-    const auto         flat_block_id        = ::rocprim::detail::block_id<0>();
+    const size_t       flat_block_id
+        = ordered_bid.get(flat_block_thread_id,
+                          storage.ordered_bid); // ::rocprim::detail::block_id<0>();
     const unsigned int block_offset         = flat_block_id * items_per_block;
     const auto         valid_in_last_block  = size - items_per_block * (number_of_blocks - 1);
 

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_by_key.hpp
@@ -21,6 +21,7 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_BY_KEY_HPP_
 #define ROCPRIM_DEVICE_DETAIL_DEVICE_SCAN_BY_KEY_HPP_
 
+#include "device_config_helper.hpp"
 #include "device_scan_common.hpp"
 #include "lookback_scan_state.hpp"
 
@@ -32,7 +33,7 @@
 #include "../../detail/binary_op_wrappers.hpp"
 #include "../../intrinsics/thread.hpp"
 #include "../../types/tuple.hpp"
-#include "device_config_helper.hpp"
+#include "../detail/ordered_block_id.hpp"
 
 #include <type_traits>
 
@@ -76,17 +77,20 @@ struct load_values_flagged
     //   restart the scan from that value
     template<typename KeyIterator, typename ValueIterator, typename CompareFunction>
     ROCPRIM_DEVICE
-    void load(KeyIterator        keys_input,
-              ValueIterator      values_input,
-              CompareFunction    compare,
-              const result_type  initial_value,
-              const unsigned int flat_block_id,
-              const size_t       starting_block,
-              const size_t       number_of_blocks,
-              const unsigned int flat_thread_id,
-              const size_t       size,
-              rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
-              storage_type& storage)
+    void load(
+        KeyIterator        keys_input,
+        ValueIterator      values_input,
+        CompareFunction    compare,
+        const result_type  initial_value,
+        const unsigned int flat_block_id,
+        const size_t       starting_block,
+        const size_t       number_of_blocks,
+        const unsigned int flat_thread_id,
+        const size_t       size,
+        bool               use_last_keys,
+        const typename std::iterator_traits<KeyIterator>::value_type* const __restrict__ last_keys,
+        rocprim::tuple<result_type, bool> (&wrapped_values)[items_per_thread],
+        storage_type& storage)
     {
         constexpr static unsigned int items_per_block = items_per_thread * block_size;
         const unsigned int            block_offset    = flat_block_id * items_per_block;
@@ -98,13 +102,14 @@ struct load_values_flagged
         bool        flags[items_per_thread];
 
         auto not_equal = [compare](const auto& a, const auto& b) mutable { return !compare(a, b); };
+        const auto global_block_id = starting_block + flat_block_id;
 
         const auto flag_segment_boundaries = [&]()
         {
-            if(Exclusive)
+            if constexpr(Exclusive)
             {
                 const key_type tile_successor
-                    = starting_block + flat_block_id < number_of_blocks - 1
+                    = global_block_id < number_of_blocks - 1
                           ? static_cast<key_type>(block_keys[items_per_block])
                           : static_cast<key_type>(*block_keys);
                 block_discontinuity{}.flag_tails(flags,
@@ -114,10 +119,12 @@ struct load_values_flagged
                                                  storage.keys.flag);
             }
             else
-            {
-                const key_type tile_predecessor = starting_block + flat_block_id > 0
-                                                      ? static_cast<key_type>(block_keys[-1])
-                                                      : static_cast<key_type>(*block_keys);
+            { // Inclusive
+                const key_type tile_predecessor
+                    = global_block_id > 0
+                          ? (use_last_keys ? static_cast<key_type>(last_keys[global_block_id - 1])
+                                           : static_cast<key_type>(block_keys[-1]))
+                          : static_cast<key_type>(*block_keys);
                 block_discontinuity{}.flag_heads(flags,
                                                  tile_predecessor,
                                                  keys,
@@ -126,7 +133,7 @@ struct load_values_flagged
             }
         };
 
-        if(starting_block + flat_block_id < number_of_blocks - 1)
+        if(global_block_id < number_of_blocks - 1)
         {
             block_load_keys{}.load(block_keys, keys, storage.keys.load);
 
@@ -255,7 +262,8 @@ struct unwrap_store
              typename ResultType,
              typename CompareFunction,
              typename BinaryFunction,
-             typename LookbackScanState>
+             typename LookbackScanState,
+             typename WrappedBlockId>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
         device_scan_by_key_kernel_impl(KeyInputIterator,
                                        InputIterator,
@@ -267,7 +275,10 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                                        const size_t,
                                        const size_t,
                                        const size_t,
-                                       const rocprim::tuple<ResultType, bool>* const)
+                                       const rocprim::tuple<ResultType, bool>* const,
+                                       bool,
+                                       const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__,
+                                       WrappedBlockId)
             -> std::enable_if_t<!is_lookback_kernel_runnable<LookbackScanState>()>
     {
         // No need to build the kernel with sleep on a device that does not require it
@@ -282,7 +293,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
              typename ResultType,
              typename CompareFunction,
              typename BinaryFunction,
-             typename LookbackScanState>
+             typename LookbackScanState,
+             typename WrappedBlockId>
     ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto device_scan_by_key_kernel_impl(
         KeyInputIterator                              keys,
         InputIterator                                 values,
@@ -294,7 +306,10 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
         const size_t                                  size,
         const size_t                                  starting_block,
         const size_t                                  number_of_blocks,
-        const rocprim::tuple<ResultType, bool>* const previous_last_value)
+        const rocprim::tuple<ResultType, bool>* const previous_last_value,
+        bool use_last_keys,
+        const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__ last_keys,
+        WrappedBlockId ordered_bid)
         -> std::enable_if_t<is_lookback_kernel_runnable<LookbackScanState>()>
     {
         using result_type = ResultType;
@@ -328,13 +343,18 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
 
         ROCPRIM_SHARED_MEMORY union
         {
+            typename WrappedBlockId::storage_type  ordered_bid;
             typename load_flagged::storage_type    load;
             typename block_scan_type::storage_type scan;
             typename store_unwrap::storage_type    store;
         } storage;
 
         const auto flat_thread_id = ::rocprim::detail::block_thread_id<0>();
-        const auto flat_block_id  = ::rocprim::detail::block_id<0>();
+        const auto flat_block_id
+            = ordered_bid.get(flat_thread_id,
+                              storage.ordered_bid); // ::rocprim::detail::block_id<0>();
+
+        ::rocprim::syncthreads();
 
         // Load input
         wrapped_type wrapped_values[items_per_thread];
@@ -347,6 +367,8 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
                             number_of_blocks,
                             flat_thread_id,
                             size,
+                            use_last_keys,
+                            last_keys,
                             wrapped_values,
                             storage.load);
 
@@ -362,7 +384,7 @@ ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE auto
             // multi grid launch
             if(previous_last_value != nullptr)
             {
-                if(Exclusive)
+                if constexpr(Exclusive)
                 {
                     rocprim::get<0>(wrapped_initial_value) = rocprim::get<0>(*previous_last_value);
                 }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_common.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_scan_common.hpp
@@ -25,7 +25,6 @@
 #include "../../intrinsics/thread.hpp"
 
 #include "lookback_scan_state.hpp"
-#include "ordered_block_id.hpp"
 
 #include <hip/hip_runtime.h>
 
@@ -54,12 +53,12 @@ void access_indexed_lookback_value(LookBackScanState  lookback_scan_state,
     }
 }
 
-template<typename LookBackScanState>
-ROCPRIM_DEVICE ROCPRIM_INLINE void
-    init_lookback_scan_state(LookBackScanState              lookback_scan_state,
-                             const unsigned int             number_of_blocks,
-                             ordered_block_id<unsigned int> ordered_bid,
-                             unsigned int                   flat_thread_id)
+template<class LookBackScanState, class BlockIdWrapper>
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void init_lookback_scan_state(LookBackScanState  lookback_scan_state,
+                              const unsigned int number_of_blocks,
+                              BlockIdWrapper     ordered_bid,
+                              unsigned int       flat_thread_id)
 {
     // Reset ordered_block_id.
     if(flat_thread_id == 0)
@@ -71,25 +70,24 @@ ROCPRIM_DEVICE ROCPRIM_INLINE void
     lookback_scan_state.initialize_prefix(flat_thread_id, number_of_blocks);
 }
 
-template<typename LookBackScanState>
-ROCPRIM_DEVICE ROCPRIM_INLINE void init_lookback_scan_state(LookBackScanState  lookback_scan_state,
-                                                            const unsigned int number_of_blocks,
-                                                            unsigned int       flat_thread_id)
+template<class LookBackScanState>
+ROCPRIM_DEVICE ROCPRIM_INLINE
+void init_lookback_scan_state(LookBackScanState  lookback_scan_state,
+                              const unsigned int number_of_blocks,
+                              unsigned int       flat_thread_id)
 {
 
     // Initialize lookback scan status.
     lookback_scan_state.initialize_prefix(flat_thread_id, number_of_blocks);
 }
 
-template<typename LookBackScanState>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
-    init_lookback_scan_state_kernel(LookBackScanState              lookback_scan_state,
-                                    const unsigned int             number_of_blocks,
-                                    ordered_block_id<unsigned int> ordered_bid,
-                                    unsigned int                   save_index = 0,
-                                    typename LookBackScanState::value_type* const save_dest
-                                    = nullptr)
+template<class LookBackScanState, class WrappedBlockId>
+ROCPRIM_FORCE_INLINE ROCPRIM_DEVICE 
+void init_lookback_scan_state_kernel_impl(LookBackScanState              lookback_scan_state,
+                                          const unsigned int             number_of_blocks,
+                                          WrappedBlockId ordered_bid, // ordered block id is passed by value, so no need to call its constructor
+                                          unsigned int                   save_index,
+                                          typename LookBackScanState::value_type* const save_dest)
 {
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();
@@ -111,13 +109,11 @@ ROCPRIM_KERNEL
 }
 
 template<typename LookBackScanState>
-ROCPRIM_KERNEL
-    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
-    init_lookback_scan_state_kernel(LookBackScanState  lookback_scan_state,
+ROCPRIM_FORCE_INLINE ROCPRIM_DEVICE 
+void init_lookback_scan_state_kernel_impl(LookBackScanState  lookback_scan_state,
                                     const unsigned int number_of_blocks,
-                                    unsigned int       save_index = 0,
-                                    typename LookBackScanState::value_type* const save_dest
-                                    = nullptr)
+                                    unsigned int       save_index,
+                                    typename LookBackScanState::value_type* const save_dest)
 {
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();
@@ -136,6 +132,38 @@ ROCPRIM_KERNEL
     }
 
     init_lookback_scan_state(lookback_scan_state, number_of_blocks, flat_thread_id);
+}
+
+template<class LookBackScanState, class WrappedBlockId>
+ROCPRIM_KERNEL
+    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
+    init_lookback_scan_state_kernel(LookBackScanState  lookback_scan_state,
+                                    const unsigned int number_of_blocks,
+                                    WrappedBlockId     ordered_bid,
+                                    unsigned int       save_index = 0,
+                                    typename LookBackScanState::value_type* const save_dest
+                                    = nullptr)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         ordered_bid,
+                                         save_index,
+                                         save_dest);
+}
+
+template<typename LookBackScanState>
+ROCPRIM_KERNEL
+    ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
+    init_lookback_scan_state_kernel(LookBackScanState  lookback_scan_state,
+                                    const unsigned int number_of_blocks,
+                                    unsigned int       save_index = 0,
+                                    typename LookBackScanState::value_type* const save_dest
+                                    = nullptr)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         save_index,
+                                         save_dest);
 }
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -1035,7 +1035,7 @@ hipError_t is_sleep_scan_state_used(const hipStream_t stream, bool& use_sleep)
     {
         return error;
     }
-    else if(const hipError_t error = hipGetDeviceProperties(&prop, device_id))
+    if(const hipError_t error = hipGetDeviceProperties(&prop, device_id))
     {
         return error;
     }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
@@ -21,45 +21,73 @@
 #ifndef ROCPRIM_DEVICE_DETAIL_ORDERED_BLOCK_ID_HPP_
 #define ROCPRIM_DEVICE_DETAIL_ORDERED_BLOCK_ID_HPP_
 
-#include <type_traits>
-
+#include "../../config.hpp"
 #include "../../detail/temp_storage.hpp"
 #include "../../intrinsics/atomic.hpp"
 #include "../../intrinsics/thread.hpp"
+#include "../config_types.hpp"
+
+#include <atomic>
+#include <exception>
+#include <type_traits>
 
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
 
-// Helper struct for generating ordered unique ids for blocks in a grid.
+/// Helper struct for generating ordered unique ids for blocks in a grid.
 template<class T /* id type */ = unsigned int>
 struct ordered_block_id
 {
+    // It's a bit confusing on how this API *should* be used. So here is how it should be initialized:
+    //   using ordered_bid_type = ordered_block_id<>;
+    //   ordered_bid_type::id_type* ordered_bid_storage;
+    //
+    //   detail::temp_storage::make_linear_partition(
+    //     detail::temp_storage::make_partition(&ordered_bid_storage, ordered_bid_type::get_temp_storage_layout())
+    //   );
+    //
+    //   auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+    //
+    //   my_kernel<<<x, y>>>(ordered_bid);
+    //
+    // On the kernel side it should be:
+    //   __globbal__ my_kernel(ordered_block_id<> ordered_bid)
+    //   {
+    //     __shared__ ordered_block_id<>::storage ordered_bid_storage;
+    //
+    //     auto tid      = threadIdx.x;
+    //     auto block_id = ordered_bid.get(tid, ordered_bid_storage);
+    //   }
     static_assert(std::is_integral<T>::value, "T must be integer");
     using id_type = T;
 
-    // shared memory temporary storage type
+    /// Pointer to global memory that contains the atomic counter for block id.
+    id_type* id;
+
+    /// Shared memory for sharing the received block id to other threads in the block.
     struct storage_type
     {
         id_type id;
     };
 
-    ROCPRIM_HOST static inline
-    ordered_block_id create(id_type * id)
+    ROCPRIM_HOST
+    static inline ordered_block_id create(id_type* ordered_bid_storage)
     {
         ordered_block_id ordered_id;
-        ordered_id.id = id;
+        ordered_id.id = ordered_bid_storage;
         return ordered_id;
     }
 
-    ROCPRIM_HOST static inline
-    size_t get_storage_size()
+    ROCPRIM_HOST
+    static inline size_t get_storage_size()
     {
         return sizeof(id_type);
     }
 
-    ROCPRIM_HOST static inline detail::temp_storage::layout get_temp_storage_layout()
+    ROCPRIM_HOST
+    static inline detail::temp_storage::layout get_temp_storage_layout()
     {
         return detail::temp_storage::layout{get_storage_size(), alignof(id_type)};
     }
@@ -81,7 +109,13 @@ struct ordered_block_id
         return storage.id;
     }
 
-    id_type* id;
+    /// Resets the ordered block id from host. Don't use this if we have an init kernel!
+    /// Call `ordered_block_id::reset()` from that kernel instead.
+    ROCPRIM_HOST ROCPRIM_INLINE
+    hipError_t reset_from_host(const hipStream_t = hipStreamDefault)
+    {
+        return hipMemset(id, 0, sizeof(id_type));
+    }
 };
 
 template<class T = unsigned int, bool UsingOrderedBlockId = false>
@@ -97,7 +131,7 @@ struct block_id_wrapper<T, false>
     {};
 
     ROCPRIM_HOST
-    static inline block_id_wrapper create(id_type* /*id*/)
+    static inline block_id_wrapper create(void* /*id*/)
     {
         block_id_wrapper ordered_id;
         return ordered_id;
@@ -140,10 +174,11 @@ struct block_id_wrapper<T, true>
     using storage_type = typename ::rocprim::detail::ordered_block_id<id_type>::storage_type;
 
     ROCPRIM_HOST
-    static inline block_id_wrapper create(id_type* id)
+    static inline block_id_wrapper create(void* id)
     {
         block_id_wrapper id_wrapper;
-        id_wrapper.ordered_id = detail::ordered_block_id<id_type>::create(id);
+        id_wrapper.ordered_id
+            = detail::ordered_block_id<id_type>::create(static_cast<id_type*>(id));
         return id_wrapper;
     }
 
@@ -181,6 +216,88 @@ struct block_id_wrapper<T, true>
 
     ::rocprim::detail::ordered_block_id<id_type> ordered_id;
 };
+
+ROCPRIM_INLINE ROCPRIM_HOST
+hipError_t check_if_using_atomic_block_id(hipStream_t stream, bool& enable)
+{
+    // Define possible options
+    enum class use_atomic_block_id : int
+    {
+        never  = 0,
+        hotfix = 1,
+        always = 2,
+
+        default_option = use_atomic_block_id::hotfix,
+    };
+
+    struct data_t
+    {
+        bool                valid  = false;
+        use_atomic_block_id option = use_atomic_block_id::hotfix;
+    };
+
+    static_assert(std::is_trivially_copyable_v<data_t>);
+
+    // Store our data in a static atomic.
+    static std::atomic<data_t> cache{data_t{}};
+
+    // First load the atomic, if it's invalid, we need to check the env vars.
+    data_t data = cache.load(std::memory_order_acquire);
+    if(!data.valid)
+    {
+        // Try to parse the env var, if it fails fall back to the default option.
+        auto* env = std::getenv("ROCPRIM_USE_ATOMIC_BLOCK_ID");
+
+        data.option = use_atomic_block_id::default_option;
+        try
+        {
+            if(env != nullptr)
+            {
+                data.option = use_atomic_block_id{std::stoi(env)};
+            }
+        }
+        catch(std::exception)
+        {
+            data.option = use_atomic_block_id::default_option;
+        }
+
+        data.valid = true;
+        // Now finally update our static atomic.
+        cache.store(data, std::memory_order_release);
+    }
+
+    // Now we have our data, we need to check what the behaviour is.
+    bool needs_hotfix = false;
+    if(data.option == use_atomic_block_id::hotfix)
+    {
+        // First get the device ID.
+        int device_id;
+        ROCPRIM_RETURN_ON_ERROR(::rocprim::detail::get_device_from_stream(stream, device_id));
+
+        // Then we get the arch. This property is cached.
+        target_arch arch;
+        ROCPRIM_RETURN_ON_ERROR(rocprim::detail::get_device_arch(device_id, arch));
+
+        needs_hotfix = (arch == target_arch::gfx942) || (arch == target_arch::gfx950);
+    }
+
+    switch(data.option)
+    {
+            // clang-format off
+        case use_atomic_block_id::never:
+            enable = false;
+            break;
+        case use_atomic_block_id::always:
+            enable = true;
+            break;
+        case use_atomic_block_id::hotfix:
+        default:
+            enable = needs_hotfix;
+        //clang-format on
+    }
+
+    return hipSuccess;
+}
 
 } // end of detail namespace
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_find_first_of.hpp
@@ -23,6 +23,7 @@
 
 #include "../config.hpp"
 #include "../detail/temp_storage.hpp"
+#include "../detail/various.hpp"
 #include "config_types.hpp"
 #include "detail/ordered_block_id.hpp"
 #include "device_find_first_of_config.hpp"

--- a/projects/rocprim/rocprim/include/rocprim/device/device_nth_element.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_nth_element.hpp
@@ -22,6 +22,7 @@
 #define ROCPRIM_DEVICE_DEVICE_NTH_ELEMENT_HPP_
 
 #include "detail/device_nth_element.hpp"
+#include "detail/ordered_block_id.hpp"
 
 #include "../detail/temp_storage.hpp"
 
@@ -59,105 +60,130 @@ hipError_t
     using key_type = typename std::iterator_traits<KeysIterator>::value_type;
     using config   = wrapped_nth_element_config<Config, key_type>;
 
-    target_arch target_arch;
-    hipError_t  result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const nth_element_config_params params = dispatch_target_arch<config, false>(target_arch);
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    constexpr unsigned int num_partitions        = 3;
-    const unsigned int     num_buckets           = params.number_of_buckets;
-    const unsigned int     num_splitters         = num_buckets - 1;
-    const unsigned int     stop_recursion_size   = params.stop_recursion_size;
-    const unsigned int     num_items_per_threads = params.kernel_config.items_per_thread;
-    const unsigned int     num_threads_per_block = params.kernel_config.block_size;
-    const unsigned int     num_items_per_block   = num_threads_per_block * num_items_per_threads;
-    const unsigned int     num_blocks            = ceiling_div(size, num_items_per_block);
-
-    key_type*                            tree             = nullptr;
-    unsigned int*                        buckets          = nullptr;
-    n_th_element_iteration_data*         nth_element_data = nullptr;
-    bool*                                equality_buckets = nullptr;
-    nth_element_onesweep_lookback_state* lookback_states  = nullptr;
-
-    key_type* keys_buffer = nullptr;
-
-    {
-        using namespace temp_storage;
-
-        hipError_t partition_result;
-        if(keys_double_buffer == nullptr)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_atomic_block_id)
         {
-            partition_result
-                = partition(temporary_storage,
-                            storage_size,
-                            make_linear_partition(
-                                ptr_aligned_array(&tree, num_splitters),
-                                ptr_aligned_array(&equality_buckets, num_buckets),
-                                ptr_aligned_array(&buckets, num_buckets),
-                                ptr_aligned_array(&keys_buffer, size),
-                                ptr_aligned_array(&nth_element_data, 1),
-                                ptr_aligned_array(&lookback_states, num_partitions * num_blocks)));
-        }
-        else
-        {
-            partition_result
-                = partition(temporary_storage,
-                            storage_size,
-                            make_linear_partition(
-                                ptr_aligned_array(&tree, num_splitters),
-                                ptr_aligned_array(&equality_buckets, num_buckets),
-                                ptr_aligned_array(&buckets, num_buckets),
-                                ptr_aligned_array(&nth_element_data, 1),
-                                ptr_aligned_array(&lookback_states, num_partitions * num_blocks)));
-            keys_buffer = keys_double_buffer;
-        }
+            target_arch target_arch;
+            hipError_t  result = host_target_arch(stream, target_arch);
+            if(result != hipSuccess)
+            {
+                return result;
+            }
+            const nth_element_config_params params
+                = dispatch_target_arch<config, false>(target_arch);
 
-        if(partition_result != hipSuccess || temporary_storage == nullptr)
-        {
-            return partition_result;
-        }
-    }
+            constexpr unsigned int num_partitions        = 3;
+            const unsigned int     num_buckets           = params.number_of_buckets;
+            const unsigned int     num_splitters         = num_buckets - 1;
+            const unsigned int     stop_recursion_size   = params.stop_recursion_size;
+            const unsigned int     num_items_per_threads = params.kernel_config.items_per_thread;
+            const unsigned int     num_threads_per_block = params.kernel_config.block_size;
+            const unsigned int num_items_per_block = num_threads_per_block * num_items_per_threads;
+            const unsigned int num_blocks          = ceiling_div(size, num_items_per_block);
 
-    if((size == 0) || (size == 1 && nth == 0))
-    {
-        return hipSuccess;
-    }
+            key_type*                            tree             = nullptr;
+            unsigned int*                        buckets          = nullptr;
+            n_th_element_iteration_data*         nth_element_data = nullptr;
+            bool*                                equality_buckets = nullptr;
+            nth_element_onesweep_lookback_state* lookback_states  = nullptr;
 
-    if(nth >= size)
-    {
-        return hipErrorInvalidValue;
-    }
+            key_type* keys_buffer = nullptr;
 
-    if(debug_synchronous)
-    {
-        std::cout << "-----" << '\n';
-        std::cout << "size: " << size << '\n';
-        std::cout << "num_buckets: " << num_buckets << '\n';
-        std::cout << "num_threads_per_block: " << num_threads_per_block << '\n';
-        std::cout << "num_blocks: " << num_blocks << '\n';
-        std::cout << "storage_size: " << storage_size << '\n';
-    }
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
+            typename ordered_bid_type::id_type* ordered_bid_storage;
 
-    return nth_element_keys_impl<config, num_partitions>(target_arch,
-                                                         keys,
-                                                         keys_buffer,
-                                                         tree,
-                                                         nth,
-                                                         size,
-                                                         buckets,
-                                                         equality_buckets,
-                                                         lookback_states,
-                                                         num_buckets,
-                                                         stop_recursion_size,
-                                                         num_threads_per_block,
-                                                         num_items_per_threads,
-                                                         nth_element_data,
-                                                         compare_function,
-                                                         stream,
-                                                         debug_synchronous);
+            {
+                using namespace temp_storage;
+
+                hipError_t partition_result;
+                if(keys_double_buffer == nullptr)
+                {
+                    partition_result = partition(
+                        temporary_storage,
+                        storage_size,
+                        make_linear_partition(
+                            ptr_aligned_array(&tree, num_splitters),
+                            ptr_aligned_array(&equality_buckets, num_buckets),
+                            ptr_aligned_array(&buckets, num_buckets),
+                            ptr_aligned_array(&keys_buffer, size),
+                            ptr_aligned_array(&nth_element_data, 1),
+                            ptr_aligned_array(&lookback_states, num_partitions * num_blocks),
+                            detail::temp_storage::make_partition(
+                                &ordered_bid_storage,
+                                ordered_bid_type::get_temp_storage_layout())));
+                }
+                else
+                {
+                    partition_result = partition(
+                        temporary_storage,
+                        storage_size,
+                        make_linear_partition(
+                            ptr_aligned_array(&tree, num_splitters),
+                            ptr_aligned_array(&equality_buckets, num_buckets),
+                            ptr_aligned_array(&buckets, num_buckets),
+                            ptr_aligned_array(&nth_element_data, 1),
+                            ptr_aligned_array(&lookback_states, num_partitions * num_blocks),
+                            detail::temp_storage::make_partition(
+                                &ordered_bid_storage,
+                                ordered_bid_type::get_temp_storage_layout())));
+                    keys_buffer = keys_double_buffer;
+                }
+
+                if(partition_result != hipSuccess || temporary_storage == nullptr)
+                {
+                    return partition_result;
+                }
+            }
+
+            if((size == 0) || (size == 1 && nth == 0))
+            {
+                return hipSuccess;
+            }
+
+            if(nth >= size)
+            {
+                return hipErrorInvalidValue;
+            }
+
+            if(debug_synchronous)
+            {
+                std::cout << "-----" << '\n';
+                std::cout << "size: " << size << '\n';
+                std::cout << "num_buckets: " << num_buckets << '\n';
+                std::cout << "num_threads_per_block: " << num_threads_per_block << '\n';
+                std::cout << "num_blocks: " << num_blocks << '\n';
+                std::cout << "storage_size: " << storage_size << '\n';
+            }
+
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            return nth_element_keys_impl<config, num_partitions>(target_arch,
+                                                                 keys,
+                                                                 keys_buffer,
+                                                                 tree,
+                                                                 nth,
+                                                                 size,
+                                                                 buckets,
+                                                                 equality_buckets,
+                                                                 lookback_states,
+                                                                 num_buckets,
+                                                                 stop_recursion_size,
+                                                                 num_threads_per_block,
+                                                                 num_items_per_threads,
+                                                                 nth_element_data,
+                                                                 compare_function,
+                                                                 stream,
+                                                                 debug_synchronous,
+                                                                 ordered_bid);
+        },
+        use_atomic_block_id_variant));
+    return hipSuccess;
 }
 
 } // namespace detail

--- a/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_partition.hpp
@@ -32,8 +32,6 @@
 #include "../detail/temp_storage.hpp"
 #include "../detail/various.hpp"
 #include "../functional.hpp"
-#include "../iterator/reverse_iterator.hpp"
-#include "../type_traits.hpp"
 #include "../types.hpp"
 
 #include "detail/device_partition.hpp"
@@ -42,6 +40,7 @@
 #include "device_transform.hpp"
 #include "rocprim/detail/virtual_shared_memory.hpp"
 #include "rocprim/device/config_types.hpp"
+#include "rocprim/device/detail/lookback_scan_state.hpp"
 #include "rocprim/device/detail/ordered_block_id.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
@@ -147,7 +146,9 @@ inline size_t get_partition_vsmem_size_per_block(detail::target_arch arch)
         {
             constexpr target_arch Arch = decltype(arch_tag)::value;
             if(Arch != arch || vsmem_per_block)
+            {
                 return;
+            }
 
             using ArchConfig               = typename Config::template architecture_config<Arch>;
             using partition_kernel_impl_t  = partition_kernel_impl_<ArchConfig,
@@ -210,240 +211,186 @@ inline hipError_t partition_impl(void*                       temporary_storage,
     using key_type    = typename std::iterator_traits<KeyIterator>::value_type;
     using value_type  = typename std::iterator_traits<ValueIterator>::value_type;
 
-    using config = wrapped_partition_config<Config, SubAlgo, key_type, value_type>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    constexpr bool write_only_selected = SubAlgo == partition_subalgo::select_flag
-                                         || SubAlgo == partition_subalgo::select_predicate
-                                         || SubAlgo == partition_subalgo::select_predicated_flag
-                                         || SubAlgo == partition_subalgo::select_unique
-                                         || SubAlgo == partition_subalgo::select_unique_by_key;
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
+    ;
+    const auto use_sleepy_scan_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(use_sleepy_scan);
 
-    constexpr bool is_unique = SubAlgo == partition_subalgo::select_unique
-                               || SubAlgo == partition_subalgo::select_unique_by_key;
-    constexpr bool is_flag = SubAlgo == partition_subalgo::partition_two_way_flag
-                             || SubAlgo == partition_subalgo::partition_flag
-                             || SubAlgo == partition_subalgo::select_flag;
-    constexpr bool is_predicated_flag = SubAlgo == partition_subalgo::select_predicated_flag;
-    constexpr select_method method
-        = is_unique
-              ? select_method::unique
-              : (is_predicated_flag ? select_method::predicated_flag
-                                    : (is_flag ? select_method::flag : select_method::predicate));
-
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const partition_config_params params = dispatch_target_arch<config, false>(target_arch);
-
-    using offset_scan_state_type            = detail::lookback_scan_state<offset_type>;
-    using offset_scan_state_with_sleep_type = detail::lookback_scan_state<offset_type, true>;
-
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const auto         items_per_block  = block_size * items_per_thread;
-
-    static constexpr bool         is_three_way        = sizeof...(UnaryPredicates) == 2;
-    static constexpr const size_t selected_count_size = is_three_way ? 2 : 1;
-
-    const size_t size_limit = params.kernel_config.size_limit;
-    const size_t aligned_size_limit
-        = ::rocprim::max<size_t>(size_limit - (size_limit % items_per_block), items_per_block);
-    const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
-    const bool   use_limited_size = limited_size == aligned_size_limit;
-
-    const unsigned int number_of_blocks
-        = static_cast<unsigned int>(::rocprim::detail::ceiling_div(limited_size, items_per_block));
-
-    // Calculate required temporary storage
-    void*   offset_scan_state_storage;
-    size_t* selected_count;
-    size_t* prev_selected_count;
-
-    detail::temp_storage::layout layout{};
-    result = offset_scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    using block_id_wrapper_type = block_id_wrapper<uint32_t, UsingOrderedBlockId>;
-
-    typename block_id_wrapper_type::id_type* block_id_pool = nullptr;
-
-    bool use_sleep;
-    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleep));
-
-    // vsmem size
-    void*  vsmem                      = nullptr;
-    size_t virtual_shared_memory_size = 0;
-    using flag_type =
-        typename std::conditional<method == select_method::predicated_flag,
-                                  typename std::iterator_traits<FlagIterator>::value_type,
-                                  bool>::type;
-    if(use_sleep)
-    {
-        virtual_shared_memory_size
-            = get_partition_vsmem_size_per_block<config,
-                                                 method,
-                                                 write_only_selected,
-                                                 key_type,
-                                                 value_type,
-                                                 flag_type,
-                                                 offset_scan_state_with_sleep_type,
-                                                 block_id_wrapper_type>(target_arch);
-    }
-    else
-    {
-        virtual_shared_memory_size
-            = get_partition_vsmem_size_per_block<config,
-                                                 method,
-                                                 write_only_selected,
-                                                 key_type,
-                                                 value_type,
-                                                 flag_type,
-                                                 offset_scan_state_type,
-                                                 block_id_wrapper_type>(target_arch);
-    }
-    virtual_shared_memory_size *= number_of_blocks;
-
-    // temporary storage partition
-
-    result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with offset_scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&offset_scan_state_storage, layout),
-            // Note: the following two are to be allocated continuously, so that they can be initialized
-            // simultaneously.
-            // They have the same base type, so there is no padding between the types.
-            detail::temp_storage::ptr_aligned_array(&selected_count, selected_count_size),
-            detail::temp_storage::ptr_aligned_array(&prev_selected_count, selected_count_size),
-            detail::temp_storage::ptr_aligned_array(&block_id_pool,
-                                                    block_id_wrapper_type::get_storage_size()),
-            // vsmem
-            detail::temp_storage::make_partition(&vsmem,
-                                                 virtual_shared_memory_size,
-                                                 cache_line_size)));
-
-    if(result != hipSuccess || temporary_storage == nullptr)
-    {
-        return result;
-    }
-
-    auto block_id = block_id_wrapper_type::create(block_id_pool);
-
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-
-    // Create and initialize lookback_scan_state obj
-    offset_scan_state_type offset_scan_state{};
-    result = offset_scan_state_type::create(offset_scan_state,
-                                            offset_scan_state_storage,
-                                            number_of_blocks,
-                                            stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    offset_scan_state_with_sleep_type offset_scan_state_with_sleep{};
-    result = offset_scan_state_with_sleep_type::create(offset_scan_state_with_sleep,
-                                                       offset_scan_state_storage,
-                                                       number_of_blocks,
-                                                       stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    // Call the provided function with either offset_scan_state or offset_scan_state_with_sleep based on
-    // the value of use_sleep
-    auto with_scan_state = [use_sleep, offset_scan_state, offset_scan_state_with_sleep](
-                               auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(offset_scan_state_with_sleep);
-        }
-        else
-        {
-            return func(offset_scan_state);
-        }
-    };
+            using scan_state_type = detail::lookback_scan_state<offset_type, use_sleepy_scan>;
+            using block_id_type   = detail::block_id_wrapper<uint32_t, use_atomic_block_id>;
 
-    // Memset selected_count and prev_selected_count at once
-    result = hipMemsetAsync(selected_count,
-                            0,
-                            sizeof(*selected_count) * 2 * selected_count_size,
-                            stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+            using config = wrapped_partition_config<Config, SubAlgo, key_type, value_type>;
 
-    const size_t number_of_launches = ::rocprim::detail::ceiling_div(size, aligned_size_limit);
+            constexpr bool write_only_selected
+                = SubAlgo == partition_subalgo::select_flag
+                  || SubAlgo == partition_subalgo::select_predicate
+                  || SubAlgo == partition_subalgo::select_predicated_flag
+                  || SubAlgo == partition_subalgo::select_unique
+                  || SubAlgo == partition_subalgo::select_unique_by_key;
 
-    if(debug_synchronous)
-    {
-        std::cout << "use_limited_size " << use_limited_size << '\n';
-        std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
-        std::cout << "number_of_launches " << number_of_launches << '\n';
-        std::cout << "size " << size << '\n';
-        std::cout << "block_size " << block_size << '\n';
-        std::cout << "number of blocks " << number_of_blocks << '\n';
-        std::cout << "items_per_block " << items_per_block << '\n';
-    }
+            constexpr bool is_unique = SubAlgo == partition_subalgo::select_unique
+                                       || SubAlgo == partition_subalgo::select_unique_by_key;
+            constexpr bool is_flag = SubAlgo == partition_subalgo::partition_two_way_flag
+                                     || SubAlgo == partition_subalgo::partition_flag
+                                     || SubAlgo == partition_subalgo::select_flag;
+            constexpr bool is_predicated_flag
+                = SubAlgo == partition_subalgo::select_predicated_flag;
+            constexpr select_method method
+                = is_unique ? select_method::unique
+                            : (is_predicated_flag
+                                   ? select_method::predicated_flag
+                                   : (is_flag ? select_method::flag : select_method::predicate));
 
-    for(size_t i = 0, prev_processed = 0; i < number_of_launches;
-        i++, prev_processed += limited_size)
-    {
-        const unsigned int current_size
-            = static_cast<unsigned int>(std::min<size_t>(size - prev_processed, limited_size));
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+            const partition_config_params params = dispatch_target_arch<config, false>(target_arch);
 
-        const unsigned int current_number_of_blocks
-            = ::rocprim::detail::ceiling_div(current_size, items_per_block);
+            const unsigned int block_size       = params.kernel_config.block_size;
+            const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+            const auto         items_per_block  = block_size * items_per_thread;
 
-        if(debug_synchronous)
-        {
-            std::cout << "current size " << current_size << '\n';
-            std::cout << "current number of blocks " << current_number_of_blocks << '\n';
+            static constexpr bool         is_three_way        = sizeof...(UnaryPredicates) == 2;
+            static constexpr const size_t selected_count_size = is_three_way ? 2 : 1;
 
-            start = std::chrono::steady_clock::now();
-        }
+            const size_t size_limit         = params.kernel_config.size_limit;
+            const size_t aligned_size_limit = ::rocprim::max<size_t>(
+                size_limit - (size_limit % static_cast<size_t>(items_per_block)),
+                items_per_block);
+            const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
+            const bool   use_limited_size = limited_size == aligned_size_limit;
 
-        with_scan_state(
-            [&](const auto scan_state)
+            const unsigned int number_of_blocks = static_cast<unsigned int>(
+                ::rocprim::detail::ceiling_div(limited_size, items_per_block));
+
+            // Calculate required temporary storage
+            void*   scan_state_storage;
+            size_t* selected_count;
+            size_t* prev_selected_count;
+
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
+
+            typename block_id_type::id_type* block_id_pool = nullptr;
+
+            // vsmem size
+            void*  vsmem                      = nullptr;
+            size_t virtual_shared_memory_size = 0;
+            using flag_type =
+                typename std::conditional<method == select_method::predicated_flag,
+                                          typename std::iterator_traits<FlagIterator>::value_type,
+                                          bool>::type;
+
+            virtual_shared_memory_size
+                = get_partition_vsmem_size_per_block<config,
+                                                     method,
+                                                     write_only_selected,
+                                                     key_type,
+                                                     value_type,
+                                                     flag_type,
+                                                     scan_state_type,
+                                                     block_id_type>(target_arch);
+            virtual_shared_memory_size *= number_of_blocks;
+
+            // temporary storage partition
+            ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    // Note: the following two are to be allocated continuously, so that they can be initialized
+                    // simultaneously.
+                    // They have the same base type, so there is no padding between the types.
+                    detail::temp_storage::ptr_aligned_array(&selected_count, selected_count_size),
+                    detail::temp_storage::ptr_aligned_array(&prev_selected_count,
+                                                            selected_count_size),
+                    detail::temp_storage::ptr_aligned_array(&block_id_pool,
+                                                            block_id_type::get_storage_size()),
+                    // vsmem
+                    detail::temp_storage::make_partition(&vsmem,
+                                                         virtual_shared_memory_size,
+                                                         cache_line_size))));
+
+            if(temporary_storage == nullptr)
             {
-                const unsigned int block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
-                const unsigned int grid_size
-                    = ::rocprim::detail::ceiling_div(current_number_of_blocks, block_size);
-                init_lookback_scan_state_kernel<decltype(scan_state)>
-                    <<<dim3(grid_size), dim3(block_size), 0, stream>>>(scan_state,
-                                                                       current_number_of_blocks);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_offset_scan_state_kernel",
-                                                    current_number_of_blocks,
-                                                    start);
-
-        if(UsingOrderedBlockId)
-        {
-            result = hipMemsetAsync(block_id_pool, 0, sizeof(unsigned int), stream);
-            if(result != hipSuccess)
-            {
-                return result;
+                return hipSuccess;
             }
-        }
 
-        if(debug_synchronous)
-            start = std::chrono::steady_clock::now();
+            block_id_type block_id = block_id_type::create(block_id_pool);
 
-        ROCPRIM_RETURN_ON_ERROR(with_scan_state(
-            [&](const auto scan_state)
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+
+            // Create and initialize lookback_scan_state obj
+            scan_state_type scan_state{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream));
+
+            // Memset selected_count and prev_selected_count at once
+            ROCPRIM_RETURN_ON_ERROR(
+                hipMemsetAsync(selected_count,
+                               0,
+                               sizeof(*selected_count) * 2 * selected_count_size,
+                               stream));
+
+            const size_t number_of_launches
+                = ::rocprim::detail::ceiling_div(size, aligned_size_limit);
+
+            if(debug_synchronous)
             {
-                return launch_partition<config, method, write_only_selected>(
+                std::cout << "use_limited_size " << use_limited_size << '\n';
+                std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
+                std::cout << "number_of_launches " << number_of_launches << '\n';
+                std::cout << "size " << size << '\n';
+                std::cout << "block_size " << block_size << '\n';
+                std::cout << "number of blocks " << number_of_blocks << '\n';
+                std::cout << "items_per_block " << items_per_block << '\n';
+            }
+
+            for(size_t i = 0, prev_processed = 0; i < number_of_launches;
+                i++, prev_processed += limited_size)
+            {
+                const unsigned int current_size = static_cast<unsigned int>(
+                    std::min<size_t>(size - prev_processed, limited_size));
+
+                const unsigned int current_number_of_blocks
+                    = ::rocprim::detail::ceiling_div(current_size, items_per_block);
+
+                if(debug_synchronous)
+                {
+                    std::cout << "current size " << current_size << '\n';
+                    std::cout << "current number of blocks " << current_number_of_blocks << '\n';
+
+                    start = std::chrono::steady_clock::now();
+                }
+
+                // Define block and grid sizes for init kernel.
+                const size_t init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
+                const size_t init_grid_size
+                    = ::rocprim::detail::ceiling_div(current_number_of_blocks, init_block_size);
+                init_lookback_scan_state_kernel<<<init_grid_size, init_block_size, 0, stream>>>(
+                    scan_state,
+                    current_number_of_blocks,
+                    block_id);
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_offset_scan_state_kernel",
+                                                            current_number_of_blocks,
+                                                            start);
+                if(debug_synchronous)
+                {
+                    start = std::chrono::steady_clock::now();
+                }
+
+                ROCPRIM_RETURN_ON_ERROR(launch_partition<config, method, write_only_selected>(
                     target_arch,
                     keys_input + prev_processed,
                     values_input + prev_processed,
@@ -463,23 +410,23 @@ inline hipError_t partition_impl(void*                       temporary_storage,
                     dim3(block_size),
                     0,
                     stream,
-                    predicates...);
-            }));
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", size, start);
+                    predicates...));
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("partition_kernel", size, start);
 
-        std::swap(selected_count, prev_selected_count);
-    }
+                std::swap(selected_count, prev_selected_count);
+            }
 
-    result = ::rocprim::transform(prev_selected_count,
-                                  selected_count_output,
-                                  (is_three_way ? 2 : 1),
-                                  ::rocprim::identity<>{},
-                                  stream,
-                                  debug_synchronous);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+            ROCPRIM_RETURN_ON_ERROR(::rocprim::transform(prev_selected_count,
+                                                         selected_count_output,
+                                                         (is_three_way ? 2 : 1),
+                                                         ::rocprim::identity<>{},
+                                                         stream,
+                                                         debug_synchronous));
+
+            return hipSuccess;
+        },
+        use_sleepy_scan_variant,
+        use_atomic_block_id_variant));
 
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -39,6 +39,7 @@
 #include "detail/config/device_radix_sort_onesweep.hpp"
 #include "detail/device_radix_sort.hpp"
 #include "device_transform.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 #include "specialization/device_radix_block_sort.hpp"
 #include "specialization/device_radix_merge_sort.hpp"
 
@@ -235,7 +236,8 @@ template<class Config,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Offset,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 inline hipError_t launch_onesweep_iteration(detail::target_arch      arch,
                                             KeysInputIterator        keys_input,
                                             KeysOutputIterator       keys_output,
@@ -249,6 +251,7 @@ inline hipError_t launch_onesweep_iteration(detail::target_arch      arch,
                                             const unsigned int       bit,
                                             const unsigned int       current_radix_bits,
                                             const unsigned int       full_blocks,
+                                            BlockIdWrapper           ordered_bid,
                                             dim3                     grid,
                                             dim3                     block,
                                             size_t                   shmem,
@@ -273,7 +276,8 @@ inline hipError_t launch_onesweep_iteration(detail::target_arch      arch,
                                                         decomposer,
                                                         bit,
                                                         current_radix_bits,
-                                                        full_blocks);
+                                                        full_blocks,
+                                                        ordered_bid);
     };
 
     return execute_launch_plan<Config, decltype(kernel), radix_sort_onesweep_sort_config_selector>(
@@ -292,7 +296,8 @@ template<class Config,
          class ValuesInputIterator,
          class ValuesOutputIterator,
          class Offset,
-         class Decomposer>
+         class Decomposer,
+         class BlockIdWrapper>
 hipError_t radix_sort_onesweep_iteration(
     KeysInputIterator                                               keys_input,
     typename std::iterator_traits<KeysInputIterator>::value_type*   keys_tmp,
@@ -309,6 +314,7 @@ hipError_t radix_sort_onesweep_iteration(
     Decomposer                                                      decomposer,
     const unsigned int                                              bit,
     const unsigned int                                              end_bit,
+    BlockIdWrapper                                                  ordered_bid,
     const hipStream_t                                               stream,
     const bool                                                      debug_synchronous)
 {
@@ -317,11 +323,7 @@ hipError_t radix_sort_onesweep_iteration(
     using config     = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
 
     detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
+    ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
     const radix_sort_onesweep_config_params params
         = dispatch_target_arch<config, false>(target_arch);
 
@@ -351,12 +353,11 @@ hipError_t radix_sort_onesweep_iteration(
         const unsigned int num_lookback_states = radix_size_per_place * blocks;
 
         // Reset lookback scan states to zero, indicating empty prefix.
-        hipError_t error = hipMemsetAsync(lookback_states,
-                                          0,
-                                          sizeof(onesweep_lookback_state) * num_lookback_states,
-                                          stream);
-        if(error != hipSuccess)
-            return error;
+        ROCPRIM_RETURN_ON_ERROR(
+            hipMemsetAsync(lookback_states,
+                           0,
+                           sizeof(onesweep_lookback_state) * num_lookback_states,
+                           stream));
 
         std::chrono::steady_clock::time_point start;
         if(debug_synchronous)
@@ -376,6 +377,8 @@ hipError_t radix_sort_onesweep_iteration(
             start = std::chrono::steady_clock::now();
         }
 
+        ROCPRIM_RETURN_ON_ERROR(ordered_bid.reset_from_host(stream));
+
         if(from_input && to_output)
         {
             ROCPRIM_RETURN_ON_ERROR(
@@ -392,6 +395,7 @@ hipError_t radix_sort_onesweep_iteration(
                                                               bit,
                                                               current_radix_bits,
                                                               full_blocks,
+                                                              ordered_bid,
                                                               dim3(blocks),
                                                               dim3(params.sort.block_size),
                                                               0,
@@ -413,6 +417,7 @@ hipError_t radix_sort_onesweep_iteration(
                                                               bit,
                                                               current_radix_bits,
                                                               full_blocks,
+                                                              ordered_bid,
                                                               dim3(blocks),
                                                               dim3(params.sort.block_size),
                                                               0,
@@ -434,6 +439,7 @@ hipError_t radix_sort_onesweep_iteration(
                                                               bit,
                                                               current_radix_bits,
                                                               full_blocks,
+                                                              ordered_bid,
                                                               dim3(blocks),
                                                               dim3(params.sort.block_size),
                                                               0,
@@ -455,6 +461,7 @@ hipError_t radix_sort_onesweep_iteration(
                                                               bit,
                                                               current_radix_bits,
                                                               full_blocks,
+                                                              ordered_bid,
                                                               dim3(blocks),
                                                               dim3(params.sort.block_size),
                                                               0,
@@ -497,160 +504,169 @@ hipError_t radix_sort_onesweep_impl(
     using value_type  = typename std::iterator_traits<ValuesInputIterator>::value_type;
     using offset_type = offset_type_t<Size>;
 
-    using config = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const radix_sort_onesweep_config_params params
-        = dispatch_target_arch<config, false>(target_arch);
-
-    const unsigned int sort_items_per_block = params.sort.block_size * params.sort.items_per_thread;
-    const unsigned int radix_size_per_place = 1u << params.radix_bits_per_place;
-    const unsigned int max_items_per_full_batch = 1u << 30;
-    const unsigned int items_per_full_batch
-        = max_items_per_full_batch - max_items_per_full_batch % sort_items_per_block;
-
-    const unsigned int places = ceiling_div(end_bit - begin_bit, params.radix_bits_per_place);
-    const unsigned int bins   = radix_size_per_place * places;
-    const unsigned int items_per_batch
-        = static_cast<unsigned int>(::rocprim::min<size_t>(size, items_per_full_batch));
-    const unsigned int num_lookback_states
-        = radix_size_per_place * ceiling_div(items_per_batch, sort_items_per_block);
-
-    constexpr bool with_values = !std::is_same<value_type, ::rocprim::empty_type>::value;
-
-    offset_type*             global_digit_offsets;
-    offset_type*             global_digit_offsets_tmp;
-    onesweep_lookback_state* lookback_states;
-    key_type*                keys_tmp_storage;
-    value_type*              values_tmp_storage;
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            detail::temp_storage::ptr_aligned_array(&global_digit_offsets, bins),
-            detail::temp_storage::ptr_aligned_array(&global_digit_offsets_tmp,
-                                                    radix_size_per_place),
-            detail::temp_storage::ptr_aligned_array(&lookback_states, num_lookback_states),
-            detail::temp_storage::ptr_aligned_array(&keys_tmp_storage,
-                                                    !no_allocate_tmp_buffer ? size : 0),
-            detail::temp_storage::ptr_aligned_array(&values_tmp_storage,
-                                                    !no_allocate_tmp_buffer && with_values ? size
-                                                                                           : 0)));
-
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return partition_result;
-    }
-
-    if(size == 0)
-        return hipSuccess;
-
-    if(debug_synchronous)
-    {
-        std::cout << "radix_size " << radix_size_per_place << '\n';
-        std::cout << "digit_places " << places << '\n';
-        std::cout << "histograms_size " << bins << '\n';
-        std::cout << "num_lookback_states " << num_lookback_states << '\n';
-        hipError_t error = hipStreamSynchronize(stream);
-        if(error != hipSuccess)
-            return error;
-    }
-
-    // Compute the global digit offset, for each digit and for each digit place.
-    {
-        hipError_t error
-            = radix_sort_onesweep_global_offsets<Config, Descending>(keys_input,
-                                                                     values_input,
-                                                                     global_digit_offsets,
-                                                                     static_cast<offset_type>(size),
-                                                                     places,
-                                                                     decomposer,
-                                                                     begin_bit,
-                                                                     end_bit,
-                                                                     stream,
-                                                                     debug_synchronous);
-        if(error != hipSuccess)
-            return error;
-    }
-
-    if(!no_allocate_tmp_buffer)
-    {
-        keys_tmp   = keys_tmp_storage;
-        values_tmp = values_tmp_storage;
-    }
-
-    // Copy input keys and values if necessary (in-place sorting: input and output iterators are equal).
-    bool to_output  = no_allocate_tmp_buffer || (places - 1) % 2 == 0;
-    bool from_input = true;
-    if(!no_allocate_tmp_buffer && to_output)
-    {
-        const bool keys_alias
-            = ::rocprim::detail::can_iterators_alias(keys_input, keys_output, size);
-        const bool values_alias
-            = with_values
-              && ::rocprim::detail::can_iterators_alias(values_input, values_output, size);
-        if(keys_alias || values_alias)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_atomic_block_id)
         {
-            hipError_t error = ::rocprim::transform(keys_input,
-                                                    keys_tmp,
-                                                    size,
-                                                    ::rocprim::identity<key_type>(),
-                                                    stream,
-                                                    debug_synchronous);
-            if(error != hipSuccess)
-                return error;
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
+            using config = wrapped_radix_sort_onesweep_config<Config, key_type, value_type>;
 
-            if(with_values)
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+
+            const radix_sort_onesweep_config_params params
+                = dispatch_target_arch<config, false>(target_arch);
+
+            const unsigned int sort_items_per_block
+                = params.sort.block_size * params.sort.items_per_thread;
+            const unsigned int radix_size_per_place     = 1u << params.radix_bits_per_place;
+            const unsigned int max_items_per_full_batch = 1u << 30;
+            const unsigned int items_per_full_batch
+                = max_items_per_full_batch - (max_items_per_full_batch % sort_items_per_block);
+
+            const unsigned int places
+                = ceiling_div(end_bit - begin_bit, params.radix_bits_per_place);
+            const unsigned int bins = radix_size_per_place * places;
+            const unsigned int items_per_batch
+                = static_cast<unsigned int>(::rocprim::min<size_t>(size, items_per_full_batch));
+            const unsigned int num_lookback_states
+                = radix_size_per_place * ceiling_div(items_per_batch, sort_items_per_block);
+
+            constexpr bool with_values = !std::is_same<value_type, ::rocprim::empty_type>::value;
+
+            offset_type*                        global_digit_offsets;
+            offset_type*                        global_digit_offsets_tmp;
+            onesweep_lookback_state*            lookback_states;
+            key_type*                           keys_tmp_storage;
+            value_type*                         values_tmp_storage;
+            typename ordered_bid_type::id_type* ordered_bid_storage;
+
+            ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    detail::temp_storage::ptr_aligned_array(&global_digit_offsets, bins),
+                    detail::temp_storage::ptr_aligned_array(&global_digit_offsets_tmp,
+                                                            radix_size_per_place),
+                    detail::temp_storage::ptr_aligned_array(&lookback_states, num_lookback_states),
+                    detail::temp_storage::ptr_aligned_array(&keys_tmp_storage,
+                                                            !no_allocate_tmp_buffer ? size : 0),
+                    detail::temp_storage::ptr_aligned_array(
+                        &values_tmp_storage,
+                        !no_allocate_tmp_buffer && with_values ? size : 0),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        ordered_bid_type::get_temp_storage_layout()))));
+
+            if(temporary_storage == nullptr || size == 0)
             {
-                hipError_t error = ::rocprim::transform(values_input,
-                                                        values_tmp,
-                                                        size,
-                                                        ::rocprim::identity<value_type>(),
-                                                        stream,
-                                                        debug_synchronous);
+                return hipSuccess;
+            }
+
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            if(debug_synchronous)
+            {
+                std::cout << "radix_size " << radix_size_per_place << '\n';
+                std::cout << "digit_places " << places << '\n';
+                std::cout << "histograms_size " << bins << '\n';
+                std::cout << "num_lookback_states " << num_lookback_states << '\n';
+                hipError_t error = hipStreamSynchronize(stream);
                 if(error != hipSuccess)
                     return error;
             }
 
-            from_input = false;
-        }
-    }
+            // Compute the global digit offset, for each digit and for each digit place.
+            {
+                ROCPRIM_RETURN_ON_ERROR(radix_sort_onesweep_global_offsets<Config, Descending>(
+                    keys_input,
+                    values_input,
+                    global_digit_offsets,
+                    static_cast<offset_type>(size),
+                    places,
+                    decomposer,
+                    begin_bit,
+                    end_bit,
+                    stream,
+                    debug_synchronous));
+            }
 
-    // Sort each digit place iteratively.
-    for(unsigned bit = begin_bit, place = 0; bit < end_bit;
-        bit += params.radix_bits_per_place, ++place)
-    {
-        hipError_t error = radix_sort_onesweep_iteration<Config, Descending>(
-            keys_input,
-            keys_tmp,
-            keys_output,
-            values_input,
-            values_tmp,
-            values_output,
-            static_cast<offset_type>(size),
-            global_digit_offsets + place * radix_size_per_place,
-            global_digit_offsets_tmp,
-            lookback_states,
-            from_input,
-            to_output,
-            decomposer,
-            bit,
-            end_bit,
-            stream,
-            debug_synchronous);
-        if(error != hipSuccess)
-            return error;
+            if(!no_allocate_tmp_buffer)
+            {
+                keys_tmp   = keys_tmp_storage;
+                values_tmp = values_tmp_storage;
+            }
 
-        is_result_in_output = to_output;
-        from_input          = false;
-        to_output           = !to_output;
-    }
+            // Copy input keys and values if necessary (in-place sorting: input and output iterators are equal).
+            bool to_output  = no_allocate_tmp_buffer || (places - 1) % 2 == 0;
+            bool from_input = true;
+            if(!no_allocate_tmp_buffer && to_output)
+            {
+                const bool keys_alias
+                    = ::rocprim::detail::can_iterators_alias(keys_input, keys_output, size);
+                const bool values_alias
+                    = with_values
+                      && ::rocprim::detail::can_iterators_alias(values_input, values_output, size);
+                if(keys_alias || values_alias)
+                {
+                    ROCPRIM_RETURN_ON_ERROR(::rocprim::transform(keys_input,
+                                                                 keys_tmp,
+                                                                 size,
+                                                                 ::rocprim::identity<key_type>(),
+                                                                 stream,
+                                                                 debug_synchronous));
+
+                    if(with_values)
+                    {
+                        ROCPRIM_RETURN_ON_ERROR(
+                            ::rocprim::transform(values_input,
+                                                 values_tmp,
+                                                 size,
+                                                 ::rocprim::identity<value_type>(),
+                                                 stream,
+                                                 debug_synchronous));
+                    }
+
+                    from_input = false;
+                }
+            }
+
+            // Sort each digit place iteratively.
+            for(unsigned bit = begin_bit, place = 0; bit < end_bit;
+                bit += params.radix_bits_per_place, ++place)
+            {
+                ROCPRIM_RETURN_ON_ERROR(radix_sort_onesweep_iteration<Config, Descending>(
+                    keys_input,
+                    keys_tmp,
+                    keys_output,
+                    values_input,
+                    values_tmp,
+                    values_output,
+                    static_cast<offset_type>(size),
+                    global_digit_offsets + place * radix_size_per_place,
+                    global_digit_offsets_tmp,
+                    lookback_states,
+                    from_input,
+                    to_output,
+                    decomposer,
+                    bit,
+                    end_bit,
+                    ordered_bid,
+                    stream,
+                    debug_synchronous));
+
+                is_result_in_output = to_output;
+                from_input          = false;
+                to_output           = !to_output;
+            }
+            return hipSuccess;
+        },
+        use_atomic_block_id_variant));
 
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce_by_key.hpp
@@ -38,6 +38,7 @@
 #include "../intrinsics/thread.hpp"
 #include "../iterator/constant_iterator.hpp"
 #include "../type_traits.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 
 #include <chrono>
 #include <iostream>
@@ -51,15 +52,18 @@ BEGIN_ROCPRIM_NAMESPACE
 namespace detail
 {
 
-template<typename LookBackScanState, typename AccumulatorType>
+template<typename LookBackScanState, typename AccumulatorType, typename BlockIdWrapper>
 ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
     reduce_by_key_init_kernel(LookBackScanState      lookback_scan_state,
                               const unsigned int     number_of_blocks,
                               const bool             is_first_launch,
                               const unsigned int     block_save_idx,
                               std::size_t* const     global_head_count,
-                              AccumulatorType* const previous_accumulated)
+                              AccumulatorType* const previous_accumulated,
+                              BlockIdWrapper         ordered_bid)
 {
+    // 'ordered_bid' gets reset by 'init_lookback_scan_state'.
+
     const unsigned int block_id        = ::rocprim::detail::block_id<0>();
     const unsigned int block_size      = ::rocprim::detail::block_size<0>();
     const unsigned int block_thread_id = ::rocprim::detail::block_thread_id<0>();
@@ -89,7 +93,7 @@ ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
                                       update_func);
     }
 
-    init_lookback_scan_state(lookback_scan_state, number_of_blocks, flat_thread_id);
+    init_lookback_scan_state(lookback_scan_state, number_of_blocks, ordered_bid, flat_thread_id);
 }
 
 template<typename Config,
@@ -102,7 +106,8 @@ template<typename Config,
          typename UniqueCountIterator,
          typename CompareFunction,
          typename BinaryOp,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename BlockIdWrapper>
 inline hipError_t launch_reduce_by_key(detail::target_arch          arch,
                                        const KeyIterator            keys_input,
                                        const ValueIterator          values_input,
@@ -117,6 +122,7 @@ inline hipError_t launch_reduce_by_key(detail::target_arch          arch,
                                        const std::size_t            size,
                                        const std::size_t* const     global_head_count,
                                        const AccumulatorType* const previous_accumulated,
+                                       BlockIdWrapper               ordered_bid,
                                        dim3                         grid,
                                        dim3                         block,
                                        size_t                       shmem,
@@ -136,7 +142,8 @@ inline hipError_t launch_reduce_by_key(detail::target_arch          arch,
                                                                        total_number_of_blocks,
                                                                        size,
                                                                        global_head_count,
-                                                                       previous_accumulated);
+                                                                       previous_accumulated,
+                                                                       ordered_bid);
     };
 
     return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
@@ -165,160 +172,139 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
                                              const bool                debug_synchronous)
 {
     using accumulator_type = reduce_by_key::accumulator_type_t<ValuesInputIterator, BinaryFunction>;
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const reduce_by_key_config_params params = dispatch_target_arch<config, false>(target_arch);
 
-    using scan_state_type
-        = reduce_by_key::lookback_scan_state_t<accumulator_type, /*UseSleep=*/false>;
-    using scan_state_with_sleep_type
-        = reduce_by_key::lookback_scan_state_t<accumulator_type, /*UseSleep=*/true>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    const unsigned int block_size      = params.kernel_config.block_size;
-    const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
+    const auto use_sleepy_scan_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(use_sleepy_scan);
 
-    const size_t size_limit = params.kernel_config.size_limit;
-    const size_t aligned_size_limit
-        = ::rocprim::max<size_t>(size_limit - size_limit % items_per_block, items_per_block);
-
-    const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
-    const bool   use_limited_size = limited_size == aligned_size_limit;
-
-    // Number of blocks in a single launch (or the only launch if it fits)
-    const std::size_t number_of_blocks = detail::ceiling_div(limited_size, items_per_block);
-
-    // Calculate required temporary storage
-    void* scan_state_storage;
-    // The number of segment heads in previous launches.
-    std::size_t* d_global_head_count = nullptr;
-    // The running accumulation across the launch boundary.
-    accumulator_type* d_previous_accumulated = nullptr;
-
-    detail::temp_storage::layout layout{};
-    result = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&d_global_head_count, use_limited_size ? 1 : 0),
-            detail::temp_storage::ptr_aligned_array(&d_previous_accumulated,
-                                                    use_limited_size ? 1 : 0)));
-    if(result != hipSuccess || temporary_storage == nullptr)
-    {
-        return result;
-    }
-
-    bool use_sleep;
-    result = detail::is_sleep_scan_state_used(stream, use_sleep);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    scan_state_type scan_state{};
-    result = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    scan_state_with_sleep_type scan_state_with_sleep{};
-    result = scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                scan_state_storage,
-                                                number_of_blocks,
-                                                stream);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-
-    auto with_scan_state
-        = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(scan_state_with_sleep);
-        }
-        else
-        {
-            return func(scan_state);
-        }
-    };
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+            const reduce_by_key_config_params params
+                = dispatch_target_arch<config, false>(target_arch);
 
-    if(size == 0)
-    {
-        // Fill out unique_count_output with zero
-        return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
-                                  unique_count_output,
-                                  1,
-                                  rocprim::identity<std::size_t>{},
-                                  stream,
-                                  debug_synchronous);
-    }
+            using scan_state_type
+                = reduce_by_key::lookback_scan_state_t<accumulator_type, use_sleepy_scan>;
+            const unsigned int block_size      = params.kernel_config.block_size;
+            const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
 
-    // Total number of blocks in all launches
-    const std::size_t total_number_of_blocks = ceiling_div(size, items_per_block);
-    const std::size_t number_of_launch       = ceiling_div(size, limited_size);
+            const size_t size_limit         = params.kernel_config.size_limit;
+            const size_t aligned_size_limit = ::rocprim::max<size_t>(
+                size_limit - (size_limit % static_cast<std::size_t>(items_per_block)),
+                items_per_block);
 
-    if(debug_synchronous)
-    {
-        std::cout << "size:               " << size << '\n';
-        std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
-        std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
-        std::cout << "number_of_launch:   " << number_of_launch << '\n';
-        std::cout << "block_size:         " << block_size << '\n';
-        std::cout << "number_of_blocks:   " << number_of_blocks << '\n';
-        std::cout << "items_per_block:    " << items_per_block << '\n';
-    }
+            const size_t limited_size     = std::min<size_t>(size, aligned_size_limit);
+            const bool   use_limited_size = limited_size == aligned_size_limit;
 
-    for(size_t i = 0, offset = 0; i < number_of_launch; ++i, offset += limited_size)
-    {
-        const std::size_t current_size = std::min<std::size_t>(size - offset, limited_size);
-        const std::size_t number_of_blocks_launch = ceiling_div(current_size, items_per_block);
+            // Number of blocks in a single launch (or the only launch if it fits)
+            const std::size_t number_of_blocks = detail::ceiling_div(limited_size, items_per_block);
 
-        // Start point for time measurements
-        std::chrono::steady_clock::time_point start;
-        if(debug_synchronous)
-        {
-            std::cout << "index:            " << i << '\n';
-            std::cout << "current_size:     " << current_size << '\n';
-            std::cout << "number of blocks: " << number_of_blocks_launch << '\n';
+            // Calculate required temporary storage
+            void* scan_state_storage;
+            // The number of segment heads in previous launches.
+            std::size_t* d_global_head_count = nullptr;
+            // The running accumulation across the launch boundary.
+            accumulator_type* d_previous_accumulated = nullptr;
 
-            start = std::chrono::steady_clock::now();
-        }
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
 
-        with_scan_state(
-            [&](const auto scan_state)
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
+            typename ordered_bid_type::id_type* ordered_bid_storage;
+
+            auto result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::ptr_aligned_array(&d_global_head_count,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::ptr_aligned_array(&d_previous_accumulated,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        ordered_bid_type::get_temp_storage_layout())));
+            if(result != hipSuccess || temporary_storage == nullptr)
             {
-                const unsigned int block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
-                const std::size_t  grid_size
-                    = detail::ceiling_div(number_of_blocks_launch, block_size);
+                return result;
+            }
 
-                reduce_by_key_init_kernel<<<dim3(grid_size), dim3(block_size), 0, stream>>>(
+            scan_state_type scan_state{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream));
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            if(size == 0)
+            {
+                // Fill out unique_count_output with zero
+                return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
+                                          unique_count_output,
+                                          1,
+                                          rocprim::identity<std::size_t>{},
+                                          stream,
+                                          debug_synchronous);
+            }
+
+            // Total number of blocks in all launches
+            const std::size_t total_number_of_blocks = ceiling_div(size, items_per_block);
+            const std::size_t number_of_launch       = ceiling_div(size, limited_size);
+
+            if(debug_synchronous)
+            {
+                std::cout << "size:               " << size << '\n';
+                std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
+                std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
+                std::cout << "number_of_launch:   " << number_of_launch << '\n';
+                std::cout << "block_size:         " << block_size << '\n';
+                std::cout << "number_of_blocks:   " << number_of_blocks << '\n';
+                std::cout << "items_per_block:    " << items_per_block << '\n';
+            }
+
+            for(size_t i = 0, offset = 0; i < number_of_launch; ++i, offset += limited_size)
+            {
+                const std::size_t current_size = std::min<std::size_t>(size - offset, limited_size);
+                const std::size_t number_of_blocks_launch
+                    = ceiling_div(current_size, items_per_block);
+
+                // Start point for time measurements
+                std::chrono::steady_clock::time_point start;
+                if(debug_synchronous)
+                {
+                    std::cout << "index:            " << i << '\n';
+                    std::cout << "current_size:     " << current_size << '\n';
+                    std::cout << "number of blocks: " << number_of_blocks_launch << '\n';
+
+                    start = std::chrono::steady_clock::now();
+                }
+
+                // Define block and grid sizes for init kernel.
+                const size_t init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
+                const size_t init_grid_size
+                    = detail::ceiling_div(number_of_blocks_launch, init_block_size);
+                reduce_by_key_init_kernel<<<init_grid_size, init_block_size, 0, stream>>>(
                     scan_state,
                     number_of_blocks_launch,
                     i == 0,
                     number_of_blocks - 1,
                     d_global_head_count,
-                    d_previous_accumulated);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_init_kernel",
-                                                    number_of_blocks_launch,
-                                                    start);
+                    d_previous_accumulated,
+                    ordered_bid);
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_init_kernel",
+                                                            number_of_blocks_launch,
+                                                            start);
 
-        ROCPRIM_RETURN_ON_ERROR(with_scan_state(
-            [&](const auto scan_state)
-            {
-                return launch_reduce_by_key<config, Determinism>(
+                ROCPRIM_RETURN_ON_ERROR(launch_reduce_by_key<config, Determinism>(
                     target_arch,
                     keys_input + offset,
                     values_input + offset,
@@ -333,13 +319,19 @@ hipError_t reduce_by_key_impl_wrapped_config(void*                     temporary
                     size,
                     i > 0 ? d_global_head_count : nullptr,
                     i > 0 ? d_previous_accumulated : nullptr,
+                    ordered_bid,
                     dim3(number_of_blocks_launch),
                     dim3(block_size),
                     0,
-                    stream);
-            }));
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_kernel", current_size, start);
-    }
+                    stream));
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("reduce_by_key_kernel",
+                                                            current_size,
+                                                            start);
+            }
+            return hipSuccess;
+        },
+        use_sleepy_scan_variant,
+        use_atomic_block_id_variant));
 
     return hipSuccess;
 }

--- a/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_run_length_encode.hpp
@@ -26,9 +26,11 @@
 
 #include "detail/device_config_helper.hpp"
 #include "detail/device_run_length_encode.hpp"
+#include "detail/ordered_block_id.hpp"
 
 #include "../common.hpp"
 #include "../config.hpp"
+#include "../detail/temp_storage.hpp"
 #include "../detail/various.hpp"
 #include "../iterator/constant_iterator.hpp"
 #include "../type_traits.hpp"
@@ -99,7 +101,8 @@ template<typename Config,
          typename OffsetsOutputIterator,
          typename CountsOutputIterator,
          typename RunsCountOutputIterator,
-         typename LookbackScanState>
+         typename LookbackScanState,
+         typename BlockIdWrapper>
 inline hipError_t launch_non_trivial(detail::target_arch           arch,
                                      const InputIterator           input,
                                      const OffsetsOutputIterator   offsets_output,
@@ -108,6 +111,7 @@ inline hipError_t launch_non_trivial(detail::target_arch           arch,
                                      const LookbackScanState       scan_state,
                                      const std::size_t             grid_size,
                                      const std::size_t             size,
+                                     BlockIdWrapper                ordered_bid,
                                      dim3                          grid,
                                      dim3                          block,
                                      size_t                        shmem,
@@ -122,7 +126,8 @@ inline hipError_t launch_non_trivial(detail::target_arch           arch,
             runs_count_output,
             scan_state,
             grid_size,
-            size);
+            size,
+            ordered_bid);
     };
 
     return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
@@ -149,124 +154,119 @@ hipError_t run_length_encode_non_trivial_runs_impl(void*                   tempo
     using offset_count_pair_type
         = run_length_encode::offset_count_pair_type_t<offset_type, count_type>; // accumulator_type
 
-    using config = rocprim::detail::wrapped_non_trivial_runs_config<Config, input_type>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    using scan_state_type
-        = ::rocprim::detail::lookback_scan_state<offset_count_pair_type, /*UseSleep=*/false>;
-    using scan_state_with_sleep_type
-        = ::rocprim::detail::lookback_scan_state<offset_count_pair_type, /*UseSleep=*/true>;
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
+    const auto use_sleepy_scan_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(use_sleepy_scan);
 
-    detail::target_arch target_arch;
-    ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
-
-    const non_trivial_runs_config_params params = dispatch_target_arch<config, false>(target_arch);
-    const unsigned int                   block_size = params.kernel_config.block_size;
-    const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
-    const std::size_t  grid_size       = detail::ceiling_div(size, items_per_block);
-
-    // Calculate required temporary storage
-    void* scan_state_storage;
-
-    detail::temp_storage::layout layout{};
-    ROCPRIM_RETURN_ON_ERROR(scan_state_type::get_temp_storage_layout(grid_size, stream, layout));
-
-    hipError_t result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout)));
-
-    if(result != hipSuccess || temporary_storage == nullptr)
-    {
-        return result;
-    }
-
-    bool use_sleep;
-    ROCPRIM_RETURN_ON_ERROR(detail::is_sleep_scan_state_used(stream, use_sleep));
-
-    scan_state_type            scan_state{};
-    scan_state_with_sleep_type scan_state_with_sleep{};
-    ROCPRIM_RETURN_ON_ERROR(
-        scan_state_type::create(scan_state, scan_state_storage, grid_size, stream));
-    ROCPRIM_RETURN_ON_ERROR(scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                               scan_state_storage,
-                                                               grid_size,
-                                                               stream));
-
-    auto with_scan_state
-        = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(scan_state_with_sleep);
-        }
-        else
-        {
-            return func(scan_state);
-        }
-    };
+            using config = rocprim::detail::wrapped_non_trivial_runs_config<Config, input_type>;
 
-    if(size == 0)
-    {
-        // Fill out runs_count_output with zero
-        return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
-                                  runs_count_output,
-                                  1,
-                                  rocprim::identity<std::size_t>{},
-                                  stream,
-                                  debug_synchronous);
-    }
+            using scan_state_type
+                = ::rocprim::detail::lookback_scan_state<offset_count_pair_type, use_sleepy_scan>;
 
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-    if(debug_synchronous)
-    {
-        std::cout << "size:               " << size << '\n';
-        std::cout << "block_size:         " << block_size << '\n';
-        std::cout << "grid_size:          " << grid_size << '\n';
-        std::cout << "items_per_block:    " << items_per_block << '\n';
-        start = std::chrono::steady_clock::now();
-    }
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
 
-    with_scan_state(
-        [&](const auto scan_state)
-        {
+            const non_trivial_runs_config_params params
+                = dispatch_target_arch<config, false>(target_arch);
+            const unsigned int block_size      = params.kernel_config.block_size;
+            const unsigned int items_per_block = block_size * params.kernel_config.items_per_thread;
+            const std::size_t  grid_size       = detail::ceiling_div(size, items_per_block);
+
+            // Calculate required temporary storage
+            void* scan_state_storage;
+
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(grid_size, stream, layout));
+
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
+            typename ordered_bid_type::id_type* ordered_bid_storage;
+
+            hipError_t result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        ordered_bid_type::get_temp_storage_layout())));
+
+            if(result != hipSuccess || temporary_storage == nullptr)
+            {
+                return result;
+            }
+
+            scan_state_type scan_state{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::create(scan_state, scan_state_storage, grid_size, stream));
+
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            if(size == 0)
+            {
+                // Fill out runs_count_output with zero
+                return rocprim::transform(rocprim::constant_iterator<std::size_t>(0),
+                                          runs_count_output,
+                                          1,
+                                          rocprim::identity<std::size_t>{},
+                                          stream,
+                                          debug_synchronous);
+            }
+
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+            if(debug_synchronous)
+            {
+                std::cout << "size:               " << size << '\n';
+                std::cout << "block_size:         " << block_size << '\n';
+                std::cout << "grid_size:          " << grid_size << '\n';
+                std::cout << "items_per_block:    " << items_per_block << '\n';
+                start = std::chrono::steady_clock::now();
+            }
+
             const unsigned int init_block_size = ROCPRIM_DEFAULT_MAX_BLOCK_SIZE;
             const std::size_t  init_grid_size  = detail::ceiling_div(grid_size, init_block_size);
-            hipLaunchKernelGGL(init_lookback_scan_state_kernel,
-                               dim3(init_grid_size),
-                               dim3(init_block_size),
-                               0,
-                               stream,
-                               scan_state,
-                               grid_size);
-        });
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                grid_size,
-                                                start);
-
-    ROCPRIM_RETURN_ON_ERROR(with_scan_state(
-        [&](const auto scan_state)
-        {
-            return run_length_encode::launch_non_trivial<config, offset_count_pair_type>(
-                target_arch,
-                input + 0,
-                offsets_output,
-                counts_output,
-                runs_count_output,
+            init_lookback_scan_state_kernel<<<init_grid_size, init_block_size, 0, stream>>>(
                 scan_state,
                 grid_size,
-                size,
-                dim3(grid_size),
-                dim3(block_size),
-                0,
-                stream);
-        }));
-    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("run_length_encode::non_trivial_kernel",
-                                                size,
-                                                start);
+                ordered_bid);
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
+                                                        grid_size,
+                                                        start);
 
+            ROCPRIM_RETURN_ON_ERROR(
+                run_length_encode::launch_non_trivial<config, offset_count_pair_type>(
+                    target_arch,
+                    input + 0,
+                    offsets_output,
+                    counts_output,
+                    runs_count_output,
+                    scan_state,
+                    grid_size,
+                    size,
+                    ordered_bid,
+                    dim3(grid_size),
+                    dim3(block_size),
+                    0,
+                    stream));
+            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("run_length_encode::non_trivial_kernel",
+                                                        size,
+                                                        start);
+            return hipSuccess;
+        },
+        use_sleepy_scan_variant,
+        use_atomic_block_id_variant));
     return hipSuccess;
 }
 } // namespace run_length_encode

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan.hpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <iterator>
 #include <type_traits>
+#include <variant>
 
 #include "../common.hpp"
 #include "../config.hpp"
@@ -37,6 +38,7 @@
 #include "detail/device_scan_common.hpp"
 #include "device_scan_config.hpp"
 #include "device_transform.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 
 BEGIN_ROCPRIM_NAMESPACE
 
@@ -136,7 +138,8 @@ template<class Config,
          class BinaryFunction,
          class InitValueType,
          class AccType,
-         class LookBackScanState>
+         class LookBackScanState,
+         class BlockIdWrapper>
 inline hipError_t launch_lookback_scan(detail::target_arch arch,
                                        InputIterator       input,
                                        OutputIterator      output,
@@ -149,10 +152,11 @@ inline hipError_t launch_lookback_scan(detail::target_arch arch,
                                        dim3                block,
                                        size_t              shmem,
                                        hipStream_t         stream,
-                                       AccType*            previous_last_element = nullptr,
-                                       AccType*            new_last_element      = nullptr,
-                                       bool                override_first_value  = false,
-                                       bool                save_last_value       = false)
+                                       AccType*            previous_last_element,
+                                       AccType*            new_last_element,
+                                       bool                override_first_value,
+                                       bool                save_last_value,
+                                       BlockIdWrapper      ordered_bid)
 {
     auto kernel = [=](auto arch_config)
     {
@@ -167,7 +171,8 @@ inline hipError_t launch_lookback_scan(detail::target_arch arch,
             previous_last_element,
             new_last_element,
             override_first_value,
-            save_last_value);
+            save_last_value,
+            ordered_bid);
     };
 
     return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
@@ -192,223 +197,210 @@ inline auto scan_impl(void*               temporary_storage,
                       const hipStream_t   stream,
                       bool                debug_synchronous)
 {
-    using config = wrapped_scan_config<Config, AccType>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const scan_config_params params = dispatch_target_arch<config, false>(target_arch);
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
+    const auto use_sleepy_scan_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(use_sleepy_scan);
 
-    using scan_state_type            = detail::lookback_scan_state<AccType>;
-    using scan_state_with_sleep_type = detail::lookback_scan_state<AccType, true>;
-
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const auto         items_per_block  = block_size * items_per_thread;
-
-    const size_t size_limit = params.kernel_config.size_limit;
-    const size_t aligned_size_limit
-        = ::rocprim::max<size_t>(size_limit - size_limit % items_per_block, items_per_block);
-    size_t     limited_size     = std::min<size_t>(size, aligned_size_limit);
-    const bool use_limited_size = limited_size == aligned_size_limit;
-
-    unsigned int number_of_blocks = (limited_size + items_per_block - 1) / items_per_block;
-
-    // Pointer to array with block_prefixes
-    void*    scan_state_storage;
-    AccType* previous_last_element;
-    AccType* new_last_element;
-
-    detail::temp_storage::layout layout{};
-    hipError_t                   layout_result
-        = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(layout_result != hipSuccess)
-    {
-        return layout_result;
-    }
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with offset_scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&previous_last_element,
-                                                    use_limited_size ? 1 : 0),
-            detail::temp_storage::ptr_aligned_array(&new_last_element, use_limited_size ? 1 : 0)));
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return partition_result;
-    }
-
-    // Start point for time measurements
-    std::chrono::steady_clock::time_point start;
-
-    if(number_of_blocks == 0u)
-        return hipSuccess;
-
-    if(number_of_blocks > 1 || use_limited_size)
-    {
-        bool use_sleep;
-        if(const hipError_t error = is_sleep_scan_state_used(stream, use_sleep))
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return error;
-        }
+            using scan_state_type = detail::lookback_scan_state<AccType, use_sleepy_scan>;
+            using block_id_type   = detail::block_id_wrapper<unsigned int, use_atomic_block_id>;
+            scan_state_type scan_state;
+            block_id_type   block_id;
 
-        // Create and initialize lookback_scan_state obj
-        scan_state_type scan_state{};
-        hipError_t      result
-            = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
-        scan_state_with_sleep_type scan_state_with_sleep{};
-        result = scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                    scan_state_storage,
-                                                    number_of_blocks,
-                                                    stream);
-        if(result != hipSuccess)
-        {
-            return result;
-        }
+            using config = wrapped_scan_config<Config, AccType>;
 
-        // Call the provided function with either scan_state or scan_state_with_sleep based on
-        // the value of use_sleep
-        auto with_scan_state
-            = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-        {
-            if(use_sleep)
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+
+            const auto         params           = dispatch_target_arch<config, false>(target_arch);
+            const unsigned int block_size       = params.kernel_config.block_size;
+            const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+            const unsigned int items_per_block  = block_size * items_per_thread;
+
+            const size_t size_limit         = params.kernel_config.size_limit;
+            const size_t aligned_size_limit = ::rocprim::max<size_t>(
+                size_limit - (size_limit % static_cast<size_t>(items_per_block)),
+                items_per_block);
+            size_t     limited_size     = std::min<size_t>(size, aligned_size_limit);
+            const bool use_limited_size = limited_size == aligned_size_limit;
+
+            unsigned int number_of_blocks = (limited_size + items_per_block - 1) / items_per_block;
+
+            // Pointer to array with block_prefixes
+            void*    scan_state_storage;
+            AccType* previous_last_element;
+            AccType* new_last_element;
+
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
+
+            void* block_id_storage;
+
+            ROCPRIM_RETURN_ON_ERROR(detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with offset_scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::ptr_aligned_array(&previous_last_element,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::ptr_aligned_array(&new_last_element,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::make_partition(
+                        &block_id_storage,
+                        block_id_type::get_temp_storage_layout()))));
+
+            if(temporary_storage == nullptr || number_of_blocks == 0u)
             {
-                return func(scan_state_with_sleep);
-            }
-            else
-            {
-                return func(scan_state);
-            }
-        };
-
-        if(debug_synchronous)
-            start = std::chrono::steady_clock::now();
-
-        size_t number_of_launch = (size + limited_size - 1) / limited_size;
-        for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
-        {
-            size_t current_size = std::min<size_t>(size - offset, limited_size);
-            number_of_blocks    = (current_size + items_per_block - 1) / items_per_block;
-            auto grid_size      = (number_of_blocks + block_size - 1) / block_size;
-
-            if(debug_synchronous)
-            {
-                std::cout << "use_limited_size " << use_limited_size << '\n';
-                std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
-                std::cout << "number_of_launch " << number_of_launch << '\n';
-                std::cout << "index " << i << '\n';
-                std::cout << "size " << current_size << '\n';
-                std::cout << "block_size " << block_size << '\n';
-                std::cout << "number of blocks " << number_of_blocks << '\n';
-                std::cout << "items_per_block " << items_per_block << '\n';
+                return hipSuccess;
             }
 
-            with_scan_state(
-                [&](const auto scan_state)
+            // Start point for time measurements
+            std::chrono::steady_clock::time_point start;
+
+            if(number_of_blocks > 1 || use_limited_size)
+            {
+                // Create and initialize lookback_scan_state obj
+                ROCPRIM_RETURN_ON_ERROR(
+                    scan_state.create(scan_state, scan_state_storage, number_of_blocks, stream));
+                block_id = block_id.create(block_id_storage);
+                if(debug_synchronous)
                 {
+                    start = std::chrono::steady_clock::now();
+                }
+
+                const size_t number_of_launch = (size + limited_size - 1) / limited_size;
+                for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
+                {
+                    size_t current_size = std::min<size_t>(size - offset, limited_size);
+                    number_of_blocks    = (current_size + items_per_block - 1) / items_per_block;
+                    auto grid_size      = (number_of_blocks + block_size - 1) / block_size;
+
+                    if(debug_synchronous)
+                    {
+                        std::cout << "use_limited_size " << use_limited_size << '\n';
+                        std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
+                        std::cout << "number_of_launch " << number_of_launch << '\n';
+                        std::cout << "index " << i << '\n';
+                        std::cout << "size " << current_size << '\n';
+                        std::cout << "block_size " << block_size << '\n';
+                        std::cout << "number of blocks " << number_of_blocks << '\n';
+                        std::cout << "items_per_block " << items_per_block << '\n';
+                    }
+
                     init_lookback_scan_state_kernel<<<dim3(grid_size),
                                                       dim3(block_size),
                                                       0,
-                                                      stream>>>(scan_state, number_of_blocks);
-                });
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                        number_of_blocks,
-                                                        start);
+                                                      stream>>>(scan_state,
+                                                                number_of_blocks,
+                                                                block_id);
+                    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
+                                                                number_of_blocks,
+                                                                start);
 
-            if(debug_synchronous)
-                start = std::chrono::steady_clock::now();
-            grid_size = number_of_blocks;
+                    if(debug_synchronous)
+                    {
+                        start = std::chrono::steady_clock::now();
+                    }
+                    grid_size = number_of_blocks;
 
-            if(debug_synchronous)
-            {
-                std::cout << "use_limited_size " << use_limited_size << '\n';
-                std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
-                std::cout << "size " << current_size << '\n';
-                std::cout << "block_size " << block_size << '\n';
-                std::cout << "number of blocks " << number_of_blocks << '\n';
-                std::cout << "items_per_block " << items_per_block << '\n';
+                    if(debug_synchronous)
+                    {
+                        std::cout << "use_limited_size " << use_limited_size << '\n';
+                        std::cout << "aligned_size_limit " << aligned_size_limit << '\n';
+                        std::cout << "size " << current_size << '\n';
+                        std::cout << "block_size " << block_size << '\n';
+                        std::cout << "number of blocks " << number_of_blocks << '\n';
+                        std::cout << "items_per_block " << items_per_block << '\n';
+                    }
+
+                    ROCPRIM_RETURN_ON_ERROR(launch_lookback_scan<config,
+                                                                 Determinism,
+                                                                 Exclusive,
+                                                                 UseInitialValue,
+                                                                 InputIterator,
+                                                                 OutputIterator,
+                                                                 BinaryFunction,
+                                                                 InitValueType,
+                                                                 AccType>(target_arch,
+                                                                          input + offset,
+                                                                          output + offset,
+                                                                          current_size,
+                                                                          initial_value,
+                                                                          scan_op,
+                                                                          scan_state,
+                                                                          number_of_blocks,
+                                                                          dim3(grid_size),
+                                                                          dim3(block_size),
+                                                                          0,
+                                                                          stream,
+                                                                          previous_last_element,
+                                                                          new_last_element,
+                                                                          i != size_t(0),
+                                                                          number_of_launch > 1,
+                                                                          block_id));
+                    ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("lookback_scan_kernel",
+                                                                current_size,
+                                                                start);
+
+                    // Swap the last_elements
+                    if(number_of_launch > 1)
+                    {
+                        ROCPRIM_RETURN_ON_ERROR(::rocprim::transform(new_last_element,
+                                                                     previous_last_element,
+                                                                     1,
+                                                                     ::rocprim::identity<AccType>(),
+                                                                     stream,
+                                                                     debug_synchronous));
+                    }
+                }
             }
-
-            ROCPRIM_RETURN_ON_ERROR(with_scan_state(
-                [&](const auto scan_state)
+            else
+            {
+                if(debug_synchronous)
                 {
-                    return launch_lookback_scan<config,
-                                                Determinism,
-                                                Exclusive,
-                                                UseInitialValue,
-                                                InputIterator,
-                                                OutputIterator,
-                                                BinaryFunction,
-                                                InitValueType,
-                                                AccType>(target_arch,
-                                                         input + offset,
-                                                         output + offset,
-                                                         current_size,
-                                                         initial_value,
-                                                         scan_op,
-                                                         scan_state,
-                                                         number_of_blocks,
-                                                         dim3(grid_size),
-                                                         dim3(block_size),
-                                                         0,
-                                                         stream,
-                                                         previous_last_element,
-                                                         new_last_element,
-                                                         i != size_t(0),
-                                                         number_of_launch > 1);
-                }));
-            ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("lookback_scan_kernel",
-                                                        current_size,
-                                                        start);
+                    std::cout << "size " << size << '\n';
+                    std::cout << "block_size " << block_size << '\n';
+                    std::cout << "number of blocks " << number_of_blocks << '\n';
+                    std::cout << "items_per_block " << items_per_block << '\n';
+                    start = std::chrono::steady_clock::now();
+                }
 
-            // Swap the last_elements
-            if(number_of_launch > 1)
-            {
-                ROCPRIM_RETURN_ON_ERROR(::rocprim::transform(new_last_element,
-                                                             previous_last_element,
-                                                             1,
-                                                             ::rocprim::identity<AccType>(),
-                                                             stream,
-                                                             debug_synchronous));
+                ROCPRIM_RETURN_ON_ERROR(
+                    launch_single_scan<config,
+                                       Exclusive, // flag for exclusive scan operation
+                                       UseInitialValue,
+                                       InputIterator,
+                                       OutputIterator,
+                                       BinaryFunction,
+                                       InitValueType,
+                                       AccType>(target_arch,
+                                                input,
+                                                size,
+                                                initial_value,
+                                                output,
+                                                scan_op,
+                                                dim3(1),
+                                                dim3(block_size),
+                                                0,
+                                                stream));
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("single_scan_kernel", size, start);
             }
-        }
-    }
-    else
-    {
-        if(debug_synchronous)
-        {
-            std::cout << "size " << size << '\n';
-            std::cout << "block_size " << block_size << '\n';
-            std::cout << "number of blocks " << number_of_blocks << '\n';
-            std::cout << "items_per_block " << items_per_block << '\n';
-            start = std::chrono::steady_clock::now();
-        }
+            return hipSuccess;
+        },
+        use_sleepy_scan_variant,
+        use_atomic_block_id_variant));
 
-        ROCPRIM_RETURN_ON_ERROR(launch_single_scan<config,
-                                                   Exclusive, // flag for exclusive scan operation
-                                                   UseInitialValue,
-                                                   InputIterator,
-                                                   OutputIterator,
-                                                   BinaryFunction,
-                                                   InitValueType,
-                                                   AccType>(target_arch,
-                                                            input,
-                                                            size,
-                                                            initial_value,
-                                                            output,
-                                                            scan_op,
-                                                            dim3(1),
-                                                            dim3(block_size),
-                                                            0,
-                                                            stream));
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("single_scan_kernel", size, start);
-    }
     return hipSuccess;
 }
 

--- a/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_scan_by_key.hpp
@@ -21,6 +21,13 @@
 #ifndef ROCPRIM_DEVICE_DEVICE_SCAN_BY_KEY_HPP_
 #define ROCPRIM_DEVICE_DEVICE_SCAN_BY_KEY_HPP_
 
+#include "config_types.hpp"
+#include "detail/device_config_helper.hpp"
+#include "detail/device_scan_by_key.hpp"
+#include "detail/lookback_scan_state.hpp"
+#include "detail/ordered_block_id.hpp"
+#include "device_scan_by_key_config.hpp"
+
 #include "../common.hpp"
 #include "../config.hpp"
 #include "../detail/temp_storage.hpp"
@@ -28,23 +35,67 @@
 #include "../functional.hpp"
 #include "../types/future_value.hpp"
 #include "../types/tuple.hpp"
-#include "config_types.hpp"
-#include "detail/config/device_scan_by_key.hpp"
-#include "detail/device_config_helper.hpp"
-#include "detail/device_scan_by_key.hpp"
-#include "detail/lookback_scan_state.hpp"
-#include "device_scan_by_key_config.hpp"
 
 #include <hip/hip_runtime.h>
 
 #include <iostream>
 #include <iterator>
-#include <type_traits>
 
 BEGIN_ROCPRIM_NAMESPACE
 
 namespace detail
 {
+
+template<typename LookBackScanState, class BlockIdWrapper>
+ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void
+    init_device_scan_by_key_kernel(LookBackScanState  lookback_scan_state,
+                                   const unsigned int number_of_blocks,
+                                   unsigned int       save_index,
+                                   typename LookBackScanState::value_type* const save_dest,
+                                   BlockIdWrapper                                block_id)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         block_id,
+                                         save_index,
+                                         save_dest);
+}
+
+template<typename LookBackScanState,
+         class KeysInputIterator,
+         class ItemPerBlockType,
+         class BlockIdWrapper>
+ROCPRIM_KERNEL ROCPRIM_LAUNCH_BOUNDS(ROCPRIM_DEFAULT_MAX_BLOCK_SIZE) void init_device_scan_by_key_kernel(
+    LookBackScanState                             lookback_scan_state,
+    const unsigned int                            number_of_blocks,
+    unsigned int                                  save_index,
+    typename LookBackScanState::value_type* const save_dest,
+    KeysInputIterator                             keys, // keys from the 0 without any offsets
+    typename std::iterator_traits<
+        KeysInputIterator>::value_type* __restrict__ last_keys_of_each_block,
+    size_t                 num_last_keys_of_each_block,
+    const ItemPerBlockType items_per_block,
+    BlockIdWrapper block_id)
+{
+    init_lookback_scan_state_kernel_impl(lookback_scan_state,
+                                         number_of_blocks,
+                                         block_id,
+                                         save_index,
+                                         save_dest);
+
+    // Initialize the last_keys_of_each_block
+    const auto block_size = ::rocprim::detail::block_size<0>();
+    const auto global_tid
+        = (::rocprim::detail::block_id<0>() * block_size) + ::rocprim::detail::block_thread_id<0>();
+    const auto total_threads = ::rocprim::detail::grid_size<0>() * block_size;
+    using common_size_t      = typename std::common_type<decltype(num_last_keys_of_each_block),
+                                                    decltype(total_threads)>::type;
+    for(common_size_t i = global_tid; i < static_cast<common_size_t>(num_last_keys_of_each_block);
+        i += static_cast<common_size_t>(total_threads))
+    {
+        last_keys_of_each_block[i] = keys[(i * items_per_block) + (items_per_block - 1)];
+    }
+}
 
 template<typename Config,
          lookback_scan_determinism Determinism,
@@ -56,24 +107,28 @@ template<typename Config,
          typename CompareFunction,
          typename BinaryFunction,
          typename LookbackScanState,
-         typename AccType>
-inline hipError_t
-    launch_device_scan_by_key(detail::target_arch                          arch,
-                              const KeyInputIterator                       keys,
-                              const InputIterator                          values,
-                              const OutputIterator                         output,
-                              const InitialValueType                       initial_value,
-                              const CompareFunction                        compare,
-                              const BinaryFunction                         scan_op,
-                              const LookbackScanState                      scan_state,
-                              const size_t                                 size,
-                              const size_t                                 starting_block,
-                              const size_t                                 number_of_blocks,
-                              const ::rocprim::tuple<AccType, bool>* const previous_last_value,
-                              dim3                                         grid,
-                              dim3                                         block,
-                              size_t                                       shmem,
-                              hipStream_t                                  stream)
+         typename AccType,
+         typename WrappedBlockId>
+inline hipError_t launch_device_scan_by_key(
+    detail::target_arch                          arch,
+    const KeyInputIterator                       keys,
+    const InputIterator                          values,
+    const OutputIterator                         output,
+    const InitialValueType                       initial_value,
+    const CompareFunction                        compare,
+    const BinaryFunction                         scan_op,
+    const LookbackScanState                      scan_state,
+    const size_t                                 size,
+    const size_t                                 starting_block,
+    const size_t                                 number_of_blocks,
+    const ::rocprim::tuple<AccType, bool>* const previous_last_value,
+    bool                                         use_last_keys,
+    const typename std::iterator_traits<KeyInputIterator>::value_type* const __restrict__ last_keys,
+    WrappedBlockId ordered_bid,
+    dim3                           grid,
+    dim3                           block,
+    size_t                         shmem,
+    hipStream_t                    stream)
 {
 
     auto kernel = [=](auto arch_config)
@@ -89,10 +144,49 @@ inline hipError_t
             size,
             starting_block,
             number_of_blocks,
-            previous_last_value);
+            previous_last_value,
+            use_last_keys,
+            last_keys,
+            ordered_bid);
     };
 
     return execute_launch_plan<Config>(arch, kernel, grid, block, shmem, stream);
+}
+
+/// \return 0 if in-place is not detected
+template<bool Exclusive,
+         typename KeysInputIterator,
+         typename OutputIterator,
+         typename SizeType,
+         typename NumBlockType>
+ROCPRIM_FORCE_INLINE ROCPRIM_HOST size_t detect_reusing_keys(
+    KeysInputIterator keys,
+    OutputIterator output,
+    SizeType size,
+    NumBlockType number_of_blocks)
+{
+    using key_type    = typename std::iterator_traits<KeysInputIterator>::value_type;
+    using output_type = typename std::iterator_traits<OutputIterator>::value_type;
+    if constexpr(std::is_same<KeysInputIterator, OutputIterator>::value)
+    {
+        if(static_cast<SizeType>(std::distance(keys, output)) < size)
+        {
+            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
+            return sizeof(key_type) * (number_of_blocks - 1);
+        }
+    }
+    else if constexpr(std::is_pointer<KeysInputIterator>::value
+                      && std::is_pointer<OutputIterator>::value
+                      && std::is_convertible<key_type, output_type>::value)
+    {
+        if(static_cast<SizeType>(std::distance(keys, reinterpret_cast<KeysInputIterator>(output)))
+           < size)
+        {
+            // In this case, there is overlap on `keys` and `output`. So we allocate a temp buffer
+            return sizeof(key_type) * (number_of_blocks - 1);
+        }
+    }
+    return 0;
 }
 
 template<lookback_scan_determinism Determinism,
@@ -119,161 +213,168 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
 {
     using key_type = typename std::iterator_traits<KeysInputIterator>::value_type;
 
-    using config = wrapped_scan_by_key_config<Config, key_type, AccType>;
+    bool use_atomic_block_id;
+    ROCPRIM_RETURN_ON_ERROR(check_if_using_atomic_block_id(stream, use_atomic_block_id));
+    const auto use_atomic_block_id_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(
+            use_atomic_block_id);
 
-    detail::target_arch target_arch;
-    hipError_t          result = host_target_arch(stream, target_arch);
-    if(result != hipSuccess)
-    {
-        return result;
-    }
-    const scan_by_key_config_params params = dispatch_target_arch<config, false>(target_arch);
+    bool use_sleepy_scan;
+    ROCPRIM_RETURN_ON_ERROR(is_sleep_scan_state_used(stream, use_sleepy_scan));
+    const auto use_sleepy_scan_variant
+        = ::rocprim::detail::constexpr_value_variant<bool, false, true>::create(use_sleepy_scan);
 
-    using wrapped_type = ::rocprim::tuple<AccType, bool>;
-
-    using scan_state_type            = detail::lookback_scan_state<wrapped_type>;
-    using scan_state_with_sleep_type = detail::lookback_scan_state<wrapped_type, true>;
-
-    const unsigned int block_size       = params.kernel_config.block_size;
-    const unsigned int items_per_thread = params.kernel_config.items_per_thread;
-    const unsigned int items_per_block  = block_size * items_per_thread;
-
-    const unsigned int size_limit = params.kernel_config.size_limit;
-    const unsigned int aligned_size_limit
-        = std::max(size_limit - size_limit % items_per_block, items_per_block);
-
-    const unsigned int limited_size
-        = static_cast<unsigned int>(std::min<size_t>(size, aligned_size_limit));
-    const bool use_limited_size = limited_size == aligned_size_limit;
-
-    // Number of blocks in a single launch (or the only launch if it fits)
-    const unsigned int number_of_blocks = ceiling_div(limited_size, items_per_block);
-
-    void*         scan_state_storage;
-    wrapped_type* previous_last_value;
-
-    detail::temp_storage::layout layout{};
-    const hipError_t             layout_result
-        = scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout);
-    if(layout_result != hipSuccess)
-    {
-        return layout_result;
-    }
-
-    const hipError_t partition_result = detail::temp_storage::partition(
-        temporary_storage,
-        storage_size,
-        detail::temp_storage::make_linear_partition(
-            // This is valid even with offset_scan_state_with_sleep_type
-            detail::temp_storage::make_partition(&scan_state_storage, layout),
-            detail::temp_storage::ptr_aligned_array(&previous_last_value,
-                                                    use_limited_size ? 1 : 0)));
-    if(partition_result != hipSuccess || temporary_storage == nullptr)
-    {
-        return partition_result;
-    }
-
-    if(number_of_blocks == 0u)
-    {
-        return hipSuccess;
-    }
-
-    bool use_sleep;
-    if(const hipError_t error = is_sleep_scan_state_used(stream, use_sleep))
-    {
-        return error;
-    }
-
-    scan_state_type scan_state{};
-    hipError_t      scan_state_result
-        = scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream);
-    scan_state_with_sleep_type scan_state_with_sleep{};
-    scan_state_result = scan_state_with_sleep_type::create(scan_state_with_sleep,
-                                                           scan_state_storage,
-                                                           number_of_blocks,
-                                                           stream);
-    if(scan_state_result != hipSuccess)
-    {
-        return scan_state_result;
-    }
-
-    // Call the provided function with either scan_state or scan_state_with_sleep based on
-    // the value of use_sleep
-    auto with_scan_state
-        = [use_sleep, scan_state, scan_state_with_sleep](auto&& func) mutable -> decltype(auto)
-    {
-        if(use_sleep)
+    ROCPRIM_RETURN_ON_ERROR(std::visit(
+        [&](auto use_sleepy_scan, auto use_atomic_block_id)
         {
-            return func(scan_state_with_sleep);
-        }
-        else
-        {
-            return func(scan_state);
-        }
-    };
+            using config = wrapped_scan_by_key_config<Config, key_type, AccType>;
 
-    // Total number of blocks in all launches
-    const auto   total_number_of_blocks = ceiling_div(size, items_per_block);
-    const size_t number_of_launch       = ceiling_div(size, limited_size);
+            detail::target_arch target_arch;
+            ROCPRIM_RETURN_ON_ERROR(host_target_arch(stream, target_arch));
+            const scan_by_key_config_params params
+                = dispatch_target_arch<config, false>(target_arch);
 
-    if(debug_synchronous)
-    {
-        std::cout << "----------------------------------\n";
-        std::cout << "size:               " << size << '\n';
-        std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
-        std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
-        std::cout << "number_of_launch:   " << number_of_launch << '\n';
-        std::cout << "block_size:         " << block_size << '\n';
-        std::cout << "items_per_block:    " << items_per_block << '\n';
-        std::cout << "----------------------------------\n";
-    }
+            using wrapped_type     = ::rocprim::tuple<AccType, bool>;
+            using scan_state_type  = detail::lookback_scan_state<wrapped_type, use_sleepy_scan>;
+            using ordered_bid_type = block_id_wrapper<unsigned int, use_atomic_block_id>;
 
-    for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
-    {
-        // limited_size is of type unsigned int, so current_size also fits in an unsigned int
-        // size_t is necessary as type of std::min because 'size - offset' can exceed the
-        // upper limit of unsigned int and converting it can lead to wrong results
-        const unsigned int current_size
-            = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
-        const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
-        const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
+            const unsigned int block_size       = params.kernel_config.block_size;
+            const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+            const unsigned int items_per_block  = block_size * items_per_thread;
 
-        // Start point for time measurements
-        std::chrono::steady_clock::time_point start;
-        if(debug_synchronous)
-        {
-            std::cout << "index:            " << i << '\n';
-            std::cout << "current_size:     " << current_size << '\n';
-            std::cout << "number of blocks: " << scan_blocks << '\n';
+            const unsigned int size_limit = params.kernel_config.size_limit;
+            const unsigned int aligned_size_limit
+                = std::max<size_t>(size_limit - (size_limit % static_cast<size_t>(items_per_block)),
+                                   items_per_block);
 
-            start = std::chrono::steady_clock::now();
-        }
+            const unsigned int limited_size
+                = static_cast<unsigned int>(std::min<size_t>(size, aligned_size_limit));
+            const bool use_limited_size = limited_size == aligned_size_limit;
 
-        with_scan_state(
-            [&](const auto scan_state)
+            // Number of blocks in a single launch (or the only launch if it fits)
+            const unsigned int number_of_blocks = ceiling_div(limited_size, items_per_block);
+
+            void*         scan_state_storage;
+            wrapped_type* previous_last_value;
+
+            detail::temp_storage::layout layout{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::get_temp_storage_layout(number_of_blocks, stream, layout));
+
+            typename ordered_bid_type::id_type* ordered_bid_storage;
+
+            key_type*  last_keys_of_each_block;
+            const auto last_keys_of_each_block_size_byte
+                = items_per_thread
+                      ? detect_reusing_keys<Exclusive>(keys,
+                                                       output,
+                                                       size,
+                                                       ceiling_div(size, items_per_block))
+                      : 0;
+
+            const hipError_t partition_result = detail::temp_storage::partition(
+                temporary_storage,
+                storage_size,
+                detail::temp_storage::make_linear_partition(
+                    // This is valid even with offset_scan_state_with_sleep_type
+                    detail::temp_storage::make_partition(&scan_state_storage, layout),
+                    detail::temp_storage::ptr_aligned_array(&previous_last_value,
+                                                            use_limited_size ? 1 : 0),
+                    detail::temp_storage::ptr_aligned_array(&last_keys_of_each_block,
+                                                            last_keys_of_each_block_size_byte),
+                    detail::temp_storage::make_partition(
+                        &ordered_bid_storage,
+                        ordered_bid_type::get_temp_storage_layout())));
+            if(partition_result != hipSuccess || temporary_storage == nullptr)
             {
-                hipLaunchKernelGGL(init_lookback_scan_state_kernel,
-                                   dim3(init_grid_size),
-                                   dim3(block_size),
-                                   0,
-                                   stream,
-                                   scan_state,
-                                   scan_blocks,
-                                   number_of_blocks - 1,
-                                   i > 0 ? previous_last_value : nullptr);
-            });
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
-                                                    scan_blocks,
-                                                    start);
+                return partition_result;
+            }
 
-        if(debug_synchronous)
-        {
-            start = std::chrono::steady_clock::now();
-        }
-        ROCPRIM_RETURN_ON_ERROR(with_scan_state(
-            [&](auto& scan_state)
+            if(number_of_blocks == 0u)
             {
-                return launch_device_scan_by_key<config, Determinism, Exclusive>(
+                return hipSuccess;
+            }
+
+            scan_state_type scan_state{};
+            ROCPRIM_RETURN_ON_ERROR(
+                scan_state_type::create(scan_state, scan_state_storage, number_of_blocks, stream));
+
+            auto ordered_bid = ordered_bid_type::create(ordered_bid_storage);
+
+            // Total number of blocks in all launches
+            const auto   total_number_of_blocks = ceiling_div(size, items_per_block);
+            const size_t number_of_launch       = ceiling_div(size, limited_size);
+
+            if(debug_synchronous)
+            {
+                std::cout << "----------------------------------\n";
+                std::cout << "size:               " << size << '\n';
+                std::cout << "aligned_size_limit: " << aligned_size_limit << '\n';
+                std::cout << "use_limited_size:   " << std::boolalpha << use_limited_size << '\n';
+                std::cout << "number_of_launch:   " << number_of_launch << '\n';
+                std::cout << "block_size:         " << block_size << '\n';
+                std::cout << "items_per_block:    " << items_per_block << '\n';
+                std::cout << "----------------------------------\n";
+            }
+
+            for(size_t i = 0, offset = 0; i < number_of_launch; i++, offset += limited_size)
+            {
+                // limited_size is of type unsigned int, so current_size also fits in an unsigned int
+                // size_t is necessary as type of std::min because 'size - offset' can exceed the
+                // upper limit of unsigned int and converting it can lead to wrong results
+                const unsigned int current_size
+                    = static_cast<unsigned int>(std::min<size_t>(size - offset, limited_size));
+                const unsigned int scan_blocks    = ceiling_div(current_size, items_per_block);
+                const unsigned int init_grid_size = ceiling_div(scan_blocks, block_size);
+
+                // Start point for time measurements
+                std::chrono::steady_clock::time_point start;
+                if(debug_synchronous)
+                {
+                    std::cout << "index:            " << i << '\n';
+                    std::cout << "current_size:     " << current_size << '\n';
+                    std::cout << "number of blocks: " << scan_blocks << '\n';
+
+                    start = std::chrono::steady_clock::now();
+                }
+                if (!Exclusive && last_keys_of_each_block_size_byte != 0 && i == 0)
+                {
+                    init_device_scan_by_key_kernel<<<dim3(init_grid_size),
+                                                     dim3(block_size),
+                                                     0,
+                                                     stream>>>(
+                        scan_state,
+                        scan_blocks,
+                        number_of_blocks - 1,
+                        i > 0 ? previous_last_value : nullptr,
+                        keys,
+                        last_keys_of_each_block,
+                        last_keys_of_each_block_size_byte
+                            / sizeof(decltype(*last_keys_of_each_block)),
+                        items_per_block,
+                        ordered_bid);
+                }
+                else
+                {
+                    init_device_scan_by_key_kernel<<<dim3(init_grid_size),
+                                                     dim3(block_size),
+                                                     0,
+                                                     stream>>>(scan_state,
+                                                               scan_blocks,
+                                                               number_of_blocks - 1,
+                                                               i > 0 ? previous_last_value
+                                                                     : nullptr,
+                                                               ordered_bid);
+                }
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("init_lookback_scan_state_kernel",
+                                                            scan_blocks,
+                                                            start);
+
+                if(debug_synchronous)
+                {
+                    start = std::chrono::steady_clock::now();
+                }
+                ROCPRIM_RETURN_ON_ERROR(launch_device_scan_by_key<config, Determinism, Exclusive>(
                     target_arch,
                     keys + offset,
                     input + offset,
@@ -286,15 +387,21 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
                     i * number_of_blocks,
                     total_number_of_blocks,
                     i > 0 ? as_const_ptr(previous_last_value) : nullptr,
+                    last_keys_of_each_block_size_byte != 0,
+                    last_keys_of_each_block,
+                    ordered_bid,
                     dim3(scan_blocks),
                     dim3(block_size),
                     0,
-                    stream);
-            }));
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
-                                                    current_size,
-                                                    start);
-    }
+                    stream));
+                ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("device_scan_by_key_kernel",
+                                                            current_size,
+                                                            start);
+            }
+            return hipSuccess;
+        },
+        use_sleepy_scan_variant,
+        use_atomic_block_id_variant));
     return hipSuccess;
 }
 
@@ -321,6 +428,13 @@ inline hipError_t scan_by_key_impl(void* const           temporary_storage,
 /// if \p temporary_storage in a null pointer.
 /// * Ranges specified by \p keys_input, \p values_input, and \p values_output must have
 /// at least \p size elements.
+///
+/// \note In-place inclusive_scan_by_key
+/// In these situations, in-place inclusive_scan_by_key is supported:
+/// - The buffers in `keys_input` and `values_output` are overlaped to each other, and `KeysInputIterator` and `ValuesOutputIterator` are the same.
+/// - The buffers in `keys_input` and `values_output` are overlaped to each other, `KeysInputIterator` and `ValuesOutputIterator` are the different,
+///   but they are both pointer types, and their "std::iterator_traits<KeysInputIterator>::value_type" is convertible to
+///   "std::iterator_traits<ValuesOutputIterator>::value_type"
 ///
 /// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `scan_by_key_config`.
 /// \tparam KeysInputIterator random-access iterator type of the input range. It can be
@@ -513,6 +627,9 @@ inline hipError_t deterministic_inclusive_scan_by_key(void* const               
 /// if \p temporary_storage in a null pointer.
 /// * Ranges specified by \p keys_input, \p values_input, and \p values_output must have
 /// at least \p size elements.
+///
+/// \note In-place exclusive_scan_by_key
+/// In-place exclusive_scan_by_key is supported.
 ///
 /// \tparam Config [optional] Configuration of the primitive, must be `default_config` or `scan_by_key_config`.
 /// \tparam KeysInputIterator random-access iterator type of the input range. It can be

--- a/projects/rocprim/test/rocprim/test_device_scan.cpp
+++ b/projects/rocprim/test/rocprim/test_device_scan.cpp
@@ -28,6 +28,7 @@
 // Required test headers
 #include "bounds_checking_iterator.hpp"
 #include "identity_iterator.hpp"
+#include "rocprim/device/detail/ordered_block_id.hpp"
 #include "test_utils.hpp"
 #include "test_utils_assertions.hpp"
 #include "test_utils_custom_test_types.hpp"
@@ -425,6 +426,12 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
                                                          number_of_blocks,
                                                          stream));
 
+            // Create ordered block id.
+            using block_id_type = rocprim::detail::block_id_wrapper<unsigned int>;
+            common::device_ptr<void> ordered_bid_storage(sizeof(block_id_type::id_type));
+            auto ordered_bid = block_id_type::create(ordered_bid_storage.get());
+            HIP_CHECK(ordered_bid.reset_from_host(stream));
+
             // Call the provided function with either scan_state or scan_state_with_sleep based on
             // the value of use_sleep
             bool use_sleep;
@@ -449,7 +456,8 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
                                                                        dim3(block_size),
                                                                        0,
                                                                        stream>>>(scan_state,
-                                                                                 number_of_blocks);
+                                                                                 number_of_blocks,
+                                                                                 ordered_bid);
                 });
 
             HIP_CHECK(hipGetLastError());
@@ -489,7 +497,8 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScan)
                                        previous_last_element,
                                        new_last_element,
                                        false,
-                                       false);
+                                       false,
+                                       ordered_bid);
                 });
 
             ASSERT_EQ(hipSuccess, launch_err);
@@ -652,6 +661,11 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
                                                      number_of_blocks,
                                                      stream));
 
+        // Create ordered block id.
+        common::device_ptr<unsigned int> ordered_bid_storage(1);
+        auto                             ordered_bid
+            = rocprim::detail::ordered_block_id<unsigned int>::create(ordered_bid_storage.get());
+
         // Call the provided function with either scan_state or scan_state_with_sleep based on
         // the value of use_sleep
         bool use_sleep;
@@ -676,7 +690,8 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
                                                                    dim3(block_size),
                                                                    0,
                                                                    stream>>>(scan_state,
-                                                                             number_of_blocks);
+                                                                             number_of_blocks,
+                                                                             ordered_bid);
             });
 
         HIP_CHECK(hipGetLastError());
@@ -715,7 +730,8 @@ TYPED_TEST(RocprimDeviceScanTests, LookBackScanGetCompleteValue)
                                    previous_last_element,
                                    new_last_element,
                                    false,
-                                   false);
+                                   false,
+                                   ordered_bid);
             });
 
         ASSERT_EQ(hipSuccess, launch_err);


### PR DESCRIPTION
DO NOT MERGE UNTIL PM APPROVAL GIVEN.

In some cases, using an atomic block ID is desired. This PR introduces a way to enable/disable this via an environment variable.

This change is quite significant. And requires changes to most lookback scan algorithms to reduce logical complexity in handling kernel variants.

The changes are as following:
* In `device/detail/ordered_block_id`: introduce `check_if_using_atomic_block_id`.
* This is runtime host logic to decide to check if atomic block id is desired.
* Change multiple algorithms to use `std::variant` and `std::visit` to encapsulate and abstract multiple compile-time kernel variants.
* In `detail/various.hpp`: introduce `detail::constexpr_type_variant` and `detail::constexpr_value_variant` to help generate variant types.
* We use some variadic folding magic to generate switch to select compile time variants on run time. Idem to:
    ```cpp
    if (use_a) {
        f<true>();
    } else {
        f<false>();
    }
    ```
Only now store the intermediate result as a `std::integral_constant`.
    ```cpp
    if (use_a) {
      my_variant = std::integral_constant<bool, true>{};
    } else {
      my_variant = std::integral_constant<bool, true>{};
    }
    ```
But of course writing this out by hand is annoying, hence the folding expression.
* Simplify sleepy lookback scan variant logic in various algorithms.

- Verify that disabling atomics work by launching with `ROCPRIM_USE_ATOMIC_BLOCK_ID=0`.
- Verify that force-enabling atomics works by launching with `ROCPRIM_USE_ATOMIC_BLOCK_ID=2`.
- Verify default behaviour by launching with no environment variables and with `ROCPRIM_USE_ATOMIC_BLOCK_ID=1`.

Debug compile when targeting many device architectures may result in linker errors due to symbols being to far apart.

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

