### PR TITLE
[hipblasLT] Add compute_type to TypePredicate

### DIFF
--- a/projects/hipblaslt/clients/common/include/testing_auxiliary.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_auxiliary.hpp
@@ -1626,6 +1626,62 @@ void testing_aux_matmul_bad_ws_size(const Arguments& arg)
     CHECK_HIPBLASLT_ERROR(hipblasLtDestroy(handle));
     CHECK_HIP_ERROR(hipStreamDestroy(stream));
 }
+
+void testing_aux_matmul_bad_input_types(const Arguments& arg)
+{
+    hipStream_t        stream;
+    hipblasLtHandle_t  handle;
+    hipblasOperation_t trans_a     = HIPBLAS_OP_N;
+    hipblasOperation_t trans_b     = HIPBLAS_OP_N;
+    int64_t            m           = 128;
+    int64_t            n           = 128;
+    int64_t            k           = 128;
+
+    CHECK_HIP_ERROR(hipStreamCreate(&stream));
+    CHECK_HIPBLASLT_ERROR(hipblasLtCreate(&handle));
+
+    hipblasLtMatrixLayout_t matA, matB, matC, matD;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matA, arg.a_type, m, k, m));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matB, arg.b_type, k, n, k));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matC, arg.c_type, m, n, m));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matD, arg.d_type, m, n, m));
+
+    hipblasLtMatmulDesc_t matmul;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescCreate(&matmul, arg.compute_type, arg.scale_type));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_TRANSA, &trans_a, sizeof(int32_t)));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(int32_t)));
+
+    hipblasLtMatmulPreference_t pref;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceCreate(&pref));
+
+    const int                        request_solutions = 50;
+    hipblasLtMatmulHeuristicResult_t heuristicResult[request_solutions];
+    int                              returnedAlgoCount = 0;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulAlgoGetHeuristic(handle,
+                                                          matmul,
+                                                          matA,
+                                                          matB,
+                                                          matC,
+                                                          matD,
+                                                          pref,
+                                                          request_solutions,
+                                                          heuristicResult,
+                                                          &returnedAlgoCount));
+
+    // We are passing in invalid datatype combinations, so we shouldn't get any valid solutions
+    ASSERT_TRUE(returnedAlgoCount == 0);
+
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescDestroy(matmul));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matA));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matB));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matC));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matD));
+    CHECK_HIPBLASLT_ERROR(hipblasLtDestroy(handle));
+    CHECK_HIP_ERROR(hipStreamDestroy(stream));
+}
+
 void testing_aux_matmul_pref_init_bad_arg(const Arguments& arg)
 {
     hipblasLtMatmulPreference_t pref;

--- a/projects/hipblaslt/clients/tests/data/auxiliary_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/auxiliary_gtest.yaml
@@ -138,6 +138,11 @@ Tests:
   function:
     - aux_matmul_bad_ws_size: *hpa_half_precision
 
+- name: aux_matmul_bad_input_types
+  category: pre_checkin
+  function:
+    - aux_matmul_bad_input_types: *invalid_precisions
+
 - name: aux_mat_copy
   category: pre_checkin
   function:

--- a/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
+++ b/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
@@ -487,6 +487,12 @@ Real precisions 1 bytes: &real_precisions_mx
   - &mxf4_mxf4_precision_dst_bfp16
     { a_type: f4_r, b_type: f4_r, c_type: bf16_r, d_type: bf16_r, compute_type: c_f32_r, scaleA: 3, scaleB: 3, scale_type: f32_r}
 
+invalid datatypes for testing: &invalid_precisions
+  - &bad_precision_fp64_fp32
+    { a_type: f64_r, b_type: f64_r, c_type: f64_r, d_type: f64_r, compute_type: c_f32_r, scale_type: f32_r }
+  - &bad_precision_fp32_fp16
+    { a_type: f32_r, b_type: f32_r, c_type: f32_r, d_type: f32_r, compute_type: c_i32_r, scale_type: f32_r }
+
 # rocRoller predicate
 rocRoller predicate: &rocroller_predicate
   - &unrollKPredicate

--- a/projects/hipblaslt/clients/tests/src/auxiliary_gtest.cpp
+++ b/projects/hipblaslt/clients/tests/src/auxiliary_gtest.cpp
@@ -94,6 +94,8 @@ namespace
                 testing_aux_matmul_alg_null_matmul(arg);
             else if(!strcmp(arg.function, "aux_matmul_bad_ws_size"))
                 testing_aux_matmul_bad_ws_size(arg);
+            else if(!strcmp(arg.function, "aux_matmul_bad_input_types"))
+                testing_aux_matmul_bad_input_types(arg);
 #ifdef CODE_COVERAGE
             else if(!strcmp(arg.function, "aux_auxiliary_func"))
                 testing_aux_auxiliary_func(arg);
@@ -156,6 +158,7 @@ namespace
                    || !strcmp(arg.function, "aux_matmul_plan_init")
                    || !strcmp(arg.function, "aux_matmul_alg_null_matmul")
                    || !strcmp(arg.function, "aux_matmul_bad_ws_size")
+                   || !strcmp(arg.function, "aux_matmul_bad_input_types")
                    || !strcmp(arg.function, "aux_matmul_pref_get_attr_bad_arg")
                    || !strcmp(arg.function, "aux_matmul_pref_get_attr")
 #ifdef CODE_COVERAGE

--- a/projects/hipblaslt/tensilelite/Tensile/Contractions.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Contractions.py
@@ -370,7 +370,7 @@ class ProblemType:
             # predicates.append(ProblemPredicate("GroupedGemm", value=self.groupedGemm))
 
         if includeType:
-            predicates.append(ProblemPredicate("TypesEqual", value=(self.aType, self.bType, self.cType, self.dType, self.computeInputType)))
+            predicates.append(ProblemPredicate("TypesEqual", value=(self.aType, self.bType, self.cType, self.dType, self.computeInputType, self.computeType)))
             predicates.append(ProblemPredicate("HighPrecisionAccumulate", value=self.highPrecisionAccumulate))
             predicates.append(ProblemPredicate("Activation", value=self.activationType))
             predicates.append(ProblemPredicate("ActivationComputeType", value=self.activationComputeDataType))

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1253,7 +1253,7 @@ namespace TensileLite
                 };
                 TypesEqual() = default;
 
