### PR TITLE
[hipblasLT] Hotfix - Add compute_type to TypePredicate

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Contractions.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Contractions.py
@@ -370,7 +370,7 @@ class ProblemType:
             # predicates.append(ProblemPredicate("GroupedGemm", value=self.groupedGemm))
 
         if includeType:
-            predicates.append(ProblemPredicate("TypesEqual", value=(self.aType, self.bType, self.cType, self.dType, self.computeInputType)))
+            predicates.append(ProblemPredicate("TypesEqual", value=(self.aType, self.bType, self.cType, self.dType, self.computeInputType, self.computeType)))
             predicates.append(ProblemPredicate("HighPrecisionAccumulate", value=self.highPrecisionAccumulate))
             predicates.append(ProblemPredicate("Activation", value=self.activationType))
             predicates.append(ProblemPredicate("ActivationComputeType", value=self.activationComputeDataType))

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1253,7 +1253,7 @@ namespace TensileLite
                 };
                 TypesEqual() = default;
 
-                std::array<rocisa::DataType, 5> value;
+                std::array<rocisa::DataType, 6> value;
 
                 static std::string Type()
                 {
@@ -1265,7 +1265,8 @@ namespace TensileLite
                     return problem.a().dataType() == value[0] && problem.b().dataType() == value[1]
                            && problem.c().dataType() == value[2]
                            && problem.d().dataType() == value[3]
-                           && problem.computeInputType() == value[4];
+                           && problem.computeInputType() == value[4]
+                           && problem.computeType() == value[5];
                 }
 
                 virtual std::string toString() const override
@@ -1280,7 +1281,9 @@ namespace TensileLite
                                        ", d:",
                                        value[3],
                                        ", compute input type:",
-                                       value[4]);
+                                       value[4],
+                                       ", compute type:",
+                                       value[5]);
                 }
 
                 virtual bool debugEval(ContractionProblemGemm const& problem,


### PR DESCRIPTION
## Motivation

This is a hotfix for the 7.1 branch. This PR is a cherry pick of #2315, and the description is a copy/paste from there as well.

When calling hipblasLT, there's no explicit check for input/output/compute types. We rely on solution-selection to either find a solution, or return no-solution-found. When calling hipblasLT with a mismatched compute-type (e.g. fp64 input/output and fp32 compute), hipblasLT may launch a kernel which doesn't match the compute type, giving undefined behaviour (I've seen incorrect results and a hang).

## Technical Details

This PR adds computeType to the TypesEqual predicate within tensilelite. Before, computeInputType was checked, but not the computeType iteself.

## Test Plan

Manually ran a mismatched datatype, wait for CI.

## Test Result

Manual mismatched datatypes gave No solution found, tbd CI.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
