### PR TITLE
[hipblaslt] matrix transform hotfix

### DIFF
--- a/projects/hipblaslt/device-library/matrix-transform/CMakeLists.txt
+++ b/projects/hipblaslt/device-library/matrix-transform/CMakeLists.txt
@@ -29,7 +29,7 @@ list(REMOVE_DUPLICATES archs)
 # Create separate --offload-arch flags for each architecture
 set(arch_flags "")
 foreach(arch IN LISTS archs)
-    list(APPEND arch_flags " --offload-arch=${arch} ")
+    list(APPEND arch_flags "--offload-arch=${arch}")
 endforeach()
 
 set(output_library "${CMAKE_CURRENT_BINARY_DIR}/hipblasltTransform.hsaco")

--- a/projects/hipblaslt/device-library/matrix-transform/CMakeLists.txt
+++ b/projects/hipblaslt/device-library/matrix-transform/CMakeLists.txt
@@ -25,13 +25,18 @@
 
 string(REGEX MATCHALL "gfx[a-z0-9]+" archs "${GPU_TARGETS}")
 list(REMOVE_DUPLICATES archs)
-list(JOIN archs "," archs)
+
+# Create separate --offload-arch flags for each architecture
+set(arch_flags "")
+foreach(arch IN LISTS archs)
+    list(APPEND arch_flags " --offload-arch=${arch} ")
+endforeach()
 
 set(output_library "${CMAKE_CURRENT_BINARY_DIR}/hipblasltTransform.hsaco")
 set(matrix_transform_cpp "${CMAKE_CURRENT_SOURCE_DIR}/matrix_transform.cpp")
 
 add_custom_command(
-    COMMAND ${CMAKE_CXX_COMPILER} -x hip ${matrix_transform_cpp} --offload-arch="${archs}" -c --offload-device-only -Xoffload-linker --build-id=sha1 -O3 -o ${output_library}
+    COMMAND ${CMAKE_CXX_COMPILER} -x hip ${matrix_transform_cpp} ${arch_flags} -c --offload-device-only -Xoffload-linker --build-id=sha1 -O3 -o ${output_library}
     OUTPUT ${output_library}
     COMMENT "Building hipblasltTransform.hsaco"
 )


### PR DESCRIPTION
## Motivation

Convert:

```
/opt/rocm/bin/amdclang++ -x hip hipblaslt/device-library/matrix-transform/matrix_transform.cpp --offload-arch="gfx908,gfx90a,gfx942,gfx950,gfx1100,gfx1101,gfx1103,gfx1150,gfx1151,gfx1200,gfx1201" -c --offload-device-only -Xoffload-linker --build-id=sha1 -O3 -o hipblaslt/build/device-library/matrix-transform/hipblasltTransform.hsaco
```

to:

```
/opt/rocm/bin/amdclang++ -x hip hipblaslt/device-library/matrix-transform/matrix_transform.cpp --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx950 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1103 --offload-arch=gfx1150 --offload-arch=gfx1151 --offload-arch=gfx1200 --offload-arch=gfx1201 -c --offload-device-only -Xoffload-linker --build-id=sha1 -O3 -o hipblaslt/build-test/device-library/matrix-transform/hipblasltTransform.hsaco
```

such that the resulting library is built for all targets. That is, the following should be true:

```
/opt/rocm/llvm/bin/clang-offload-bundler -list -type=a -input=hipblasltTransform.hsaco
hipv4-amdgcn-amd-amdhsa--gfx1103
hipv4-amdgcn-amd-amdhsa--gfx1150
hipv4-amdgcn-amd-amdhsa--gfx1200
hipv4-amdgcn-amd-amdhsa--gfx908
hipv4-amdgcn-amd-amdhsa--gfx1201
hipv4-amdgcn-amd-amdhsa--gfx90a
hipv4-amdgcn-amd-amdhsa--gfx1100
hipv4-amdgcn-amd-amdhsa--gfx1101
hipv4-amdgcn-amd-amdhsa--gfx950
hipv4-amdgcn-amd-amdhsa--gfx942
host-x86_64-unknown-linux-gnu-
hipv4-amdgcn-amd-amdhsa--gfx1151
```

Prior to this change, in some environments we would see the following:

```
/opt/rocm/llvm/bin/clang-offload-bundler -list -type=a -input=hipblasltTransform.hsaco
hipv4-amdgcn-amd-amdhsa--gfx908
host-x86_64-unknown-linux-gnu-
```

## Technical Details

- Expands arch list into --offload-arch=<target> for each target rather than a comma separated list.

## Test Plan

Tested in standard pipelines and in environment where issue is observed.