### PR TITLE
[MIOpen] Fix compile error in windows build (no CK)

### DIFF
--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -47,8 +47,10 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS_AI
 #include <miopen/solver/implicitgemm_ck_util.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
 
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 /// https://github.com/ROCm/rocm-libraries/issues/2293 AI heuristics splitk validity issue.
 #define WORKAROUND_ROCMLIBS_ISSUE_2293 1
+#endif
 
 namespace miopen {
 namespace solver {


### PR DESCRIPTION
This PR fixes a compile issue that was observed in a windows CI build that happens when MIOpen is built without CK.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
