### PR TITLE
rocRAND full SPIR-V support

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -451,11 +451,10 @@ auto make_launch_plan(target_arch arch, Kernel kernel) -> launch_plan<Kernel>
     for_each_arch(
         [&](auto arch_tag)
         {
-            constexpr target_arch Arch = decltype(arch_tag)::value;
-            if(Arch != arch || tuned_kernel)
+            if(arch_tag != arch || tuned_kernel)
                 return;
 
-            tuned_kernel = trampoline_kernel<Config, Arch, Kernel, LaunchSelector>;
+            tuned_kernel = trampoline_kernel<Config, arch_tag, Kernel, LaunchSelector>;
         });
 
     if(!tuned_kernel)

--- a/projects/rocrand/.gitignore
+++ b/projects/rocrand/.gitignore
@@ -7,8 +7,7 @@
 .tag*
 
 ### build dirs ###
-build/
-build_package_test/
+build*/
 
 ### C++ ###
 # Compiled Object files

--- a/projects/rocrand/CHANGELOG.md
+++ b/projects/rocrand/CHANGELOG.md
@@ -11,7 +11,7 @@ Documentation for rocRAND is available at
 
 ### Changed
 
-* Changed the `launch` method in `host_system` and `device_system`, so that kernels with all supported arches can be compiled with correct configuration during host pass. All generators are updated accordingly for support of SPIR-V, to invoke SIPR-V,  it should be built with `-DAMDGPU_TARGETS=amdgcnspirv`.
+* Changed the `launch` method in `host_system` and `device_system`, so that kernels with all supported arches can be compiled with correct configuration during host pass. All generators are updated accordingly for support of SPIR-V. To invoke SIPR-V, it should be built with `-DAMDGPU_TARGETS=amdgcnspirv`.
 
 ## rocRAND 4.1.0 for ROCm 7.1
 

--- a/projects/rocrand/CHANGELOG.md
+++ b/projects/rocrand/CHANGELOG.md
@@ -9,6 +9,10 @@ Documentation for rocRAND is available at
 
 * Added a new CMake option `-DUSE_SYSTEM_LIB` to allow tests to be built from `ROCm` libraries provided by the system.
 
+### Changed
+
+* Changed the `launch` method in `host_system` and `device_system`, so that kernels with all supported arches can be compiled with correct configuration during host pass. All generators are updated accordingly for support of SPIR-V, to invoke SIPR-V,  it should be built with `-DAMDGPU_TARGETS=amdgcnspirv`.
+
 ## rocRAND 4.1.0 for ROCm 7.1
 
 ### Changed

--- a/projects/rocrand/README.md
+++ b/projects/rocrand/README.md
@@ -106,8 +106,7 @@ ctest --output-on-failure
 
 ### SPIR-V
 
-rocRAND supports the `amdgcnspirv` target, but it should be built with `USE_DEVICE_DISPATCH`
-turned off like `-DUSE_DEVICE_DISPATCH=0`.
+rocRAND supports the `amdgcnspirv` target, it should be built with `-DAMDGPU_TARGETS=amdgcnspirv`.
 
 ### HIP on Windows
 

--- a/projects/rocrand/library/src/rng/config_types.hpp
+++ b/projects/rocrand/library/src/rng/config_types.hpp
@@ -57,6 +57,35 @@ enum class target_arch : unsigned int
     unknown = std::numeric_limits<unsigned int>::max(),
 };
 
+constexpr target_arch target_architectures[] = {
+    target_arch::gfx902,
+    target_arch::gfx900,
+    target_arch::gfx904,
+    target_arch::gfx906,
+    target_arch::gfx908,
+    target_arch::gfx909,
+    target_arch::gfx90a,
+    target_arch::gfx942,
+    target_arch::gfx1030,
+    target_arch::gfx1100,
+    target_arch::gfx1101,
+    target_arch::gfx1102,
+    target_arch::gfx1201,
+};
+
+template<class F, std::size_t... Is>
+constexpr void for_each_arch_impl(F&& f, std::index_sequence<Is...>)
+{
+    (f(std::integral_constant<target_arch, target_architectures[Is]>{}), ...);
+}
+
+template<class F>
+constexpr void for_each_arch(F&& f)
+{
+    for_each_arch_impl(std::forward<F>(f),
+                       std::make_index_sequence<std::size(target_architectures)>{});
+}
+
 /// @brief Returns the detected processor architecture of the device that is currently compiled against.
 __host__ __device__ constexpr target_arch get_device_arch()
 {
@@ -346,13 +375,14 @@ hipError_t get_generator_config(const hipStream_t      stream,
 /// @tparam GeneratorType The kind of the random engine.
 /// @param dynamic_config Whether architecture-specific launch config can be selected or not.
 /// @return The selected launch config.
-template<rocrand_rng_type GeneratorType, class T>
-__host__ __device__ constexpr generator_config get_generator_config_device(bool dynamic_config)
+template<rocrand_rng_type GeneratorType, class T, target_arch Arch = host::target_arch::unknown>
+__host__ __device__
+constexpr generator_config get_generator_config_device(bool dynamic_config)
 {
     return generator_config{generator_config_selector<GeneratorType, T>::get_threads(
-                                dynamic_config ? get_device_arch() : target_arch::unknown),
+                                dynamic_config ? Arch : target_arch::unknown),
                             generator_config_selector<GeneratorType, T>::get_blocks(
-                                dynamic_config ? get_device_arch() : target_arch::unknown)};
+                                dynamic_config ? Arch : target_arch::unknown)};
 }
 
 /// @brief Loads the appropriate kernel launch config for both host and kernel code.
@@ -369,10 +399,11 @@ struct default_config_provider
     /// @tparam T The type of the generated random values.
     /// @param is_dynamic Controls if the returned config belongs to the static or the dynamic ordering.
     /// @return The kernel config struct.
-    template<class T>
-    __host__ __device__ static constexpr generator_config device_config(const bool is_dynamic)
+    template<class T, host::target_arch Arch = host::target_arch::unknown>
+    __host__ __device__
+    static constexpr generator_config device_config(const bool is_dynamic)
     {
-        return get_generator_config_device<GeneratorType, T>(is_dynamic);
+        return get_generator_config_device<GeneratorType, T, Arch>(is_dynamic);
     }
 
     /// @brief Load the config on the host for a specific architecture and ordering.
