### PR TITLE
[miopen][navi4] Batchnorm temporarily disable large serial test

### DIFF
--- a/projects/miopen/test/gtest/bn_test_data.hpp
+++ b/projects/miopen/test/gtest/bn_test_data.hpp
@@ -35,6 +35,8 @@
 #include "tensor_util.hpp"
 #include "get_handle.hpp"
 
+#define WORKAROUND_SWDEV_549725 1
+
 struct BN2DTestCase
 {
     size_t N;
@@ -144,7 +146,13 @@ inline std::vector<BN2DTestCase> Network2DLarge()
 template <>
 inline std::vector<BN3DTestCase> Network3DSerialCase()
 {
-    return {{2, 2048, 16, 128, 128, miopen::batchnorm::Direction::Backward, 0, 1}};
+    return {
+        // TODO: fix numeric issues before re-enabling large test
+#ifndef WORKAROUND_SWDEV_549725
+        {2, 2048, 16, 128, 128, miopen::batchnorm::Direction::Backward, 0, 1},
+#endif
+        {2, 128, 16, 128, 128, miopen::batchnorm::Direction::Backward, 0, 1},
+    };
 }
 
 template <>

--- a/projects/miopen/test/gtest/bn_test_data.hpp
+++ b/projects/miopen/test/gtest/bn_test_data.hpp
@@ -146,6 +146,7 @@ inline std::vector<BN2DTestCase> Network2DLarge()
 template <>
 inline std::vector<BN3DTestCase> Network3DSerialCase()
 {
+    // clang-format off
     return {
         // TODO: fix numeric issues before re-enabling large test
 #ifndef WORKAROUND_SWDEV_549725
@@ -153,6 +154,7 @@ inline std::vector<BN3DTestCase> Network3DSerialCase()
 #endif
         {2, 128, 16, 128, 128, miopen::batchnorm::Direction::Backward, 0, 1},
     };
+    // clang-format on
 }
 
 template <>


### PR DESCRIPTION
## Motivation

Batchnorm tests were failing due to extremely large test error on Navi4x with huge shapes and small N.

## Technical Details

This is created by numerical failure in the summations. For the per-activation tests, it is also exacerbated by poor statistics in the normalization values. We have plans in the works to correct this, so just get the tests passing for now.

Also refer to: https://github.com/ROCm/rocm-libraries/pull/1615

## Test Plan

CI-gtests only.

## Test Result

Expected to pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
