### PR TITLE
CTC driver CPU upgrade

### DIFF
--- a/projects/miopen/driver/ctc_driver.hpp
+++ b/projects/miopen/driver/ctc_driver.hpp
@@ -177,6 +177,7 @@ int CTCDriver<Tgpu, Tref>::AddCmdLineArgs()
     inflags.AddInputFlag(
         "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
     inflags.AddInputFlag("dump_output", 'o', "0", "Dumps the output buffers (Default=0)", "int");
+    inflags.AddInputFlag("parallel", 'p', "0", "Paralellize CPU implementation (Default=0)", "int");
     inflags.AddInputFlag(
         "ctcalgo",
         'a',
@@ -409,6 +410,7 @@ int CTCDriver<Tgpu, Tref>::RunCTCLossCPU()
                                     losses_host,
                                     gradients_host,
                                     workspace_host,
+                                    inflags.GetValueInt("parallel") == 1,
                                     blank_lb,
                                     apply_softmax,
                                     inflags.GetValueInt("verify_path"));

--- a/projects/miopen/driver/ctc_gpu_emulator.hpp
+++ b/projects/miopen/driver/ctc_gpu_emulator.hpp
@@ -25,7 +25,6 @@
  *******************************************************************************/
 #pragma once
 
-#include "timer.hpp"
 #include <cmath>
 #include <cassert>
 #include <algorithm>
@@ -34,7 +33,6 @@
 #include <cfloat>
 #include <vector>
 
-#include "../test/verify.hpp"
 #include <miopen/par_for.hpp>
 
 #define NEGATIVE_CUTOFF_VAL (-1e20)
@@ -300,27 +298,35 @@ void launchCTCLoss(const int class_sz,
               workspace_gpu.begin() + alpha_offset + max_time_step * batch_size * max_S_len,
               Tref(NEGATIVE_CUTOFF_VAL));
 
-    const int tb_count = max_time_step * batch_size;
-    const std::size_t mt_tb =
-        std::min<std::size_t>(tb_count, std::max<unsigned>(1, std::thread::hardware_concurrency()));
-    const std::size_t mt_b = std::min<std::size_t>(
-        batch_size, std::max<unsigned>(1, std::thread::hardware_concurrency()));
+    // total number of work units when softmax is applied
+    const int time_batch_task_count = max_time_step * batch_size;
+
+    const std::size_t max_threads = std::max<unsigned>(1, std::thread::hardware_concurrency());
+
+    // maximum number of threads for logsoftmax
+    const std::size_t time_batch_thread_count =
+        std::min<std::size_t>(time_batch_task_count, max_threads);
+
+    // maximum number of threads for ctc (alpha + gradient)
+    const std::size_t batch_thread_count = std::min<std::size_t>(batch_size, max_threads);
 
     if(is_softmax_applied)
     {
         if(parallel)
         {
-            miopen::par_for(tb_count, miopen::max_threads{mt_tb}, [&](std::size_t tb) {
-                subvec_logsoftmax_gpu(&(probs[0]),
-                                      &(workspace_gpu[problog_offset]),
-                                      tb * size_t(class_sz),
-                                      tb * size_t(class_sz),
-                                      size_t(class_sz));
-            });
+            miopen::par_for(time_batch_task_count,
+                            miopen::max_threads{time_batch_thread_count},
+                            [&](std::size_t tb) {
+                                subvec_logsoftmax_gpu(&(probs[0]),
+                                                      &(workspace_gpu[problog_offset]),
+                                                      tb * size_t(class_sz),
+                                                      tb * size_t(class_sz),
+                                                      size_t(class_sz));
+                            });
         }
         else
         {
-            for(int j = 0; j < max_time_step * batch_size; j++)
+            for(int j = 0; j < time_batch_task_count; j++)
                 subvec_logsoftmax_gpu(&(probs[0]),
                                       &(workspace_gpu[problog_offset]),
                                       j * class_sz,
@@ -372,7 +378,7 @@ void launchCTCLoss(const int class_sz,
 
     if(parallel)
     {
-        miopen::par_for(batch_size, miopen::max_threads{mt_b}, work_per_batch);
+        miopen::par_for(batch_size, miopen::max_threads{batch_thread_count}, work_per_batch);
     }
     else
     {

--- a/projects/miopen/driver/ctc_gpu_emulator.hpp
+++ b/projects/miopen/driver/ctc_gpu_emulator.hpp
@@ -25,18 +25,17 @@
  *******************************************************************************/
 #pragma once
 
+#include "timer.hpp"
 #include <cmath>
 #include <cassert>
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <cfloat>
-#include <fstream>
-#include <memory>
-#include <numeric>
-#include <sstream>
 #include <vector>
-#include <array>
+
+#include "../test/verify.hpp"
+#include <miopen/par_for.hpp>
 
 #define NEGATIVE_CUTOFF_VAL (-1e20)
 
@@ -78,6 +77,8 @@ void subvec_logsoftmax_gpu(Tgpu* in, Tref* out, size_t in_offset, size_t out_off
     for(int i = 0; i < length; i++)
         *(itr_out + i) = std::max(*(itr_out + i) - sum, Tref(NEGATIVE_CUTOFF_VAL));
 }
+
+// ===================== Forward (alpha) =====================
 
 template <typename T>
 void ctc_alpha_gpu(std::vector<int>& probsDesc,
@@ -136,6 +137,8 @@ void ctc_alpha_gpu(std::vector<int>& probsDesc,
     int alpha_size = input_length * label_prime_len;
     *loss          = -logaddexp_gpu(&(alpha[alpha_size - 1]), &(alpha[alpha_size - 2]));
 }
+
+// ===================== Backward (beta) + gradients =====================
 
 template <typename T>
 void ctc_gradient_gpu(std::vector<int>& probsDesc,
@@ -270,6 +273,8 @@ void ctc_gradient_gpu(std::vector<int>& probsDesc,
                                        : logaddexp_gpu(&(beta_buff0[0]), &(beta_buff0[1]));
 }
 
+// ===================== Orchestrator =====================
+
 template <typename Tgpu, typename Tref = Tgpu>
 void launchCTCLoss(const int class_sz,
                    const int batch_size,
@@ -283,6 +288,7 @@ void launchCTCLoss(const int class_sz,
                    std::vector<Tref>& gradients_gpu,
                    std::vector<Tref>& workspace_gpu,
                    std::vector<Tref>& beta_loss,
+                   bool parallel,
                    const int blank_lb      = 0,
                    bool is_softmax_applied = true)
 {
@@ -294,18 +300,38 @@ void launchCTCLoss(const int class_sz,
               workspace_gpu.begin() + alpha_offset + max_time_step * batch_size * max_S_len,
               Tref(NEGATIVE_CUTOFF_VAL));
 
+    const int tb_count = max_time_step * batch_size;
+    const std::size_t mt_tb =
+        std::min<std::size_t>(tb_count, std::max<unsigned>(1, std::thread::hardware_concurrency()));
+    const std::size_t mt_b = std::min<std::size_t>(
+        batch_size, std::max<unsigned>(1, std::thread::hardware_concurrency()));
+
     if(is_softmax_applied)
-        for(int j = 0; j < max_time_step * batch_size; j++)
-            subvec_logsoftmax_gpu(&(probs[0]),
-                                  &(workspace_gpu[problog_offset]),
-                                  j * class_sz,
-                                  j * class_sz,
-                                  class_sz);
+    {
+        if(parallel)
+        {
+            miopen::par_for(tb_count, miopen::max_threads{mt_tb}, [&](std::size_t tb) {
+                subvec_logsoftmax_gpu(&(probs[0]),
+                                      &(workspace_gpu[problog_offset]),
+                                      tb * size_t(class_sz),
+                                      tb * size_t(class_sz),
+                                      size_t(class_sz));
+            });
+        }
+        else
+        {
+            for(int j = 0; j < max_time_step * batch_size; j++)
+                subvec_logsoftmax_gpu(&(probs[0]),
+                                      &(workspace_gpu[problog_offset]),
+                                      j * class_sz,
+                                      j * class_sz,
+                                      class_sz);
+        }
+    }
     else
         std::copy(probs.begin(), probs.end(), workspace_gpu.begin() + problog_offset);
 
-    for(int j = 0; j < batch_size; j++)
-    {
+    auto work_per_batch = [&](int j) {
         int input_len     = workspace_gpu[j];
         int label_len     = workspace_gpu[batch_size + j];
         int label_offsets = workspace_gpu[2 * batch_size + j];
@@ -342,6 +368,16 @@ void launchCTCLoss(const int class_sz,
                          &(beta_loss[j]),
                          blank_lb,
                          is_softmax_applied);
+    };
+
+    if(parallel)
+    {
+        miopen::par_for(batch_size, miopen::max_threads{mt_b}, work_per_batch);
+    }
+    else
+    {
+        for(int j = 0; j < batch_size; j++)
+            work_per_batch(j);
     }
 }
 
@@ -356,6 +392,7 @@ void RunCTCLossGPUEmulator(std::vector<int>& probsDesc,
                            std::vector<Tref>& gradients_gpu,
                            std::vector<Tref>& workspace_gpu,
                            std::vector<Tref>& beta_loss,
+                           bool parallel,
                            const int blank_lb      = 0,
                            bool is_softmax_applied = true)
 {
@@ -444,6 +481,7 @@ void RunCTCLossGPUEmulator(std::vector<int>& probsDesc,
                   gradients_gpu,
                   workspace_gpu,
                   beta_loss,
+                  parallel,
                   blank_lb,
                   is_softmax_applied);
 }

--- a/projects/miopen/driver/ctc_verify.hpp
+++ b/projects/miopen/driver/ctc_verify.hpp
@@ -31,12 +31,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cfloat>
-#include <fstream>
-#include <memory>
-#include <numeric>
-#include <sstream>
 #include <vector>
-#include <array>
 #include "ctc_gpu_emulator.hpp"
 
 #define NEGATIVE_CUTOFF_VAL (-1e20)
@@ -342,6 +337,7 @@ void RunCTCLossCPUVerify(const int num_class,
                          std::vector<Tref>& losses_host,
                          std::vector<Tref>& gradients_host,
                          std::vector<Tref>& workspace_host,
+                         bool parallel,
                          const int blank_lb      = 0,
                          bool is_softmax_applied = true,
                          const int verify_path   = 1)
@@ -400,6 +396,7 @@ void RunCTCLossCPUVerify(const int num_class,
                               gradients_host,
                               workspace_host,
                               beta_loss,
+                              parallel,
                               blank_lb,
                               is_softmax_applied);
     }
@@ -418,8 +415,7 @@ void RunCTCLossCPUVerify(const int num_class,
         for(int j = 1; j < batch_size; j++)
             label_offsets[j] = label_offsets[j - 1] + labelLengths[j - 1];
 
-        for(int j = 0; j < batch_size; j++)
-        {
+        auto per_batch_work = [&](int j) {
             auto lab_begin = labels.begin() + label_offsets[j];
             std::vector<int> indiv_lab(lab_begin, lab_begin + labelLengths[j]);
 
@@ -482,6 +478,18 @@ void RunCTCLossCPUVerify(const int num_class,
                                  probs_logits_use,
                                  gradients_logits,
                                  blank_lb);
+        };
+
+        if(parallel)
+        {
+            miopen::par_for(batch_size, per_batch_work);
+        }
+        else
+        {
+            for(int j = 0; j < batch_size; j++)
+            {
+                per_batch_work(j);
+            }
         }
 
         gradients_host = is_softmax_applied ? softmaxlayer_gradients_logit : gradients_logits;


### PR DESCRIPTION
## Motivation

Improve performance of CTC loss driver (CPU side)

## Technical Details

Add new input flag that controls whether CTC loss on CPU should be parallelized or not. Uses `par_for` for parallel version.

## Test Plan

Execute both single threaded and multithreaded on various input sizes and compare performance. 

## Test Result

Tests performed on:
CPU: AMD Ryzen 9 5900X 12-Core Processor
RAM: 62 GB
GPU: AMD Radeon RX 6800 XT

Case | -n | -k | -l | -c | -m | -b | -a | serial_ms | parallel_ms | speedup
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
H00 | 8 | 4096×8 | 1024×8 | 4096 | 1 | 0 | 0 | 8889.968 | 1228.039 | 7.24x
H01 | 8 | 4096,4096,4096,4096,3584,3840,4096,3072 | 1024,960,1024,900,900,880,800,768 | 4096 | 1 | 0 | 0 | 6674.759 | 820.007 | 8.14x
H02 | 8 | 4096×8 | 1024×8 | 4096 | 0 | 0 | 0 | 4025.443 | 668.175 | 6.02x
H03 | 8 | 4096,4096,3900,4096,3800,4096,3700,4096 | 1024,1000,1000,980,980,960,960,940 | 4096 | 1 | 0 | 1 | 6092.346 | 661.084 | 9.22x
H04 | 8 | 4096 | 1024 | 4096 | 1 | 4096 | 0 | 7939.547 | 971.919 | 8.17x
H05 | 8 | 4096 | 1024 | 8192 | 1 | 0 | 0 | 14389.679 | 1767.086 | 8.14x
H06 | 4 | 8192×4 | 2048×4 | 2048 | 1 | 0 | 0 | 7963.052 | 1894.528 | 4.20x
H07 | 64 | 1024 | 256 | 2048 | 1 | 0 | 0 | 4671.503 | 327.302 | 14.27x
H08 | 16 | 2048×16 | 1020,1016,1012,1008,…,964/960 (len=16) | 1024 | 1 | 0 | 0 | 3328.817 | 305.047 | 10.91x
H09 | 8 | 3072 | 1000 | 8192 | 0 | 0 | 0 | 4128.659 | 629.248 | 6.56x
H10 | 8 | 4096 | 1600 | 2048 | 1 | 1024 | 0 | 5910.575 | 716.302 | 8.25x
H11 | 16 | 4096 | 2048 | 4096 | 1 | 0 | 1 | 17740.921 | 1436.956 | 12.35x
H12 | 1 | 16384 | 4096 | 4096 | 1 | 0 | 0 | 7164.430 | 6041.900 | 1.19x
H13 | 4 | 1024 | 256 | 16384 | 1 | 0 | 0 | 1840.577 | 222.585 | 8.27x
H14 | 12 | 2048,2048,2048,1536,…,768/768 (len=12) | 600,600,600,500,…,300/300 (len=12) | 4096 | 1 | 0 | 0 | 2994.609 | 285.169 | 10.50x
H15 | 12 | 2048,2048,2048,1536,…,768/768 (len=12) | 600,600,600,500,…,300/300 (len=12) | 4096 | 0 | 0 | 0 | 1216.066 | 227.755 | 5.34x
H16 | 6 | 3072×6 | 1536,1500,1490,1480,1470,1460 | 3072 | 1 | 1536 | 0 | 3617.260 | 537.241 | 6.73x
H17 | 96 | 1024 | 256 | 1024 | 1 | 0 | 1 | 4441.932 | 318.406 | 13.95x
H18 | 2 | 8192 | 2048 | 8192 | 1 | 0 | 0 | 6329.086 | 2132.007 | 2.97x
A02 | 16 | 600,600,580,560,…,340/320 (len=16) | 90,90,88,86,…,64/62 (len=16) | 1024 | 1 | 0 | 0 | 276.922 | 30.756 | 9.00x
O01 | 64 | 200,198,196,194,…,76/74 (len=64) | 36,36,35,35,…,14/13 (len=64) | 96 | 1 | 96 | 0 | 44.846 | 6.295 | 7.12x
H01 | 16 | 900,850,800,750,…,260/220 (len=16) | 135,128,120,113,…,39/33 (len=16) | 85 | 1 | 0 | 0 | 88.620 | 19.263 | 4.60x
K01 | 64 | 200,198,196,194,…,76/74 (len=64) | 16,16,16,16,…,6/6 (len=64) | 35 | 1 | 0 | 0 | 18.019 | 3.221 | 5.59x
L01 | 32 | 200,195,190,185,…,50/45 (len=32) | 40,39,38,37,…,10/9 (len=32) | 40 | 1 | 0 | 0 | 13.407 | 3.410 | 3.93x


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
