### PR TITLE
[MIOpen] reduce boost usage: optional, any

### DIFF
--- a/projects/miopen/driver/InputFlags.hpp
+++ b/projects/miopen/driver/InputFlags.hpp
@@ -28,8 +28,6 @@
 
 #include <miopen/miopen.h>
 
-#include <boost/optional.hpp>
-
 #include <map>
 #include <string>
 #include <vector>

--- a/projects/miopen/driver/conv_driver.hpp
+++ b/projects/miopen/driver/conv_driver.hpp
@@ -51,21 +51,17 @@
 
 #include <../test/cpu_bias.hpp>
 #include <../test/cpu_conv.hpp>
-#include <../test/serialize.hpp>
 #include <../test/tensor_holder.hpp>
 #include <../test/verify.hpp>
 
-#include <boost/optional.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <boost/range/adaptors.hpp>
 
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
-#include <float.h>
 #include <fstream>
 #include <memory>
-#include <numeric>
+#include <optional>
 #include <sstream>
 #include <type_traits>
 #include <vector>
@@ -350,7 +346,7 @@ private:
 
     InputFlags inflags;
 
-    boost::optional<uint64_t> immediate_solution;
+    std::optional<uint64_t> immediate_solution;
 
     GpumemTensor<Tgpu> in;
     GpumemVector<Tgpu> din;

--- a/projects/miopen/src/anyramdb.cpp
+++ b/projects/miopen/src/anyramdb.cpp
@@ -34,7 +34,6 @@
 #include <chrono>
 #include <ctime>
 #include <fstream>
-#include <limits>
 #include <map>
 #include <mutex>
 #include <sstream>
@@ -66,7 +65,7 @@ AnyRamDb& AnyRamDb::GetCached(const fs::path& path)
     return *instances.emplace(path, std::make_unique<AnyRamDb>(path)).first->second;
 }
 
-boost::optional<AnyRamDb::TRecord> AnyRamDb::FindRecord(const std::string& problem)
+std::optional<AnyRamDb::TRecord> AnyRamDb::FindRecord(const std::string& problem)
 {
     const auto lock = exclusive_lock(lock_file, GetLockTimeout());
     MIOPEN_VALIDATE_LOCK(lock);
@@ -91,13 +90,13 @@ bool AnyRamDb::RemoveRecord(const std::string& key)
     return true;
 }
 
-boost::optional<AnyRamDb::TRecord> AnyRamDb::FindRecordUnsafe(const std::string& problem)
+std::optional<AnyRamDb::TRecord> AnyRamDb::FindRecordUnsafe(const std::string& problem)
 {
     MIOPEN_LOG_I2("Looking for key " << problem << " in cache for file " << filename);
     const auto it = cache.find(problem);
 
     if(it == cache.end())
-        return boost::none;
+        return {};
 
     return it->second;
 }

