### PR TITLE
rocfft: clarify callback documentation for arrays and same-ness

### DIFF
--- a/projects/hipfft/clients/hipfft_params.h
+++ b/projects/hipfft/clients/hipfft_params.h
@@ -536,6 +536,25 @@ public:
         }
     }
 
+    // Return the number of expected callback entries for supplied
+    // fields.
+    static size_t expected_callback_count(const std::vector<fft_field>& fields, size_t multiGPU)
+    {
+        // if library-decomposed multi-GPU transform is being done,
+        // then we need that many callback entries
+        if(multiGPU > 1)
+            return multiGPU;
+
+        // If fields are not specified, we consider the input or
+        // output to have a single brick (and thus expect a single
+        // callback entry)
+        if(fields.empty())
+            return 1;
+        return std::accumulate(fields.begin(),
+                               fields.end(),
+                               static_cast<size_t>(0),
+                               [](size_t s, const fft_field& f) { return s + f.bricks.size(); });
+    }
     fft_status set_callbacks(std::vector<void*>* load_cb_func,
                              std::vector<void*>* load_cb_data,
                              std::vector<void*>* store_cb_func,
@@ -547,6 +566,13 @@ public:
         {
             if(!hipfft_transform_type)
                 throw std::runtime_error("callbacks require a valid hipfftType");
+
+            auto expected_load_cb_count  = expected_callback_count(ifields, multiGPU);
+            auto expected_store_cb_count = expected_callback_count(ofields, multiGPU);
+            check_callback_vec(load_cb_func, expected_load_cb_count, true);
+            check_callback_vec(load_cb_data, expected_load_cb_count, false);
+            check_callback_vec(store_cb_func, expected_store_cb_count, true);
+            check_callback_vec(store_cb_data, expected_store_cb_count, false);
 
             hipfftXtCallbackType load_type  = HIPFFT_CB_UNDEFINED;
             hipfftXtCallbackType store_type = HIPFFT_CB_UNDEFINED;

--- a/projects/hipfft/clients/hipfft_params.h
+++ b/projects/hipfft/clients/hipfft_params.h
@@ -536,146 +536,73 @@ public:
         }
     }
 