@@ -400,8 +431,9 @@ struct static_config_provider
 {
     static constexpr inline generator_config static_config = {Threads, Blocks};
 
-    template<class>
-    __host__ __device__ static constexpr generator_config device_config(const bool /*is_dynamic*/)
+    template<class, target_arch>
+    __host__ __device__
+    static constexpr generator_config device_config(const bool /*is_dynamic*/)
     {
         return static_config;
     }
@@ -434,9 +466,9 @@ struct static_block_size_config_provider
 
     static constexpr inline block_size_generator_config static_config = {Threads};
 
-    template<class>
-    __host__ __device__ static constexpr block_size_generator_config
-        device_config(const bool /*is_dynamic*/)
+    template<class, target_arch>
+    __host__ __device__
+    static constexpr block_size_generator_config device_config(const bool /*is_dynamic*/)
     {
         return static_config;
     }
@@ -503,16 +535,17 @@ hipError_t get_least_common_grid_size(const hipStream_t      stream,
 /// @param is_dynamic Whether the current kernel uses dynamic ordering or not.
 /// @return The least common multiple of all grid sizes across configurations.
 /// @tparam ConfigProvider Provider of the kernel launch configs.
-template<class ConfigProvider>
-__host__ __device__ constexpr unsigned int get_least_common_grid_size(const bool is_dynamic)
+template<class ConfigProvider, target_arch Arch>
+__host__ __device__
+constexpr unsigned int get_least_common_grid_size(const bool is_dynamic)
 {
     generator_config type_configs[6]{};
-    type_configs[0] = ConfigProvider::template device_config<unsigned int>(is_dynamic);
-    type_configs[1] = ConfigProvider::template device_config<unsigned short>(is_dynamic);
-    type_configs[2] = ConfigProvider::template device_config<unsigned char>(is_dynamic);
-    type_configs[3] = ConfigProvider::template device_config<half>(is_dynamic);
-    type_configs[4] = ConfigProvider::template device_config<float>(is_dynamic);
-    type_configs[5] = ConfigProvider::template device_config<double>(is_dynamic);
+    type_configs[0] = ConfigProvider::template device_config<unsigned int, Arch>(is_dynamic);
+    type_configs[1] = ConfigProvider::template device_config<unsigned short, Arch>(is_dynamic);
+    type_configs[2] = ConfigProvider::template device_config<unsigned char, Arch>(is_dynamic);
+    type_configs[3] = ConfigProvider::template device_config<half, Arch>(is_dynamic);
+    type_configs[4] = ConfigProvider::template device_config<float, Arch>(is_dynamic);
+    type_configs[5] = ConfigProvider::template device_config<double, Arch>(is_dynamic);
 
     unsigned int least_common_grid_size = 1;
     for(const auto config : type_configs)
@@ -530,12 +563,13 @@ __host__ __device__ constexpr unsigned int get_least_common_grid_size(const bool
 /// @param is_dynamic Whether the current kernel uses dynamic ordering or not.
 /// @tparam ConfigProvider Provider of the kernel launch configs.
 /// @tparam T The generated value type to load the config for.
-template<class ConfigProvider, class T>
-__host__ __device__ constexpr bool is_single_tile_config(const bool is_dynamic)
+template<class ConfigProvider, class T, host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__
+constexpr bool is_single_tile_config(const bool is_dynamic)
 {
-    const auto         config        = ConfigProvider::template device_config<T>(is_dynamic);
+    const auto         config        = ConfigProvider::template device_config<T, Arch>(is_dynamic);
     const unsigned int grid_size     = config.blocks * config.threads;
-    const unsigned int lcm_grid_size = get_least_common_grid_size<ConfigProvider>(is_dynamic);
+    const unsigned int lcm_grid_size = get_least_common_grid_size<ConfigProvider, Arch>(is_dynamic);
 
     return grid_size == lcm_grid_size;
 }
@@ -548,10 +582,11 @@ __host__ __device__ constexpr bool is_single_tile_config(const bool is_dynamic)
 /// @tparam T The current generated value type.
 /// @param is_dynamic Whether the current kernel uses dynamic ordering or not.
 /// @returns The number of threads per block for the current config.
-template<class ConfigProvider, class T>
-__host__ __device__ constexpr unsigned int get_block_size(const bool is_dynamic)
+template<class ConfigProvider, class T, host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__
+constexpr unsigned int get_block_size(const bool is_dynamic)
 {
-    return ConfigProvider::template device_config<T>(is_dynamic).threads;
+    return ConfigProvider::template device_config<T, Arch>(is_dynamic).threads;
 }
 
 /// @brief Extracts the `rocrand_rng_type` from a generator template.

--- a/projects/rocrand/library/src/rng/config_types.hpp
+++ b/projects/rocrand/library/src/rng/config_types.hpp
@@ -87,7 +87,8 @@ constexpr void for_each_arch(F&& f)
 }
 
 /// @brief Returns the detected processor architecture of the device that is currently compiled against.
-__host__ __device__ constexpr target_arch get_device_arch()
+__host__ __device__
+constexpr target_arch get_device_arch()
 {
 #if !USE_DEVICE_DISPATCH
     return target_arch::unknown;

--- a/projects/rocrand/library/src/rng/lfsr113.hpp
+++ b/projects/rocrand/library/src/rng/lfsr113.hpp
@@ -66,7 +66,11 @@ inline void init_lfsr113_engines(dim3 block_idx,
     }
 }
 
-template<class ConfigProvider, bool IsDynamic, class T, class Distribution, host::target_arch Arch = host::target_arch::unknown>
+template<class ConfigProvider,
+         bool IsDynamic,
+         class T,
+         class Distribution,
+         host::target_arch Arch = host::target_arch::unknown>
 __host__ __device__ __forceinline__
 void generate_lfsr113(dim3 block_idx,
                       dim3 thread_idx,

--- a/projects/rocrand/library/src/rng/lfsr113.hpp
+++ b/projects/rocrand/library/src/rng/lfsr113.hpp
@@ -45,15 +45,17 @@ namespace rocrand_impl::host
 
 typedef ::rocrand_device::lfsr113_engine lfsr113_device_engine;
 
-__host__ __device__ inline void init_lfsr113_engines(dim3 block_idx,
-                                                     dim3 thread_idx,
-                                                     dim3 /*grid_dim*/,
-                                                     dim3                   block_dim,
-                                                     lfsr113_device_engine* engines,
-                                                     const unsigned int     start_engine_id,
-                                                     const unsigned int     engines_size,
-                                                     const uint4            seeds,
-                                                     const unsigned int     offset)
+template<host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__
+inline void init_lfsr113_engines(dim3 block_idx,
+                                 dim3 thread_idx,
+                                 dim3 /*grid_dim*/,
+                                 dim3                   block_dim,
+                                 lfsr113_device_engine* engines,
+                                 const unsigned int     start_engine_id,
+                                 const unsigned int     engines_size,
+                                 const uint4            seeds,
+                                 const unsigned int     offset)
 {
     const unsigned int engine_id = block_idx.x * block_dim.x + thread_idx.x;
     if(engine_id < engines_size)
@@ -64,20 +66,21 @@ __host__ __device__ inline void init_lfsr113_engines(dim3 block_idx,
     }
 }
 
-template<class ConfigProvider, bool IsDynamic, class T, class Distribution>
-__host__ __device__ __forceinline__ void generate_lfsr113(dim3 block_idx,
-                                                          dim3 thread_idx,
-                                                          dim3 grid_dim,
-                                                          dim3 /*block_dim*/,
-                                                          lfsr113_device_engine* engines,
-                                                          const unsigned int     start_engine_id,
-                                                          T*                     data,
-                                                          const size_t           n,
-                                                          Distribution           distribution)
+template<class ConfigProvider, bool IsDynamic, class T, class Distribution, host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__ __forceinline__
+void generate_lfsr113(dim3 block_idx,
+                      dim3 thread_idx,
+                      dim3 grid_dim,
+                      dim3 /*block_dim*/,
+                      lfsr113_device_engine* engines,
+                      const unsigned int     start_engine_id,
+                      T*                     data,
+                      const size_t           n,
+                      Distribution           distribution)
 {
-    static_assert(is_single_tile_config<ConfigProvider, T>(IsDynamic),
+    static_assert(is_single_tile_config<ConfigProvider, T, Arch>(IsDynamic),
                   "This kernel should only be used with single tile configs");
-    constexpr unsigned int BlockSize    = get_block_size<ConfigProvider, T>(IsDynamic);
+    constexpr unsigned int BlockSize    = get_block_size<ConfigProvider, T, Arch>(IsDynamic);
     constexpr unsigned int input_width  = Distribution::input_width;
     constexpr unsigned int output_width = Distribution::output_width;
 
@@ -332,6 +335,13 @@ public:
             return ROCRAND_STATUS_INTERNAL_ERROR;
         }
 
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
+
         m_start_engine_id = m_offset % m_engines_size;
 
         if(m_engines != nullptr)
@@ -347,8 +357,12 @@ public:
         constexpr unsigned int init_threads = 256;
         const unsigned int     init_blocks  = (m_engines_size + init_threads - 1) / init_threads;
 
-        status = system_type::template launch<init_lfsr113_engines,
-                                              static_block_size_config_provider<init_threads>>(
+        auto init_lfsr113_engines_kernel
+            = [&](auto arch, auto... args) { init_lfsr113_engines<arch>(args...); };
+
+        status = system_type::template launch<static_block_size_config_provider<init_threads>>(
+            init_lfsr113_engines_kernel,
+            target_arch,
             dim3(init_blocks),
             dim3(init_threads),
             0,
@@ -389,6 +403,13 @@ public:
             return ROCRAND_STATUS_INTERNAL_ERROR;
         }
 
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
+
         if(data == nullptr)
         {
             return ROCRAND_STATUS_SUCCESS;
@@ -398,19 +419,20 @@ public:
             m_order,
             [&, this](auto is_dynamic)
             {
-                return system_type::template launch<
-                    generate_lfsr113<ConfigProvider, is_dynamic, T, Distribution>,
-                    ConfigProvider,
-                    T,
-                    is_dynamic>(dim3(config.blocks),
-                                dim3(config.threads),
-                                0,
-                                m_stream,
-                                m_engines,
-                                m_start_engine_id,
-                                data,
-                                data_size,
-                                distribution);
+                auto generate_lfsr113_kernel = [&](auto arch, auto... args)
+                { generate_lfsr113<ConfigProvider, is_dynamic, T, Distribution, arch>(args...); };
+                return system_type::template launch<ConfigProvider, T, is_dynamic>(
+                    generate_lfsr113_kernel,
+                    target_arch,
+                    dim3(config.blocks),
+                    dim3(config.threads),
+                    0,
+                    m_stream,
+                    m_engines,
+                    m_start_engine_id,
+                    data,
+                    data_size,
+                    distribution);
             });
 
         if(status != ROCRAND_STATUS_SUCCESS)

--- a/projects/rocrand/library/src/rng/lfsr113.hpp
+++ b/projects/rocrand/library/src/rng/lfsr113.hpp
@@ -423,8 +423,10 @@ public:
             m_order,
             [&, this](auto is_dynamic)
             {
-                auto generate_lfsr113_kernel = [&](auto arch, auto... args)
-                { generate_lfsr113<ConfigProvider, is_dynamic, T, Distribution, arch>(args...); };
+                auto generate_lfsr113_kernel = [&] __host__ __device__(auto arch, auto... args)
+                {
+                    generate_lfsr113<ConfigProvider, is_dynamic, T, Distribution, arch>(args...);
+                };
                 return system_type::template launch<ConfigProvider, T, is_dynamic>(
                     generate_lfsr113_kernel,
                     target_arch,

--- a/projects/rocrand/library/src/rng/mrg.hpp
+++ b/projects/rocrand/library/src/rng/mrg.hpp
@@ -44,16 +44,17 @@
 namespace rocrand_impl::host
 {
 
-template<class Engine>
-__host__ __device__ void init_engines_mrg(dim3               block_idx,
-                                          dim3               thread_idx,
-                                          dim3               grid_dim,
-                                          dim3               block_dim,
-                                          Engine*            engines,
-                                          const unsigned int start_engine_id,
-                                          const unsigned int engines_size,
-                                          unsigned long long seed,
-                                          unsigned long long offset)
+template<class Engine, host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__
+void init_engines_mrg(dim3               block_idx,
+                      dim3               thread_idx,
+                      dim3               grid_dim,
+                      dim3               block_dim,
+                      Engine*            engines,
+                      const unsigned int start_engine_id,
+                      const unsigned int engines_size,
+                      unsigned long long seed,
+                      unsigned long long offset)
 {
     (void)grid_dim;
     const unsigned int engine_id = block_idx.x * block_dim.x + thread_idx.x;
@@ -64,20 +65,26 @@ __host__ __device__ void init_engines_mrg(dim3               block_idx,
     }
 }
 
-template<class ConfigProvider, bool IsDynamic, class Engine, class T, class Distribution>
-__host__ __device__ __forceinline__ void generate_mrg(dim3 block_idx,
-                                      dim3 thread_idx,
-                                      dim3 grid_dim,
-                                      dim3 /*block_dim*/,
-                                      Engine*            engines,
-                                      const unsigned int start_engine_id,
-                                      T*                 data,
-                                      const size_t       n,
-                                      Distribution       distribution)
+template<class ConfigProvider,
+         bool IsDynamic,
+         class Engine,
+         class T,
+         class Distribution,
+         host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__ __forceinline__
+void generate_mrg(dim3 block_idx,
+                  dim3 thread_idx,
+                  dim3 grid_dim,
+                  dim3 /*block_dim*/,
+                  Engine*            engines,
+                  const unsigned int start_engine_id,
+                  T*                 data,
+                  const size_t       n,
+                  Distribution       distribution)
 {
-    static_assert(is_single_tile_config<ConfigProvider, T>(IsDynamic),
+    static_assert(is_single_tile_config<ConfigProvider, T, Arch>(IsDynamic),
                   "This kernel should only be used with single tile configs");
-    constexpr unsigned int block_size   = get_block_size<ConfigProvider, T>(IsDynamic);
+    constexpr unsigned int block_size   = get_block_size<ConfigProvider, T, Arch>(IsDynamic);
     constexpr unsigned int input_width  = Distribution::input_width;
     constexpr unsigned int output_width = Distribution::output_width;
 
@@ -297,6 +304,13 @@ public:
             return ROCRAND_STATUS_INTERNAL_ERROR;
         }
 
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
+
         m_start_engine_id = m_offset % m_engines_size;
 
         if(m_engines != nullptr)
@@ -312,8 +326,12 @@ public:
         constexpr unsigned int init_threads = ROCRAND_DEFAULT_MAX_BLOCK_SIZE;
         const unsigned int     init_blocks  = (m_engines_size + init_threads - 1) / init_threads;
 
-        status = system_type::template launch<init_engines_mrg<engine_type>,
-                                              static_block_size_config_provider<init_threads>>(
+        auto init_engines_mrg_kernel
+            = [&](auto arch, auto... args) { init_engines_mrg<engine_type, arch>(args...); };
+
+        status = system_type::template launch<static_block_size_config_provider<init_threads>>(
+            init_engines_mrg_kernel,
+            target_arch,
             dim3(init_blocks),
             dim3(init_threads),
             0,
@@ -359,23 +377,33 @@ public:
             return ROCRAND_STATUS_SUCCESS;
         }
 
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
+
         status = dynamic_dispatch(
             m_order,
             [&, this](auto is_dynamic)
             {
-                return system_type::template launch<
-                    generate_mrg<ConfigProvider, is_dynamic, engine_type, T, Distribution>,
-                    ConfigProvider,
-                    T,
-                    is_dynamic>(dim3(config.blocks),
-                                dim3(config.threads),
-                                0,
-                                m_stream,
-                                m_engines,
-                                m_start_engine_id,
-                                data,
-                                data_size,
-                                distribution);
+                auto generate_mrg_kernel = [&](auto arch, auto... args) {
+                    generate_mrg<ConfigProvider, is_dynamic, engine_type, T, Distribution, arch>(
+                        args...);
+                };
+                return system_type::template launch<ConfigProvider, T, is_dynamic>(
+                    generate_mrg_kernel,
+                    target_arch,
+                    dim3(config.blocks),
+                    dim3(config.threads),
+                    0,
+                    m_stream,
+                    m_engines,
+                    m_start_engine_id,
+                    data,
+                    data_size,
+                    distribution);
             });
 
         // Check kernel status

--- a/projects/rocrand/library/src/rng/mrg.hpp
+++ b/projects/rocrand/library/src/rng/mrg.hpp
@@ -388,7 +388,8 @@ public:
             m_order,
             [&, this](auto is_dynamic)
             {
-                auto generate_mrg_kernel = [&](auto arch, auto... args) {
+                auto generate_mrg_kernel = [&] __host__ __device__(auto arch, auto... args)
+                {
                     generate_mrg<ConfigProvider, is_dynamic, engine_type, T, Distribution, arch>(
                         args...);
                 };

--- a/projects/rocrand/library/src/rng/mt19937.hpp
+++ b/projects/rocrand/library/src/rng/mt19937.hpp
@@ -82,7 +82,10 @@ unsigned int wrap_n(unsigned int i)
 
 // Config is not actually used for kernel launch here, but is needed to check the number of generators
 // As this kernel is not dependent on any type just use void for the config, as mt19937 is not tuned for types independently, so all configs are the same for different types.
-template<unsigned int jump_ahead_thread_count, class ConfigProvider, bool IsDynamic>
+template<unsigned int      jump_ahead_thread_count,
+         class ConfigProvider,
+         bool IsDynamic,
+         host::target_arch Arch = host::target_arch::unknown>
 __forceinline__ __host__ __device__
 void jump_ahead_mt19937(dim3 block_idx,
                         dim3 thread_idx,
@@ -102,7 +105,8 @@ void jump_ahead_mt19937(dim3 block_idx,
     }
 #endif
 
-    constexpr generator_config config = ConfigProvider::template device_config<void>(IsDynamic);
+    constexpr generator_config config
+        = ConfigProvider::template device_config<void, Arch>(IsDynamic);
     constexpr unsigned int     GeneratorCount
         = config.threads * config.blocks / mt19937_octo_engine::threads_per_generator;
     static_assert(GeneratorCount <= mt19937_jumps_radix * mt19937_jumps_radix
@@ -276,7 +280,7 @@ void jump_ahead_mt19937(dim3 block_idx,
 
 // This kernel is not explicitly tuned, but uses the same configs as the generate-kernels.
 // As this kernel is not dependent on any type just use void for the config, as mt19937 is not tuned for types independently, so all configs are the same for different types.
-template<class ConfigProvider, bool IsDynamic>
+template<class ConfigProvider, bool IsDynamic, host::target_arch Arch = host::target_arch::unknown>
 __forceinline__ __host__ __device__
 void init_engines_mt19937(dim3 block_idx,
                           dim3 thread_idx,
@@ -285,7 +289,8 @@ void init_engines_mt19937(dim3 block_idx,
                           unsigned int* __restrict__ octo_engines,
                           const unsigned int* __restrict__ engines)
 {
-    constexpr generator_config config     = ConfigProvider::template device_config<void>(IsDynamic);
+    constexpr generator_config config
+        = ConfigProvider::template device_config<void, Arch>(IsDynamic);
     constexpr unsigned int     block_size = config.threads;
     constexpr unsigned int     grid_size  = config.blocks;
     constexpr unsigned int     stride     = block_size * grid_size;
@@ -304,7 +309,12 @@ void init_engines_mt19937(dim3 block_idx,
     accessor.save(thread_id, engine);
 }
 
-template<class ConfigProvider, bool IsDynamic, class T, class VecT, class Distribution>
+template<class ConfigProvider,
+         bool IsDynamic,
+         class T,
+         class VecT,
+         class Distribution,
+         host::target_arch Arch = host::target_arch::unknown>
 __forceinline__ __host__ __device__
 void generate_short_mt19937(dim3 block_idx,
                             dim3 thread_idx,
@@ -326,7 +336,7 @@ void generate_short_mt19937(dim3 block_idx,
         return;
     }
 #endif
-    constexpr generator_config config     = ConfigProvider::template device_config<T>(IsDynamic);
+    constexpr generator_config config = ConfigProvider::template device_config<T, Arch>(IsDynamic);
     constexpr unsigned int     block_size = config.threads;
     constexpr unsigned int     grid_size  = config.blocks;
     constexpr unsigned int     stride     = block_size * grid_size;
@@ -432,7 +442,12 @@ void generate_short_mt19937(dim3 block_idx,
     // clang-format on
 }
 
-template<class ConfigProvider, bool IsDynamic, class T, class VecT, class Distribution>
+template<class ConfigProvider,
+         bool IsDynamic,
+         class T,
+         class VecT,
+         class Distribution,
+         host::target_arch Arch = host::target_arch::unknown>
 __forceinline__ __host__ __device__
 void generate_long_mt19937(dim3 block_idx,
                            dim3 thread_idx,
@@ -454,7 +469,7 @@ void generate_long_mt19937(dim3 block_idx,
         return;
     }
 #endif
-    constexpr generator_config config     = ConfigProvider::template device_config<T>(IsDynamic);
+    constexpr generator_config config = ConfigProvider::template device_config<T, Arch>(IsDynamic);
     constexpr unsigned int     block_size = config.threads;
     constexpr unsigned int     grid_size  = config.blocks;
     constexpr unsigned int     threads_per_generator = mt19937_octo_engine::threads_per_generator;
@@ -808,6 +823,13 @@ public:
         }
         m_generator_count = config.threads * config.blocks / threads_per_generator;
 
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
+
         if(m_engines != nullptr)
         {
             system_type::free(m_engines);
@@ -853,10 +875,15 @@ public:
             m_order,
             [&, this](auto is_dynamic)
             {
-                status = system_type::template launch<
+                auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args) {
+                    jump_ahead_mt19937<jump_ahead_thread_count, ConfigProvider, is_dynamic, arch>(
+                        args...);
+                };
 
-                    jump_ahead_mt19937<jump_ahead_thread_count, ConfigProvider, is_dynamic>,
+                status = system_type::template launch<
                     static_block_size_config_provider<jump_ahead_thread_count>>(
+                    jump_ahead_mt19937_kernel,
+                    target_arch,
                     dim3(m_generator_count),
                     dim3(jump_ahead_thread_count),
                     0,
@@ -875,19 +902,21 @@ public:
         system_type::free(d_mt19937_jump);
 
         // This kernel is not actually tuned for ordering, but config is needed for device-side compile time check of the generator count
-        dynamic_dispatch(
-            m_order,
-            [&, this](auto is_dynamic)
-            {
-                status
-                    = system_type::template launch<init_engines_mt19937<ConfigProvider, is_dynamic>,
-                                                   ConfigProvider>(dim3(config.blocks),
-                                                                   dim3(config.threads),
-                                                                   0,
-                                                                   m_stream,
-                                                                   m_engines,
-                                                                   d_engines);
-            });
+        dynamic_dispatch(m_order,
+                         [&, this](auto is_dynamic)
+                         {
+                             auto init_engines_mt19937_kernel = [&](auto arch, auto... args)
+                             { init_engines_mt19937<ConfigProvider, is_dynamic, arch>(args...); };
+                             status = system_type::template launch<ConfigProvider>(
+                                 init_engines_mt19937_kernel,
+                                 target_arch,
+                                 dim3(config.blocks),
+                                 dim3(config.threads),
+                                 0,
+                                 m_stream,
+                                 m_engines,
+                                 d_engines);
+                         });
         if(status != ROCRAND_STATUS_SUCCESS)
         {
             system_type::free(d_engines);
@@ -937,6 +966,13 @@ public:
             return ROCRAND_STATUS_SUCCESS;
         }
 
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
+
         using vec_type = rocrand_impl::aligned_vec_type<T, output_width>;
 
         const uintptr_t uintptr = reinterpret_cast<uintptr_t>(data);
@@ -977,31 +1013,35 @@ public:
             // Engines have enough values, generated by the previous generate_long_mt19937 call.
             // This kernel does not load and store engines but loads values directly from global
             // memory.
-            dynamic_dispatch(
-                m_order,
-                [&, this](auto is_dynamic)
-                {
-                    status = system_type::template launch<generate_short_mt19937<ConfigProvider,
-                                                                                 is_dynamic,
-                                                                                 T,
-                                                                                 vec_type,
-                                                                                 Distribution>,
-                                                          ConfigProvider,
-                                                          T,
-                                                          is_dynamic>(dim3(config.blocks),
-                                                                      dim3(config.threads),
-                                                                      0,
-                                                                      m_stream,
-                                                                      m_engines,
-                                                                      m_start_input,
-                                                                      data,
-                                                                      size,
-                                                                      vec_data,
-                                                                      vec_size,
-                                                                      head_size,
-                                                                      tail_size,
-                                                                      distribution);
-                });
+            dynamic_dispatch(m_order,
+                             [&, this](auto is_dynamic)
+                             {
+                                 auto generate_short_mt19937_kernel = [&](auto arch, auto... args) {
+                                     generate_short_mt19937<ConfigProvider,
+                                                            is_dynamic,
+                                                            T,
+                                                            vec_type,
+                                                            Distribution,
+                                                            arch>(args...);
+                                 };
+                                 status
+                                     = system_type::template launch<ConfigProvider, T, is_dynamic>(
+                                         generate_short_mt19937_kernel,
+                                         target_arch,
+                                         dim3(config.blocks),
+                                         dim3(config.threads),
+                                         0,
+                                         m_stream,
+                                         m_engines,
+                                         m_start_input,
+                                         data,
+                                         size,
+                                         vec_data,
+                                         vec_size,
+                                         head_size,
+                                         tail_size,
+                                         distribution);
+                             });
             if(status != ROCRAND_STATUS_SUCCESS)
             {
                 return status;
@@ -1010,31 +1050,35 @@ public:
         else
         {
             // There are not enough generated values or no values at all
-            dynamic_dispatch(
-                m_order,
-                [&, this](auto is_dynamic)
-                {
-                    status = system_type::template launch<generate_long_mt19937<ConfigProvider,
-                                                                                is_dynamic,
-                                                                                T,
-                                                                                vec_type,
-                                                                                Distribution>,
-                                                          ConfigProvider,
-                                                          T,
-                                                          is_dynamic>(dim3(config.blocks),
-                                                                      dim3(config.threads),
-                                                                      0,
-                                                                      m_stream,
-                                                                      m_engines,
-                                                                      m_start_input,
-                                                                      data,
-                                                                      size,
-                                                                      vec_data,
-                                                                      vec_size,
-                                                                      head_size,
-                                                                      tail_size,
-                                                                      distribution);
-                });
+            dynamic_dispatch(m_order,
+                             [&, this](auto is_dynamic)
+                             {
+                                 auto generate_long_mt19937_kernel = [&](auto arch, auto... args) {
+                                     generate_long_mt19937<ConfigProvider,
+                                                           is_dynamic,
+                                                           T,
+                                                           vec_type,
+                                                           Distribution,
+                                                           arch>(args...);
+                                 };
+                                 status
+                                     = system_type::template launch<ConfigProvider, T, is_dynamic>(
+                                         generate_long_mt19937_kernel,
+                                         target_arch,
+                                         dim3(config.blocks),
+                                         dim3(config.threads),
+                                         0,
+                                         m_stream,
+                                         m_engines,
+                                         m_start_input,
+                                         data,
+                                         size,
+                                         vec_data,
+                                         vec_size,
+                                         head_size,
+                                         tail_size,
+                                         distribution);
+                             });
             if(status != ROCRAND_STATUS_SUCCESS)
             {
                 return status;

--- a/projects/rocrand/library/src/rng/mt19937.hpp
+++ b/projects/rocrand/library/src/rng/mt19937.hpp
@@ -82,9 +82,9 @@ unsigned int wrap_n(unsigned int i)
 
 // Config is not actually used for kernel launch here, but is needed to check the number of generators
 // As this kernel is not dependent on any type just use void for the config, as mt19937 is not tuned for types independently, so all configs are the same for different types.
-template<unsigned int      jump_ahead_thread_count,
+template<unsigned int jump_ahead_thread_count,
          class ConfigProvider,
-         bool IsDynamic,
+         bool              IsDynamic,
          host::target_arch Arch = host::target_arch::unknown>
 __forceinline__ __host__ __device__
 void jump_ahead_mt19937(dim3 block_idx,

--- a/projects/rocrand/library/src/rng/mt19937.hpp
+++ b/projects/rocrand/library/src/rng/mt19937.hpp
@@ -875,7 +875,8 @@ public:
             m_order,
             [&, this](auto is_dynamic)
             {
-                auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args) {
+                auto jump_ahead_mt19937_kernel = [&] __host__ __device__(auto arch, auto... args)
+                {
                     jump_ahead_mt19937<jump_ahead_thread_count, ConfigProvider, is_dynamic, arch>(
                         args...);
                 };
@@ -902,21 +903,23 @@ public:
         system_type::free(d_mt19937_jump);
 
         // This kernel is not actually tuned for ordering, but config is needed for device-side compile time check of the generator count
-        dynamic_dispatch(m_order,
-                         [&, this](auto is_dynamic)
-                         {
-                             auto init_engines_mt19937_kernel = [&](auto arch, auto... args)
-                             { init_engines_mt19937<ConfigProvider, is_dynamic, arch>(args...); };
-                             status = system_type::template launch<ConfigProvider>(
-                                 init_engines_mt19937_kernel,
-                                 target_arch,
-                                 dim3(config.blocks),
-                                 dim3(config.threads),
-                                 0,
-                                 m_stream,
-                                 m_engines,
-                                 d_engines);
-                         });
+        dynamic_dispatch(
+            m_order,
+            [&, this](auto is_dynamic)
+            {
+                auto init_engines_mt19937_kernel = [&] __host__ __device__(auto arch, auto... args)
+                {
+                    init_engines_mt19937<ConfigProvider, is_dynamic, arch>(args...);
+                };
+                status = system_type::template launch<ConfigProvider>(init_engines_mt19937_kernel,
+                                                                      target_arch,
+                                                                      dim3(config.blocks),
+                                                                      dim3(config.threads),
+                                                                      0,
+                                                                      m_stream,
+                                                                      m_engines,
+                                                                      d_engines);
+            });
         if(status != ROCRAND_STATUS_SUCCESS)
         {
             system_type::free(d_engines);
@@ -1016,7 +1019,8 @@ public:
             dynamic_dispatch(m_order,
                              [&, this](auto is_dynamic)
                              {
-                                 auto generate_short_mt19937_kernel = [&](auto arch, auto... args) {
+                                 auto generate_short_mt19937_kernel = [&] __host__ __device__(auto arch, auto... args)
+                                 {
                                      generate_short_mt19937<ConfigProvider,
                                                             is_dynamic,
                                                             T,
@@ -1053,7 +1057,8 @@ public:
             dynamic_dispatch(m_order,
                              [&, this](auto is_dynamic)
                              {
-                                 auto generate_long_mt19937_kernel = [&](auto arch, auto... args) {
+                                 auto generate_long_mt19937_kernel = [&] __host__ __device__(auto arch, auto... args)
+                                 {
                                      generate_long_mt19937<ConfigProvider,
                                                            is_dynamic,
                                                            T,

--- a/projects/rocrand/library/src/rng/mtgp32.hpp
+++ b/projects/rocrand/library/src/rng/mtgp32.hpp
@@ -517,8 +517,10 @@ public:
             m_order,
             [&, this](auto is_dynamic)
             {
-                auto generate_mtgp_kernel = [&](auto arch, auto... args)
-                { generate_mtgp<ConfigProvider, is_dynamic, T, Distribution, arch>(args...); };
+                auto generate_mtgp_kernel = [&] __host__ __device__(auto arch, auto... args)
+                {
+                    generate_mtgp<ConfigProvider, is_dynamic, T, Distribution, arch>(args...);
+                };
                 return system_type::template launch<ConfigProvider, T, is_dynamic>(
                     generate_mtgp_kernel,
                     target_arch,

--- a/projects/rocrand/library/src/rng/mtgp32.hpp
+++ b/projects/rocrand/library/src/rng/mtgp32.hpp
@@ -230,7 +230,11 @@ void save_head_tail(T (&output)[output_width],
     save_head_tail_impl(output, index, data, n, head_size, tail_size, vec_n_up);
 }
 
-template<class ConfigProvider, bool IsDynamic, class T, class Distribution, host::target_arch Arch = host::target_arch::unknown>
+template<class ConfigProvider,
+         bool IsDynamic,
+         class T,
+         class Distribution,
+         host::target_arch Arch = host::target_arch::unknown>
 __host__ __device__ __forceinline__
 void generate_mtgp(dim3 block_idx,
                    dim3 thread_idx,

--- a/projects/rocrand/library/src/rng/mtgp32.hpp
+++ b/projects/rocrand/library/src/rng/mtgp32.hpp
@@ -230,19 +230,20 @@ void save_head_tail(T (&output)[output_width],
     save_head_tail_impl(output, index, data, n, head_size, tail_size, vec_n_up);
 }
 
-template<class ConfigProvider, bool IsDynamic, class T, class Distribution>
-__host__ __device__ __forceinline__ void generate_mtgp(dim3 block_idx,
-                                       dim3 thread_idx,
-                                       dim3 grid_dim,
-                                       dim3 /*block_dim*/,
-                                       mtgp32_device_engine* engines,
-                                       T*                    data,
-                                       const size_t          n,
-                                       Distribution          distribution)
+template<class ConfigProvider, bool IsDynamic, class T, class Distribution, host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__ __forceinline__
+void generate_mtgp(dim3 block_idx,
+                   dim3 thread_idx,
+                   dim3 grid_dim,
+                   dim3 /*block_dim*/,
+                   mtgp32_device_engine* engines,
+                   T*                    data,
+                   const size_t          n,
+                   Distribution          distribution)
 {
-    static_assert(is_single_tile_config<ConfigProvider, T>(IsDynamic),
+    static_assert(is_single_tile_config<ConfigProvider, T, Arch>(IsDynamic),
                   "This kernel should only be used with single tile configs");
-    constexpr unsigned int BlockSize    = get_block_size<ConfigProvider, T>(IsDynamic);
+    constexpr unsigned int BlockSize    = get_block_size<ConfigProvider, T, Arch>(IsDynamic);
     constexpr unsigned int input_width  = Distribution::input_width;
     constexpr unsigned int output_width = Distribution::output_width;
 
@@ -498,26 +499,34 @@ public:
             return ROCRAND_STATUS_SUCCESS;
         }
 
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
+
         // The host generator uses a block of size one to emulate a device generator that uses a shared memory state
         const dim3 threads
             = std::is_same_v<system_type, system::device_system> ? config.threads : dim3(1);
-        status
-            = dynamic_dispatch(m_order,
-                               [&, this](auto is_dynamic)
-                               {
-                                   return system_type::template launch<
-                                       generate_mtgp<ConfigProvider, is_dynamic, T, Distribution>,
-                                       ConfigProvider,
-                                       T,
-                                       is_dynamic>(dim3(config.blocks),
-                                                   dim3(threads),
-                                                   0,
-                                                   m_stream,
-                                                   m_engines,
-                                                   data,
-                                                   data_size,
-                                                   distribution);
-                               });
+        status = dynamic_dispatch(
+            m_order,
+            [&, this](auto is_dynamic)
+            {
+                auto generate_mtgp_kernel = [&](auto arch, auto... args)
+                { generate_mtgp<ConfigProvider, is_dynamic, T, Distribution, arch>(args...); };
+                return system_type::template launch<ConfigProvider, T, is_dynamic>(
+                    generate_mtgp_kernel,
+                    target_arch,
+                    dim3(config.blocks),
+                    dim3(threads),
+                    0,
+                    m_stream,
+                    m_engines,
+                    data,
+                    data_size,
+                    distribution);
+            });
 
         // Check kernel status
         if(status != ROCRAND_STATUS_SUCCESS)

--- a/projects/rocrand/library/src/rng/philox4x32_10.hpp
+++ b/projects/rocrand/library/src/rng/philox4x32_10.hpp
@@ -105,15 +105,16 @@ struct philox4x32_10_device_engine : public ::rocrand_device::philox4x32_10_engi
     // m_state from base class
 };
 
-template<typename T, typename Distribution>
-__host__ __device__ __forceinline__ void generate_philox(dim3                        block_idx,
-                                                         dim3                        thread_idx,
-                                                         dim3                        grid_dim,
-                                                         dim3                        block_dim,
-                                                         philox4x32_10_device_engine engine,
-                                                         T*                          data,
-                                                         const size_t                n,
-                                                         Distribution                distribution)
+template<typename T, typename Distribution, host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__ __forceinline__
+void generate_philox(dim3                        block_idx,
+                     dim3                        thread_idx,
+                     dim3                        grid_dim,
+                     dim3                        block_dim,
+                     philox4x32_10_device_engine engine,
+                     T*                          data,
+                     const size_t                n,
+                     Distribution                distribution)
 {
     constexpr unsigned int input_width  = Distribution::input_width;
     constexpr unsigned int output_width = Distribution::output_width;
@@ -327,21 +328,31 @@ public:
             return ROCRAND_STATUS_SUCCESS;
         }
 
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
+
+        auto generate_philox_kernel
+            = [&](auto arch, auto... args) { generate_philox<T, Distribution, arch>(args...); };
+
         status = dynamic_dispatch(
             m_order,
             [&, this](auto is_dynamic)
             {
-                return system_type::template launch<generate_philox<T, Distribution>,
-                                                    ConfigProvider,
-                                                    T,
-                                                    is_dynamic>(dim3(config.blocks),
-                                                                dim3(config.threads),
-                                                                0,
-                                                                m_stream,
-                                                                m_engine,
-                                                                data,
-                                                                data_size,
-                                                                distribution);
+                return system_type::template launch<ConfigProvider, T, is_dynamic>(
+                    generate_philox_kernel,
+                    target_arch,
+                    dim3(config.blocks),
+                    dim3(config.threads),
+                    0,
+                    m_stream,
+                    m_engine,
+                    data,
+                    data_size,
+                    distribution);
             });
         if(status != ROCRAND_STATUS_SUCCESS)
         {

--- a/projects/rocrand/library/src/rng/sobol.hpp
+++ b/projects/rocrand/library/src/rng/sobol.hpp
@@ -70,12 +70,13 @@ Engine create_engine(const Constant*           vectors,
 
 // Use compiler-defined macro to only define the kernel once, for host and device compilation.
 #ifdef __HIP_DEVICE_COMPILE__
-template<unsigned int OutputPerThread,
-         bool         Scrambled,
+template<unsigned int      OutputPerThread,
+         bool              Scrambled,
          class Engine,
          class Constant,
          class T,
-         class Distribution>
+         class Distribution,
+         host::target_arch Arch = host::target_arch::unknown>
 void generate_sobol_host(dim3,
                          dim3,
                          dim3,
@@ -116,12 +117,13 @@ void generate_sobol_kernel(
     T*, const size_t, const Constant*, const Constant*, const unsigned int, Distribution)
 {}
 
-template<unsigned int OutputPerThread,
-         bool         Scrambled,
+template<unsigned int      OutputPerThread,
+         bool              Scrambled,
          class Engine,
          class Constant,
          class T,
-         class Distribution>
+         class Distribution,
+         host::target_arch Arch = host::target_arch::unknown>
 void generate_sobol_host(dim3               block_idx,
                          dim3               thread_idx,
                          dim3               grid_dim,
@@ -717,13 +719,27 @@ public:
         else
         {
             using block_size_provider = static_block_size_config_provider<threads>;
-            status = system_type::template launch<generate_sobol_host<output_per_thread,
-                                                                      Scrambled,
-                                                                      engine_type,
-                                                                      constant_type,
-                                                                      T,
-                                                                      Distribution>,
-                                                  block_size_provider>(dim3(blocks_x, blocks_y),
+
+            host::target_arch target_arch;
+            hipError_t        result = host::get_device_arch(m_stream, target_arch);
+            if(result != hipSuccess)
+            {
+                return ROCRAND_STATUS_INTERNAL_ERROR;
+            }
+
+            auto generate_sobol_host_kernel = [&](auto arch, auto... args)
+            {
+                generate_sobol_host<output_per_thread,
+                                    Scrambled,
+                                    engine_type,
+                                    constant_type,
+                                    T,
+                                    Distribution,
+                                    arch>(args...);
+            };
+            status = system_type::template launch<block_size_provider>(generate_sobol_host_kernel,
+                                                                       target_arch,
+                                                                       dim3(blocks_x, blocks_y),
                                                                        dim3(threads),
                                                                        shared_mem_bytes,
                                                                        m_stream,

--- a/projects/rocrand/library/src/rng/sobol.hpp
+++ b/projects/rocrand/library/src/rng/sobol.hpp
@@ -727,7 +727,7 @@ public:
                 return ROCRAND_STATUS_INTERNAL_ERROR;
             }
 
-            auto generate_sobol_host_kernel = [&](auto arch, auto... args)
+            auto generate_sobol_host_kernel = [&] __host__ __device__(auto arch, auto... args)
             {
                 generate_sobol_host<output_per_thread,
                                     Scrambled,

--- a/projects/rocrand/library/src/rng/sobol.hpp
+++ b/projects/rocrand/library/src/rng/sobol.hpp
@@ -70,8 +70,8 @@ Engine create_engine(const Constant*           vectors,
 
 // Use compiler-defined macro to only define the kernel once, for host and device compilation.
 #ifdef __HIP_DEVICE_COMPILE__
-template<unsigned int      OutputPerThread,
-         bool              Scrambled,
+template<unsigned int OutputPerThread,
+         bool         Scrambled,
          class Engine,
          class Constant,
          class T,
@@ -117,8 +117,8 @@ void generate_sobol_kernel(
     T*, const size_t, const Constant*, const Constant*, const unsigned int, Distribution)
 {}
 
-template<unsigned int      OutputPerThread,
-         bool              Scrambled,
+template<unsigned int OutputPerThread,
+         bool         Scrambled,
          class Engine,
          class Constant,
          class T,

--- a/projects/rocrand/library/src/rng/system.hpp
+++ b/projects/rocrand/library/src/rng/system.hpp
@@ -269,7 +269,7 @@ namespace detail
 
 template<typename ConfigProvider,
          typename T,
-         bool IsDynamic,
+         bool              IsDynamic,
          host::target_arch Arch,
          typename Kernel,
          typename... Args>

--- a/projects/rocrand/library/src/rng/system.hpp
+++ b/projects/rocrand/library/src/rng/system.hpp
@@ -118,41 +118,50 @@ struct host_system
         return ROCRAND_STATUS_SUCCESS;
     }
 
-    template<typename... UserArgs>
+    template<typename Kernel, typename... UserArgs>
     struct KernelArgs
     {
         dim3                    num_blocks;
         dim3                    num_threads;
+        Kernel                  f;
         std::tuple<UserArgs...> user_args;
     };
 
-    template<auto Kernel, size_t... Is, typename... Args>
-    static void invoke_kernel(dim3 block,
-                              dim3 thread,
-                              dim3 grid_dim,
-                              dim3 block_dim,
+    template<host::target_arch Arch, typename Kernel, size_t... Is, typename... Args>
+    static void invoke_kernel(Kernel f,
+                              dim3   block,
+                              dim3   thread,
+                              dim3   grid_dim,
+                              dim3   block_dim,
                               std::index_sequence<Is...>,
                               const std::tuple<Args...>& args)
     {
-        Kernel(block, thread, grid_dim, block_dim, std::get<Is>(args)...);
+        f(std::integral_constant<host::target_arch, Arch>{},
+          block,
+          thread,
+          grid_dim,
+          block_dim,
+          std::get<Is>(args)...);
     }
 
-    template<auto Kernel,
-             typename ConfigProvider
+    template<typename ConfigProvider
              = host::static_block_size_config_provider<ROCRAND_DEFAULT_MAX_BLOCK_SIZE>,
              typename T     = unsigned int,
              bool IsDynamic = false,
+             typename Kernel,
              typename... Args>
-    static rocrand_status launch(dim3                         num_blocks,
-                                 dim3                         num_threads,
-                                 unsigned int                 shared_bytes,
-                                 [[maybe_unused]] hipStream_t stream,
+    static rocrand_status launch(Kernel                             f,
+                                 [[maybe_unused]] host::target_arch arch,
+                                 dim3                               num_blocks,
+                                 dim3                               num_threads,
+                                 unsigned int                       shared_bytes,
+                                 [[maybe_unused]] hipStream_t       stream,
                                  Args... args)
     {
         (void)IsDynamic; // Not relevant on host launches
         (void)shared_bytes; // shared memory not supported on host
 
-        using KernelArgsType = KernelArgs<Args...>;
+        using KernelArgsType = KernelArgs<Kernel, Args...>;
 
         const auto kernel_callback = [](void* userdata)
         {
@@ -167,12 +176,14 @@ struct host_system
                     {
                         for(uint32_t tx = 0; tx < num_threads.x; ++tx)
                         {
-                            invoke_kernel<Kernel>(block_idx,
-                                                  dim3(tx, ty, tz),
-                                                  num_blocks,
-                                                  num_threads,
-                                                  std::make_index_sequence<sizeof...(Args)>(),
-                                                  kernel_args->user_args);
+                            invoke_kernel<host::target_arch{}, Kernel>(
+                                kernel_args->f,
+                                block_idx,
+                                dim3(tx, ty, tz),
+                                num_blocks,
+                                num_threads,
+                                std::make_index_sequence<sizeof...(Args)>(),
+                                kernel_args->user_args);
                         }
                     }
                 }
@@ -190,7 +201,7 @@ struct host_system
         };
 
         auto* kernel_args
-            = new KernelArgsType{num_blocks, num_threads, std::tuple<Args...>(args...)};
+            = new KernelArgsType{num_blocks, num_threads, f, std::tuple<Args...>(args...)};
 
         if constexpr(UseHostFunc)
         {
@@ -256,11 +267,26 @@ struct host_system
 namespace detail
 {
 
-template<auto Kernel, typename ConfigProvider, typename T, bool IsDynamic, typename... Args>
-__global__ __launch_bounds__(
-    (host::get_block_size<ConfigProvider, T>(IsDynamic))) void kernel_wrapper(Args... args)
+template<typename ConfigProvider,
+         typename T,
+         bool IsDynamic,
+         host::target_arch Arch,
+         typename Kernel,
+         typename... Args>
+__global__ __launch_bounds__((host::get_block_size<ConfigProvider, T, Arch>(IsDynamic)))
+void trampoline_kernel(Kernel f, Args... args)
 {
-    Kernel(blockIdx, threadIdx, gridDim, blockDim, args...);
+#if !defined(__SPIRV__)
+    if constexpr(Arch == host::get_device_arch())
+#endif
+    {
+        f(std::integral_constant<host::target_arch, Arch>{},
+          blockIdx,
+          threadIdx,
+          gridDim,
+          blockDim,
+          args...);
+    }
 }
 
 } // namespace detail
@@ -299,20 +325,39 @@ struct device_system
         return ROCRAND_STATUS_SUCCESS;
     }
 
-    template<auto Kernel,
-             typename ConfigProvider
+    template<typename ConfigProvider
              = host::static_block_size_config_provider<ROCRAND_DEFAULT_MAX_BLOCK_SIZE>,
              typename T     = unsigned int,
              bool IsDynamic = false,
+             typename Kernel,
              typename... Args>
-    static rocrand_status launch(dim3         num_blocks,
-                                 dim3         num_threads,
-                                 unsigned int shared_bytes,
-                                 hipStream_t  stream,
+    static rocrand_status launch(Kernel            f,
+                                 host::target_arch arch,
+                                 dim3              num_blocks,
+                                 dim3              num_threads,
+                                 unsigned int      shared_bytes,
+                                 hipStream_t       stream,
                                  Args... args)
     {
-        detail::kernel_wrapper<Kernel, ConfigProvider, T, IsDynamic>
-            <<<num_blocks, num_threads, shared_bytes, stream>>>(args...);
+        bool launched = false;
+        host::for_each_arch(
+            [&](auto arch_tag)
+            {
+                if(arch_tag != arch)
+                {
+                    return;
+                }
+
+                detail::trampoline_kernel<ConfigProvider, T, IsDynamic, arch_tag>
+                    <<<num_blocks, num_threads, shared_bytes, stream>>>(f, args...);
+
+                launched = true;
+            });
+        if(!launched)
+        {
+            detail::trampoline_kernel<ConfigProvider, T, IsDynamic, host::target_arch::unknown>
+                <<<num_blocks, num_threads, shared_bytes, stream>>>(f, args...);
+        }
         if(hipGetLastError() != hipSuccess)
         {
             return ROCRAND_STATUS_LAUNCH_FAILURE;

--- a/projects/rocrand/library/src/rng/threefry.hpp
+++ b/projects/rocrand/library/src/rng/threefry.hpp
@@ -84,7 +84,10 @@ struct threefry_device_engine : public BaseType
     // m_state from base class
 };
 
-template<class Engine, class T, class Distribution, host::target_arch Arch = host::target_arch::unknown>
+template<class Engine,
+         class T,
+         class Distribution,
+         host::target_arch Arch = host::target_arch::unknown>
 __host__ __device__ __forceinline__
 void generate_threefry(dim3         block_idx,
                        dim3         thread_idx,

--- a/projects/rocrand/library/src/rng/threefry.hpp
+++ b/projects/rocrand/library/src/rng/threefry.hpp
@@ -355,8 +355,10 @@ public:
                 return ROCRAND_STATUS_INTERNAL_ERROR;
             }
 
-            auto generate_threefry_kernel = [&](auto arch, auto... args)
-            { generate_threefry<engine_type, T, Distribution, arch>(args...); };
+            auto generate_threefry_kernel = [&] __host__ __device__(auto arch, auto... args)
+            {
+                generate_threefry<engine_type, T, Distribution, arch>(args...);
+            };
 
             status = dynamic_dispatch(
                 m_order,

--- a/projects/rocrand/library/src/rng/threefry.hpp
+++ b/projects/rocrand/library/src/rng/threefry.hpp
@@ -84,15 +84,16 @@ struct threefry_device_engine : public BaseType
     // m_state from base class
 };
 
-template<class Engine, class T, class Distribution>
-__host__ __device__ __forceinline__ void generate_threefry(dim3         block_idx,
-                                                           dim3         thread_idx,
-                                                           dim3         grid_dim,
-                                                           dim3         block_dim,
-                                                           Engine       engine,
-                                                           T*           data,
-                                                           const size_t n,
-                                                           Distribution distribution)
+template<class Engine, class T, class Distribution, host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__ __forceinline__
+void generate_threefry(dim3         block_idx,
+                       dim3         thread_idx,
+                       dim3         grid_dim,
+                       dim3         block_dim,
+                       Engine       engine,
+                       T*           data,
+                       const size_t n,
+                       Distribution distribution)
 {
     using engine_scalar_type = typename Engine::scalar_type;
 
@@ -344,22 +345,32 @@ public:
                 return ROCRAND_STATUS_SUCCESS;
             }
 
-            status = dynamic_dispatch(m_order,
-                                      [&, this](auto is_dynamic)
-                                      {
-                                          return system_type::template launch<
-                                              generate_threefry<engine_type, T, Distribution>,
-                                              ConfigProvider,
-                                              T,
-                                              is_dynamic>(dim3(config.blocks),
-                                                          dim3(config.threads),
-                                                          0,
-                                                          m_stream,
-                                                          m_engine,
-                                                          data,
-                                                          data_size,
-                                                          distribution);
-                                      });
+            host::target_arch target_arch;
+            hipError_t        result = host::get_device_arch(m_stream, target_arch);
+            if(result != hipSuccess)
+            {
+                return ROCRAND_STATUS_INTERNAL_ERROR;
+            }
+
+            auto generate_threefry_kernel = [&](auto arch, auto... args)
+            { generate_threefry<engine_type, T, Distribution, arch>(args...); };
+
+            status = dynamic_dispatch(
+                m_order,
+                [&, this](auto is_dynamic)
+                {
+                    return system_type::template launch<ConfigProvider, T, is_dynamic>(
+                        generate_threefry_kernel,
+                        target_arch,
+                        dim3(config.blocks),
+                        dim3(config.threads),
+                        0,
+                        m_stream,
+                        m_engine,
+                        data,
+                        data_size,
+                        distribution);
+                });
 
             // Check kernel status
             if(status != ROCRAND_STATUS_SUCCESS)

--- a/projects/rocrand/library/src/rng/xorwow.hpp
+++ b/projects/rocrand/library/src/rng/xorwow.hpp
@@ -386,8 +386,10 @@ public:
             m_order,
             [&, this](auto is_dynamic)
             {
-                auto generate_xorwow_kernel = [&](auto arch, auto... args)
-                { generate_xorwow<ConfigProvider, is_dynamic, T, Distribution, arch>(args...); };
+                auto generate_xorwow_kernel = [&] __host__ __device__(auto arch, auto... args)
+                {
+                    generate_xorwow<ConfigProvider, is_dynamic, T, Distribution, arch>(args...);
+                };
                 return system_type::template launch<ConfigProvider, T, is_dynamic>(
                     generate_xorwow_kernel,
                     target_arch,

--- a/projects/rocrand/library/src/rng/xorwow.hpp
+++ b/projects/rocrand/library/src/rng/xorwow.hpp
@@ -64,7 +64,11 @@ inline void init_xorwow_engines(dim3 block_idx,
     }
 }
 
-template<class ConfigProvider, bool IsDynamic, class T, class Distribution, host::target_arch Arch = host::target_arch::unknown>
+template<class ConfigProvider,
+         bool IsDynamic,
+         class T,
+         class Distribution,
+         host::target_arch Arch = host::target_arch::unknown>
 __host__ __device__ __forceinline__
 void generate_xorwow(dim3 block_idx,
                      dim3 thread_idx,

--- a/projects/rocrand/library/src/rng/xorwow.hpp
+++ b/projects/rocrand/library/src/rng/xorwow.hpp
@@ -44,15 +44,17 @@ namespace rocrand_impl::host
 
 typedef ::rocrand_device::xorwow_engine xorwow_device_engine;
 
-__host__ __device__ inline void init_xorwow_engines(dim3 block_idx,
-                                                    dim3 thread_idx,
-                                                    dim3 /*grid_dim*/,
-                                                    dim3                  block_dim,
-                                                    xorwow_device_engine* engines,
-                                                    const unsigned int    start_engine_id,
-                                                    const unsigned int    engines_size,
-                                                    unsigned long long    seed,
-                                                    unsigned long long    offset)
+template<host::target_arch>
+__host__ __device__
+inline void init_xorwow_engines(dim3 block_idx,
+                                dim3 thread_idx,
+                                dim3 /*grid_dim*/,
+                                dim3                  block_dim,
+                                xorwow_device_engine* engines,
+                                const unsigned int    start_engine_id,
+                                const unsigned int    engines_size,
+                                unsigned long long    seed,
+                                unsigned long long    offset)
 {
     const unsigned int engine_id = block_idx.x * block_dim.x + thread_idx.x;
     if(engine_id < engines_size)
@@ -62,20 +64,21 @@ __host__ __device__ inline void init_xorwow_engines(dim3 block_idx,
     }
 }
 
-template<class ConfigProvider, bool IsDynamic, class T, class Distribution>
-__host__ __device__ __forceinline__ void generate_xorwow(dim3 block_idx,
-                                         dim3 thread_idx,
-                                         dim3 grid_dim,
-                                         dim3 /*block_dim*/,
-                                         xorwow_device_engine* engines,
-                                         const unsigned int    start_engine_id,
-                                         T*                    data,
-                                         const size_t          n,
-                                         Distribution          distribution)
+template<class ConfigProvider, bool IsDynamic, class T, class Distribution, host::target_arch Arch = host::target_arch::unknown>
+__host__ __device__ __forceinline__
+void generate_xorwow(dim3 block_idx,
+                     dim3 thread_idx,
+                     dim3 grid_dim,
+                     dim3 /*block_dim*/,
+                     xorwow_device_engine* engines,
+                     const unsigned int    start_engine_id,
+                     T*                    data,
+                     const size_t          n,
+                     Distribution          distribution)
 {
-    static_assert(is_single_tile_config<ConfigProvider, T>(IsDynamic),
+    static_assert(is_single_tile_config<ConfigProvider, T, Arch>(IsDynamic),
                   "This kernel should only be used with single tile configs");
-    constexpr unsigned int BlockSize    = get_block_size<ConfigProvider, T>(IsDynamic);
+    constexpr unsigned int BlockSize    = get_block_size<ConfigProvider, T, Arch>(IsDynamic);
     constexpr unsigned int input_width  = Distribution::input_width;
     constexpr unsigned int output_width = Distribution::output_width;
 
@@ -294,6 +297,13 @@ public:
             return ROCRAND_STATUS_INTERNAL_ERROR;
         }
 
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
+
         m_start_engine_id = m_offset % m_engines_size;
 
         if(m_engines != nullptr)
@@ -309,8 +319,12 @@ public:
         constexpr unsigned int init_threads = ROCRAND_DEFAULT_MAX_BLOCK_SIZE;
         const unsigned int     init_blocks  = (m_engines_size + init_threads - 1) / init_threads;
 
-        status = system_type::template launch<init_xorwow_engines,
-                                              static_block_size_config_provider<init_threads>>(
+        auto init_xorwow_engines_kernel
+            = [&](auto arch, auto... args) { init_xorwow_engines<arch>(args...); };
+
+        status = system_type::template launch<static_block_size_config_provider<init_threads>>(
+            init_xorwow_engines_kernel,
+            target_arch,
             dim3(init_blocks),
             dim3(init_threads),
             0,
@@ -357,25 +371,32 @@ public:
             return ROCRAND_STATUS_SUCCESS;
         }
 
-        status
-            = dynamic_dispatch(m_order,
-                               [&, this](auto is_dynamic)
-                               {
-                                   return system_type::template launch<
+        host::target_arch target_arch;
+        hipError_t        result = host::get_device_arch(m_stream, target_arch);
+        if(result != hipSuccess)
+        {
+            return ROCRAND_STATUS_INTERNAL_ERROR;
+        }
 
-                                       generate_xorwow<ConfigProvider, is_dynamic, T, Distribution>,
-                                       ConfigProvider,
-                                       T,
-                                       is_dynamic>(dim3(config.blocks),
-                                                   dim3(config.threads),
-                                                   0,
-                                                   m_stream,
-                                                   m_engines,
-                                                   m_start_engine_id,
-                                                   data,
-                                                   data_size,
-                                                   distribution);
-                               });
+        status = dynamic_dispatch(
+            m_order,
+            [&, this](auto is_dynamic)
+            {
+                auto generate_xorwow_kernel = [&](auto arch, auto... args)
+                { generate_xorwow<ConfigProvider, is_dynamic, T, Distribution, arch>(args...); };
+                return system_type::template launch<ConfigProvider, T, is_dynamic>(
+                    generate_xorwow_kernel,
+                    target_arch,
+                    dim3(config.blocks),
+                    dim3(config.threads),
+                    0,
+                    m_stream,
+                    m_engines,
+                    m_start_engine_id,
+                    data,
+                    data_size,
+                    distribution);
+            });
 
         // Check kernel status
         if(status != ROCRAND_STATUS_SUCCESS)

--- a/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
@@ -178,8 +178,10 @@ template<class ConfigProvider>
 __global__
 void least_common_grid_size_kernel(unsigned int* least_common_grid_size, rocrand_ordering order)
 {
-    *least_common_grid_size = rocrand_impl::host::get_least_common_grid_size<ConfigProvider, rocrand_impl::host::target_arch{}>(
-        rocrand_impl::host::is_ordering_dynamic(order));
+    *least_common_grid_size
+        = rocrand_impl::host::get_least_common_grid_size<ConfigProvider,
+                                                         rocrand_impl::host::target_arch{}>(
+            rocrand_impl::host::is_ordering_dynamic(order));
 }
 
 TEST(rocrand_config_dispatch_tests, default_config_provider)

--- a/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
@@ -178,7 +178,7 @@ template<class ConfigProvider>
 __global__
 void least_common_grid_size_kernel(unsigned int* least_common_grid_size, rocrand_ordering order)
 {
-    *least_common_grid_size = rocrand_impl::host::get_least_common_grid_size<ConfigProvider>(
+    *least_common_grid_size = rocrand_impl::host::get_least_common_grid_size<ConfigProvider, rocrand_impl::host::target_arch{}>(
         rocrand_impl::host::is_ordering_dynamic(order));
 }
 

--- a/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
@@ -24,10 +24,15 @@
 #include <gtest/gtest.h>
 
 __global__
-void write_target_arch(rocrand_impl::host::target_arch* dest_arch)
+void write_target_arch([[maybe_unused]] rocrand_impl::host::target_arch host_arch,
+                       int* __restrict__ result)
 {
+#if !defined(__SPIRV__)
     constexpr auto arch = rocrand_impl::host::get_device_arch();
-    *dest_arch          = arch;
+    *result = arch == host_arch;
+#else
+    *result = -1;
+#endif
 }
 
 static constexpr rocrand_rng_type dummy_rng_type = rocrand_rng_type(0);
@@ -79,19 +84,26 @@ TEST(rocrand_config_dispatch_tests, host_matches_device)
     rocrand_impl::host::target_arch host_arch;
     HIP_CHECK(rocrand_impl::host::get_device_arch(stream, host_arch));
 
-    rocrand_impl::host::target_arch* device_arch_ptr;
-    HIP_CHECK(hipMallocHelper(&device_arch_ptr, sizeof(*device_arch_ptr)));
+    int* result_ptr = nullptr;
+    HIP_CHECK(hipMallocHelper(&result_ptr, sizeof(result_ptr)));
 
-    hipLaunchKernelGGL(write_target_arch, dim3(1), dim3(1), 0, stream, device_arch_ptr);
+    hipLaunchKernelGGL(write_target_arch, dim3(1), dim3(1), 0, stream, host_arch, result_ptr);
     HIP_CHECK(hipGetLastError());
 
-    rocrand_impl::host::target_arch device_arch;
-    HIP_CHECK(hipMemcpy(&device_arch, device_arch_ptr, sizeof(device_arch), hipMemcpyDeviceToHost));
+    int result = -1;
+    HIP_CHECK(hipMemcpy(&result, result_ptr, sizeof(result), hipMemcpyDeviceToHost));
 
-    ASSERT_NE(host_arch, rocrand_impl::host::target_arch::invalid);
-    ASSERT_EQ(host_arch, device_arch);
+    if(result != -1)
+    {
+        ASSERT_NE(host_arch, rocrand_impl::host::target_arch::invalid);
+        ASSERT_EQ(result, 1);
+    }
+    else
+    {
+        GTEST_SKIP() << "SPIR-V build: result is null; skipping arch match assertion.";
+    }
 
-    HIP_CHECK(hipFree(device_arch_ptr));
+    HIP_CHECK(hipFree(result_ptr));
 }
 
 TEST(rocrand_config_dispatch_tests, parse_common_architectures)

--- a/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_config_dispatch.cpp
@@ -29,6 +29,7 @@ void write_target_arch([[maybe_unused]] rocrand_impl::host::target_arch host_arc
 {
 #if !defined(__SPIRV__)
     constexpr auto arch = rocrand_impl::host::get_device_arch();
+
     *result = arch == host_arch;
 #else
     *result = -1;

--- a/projects/rocrand/test/internal/test_rocrand_mt19937_prng.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_mt19937_prng.cpp
@@ -760,7 +760,7 @@ TYPED_TEST(mt19937_generator_engine_tests, subsequence_test)
 
     // dummy config provider, kernel just needs to verify the amount of generators for the actual call
     using ConfigProvider = default_config_provider<ROCRAND_RNG_PSEUDO_MT19937>;
-    auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args)
+    auto jump_ahead_mt19937_kernel = [&] __host__ __device__(auto arch, auto... args)
     {
         rocrand_impl::host::
             jump_ahead_mt19937<generator_t::jump_ahead_thread_count, ConfigProvider, false, arch>(
@@ -1185,7 +1185,7 @@ TYPED_TEST(mt19937_generator_engine_tests, jump_ahead_test)
         {
             rocrand_impl::host::target_arch target_arch;
             HIP_CHECK(rocrand_impl::host::get_device_arch(0, target_arch));
-            auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args)
+            auto jump_ahead_mt19937_kernel = [&] __host__ __device__(auto arch, auto... args)
             {
                 rocrand_impl::host::jump_ahead_mt19937<generator_t::jump_ahead_thread_count,
                                                        ConfigProvider,

--- a/projects/rocrand/test/internal/test_rocrand_mt19937_prng.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_mt19937_prng.cpp
@@ -760,11 +760,13 @@ TYPED_TEST(mt19937_generator_engine_tests, subsequence_test)
 
     // dummy config provider, kernel just needs to verify the amount of generators for the actual call
     using ConfigProvider = default_config_provider<ROCRAND_RNG_PSEUDO_MT19937>;
-    auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args) {
-        rocrand_impl::host::jump_ahead_mt19937<generator_t::jump_ahead_thread_count, ConfigProvider, false, arch>(
-                        args...);
-                };
-    
+    auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args)
+    {
+        rocrand_impl::host::
+            jump_ahead_mt19937<generator_t::jump_ahead_thread_count, ConfigProvider, false, arch>(
+                args...);
+    };
+
     rocrand_status status = rocrand_impl::system::device_system::template launch<
         rocrand_impl::host::static_block_size_config_provider<
             generator_t::jump_ahead_thread_count>>(jump_ahead_mt19937_kernel,
@@ -1183,12 +1185,13 @@ TYPED_TEST(mt19937_generator_engine_tests, jump_ahead_test)
         {
             rocrand_impl::host::target_arch target_arch;
             HIP_CHECK(rocrand_impl::host::get_device_arch(0, target_arch));
-            auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args) {
-            rocrand_impl::host::jump_ahead_mt19937<generator_t::jump_ahead_thread_count,
+            auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args)
+            {
+                rocrand_impl::host::jump_ahead_mt19937<generator_t::jump_ahead_thread_count,
                                                        ConfigProvider,
-                                                       is_dynamic, arch>(
-                        args...);
-                };
+                                                       is_dynamic,
+                                                       arch>(args...);
+            };
             rocrand_status status = rocrand_impl::system::device_system::template launch<
                 rocrand_impl::host::static_block_size_config_provider<
                     generator_t::jump_ahead_thread_count>>(

--- a/projects/rocrand/test/internal/test_rocrand_mt19937_prng.cpp
+++ b/projects/rocrand/test/internal/test_rocrand_mt19937_prng.cpp
@@ -755,14 +755,21 @@ TYPED_TEST(mt19937_generator_engine_tests, subsequence_test)
     unsigned int* d_engines{};
     HIP_CHECK(hipMalloc(&d_engines, generator_count * state_size * sizeof(unsigned int)));
 
+    rocrand_impl::host::target_arch target_arch;
+    HIP_CHECK(rocrand_impl::host::get_device_arch(0, target_arch));
+
     // dummy config provider, kernel just needs to verify the amount of generators for the actual call
     using ConfigProvider = default_config_provider<ROCRAND_RNG_PSEUDO_MT19937>;
-
+    auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args) {
+        rocrand_impl::host::jump_ahead_mt19937<generator_t::jump_ahead_thread_count, ConfigProvider, false, arch>(
+                        args...);
+                };
+    
     rocrand_status status = rocrand_impl::system::device_system::template launch<
-        rocrand_impl::host::
-            jump_ahead_mt19937<generator_t::jump_ahead_thread_count, ConfigProvider, false>,
         rocrand_impl::host::static_block_size_config_provider<
-            generator_t::jump_ahead_thread_count>>(dim3(generator_count),
+            generator_t::jump_ahead_thread_count>>(jump_ahead_mt19937_kernel,
+                                                   target_arch,
+                                                   dim3(generator_count),
                                                    dim3(generator_t::jump_ahead_thread_count),
                                                    0,
                                                    0,
@@ -1174,12 +1181,19 @@ TYPED_TEST(mt19937_generator_engine_tests, jump_ahead_test)
         ROCRAND_ORDERING_PSEUDO_DEFAULT,
         [&](auto is_dynamic)
         {
-            rocrand_status status = rocrand_impl::system::device_system::template launch<
-                rocrand_impl::host::jump_ahead_mt19937<generator_t::jump_ahead_thread_count,
+            rocrand_impl::host::target_arch target_arch;
+            HIP_CHECK(rocrand_impl::host::get_device_arch(0, target_arch));
+            auto jump_ahead_mt19937_kernel = [&](auto arch, auto... args) {
+            rocrand_impl::host::jump_ahead_mt19937<generator_t::jump_ahead_thread_count,
                                                        ConfigProvider,
-                                                       is_dynamic>,
+                                                       is_dynamic, arch>(
+                        args...);
+                };
+            rocrand_status status = rocrand_impl::system::device_system::template launch<
                 rocrand_impl::host::static_block_size_config_provider<
                     generator_t::jump_ahead_thread_count>>(
+                jump_ahead_mt19937_kernel,
+                target_arch,
                 dim3(generator_count),
                 dim3(generator_t::jump_ahead_thread_count),
                 0,


### PR DESCRIPTION
## Motivation

We need to let rocRAND also use correct configuration when targetting SPIR-V.

## Technical Details

In `system.hpp`, `trampoline_kernel` is introduced to replace the old `kernel_wrapper` for device rng, so that kernels with all supported arches can be compiled during host pass.

Using `for_each_arch`, the arches are iterated in one override of `system_type::template launch` (device_system::launch). The other `launch` template (host_system::launch), and the `invoke_kernel` it calls are also changed to keep the API consistent.

In some device functions, the architecture was needed in the function body, like in `generate_lfsr113` it's needed for `is_single_tile_config<ConfigProvider, T, Arch>`, so a lambda function like `generate_lfsr113_kernel` was introduced, specifically for the arch can only be specified in `for_each_arch` in `system_type::template launch`.

The `host_matches_device` test in `test_rocrand_config_dispatch.cpp` is changed, for `get_device_arch` is not meaningful when targetting SPIR-V, thus this test is changed so that it only tests when targetting generic arches.

A small change in `rocPRIM` is also applied.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
