### PR TITLE
build(rocprim): fix offload compress detection not working

### DIFF
--- a/projects/rocprim/CMakeLists.txt
+++ b/projects/rocprim/CMakeLists.txt
@@ -82,7 +82,7 @@ cmake_dependent_option(USE_HIPCXX "Use CMake HIP language support" OFF CMAKE_HIP
 include(CheckCXXCompilerFlag)
 
 if(BUILD_OFFLOAD_COMPRESS)
-  check_cxx_compiler_flag("--offload-compress" CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+  check_cxx_compiler_flag("--offload-compress -x hip" CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
   if(CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --offload-compress")
   else()


### PR DESCRIPTION
## Motivation

We've noticed CI failures due to linker errors.

## Technical Details

When building tests on multiple architectures, linking sometimes fails due to big/fat kernels bloating the code object file. Offload compress is supposed to help with that. But this broke in the recent updates.

## Test Plan

When compiling on ROCm 7.x, offload compress detection should not fail on standard ROCm setups.

## Test Result

Works on my machine (and our internal CI).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