-    fft_status set_callbacks(void*  load_cb_host,
-                             void*  load_cb_data,
-                             void*  store_cb_host,
-                             void*  store_cb_data,
-                             size_t load_cb_shared_mem_bytes  = 0,
-                             size_t store_cb_shared_mem_bytes = 0) override
+    fft_status set_callbacks(std::vector<void*>* load_cb_func,
+                             std::vector<void*>* load_cb_data,
+                             std::vector<void*>* store_cb_func,
+                             std::vector<void*>* store_cb_data,
+                             size_t              load_cb_shared_mem_bytes  = 0,
+                             size_t              store_cb_shared_mem_bytes = 0) override
     {
         if(run_callbacks)
         {
             if(!hipfft_transform_type)
                 throw std::runtime_error("callbacks require a valid hipfftType");
 
+            hipfftXtCallbackType load_type  = HIPFFT_CB_UNDEFINED;
+            hipfftXtCallbackType store_type = HIPFFT_CB_UNDEFINED;
+
             hipfftResult ret{HIPFFT_EXEC_FAILED};
             switch(*hipfft_transform_type)
             {
             case HIPFFT_R2C:
-                ret = hipfftXtSetCallback(plan, &load_cb_host, HIPFFT_CB_LD_REAL, &load_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallback(
-                    plan, &store_cb_host, HIPFFT_CB_ST_COMPLEX, &store_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_LD_REAL, load_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_ST_COMPLEX, store_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
+                load_type  = HIPFFT_CB_LD_REAL;
+                store_type = HIPFFT_CB_ST_COMPLEX;
                 break;
             case HIPFFT_D2Z:
-                ret = hipfftXtSetCallback(
-                    plan, &load_cb_host, HIPFFT_CB_LD_REAL_DOUBLE, &load_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallback(
-                    plan, &store_cb_host, HIPFFT_CB_ST_COMPLEX_DOUBLE, &store_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_LD_REAL_DOUBLE, load_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_ST_COMPLEX_DOUBLE, store_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
+                load_type  = HIPFFT_CB_LD_REAL_DOUBLE;
+                store_type = HIPFFT_CB_ST_COMPLEX_DOUBLE;
                 break;
             case HIPFFT_C2R:
-                ret = hipfftXtSetCallback(plan, &load_cb_host, HIPFFT_CB_LD_COMPLEX, &load_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallback(plan, &store_cb_host, HIPFFT_CB_ST_REAL, &store_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_LD_COMPLEX, load_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_ST_REAL, store_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
+                load_type  = HIPFFT_CB_LD_COMPLEX;
+                store_type = HIPFFT_CB_ST_REAL;
                 break;
             case HIPFFT_Z2D:
-                ret = hipfftXtSetCallback(
-                    plan, &load_cb_host, HIPFFT_CB_LD_COMPLEX_DOUBLE, &load_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallback(
-                    plan, &store_cb_host, HIPFFT_CB_ST_REAL_DOUBLE, &store_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_LD_COMPLEX_DOUBLE, load_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_ST_REAL_DOUBLE, store_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
+                load_type  = HIPFFT_CB_LD_COMPLEX_DOUBLE;
+                store_type = HIPFFT_CB_ST_REAL_DOUBLE;
                 break;
             case HIPFFT_C2C:
-                ret = hipfftXtSetCallback(plan, &load_cb_host, HIPFFT_CB_LD_COMPLEX, &load_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallback(
-                    plan, &store_cb_host, HIPFFT_CB_ST_COMPLEX, &store_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_LD_COMPLEX, load_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_ST_COMPLEX, store_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
+                load_type  = HIPFFT_CB_LD_COMPLEX;
+                store_type = HIPFFT_CB_ST_COMPLEX;
                 break;
             case HIPFFT_Z2Z:
-                ret = hipfftXtSetCallback(
-                    plan, &load_cb_host, HIPFFT_CB_LD_COMPLEX_DOUBLE, &load_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallback(
-                    plan, &store_cb_host, HIPFFT_CB_ST_COMPLEX_DOUBLE, &store_cb_data);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_LD_COMPLEX_DOUBLE, load_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
-
-                ret = hipfftXtSetCallbackSharedSize(
-                    plan, HIPFFT_CB_ST_COMPLEX_DOUBLE, store_cb_shared_mem_bytes);
-                if(ret != HIPFFT_SUCCESS)
-                    return fft_status_from_hipfftparams(ret);
+                load_type  = HIPFFT_CB_LD_COMPLEX_DOUBLE;
+                store_type = HIPFFT_CB_ST_COMPLEX_DOUBLE;
                 break;
             default:
                 throw std::runtime_error("Invalid execution type");
             }
+
+            ret = hipfftXtSetCallback(plan,
+                                      load_cb_func ? load_cb_func->data() : nullptr,
+                                      load_type,
+                                      load_cb_data ? load_cb_data->data() : nullptr);
+            if(ret != HIPFFT_SUCCESS)
+                return fft_status_from_hipfftparams(ret);
+
+            ret = hipfftXtSetCallback(plan,
+                                      store_cb_func ? store_cb_func->data() : nullptr,
+                                      store_type,
+                                      store_cb_data ? store_cb_data->data() : nullptr);
+            if(ret != HIPFFT_SUCCESS)
+                return fft_status_from_hipfftparams(ret);
+
+            ret = hipfftXtSetCallbackSharedSize(plan, load_type, load_cb_shared_mem_bytes);
+            if(ret != HIPFFT_SUCCESS)
+                return fft_status_from_hipfftparams(ret);
+
+            ret = hipfftXtSetCallbackSharedSize(plan, store_type, store_cb_shared_mem_bytes);
+            if(ret != HIPFFT_SUCCESS)
+                return fft_status_from_hipfftparams(ret);
         }
         return fft_status_success;
     }

--- a/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
+++ b/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
@@ -184,14 +184,7 @@ __host__ __device__ Tdata load_callback(Tdata* input, size_t offset, void* cbdat
 {
     auto testdata = static_cast<const callback_test_data*>(cbdata);
     // multiply each element by scalar
-    if(input == testdata->base)
-        return input[offset] * testdata->scalar;
-    // wrong base address passed, return something obviously wrong
-    else
-    {
-        // wrong base address passed, return something obviously wrong
-        return input[0];
-    }
+    return input[offset] * testdata->scalar;
 }
 
 __device__ auto load_callback_dev_half           = load_callback<rocfft_fp16>;
@@ -209,14 +202,7 @@ __host__ __device__ Tdata
 {
     auto testdata = static_cast<const callback_test_data*>(cbdata);
     // subtract each element by scalar
-    if(input == testdata->base)
-        return input[offset] - testdata->scalar;
-    // wrong base address passed, return something obviously wrong
-    else
-    {
-        // wrong base address passed, return something obviously wrong
-        return input[0];
-    }
+    return input[offset] - testdata->scalar;
 }
 
 __device__ auto load_callback_round_trip_inverse_dev_half
@@ -366,11 +352,7 @@ __host__ __device__ static void
 {
     auto testdata = static_cast<callback_test_data*>(cbdata);
     // add scalar to each element
-    if(output == testdata->base)
-    {
-        output[offset] = element + testdata->scalar;
-    }
-    // otherwise, wrong base address passed, just don't write
+    output[offset] = element + testdata->scalar;
 }
 
 __device__ auto store_callback_dev_half           = store_callback<rocfft_fp16>;
@@ -386,11 +368,7 @@ __host__ __device__ static void store_callback_round_trip_inverse(
 {
     auto testdata = static_cast<callback_test_data*>(cbdata);
     // divide each element by scalar
-    if(output == testdata->base)
-    {
-        output[offset] = element / testdata->scalar;
-    }
-    // otherwise, wrong base address passed, just don't write
+    output[offset] = element / testdata->scalar;
 }
 __device__ auto store_callback_round_trip_inverse_dev_half
     = store_callback_round_trip_inverse<rocfft_fp16>;
@@ -541,7 +519,6 @@ void apply_store_callback(const fft_params& params, std::vector<hostbuf>& output
 
     callback_test_data cbdata;
     cbdata.scalar = params.store_cb_scalar;
-    cbdata.base   = output.front().data();
 
     switch(params.otype)
     {
@@ -661,7 +638,6 @@ void apply_load_callback(const fft_params& params, std::vector<hostbuf>& input)
 
     callback_test_data cbdata;
     cbdata.scalar = params.load_cb_scalar;
-    cbdata.base   = input.front().data();
 
     switch(params.itype)
     {

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -238,115 +238,161 @@ inline void execute_gpu_fft(Tparams&              params,
                             std::vector<hostbuf>& gpu_output,
                             bool                  round_trip_inverse = false)
 {
-    gpubuf_t<callback_test_data> load_cb_data_dev;
-    gpubuf_t<callback_test_data> store_cb_data_dev;
+    // Vector of callback data - at function scope so they live until
+    // after the transform is completed
+    std::vector<gpubuf_t<callback_test_data>> all_cb_data;
+
     if(params.run_callbacks)
     {
-        void* load_cb_host
-            = get_load_callback_host(params.itype, params.precision, round_trip_inverse);
+        std::vector<void*> load_cb_func;
+        std::vector<void*> load_cb_data;
+        std::vector<void*> store_cb_func;
+        std::vector<void*> store_cb_data;
 
-        callback_test_data load_cb_data_host;
+        auto add_load_cb = [&](void* ibuffer) {
+            void* load_cb_host
+                = get_load_callback_host(params.itype, params.precision, round_trip_inverse);
 
-        if(round_trip_inverse)
+            callback_test_data load_cb_data_host;
+
+            if(round_trip_inverse)
+            {
+                load_cb_data_host.scalar = params.store_cb_scalar;
+            }
+            else
+            {
+                load_cb_data_host.scalar = params.load_cb_scalar;
+            }
+
+            load_cb_data_host.base = ibuffer;
+
+            auto& load_cb_data_dev = all_cb_data.emplace_back();
+            auto  hip_status       = load_cb_data_dev.alloc(sizeof(callback_test_data));
+            if(hip_status != hipSuccess)
+            {
+                ++n_hip_failures;
+                std::stringstream ss;
+                ss << "Error occurred when allocating device memory for loading callback";
+                if(skip_runtime_fails)
+                {
+                    throw ROCFFT_SKIP{ss.str()};
+                }
+                else
+                {
+                    throw ROCFFT_FAIL{ss.str()};
+                }
+            }
+            hip_status = hipMemcpy(load_cb_data_dev.data(),
+                                   &load_cb_data_host,
+                                   sizeof(callback_test_data),
+                                   hipMemcpyHostToDevice);
+            if(hip_status != hipSuccess)
+            {
+                ++n_hip_failures;
+                std::stringstream ss;
+                ss << "Error occurred when copying data to device for loading callback";
+                if(skip_runtime_fails)
+                {
+                    throw ROCFFT_SKIP{ss.str()};
+                }
+                else
+                {
+                    throw ROCFFT_FAIL{ss.str()};
+                }
+            }
+            load_cb_func.push_back(load_cb_host);
+            load_cb_data.push_back(load_cb_data_dev.data());
+        };
+
+        if(params.ifields.empty())
         {
-            load_cb_data_host.scalar = params.store_cb_scalar;
+            // load cb for current HIP device
+            add_load_cb(pibuffer.front());
         }
         else
         {
-            load_cb_data_host.scalar = params.load_cb_scalar;
+            for(size_t i = 0; i < params.ifields.front().bricks.size(); ++i)
+            {
+                // load cb for this brick's device
+                rocfft_scoped_device dev(params.ifields.front().bricks[i].device);
+                add_load_cb(pibuffer[i]);
+            }
         }
 
-        load_cb_data_host.base = pibuffer.front();
+        auto add_store_cb = [&](void* obuffer) {
+            void* store_cb_host
+                = get_store_callback_host(params.otype, params.precision, round_trip_inverse);
 
-        auto hip_status = hipSuccess;
+            callback_test_data store_cb_data_host;
 
-        hip_status = load_cb_data_dev.alloc(sizeof(callback_test_data));
-        if(hip_status != hipSuccess)
-        {
-            ++n_hip_failures;
-            std::stringstream ss;
-            ss << "Error occurred when allocating device memory for loading callback";
-            if(skip_runtime_fails)
+            if(round_trip_inverse)
             {
-                throw ROCFFT_SKIP{ss.str()};
+                store_cb_data_host.scalar = params.load_cb_scalar;
             }
             else
             {
-                throw ROCFFT_FAIL{ss.str()};
+                store_cb_data_host.scalar = params.store_cb_scalar;
             }
-        }
-        hip_status = hipMemcpy(load_cb_data_dev.data(),
-                               &load_cb_data_host,
-                               sizeof(callback_test_data),
-                               hipMemcpyHostToDevice);
-        if(hip_status != hipSuccess)
-        {
-            ++n_hip_failures;
-            std::stringstream ss;
-            ss << "Error occurred when copying data to device for loading callback";
-            if(skip_runtime_fails)
+
+            store_cb_data_host.base = pobuffer.front();
+
+            auto& store_cb_data_dev = all_cb_data.emplace_back();
+            auto  hip_status        = store_cb_data_dev.alloc(sizeof(callback_test_data));
+            if(hip_status != hipSuccess)
             {
-                throw ROCFFT_SKIP{ss.str()};
+                ++n_hip_failures;
+                std::stringstream ss;
+                ss << "Error occurred when allocating device memory for storing callback";
+                if(skip_runtime_fails)
+                {
+                    throw ROCFFT_SKIP{ss.str()};
+                }
+                else
+                {
+                    throw ROCFFT_FAIL{ss.str()};
+                }
             }
-            else
+
+            hip_status = hipMemcpy(store_cb_data_dev.data(),
+                                   &store_cb_data_host,
+                                   sizeof(callback_test_data),
+                                   hipMemcpyHostToDevice);
+            if(hip_status != hipSuccess)
             {
-                throw ROCFFT_FAIL{ss.str()};
+                ++n_hip_failures;
+                std::stringstream ss;
+                ss << "Error occurred when copying data to device for storing callback";
+                if(skip_runtime_fails)
+                {
+                    throw ROCFFT_SKIP{ss.str()};
+                }
+                else
+                {
+                    throw ROCFFT_FAIL{ss.str()};
+                }
             }
-        }
 
-        void* store_cb_host
-            = get_store_callback_host(params.otype, params.precision, round_trip_inverse);
+            store_cb_func.push_back(store_cb_host);
+            store_cb_data.push_back(store_cb_data_dev.data());
+        };
 
-        callback_test_data store_cb_data_host;
-
-        if(round_trip_inverse)
+        if(params.ofields.empty())
         {
-            store_cb_data_host.scalar = params.load_cb_scalar;
+            // store cb for current HIP device
+            add_store_cb(pobuffer.front());
         }
         else
         {
-            store_cb_data_host.scalar = params.store_cb_scalar;
-        }
-
-        store_cb_data_host.base = pobuffer.front();
-
-        hip_status = store_cb_data_dev.alloc(sizeof(callback_test_data));
-        if(hip_status != hipSuccess)
-        {
-            ++n_hip_failures;
-            std::stringstream ss;
-            ss << "Error occurred when allocating device memory for storing callback";
-            if(skip_runtime_fails)
+            for(size_t i = 0; i < params.ofields.front().bricks.size(); ++i)
             {
-                throw ROCFFT_SKIP{ss.str()};
-            }
-            else
-            {
-                throw ROCFFT_FAIL{ss.str()};
+                // store cb for this brick's device
+                rocfft_scoped_device dev(params.ofields.front().bricks[i].device);
+                add_store_cb(pobuffer[i]);
             }
         }
 
-        hip_status = hipMemcpy(store_cb_data_dev.data(),
-                               &store_cb_data_host,
-                               sizeof(callback_test_data),
-                               hipMemcpyHostToDevice);
-        if(hip_status != hipSuccess)
-        {
-            ++n_hip_failures;
-            std::stringstream ss;
-            ss << "Error occurred when copying data to device for storing callback";
-            if(skip_runtime_fails)
-            {
-                throw ROCFFT_SKIP{ss.str()};
-            }
-            else
-            {
-                throw ROCFFT_FAIL{ss.str()};
-            }
-        }
-
-        auto fft_status = params.set_callbacks(
-            load_cb_host, load_cb_data_dev.data(), store_cb_host, store_cb_data_dev.data());
+        auto fft_status
+            = params.set_callbacks(&load_cb_func, &load_cb_data, &store_cb_func, &store_cb_data);
         if(fft_status != fft_status_success)
             throw std::runtime_error("set callback failure");
     }

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -247,7 +247,7 @@ inline void execute_gpu_fft(Tparams&              params,
 
     if(params.run_callbacks)
     {
-        auto add_load_cb = [&](void* ibuffer) {
+        auto add_load_cb = [&]() {
             void* load_cb_host
                 = get_load_callback_host(params.itype, params.precision, round_trip_inverse);
 
@@ -302,8 +302,20 @@ inline void execute_gpu_fft(Tparams&              params,
 
         if(params.ifields.empty())
         {
-            // load cb for current HIP device
-            add_load_cb(pibuffer.front());
+            // for library-decomposed multi-GPU, one cb for each device
+            if(params.multiGPU > 1)
+            {
+                for(int i = 0; i < static_cast<int>(params.multiGPU); ++i)
+                {
+                    rocfft_scoped_device dev(i);
+                    add_load_cb();
+                }
+            }
+            else
+            {
+                // load cb for current HIP device
+                add_load_cb();
+            }
         }
         else
         {
@@ -311,11 +323,11 @@ inline void execute_gpu_fft(Tparams&              params,
             {
                 // load cb for this brick's device
                 rocfft_scoped_device dev(params.ifields.front().bricks[i].device);
-                add_load_cb(pibuffer[i]);
+                add_load_cb();
             }
         }
 
-        auto add_store_cb = [&](void* obuffer) {
+        auto add_store_cb = [&]() {
             void* store_cb_host
                 = get_store_callback_host(params.otype, params.precision, round_trip_inverse);
 
@@ -372,8 +384,20 @@ inline void execute_gpu_fft(Tparams&              params,
 
         if(params.ofields.empty())
         {
-            // store cb for current HIP device
-            add_store_cb(pobuffer.front());
+            // for library-decomposed multi-GPU, one cb for each device
+            if(params.multiGPU > 1)
+            {
+                for(int i = 0; i < static_cast<int>(params.multiGPU); ++i)
+                {
+                    rocfft_scoped_device dev(i);
+                    add_store_cb();
+                }
+            }
+            else
+            {
+                // store cb for current HIP device
+                add_store_cb();
+            }
         }
         else
         {
@@ -381,7 +405,7 @@ inline void execute_gpu_fft(Tparams&              params,
             {
                 // store cb for this brick's device
                 rocfft_scoped_device dev(params.ofields.front().bricks[i].device);
-                add_store_cb(pobuffer[i]);
+                add_store_cb();
             }
         }
 

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -165,8 +165,6 @@ struct callback_test_data
 {
     // scalar to modify the input/output with
     double scalar;
-    // base address of input, to ensure that each callback gets an offset from that base
-    void* base;
 };
 
 void* get_load_callback_host(fft_array_type itype,
@@ -242,13 +240,13 @@ inline void execute_gpu_fft(Tparams&              params,
     // after the transform is completed
     std::vector<gpubuf_t<callback_test_data>> all_cb_data;
 
+    std::vector<void*> load_cb_func;
+    std::vector<void*> load_cb_data;
+    std::vector<void*> store_cb_func;
+    std::vector<void*> store_cb_data;
+
     if(params.run_callbacks)
     {
-        std::vector<void*> load_cb_func;
-        std::vector<void*> load_cb_data;
-        std::vector<void*> store_cb_func;
-        std::vector<void*> store_cb_data;
-
         auto add_load_cb = [&](void* ibuffer) {
             void* load_cb_host
                 = get_load_callback_host(params.itype, params.precision, round_trip_inverse);
@@ -263,8 +261,6 @@ inline void execute_gpu_fft(Tparams&              params,
             {
                 load_cb_data_host.scalar = params.load_cb_scalar;
             }
-
-            load_cb_data_host.base = ibuffer;
 
             auto& load_cb_data_dev = all_cb_data.emplace_back();
             auto  hip_status       = load_cb_data_dev.alloc(sizeof(callback_test_data));
@@ -333,8 +329,6 @@ inline void execute_gpu_fft(Tparams&              params,
             {
                 store_cb_data_host.scalar = params.store_cb_scalar;
             }
-
-            store_cb_data_host.base = pobuffer.front();
 
             auto& store_cb_data_dev = all_cb_data.emplace_back();
             auto  hip_status        = store_cb_data_dev.alloc(sizeof(callback_test_data));

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -829,6 +829,21 @@ public:
     std::vector<fft_field> ifields;
     std::vector<fft_field> ofields;
 
+    // Check that a supplied vector of callback pointers has an
+    // expected size.  Optionally also check that each pointer is
+    // non-null.  Throws an exception if a check fails.  The vector
+    // itself can be null, as callbacks are optional.
+    static void check_callback_vec(std::vector<void*>* cb, size_t expected_size, bool nonnull)
+    {
+        if(!cb)
+            return;
+        if(cb->size() != expected_size)
+            throw std::invalid_argument("expected " + std::to_string(expected_size)
+                                        + " callback pointers, got " + std::to_string(cb->size()));
+        if(nonnull && std::any_of(cb->begin(), cb->end(), [](void* p) { return p == nullptr; }))
+            throw std::invalid_argument("null callback function");
+    }
+
     // simple "multi-GPU" count, meaning the library decides on the
     // decomposition instead of it being explicit as bricks.  only
     // has an effect if set to a number > 1.

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -2329,12 +2329,18 @@ public:
         }
     }
 
-    virtual fft_status set_callbacks(void*  load_cb_host,
-                                     void*  load_cb_data,
-                                     void*  store_cb_host,
-                                     void*  store_cb_data,
-                                     size_t load_cb_shared_mem_bytes,
-                                     size_t store_cb_shared_mem_bytes)
+    // A callback is expressed as a pair of device function pointer +
+    // device function data.
+    //
+    // Load and store callbacks are provided as vectors of those
+    // pointers, as we need a separate function+data for each device
+    // being loaded from or stored to.
+    virtual fft_status set_callbacks(std::vector<void*>* load_cb_func,
+                                     std::vector<void*>* load_cb_data,
+                                     std::vector<void*>* store_cb_func,
+                                     std::vector<void*>* store_cb_data,
+                                     size_t              load_cb_shared_mem_bytes,
+                                     size_t              store_cb_shared_mem_bytes)
     {
         return fft_status_success;
     }

--- a/projects/hipfft/shared/rocfft_params.h
+++ b/projects/hipfft/shared/rocfft_params.h
@@ -512,6 +512,21 @@ public:
         return ret;
     }
 
+    // Return the number of expected callback entries for supplied
+    // fields.
+    static size_t expected_callback_count(const std::vector<fft_field>& fields)
+    {
+        // If fields are not specified, we consider the input or
+        // output to have a single brick (and thus expect a single
+        // callback entry)
+        if(fields.empty())
+            return 1;
+        return std::accumulate(fields.begin(),
+                               fields.end(),
+                               static_cast<size_t>(0),
+                               [](size_t s, const fft_field& f) { return s + f.bricks.size(); });
+    }
+
     fft_status set_callbacks(std::vector<void*>* load_cb_func,
                              std::vector<void*>* load_cb_data,
                              std::vector<void*>* store_cb_func,
@@ -521,6 +536,13 @@ public:
     {
         if(run_callbacks)
         {
+            auto expected_load_cb_count  = expected_callback_count(ifields);
+            auto expected_store_cb_count = expected_callback_count(ofields);
+            check_callback_vec(load_cb_func, expected_load_cb_count, true);
+            check_callback_vec(load_cb_data, expected_load_cb_count, false);
+            check_callback_vec(store_cb_func, expected_store_cb_count, true);
+            check_callback_vec(store_cb_data, expected_store_cb_count, false);
+
             auto roc_status = rocfft.execution_info_set_load_callback(
                 info,
                 load_cb_func ? load_cb_func->data() : nullptr,

--- a/projects/hipfft/shared/rocfft_params.h
+++ b/projects/hipfft/shared/rocfft_params.h
@@ -512,22 +512,28 @@ public:
         return ret;
     }
 
-    fft_status set_callbacks(void*  load_cb_host,
-                             void*  load_cb_data,
-                             void*  store_cb_host,
-                             void*  store_cb_data,
-                             size_t load_cb_shared_mem_bytes  = 0,
-                             size_t store_cb_shared_mem_bytes = 0) override
+    fft_status set_callbacks(std::vector<void*>* load_cb_func,
+                             std::vector<void*>* load_cb_data,
+                             std::vector<void*>* store_cb_func,
+                             std::vector<void*>* store_cb_data,
+                             size_t              load_cb_shared_mem_bytes  = 0,
+                             size_t              store_cb_shared_mem_bytes = 0) override
     {
         if(run_callbacks)
         {
             auto roc_status = rocfft.execution_info_set_load_callback(
-                info, &load_cb_host, &load_cb_data, load_cb_shared_mem_bytes);
+                info,
+                load_cb_func ? load_cb_func->data() : nullptr,
+                load_cb_data ? load_cb_data->data() : nullptr,
+                load_cb_shared_mem_bytes);
             if(roc_status != rocfft_status_success)
                 return fft_status_from_rocfftparams(roc_status);
 
             roc_status = rocfft.execution_info_set_store_callback(
-                info, &store_cb_host, &store_cb_data, store_cb_shared_mem_bytes);
+                info,
+                store_cb_func ? store_cb_func->data() : nullptr,
+                store_cb_data ? store_cb_data->data() : nullptr,
+                store_cb_shared_mem_bytes);
             if(roc_status != rocfft_status_success)
                 return fft_status_from_rocfftparams(roc_status);
         }

--- a/projects/rocfft/clients/tests/accuracy_test.cpp
+++ b/projects/rocfft/clients/tests/accuracy_test.cpp
@@ -30,14 +30,7 @@ __host__ __device__ Tdata load_callback(Tdata* input, size_t offset, void* cbdat
 {
     auto testdata = static_cast<const callback_test_data*>(cbdata);
     // multiply each element by scalar
-    if(input == testdata->base)
-        return input[offset] * testdata->scalar;
-    // wrong base address passed, return something obviously wrong
-    else
-    {
-        // wrong base address passed, return something obviously wrong
-        return input[0];
-    }
+    return input[offset] * testdata->scalar;
 }
 
 __device__ auto load_callback_dev_half           = load_callback<rocfft_fp16>;
@@ -55,14 +48,7 @@ __host__ __device__ Tdata
 {
     auto testdata = static_cast<const callback_test_data*>(cbdata);
     // subtract each element by scalar
-    if(input == testdata->base)
-        return input[offset] - testdata->scalar;
-    // wrong base address passed, return something obviously wrong
-    else
-    {
-        // wrong base address passed, return something obviously wrong
-        return input[0];
-    }
+    return input[offset] - testdata->scalar;
 }
 
 __device__ auto load_callback_round_trip_inverse_dev_half
@@ -212,11 +198,7 @@ __host__ __device__ static void
 {
     auto testdata = static_cast<callback_test_data*>(cbdata);
     // add scalar to each element
-    if(output == testdata->base)
-    {
-        output[offset] = element + testdata->scalar;
-    }
-    // otherwise, wrong base address passed, just don't write
+    output[offset] = element + testdata->scalar;
 }
 __device__ auto store_callback_dev_half           = store_callback<rocfft_fp16>;
 __device__ auto store_callback_dev_complex_half   = store_callback<rocfft_complex<rocfft_fp16>>;
@@ -231,11 +213,7 @@ __host__ __device__ static void store_callback_round_trip_inverse(
 {
     auto testdata = static_cast<callback_test_data*>(cbdata);
     // divide each element by scalar
-    if(output == testdata->base)
-    {
-        output[offset] = element / testdata->scalar;
-    }
-    // otherwise, wrong base address passed, just don't write
+    output[offset] = element / testdata->scalar;
 }
 __device__ auto store_callback_round_trip_inverse_dev_half
     = store_callback_round_trip_inverse<rocfft_fp16>;
@@ -386,7 +364,6 @@ void apply_store_callback(const fft_params& params, std::vector<hostbuf>& output
 
     callback_test_data cbdata;
     cbdata.scalar = params.store_cb_scalar;
-    cbdata.base   = output.front().data();
 
     switch(params.otype)
     {
@@ -506,7 +483,6 @@ void apply_load_callback(const fft_params& params, std::vector<hostbuf>& input)
 
     callback_test_data cbdata;
     cbdata.scalar = params.load_cb_scalar;
-    cbdata.base   = input.front().data();
 
     switch(params.itype)
     {

--- a/projects/rocfft/clients/tests/callback_change_type.cpp
+++ b/projects/rocfft/clients/tests/callback_change_type.cpp
@@ -152,7 +152,8 @@ TEST_P(change_type, short_to_float)
                           &callback_host, HIP_SYMBOL(load_callback_short2_dev), sizeof(void*)),
                       hipSuccess);
         }
-        ASSERT_EQ(params.set_callbacks(callback_host, nullptr, nullptr, nullptr),
+        std::vector<void*> callback_host_vec{callback_host};
+        ASSERT_EQ(params.set_callbacks(&callback_host_vec, nullptr, nullptr, nullptr),
                   fft_status_success);
 
         // run rocFFT

--- a/projects/rocfft/docs/how-to/load-store-callbacks.rst
+++ b/projects/rocfft/docs/how-to/load-store-callbacks.rst
@@ -18,7 +18,7 @@ to the library using
 :cpp:func:`rocfft_execution_info_set_store_callback`.
 
 Callback functions are passed as arrays of function pointers, with
-one function per brick in the input or output field.  For example, to
+one function per brick in the :ref:`input or output field<input_output_fields>`.  For example, to
 specify a load callback on a transform with 4 input bricks, pass an
 array of 4 function pointers to
 :cpp:func:`rocfft_execution_info_set_load_callback`.  Or, to specify
@@ -35,7 +35,7 @@ All functions in an array must perform the same logical operation.
 That is, any function in an array must be substitutable for any other
 function in the array if the data being loaded or stored were moved
 to another brick.  Behavior of the transform is not defined if
-functions in a array do not behave the same.
+functions in an array do not behave the same.
 
 .. note::
 

--- a/projects/rocfft/docs/how-to/load-store-callbacks.rst
+++ b/projects/rocfft/docs/how-to/load-store-callbacks.rst
@@ -17,6 +17,26 @@ to the library using
 :cpp:func:`rocfft_execution_info_set_load_callback` and
 :cpp:func:`rocfft_execution_info_set_store_callback`.
 
+Callback functions are passed as arrays of function pointers, with
+one function per brick in the input or output field.  For example, to
+specify a load callback on a transform with 4 input bricks, pass an
+array of 4 function pointers to
+:cpp:func:`rocfft_execution_info_set_load_callback`.  Or, to specify
+a store callback on a transform with 6 output bricks, pass an array of
+6 function pointers to
+:cpp:func:`rocfft_execution_info_set_store_callback`.  The order of
+the function pointers must match the order that the bricks were added
+to the input or output fields with
+:cpp:func:`rocfft_field_add_brick`.  If the input or output field of
+a transform is unspecified, the input or output is considered to have
+one brick.
+
+All functions in an array must perform the same logical operation.
+That is, any function in an array must be substitutable for any other
+function in the array if the data being loaded or stored were moved
+to another brick.  Behavior of the transform is not defined if
+functions in a array do not behave the same.
+
 .. note::
 
    Callback functions must be built as relocatable device code by

--- a/projects/rocfft/library/include/rocfft/rocfft.h
+++ b/projects/rocfft/library/include/rocfft/rocfft.h
@@ -537,8 +537,14 @@ ROCFFT_EXPORT rocfft_status rocfft_execution_info_set_stream(rocfft_execution_in
  *  transform.  Callbacks are an experimental feature in rocFFT.
  *
  *  Callback function pointers/data are given as arrays, with one
- *  function/data pointer per device executing this plan.  Currently,
- *  plans can only use one device.
+ *  function/data pointer per brick in the input field of the plan.
+ *  A plan with no input field specified is considered to have one
+ *  brick.
+ *
+ *  All functions in the array must perform the same logical
+ *  operation.  That is, any function in the array must be
+ *  substitutable for any other function in the array if the data
+ *  being loaded were moved to another brick.
  *
  *  The provided function pointers replace any previously-specified
  *  load callback for this execution info handle.
@@ -555,8 +561,9 @@ ROCFFT_EXPORT rocfft_status rocfft_execution_info_set_stream(rocfft_execution_in
  *  real-to-complex transform would load single-precision real
  *  elements).
  *
- *  A null value for 'cb' may be specified to clear any previously
- *  registered load callback.
+ *  A null value for 'cb_functions' may be specified to clear any
+ *  previously registered load callback.  'cb_data' may be null if
+ *  the functions require no additional pointer to be passed to them.
  *
  *  Currently, 'shared_mem_bytes' must be 0.  Callbacks are not
  *  supported on transforms that use planar formats for either input
@@ -580,6 +587,16 @@ ROCFFT_EXPORT rocfft_status rocfft_execution_info_set_load_callback(rocfft_execu
  *  function/data pointer per device executing this plan.  Currently,
  *  plans can only use one device.
  *
+ *  Callback function pointers/data are given as arrays, with one
+ *  function/data pointer per brick in the output field of the plan.
+ *  A plan with no output field specified is considered to have one
+ *  brick.
+ *
+ *  All functions in the array must perform the same logical
+ *  operation.  That is, any function in the array must be
+ *  substitutable for any other function in the array if the data
+ *  being stored were moved to another brick.
+ *
  *  The provided function pointers replace any previously-specified
  *  store callback for this execution info handle.
  *
@@ -595,15 +612,16 @@ ROCFFT_EXPORT rocfft_status rocfft_execution_info_set_load_callback(rocfft_execu
  *  real-to-complex transform would store single-precision complex
  *  elements).
  *
- *  A null value for 'cb' may be specified to clear any previously
- *  registered store callback.
+ *  A null value for 'cb_functions' may be specified to clear any
+ *  previously registered load callback.  'cb_data' may be null if
+ *  the functions require no additional pointer to be passed to them.
  *
  *  Currently, 'shared_mem_bytes' must be 0.  Callbacks are not
  *  supported on transforms that use planar formats for either input
  *  or output.
  *
  *  @param[in] info execution info handle
- *  @param[in] cb_functions callbacks function pointers
+ *  @param[in] cb_functions callback function pointers
  *  @param[in] cb_data callback function data, passed to the function pointer when it is called
  *  @param[in] shared_mem_bytes amount of shared memory to allocate for the callback function to use
  *  */

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -247,7 +247,7 @@ inline void execute_gpu_fft(Tparams&              params,
 
     if(params.run_callbacks)
     {
-        auto add_load_cb = [&](void* ibuffer) {
+        auto add_load_cb = [&]() {
             void* load_cb_host
                 = get_load_callback_host(params.itype, params.precision, round_trip_inverse);
 
@@ -302,8 +302,20 @@ inline void execute_gpu_fft(Tparams&              params,
 
         if(params.ifields.empty())
         {
-            // load cb for current HIP device
-            add_load_cb(pibuffer.front());
+            // for library-decomposed multi-GPU, one cb for each device
+            if(params.multiGPU > 1)
+            {
+                for(int i = 0; i < static_cast<int>(params.multiGPU); ++i)
+                {
+                    rocfft_scoped_device dev(i);
+                    add_load_cb();
+                }
+            }
+            else
+            {
+                // load cb for current HIP device
+                add_load_cb();
+            }
         }
         else
         {
@@ -311,11 +323,11 @@ inline void execute_gpu_fft(Tparams&              params,
             {
                 // load cb for this brick's device
                 rocfft_scoped_device dev(params.ifields.front().bricks[i].device);
-                add_load_cb(pibuffer[i]);
+                add_load_cb();
             }
         }
 
-        auto add_store_cb = [&](void* obuffer) {
+        auto add_store_cb = [&]() {
             void* store_cb_host
                 = get_store_callback_host(params.otype, params.precision, round_trip_inverse);
 
@@ -372,8 +384,20 @@ inline void execute_gpu_fft(Tparams&              params,
 
         if(params.ofields.empty())
         {
-            // store cb for current HIP device
-            add_store_cb(pobuffer.front());
+            // for library-decomposed multi-GPU, one cb for each device
+            if(params.multiGPU > 1)
+            {
+                for(int i = 0; i < static_cast<int>(params.multiGPU); ++i)
+                {
+                    rocfft_scoped_device dev(i);
+                    add_store_cb();
+                }
+            }
+            else
+            {
+                // store cb for current HIP device
+                add_store_cb();
+            }
         }
         else
         {
@@ -381,7 +405,7 @@ inline void execute_gpu_fft(Tparams&              params,
             {
                 // store cb for this brick's device
                 rocfft_scoped_device dev(params.ofields.front().bricks[i].device);
-                add_store_cb(pobuffer[i]);
+                add_store_cb();
             }
         }
 

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -165,8 +165,6 @@ struct callback_test_data
 {
     // scalar to modify the input/output with
     double scalar;
-    // base address of input, to ensure that each callback gets an offset from that base
-    void* base;
 };
 
 void* get_load_callback_host(fft_array_type itype,
@@ -264,8 +262,6 @@ inline void execute_gpu_fft(Tparams&              params,
                 load_cb_data_host.scalar = params.load_cb_scalar;
             }
 
-            load_cb_data_host.base = ibuffer;
-
             auto& load_cb_data_dev = all_cb_data.emplace_back();
             auto  hip_status       = load_cb_data_dev.alloc(sizeof(callback_test_data));
             if(hip_status != hipSuccess)
@@ -333,8 +329,6 @@ inline void execute_gpu_fft(Tparams&              params,
             {
                 store_cb_data_host.scalar = params.store_cb_scalar;
             }
-
-            store_cb_data_host.base = obuffer;
 
             auto& store_cb_data_dev = all_cb_data.emplace_back();
             auto  hip_status        = store_cb_data_dev.alloc(sizeof(callback_test_data));

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -238,115 +238,161 @@ inline void execute_gpu_fft(Tparams&              params,
                             std::vector<hostbuf>& gpu_output,
                             bool                  round_trip_inverse = false)
 {
-    gpubuf_t<callback_test_data> load_cb_data_dev;
-    gpubuf_t<callback_test_data> store_cb_data_dev;
+    // Vector of callback data - at function scope so they live until
+    // after the transform is completed
+    std::vector<gpubuf_t<callback_test_data>> all_cb_data;
+
+    std::vector<void*> load_cb_func;
+    std::vector<void*> load_cb_data;
+    std::vector<void*> store_cb_func;
+    std::vector<void*> store_cb_data;
+
     if(params.run_callbacks)
     {
-        void* load_cb_host
-            = get_load_callback_host(params.itype, params.precision, round_trip_inverse);
+        auto add_load_cb = [&](void* ibuffer) {
+            void* load_cb_host
+                = get_load_callback_host(params.itype, params.precision, round_trip_inverse);
 
-        callback_test_data load_cb_data_host;
+            callback_test_data load_cb_data_host;
 
-        if(round_trip_inverse)
+            if(round_trip_inverse)
+            {
+                load_cb_data_host.scalar = params.store_cb_scalar;
+            }
+            else
+            {
+                load_cb_data_host.scalar = params.load_cb_scalar;
+            }
+
+            load_cb_data_host.base = ibuffer;
+
+            auto& load_cb_data_dev = all_cb_data.emplace_back();
+            auto  hip_status       = load_cb_data_dev.alloc(sizeof(callback_test_data));
+            if(hip_status != hipSuccess)
+            {
+                ++n_hip_failures;
+                std::stringstream ss;
+                ss << "Error occurred when allocating device memory for loading callback";
+                if(skip_runtime_fails)
+                {
+                    throw ROCFFT_SKIP{ss.str()};
+                }
+                else
+                {
+                    throw ROCFFT_FAIL{ss.str()};
+                }
+            }
+            hip_status = hipMemcpy(load_cb_data_dev.data(),
+                                   &load_cb_data_host,
+                                   sizeof(callback_test_data),
+                                   hipMemcpyHostToDevice);
+            if(hip_status != hipSuccess)
+            {
+                ++n_hip_failures;
+                std::stringstream ss;
+                ss << "Error occurred when copying data to device for loading callback";
+                if(skip_runtime_fails)
+                {
+                    throw ROCFFT_SKIP{ss.str()};
+                }
+                else
+                {
+                    throw ROCFFT_FAIL{ss.str()};
+                }
+            }
+            load_cb_func.push_back(load_cb_host);
+            load_cb_data.push_back(load_cb_data_dev.data());
+        };
+
+        if(params.ifields.empty())
         {
-            load_cb_data_host.scalar = params.store_cb_scalar;
+            // load cb for current HIP device
+            add_load_cb(pibuffer.front());
         }
         else
         {
-            load_cb_data_host.scalar = params.load_cb_scalar;
+            for(size_t i = 0; i < params.ifields.front().bricks.size(); ++i)
+            {
+                // load cb for this brick's device
+                rocfft_scoped_device dev(params.ifields.front().bricks[i].device);
+                add_load_cb(pibuffer[i]);
+            }
         }
 
-        load_cb_data_host.base = pibuffer.front();
+        auto add_store_cb = [&](void* obuffer) {
+            void* store_cb_host
+                = get_store_callback_host(params.otype, params.precision, round_trip_inverse);
 
-        auto hip_status = hipSuccess;
+            callback_test_data store_cb_data_host;
 
-        hip_status = load_cb_data_dev.alloc(sizeof(callback_test_data));
-        if(hip_status != hipSuccess)
-        {
-            ++n_hip_failures;
-            std::stringstream ss;
-            ss << "Error occurred when allocating device memory for loading callback";
-            if(skip_runtime_fails)
+            if(round_trip_inverse)
             {
-                throw ROCFFT_SKIP{ss.str()};
+                store_cb_data_host.scalar = params.load_cb_scalar;
             }
             else
             {
-                throw ROCFFT_FAIL{ss.str()};
+                store_cb_data_host.scalar = params.store_cb_scalar;
             }
-        }
-        hip_status = hipMemcpy(load_cb_data_dev.data(),
-                               &load_cb_data_host,
-                               sizeof(callback_test_data),
-                               hipMemcpyHostToDevice);
-        if(hip_status != hipSuccess)
-        {
-            ++n_hip_failures;
-            std::stringstream ss;
-            ss << "Error occurred when copying data to device for loading callback";
-            if(skip_runtime_fails)
+
+            store_cb_data_host.base = obuffer;
+
+            auto& store_cb_data_dev = all_cb_data.emplace_back();
+            auto  hip_status        = store_cb_data_dev.alloc(sizeof(callback_test_data));
+            if(hip_status != hipSuccess)
             {
-                throw ROCFFT_SKIP{ss.str()};
+                ++n_hip_failures;
+                std::stringstream ss;
+                ss << "Error occurred when allocating device memory for storing callback";
+                if(skip_runtime_fails)
+                {
+                    throw ROCFFT_SKIP{ss.str()};
+                }
+                else
+                {
+                    throw ROCFFT_FAIL{ss.str()};
+                }
             }
-            else
+
+            hip_status = hipMemcpy(store_cb_data_dev.data(),
+                                   &store_cb_data_host,
+                                   sizeof(callback_test_data),
+                                   hipMemcpyHostToDevice);
+            if(hip_status != hipSuccess)
             {
-                throw ROCFFT_FAIL{ss.str()};
+                ++n_hip_failures;
+                std::stringstream ss;
+                ss << "Error occurred when copying data to device for storing callback";
+                if(skip_runtime_fails)
+                {
+                    throw ROCFFT_SKIP{ss.str()};
+                }
+                else
+                {
+                    throw ROCFFT_FAIL{ss.str()};
+                }
             }
-        }
 
-        void* store_cb_host
-            = get_store_callback_host(params.otype, params.precision, round_trip_inverse);
+            store_cb_func.push_back(store_cb_host);
+            store_cb_data.push_back(store_cb_data_dev.data());
+        };
 
-        callback_test_data store_cb_data_host;
-
-        if(round_trip_inverse)
+        if(params.ofields.empty())
         {
-            store_cb_data_host.scalar = params.load_cb_scalar;
+            // store cb for current HIP device
+            add_store_cb(pobuffer.front());
         }
         else
         {
-            store_cb_data_host.scalar = params.store_cb_scalar;
-        }
-
-        store_cb_data_host.base = pobuffer.front();
-
-        hip_status = store_cb_data_dev.alloc(sizeof(callback_test_data));
-        if(hip_status != hipSuccess)
-        {
-            ++n_hip_failures;
-            std::stringstream ss;
-            ss << "Error occurred when allocating device memory for storing callback";
-            if(skip_runtime_fails)
+            for(size_t i = 0; i < params.ofields.front().bricks.size(); ++i)
             {
-                throw ROCFFT_SKIP{ss.str()};
-            }
-            else
-            {
-                throw ROCFFT_FAIL{ss.str()};
+                // store cb for this brick's device
+                rocfft_scoped_device dev(params.ofields.front().bricks[i].device);
+                add_store_cb(pobuffer[i]);
             }
         }
 
-        hip_status = hipMemcpy(store_cb_data_dev.data(),
-                               &store_cb_data_host,
-                               sizeof(callback_test_data),
-                               hipMemcpyHostToDevice);
-        if(hip_status != hipSuccess)
-        {
-            ++n_hip_failures;
-            std::stringstream ss;
-            ss << "Error occurred when copying data to device for storing callback";
-            if(skip_runtime_fails)
-            {
-                throw ROCFFT_SKIP{ss.str()};
-            }
-            else
-            {
-                throw ROCFFT_FAIL{ss.str()};
-            }
-        }
-
-        auto fft_status = params.set_callbacks(
-            load_cb_host, load_cb_data_dev.data(), store_cb_host, store_cb_data_dev.data());
+        auto fft_status
+            = params.set_callbacks(&load_cb_func, &load_cb_data, &store_cb_func, &store_cb_data);
         if(fft_status != fft_status_success)
             throw std::runtime_error("set callback failure");
     }

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -829,6 +829,21 @@ public:
     std::vector<fft_field> ifields;
     std::vector<fft_field> ofields;
 
+    // Check that a supplied vector of callback pointers has an
+    // expected size.  Optionally also check that each pointer is
+    // non-null.  Throws an exception if a check fails.  The vector
+    // itself can be null, as callbacks are optional.
+    static void check_callback_vec(std::vector<void*>* cb, size_t expected_size, bool nonnull)
+    {
+        if(!cb)
+            return;
+        if(cb->size() != expected_size)
+            throw std::invalid_argument("expected " + std::to_string(expected_size)
+                                        + " callback pointers, got " + std::to_string(cb->size()));
+        if(nonnull && std::any_of(cb->begin(), cb->end(), [](void* p) { return p == nullptr; }))
+            throw std::invalid_argument("null callback function");
+    }
+
     // simple "multi-GPU" count, meaning the library decides on the
     // decomposition instead of it being explicit as bricks.  only
     // has an effect if set to a number > 1.

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -2329,12 +2329,18 @@ public:
         }
     }
 
-    virtual fft_status set_callbacks(void*  load_cb_host,
-                                     void*  load_cb_data,
-                                     void*  store_cb_host,
-                                     void*  store_cb_data,
-                                     size_t load_cb_shared_mem_bytes,
-                                     size_t store_cb_shared_mem_bytes)
+    // A callback is expressed as a pair of device function pointer +
+    // device function data.
+    //
+    // Load and store callbacks are provided as vectors of those
+    // pointers, as we need a separate function+data for each device
+    // being loaded from or stored to.
+    virtual fft_status set_callbacks(std::vector<void*>* load_cb_func,
+                                     std::vector<void*>* load_cb_data,
+                                     std::vector<void*>* store_cb_func,
+                                     std::vector<void*>* store_cb_data,
+                                     size_t              load_cb_shared_mem_bytes,
+                                     size_t              store_cb_shared_mem_bytes)
     {
         return fft_status_success;
     }

--- a/projects/rocfft/shared/rocfft_params.h
+++ b/projects/rocfft/shared/rocfft_params.h
@@ -512,6 +512,21 @@ public:
         return ret;
     }
 
+    // Return the number of expected callback entries for supplied
+    // fields.
+    static size_t expected_callback_count(const std::vector<fft_field>& fields)
+    {
+        // If fields are not specified, we consider the input or
+        // output to have a single brick (and thus expect a single
+        // callback entry)
+        if(fields.empty())
+            return 1;
+        return std::accumulate(fields.begin(),
+                               fields.end(),
+                               static_cast<size_t>(0),
+                               [](size_t s, const fft_field& f) { return s + f.bricks.size(); });
+    }
+
     fft_status set_callbacks(std::vector<void*>* load_cb_func,
                              std::vector<void*>* load_cb_data,
                              std::vector<void*>* store_cb_func,
@@ -521,6 +536,13 @@ public:
     {
         if(run_callbacks)
         {
+            auto expected_load_cb_count  = expected_callback_count(ifields);
+            auto expected_store_cb_count = expected_callback_count(ofields);
+            check_callback_vec(load_cb_func, expected_load_cb_count, true);
+            check_callback_vec(load_cb_data, expected_load_cb_count, false);
+            check_callback_vec(store_cb_func, expected_store_cb_count, true);
+            check_callback_vec(store_cb_data, expected_store_cb_count, false);
+
             auto roc_status = rocfft.execution_info_set_load_callback(
                 info,
                 load_cb_func ? load_cb_func->data() : nullptr,

--- a/projects/rocfft/shared/rocfft_params.h
+++ b/projects/rocfft/shared/rocfft_params.h
@@ -512,22 +512,28 @@ public:
         return ret;
     }
 
-    fft_status set_callbacks(void*  load_cb_host,
-                             void*  load_cb_data,
-                             void*  store_cb_host,
-                             void*  store_cb_data,
-                             size_t load_cb_shared_mem_bytes  = 0,
-                             size_t store_cb_shared_mem_bytes = 0) override
+    fft_status set_callbacks(std::vector<void*>* load_cb_func,
+                             std::vector<void*>* load_cb_data,
+                             std::vector<void*>* store_cb_func,
+                             std::vector<void*>* store_cb_data,
+                             size_t              load_cb_shared_mem_bytes  = 0,
+                             size_t              store_cb_shared_mem_bytes = 0) override
     {
         if(run_callbacks)
         {
             auto roc_status = rocfft.execution_info_set_load_callback(
-                info, &load_cb_host, &load_cb_data, load_cb_shared_mem_bytes);
+                info,
+                load_cb_func ? load_cb_func->data() : nullptr,
+                load_cb_data ? load_cb_data->data() : nullptr,
+                load_cb_shared_mem_bytes);
             if(roc_status != rocfft_status_success)
                 return fft_status_from_rocfftparams(roc_status);
 
             roc_status = rocfft.execution_info_set_store_callback(
-                info, &store_cb_host, &store_cb_data, store_cb_shared_mem_bytes);
+                info,
+                store_cb_func ? store_cb_func->data() : nullptr,
+                store_cb_data ? store_cb_data->data() : nullptr,
+                store_cb_shared_mem_bytes);
             if(roc_status != rocfft_status_success)
                 return fft_status_from_rocfftparams(roc_status);
         }


### PR DESCRIPTION
## Motivation

Improve documentation and tests for callback functions.

## Technical Details

Callback functions are meant to be specified to `rocfft_plan_description_set_load_callback` or `rocfft_plan_description_set_store_callback` as arrays of function pointers.  The intent is that for an N-device transform, N function pointers must be specified, as the pointers point to per-device functions.

Updated the tests to actually collect N function pointers into an array, for an N-device transform.

Updated the documentation to make this clear.

Also clarified that the functions supplied in an array must all behave the same, as rocFFT cannot guarantee exactly which data is passed to which function in an array.  Updated the tests to not attempt to depend on this non-existent guarantee.

## Test Plan

Existing callback tests have been improved.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
