### PR TITLE
[hipblaslt] TF32 cvt syncing fix

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -197,7 +197,7 @@ class LocalReadMFMA(LocalRead):
         module.add(VCvtPkF32toBF16(dst=dst0, src0=v0, src1=v1))
         commentStr = ""
         if (index % 8) == 4:
-            commentStr = "__TF32_1_"+tct
+            commentStr = "__TF32_1_" + tct
         module.add(VCvtPkF32toBF16(dst=dst1, src0=v2, src1=v3, comment=commentStr))
 
 
@@ -439,10 +439,10 @@ class LocalReadMFMA(LocalRead):
                                         v5 = vgpr("Valu%s_X%u_I%u+%u+5"%(tc, bufferIdx, iui, baseValuiIdx))
                                         v6 = vgpr("Valu%s_X%u_I%u+%u+6"%(tc, bufferIdx, iui, baseValuiIdx))
                                         v7 = vgpr("Valu%s_X%u_I%u+%u+7"%(tc, bufferIdx, iui, baseValuiIdx))
-                                        packCodeT.add(VCvtPkF32toBF16(dst=v7, src0=v6, src1=v7, comment="pack tail begin"))
+                                        packCodeT.add(VCvtPkF32toBF16(dst=v7, src0=v6, src1=v7, comment="pack final begin"))
                                         packCodeT.add(VCvtPkF32toBF16(dst=v6, src0=v4, src1=v5))
                                         packCodeT.add(VCvtPkF32toBF16(dst=v5, src0=v2, src1=v3))
-                                        commentStr ="__TF32_2_" + tc + " pack tail end"
+                                        commentStr = "__TF32_2_" + tc + " pack final end"
                                         packCodeT.add(VCvtPkF32toBF16(dst=v4, src0=v0, src1=v1, comment=commentStr))
                                         if kernel["UseDirect32XEmulation"]:
                                             index = len(tmpvgprFP32) - 1

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -284,7 +284,7 @@ class StateValues:
   numGlobalReadInsPerMfma: int           = 0
   numLocalWriteModPerMfma: int           = 0
   HHH_WMMA: bool                         = False
-  tmpvgpr: List[int]                     = field(init=False) # vgpr storage for localread
+  tmpvgpr: List[int]                     = field(init=False) # vgpr dict for localread
   numPackCvt: int                        = 0
 
   lraTileProperties: Dict[int, LraTileProperties] = field(init=False)
@@ -567,10 +567,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
       numPack = 999
     for n in range(numPack):
       if srcPackItems:
-        numPacked += 1
         item = srcPackItems.pop(0)
         dstPackItems.append(item)
-        itemStr = str(item)
+        numPacked += 1
+        itemStr = str(item.comment)
         for string in searchStrings:
           if string in itemStr:
             return numPacked
@@ -1125,7 +1125,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
         elif isinstance(inst, SMFMAInstruction):
           srcRegs = [inst.a, inst.b, inst.metadata]
         else:
-          srcRegs = inst.srcs
+          if hasattr(inst, 'srcs'):
+            srcRegs = inst.srcs
+          else:
+            srcRegs = []
 
         return any((lrDataReg & r) for r in srcRegs if isinstance(r, RegisterContainer))
 


### PR DESCRIPTION
## Motivation

TF32 conversion operation interleaving relied on sync points in comments, which are now removed through changes to disable asm comments by default. Code is modified to directly check comment variable of instruction instead of string output.
 

## Test Plan

CI xf32 tests
