### PR TITLE
[ci] Adding CI nightly status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This table provides the current status of the migration of specific ROCm librari
 
 Note TheRock CI performs multi-component testing on top of builds leveraging [TheRock](https://github.com/ROCm/TheRock) build system.
 
-[![The Rock CI](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci.yml/badge.svg?branch%3Adevelop+event%3Apush)](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci.yml?query=branch%3Adevelop+event%3Apush)
+[![TheRock CI Nightly](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci-nightly.yml/badge.svg)](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci-nightly.yml)
 
 ---
 


### PR DESCRIPTION
Currently, the CI system runs dependent on what files were changed. Since this does not accurately reflect the CI system and its health, we added CI nightly to run everything. Now, this badge will correctly reflect all builds + tests