-                std::array<rocisa::DataType, 5> value;
+                std::array<rocisa::DataType, 6> value;
 
                 static std::string Type()
                 {
@@ -1265,7 +1265,8 @@ namespace TensileLite
                     return problem.a().dataType() == value[0] && problem.b().dataType() == value[1]
                            && problem.c().dataType() == value[2]
                            && problem.d().dataType() == value[3]
-                           && problem.computeInputType() == value[4];
+                           && problem.computeInputType() == value[4]
+                           && problem.computeType() == value[5];
                 }
 
                 virtual std::string toString() const override
@@ -1280,7 +1281,9 @@ namespace TensileLite
                                        ", d:",
                                        value[3],
                                        ", compute input type:",
-                                       value[4]);
+                                       value[4],
+                                       ", compute type:",
+                                       value[5]);
                 }
 
                 virtual bool debugEval(ContractionProblemGemm const& problem,


### PR DESCRIPTION
## Motivation

When calling hipblasLT, there's no explicit check for input/output/compute types. We rely on solution-selection to either find a solution, or return no-solution-found. When calling hipblasLT with a mismatched compute-type (e.g. fp64 input/output and fp32 compute), hipblasLT may launch a kernel which doesn't match the compute type, giving undefined behaviour (I've seen incorrect results and a hang).

## Technical Details

This PR adds computeType to the TypesEqual predicate within tensilelite. Before, computeInputType was checked, but not the computeType iteself.

## Test Plan

Manually ran a mismatched datatype, wait for CI.

## Test Result

Manual mismatched datatypes gave No solution found, tbd CI.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