--- a/projects/miopen/src/anyramdb.cpp
+++ b/projects/miopen/src/anyramdb.cpp
@@ -36,6 +36,7 @@
 #include <fstream>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <sstream>
 
 namespace miopen {

--- a/projects/miopen/src/comgr.cpp
+++ b/projects/miopen/src/comgr.cpp
@@ -641,8 +641,9 @@ void BuildAsm(const std::string& name,
         action.SetLogging(true);
         auto optAsm = miopen::SplitSpaceSeparated(options);
 #if WORKAROUND_ISSUE_3001
-        if(target.Xnack() && !*target.Xnack())
-            optAsm.emplace_back("-mno-xnack");
+        if(const auto xnack = target.Xnack(); xnack.has_value())
+            if(!*xnack)
+                optAsm.emplace_back("-mno-xnack");
 #endif
         compiler::lc::gcnasm::RemoveOptionsUnwanted(optAsm);
 #if WORKAROUND_ROCMCOMPILERSUPPORT_ISSUE_67

--- a/projects/miopen/src/comgr.cpp
+++ b/projects/miopen/src/comgr.cpp
@@ -641,9 +641,8 @@ void BuildAsm(const std::string& name,
         action.SetLogging(true);
         auto optAsm = miopen::SplitSpaceSeparated(options);
 #if WORKAROUND_ISSUE_3001
-        if(const auto xnack = target.Xnack(); xnack.has_value())
-            if(!*xnack)
-                optAsm.emplace_back("-mno-xnack");
+        if(!target.isXnackEnabled())
+            optAsm.emplace_back("-mno-xnack");
 #endif
         compiler::lc::gcnasm::RemoveOptionsUnwanted(optAsm);
 #if WORKAROUND_ROCMCOMPILERSUPPORT_ISSUE_67

--- a/projects/miopen/src/conv/heuristics/ai_heuristics.cpp
+++ b/projects/miopen/src/conv/heuristics/ai_heuristics.cpp
@@ -513,8 +513,8 @@ GetCachedPrediction(const conv::ProblemDescription& problem, const std::string& 
     MIOPEN_LOG_I2("Cached " << model_type << "heuristic (TunaNet) result found");
 
     std::vector<uint64_t> db_sol(db_res->size());
-    std::transform(db_res->begin(), db_res->end(), db_sol.begin(), [](boost::any id) {
-        return boost::any_cast<uint64_t>(id);
+    std::transform(db_res->begin(), db_res->end(), db_sol.begin(), [](std::any id) {
+        return std::any_cast<uint64_t>(id);
     });
 
     if(miopen::IsLogging(LoggingLevel::Info2))
@@ -538,7 +538,7 @@ GetCachedPrediction(const conv::ProblemDescription& problem, const std::string& 
 void StorePredictionCache(const conv::ProblemDescription& problem,
                           const std::string& device,
                           bool is3d,
-                          std::vector<boost::any>& any_sol)
+                          std::vector<std::any>& any_sol)
 {
     std::string est_name = is3d ? (":memory:3d_" + device) : (":memory:" + device);
     auto& db             = AnyRamDb::GetCached(est_name);
@@ -550,8 +550,8 @@ void StorePredictionCache(const conv::ProblemDescription& problem,
  */
 struct PredictionResult
 {
-    std::vector<uint64_t> solver_ids;       ///< Sorted solver IDs by probability
-    std::vector<boost::any> any_solver_ids; ///< Same IDs in boost::any format for caching
+    std::vector<uint64_t> solver_ids;     ///< Sorted solver IDs by probability
+    std::vector<std::any> any_solver_ids; ///< Same IDs in std::any format for caching
 };
 
 /**

--- a/projects/miopen/src/conv/heuristics/ai_heuristics.cpp
+++ b/projects/miopen/src/conv/heuristics/ai_heuristics.cpp
@@ -37,6 +37,8 @@
 #include <miopen/filesystem.hpp>
 #include <miopen/env.hpp>
 
+#include <any>
+
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_AI_FDEEP_USE_SINGLE_THREAD_PREDICT)
 
 // 3D AI heuristics - now declared properly in header

--- a/projects/miopen/src/conv/invokers/impl_gemm.cpp
+++ b/projects/miopen/src/conv/invokers/impl_gemm.cpp
@@ -8,8 +8,6 @@
 #include <miopen/handle.hpp>
 #include <miopen/tensor_ops.hpp>
 
-#include <boost/any.hpp>
-
 namespace miopen {
 namespace conv {
 

--- a/projects/miopen/src/conv/invokers/impl_gemm_dynamic.cpp
+++ b/projects/miopen/src/conv/invokers/impl_gemm_dynamic.cpp
@@ -4,12 +4,10 @@
 #include <miopen/buffer_info.hpp>
 #include <miopen/conv/invokers/impl_gemm_dynamic.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
-#include <miopen/algorithm.hpp>
 #include <miopen/handle.hpp>
 #include <miopen/tensor_ops.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/batched_transpose_sol.hpp>
-#include <boost/any.hpp>
 #include <miopen/solver/problem_description_interpreter.hpp>
 
 namespace miopen {

--- a/projects/miopen/src/conv/invokers/mlir_impl_gemm.cpp
+++ b/projects/miopen/src/conv/invokers/mlir_impl_gemm.cpp
@@ -34,7 +34,6 @@
 
 #include <Miir.h>
 
-#include <boost/any.hpp>
 #include <boost/range/adaptors.hpp>
 
 #if MIIR_VERSION_FLAT >= 6

--- a/projects/miopen/src/db.cpp
+++ b/projects/miopen/src/db.cpp
@@ -209,7 +209,7 @@ std::optional<DbRecord> PlainTextDb::FindRecordUnsafe(const std::string& key, Re
         return record;
     }
     // Record was not found
-    return std::nullopt;
+    return {};
 }
 
 static void Copy(std::istream& from, std::ostream& to, std::streamoff count)

--- a/projects/miopen/src/db.cpp
+++ b/projects/miopen/src/db.cpp
@@ -31,8 +31,6 @@
 #include <miopen/filesystem.hpp>
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -84,7 +82,7 @@ static std::chrono::seconds GetLockTimeout() { return std::chrono::seconds{60}; 
 using exclusive_lock = std::unique_lock<LockFile>;
 using shared_lock    = std::shared_lock<LockFile>;
 
-boost::optional<DbRecord> PlainTextDb::FindRecord(const std::string& key)
+std::optional<DbRecord> PlainTextDb::FindRecord(const std::string& key)
 {
     if(DisableUserDbFileIO)
         return {};
@@ -135,7 +133,7 @@ bool PlainTextDb::Remove(const std::string& key, const std::string& id)
     return StoreRecordUnsafe(*record);
 }
 
-boost::optional<DbRecord> PlainTextDb::FindRecordUnsafe(const std::string& key,
+std::optional<DbRecord> PlainTextDb::FindRecordUnsafe(const std::string& key,
                                                         RecordPositions* pos)
 {
     if(pos != nullptr)
@@ -154,7 +152,7 @@ boost::optional<DbRecord> PlainTextDb::FindRecordUnsafe(const std::string& key,
                                    ? LoggingLevel::Warning
                                    : LoggingLevel::Info2;
         MIOPEN_LOG(log_level, "File is unreadable: " << filename);
-        return boost::none;
+        return {};
     }
 
     int n_line = 0;
@@ -212,7 +210,7 @@ boost::optional<DbRecord> PlainTextDb::FindRecordUnsafe(const std::string& key,
         return record;
     }
     // Record was not found
-    return boost::none;
+    return std::nullopt;
 }
 
 static void Copy(std::istream& from, std::ostream& to, std::streamoff count)

--- a/projects/miopen/src/db.cpp
+++ b/projects/miopen/src/db.cpp
@@ -39,6 +39,7 @@
 #include <fstream>
 #include <ios>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <vector>

--- a/projects/miopen/src/db.cpp
+++ b/projects/miopen/src/db.cpp
@@ -133,8 +133,7 @@ bool PlainTextDb::Remove(const std::string& key, const std::string& id)
     return StoreRecordUnsafe(*record);
 }
 
-std::optional<DbRecord> PlainTextDb::FindRecordUnsafe(const std::string& key,
-                                                        RecordPositions* pos)
+std::optional<DbRecord> PlainTextDb::FindRecordUnsafe(const std::string& key, RecordPositions* pos)
 {
     if(pos != nullptr)
     {

--- a/projects/miopen/src/env_debug.cpp
+++ b/projects/miopen/src/env_debug.cpp
@@ -28,6 +28,7 @@
 #include <charconv>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <type_traits>
 #include <unordered_map>
 

--- a/projects/miopen/src/env_debug.cpp
+++ b/projects/miopen/src/env_debug.cpp
@@ -112,7 +112,7 @@ private:
         std::optional<std::string> Get() const override
         {
             if(!var)
-                return std::nullopt;
+                return {};
 
             const auto value = miopen::env::value(var);
 

--- a/projects/miopen/src/find_controls.cpp
+++ b/projects/miopen/src/find_controls.cpp
@@ -33,13 +33,11 @@
 #include <miopen/solver_id.hpp>
 #include <miopen/stringutils.hpp>
 
-#include <boost/optional.hpp>
-
-#include <ostream>
 #include <cstdlib>
 #include <cstring>
-#include <string_view>
 #include <optional>
+#include <ostream>
+#include <string_view>
 
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_FIND_ENFORCE)
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_DEBUG_FIND_ONLY_SOLVER)
@@ -117,7 +115,7 @@ FindEnforceAction GetFindEnforceActionImpl()
     return FindEnforceAction::Default_;
 }
 
-boost::optional<std::vector<solver::Id>> GetEnvFindOnlySolverImpl()
+std::optional<std::vector<solver::Id>> GetEnvFindOnlySolverImpl()
 {
     static_assert(miopen::solver::Id::invalid_value == 0, "miopen::solver::Id::invalid_value == 0");
     const auto slv_str = env::value(MIOPEN_DEBUG_FIND_ONLY_SOLVER);
@@ -159,7 +157,7 @@ boost::optional<std::vector<solver::Id>> GetEnvFindOnlySolverImpl()
         }
     }
     if(res.empty())
-        return boost::none;
+        return {};
     else
         return {res};
 }
@@ -173,10 +171,10 @@ std::ostream& operator<<(std::ostream& os, const FindEnforce& val)
     return os << ToCString(val.action) << '(' << static_cast<int>(val.action) << ')';
 }
 
-boost::optional<std::vector<solver::Id>> GetEnvFindOnlySolver()
+std::optional<std::vector<solver::Id>> GetEnvFindOnlySolver()
 {
     if(miopen::debug::IsWarmupOngoing)
-        return boost::none;
+        return {};
     static const auto once = GetEnvFindOnlySolverImpl();
     return once;
 }

--- a/projects/miopen/src/find_db.cpp
+++ b/projects/miopen/src/find_db.cpp
@@ -44,10 +44,10 @@ namespace debug {
 MIOPEN_EXPORT bool testing_find_db_enabled = true;
 
 /// \todo Remove when #1723 is resolved.
-boost::optional<fs::path>& testing_find_db_path_override()
+std::optional<fs::path>& testing_find_db_path_override()
 {
     // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
-    static boost::optional<fs::path> data = boost::none;
+    static std::optional<fs::path> data{std::nullopt};
     return data;
 }
 

--- a/projects/miopen/src/find_db.cpp
+++ b/projects/miopen/src/find_db.cpp
@@ -33,6 +33,8 @@
 #include <miopen_data.hpp>
 #endif
 #include <miopen/filesystem.hpp>
+
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -233,22 +235,29 @@ bool FindDbRecord_t<TDb>::Validate(const Handle& handle, const NetworkConfig& co
     auto unbuilt = false;
     auto any     = false;
 
-    for(const auto& pair : content->As<FindDbData>())
+    if(content.has_value())
     {
-        if(in_sync)
+        for(const auto& pair : content->As<FindDbData>())
         {
-            if(!handle.GetInvoker(config, {{pair.first}}))
+            if(in_sync)
             {
-                unbuilt = true;
-                // This is not an logged as error because no error was detected.
-                // Find wasn't executed yet and invokers were not prepared.
-                LogFindDbItem(pair);
-                break;
-            }
+                if(!handle.GetInvoker(config, {{pair.first}}))
+                {
+                    unbuilt = true;
+                    // This is not an logged as error because no error was detected.
+                    // Find wasn't executed yet and invokers were not prepared.
+                    LogFindDbItem(pair);
+                    break;
+                }
 
-            any = true;
-            continue;
+                any = true;
+                continue;
+            }
         }
+    }
+    else
+    {
+        MIOPEN_LOG_E("Error: no content.");
     }
 
     return !any || unbuilt;
@@ -257,20 +266,34 @@ bool FindDbRecord_t<TDb>::Validate(const Handle& handle, const NetworkConfig& co
 template <class TDb>
 void FindDbRecord_t<TDb>::CopyTo(std::vector<Solution>& to) const
 {
-    const auto range = content->As<FindDbData>();
-    std::transform(range.begin(), range.end(), std::back_inserter(to), [](const auto& pair) {
-        return Solution{solver::Id{pair.first}, pair.second.time, pair.second.workspace};
-    });
+    if(content.has_value())
+    {
+        const auto range = content->As<FindDbData>();
+        std::transform(range.begin(), range.end(), std::back_inserter(to), [](const auto& pair) {
+            return Solution{solver::Id{pair.first}, pair.second.time, pair.second.workspace};
+        });
+    }
+    else
+    {
+        MIOPEN_LOG_E("Error: no content.");
+    }
 }
 
 template <class TDb>
 void FindDbRecord_t<TDb>::LogFindDbItem(const std::pair<std::string, FindDbData>& item) const
 {
-    MIOPEN_LOG_I2("Kernel cache entry not found for solver: "
-                  << item.first << " at network config: " << content->GetKey());
+    if(content.has_value())
+    {
+        MIOPEN_LOG_I2("Kernel cache entry not found for solver: "
+                      << item.first << " at network config: " << content->GetKey());
 
-    for(const auto& pair2 : content->As<FindDbData>())
-        MIOPEN_LOG_I2("Find-db record content: " << pair2.first << ':' << pair2.second);
+        for(const auto& pair2 : content->As<FindDbData>())
+            MIOPEN_LOG_I2("Find-db record content: " << pair2.first << ':' << pair2.second);
+    }
+    else
+    {
+        MIOPEN_LOG_E("Error: no content.");
+    }
 }
 
 template class FindDbRecord_t<FindDb>;

--- a/projects/miopen/src/fusion.cpp
+++ b/projects/miopen/src/fusion.cpp
@@ -31,7 +31,6 @@
 #include <miopen/logger.hpp>
 #include <miopen/handle.hpp>
 #include <miopen/visit_float.hpp>
-#include <miopen/stringutils.hpp>
 #include <miopen/solver_id.hpp>
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/fusion/fusion_invoke_params.hpp>
@@ -40,10 +39,8 @@
 #include <miopen/find_solution.hpp>
 #include <miopen/conv/solver_finders.hpp>
 #include <miopen/driver_arguments.hpp>
-#include <miopen/config.hpp>
 
 #include <ostream>
-#include <ios>
 #include <algorithm>
 #include <string>
 #include <half/half.hpp>
@@ -1001,7 +998,7 @@ miopenStatus_t FusionPlanDescriptor::Compile(const Handle& handle)
 
     {
         FindMode findMode(solver::Primitive::Fusion);
-        auto sol = boost::optional<miopenConvSolution_t>{};
+        auto sol = std::optional<miopenConvSolution_t>{};
         if(findMode.IsFast(fusion_problem) || findMode.IsHybrid(fusion_problem))
         {
             const auto ctx      = FusionContext{handle};

--- a/projects/miopen/src/fusion.cpp
+++ b/projects/miopen/src/fusion.cpp
@@ -23,8 +23,6 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-#include <array>
-#include <cassert>
 #include <miopen/batch_norm.hpp>
 #include <miopen/fusion.hpp>
 #include <miopen/fusion_plan.hpp>
@@ -40,10 +38,14 @@
 #include <miopen/conv/solver_finders.hpp>
 #include <miopen/driver_arguments.hpp>
 
-#include <ostream>
-#include <algorithm>
-#include <string>
 #include <half/half.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <optional>
+#include <ostream>
+#include <string>
 
 #define MIOPEN_CHECK(x)          \
     if(x != miopenStatusSuccess) \

--- a/projects/miopen/src/hip/hip_build_utils.cpp
+++ b/projects/miopen/src/hip/hip_build_utils.cpp
@@ -31,7 +31,7 @@
 #include <miopen/logger.hpp>
 #include <miopen/env.hpp>
 #include <miopen/target_properties.hpp>
-#include <boost/optional.hpp>
+
 #include <sstream>
 #include <string>
 

--- a/projects/miopen/src/hipoc/hipoc_program.cpp
+++ b/projects/miopen/src/hipoc/hipoc_program.cpp
@@ -220,7 +220,7 @@ void HIPOCProgramImpl::BuildCodeObjectInFile(std::string& params,
                                              const fs::path& filename)
 {
     dir.emplace(filename.filename().string());
-    hsaco_file = make_object_file_name(dir.get() / filename);
+    hsaco_file = make_object_file_name(dir.value() / filename);
 
     if(filename.extension() == dynamic_library_postfix) // ".so" or ".dll"
     {
@@ -233,7 +233,7 @@ void HIPOCProgramImpl::BuildCodeObjectInFile(std::string& params,
     }
     else if(filename.extension() == ".cpp")
     {
-        hsaco_file = HipBuild(dir.get(), filename, src, params, target);
+        hsaco_file = HipBuild(dir.value(), filename, src, params, target);
     }
 #if MIOPEN_USE_MLIR
     else if(filename.extension() == ".mlir")
@@ -248,7 +248,7 @@ void HIPOCProgramImpl::BuildCodeObjectInFile(std::string& params,
         params += " " + GetCodeObjectVersionOption();
         if(env::enabled(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP))
             params += " -mwavefrontsize64 -mcumode";
-        WriteFile(src, dir.get() / filename);
+        WriteFile(src, dir.value() / filename);
         params += " -target amdgcn-amd-amdhsa -x cl -D__AMD__=1  -O3";
         params += " -cl-kernel-arg-info -cl-denorms-are-zero";
         params += " -cl-std=CL2.0 -mllvm -amdgpu-early-inline-all";

--- a/projects/miopen/src/hipoc/hipoc_program.cpp
+++ b/projects/miopen/src/hipoc/hipoc_program.cpp
@@ -39,10 +39,10 @@
 #include <miopen/write_file.hpp>
 #include <miopen/env.hpp>
 #include <miopen/comgr.hpp>
-#include <boost/optional.hpp>
 
 #include <cstring>
 #include <mutex>
+#include <optional>
 #include <sstream>
 
 #if defined(__linux__)
@@ -391,7 +391,7 @@ void HIPOCProgram::AttachBinary(std::vector<char> binary) { impl->binary = std::
 void HIPOCProgram::AttachBinary(fs::path binary)
 {
     if(impl->hsaco_file != binary)
-        impl->dir = boost::none;
+        impl->dir.reset();
     impl->hsaco_file = std::move(binary);
 }
 

--- a/projects/miopen/src/include/miopen/anyramdb.hpp
+++ b/projects/miopen/src/include/miopen/anyramdb.hpp
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <miopen/db.hpp>
+#include <miopen/db_record.hpp>
 #include <miopen/lock_file.hpp>
 
 #include <any>

--- a/projects/miopen/src/include/miopen/anyramdb.hpp
+++ b/projects/miopen/src/include/miopen/anyramdb.hpp
@@ -26,14 +26,12 @@
 #pragma once
 
 #include <miopen/db.hpp>
-#include <miopen/db_record.hpp>
 #include <miopen/lock_file.hpp>
 
-#include <boost/optional.hpp>
-#include <boost/any.hpp>
-
+#include <any>
 #include <chrono>
 #include <map>
+#include <optional>
 #include <string>
 #include <sstream>
 
@@ -43,7 +41,7 @@ class LockFile;
 
 struct MIOPEN_INTERNALS_EXPORT AnyRamDb
 {
-    using TRecord = std::vector<boost::any>;
+    using TRecord = std::vector<std::any>;
 
 public:
     AnyRamDb(const fs::path& filename_)
@@ -56,12 +54,12 @@ public:
 
     static AnyRamDb& GetCached(const fs::path& path);
 
-    boost::optional<AnyRamDb::TRecord> FindRecord(const std::string& problem);
+    std::optional<AnyRamDb::TRecord> FindRecord(const std::string& problem);
     bool RemoveRecord(const std::string& key);
     bool StoreRecord(const std::string& problem, TRecord& record);
 
     template <class TProblem>
-    boost::optional<TRecord> FindRecord(const TProblem& problem)
+    std::optional<TRecord> FindRecord(const TProblem& problem)
     {
         std::stringstream ss;
         problem.Serialize(ss);
@@ -87,10 +85,10 @@ public:
     }
 
 private:
-    std::map<std::string, std::vector<boost::any>> cache;
+    std::map<std::string, std::vector<std::any>> cache;
     fs::path filename;
     LockFile& lock_file;
-    boost::optional<TRecord> FindRecordUnsafe(const std::string& problem);
+    std::optional<TRecord> FindRecordUnsafe(const std::string& problem);
     void UpdateCacheEntryUnsafe(const std::string& key, const TRecord& value);
 };
 

--- a/projects/miopen/src/include/miopen/binary_cache.hpp
+++ b/projects/miopen/src/include/miopen/binary_cache.hpp
@@ -30,7 +30,9 @@
 #include <miopen/config.hpp>
 #include <miopen/target_properties.hpp>
 #include <miopen/filesystem.hpp>
+
 #include <string>
+#include <vector>
 
 namespace miopen {
 

--- a/projects/miopen/src/include/miopen/conv/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/conv/problem_description.hpp
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <boost/any.hpp>
 #include <miopen/conv_algo_name.hpp>
 #include <miopen/names.hpp>
 #include <miopen/scalar.hpp>

--- a/projects/miopen/src/include/miopen/conv_solution.hpp
+++ b/projects/miopen/src/include/miopen/conv_solution.hpp
@@ -31,6 +31,7 @@
 #include <miopen/kernel_info.hpp>
 #include <miopen/invoker.hpp>
 
+#include <ostream>
 #include <optional>
 #include <string>
 #include <vector>
@@ -67,7 +68,6 @@ struct ConvSolution
     ConvSolution(miopenStatus_t status_ = miopenStatusSuccess)
         : status(status_),
           solver_id("<unknown>"),
-          invoker_factory(std::nullopt),
           workspace_sz(0),
           grp_tile1(-1),
           grp_tile0(-1),

--- a/projects/miopen/src/include/miopen/conv_solution.hpp
+++ b/projects/miopen/src/include/miopen/conv_solution.hpp
@@ -34,7 +34,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-//#include <ostream>
 
 namespace miopen {
 

--- a/projects/miopen/src/include/miopen/conv_solution.hpp
+++ b/projects/miopen/src/include/miopen/conv_solution.hpp
@@ -31,8 +31,8 @@
 #include <miopen/kernel_info.hpp>
 #include <miopen/invoker.hpp>
 
-#include <ostream>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <vector>
 

--- a/projects/miopen/src/include/miopen/conv_solution.hpp
+++ b/projects/miopen/src/include/miopen/conv_solution.hpp
@@ -31,11 +31,10 @@
 #include <miopen/kernel_info.hpp>
 #include <miopen/invoker.hpp>
 
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <string>
 #include <vector>
-#include <ostream>
+//#include <ostream>
 
 namespace miopen {
 
@@ -53,7 +52,7 @@ struct ConvSolution
     std::vector<KernelInfo> construction_params; // impl may consist of multiple kernels.
     miopenStatus_t status;
     std::string solver_id;
-    boost::optional<InvokerFactory> invoker_factory;
+    std::optional<InvokerFactory> invoker_factory;
 
     size_t workspace_sz;
     int grp_tile1;       // total number ALUs per group
@@ -69,7 +68,7 @@ struct ConvSolution
     ConvSolution(miopenStatus_t status_ = miopenStatusSuccess)
         : status(status_),
           solver_id("<unknown>"),
-          invoker_factory(boost::none),
+          invoker_factory(std::nullopt),
           workspace_sz(0),
           grp_tile1(-1),
           grp_tile0(-1),

--- a/projects/miopen/src/include/miopen/convolution.hpp
+++ b/projects/miopen/src/include/miopen/convolution.hpp
@@ -33,20 +33,17 @@
 #include <miopen/miopen.h>
 #include <miopen/object.hpp>
 #include <miopen/solver_id.hpp>
-#include <miopen/names.hpp>
 #include <miopen/invoke_params.hpp>
 #include <miopen/invoker.hpp>
 #include <miopen/conv/tensors.hpp>
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <boost/any.hpp>
-
+#include <random>
 #include <string>
 #include <tuple>
-#include <vector>
 #include <unordered_map>
-#include <random>
+#include <vector>
 
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL)
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)

--- a/projects/miopen/src/include/miopen/db.hpp
+++ b/projects/miopen/src/include/miopen/db.hpp
@@ -30,8 +30,6 @@
 #include <miopen/rank.hpp>
 #include <miopen/filesystem.hpp>
 
-#include <boost/core/explicit_operator_bool.hpp>
-
 #include <chrono>
 #include <optional>
 #include <string>

--- a/projects/miopen/src/include/miopen/db.hpp
+++ b/projects/miopen/src/include/miopen/db.hpp
@@ -31,10 +31,9 @@
 #include <miopen/filesystem.hpp>
 
 #include <boost/core/explicit_operator_bool.hpp>
-#include <boost/none.hpp>
-#include <boost/optional/optional.hpp>
 
 #include <chrono>
+#include <optional>
 #include <string>
 
 namespace miopen {
@@ -56,10 +55,10 @@ public:
     PlainTextDb(DbKinds db_kind_, const fs::path& filename_, bool is_system = false);
 
     /// Searches db for provided key and returns found record or none if key not found in database
-    boost::optional<DbRecord> FindRecord(const std::string& key);
+    std::optional<DbRecord> FindRecord(const std::string& key);
 
     template <class T>
-    inline boost::optional<DbRecord> FindRecord(const T& problem_config)
+    inline std::optional<DbRecord> FindRecord(const T& problem_config)
     {
         const auto key = DbRecord::SerializeKey(db_kind, problem_config);
         return FindRecord(key);
@@ -110,7 +109,7 @@ public:
     ///
     /// Returns updated record or none if update was unsuccessful.
     template <class T, class V>
-    inline boost::optional<DbRecord>
+    inline std::optional<DbRecord>
     Update(const T& problem_config, const std::string& id, const V& values)
     {
         DbRecord record(db_kind, problem_config);
@@ -119,7 +118,7 @@ public:
         if(ok)
             return record;
         else
-            return boost::none;
+            return {};
     }
 
     /// Searches for record with key PROBLEM_CONFIG and gets VALUES under the ID from it.
@@ -144,7 +143,7 @@ protected:
     LockFile& GetLockFile() { return lock_file; }
     const fs::path& GetFileName() const { return filename; }
     bool IsWarningIfUnreadable() const { return warning_if_unreadable; }
-    boost::optional<DbRecord> FindRecordUnsafe(const std::string& key, RecordPositions* pos);
+    std::optional<DbRecord> FindRecordUnsafe(const std::string& key, RecordPositions* pos);
     bool StoreRecordUnsafe(const DbRecord& record);
     bool UpdateRecordUnsafe(DbRecord& record);
     bool RemoveRecordUnsafe(const std::string& key);
@@ -157,7 +156,7 @@ private:
     bool FlushUnsafe(const DbRecord& record, const RecordPositions* pos);
 
     template <class T>
-    inline boost::optional<DbRecord> FindRecordUnsafe(const T& problem_config)
+    inline std::optional<DbRecord> FindRecordUnsafe(const T& problem_config)
     {
         const auto key = DbRecord::Serialize(problem_config);
         return FindRecordUnsafe(key, nullptr);

--- a/projects/miopen/src/include/miopen/db_record.hpp
+++ b/projects/miopen/src/include/miopen/db_record.hpp
@@ -26,7 +26,6 @@
 #ifndef GUARD_MIOPEN_DB_RECORD_HPP_
 #define GUARD_MIOPEN_DB_RECORD_HPP_
 
-#include <miopen/config.hpp>
 #include <miopen/logger.hpp>
 
 #include <cassert>

--- a/projects/miopen/src/include/miopen/find_controls.hpp
+++ b/projects/miopen/src/include/miopen/find_controls.hpp
@@ -31,8 +31,7 @@
 #include <miopen/solver_id.hpp>
 #include <miopen/miopen.h>
 
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <ostream>
 
 namespace miopen {
@@ -106,7 +105,7 @@ public:
     MIOPEN_INTERNALS_EXPORT friend std::ostream& operator<<(std::ostream&, const FindEnforce&);
 };
 
-MIOPEN_INTERNALS_EXPORT boost::optional<std::vector<solver::Id>> GetEnvFindOnlySolver();
+MIOPEN_INTERNALS_EXPORT std::optional<std::vector<solver::Id>> GetEnvFindOnlySolver();
 
 class MIOPEN_INTERNALS_EXPORT FindMode
 {

--- a/projects/miopen/src/include/miopen/find_db.hpp
+++ b/projects/miopen/src/include/miopen/find_db.hpp
@@ -29,7 +29,7 @@
 
 #include <miopen/config.h>
 #include <miopen/db.hpp>
-#include <miopen/db_path.hpp>
+//#include <miopen/db_path.hpp>
 #include <miopen/db_record.hpp>
 #include <miopen/env.hpp>
 #include <miopen/perf_field.hpp>
@@ -38,9 +38,8 @@
 #include <miopen/solution.hpp>
 #include <miopen/conv/solver_finders.hpp>
 
-#include <boost/optional.hpp>
-
 #include <functional>
+#include <optional>
 #include <vector>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_DISABLE_FIND_DB)
@@ -70,7 +69,7 @@ namespace debug {
 // For unit tests.
 MIOPEN_EXPORT extern bool
     testing_find_db_enabled; // NOLINT (cppcoreguidelines-avoid-non-const-global-variables)
-MIOPEN_EXPORT extern boost::optional<fs::path>&
+MIOPEN_EXPORT extern std::optional<fs::path>&
 testing_find_db_path_override(); /// \todo Remove when #1723 is resolved.
 
 } // namespace debug
@@ -99,15 +98,15 @@ public:
           installed_path(debug::testing_find_db_path_override()
                              ? *debug::testing_find_db_path_override()
                              : GetInstalledPath(handle, path_suffix)),
-          db(boost::make_optional<DbTimer<TDb>>(
+          db(construct_db(
               debug::testing_find_db_enabled && !env::enabled(MIOPEN_DEBUG_DISABLE_FIND_DB),
               DbTimer<TDb>{DbKinds::FindDb, installed_path, path}))
     {
-        if(!db.is_initialized())
+        if(!db)
             return;
 
         content = db->FindRecord(problem);
-        in_sync = content.is_initialized();
+        in_sync = content.has_value();
     }
 
     template <class TProblemDescription, class TTestDb = TDb>
@@ -118,25 +117,25 @@ public:
         : path(debug::testing_find_db_path_override() ? *debug::testing_find_db_path_override()
                                                       : GetUserPath(handle, path_suffix)),
 #if MIOPEN_DISABLE_USERDB
-          db(boost::optional<DbTimer<TDb>>{DbKinds::FindDb})
+          db(std::optional<DbTimer<TDb>>{DbKinds::FindDb})
 #else
-          db(boost::make_optional<DbTimer<TDb>>(debug::testing_find_db_enabled &&
-                                                    !env::enabled(MIOPEN_DEBUG_DISABLE_FIND_DB),
-                                                DbTimer<TDb>{DbKinds::FindDb, path, false}))
+          db(construct_db(
+              debug::testing_find_db_enabled && !env::enabled(MIOPEN_DEBUG_DISABLE_FIND_DB),
+              DbTimer<TDb>{DbKinds::FindDb, path, false}))
 #endif
     {
-        if(!db.is_initialized())
+        if(!db)
             return;
 
         content = db->FindRecord(problem);
-        in_sync = content.is_initialized();
+        in_sync = content.has_value();
     }
 
     ~FindDbRecord_t()
     {
-        if(dont_store || !db.is_initialized() || !content.is_initialized() || in_sync)
+        if(dont_store || !db || !content || in_sync)
             return;
-        if(!db->StoreRecord(content.get()))
+        if(!db->StoreRecord(content.value()))
             MIOPEN_LOG_E("Failed to store record to find-db at <" << path << ">");
     }
 
@@ -144,7 +143,7 @@ public:
     auto begin() { return content->As<FindDbData>().begin(); }
     auto end() const { return content->As<FindDbData>().end(); }
     auto end() { return content->As<FindDbData>().end(); }
-    bool empty() const { return !content.is_initialized(); }
+    bool empty() const { return !content.has_value(); }
 
     template <class TProblemDescription>
     static std::vector<Solution> TryLoad(const Handle& handle,
@@ -187,10 +186,19 @@ public:
 private:
     fs::path path;
     fs::path installed_path;
-    boost::optional<DbTimer<TDb>> db;
-    boost::optional<DbRecord> content{boost::none};
+    std::optional<DbTimer<TDb>> db;
+    std::optional<DbRecord> content;
     bool in_sync    = false;
     bool dont_store = false; // E.g. to skip writing sub-optimal find-db records to disk.
+
+    std::optional<DbTimer<TDb>> construct_db(bool cond, DbTimer<TDb>&& timer)
+    {
+        if(cond)
+        {
+            return std::optional<DbTimer<TDb>>(std::move(timer));
+        }
+        return std::nullopt;
+    }
 
     static fs::path GetInstalledPath(const Handle& handle, const std::string& path_suffix);
     static fs::path GetInstalledPathEmbed(const Handle& handle, const std::string& path_suffix);

--- a/projects/miopen/src/include/miopen/find_db.hpp
+++ b/projects/miopen/src/include/miopen/find_db.hpp
@@ -92,14 +92,17 @@ public:
                    const TProblemDescription& problem,
                    const std::string& path_suffix = "",
                    is_immediate_t<TTestDb>        = 0)
-        : path(debug::testing_find_db_path_override() ? *debug::testing_find_db_path_override()
-                                                      : GetUserPath(handle, path_suffix)),
-          installed_path(debug::testing_find_db_path_override()
-                             ? *debug::testing_find_db_path_override()
+        // NOLINTBEGIN (bugprone-unchecked-optional-access)
+        : path(debug::testing_find_db_path_override().has_value()
+                   ? debug::testing_find_db_path_override().value()
+                   : GetUserPath(handle, path_suffix)),
+          installed_path(debug::testing_find_db_path_override().has_value()
+                             ? debug::testing_find_db_path_override().value()
                              : GetInstalledPath(handle, path_suffix)),
           db(construct_db(debug::testing_find_db_enabled &&
                               !env::enabled(MIOPEN_DEBUG_DISABLE_FIND_DB),
                           DbTimer<TDb>{DbKinds::FindDb, installed_path, path}))
+    // NOLINTEND (bugprone-unchecked-optional-access)
     {
         if(!db)
             return;
@@ -113,8 +116,10 @@ public:
                    const TProblemDescription& problem,
                    const std::string& path_suffix = "",
                    is_find_t<TTestDb>             = 0)
-        : path(debug::testing_find_db_path_override() ? *debug::testing_find_db_path_override()
-                                                      : GetUserPath(handle, path_suffix)),
+        // NOLINTBEGIN (bugprone-unchecked-optional-access)
+        : path(debug::testing_find_db_path_override().has_value()
+                   ? debug::testing_find_db_path_override().value()
+                   : GetUserPath(handle, path_suffix)),
 #if MIOPEN_DISABLE_USERDB
           db(std::optional<DbTimer<TDb>>{DbKinds::FindDb})
 #else
@@ -122,6 +127,7 @@ public:
                               !env::enabled(MIOPEN_DEBUG_DISABLE_FIND_DB),
                           DbTimer<TDb>{DbKinds::FindDb, path, false}))
 #endif
+    // NOLINTEND (bugprone-unchecked-optional-access)
     {
         if(!db)
             return;
@@ -138,10 +144,12 @@ public:
             MIOPEN_LOG_E("Failed to store record to find-db at <" << path << ">");
     }
 
-    auto begin() const { return content->As<FindDbData>().begin(); }
-    auto begin() { return content->As<FindDbData>().begin(); }
-    auto end() const { return content->As<FindDbData>().end(); }
-    auto end() { return content->As<FindDbData>().end(); }
+    // NOLINTBEGIN (bugprone-unchecked-optional-access)
+    auto begin() const { return content.value().As<FindDbData>().begin(); }
+    auto begin() { return content.value().As<FindDbData>().begin(); }
+    auto end() const { return content.value().As<FindDbData>().end(); }
+    auto end() { return content.value().As<FindDbData>().end(); }
+    // NOLINTEND (bugprone-unchecked-optional-access)
     bool empty() const { return !content.has_value(); }
 
     template <class TProblemDescription>

--- a/projects/miopen/src/include/miopen/find_db.hpp
+++ b/projects/miopen/src/include/miopen/find_db.hpp
@@ -29,7 +29,6 @@
 
 #include <miopen/config.h>
 #include <miopen/db.hpp>
-//#include <miopen/db_path.hpp>
 #include <miopen/db_record.hpp>
 #include <miopen/env.hpp>
 #include <miopen/perf_field.hpp>
@@ -98,9 +97,9 @@ public:
           installed_path(debug::testing_find_db_path_override()
                              ? *debug::testing_find_db_path_override()
                              : GetInstalledPath(handle, path_suffix)),
-          db(construct_db(
-              debug::testing_find_db_enabled && !env::enabled(MIOPEN_DEBUG_DISABLE_FIND_DB),
-              DbTimer<TDb>{DbKinds::FindDb, installed_path, path}))
+          db(construct_db(debug::testing_find_db_enabled &&
+                              !env::enabled(MIOPEN_DEBUG_DISABLE_FIND_DB),
+                          DbTimer<TDb>{DbKinds::FindDb, installed_path, path}))
     {
         if(!db)
             return;
@@ -119,9 +118,9 @@ public:
 #if MIOPEN_DISABLE_USERDB
           db(std::optional<DbTimer<TDb>>{DbKinds::FindDb})
 #else
-          db(construct_db(
-              debug::testing_find_db_enabled && !env::enabled(MIOPEN_DEBUG_DISABLE_FIND_DB),
-              DbTimer<TDb>{DbKinds::FindDb, path, false}))
+          db(construct_db(debug::testing_find_db_enabled &&
+                              !env::enabled(MIOPEN_DEBUG_DISABLE_FIND_DB),
+                          DbTimer<TDb>{DbKinds::FindDb, path, false}))
 #endif
     {
         if(!db)

--- a/projects/miopen/src/include/miopen/fusion.hpp
+++ b/projects/miopen/src/include/miopen/fusion.hpp
@@ -26,20 +26,16 @@
 #ifndef MIOPEN_FUSION_HPP_
 #define MIOPEN_FUSION_HPP_
 
-#include <miopen/common.hpp>
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>
 #include <miopen/convolution.hpp>
 #include <miopen/conv/problem_description.hpp>
 #include <miopen/kernel_info.hpp>
-#include <miopen/op_kernel_args.hpp>
 #include <miopen/fusion_ops.hpp>
 #include <miopen/fusion/fusion_invoke_params.hpp>
 #include <miopen/activ.hpp>
 
-#include <set>
 #include <vector>
-#include <unordered_map>
 
 namespace miopen {
 

--- a/projects/miopen/src/include/miopen/fusion/utils.hpp
+++ b/projects/miopen/src/include/miopen/fusion/utils.hpp
@@ -92,9 +92,11 @@ inline bool WinoCommonIsApplicable(const FusionContext& context, const FusionDes
         return false;
     if(!conv_problem.IsDirectionForward())
         return false;
+
     const auto& target = conv_ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     return true;
 }

--- a/projects/miopen/src/include/miopen/fusion/utils.hpp
+++ b/projects/miopen/src/include/miopen/fusion/utils.hpp
@@ -94,9 +94,8 @@ inline bool WinoCommonIsApplicable(const FusionContext& context, const FusionDes
         return false;
 
     const auto& target = conv_ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     return true;
 }

--- a/projects/miopen/src/include/miopen/fusion_ops.hpp
+++ b/projects/miopen/src/include/miopen/fusion_ops.hpp
@@ -27,8 +27,8 @@
 #ifndef MIOPEN_GUARD_MLOPEN_FUSION_OPS_HPP
 #define MIOPEN_GUARD_MLOPEN_FUSION_OPS_HPP
 
-#include <ostream>
 #include <any>
+#include <ostream>
 
 namespace miopen {
 

--- a/projects/miopen/src/include/miopen/fusion_ops.hpp
+++ b/projects/miopen/src/include/miopen/fusion_ops.hpp
@@ -28,7 +28,7 @@
 #define MIOPEN_GUARD_MLOPEN_FUSION_OPS_HPP
 
 #include <ostream>
-#include <boost/any.hpp>
+#include <any>
 
 namespace miopen {
 
@@ -45,7 +45,7 @@ enum miopenFusionOp_t
     miopenFusionOpTensorScaleAdd     = 7,
 };
 
-std::ostream& operator<<(std::ostream& stream, const boost::any& a);
+std::ostream& operator<<(std::ostream& stream, const std::any& a);
 
 } // namespace miopen
 

--- a/projects/miopen/src/include/miopen/fusion_plan.hpp
+++ b/projects/miopen/src/include/miopen/fusion_plan.hpp
@@ -4,13 +4,12 @@
 #ifndef MIOPEN_GUARD_MLOPEN_FUSION_PLAN_HPP
 #define MIOPEN_GUARD_MLOPEN_FUSION_PLAN_HPP
 
-#include <miopen/config.hpp>
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>
 #include <miopen/fusion.hpp>
 #include <miopen/search_options.hpp>
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace miopen {
 

--- a/projects/miopen/src/include/miopen/generic_search.hpp
+++ b/projects/miopen/src/include/miopen/generic_search.hpp
@@ -41,14 +41,15 @@
 #include <miopen/conv/problem_description.hpp>
 
 #include <algorithm>
-#include <vector>
-#include <cstdlib>
-#include <limits>
-#include <iterator>
-#include <chrono>
 #include <cassert>
+#include <chrono>
+#include <cstdlib>
+#include <iterator>
+#include <limits>
+#include <optional>
 #include <random>
 #include <thread>
+#include <vector>
 
 namespace miopen {
 namespace solver {
@@ -553,17 +554,25 @@ auto GenericSearch(const Solver s,
 
             try
             {
-                invoker = profile_h.PrepareInvoker(*current_solution.invoker_factory,
-                                                   current_solution.construction_params);
+                if(current_solution.invoker_factory.has_value())
+                {
+                    invoker = profile_h.PrepareInvoker(*current_solution.invoker_factory,
+                                                       current_solution.construction_params);
 
-                // Warm-up run for every configuration to eliminate cold-start bias
-                invoker(profile_h, invoke_ctx);
-                profile_h.ResetKernelTime();
+                    // Warm-up run for every configuration to eliminate cold-start bias
+                    invoker(profile_h, invoke_ctx);
+                    profile_h.ResetKernelTime();
 
-                invoker(profile_h, invoke_ctx);
-                elapsed_time = profile_h.GetKernelTime();
-                samples.push_back(elapsed_time);
-                profile_h.ResetKernelTime();
+                    invoker(profile_h, invoke_ctx);
+                    elapsed_time = profile_h.GetKernelTime();
+                    samples.push_back(elapsed_time);
+                    profile_h.ResetKernelTime();
+                }
+                else
+                {
+                    MIOPEN_LOG_E("Error: solver returned a solution without invoker factory.");
+                    ret = 1;
+                }
             }
             catch(const std::exception& e)
             {
@@ -684,13 +693,20 @@ auto GenericSearch(const Solver s,
             return a.time < b.time;
         });
 
-    // Run once with the default config and show score.
-    const auto& invoker = profile_h.PrepareInvoker(*default_solution.invoker_factory,
-                                                   default_solution.construction_params);
-    invoker(profile_h, invoke_ctx);
-    const auto default_time = profile_h.GetKernelTime();
-    const auto score        = (best_time > 0.0f) ? default_time / best_time : 0.0f;
-    MIOPEN_LOG_I("...Score: " << score << " (default time " << default_time << ')');
+    if(default_solution.invoker_factory.has_value())
+    {
+        // Run once with the default config and show score.
+        const auto& invoker = profile_h.PrepareInvoker(*default_solution.invoker_factory,
+                                                       default_solution.construction_params);
+        invoker(profile_h, invoke_ctx);
+        const auto default_time = profile_h.GetKernelTime();
+        const auto score        = (best_time > 0.0f) ? default_time / best_time : 0.0f;
+        MIOPEN_LOG_I("...Score: " << score << " (default time " << default_time << ')');
+    }
+    else
+    {
+        MIOPEN_LOG_E("Error: default solution without invoker factory.");
+    }
 
     return best_config;
 }

--- a/projects/miopen/src/include/miopen/handle.hpp
+++ b/projects/miopen/src/include/miopen/handle.hpp
@@ -159,7 +159,7 @@ struct MIOPEN_EXPORT Handle : miopenHandle
     void AddProgram(Program prog, const fs::path& program_name, const std::string& params) const;
 
     void Finish() const;
-    void Flush() const; // TODO checkme
+    void Flush() const;
 
     std::size_t GetLocalMemorySize() const;
     std::size_t GetGlobalMemorySize() const;

--- a/projects/miopen/src/include/miopen/handle.hpp
+++ b/projects/miopen/src/include/miopen/handle.hpp
@@ -84,7 +84,7 @@ using hipblasLt_handle_ptr = MIOPEN_MANAGE_PTR(hipblasLtHandle_t, hipblasLtDestr
 
 struct MIOPEN_EXPORT Handle : miopenHandle
 {
-    friend struct TargetProperties;
+    friend class TargetProperties;
 
     Handle();
     Handle(miopenAcceleratorQueue_t stream);
@@ -159,7 +159,7 @@ struct MIOPEN_EXPORT Handle : miopenHandle
     void AddProgram(Program prog, const fs::path& program_name, const std::string& params) const;
 
     void Finish() const;
-    void Flush() const;
+    void Flush() const; // TODO checkme
 
     std::size_t GetLocalMemorySize() const;
     std::size_t GetGlobalMemorySize() const;

--- a/projects/miopen/src/include/miopen/hip_build_utils.hpp
+++ b/projects/miopen/src/include/miopen/hip_build_utils.hpp
@@ -31,7 +31,7 @@
 #include <miopen/kernel.hpp>
 #include <miopen/tmp_dir.hpp>
 #include <miopen/write_file.hpp>
-#include <boost/optional.hpp>
+
 #include <string>
 
 namespace miopen {

--- a/projects/miopen/src/include/miopen/hip_build_utils.hpp
+++ b/projects/miopen/src/include/miopen/hip_build_utils.hpp
@@ -58,19 +58,15 @@ public:
     const std::string targetId;
     LcOptionTargetStrings(const TargetProperties& target)
         : device(target.Name()),
-          xnack([&]() -> std::string {
-              if(target.Xnack())
-                  return std::string{":xnack"} + (*target.Xnack() ? "+" : "-");
-              return {};
-          }()),
+          xnack(std::string{":xnack"} + (target.isXnackEnabled() ? "+" : "-")),
           sramecc([&]() -> std::string {
-              if(target.Sramecc())
-                  return std::string{":sramecc"} + (*target.Sramecc() ? "+" : "-");
+              if(target.sramecc.isReported())
+                  return std::string{":sramecc"} + (target.sramecc.isEnabled() ? "+" : "-");
               return {};
           }()),
           sramecc_reported([&]() -> std::string {
-              if(target.SrameccReported())
-                  return std::string{":sramecc"} + (*target.SrameccReported() ? "+" : "-");
+              if(target.sramecc.isReported())
+                  return std::string{":sramecc"} + (target.sramecc.isReported() ? "+" : "-");
               return {};
           }()),
 #if MIOPEN_USE_COMGR

--- a/projects/miopen/src/include/miopen/hip_build_utils.hpp
+++ b/projects/miopen/src/include/miopen/hip_build_utils.hpp
@@ -58,7 +58,11 @@ public:
     const std::string targetId;
     LcOptionTargetStrings(const TargetProperties& target)
         : device(target.Name()),
-          xnack(std::string{":xnack"} + (target.isXnackEnabled() ? "+" : "-")),
+          xnack([&]() -> std::string {
+              if(target.xnack.isReported())
+                  return std::string{":xnack"} + (target.isXnackEnabled() ? "+" : "-");
+              return {};
+          }()),
           sramecc([&]() -> std::string {
               if(target.sramecc.isReported())
                   return std::string{":sramecc"} + (target.sramecc.isEnabled() ? "+" : "-");

--- a/projects/miopen/src/include/miopen/hipoc_program_impl.hpp
+++ b/projects/miopen/src/include/miopen/hipoc_program_impl.hpp
@@ -31,9 +31,8 @@
 #include <miopen/manage_ptr.hpp>
 #include <miopen/tmp_dir.hpp>
 #include <miopen/filesystem.hpp>
-#include <boost/optional.hpp>
-#include <hip/hip_runtime_api.h>
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -58,7 +57,7 @@ struct HIPOCProgramImpl
     TargetProperties target;
     fs::path hsaco_file;
     hipModulePtr module;
-    boost::optional<TmpDir> dir;
+    std::optional<TmpDir> dir;
     std::vector<char> binary;
 
 #if !MIOPEN_USE_COMGR

--- a/projects/miopen/src/include/miopen/kern_db.hpp
+++ b/projects/miopen/src/include/miopen/kern_db.hpp
@@ -35,10 +35,9 @@
 #include <miopen/md5.hpp>
 
 #include <boost/core/explicit_operator_bool.hpp>
-#include <boost/none.hpp>
-#include <boost/optional/optional.hpp>
 
 #include <functional>
+#include <optional>
 #include <string>
 
 namespace miopen {
@@ -112,10 +111,10 @@ public:
     }
 
     template <typename T>
-    boost::optional<std::vector<char>> FindRecordUnsafe(const T& problem_config)
+    std::optional<std::vector<char>> FindRecordUnsafe(const T& problem_config)
     {
         if(filename.empty())
-            return boost::none;
+            return {};
         // Where clause with inserted values defeats the purpose of a prepraed statement
         auto select_query = "SELECT kernel_blob, kernel_hash, uncompressed_size FROM " +
                             T::table_name() + " WHERE " + problem_config.Where() + ";";
@@ -140,13 +139,13 @@ public:
         }
         else if(rc == SQLITE_DONE)
         {
-            return boost::none;
+            return {};
         }
         else
         {
             MIOPEN_THROW(miopenStatusInternalError, sql.ErrorMessage());
         }
-        return boost::none;
+        return {};
     }
 
     template <typename T>

--- a/projects/miopen/src/include/miopen/mlir_build.hpp
+++ b/projects/miopen/src/include/miopen/mlir_build.hpp
@@ -29,11 +29,9 @@
 #include <miopen/config.h>
 #if MIOPEN_USE_MLIR
 
-#include <miopen/target_properties.hpp>
-#include <miopen/tmp_dir.hpp>
-#include <miopen/filesystem.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace miopen {
 

--- a/projects/miopen/src/include/miopen/mlir_build.hpp
+++ b/projects/miopen/src/include/miopen/mlir_build.hpp
@@ -29,7 +29,6 @@
 #include <miopen/config.h>
 #if MIOPEN_USE_MLIR
 
-#include <optional>
 #include <string>
 #include <vector>
 

--- a/projects/miopen/src/include/miopen/ramdb.hpp
+++ b/projects/miopen/src/include/miopen/ramdb.hpp
@@ -28,10 +28,9 @@
 #include <miopen/db.hpp>
 #include <miopen/db_record.hpp>
 
-#include <boost/optional.hpp>
-
 #include <chrono>
 #include <map>
+#include <optional>
 #include <string>
 #include <sstream>
 
@@ -76,10 +75,10 @@ public:
         return GetCached(db_kind_, path, is_system);
     }
 
-    boost::optional<DbRecord> FindRecord(const std::string& problem);
+    std::optional<DbRecord> FindRecord(const std::string& problem);
 
     template <class TProblem>
-    boost::optional<DbRecord> FindRecord(const TProblem& problem)
+    std::optional<DbRecord> FindRecord(const TProblem& problem)
     {
         const auto key = DbRecord::SerializeKey(db_kind, problem);
         return FindRecord(key);
@@ -114,7 +113,7 @@ public:
     }
 
     template <class T, class V>
-    inline boost::optional<DbRecord>
+    inline std::optional<DbRecord>
     Update(const T& problem_config, const std::string& id, const V& values)
     {
         DbRecord record(db_kind, problem_config);
@@ -123,7 +122,7 @@ public:
         if(ok)
             return record;
         else
-            return boost::none;
+            return {};
     }
 
 private:
@@ -136,7 +135,7 @@ private:
     ramdb_clock::time_point file_read_time;
     std::map<std::string, CacheItem> cache;
 
-    boost::optional<miopen::DbRecord> FindRecordUnsafe(const std::string& problem);
+    std::optional<miopen::DbRecord> FindRecordUnsafe(const std::string& problem);
 
     bool ValidateUnsafe();
     void Prefetch();

--- a/projects/miopen/src/include/miopen/readonlyramdb.hpp
+++ b/projects/miopen/src/include/miopen/readonlyramdb.hpp
@@ -29,10 +29,10 @@
 #include <miopen/db_record.hpp>
 #include <miopen/filesystem.hpp>
 
-#include <unordered_map>
+#include <optional>
 #include <string>
 #include <sstream>
-#include <optional>
+#include <unordered_map>
 
 namespace miopen {
 

--- a/projects/miopen/src/include/miopen/readonlyramdb.hpp
+++ b/projects/miopen/src/include/miopen/readonlyramdb.hpp
@@ -29,11 +29,10 @@
 #include <miopen/db_record.hpp>
 #include <miopen/filesystem.hpp>
 
-#include <boost/optional.hpp>
-
 #include <unordered_map>
 #include <string>
 #include <sstream>
+#include <optional>
 
 namespace miopen {
 
@@ -49,13 +48,13 @@ public:
     static ReadonlyRamDb&
     GetCached(DbKinds db_kind_, const fs::path& path, bool warn_if_unreadable);
 
-    boost::optional<DbRecord> FindRecord(const std::string& problem) const
+    std::optional<DbRecord> FindRecord(const std::string& problem) const
     {
         MIOPEN_LOG_I2("Looking for key " << problem << " in file " << db_path);
         const auto it = cache.find(problem);
 
         if(it == cache.end())
-            return boost::none;
+            return {};
 
         auto record = DbRecord{problem};
 
@@ -67,14 +66,14 @@ public:
             MIOPEN_LOG_E("Error parsing payload under the key: "
                          << problem << " form file " << db_path << "#" << it->second.line);
             MIOPEN_LOG_E("Contents: " << it->second.content);
-            return boost::none;
+            return {};
         }
 
         return record;
     }
 
     template <class TProblem>
-    boost::optional<DbRecord> FindRecord(const TProblem& problem) const
+    std::optional<DbRecord> FindRecord(const TProblem& problem) const
     {
         const auto key = DbRecord::SerializeKey(db_kind, problem);
         return FindRecord(key);

--- a/projects/miopen/src/include/miopen/solution.hpp
+++ b/projects/miopen/src/include/miopen/solution.hpp
@@ -38,8 +38,6 @@
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <boost/optional.hpp>
-
 #include <optional>
 #include <unordered_map>
 
@@ -71,7 +69,7 @@ struct MIOPEN_INTERNALS_EXPORT Solution : miopenSolution
 
     struct RunInput
     {
-        boost::optional<TensorDescriptor> descriptor;
+        std::optional<TensorDescriptor> descriptor;
         Data_t buffer = nullptr;
 
         inline RunInput() = default;

--- a/projects/miopen/src/include/miopen/solver.hpp
+++ b/projects/miopen/src/include/miopen/solver.hpp
@@ -176,7 +176,8 @@ struct SolverBaseNonTunable : SolverInterfaceNonTunable<Context, Problem>
     InvokerFactory GetInvokerFactory(const Context& ctx, const Problem& problem) const
     {
         const auto solution = this->GetSolution(ctx, problem);
-        return solution.invoker_factory.value(); // NOLINT (bugprone-unchecked-optional-access)
+        // NOLINTNEXTLINE (bugprone-unchecked-optional-access)
+        return solution.invoker_factory.value();
     }
 };
 

--- a/projects/miopen/src/include/miopen/solver.hpp
+++ b/projects/miopen/src/include/miopen/solver.hpp
@@ -176,7 +176,7 @@ struct SolverBaseNonTunable : SolverInterfaceNonTunable<Context, Problem>
     InvokerFactory GetInvokerFactory(const Context& ctx, const Problem& problem) const
     {
         const auto solution = this->GetSolution(ctx, problem);
-        return *solution.invoker_factory;
+        return solution.invoker_factory.value(); // NOLINT (bugprone-unchecked-optional-access)
     }
 };
 
@@ -225,7 +225,8 @@ struct SolverBaseTunable : SolverInterfaceTunable<Context, Problem>, TunableSolv
                                      const Problem& problem,
                                      const PerformanceConfig& config) const
     {
-        return *GetSolution(ctx, problem, config).invoker_factory;
+        // NOLINTNEXTLINE (bugprone-unchecked-optional-access)
+        return GetSolution(ctx, problem, config).invoker_factory.value();
     }
 };
 

--- a/projects/miopen/src/include/miopen/sqlite_db.hpp
+++ b/projects/miopen/src/include/miopen/sqlite_db.hpp
@@ -40,13 +40,12 @@
 #include <miopen/env.hpp>
 
 #include <boost/core/explicit_operator_bool.hpp>
-#include <boost/none.hpp>
-#include <boost/optional/optional.hpp>
 #include "sqlite3.h"
 #include <mutex>
 
 #include <string>
-#include <chrono>
+//#include <chrono>
+#include <optional>
 #include <unordered_map>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_DISABLE_SQL_WAL)
@@ -437,10 +436,10 @@ public:
         }
     }
     template <typename T>
-    inline boost::optional<DbRecord> FindRecordUnsafe(const T& problem_config)
+    inline std::optional<DbRecord> FindRecordUnsafe(const T& problem_config)
     {
         if(dbInvalid)
-            return boost::none;
+            return {};
 
         const auto& pdb_ovr = env::value(MIOPEN_DEBUG_PERFDB_OVERRIDE);
         if(!pdb_ovr.empty())
@@ -496,7 +495,7 @@ public:
             }
         }
         if(rec.GetSize() == 0)
-            return boost::none;
+            return {};
         else
             return {rec};
     }
@@ -538,11 +537,11 @@ public:
     /// Updates record under key PROBLEM_CONFIG with data ID:VALUES in database.
     /// Returns updated record or boost::none if insertion failed
     template <class T, class V>
-    inline boost::optional<DbRecord>
+    inline std::optional<DbRecord>
     UpdateUnsafe(const T& problem_config, const std::string& id, const V& values)
     {
         if(dbInvalid)
-            return boost::none;
+            return {};
         // UPSERT the value
         {
             std::string clause;
@@ -583,7 +582,7 @@ public:
             {
                 MIOPEN_LOG_E("Failed to insert performance record in the database: " +
                              sql.ErrorMessage());
-                return boost::none;
+                return {};
             }
         }
         DbRecord record;

--- a/projects/miopen/src/include/miopen/sqlite_db.hpp
+++ b/projects/miopen/src/include/miopen/sqlite_db.hpp
@@ -44,7 +44,6 @@
 #include <mutex>
 
 #include <string>
-//#include <chrono>
 #include <optional>
 #include <unordered_map>
 

--- a/projects/miopen/src/include/miopen/target_properties.hpp
+++ b/projects/miopen/src/include/miopen/target_properties.hpp
@@ -26,7 +26,7 @@
 #ifndef GUARD_TARGET_PROPERTIES_HPP
 #define GUARD_TARGET_PROPERTIES_HPP
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 #define WORKAROUND_ISSUE_3001 1
@@ -41,9 +41,9 @@ struct TargetProperties
 
     virtual const std::string& Name() const { return name; }
     const std::string& DbId() const { return dbId; }
-    virtual boost::optional<bool> Xnack() const { return xnack; }
-    boost::optional<bool> Sramecc() const { return sramecc; }
-    boost::optional<bool> SrameccReported() const { return sramecc_reported; }
+    virtual std::optional<bool> Xnack() const { return xnack; }
+    std::optional<bool> Sramecc() const { return sramecc; }
+    std::optional<bool> SrameccReported() const { return sramecc_reported; }
     static std::size_t GetMaxWaveScratchSize() { return MaxWaveScratchSize; }
     static std::size_t GetMaxLocalMemorySize() { return MaxLocalMemorySize; }
     void Init(const Handle*);
@@ -52,9 +52,9 @@ private:
     void InitDbId();
     std::string name;
     std::string dbId;
-    boost::optional<bool> xnack            = boost::none;
-    boost::optional<bool> sramecc          = boost::none;
-    boost::optional<bool> sramecc_reported = boost::none;
+    std::optional<bool> xnack            = std::nullopt;
+    std::optional<bool> sramecc          = std::nullopt;
+    std::optional<bool> sramecc_reported = std::nullopt;
     static const std::size_t MaxWaveScratchSize;
     static const std::size_t MaxLocalMemorySize;
 };

--- a/projects/miopen/src/include/miopen/target_properties.hpp
+++ b/projects/miopen/src/include/miopen/target_properties.hpp
@@ -109,9 +109,9 @@ class TargetProperties
     template <typename T>
     struct TargetProperty : public T
     {
-        bool initialized{false};
-        bool reported{false};
-        bool enabled{false};
+        bool initialized = false;
+        bool reported    = false;
+        bool enabled     = false;
 
         TargetProperty() = default;
         TargetProperty(const std::string& tag_) : T(tag_) {}

--- a/projects/miopen/src/include/miopen/target_properties.hpp
+++ b/projects/miopen/src/include/miopen/target_properties.hpp
@@ -26,37 +26,122 @@
 #ifndef GUARD_TARGET_PROPERTIES_HPP
 #define GUARD_TARGET_PROPERTIES_HPP
 
-#include <optional>
 #include <string>
 
+#define WORKAROUND_ISSUE_1204 1 // ROCm may incorrectly report "sramecc-" for gfx900.
 #define WORKAROUND_ISSUE_3001 1
 
 namespace miopen {
 
 struct Handle;
 
-struct TargetProperties
+class TargetProperties
 {
-    virtual ~TargetProperties() = default;
+    struct xnack_t
+    {
+        const std::string tag{":xnack"};
+        virtual ~xnack_t() = default;
+    };
 
-    virtual const std::string& Name() const { return name; }
-    const std::string& DbId() const { return dbId; }
-    virtual std::optional<bool> Xnack() const { return xnack; }
-    std::optional<bool> Sramecc() const { return sramecc; }
-    std::optional<bool> SrameccReported() const { return sramecc_reported; }
-    static std::size_t GetMaxWaveScratchSize() { return MaxWaveScratchSize; }
-    static std::size_t GetMaxLocalMemorySize() { return MaxLocalMemorySize; }
-    void Init(const Handle*);
+    struct sramecc_t
+    {
+        const std::string tag{":sramecc"};
+        virtual ~sramecc_t() = default;
+    };
 
-private:
+    template <typename T>
+    struct TargetProperty : public T
+    {
+        bool initialized{false};
+        bool reported{false};
+        bool enabled{false};
+
+        void CheckInit() const
+        {
+            if(!initialized)
+                throw std::runtime_error("Error: not initialized targetProperty " + this->tag);
+        }
+        bool isReported() const
+        {
+            CheckInit();
+            return reported;
+        }
+        bool isEnabled() const
+        {
+            CheckInit();
+            return reported && enabled;
+        }
+        bool isDisabled() const
+        {
+            CheckInit();
+            return !reported && enabled;
+        }
+
+        void Init(const std::string& raw_name, const std::string& dev_name)
+        {
+#if WORKAROUND_ISSUE_1204
+            if(std::is_same_v<T, sramecc_t> && dev_name == "gfx900")
+            {
+                initialized = true;
+                return; // reported == false, enabled == false;
+            }
+#endif
+
+            // DKMS driver older than 5.9 may report incorrect state of SRAMECC feature.
+            // Therefore we compute default SRAMECC and rely on it for now.
+            if(std::is_same_v<T, sramecc_t> && (dev_name == "gfx906" || dev_name == "gfx908"))
+            {
+                reported    = true;
+                enabled     = true;
+                initialized = true;
+            }
+
+            auto tag_pos = raw_name.find(this->tag);
+            if(tag_pos != std::string::npos)
+            {
+                tag_pos += this->tag.length();
+                if(raw_name.length() > tag_pos)
+                {
+                    if(raw_name[tag_pos] == '+')
+                    {
+                        reported = true;
+                        enabled  = true;
+                    }
+                    if(raw_name[tag_pos] == '-')
+                    {
+                        reported = true;
+                    }
+                }
+            }
+
+            initialized = true;
+        }
+    };
+
     void InitDbId();
     std::string name;
     std::string dbId;
-    std::optional<bool> xnack            = std::nullopt;
-    std::optional<bool> sramecc          = std::nullopt;
-    std::optional<bool> sramecc_reported = std::nullopt;
     static const std::size_t MaxWaveScratchSize;
     static const std::size_t MaxLocalMemorySize;
+
+public:
+    virtual ~TargetProperties() = default;
+
+    TargetProperty<xnack_t> xnack;
+    TargetProperty<sramecc_t> sramecc;
+
+    virtual const std::string& Name() const { return name; }
+    const std::string& DbId() const { return dbId; }
+
+    virtual bool isXnackEnabled() const { return xnack.isEnabled(); }
+
+    // bool Sramecc() const { return sramecc.isEnabled(); }
+    // bool SrameccReported() const { return sramecc.isReported(); }
+
+    static std::size_t GetMaxWaveScratchSize() { return MaxWaveScratchSize; }
+    static std::size_t GetMaxLocalMemorySize() { return MaxLocalMemorySize; }
+
+    void Init(const Handle*);
 };
 
 } // namespace miopen

--- a/projects/miopen/src/include/miopen/target_properties.hpp
+++ b/projects/miopen/src/include/miopen/target_properties.hpp
@@ -74,7 +74,7 @@ class TargetProperties
         bool isDisabled() const
         {
             CheckInit();
-            return !reported && enabled;
+            return !(reported && enabled);
         }
 
         void Init(const std::string& raw_name, const std::string& dev_name)
@@ -134,9 +134,6 @@ public:
     const std::string& DbId() const { return dbId; }
 
     virtual bool isXnackEnabled() const { return xnack.isEnabled(); }
-
-    // bool Sramecc() const { return sramecc.isEnabled(); }
-    // bool SrameccReported() const { return sramecc.isReported(); }
 
     static std::size_t GetMaxWaveScratchSize() { return MaxWaveScratchSize; }
     static std::size_t GetMaxLocalMemorySize() { return MaxLocalMemorySize; }

--- a/projects/miopen/src/include/miopen/target_properties.hpp
+++ b/projects/miopen/src/include/miopen/target_properties.hpp
@@ -27,6 +27,7 @@
 #define GUARD_TARGET_PROPERTIES_HPP
 
 #include <string>
+#include <tuple>
 
 #define WORKAROUND_ISSUE_1204 1 // ROCm may incorrectly report "sramecc-" for gfx900.
 #define WORKAROUND_ISSUE_3001 1
@@ -39,14 +40,70 @@ class TargetProperties
 {
     struct xnack_t
     {
-        const std::string tag{":xnack"};
-        virtual ~xnack_t() = default;
+        std::string tag;
+
+        xnack_t(const std::string& tag_) : tag(tag_) {}
+
+        auto init(const std::string& raw_name, const std::string&) const
+        {
+            bool initialized = false;
+            bool reported    = false;
+            bool enabled     = false;
+
+            auto tag_pos = raw_name.find(tag);
+            if(tag_pos != std::string::npos)
+            {
+                tag_pos += tag.length();
+                if(raw_name.length() > tag_pos)
+                {
+                    reported = true;
+                    enabled  = (raw_name[tag_pos] == '+');
+                }
+            }
+
+            initialized = true;
+            return std::make_tuple(initialized, reported, enabled);
+        }
     };
 
     struct sramecc_t
     {
-        const std::string tag{":sramecc"};
-        virtual ~sramecc_t() = default;
+        std::string tag;
+
+        sramecc_t(const std::string& tag_) : tag(tag_) {}
+
+        auto init(const std::string& raw_name, const std::string& dev_name) const
+        {
+            bool initialized = false;
+            bool reported    = false;
+            bool enabled     = (dev_name == "gfx906" || dev_name == "gfx908");
+
+#if WORKAROUND_ISSUE_1204
+            if(dev_name == "gfx900")
+            {
+                reported = false;
+            }
+            else
+#endif
+            {
+                auto tag_pos = raw_name.find(tag);
+                if(tag_pos != std::string::npos)
+                {
+                    tag_pos += tag.length();
+                    if(raw_name.length() > tag_pos)
+                    {
+                        reported = (raw_name[tag_pos] == '+');
+                    }
+                }
+                else
+                {
+                    reported = enabled;
+                }
+            }
+
+            initialized = true;
+            return std::make_tuple(initialized, reported, enabled);
+        }
     };
 
     template <typename T>
@@ -55,6 +112,9 @@ class TargetProperties
         bool initialized{false};
         bool reported{false};
         bool enabled{false};
+
+        TargetProperty() = default;
+        TargetProperty(const std::string& tag_) : T(tag_) {}
 
         void CheckInit() const
         {
@@ -77,48 +137,24 @@ class TargetProperties
             return !(reported && enabled);
         }
 
-        void Init(const std::string& raw_name, const std::string& dev_name)
+        void init(const std::string& raw_name, const std::string& dev_name)
         {
-#if WORKAROUND_ISSUE_1204
-            if(std::is_same_v<T, sramecc_t> && dev_name == "gfx900")
-            {
-                initialized = true;
-                return; // reported == false, enabled == false;
-            }
-#endif
-
-            // DKMS driver older than 5.9 may report incorrect state of SRAMECC feature.
-            // Therefore we compute default SRAMECC and rely on it for now.
-            if(std::is_same_v<T, sramecc_t> && (dev_name == "gfx906" || dev_name == "gfx908"))
-            {
-                reported    = true;
-                enabled     = true;
-                initialized = true;
-            }
-
-            auto tag_pos = raw_name.find(this->tag);
-            if(tag_pos != std::string::npos)
-            {
-                tag_pos += this->tag.length();
-                if(raw_name.length() > tag_pos)
-                {
-                    if(raw_name[tag_pos] == '+')
-                    {
-                        reported = true;
-                        enabled  = true;
-                    }
-                    if(raw_name[tag_pos] == '-')
-                    {
-                        reported = true;
-                    }
-                }
-            }
-
-            initialized = true;
+            std::tie(initialized, reported, enabled) = T::init(raw_name, dev_name);
         }
     };
 
+    struct TargetPropertyXnack : public TargetProperty<xnack_t>
+    {
+        TargetPropertyXnack() : TargetProperty<xnack_t>(":xnack") {}
+    };
+
+    struct TargetPropertySramecc : public TargetProperty<sramecc_t>
+    {
+        TargetPropertySramecc() : TargetProperty<sramecc_t>(":sramecc") {}
+    };
+
     void InitDbId();
+
     std::string name;
     std::string dbId;
     static const std::size_t MaxWaveScratchSize;
@@ -127,8 +163,8 @@ class TargetProperties
 public:
     virtual ~TargetProperties() = default;
 
-    TargetProperty<xnack_t> xnack;
-    TargetProperty<sramecc_t> sramecc;
+    TargetPropertyXnack xnack;
+    TargetPropertySramecc sramecc;
 
     virtual const std::string& Name() const { return name; }
     const std::string& DbId() const { return dbId; }

--- a/projects/miopen/src/include/miopen/utility/transposing_solver.hpp
+++ b/projects/miopen/src/include/miopen/utility/transposing_solver.hpp
@@ -473,9 +473,10 @@ struct TransposingSolver : Base
 
     ConvSolution GetSolution(const ExecutionContext& ctx, const Problem& problem) const override
     {
-        auto transposed_problem      = Transpose(problem);
-        ConvSolution sln             = Inner{}.GetSolution(ctx, transposed_problem);
-        auto old_factory             = *sln.invoker_factory;
+        auto transposed_problem = Transpose(problem);
+        ConvSolution sln        = Inner{}.GetSolution(ctx, transposed_problem);
+        // NOLINTNEXTLINE (bugprone-unchecked-optional-access)
+        auto old_factory             = sln.invoker_factory.value();
         const auto old_kernels_end   = sln.construction_params.size();
         const auto transpose_solvers = Derived::GetTransposeSolversMap();
 

--- a/projects/miopen/src/ocl/clhelper.cpp
+++ b/projects/miopen/src/ocl/clhelper.cpp
@@ -41,6 +41,7 @@
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -167,7 +168,7 @@ ClProgramPtr LoadProgram(cl_context ctx,
 
     if(program_name.extension() == ".cpp")
     {
-        boost::optional<miopen::TmpDir> dir(program_name);
+        std::optional<miopen::TmpDir> dir(program_name);
 #if MIOPEN_BUILD_DEV && !MIOPEN_WORKAROUND_COMPILER_CHANGE
         params += " -Werror";
         params += HipKernelWarningsString();

--- a/projects/miopen/src/ocl/convolutionocl.cpp
+++ b/projects/miopen/src/ocl/convolutionocl.cpp
@@ -26,7 +26,6 @@
 
 #include <miopen/convolution.hpp>
 
-#include <miopen/algorithm.hpp>
 #include <miopen/conv_algo_name.hpp>
 #include <miopen/conv/solver_finders.hpp>
 #include <miopen/check_numerics.hpp>
@@ -41,9 +40,7 @@
 #include <miopen/invoker.hpp>
 #include <miopen/kernel.hpp>
 #include <miopen/solution.hpp>
-#include <miopen/tensor_ops.hpp>
 #include <miopen/tensor.hpp>
-#include <miopen/util.hpp>
 #include <miopen/visit_float.hpp>
 #include <miopen/datatype.hpp>
 #include <miopen/any_solver.hpp>
@@ -56,9 +53,8 @@
 
 #include <cassert>
 #include <functional>
+#include <optional>
 #include <type_traits>
-
-#include <boost/range/adaptors.hpp>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_IMMED_FALLBACK)
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_DUMP_TENSOR_PATH)
@@ -427,7 +423,7 @@ std::vector<Solution> FindConvolution(const ExecutionContext& ctx,
                                       bool force_attach_binary)
 {
     auto results         = std::vector<Solution>{};
-    auto sol             = boost::optional<miopenConvSolution_t>{};
+    auto sol             = std::optional<miopenConvSolution_t>{};
     const auto& conv     = problem.GetConv();
     const auto& findMode = conv.findMode;
     auto fallback        = FallbackPath();

--- a/projects/miopen/src/ocl/convolutionocl.cpp
+++ b/projects/miopen/src/ocl/convolutionocl.cpp
@@ -201,7 +201,10 @@ static Invoker PrepareInvoker(ExecutionContext ctx,
     auto db           = MakeConvDbGetter(ctx);
     auto solution     = solver.FindSolution(ctx, problem, db, {}); // auto tune is not expected here
     auto& handle      = ctx.GetStream();
-    auto invoker = handle.PrepareInvoker(*solution.invoker_factory, solution.construction_params);
+    // NOLINTBEGIN (bugprone-unchecked-optional-access)
+    auto invoker =
+        handle.PrepareInvoker(solution.invoker_factory.value(), solution.construction_params);
+    // NOLINTEND (bugprone-unchecked-optional-access)
     const auto algo = AlgorithmName{solver_id.GetAlgo(problem.GetDirection())};
 
     handle.RegisterInvoker(invoker, config, solver_id.ToString(), algo);

--- a/projects/miopen/src/ocl/gcn_asm_utils.cpp
+++ b/projects/miopen/src/ocl/gcn_asm_utils.cpp
@@ -179,7 +179,7 @@ std::string AmdgcnAssemble(std::string_view source,
     std::ostringstream options;
     options << " -x assembler -target amdgcn--amdhsa";
 #if WORKAROUND_ISSUE_3001
-    if(target.Xnack() && !*target.Xnack())
+    if(!target.isXnackEnabled())
         options << " -mno-xnack";
 #endif
     /// \todo Hacky way to find out which CO version we need to assemble for.

--- a/projects/miopen/src/operator.cpp
+++ b/projects/miopen/src/operator.cpp
@@ -27,6 +27,8 @@
 #include <miopen/fusion.hpp>
 #include <miopen/logger.hpp>
 
+#include <any>
+
 namespace miopen {
 std::ostream& operator<<(std::ostream& stream, const FusionOpDescriptor& x)
 {
@@ -42,25 +44,25 @@ std::ostream& operator<<(std::ostream& stream, const FusionOpDescriptor& x)
     return stream;
 }
 
-std::ostream& operator<<(std::ostream& stream, const boost::any& a)
+std::ostream& operator<<(std::ostream& stream, const std::any& a)
 {
     // NOLINTBEGIN(*-braces-around-statements)
     if(a.type() == typeid(std::string))
-        stream << boost::any_cast<std::string>(a);
+        stream << std::any_cast<std::string>(a);
     else if(a.type() == typeid(int))
-        stream << boost::any_cast<int>(a);
+        stream << std::any_cast<int>(a);
     else if(a.type() == typeid(miopenConvolutionMode_t))
-        stream << boost::any_cast<miopenConvolutionMode_t>(a);
+        stream << std::any_cast<miopenConvolutionMode_t>(a);
     else if(a.type() == typeid(miopenPaddingMode_t))
-        stream << boost::any_cast<miopenPaddingMode_t>(a);
+        stream << std::any_cast<miopenPaddingMode_t>(a);
     else if(a.type() == typeid(size_t))
-        stream << boost::any_cast<size_t>(a);
+        stream << std::any_cast<size_t>(a);
     else if(a.type() == typeid(miopenBatchNormMode_t))
-        stream << boost::any_cast<miopenBatchNormMode_t>(a);
+        stream << std::any_cast<miopenBatchNormMode_t>(a);
     else if(a.type() == typeid(miopenActivationMode_t))
-        stream << boost::any_cast<miopenActivationMode_t>(a);
+        stream << std::any_cast<miopenActivationMode_t>(a);
     else if(a.type() == typeid(miopenDataType_t))
-        stream << boost::any_cast<miopenDataType_t>(a);
+        stream << std::any_cast<miopenDataType_t>(a);
     else
         stream << "Unsupported any type: " << a.type().name();
     // NOLINTEND(*-braces-around-statements)

--- a/projects/miopen/src/operator.cpp
+++ b/projects/miopen/src/operator.cpp
@@ -23,11 +23,12 @@
  * SOFTWARE.
  *
  *******************************************************************************/
+#include <any>
 #include <cassert>
+
 #include <miopen/fusion.hpp>
 #include <miopen/logger.hpp>
 
-#include <any>
 
 namespace miopen {
 std::ostream& operator<<(std::ostream& stream, const FusionOpDescriptor& x)

--- a/projects/miopen/src/operator.cpp
+++ b/projects/miopen/src/operator.cpp
@@ -29,7 +29,6 @@
 #include <miopen/fusion.hpp>
 #include <miopen/logger.hpp>
 
-
 namespace miopen {
 std::ostream& operator<<(std::ostream& stream, const FusionOpDescriptor& x)
 {

--- a/projects/miopen/src/problem.cpp
+++ b/projects/miopen/src/problem.cpp
@@ -533,11 +533,18 @@ std::vector<Solution> Problem::FindSolutionsImpl(const Handle& handle,
             const auto conv_solution =
                 result.GetSolver().GetSolver().FindSolution(ctx, conv_problem, db, invoke_ctx);
 
-            std::vector<Program> programs;
-            auto invoker = handle.PrepareInvoker(*conv_solution.invoker_factory,
-                                                 conv_solution.construction_params,
-                                                 options.attach_binaries ? &programs : nullptr);
-            result.SetInvoker(std::move(invoker), programs, conv_solution.construction_params);
+            if(conv_solution.invoker_factory.has_value())
+            {
+                std::vector<Program> programs;
+                auto invoker = handle.PrepareInvoker(*conv_solution.invoker_factory,
+                                                     conv_solution.construction_params,
+                                                     options.attach_binaries ? &programs : nullptr);
+                result.SetInvoker(std::move(invoker), programs, conv_solution.construction_params);
+            }
+            else
+            {
+                MIOPEN_LOG_E("Error: solution without invoker factory.");
+            }
         }
     }
     return results;

--- a/projects/miopen/src/ramdb.cpp
+++ b/projects/miopen/src/ramdb.cpp
@@ -35,7 +35,6 @@
 #include <chrono>
 #include <ctime>
 #include <fstream>
-#include <limits>
 #include <map>
 #include <mutex>
 #include <sstream>
@@ -116,7 +115,7 @@ RamDb& RamDb::GetCached(DbKinds db_kind_, const fs::path& path, bool is_system)
     return instance;
 }
 
-boost::optional<DbRecord> RamDb::FindRecord(const std::string& problem)
+std::optional<DbRecord> RamDb::FindRecord(const std::string& problem)
 {
     const auto lock = exclusive_lock(GetLockFile(), GetLockTimeout());
     MIOPEN_VALIDATE_LOCK(lock);
@@ -254,13 +253,13 @@ bool RamDb::Remove(const std::string& key, const std::string& id)
     return true;
 }
 
-boost::optional<miopen::DbRecord> RamDb::FindRecordUnsafe(const std::string& problem)
+std::optional<miopen::DbRecord> RamDb::FindRecordUnsafe(const std::string& problem)
 {
     MIOPEN_LOG_I2("Looking for key " << problem << " in cache for file " << GetFileName());
     const auto it = cache.find(problem);
 
     if(it == cache.end())
-        return boost::none;
+        return {};
 
     auto record = DbRecord{problem};
 
@@ -269,7 +268,7 @@ boost::optional<miopen::DbRecord> RamDb::FindRecordUnsafe(const std::string& pro
         MIOPEN_LOG_E("Error parsing payload under the key: "
                      << problem << " form file " << GetFileName() << "#" << it->second.line);
         MIOPEN_LOG_E("Contents: " << it->second.content);
-        return boost::none;
+        return {};
     }
 
     return record;

--- a/projects/miopen/src/solution.cpp
+++ b/projects/miopen/src/solution.cpp
@@ -176,23 +176,32 @@ void Solution::RunImpl(const Handle& handle,
     const auto problem_ =
         conv_desc.mode == miopenTranspose ? Transpose(problem_casted, &x, w, &y) : problem_casted;
 
+    if(!x.descriptor.has_value() || !y.descriptor.has_value() || !w.descriptor.has_value())
+    {
+        MIOPEN_THROW(miopenStatusBadParm);
+    }
+
     if(problem_.GetDirection() == miopenProblemDirectionBackward &&
        y.descriptor->GetLengths()[1] != w.descriptor->GetLengths()[0])
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
 
+    auto& x_d       = x.descriptor.value();
+    auto& y_d       = y.descriptor.value();
+    const auto& w_d = w.descriptor.value();
+
     if(miopen::CheckNumericsEnabled())
     {
         if(problem_.GetDirection() != miopenProblemDirectionBackward)
-            miopen::checkNumericsInput(handle, *x.descriptor, x.buffer);
+            miopen::checkNumericsInput(handle, x_d, x.buffer);
         if(problem_.GetDirection() != miopenProblemDirectionBackwardWeights)
-            miopen::checkNumericsInput(handle, *w.descriptor, w.buffer);
+            miopen::checkNumericsInput(handle, w_d, w.buffer);
         if(problem_.GetDirection() != miopenProblemDirectionForward)
-            miopen::checkNumericsInput(handle, *y.descriptor, y.buffer);
+            miopen::checkNumericsInput(handle, y_d, y.buffer);
     }
 
-    Problem::ValidateGroupCount(*x.descriptor, *w.descriptor, conv_desc);
+    Problem::ValidateGroupCount(x_d, w_d, conv_desc);
 
     const auto invoke_ctx =
         MakeInvokeParams(problem_, conv_desc, x, w, y, workspace, workspace_size);
@@ -201,11 +210,11 @@ void Solution::RunImpl(const Handle& handle,
         if(miopen::CheckNumericsEnabled())
         {
             if(problem_.GetDirection() == miopenProblemDirectionBackward)
-                miopen::checkNumericsOutput(handle, *x.descriptor, x.buffer);
+                miopen::checkNumericsOutput(handle, x_d, x.buffer);
             if(problem_.GetDirection() == miopenProblemDirectionBackwardWeights)
-                miopen::checkNumericsOutput(handle, *w.descriptor, w.buffer);
+                miopen::checkNumericsOutput(handle, w_d, w.buffer);
             if(problem_.GetDirection() == miopenProblemDirectionForward)
-                miopen::checkNumericsOutput(handle, *y.descriptor, y.buffer);
+                miopen::checkNumericsOutput(handle, y_d, y.buffer);
         }
     };
 
@@ -250,11 +259,18 @@ void Solution::RunImpl(const Handle& handle,
     const auto conv_solution = GetSolver().GetSolver().FindSolution(
         conv_ctx, conv_problem, db, invoke_ctx, perf_cfg.value_or(""));
 
-    invoker =
-        handle.PrepareInvoker(*conv_solution.invoker_factory, conv_solution.construction_params);
-    handle.RegisterInvoker(*invoker, net_cfg, GetSolver().ToString());
-    (*invoker)(handle, invoke_ctx);
-    checkNumericsOutput_();
+    if(conv_solution.invoker_factory.has_value())
+    {
+        invoker = handle.PrepareInvoker(*conv_solution.invoker_factory,
+                                        conv_solution.construction_params);
+        handle.RegisterInvoker(*invoker, net_cfg, GetSolver().ToString());
+        (*invoker)(handle, invoke_ctx);
+        checkNumericsOutput_();
+    }
+    else
+    {
+        MIOPEN_LOG_E("Error: solution without invoker factory.");
+    }
 }
 
 void Solution::RunImpl(const Handle& handle,
@@ -411,8 +427,16 @@ void Solution::RunImpl(const Handle& handle,
                                       : mhaBackward.GetSolution(ctx, problem_description);
         auto kernel_handles     = std::vector<Kernel>{std::begin(kernels), std::end(kernels)};
 
-        invoker = (*mha_solution.invoker_factory)(kernel_handles);
-        (*invoker)(handle, invoke_ctx);
+        if(mha_solution.invoker_factory.has_value())
+        {
+            invoker = (*mha_solution.invoker_factory)(kernel_handles);
+            (*invoker)(handle, invoke_ctx);
+        }
+        else
+        {
+            MIOPEN_LOG_E("Error: solution without invoker factory.");
+        }
+
         return;
     }
 
@@ -431,10 +455,17 @@ void Solution::RunImpl(const Handle& handle,
                                   ? mhaForward.GetSolution(ctx, problem_description)
                                   : mhaBackward.GetSolution(ctx, problem_description);
 
-    invoker =
-        handle.PrepareInvoker(*mha_solution.invoker_factory, mha_solution.construction_params);
-    handle.RegisterInvoker(*invoker, net_cfg, GetSolver().ToString());
-    (*invoker)(handle, invoke_ctx);
+    if(mha_solution.invoker_factory.has_value())
+    {
+        invoker =
+            handle.PrepareInvoker(*mha_solution.invoker_factory, mha_solution.construction_params);
+        handle.RegisterInvoker(*invoker, net_cfg, GetSolver().ToString());
+        (*invoker)(handle, invoke_ctx);
+    }
+    else
+    {
+        MIOPEN_LOG_E("Error: solution without invoker factory.");
+    }
 }
 
 void Solution::RunImpl(const Handle& handle,
@@ -514,8 +545,16 @@ void Solution::RunImpl(const Handle& handle,
                                           : attnSoftmax.GetSolution(ctx, problem_description);
         auto kernel_handles         = std::vector<Kernel>{std::begin(kernels), std::end(kernels)};
 
-        invoker = (*softmax_solution.invoker_factory)(kernel_handles);
-        (*invoker)(handle, invoke_ctx);
+        if(softmax_solution.invoker_factory.has_value())
+        {
+            invoker = (*softmax_solution.invoker_factory)(kernel_handles);
+            (*invoker)(handle, invoke_ctx);
+        }
+        else
+        {
+            MIOPEN_LOG_E("Error: solution without invoker factory.");
+        }
+
         return;
     }
 
@@ -534,10 +573,17 @@ void Solution::RunImpl(const Handle& handle,
                                       ? regularSoftmax.GetSolution(ctx, problem_description)
                                       : attnSoftmax.GetSolution(ctx, problem_description);
 
-    invoker = handle.PrepareInvoker(*softmax_solution.invoker_factory,
-                                    softmax_solution.construction_params);
-    handle.RegisterInvoker(*invoker, net_cfg, GetSolver().ToString());
-    (*invoker)(handle, invoke_ctx);
+    if(softmax_solution.invoker_factory.has_value())
+    {
+        invoker = handle.PrepareInvoker(*softmax_solution.invoker_factory,
+                                        softmax_solution.construction_params);
+        handle.RegisterInvoker(*invoker, net_cfg, GetSolver().ToString());
+        (*invoker)(handle, invoke_ctx);
+    }
+    else
+    {
+        MIOPEN_LOG_E("Error: solution without invoker factory.");
+    }
 }
 
 void Solution::RunImpl(const Handle& handle,
@@ -576,8 +622,16 @@ void Solution::RunImpl(const Handle& handle,
             MakeFusedSolution(ctx, solver, perf_cfg, fusion_problem, invoke_params);
         auto kernel_handles = std::vector<Kernel>{std::begin(kernels), std::end(kernels)};
 
-        invoker = (*solution.invoker_factory)(kernel_handles);
-        (*invoker)(handle, invoke_params);
+        if(solution.invoker_factory.has_value())
+        {
+            invoker = (*solution.invoker_factory)(kernel_handles);
+            (*invoker)(handle, invoke_params);
+        }
+        else
+        {
+            MIOPEN_LOG_E("Error: solution without invoker factory.");
+        }
+
         return;
     }
 
@@ -592,9 +646,17 @@ void Solution::RunImpl(const Handle& handle,
 
     const auto ctx      = FusionContext{handle};
     const auto solution = MakeFusedSolution(ctx, solver, perf_cfg, fusion_problem, invoke_params);
-    invoker = handle.PrepareInvoker(*solution.invoker_factory, solution.construction_params);
-    handle.RegisterInvoker(*invoker, net_cfg, GetSolver().ToString());
-    (*invoker)(handle, invoke_params);
+
+    if(solution.invoker_factory.has_value())
+    {
+        invoker = handle.PrepareInvoker(*solution.invoker_factory, solution.construction_params);
+        handle.RegisterInvoker(*invoker, net_cfg, GetSolver().ToString());
+        (*invoker)(handle, invoke_params);
+    }
+    else
+    {
+        MIOPEN_LOG_E("Error: solution without invoker factory.");
+    }
 }
 
 AnyInvokeParams Solution::MakeInvokeParams(const Problem& problem_,
@@ -605,26 +667,33 @@ AnyInvokeParams Solution::MakeInvokeParams(const Problem& problem_,
                                            Data_t workspace,
                                            size_t workspace_size)
 {
+    if(!x.descriptor.has_value() || !y.descriptor.has_value() || !w.descriptor.has_value())
+    {
+        MIOPEN_LOG_E("Error: incorrect parameters.");
+        MIOPEN_THROW(miopenStatusBadParm);
+    }
+
+    const auto& x_d = x.descriptor.value();
+    const auto& y_d = y.descriptor.value();
+    const auto& w_d = w.descriptor.value();
+
     switch(problem_.GetDirection())
     {
     case miopenProblemDirectionForward:
-        return conv::DataInvokeParams(
-            {*x.descriptor, x.buffer, *w.descriptor, w.buffer, *y.descriptor, y.buffer},
-            workspace,
-            workspace_size,
-            conv_desc.attribute.gfx90aFp16alt.GetFwd());
+        return conv::DataInvokeParams({x_d, x.buffer, w_d, w.buffer, y_d, y.buffer},
+                                      workspace,
+                                      workspace_size,
+                                      conv_desc.attribute.gfx90aFp16alt.GetFwd());
     case miopenProblemDirectionBackward:
-        return conv::DataInvokeParams(
-            {*y.descriptor, y.buffer, *w.descriptor, w.buffer, *x.descriptor, x.buffer},
-            workspace,
-            workspace_size,
-            conv_desc.attribute.gfx90aFp16alt.GetBwd());
+        return conv::DataInvokeParams({y_d, y.buffer, w_d, w.buffer, x_d, x.buffer},
+                                      workspace,
+                                      workspace_size,
+                                      conv_desc.attribute.gfx90aFp16alt.GetBwd());
     case miopenProblemDirectionBackwardWeights:
-        return conv::WrWInvokeParams{
-            {*y.descriptor, y.buffer, *x.descriptor, x.buffer, *w.descriptor, w.buffer},
-            workspace,
-            workspace_size,
-            conv_desc.attribute.gfx90aFp16alt.GetWrW()};
+        return conv::WrWInvokeParams{{y_d, y.buffer, x_d, x.buffer, w_d, w.buffer},
+                                     workspace,
+                                     workspace_size,
+                                     conv_desc.attribute.gfx90aFp16alt.GetWrW()};
     default: MIOPEN_THROW(miopenStatusNotImplemented);
     }
 }

--- a/projects/miopen/src/solver/conv/conv_MP_bidirectional_winograd.cpp
+++ b/projects/miopen/src/solver/conv/conv_MP_bidirectional_winograd.cpp
@@ -192,9 +192,8 @@ static bool IsApplicableTransform(const ExecutionContext& ctx, const ProblemDesc
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     const std::string name = ctx.GetStream().GetDeviceName();
     if(!StartsWith(name, "gfx9"))

--- a/projects/miopen/src/solver/conv/conv_MP_bidirectional_winograd.cpp
+++ b/projects/miopen/src/solver/conv/conv_MP_bidirectional_winograd.cpp
@@ -39,7 +39,6 @@
 #include <miopen/generic_search.hpp>
 #include <miopen/conv/invokers/impl_gemm.hpp>
 
-#include <boost/any.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 
 #if MIOPEN_BACKEND_HIP
@@ -193,8 +192,9 @@ static bool IsApplicableTransform(const ExecutionContext& ctx, const ProblemDesc
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     const std::string name = ctx.GetStream().GetDeviceName();
     if(!StartsWith(name, "gfx9"))
@@ -930,9 +930,11 @@ ConvMPBidirectWinograd_xdlops<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>::G
     result.construction_params.push_back(wino_transform.construction_params[2]);
     result.construction_params.push_back(xdlops_conv.construction_params[0]);
 
+    // NOLINTBEGIN (bugprone-unchecked-optional-access)
     result.invoker_factory =
         MakeWinogradInvokerFactory<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>(
             ctx, problem, xdlops_conv.invoker_factory.value(), true);
+    // NOLINTEND (bugprone-unchecked-optional-access)
 
     return result;
 }

--- a/projects/miopen/src/solver/conv/conv_asm_1x1u.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_1x1u.cpp
@@ -548,8 +548,9 @@ bool ConvAsm1x1U::IsApplicable(const ExecutionContext& ctx, const ProblemDescrip
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     if(!problem.IsLayoutDefault())
         return false;

--- a/projects/miopen/src/solver/conv/conv_asm_1x1u.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_1x1u.cpp
@@ -548,9 +548,8 @@ bool ConvAsm1x1U::IsApplicable(const ExecutionContext& ctx, const ProblemDescrip
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     if(!problem.IsLayoutDefault())
         return false;

--- a/projects/miopen/src/solver/conv/conv_asm_1x1u_stride2.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_1x1u_stride2.cpp
@@ -508,9 +508,8 @@ bool ConvAsm1x1UV2::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     if(!problem.IsLayoutDefault())
         return false;

--- a/projects/miopen/src/solver/conv/conv_asm_1x1u_stride2.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_1x1u_stride2.cpp
@@ -508,8 +508,9 @@ bool ConvAsm1x1UV2::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     if(!problem.IsLayoutDefault())
         return false;

--- a/projects/miopen/src/solver/conv/conv_asm_3x3u.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_3x3u.cpp
@@ -194,8 +194,9 @@ bool ConvAsm3x3U::IsApplicable(const ExecutionContext& ctx, const ProblemDescrip
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     if(problem.IsTensorsCasted())
         return false;

--- a/projects/miopen/src/solver/conv/conv_asm_3x3u.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_3x3u.cpp
@@ -194,9 +194,8 @@ bool ConvAsm3x3U::IsApplicable(const ExecutionContext& ctx, const ProblemDescrip
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     if(problem.IsTensorsCasted())
         return false;

--- a/projects/miopen/src/solver/conv/conv_asm_5x10u2v2b1.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_5x10u2v2b1.cpp
@@ -59,9 +59,8 @@ bool ConvAsm5x10u2v2b1::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     const std::string name = ctx.GetStream().GetDeviceName();
     const bool device_is_gfx8_9_no_xnack =

--- a/projects/miopen/src/solver/conv/conv_asm_5x10u2v2b1.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_5x10u2v2b1.cpp
@@ -59,8 +59,9 @@ bool ConvAsm5x10u2v2b1::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     const std::string name = ctx.GetStream().GetDeviceName();
     const bool device_is_gfx8_9_no_xnack =

--- a/projects/miopen/src/solver/conv/conv_asm_5x10u2v2f1.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_5x10u2v2f1.cpp
@@ -59,9 +59,8 @@ bool ConvAsm5x10u2v2f1::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     const std::string name = ctx.GetStream().GetDeviceName();
     const bool device_is_gfx8_9_no_xnack =

--- a/projects/miopen/src/solver/conv/conv_asm_5x10u2v2f1.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_5x10u2v2f1.cpp
@@ -59,8 +59,9 @@ bool ConvAsm5x10u2v2f1::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     const std::string name = ctx.GetStream().GetDeviceName();
     const bool device_is_gfx8_9_no_xnack =

--- a/projects/miopen/src/solver/conv/conv_asm_7x7c3h224w224k64u2v2p3q3f1.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_7x7c3h224w224k64u2v2p3q3f1.cpp
@@ -64,8 +64,9 @@ bool ConvAsm7x7c3h224w224k64u2v2p3q3f1::IsApplicable(const ExecutionContext& ctx
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     const std::string name = ctx.GetStream().GetDeviceName();
 #if WORKAROUND_ISSUE_1146

--- a/projects/miopen/src/solver/conv/conv_asm_7x7c3h224w224k64u2v2p3q3f1.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_7x7c3h224w224k64u2v2p3q3f1.cpp
@@ -64,9 +64,8 @@ bool ConvAsm7x7c3h224w224k64u2v2p3q3f1::IsApplicable(const ExecutionContext& ctx
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     const std::string name = ctx.GetStream().GetDeviceName();
 #if WORKAROUND_ISSUE_1146

--- a/projects/miopen/src/solver/conv/conv_asm_dir_BwdWrW1x1.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_dir_BwdWrW1x1.cpp
@@ -499,8 +499,9 @@ bool ConvAsmBwdWrW1x1::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     if(!problem.IsLayoutDefault())
         return false;

--- a/projects/miopen/src/solver/conv/conv_asm_dir_BwdWrW1x1.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_dir_BwdWrW1x1.cpp
@@ -499,9 +499,8 @@ bool ConvAsmBwdWrW1x1::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     if(!problem.IsLayoutDefault())
         return false;

--- a/projects/miopen/src/solver/conv/conv_asm_dir_BwdWrW3x3.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_dir_BwdWrW3x3.cpp
@@ -412,9 +412,8 @@ bool ConvAsmBwdWrW3x3::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     if(!problem.IsLayoutDefault())
         return false;

--- a/projects/miopen/src/solver/conv/conv_asm_dir_BwdWrW3x3.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_dir_BwdWrW3x3.cpp
@@ -412,8 +412,10 @@ bool ConvAsmBwdWrW3x3::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
+
     if(!problem.IsLayoutDefault())
         return false;
     if(problem.IsTensorsCasted())

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
@@ -173,9 +173,8 @@ bool ConvAsmImplicitGemmV4R1DynamicBwd::IsApplicable(const ExecutionContext& ctx
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     std::string kernel_name;
     int block_size;

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
@@ -173,8 +173,9 @@ bool ConvAsmImplicitGemmV4R1DynamicBwd::IsApplicable(const ExecutionContext& ctx
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     std::string kernel_name;
     int block_size;

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_bwd.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_bwd.cpp
@@ -1020,8 +1020,9 @@ bool ConvAsmImplicitGemmGTCDynamicBwdXdlops::IsApplicable(const ExecutionContext
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     bool isValid;
     std::tie(isValid, std::ignore, std::ignore, std::ignore, std::ignore) =

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_bwd.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_bwd.cpp
@@ -1020,9 +1020,8 @@ bool ConvAsmImplicitGemmGTCDynamicBwdXdlops::IsApplicable(const ExecutionContext
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     bool isValid;
     std::tie(isValid, std::ignore, std::ignore, std::ignore, std::ignore) =

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -1012,9 +1012,8 @@ bool ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC::IsApplicable(
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     if(0 ==
        igemm_split_batch_size(ProblemInterpreter::GetInputHeightHi(problem),

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -1012,8 +1012,9 @@ bool ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC::IsApplicable(
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false; // NOLINT (readability-simplify-boolean-expr)
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     if(0 ==
        igemm_split_batch_size(ProblemInterpreter::GetInputHeightHi(problem),

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd.cpp
@@ -1554,8 +1554,9 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlops::IsApplicable(const ExecutionContext
 #endif
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false;
 
     bool isValid;
     std::tie(isValid, std::ignore, std::ignore, std::ignore, std::ignore) =

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd.cpp
@@ -1554,9 +1554,8 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlops::IsApplicable(const ExecutionContext
 #endif
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false;
+    if(target.isXnackEnabled())
+        return false;
 
     bool isValid;
     std::tie(isValid, std::ignore, std::ignore, std::ignore, std::ignore) =

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
@@ -595,8 +595,9 @@ bool ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC::IsApplicable(
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false; // NOLINT (readability-simplify-boolean-expr)
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     if(0 ==
        igemm_split_batch_size(ProblemInterpreter::GetInputHeightHi(problem),

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
@@ -595,9 +595,8 @@ bool ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC::IsApplicable(
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     if(0 ==
        igemm_split_batch_size(ProblemInterpreter::GetInputHeightHi(problem),

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -935,9 +935,8 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC::IsApplicable(
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     if(0 ==
        igemm_split_batch_size(ProblemInterpreter::GetInputHeightHi(problem),

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -935,8 +935,9 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC::IsApplicable(
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false; // NOLINT (readability-simplify-boolean-expr)
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     if(0 ==
        igemm_split_batch_size(ProblemInterpreter::GetInputHeightHi(problem),

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -904,8 +904,9 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false; // NOLINT (readability-simplify-boolean-expr)
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     if(0 ==
        igemm_split_batch_size(ProblemInterpreter::GetInputHeightHi(problem),

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -905,7 +905,7 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(
 
     const auto& target = ctx.GetStream().GetTargetProperties();
     if(target.isXnackEnabled())
-        return false; // NOLINT (readability-simplify-boolean-expr)
+        return false;
 
     if(0 ==
        igemm_split_batch_size(ProblemInterpreter::GetInputHeightHi(problem),

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -904,9 +904,8 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false; // NOLINT (readability-simplify-boolean-expr)
 
     if(0 ==
        igemm_split_batch_size(ProblemInterpreter::GetInputHeightHi(problem),

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_v4r1_dynamic.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_v4r1_dynamic.cpp
@@ -324,8 +324,10 @@ bool ConvAsmImplicitGemmV4R1DynamicFwd::IsApplicable(const ExecutionContext& ctx
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
+
     auto tunables = GetImplicitGemmV4R1DynamicTunables();
     return !std::none_of(tunables.begin(), tunables.end(), [&](auto tunable) {
         return tunable.IsValid(ctx, problem);
@@ -371,8 +373,10 @@ bool ConvAsmImplicitGemmV4R1DynamicFwd_1x1::IsApplicable(const ExecutionContext&
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
+
     auto tunables = GetImplicitGemmV4R1DynamicTunables();
     return !std::none_of(tunables.begin(), tunables.end(), [&](auto tunable) {
         return tunable.IsValid(ctx, problem);

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_v4r1_dynamic.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_v4r1_dynamic.cpp
@@ -324,9 +324,8 @@ bool ConvAsmImplicitGemmV4R1DynamicFwd::IsApplicable(const ExecutionContext& ctx
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     auto tunables = GetImplicitGemmV4R1DynamicTunables();
     return !std::none_of(tunables.begin(), tunables.end(), [&](auto tunable) {
@@ -373,9 +372,8 @@ bool ConvAsmImplicitGemmV4R1DynamicFwd_1x1::IsApplicable(const ExecutionContext&
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     auto tunables = GetImplicitGemmV4R1DynamicTunables();
     return !std::none_of(tunables.begin(), tunables.end(), [&](auto tunable) {

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
@@ -864,9 +864,8 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlops::IsApplicable(const ExecutionContext
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false; // NOLINT (readability-simplify-boolean-expr)
 
     bool is_valid;
     std::tie(is_valid, std::ignore, std::ignore, std::ignore, std::ignore) =

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
@@ -864,8 +864,10 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlops::IsApplicable(const ExecutionContext
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
+
     bool is_valid;
     std::tie(is_valid, std::ignore, std::ignore, std::ignore, std::ignore) =
         FindImplicitGemmWrwGTCDynamicXdlopsKernel(problem);

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
@@ -865,7 +865,7 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlops::IsApplicable(const ExecutionContext
 
     const auto& target = ctx.GetStream().GetTargetProperties();
     if(target.isXnackEnabled())
-        return false; // NOLINT (readability-simplify-boolean-expr)
+        return false;
 
     bool is_valid;
     std::tie(is_valid, std::ignore, std::ignore, std::ignore, std::ignore) =

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
@@ -343,8 +343,10 @@ bool ConvAsmImplicitGemmV4R1DynamicWrw::IsApplicable(const ExecutionContext& ctx
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
+
     std::string kernel_name;
     int block_size;
     int grid_size;

--- a/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
+++ b/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
@@ -343,9 +343,8 @@ bool ConvAsmImplicitGemmV4R1DynamicWrw::IsApplicable(const ExecutionContext& ctx
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     std::string kernel_name;
     int block_size;

--- a/projects/miopen/src/solver/conv/conv_bin_wino3x3U.cpp
+++ b/projects/miopen/src/solver/conv/conv_bin_wino3x3U.cpp
@@ -33,8 +33,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/conv/tensors.hpp>
 
-#include <boost/any.hpp>
-
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_AMD_WINOGRAD_3X3)
 
 namespace miopen {
@@ -56,8 +54,9 @@ bool ConvBinWinograd3x3U::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     const auto name = ctx.GetStream().GetDeviceName();
     if(!(name == "gfx803" || name == "gfx900" || name == "gfx906" || name == "gfx908"))

--- a/projects/miopen/src/solver/conv/conv_bin_wino3x3U.cpp
+++ b/projects/miopen/src/solver/conv/conv_bin_wino3x3U.cpp
@@ -54,9 +54,8 @@ bool ConvBinWinograd3x3U::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false; // NOLINT (readability-simplify-boolean-expr)
 
     const auto name = ctx.GetStream().GetDeviceName();
     if(!(name == "gfx803" || name == "gfx900" || name == "gfx906" || name == "gfx908"))

--- a/projects/miopen/src/solver/conv/conv_bin_wino3x3U.cpp
+++ b/projects/miopen/src/solver/conv/conv_bin_wino3x3U.cpp
@@ -55,7 +55,7 @@ bool ConvBinWinograd3x3U::IsApplicable(const ExecutionContext& ctx,
 
     const auto& target = ctx.GetStream().GetTargetProperties();
     if(target.isXnackEnabled())
-        return false; // NOLINT (readability-simplify-boolean-expr)
+        return false;
 
     const auto name = ctx.GetStream().GetDeviceName();
     if(!(name == "gfx803" || name == "gfx900" || name == "gfx906" || name == "gfx908"))

--- a/projects/miopen/src/solver/conv/conv_bin_winoRxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_bin_winoRxS.cpp
@@ -33,8 +33,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/conv/tensors.hpp>
 
-#include <boost/any.hpp>
-
 /// Global switch
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_AMD_WINOGRAD_RXS)
 /// Sub-switches for testing/debugging
@@ -250,8 +248,9 @@ bool ConvBinWinogradRxS::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     const auto name = ctx.GetStream().GetDeviceName();
     const bool fp16 = problem.IsFp16();

--- a/projects/miopen/src/solver/conv/conv_bin_winoRxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_bin_winoRxS.cpp
@@ -248,9 +248,8 @@ bool ConvBinWinogradRxS::IsApplicable(const ExecutionContext& ctx,
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     const auto name = ctx.GetStream().GetDeviceName();
     const bool fp16 = problem.IsFp16();

--- a/projects/miopen/src/solver/conv/conv_multipass_wino3x3WrW.cpp
+++ b/projects/miopen/src/solver/conv/conv_multipass_wino3x3WrW.cpp
@@ -478,9 +478,8 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     if(!(InTransform<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>::IsApplicable(ctx, problem) &&
          OutTransform<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>::IsApplicable(problem) &&

--- a/projects/miopen/src/solver/conv/conv_multipass_wino3x3WrW.cpp
+++ b/projects/miopen/src/solver/conv/conv_multipass_wino3x3WrW.cpp
@@ -478,8 +478,9 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     if(!(InTransform<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>::IsApplicable(ctx, problem) &&
          OutTransform<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>::IsApplicable(problem) &&

--- a/projects/miopen/src/solver/conv/conv_winoRxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_winoRxS.cpp
@@ -38,9 +38,7 @@
 #include <miopen/sequences.hpp>
 #include <miopen/stringutils.hpp>
 
-#include <boost/any.hpp>
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <tuple>
 
 // ConvBinWinoRxS<2,3> is intended to handle group convolutions, but
@@ -779,7 +777,7 @@ bool ConvBinWinoRxS<Winodata, Winofilter>::IsApplicable(const ExecutionContext& 
 }
 
 template <int Winodata, int Winofilter>
-static inline boost::optional<PerformanceConfigConvBinWinogradRxS>
+static inline std::optional<PerformanceConfigConvBinWinogradRxS>
 GetPerfConfFromEnv(const ExecutionContext& ctx)
 {
     PerformanceConfigConvBinWinogradRxS fromEnv;
@@ -803,7 +801,7 @@ GetPerfConfFromEnv(const ExecutionContext& ctx)
     if(!fromEnv.Deserialize(s) || !fromEnv.IsValid(ctx))
     {
         MIOPEN_LOG_E(env_name << "Tuning config: Bad value or invalid format: `" << s << '\'');
-        return boost::none;
+        return {};
     }
 
     MIOPEN_LOG_I("Overridden from env: " << fromEnv.ToString());

--- a/projects/miopen/src/solver/conv/conv_winoRxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_winoRxS.cpp
@@ -670,8 +670,9 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(target.Xnack() && *target.Xnack())
-        return false;
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     const auto name = ctx.GetStream().GetDeviceName();
     if(!(StartsWith(name, "gfx9") || StartsWith(name, "gfx10") || StartsWith(name, "gfx11")))

--- a/projects/miopen/src/solver/conv/conv_winoRxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_winoRxS.cpp
@@ -670,9 +670,8 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     const auto name = ctx.GetStream().GetDeviceName();
     if(!(StartsWith(name, "gfx9") || StartsWith(name, "gfx10") || StartsWith(name, "gfx11")))

--- a/projects/miopen/src/solver/conv/conv_wino_rage_RxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_wino_rage_RxS.cpp
@@ -84,9 +84,10 @@ bool ConvWinoRageRxSCommon<Winodata, Winofilter>::IsApplicable(const ExecutionCo
     if(!(devName == "gfx942"))
         return false;
 
-    const auto& targetProperties = ctx.GetStream().GetTargetProperties();
-    if(targetProperties.Xnack() && *targetProperties.Xnack())
-        return false;
+    const auto& target = ctx.GetStream().GetTargetProperties();
+    if(const auto xnack = target.Xnack(); xnack.has_value())
+        if(*xnack)
+            return false; // NOLINT (readability-simplify-boolean-expr)
 
     if(!(problem.GetKernelStrideH() == 1 && problem.GetKernelStrideW() == 1))
         return false;

--- a/projects/miopen/src/solver/conv/conv_wino_rage_RxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_wino_rage_RxS.cpp
@@ -85,9 +85,8 @@ bool ConvWinoRageRxSCommon<Winodata, Winofilter>::IsApplicable(const ExecutionCo
         return false;
 
     const auto& target = ctx.GetStream().GetTargetProperties();
-    if(const auto xnack = target.Xnack(); xnack.has_value())
-        if(*xnack)
-            return false; // NOLINT (readability-simplify-boolean-expr)
+    if(target.isXnackEnabled())
+        return false;
 
     if(!(problem.GetKernelStrideH() == 1 && problem.GetKernelStrideW() == 1))
         return false;

--- a/projects/miopen/src/solver/conv/fft.cpp
+++ b/projects/miopen/src/solver/conv/fft.cpp
@@ -33,8 +33,6 @@
 #include <miopen/env.hpp>
 #include <miopen/tensor.hpp>
 
-#include <boost/any.hpp>
-
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_FFT)
 
 namespace miopen {

--- a/projects/miopen/src/solver/conv/gemm.cpp
+++ b/projects/miopen/src/solver/conv/gemm.cpp
@@ -36,7 +36,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/gemm_common.hpp>
 
-#include <boost/any.hpp>
 #include <boost/range/adaptors.hpp>
 
 namespace miopen {

--- a/projects/miopen/src/solver/conv/gemm_bwd.cpp
+++ b/projects/miopen/src/solver/conv/gemm_bwd.cpp
@@ -36,7 +36,6 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/gemm_common.hpp>
 
-#include <boost/any.hpp>
 #include <boost/range/adaptors.hpp>
 
 namespace miopen {

--- a/projects/miopen/src/solver/conv_winoRxS_fused.cpp
+++ b/projects/miopen/src/solver/conv_winoRxS_fused.cpp
@@ -26,19 +26,17 @@
 
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/conv/compiled_in_parameters.hpp>
-#include <miopen/conv/wrw_invoke_params.hpp>
+//#include <miopen/conv/wrw_invoke_params.hpp>
 #include <miopen/env.hpp>
 #include <miopen/generic_search.hpp>
 #include <miopen/invoke_params.hpp>
 #include <miopen/kernel_build_params.hpp>
-#include <miopen/sequences.hpp>
+//#include <miopen/sequences.hpp>
 #include <miopen/stringutils.hpp>
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/fusion/utils.hpp>
 
-#include <boost/any.hpp>
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <tuple>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1)

--- a/projects/miopen/src/solver/conv_winoRxS_fused.cpp
+++ b/projects/miopen/src/solver/conv_winoRxS_fused.cpp
@@ -26,12 +26,10 @@
 
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/conv/compiled_in_parameters.hpp>
-//#include <miopen/conv/wrw_invoke_params.hpp>
 #include <miopen/env.hpp>
 #include <miopen/generic_search.hpp>
 #include <miopen/invoke_params.hpp>
 #include <miopen/kernel_build_params.hpp>
-//#include <miopen/sequences.hpp>
 #include <miopen/stringutils.hpp>
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/fusion/utils.hpp>

--- a/projects/miopen/src/solver/conv_winoRxS_fused.cpp
+++ b/projects/miopen/src/solver/conv_winoRxS_fused.cpp
@@ -34,7 +34,6 @@
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/fusion/utils.hpp>
 
-#include <optional>
 #include <tuple>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1)

--- a/projects/miopen/src/sqlite_db.cpp
+++ b/projects/miopen/src/sqlite_db.cpp
@@ -45,7 +45,6 @@
 #include <fstream>
 #include <ios>
 #include <mutex>
-#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <thread>

--- a/projects/miopen/src/sqlite_db.cpp
+++ b/projects/miopen/src/sqlite_db.cpp
@@ -36,8 +36,6 @@
 #include <miopen_data.hpp>
 #endif
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 
 #include <memory>
 #include <algorithm>
@@ -47,6 +45,7 @@
 #include <fstream>
 #include <ios>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <thread>

--- a/projects/miopen/src/target_properties.cpp
+++ b/projects/miopen/src/target_properties.cpp
@@ -81,8 +81,8 @@ void TargetProperties::Init(const Handle* const handle)
     }();
     name = GetDeviceNameFromMap(rawName);
 
-    xnack.Init(rawName, name);
-    sramecc.Init(rawName, name);
+    xnack.init(rawName, name);
+    sramecc.init(rawName, name);
 
     InitDbId();
 }

--- a/projects/miopen/src/target_properties.cpp
+++ b/projects/miopen/src/target_properties.cpp
@@ -28,10 +28,7 @@
 #include <miopen/target_properties.hpp>
 
 #include <map>
-#include <optional>
 #include <string>
-
-#define WORKAROUND_ISSUE_1204 1 // ROCm may incorrectly report "sramecc-" for gfx900.
 
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_DEBUG_ENFORCE_DEVICE)
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_DEVICE_ARCH)
@@ -83,33 +80,10 @@ void TargetProperties::Init(const Handle* const handle)
         return handle->GetDeviceNameImpl();
     }();
     name = GetDeviceNameFromMap(rawName);
-    // DKMS driver older than 5.9 may report incorrect state of SRAMECC feature.
-    // Therefore we compute default SRAMECC and rely on it for now.
-    sramecc = [&]() -> std::optional<bool> {
-        if(name == "gfx906" || name == "gfx908")
-            return {true};
-        return {};
-    }();
-    // However we need to store the reported state, even if it is incorrect,
-    // to use together with COMGR.
-    sramecc_reported = [&]() -> std::optional<bool> {
-#if WORKAROUND_ISSUE_1204
-        if(name == "gfx900")
-            return {};
-#endif
-        if(rawName.find(":sramecc+") != std::string::npos)
-            return true;
-        if(rawName.find(":sramecc-") != std::string::npos)
-            return false;
-        return sramecc; // default
-    }();
-    xnack = [&]() -> std::optional<bool> {
-        if(rawName.find(":xnack+") != std::string::npos)
-            return true;
-        if(rawName.find(":xnack-") != std::string::npos)
-            return false;
-        return {}; // default
-    }();
+
+    xnack.Init(rawName, name);
+    sramecc.Init(rawName, name);
+
     InitDbId();
 }
 
@@ -122,15 +96,15 @@ void TargetProperties::InitDbId()
         // When feature equal to the default (SRAMECC ON), do not
         // append feature suffix. This is for backward compatibility
         // with legacy databases ONLY!
-        if(!sramecc || !(*sramecc))
+        if(sramecc.isDisabled())
             dbId += "_nosramecc";
     }
     else
     {
-        if(sramecc && *sramecc)
+        if(sramecc.isEnabled())
             dbId += "_sramecc";
     }
-    if(xnack && *xnack)
+    if(xnack.isEnabled())
         dbId += "_xnack";
 }
 

--- a/projects/miopen/src/target_properties.cpp
+++ b/projects/miopen/src/target_properties.cpp
@@ -28,6 +28,7 @@
 #include <miopen/target_properties.hpp>
 
 #include <map>
+#include <optional>
 #include <string>
 
 #define WORKAROUND_ISSUE_1204 1 // ROCm may incorrectly report "sramecc-" for gfx900.

--- a/projects/miopen/src/target_properties.cpp
+++ b/projects/miopen/src/target_properties.cpp
@@ -25,8 +25,8 @@
  *******************************************************************************/
 #include <miopen/env.hpp>
 #include <miopen/handle.hpp>
-#include <miopen/stringutils.hpp>
 #include <miopen/target_properties.hpp>
+
 #include <map>
 #include <string>
 
@@ -84,14 +84,14 @@ void TargetProperties::Init(const Handle* const handle)
     name = GetDeviceNameFromMap(rawName);
     // DKMS driver older than 5.9 may report incorrect state of SRAMECC feature.
     // Therefore we compute default SRAMECC and rely on it for now.
-    sramecc = [&]() -> boost::optional<bool> {
+    sramecc = [&]() -> std::optional<bool> {
         if(name == "gfx906" || name == "gfx908")
             return {true};
         return {};
     }();
     // However we need to store the reported state, even if it is incorrect,
     // to use together with COMGR.
-    sramecc_reported = [&]() -> boost::optional<bool> {
+    sramecc_reported = [&]() -> std::optional<bool> {
 #if WORKAROUND_ISSUE_1204
         if(name == "gfx900")
             return {};
@@ -102,7 +102,7 @@ void TargetProperties::Init(const Handle* const handle)
             return false;
         return sramecc; // default
     }();
-    xnack = [&]() -> boost::optional<bool> {
+    xnack = [&]() -> std::optional<bool> {
         if(rawName.find(":xnack+") != std::string::npos)
             return true;
         if(rawName.find(":xnack-") != std::string::npos)

--- a/projects/miopen/src/tensor.cpp
+++ b/projects/miopen/src/tensor.cpp
@@ -36,7 +36,6 @@
 #include <miopen/tensorOp/solvers.hpp>
 #include <miopen/find_solution.hpp>
 #include <miopen/visit_float.hpp>
-#include <miopen/util.hpp>
 
 #include <boost/range/combine.hpp>
 
@@ -45,6 +44,7 @@
 #include <algorithm>
 #include <cassert>
 #include <numeric>
+#include <optional>
 #include <string>
 
 namespace miopen {
@@ -94,7 +94,7 @@ std::optional<miopenTensorLayout_t> GetDefaultLayout(unsigned num_dims)
     {
     case 4: return miopenTensorNCHW;
     case 5: return miopenTensorNCDHW;
-    default: return std::nullopt;
+    default: return {};
     }
 }
 

--- a/projects/miopen/test/gtest/cache.cpp
+++ b/projects/miopen/test/gtest/cache.cpp
@@ -108,7 +108,7 @@ TEST(CPU_Cache_NONE, check_kern_db)
         EXPECT_TRUE(clean_db.StoreRecordUnsafe(cfg0));
         auto readout = clean_db.FindRecordUnsafe(cfg0);
         EXPECT_TRUE(readout);
-        EXPECT_TRUE(readout.get() == cfg0.kernel_blob);
+        EXPECT_TRUE(readout.value() == cfg0.kernel_blob);
         EXPECT_TRUE(clean_db.RemoveRecordUnsafe(cfg0));
         EXPECT_FALSE(clean_db.FindRecordUnsafe(cfg0));
     }

--- a/projects/miopen/test/gtest/cache.cpp
+++ b/projects/miopen/test/gtest/cache.cpp
@@ -23,17 +23,18 @@
  * SOFTWARE.
  *
  *******************************************************************************/
+#include <gtest/gtest.h>
 
 #include <miopen/binary_cache.hpp>
 #include <miopen/bz2.hpp>
 #include <miopen/kern_db.hpp>
 #include <miopen/temp_file.hpp>
-#include <algorithm>
-#include <vector>
+
 #include "test.hpp"
 #include "random.hpp"
 
-#include <gtest/gtest.h>
+#include <algorithm>
+#include <vector>
 
 #if MIOPEN_ENABLE_SQLITE
 std::vector<char> random_bytes(size_t length)

--- a/projects/miopen/test/gtest/conv_common.cpp
+++ b/projects/miopen/test/gtest/conv_common.cpp
@@ -28,8 +28,6 @@
 
 bool get_handle_xnack()
 {
-    auto& handle    = get_handle();
-    auto is_xnack_b = handle.GetTargetProperties().Xnack();
-    bool is_xnack   = (is_xnack_b) ? *is_xnack_b : false;
-    return is_xnack;
+    auto& handle = get_handle();
+    return handle.GetTargetProperties().isXnackEnabled();
 }

--- a/projects/miopen/test/gtest/conv_igemm_dynamic_xdlops_nhwc_bf16.cpp
+++ b/projects/miopen/test/gtest/conv_igemm_dynamic_xdlops_nhwc_bf16.cpp
@@ -97,7 +97,7 @@ bool IsTestSupportedForDevice(const miopen::Handle& handle)
 {
     const auto& target  = handle.GetTargetProperties();
     std::string devName = handle.GetDeviceName();
-    if(target.Xnack() && *target.Xnack())
+    if(target.isXnackEnabled())
         return false;
 
     if(devName == "gfx90a" || devName == "gfx942")

--- a/projects/miopen/test/gtest/conv_igemm_dynamic_xdlops_nhwc_nchw.cpp
+++ b/projects/miopen/test/gtest/conv_igemm_dynamic_xdlops_nhwc_nchw.cpp
@@ -106,7 +106,7 @@ bool IsTestSupportedForDevice(const miopen::Handle& handle)
 {
     const auto& target  = handle.GetTargetProperties();
     std::string devName = handle.GetDeviceName();
-    if(target.Xnack() && *target.Xnack())
+    if(target.isXnackEnabled())
         return false;
     if(devName == "gfx908" || devName == "gfx90a" || devName == "gfx942")
         return true;

--- a/projects/miopen/test/gtest/gtest_common.cpp
+++ b/projects/miopen/test/gtest/gtest_common.cpp
@@ -40,9 +40,9 @@ MockTargetProperties::MockTargetProperties(const TargetProperties& target_proper
 
 const std::string& MockTargetProperties::Name() const { return name; }
 
-std::optional<bool> MockTargetProperties::Xnack() const
+bool MockTargetProperties::isXnackEnabled() const
 {
-    return xnack_disabled ? std::nullopt : TargetProperties::Xnack();
+    return xnack_disabled ? false : TargetProperties::isXnackEnabled();
 }
 
 MockHandle::MockHandle(const DevDescription& dev_description, bool disable_xnack)

--- a/projects/miopen/test/gtest/gtest_common.cpp
+++ b/projects/miopen/test/gtest/gtest_common.cpp
@@ -40,9 +40,9 @@ MockTargetProperties::MockTargetProperties(const TargetProperties& target_proper
 
 const std::string& MockTargetProperties::Name() const { return name; }
 
-boost::optional<bool> MockTargetProperties::Xnack() const
+std::optional<bool> MockTargetProperties::Xnack() const
 {
-    return xnack_disabled ? boost::none : TargetProperties::Xnack();
+    return xnack_disabled ? std::nullopt : TargetProperties::Xnack();
 }
 
 MockHandle::MockHandle(const DevDescription& dev_description, bool disable_xnack)

--- a/projects/miopen/test/gtest/gtest_common.hpp
+++ b/projects/miopen/test/gtest/gtest_common.hpp
@@ -203,7 +203,7 @@ public:
 
     // Add additional methods here if needed
     const std::string& Name() const override;
-    boost::optional<bool> Xnack() const override;
+    std::optional<bool> Xnack() const override;
 
 private:
     std::string name;

--- a/projects/miopen/test/gtest/gtest_common.hpp
+++ b/projects/miopen/test/gtest/gtest_common.hpp
@@ -203,7 +203,7 @@ public:
 
     // Add additional methods here if needed
     const std::string& Name() const override;
-    std::optional<bool> Xnack() const override;
+    bool isXnackEnabled() const override;
 
 private:
     std::string name;

--- a/projects/miopen/test/gtest/layout_transpose.cpp
+++ b/projects/miopen/test/gtest/layout_transpose.cpp
@@ -25,15 +25,9 @@
  *******************************************************************************/
 #include <gtest/gtest.h>
 
-#include <cstdlib>
-#include <ctime>
-#include <vector>
-
-#include <boost/optional.hpp>
 #include "../../driver/conv_common.hpp"
 #include <miopen/batched_transpose_sol.hpp>
 #include <miopen/handle.hpp>
-#include <miopen/invoke_params.hpp>
 #include <miopen/invoker.hpp>
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>
@@ -41,7 +35,8 @@
 #include <miopen/tensor_layout.hpp>
 
 #include "driver.hpp"
-#include "random.hpp"
+
+#include <vector>
 
 namespace {
 

--- a/projects/miopen/test/perfdb.cpp
+++ b/projects/miopen/test/perfdb.cpp
@@ -707,12 +707,14 @@ private:
         std::ofstream log_err;
         std::streambuf *cout_buf = nullptr, *cerr_buf = nullptr;
 
-        if(thread_logs_root())
+        if(thread_logs_root().has_value())
         {
-            const auto out_path =
-                *thread_logs_root() / ("thread-" + std::to_string(id) + "_" + log_postfix + ".log");
-            const auto err_path = *thread_logs_root() /
+            // NOLINTBEGIN (bugprone-unchecked-optional-access)
+            const auto out_path = thread_logs_root().value() /
+                                  ("thread-" + std::to_string(id) + "_" + log_postfix + ".log");
+            const auto err_path = thread_logs_root().value() /
                                   ("thread-" + std::to_string(id) + "_" + log_postfix + "-err.log");
+            // NOLINTEND (bugprone-unchecked-optional-access)
 
             fs::remove(out_path);
             fs::remove(err_path);
@@ -727,7 +729,7 @@ private:
 
         worker();
 
-        if(thread_logs_root())
+        if(thread_logs_root().has_value())
         {
             std::cout.rdbuf(cout_buf);
             std::cerr.rdbuf(cerr_buf);
@@ -992,9 +994,10 @@ public:
                                 " --" + ArgsHelper::path_arg + " " + temp_file.Path() +
                                 " --" + ArgsHelper::db_class_arg + " " + ArgsHelper::db_class::Get<TDb>();
 
-                if(thread_logs_root())
+                if(thread_logs_root().has_value())
                 {
-                    args += std::string{" --"} + ArgsHelper::logs_path_arg + " " + *thread_logs_root();
+                // NOLINTNEXTLINE (bugprone-unchecked-optional-access)
+                    args += std::string{" --"} + ArgsHelper::logs_path_arg + " " + thread_logs_root().value();
                 }
 
                 if(full_set())
@@ -1077,9 +1080,10 @@ public:
                                " --" + ArgsHelper::path_arg + " " + temp_file +
                                " --" + ArgsHelper::db_class_arg + " " + ArgsHelper::db_class::Get<TDb>();
 
-                if(thread_logs_root())
+                if(thread_logs_root().has_value())
                 {
-                    args += std::string{" --"} + ArgsHelper::logs_path_arg + " " + *thread_logs_root();
+                    // NOLINTNEXTLINE (bugprone-unchecked-optional-access)
+                    args += std::string{" --"} + ArgsHelper::logs_path_arg + " " + thread_logs_root().value();
                 }
 
                 if(full_set())

--- a/projects/miopen/test/perfdb.cpp
+++ b/projects/miopen/test/perfdb.cpp
@@ -36,14 +36,12 @@
 #include <miopen/readonlyramdb.hpp>
 #include <miopen/temp_file.hpp>
 
-#include <boost/optional.hpp>
-
 #include <array>
 #include <cstdio>
-#include <cstdlib>
 #include <fstream>
 #include <mutex>
 #include <limits>
+#include <optional>
 #include <random>
 #include <shared_mutex>
 #include <string>
@@ -73,14 +71,14 @@ static fs::path& exe_path()
     return exe_path;
 }
 
-static boost::optional<fs::path>& thread_logs_root()
+static std::optional<fs::path>& thread_logs_root()
 {
     // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
     static std::mutex mutex;
     std::lock_guard<std::mutex> lock(mutex);
 
     // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
-    static boost::optional<fs::path> path(boost::none);
+    static std::optional<fs::path> path;
     return path;
 }
 
@@ -310,7 +308,7 @@ protected:
     static void ValidateSingleEntry(
         TKey key, const std::array<std::pair<const std::string, TValue>, count> values, TDb& db)
     {
-        boost::optional<DbRecord> record = db.FindRecord(key);
+        auto record = db.FindRecord(key);
 
         EXPECT(record);
 

--- a/projects/miopen/test/sqlite_perfdb.cpp
+++ b/projects/miopen/test/sqlite_perfdb.cpp
@@ -36,14 +36,13 @@
 #include <miopen/temp_file.hpp>
 #include <miopen/filesystem.hpp>
 
-#include <boost/optional.hpp>
 #include <boost/thread.hpp>
 
 #include <array>
 #include <cstdio>
-#include <cstdlib>
 #include <fstream>
 #include <mutex>
+#include <optional>
 #include <random>
 #include <string>
 #include <thread>
@@ -57,13 +56,13 @@ static fs::path& exe_path()
     static fs::path exe_path;
     return exe_path;
 }
-static boost::optional<fs::path>& thread_logs_root()
+static std::optional<fs::path>& thread_logs_root()
 {
     // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
     static std::mutex mutex;
     std::lock_guard<std::mutex> lock(mutex);
     // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
-    static boost::optional<fs::path> path(boost::none);
+    static std::optional<fs::path> path{std::nullopt};
     return path;
 }
 
@@ -318,7 +317,7 @@ protected:
                                     const std::array<std::pair<std::string, TValue>, count> values,
                                     TDb db)
     {
-        boost::optional<DbRecord> record = db.FindRecord(key);
+        auto record = db.FindRecord(key);
 
         EXPECT(record);
 

--- a/projects/miopen/test/tensor_reorder.cpp
+++ b/projects/miopen/test/tensor_reorder.cpp
@@ -28,18 +28,19 @@
 #include <miopen/tensor_reorder_util.hpp>
 #include <miopen/tensor.hpp>
 #include <miopen/tensor_layout.hpp>
-#include <miopen/general_tensor_reorder_sol.hpp>
 #include <miopen/invoker.hpp>
 #include <miopen/invoke_params.hpp>
-#include <boost/optional.hpp>
-#include <vector>
-#include <cstdlib>
-#include <ctime>
+
 #include "test.hpp"
 #include "driver.hpp"
 #include "random.hpp"
 #include "get_handle.hpp"
 #include "workspace.hpp"
+
+#include <ctime>
+#include <cstdlib>
+#include <optional>
+#include <vector>
 
 template <typename T>
 void cpu_tensor_reorder(T* dst,
@@ -374,7 +375,7 @@ struct tensor_reorder_driver : tensor_reorder_base_driver
 
             const auto invoke_param         = reorder_invoke_param{src_dev.get(), wspace.ptr()};
             std::vector<OpKernelArg> opArgs = reorder_sol->GetKernelArg();
-            boost::optional<miopen::InvokerFactory> invoker_factory(
+            std::optional<miopen::InvokerFactory> invoker_factory(
                 [=](const std::vector<miopen::Kernel>& kernels) mutable {
                     return [=](const miopen::Handle& handle,
                                const miopen::AnyInvokeParams& primitive_param) mutable {
@@ -388,21 +389,25 @@ struct tensor_reorder_driver : tensor_reorder_base_driver
                 });
             std::vector<miopen::solver::KernelInfo> construction_params{
                 reorder_sol->GetKernelInfo()};
-            const auto invoker = handle.PrepareInvoker(*invoker_factory, construction_params);
-            // run gpu
-            invoker(handle, invoke_param);
-            // run cpu
-            cpu_reorder<T>::run(t_dst.data.data(),
-                                t_src.data.data(),
-                                dim_0,
-                                dim_1,
-                                dim_2,
-                                dim_3,
-                                order_0,
-                                order_1,
-                                order_2,
-                                order_3);
-            invoker_factory = boost::none;
+
+            if(invoker_factory.has_value())
+            {
+                const auto invoker = handle.PrepareInvoker(*invoker_factory, construction_params);
+                // run gpu
+                invoker(handle, invoke_param);
+                // run cpu
+                cpu_reorder<T>::run(t_dst.data.data(),
+                                    t_src.data.data(),
+                                    dim_0,
+                                    dim_1,
+                                    dim_2,
+                                    dim_3,
+                                    order_0,
+                                    order_1,
+                                    order_2,
+                                    order_3);
+            }
+            invoker_factory.reset();
 
             t_dst_gpu.data = wspace.Read<decltype(t_dst_gpu.data)>();
 

--- a/projects/miopen/test/tensor_reorder.cpp
+++ b/projects/miopen/test/tensor_reorder.cpp
@@ -37,8 +37,8 @@
 #include "get_handle.hpp"
 #include "workspace.hpp"
 
-#include <ctime>
 #include <cstdlib>
+#include <ctime>
 #include <optional>
 #include <vector>
 


### PR DESCRIPTION
## Motivation

This PR is a part of efforts to remove boost library as dependency, because all used functionality exists in c++17.

## Technical Details

In this PR, `boost::optional` and `boost:any` were replaced by `std::optional` and `std::any`. As result of this replacement, clang-tidy detected bunch of incorrect usage (`bugprone-unchecked-optional-access`) of `std::optional`. These usages were masked by `boost::optional`. 
E.g. [L1557](https://github.com/ROCm/rocm-libraries/blob/develop/projects/miopen/src/solver/conv/conv_asm_implicit_gemm_gtc_fwd.cpp#L1557) (`target.Xnack()` returns `std::optional<bool>`)
```c++
    ...
    if(target.Xnack() && *target.Xnack())
    ...
```
Despite of (possible) logic which will always guarantee existence of value at this point, used data type requires check.
Despite of clang-tidy implementation [access-with-operator-vs-value](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/unchecked-optional-access.html#access-with-operator-vs-value) , implementation like
```c++
    ...
    if(target.Xnack().has_value() && target.Xnack().value())
    ...
```
still trigger this warning, so fix should look like
```c++
    ...
    if(const auto xnack = target.Xnack(); xnack.has_value())
        if(*xnack)
            return false;
    ...
```
Taking all of the above into account, in some cases, this warning was switched off using `NOLINT (bugprone-unchecked-optional-access)` , especially in cases like [L143](https://github.com/ROCm/rocm-libraries/blob/develop/projects/miopen/src/include/miopen/find_db.hpp#L143) (`content` is `std::optional<DbRecord>`)
```c++
    auto begin() const { return content->As<FindDbData>().begin(); }
    auto begin() { return content->As<FindDbData>().begin(); }
    auto end() const { return content->As<FindDbData>().end(); }
    auto end() { return content->As<FindDbData>().end(); }
```
and fixed like
```c++
    // NOLINTBEGIN (bugprone-unchecked-optional-access)
    auto begin() const { return content.value().As<FindDbData>().begin(); }
    auto begin() { return content.value().As<FindDbData>().begin(); }
    auto end() const { return content.value().As<FindDbData>().end(); }
    auto end() { return content.value().As<FindDbData>().end(); }
    // NOLINTEND (bugprone-unchecked-optional-access)
```
This will replace **undefined behavior** from `operator*()` by **thrown exception** from `std::optional::value()` in case if no value was assigned.

Other places have similar fixes:
 -if it possible to handle absence of value properly, it was implemented
 -if it was not possible - warning switched off, code modified to throw an exception.

## Test Plan & Test Result
CI tests passed.

## Submission Checklist
- [x] I have ran the tests, and they are all passing locally
- [x] I have ran `make format` to ensure the changes have been formatted