### PR TITLE
[hipblaslt] perf-script --run_sh mode supports argument --yaml and --requested-solutions 

### DIFF
--- a/projects/hipblaslt/clients/scripts/performance/bench.py
+++ b/projects/hipblaslt/clients/scripts/performance/bench.py
@@ -133,26 +133,35 @@ def run_sh_cmd(cmdLine,
     cmd = [str(x) for x in cmd]
     logging.info('running: ' + ' '.join(cmd))
     if verbose:
-        print('running: ' + ' '.join(cmd))
+        print('\n---------------\nrunning: ' + ' '.join(cmd))
 
+    newProbToken = "Is supported"
     startingToken = "["
     solNameToken = "--Solution name:"
+    solIndexToken = "--Solution index:"
+    winnerToken = "Winner:"
     csvKeys = []
     benchResultsList = [] # a list with each elem is a {}
     capturingValues = False
+    isOfflineTuning = False
 
     async def run_command(*args, timeout=None):
 
         process = await asyncio.create_subprocess_exec(
             *args, stdout=asyncio.subprocess.PIPE)
 
-        nonlocal startingToken
         nonlocal csvKeys
         nonlocal benchResultsList
         nonlocal capturingValues
+        nonlocal isOfflineTuning
 
+        singleValueLine = ""
         singleValuesList = []
         solutionName = "N/A"
+        solutionIdx = "-1"
+        winner = "0"
+        supportedSols = 1
+        printWinner = False
 
         while True:
             try:
@@ -173,48 +182,96 @@ def run_sh_cmd(cmdLine,
 
                 # capturing values right after capturing keys
                 if capturingValues:
+                    singleValueLine = line
                     singleValuesList = line.split(',')
-                    # default is empty if --print_kernel_info is not in the bench cmd
+                    # by default, solution info is empty if --print_kernel_info is not in the bench cmd
                     solutionName = "N/A"
+                    solutionIdx = "-1"
                     capturingValues = False
                     continue
 
-                if line.startswith(startingToken):
-                    # if we are encountering the next problem
+                # beginning of a new bench
+                if line.startswith(newProbToken):
+                    # When we are encountering the next problem:
+                    # if we still have bench result line haven't been printed,
                     # (in a single hipblaslt-bench, this means it is called with --yaml containing multi-sizes)
-                    # then we complete the current problem and result
-                    # reset csvKeys to empty indicating a new problem
-                    if len(csvKeys) > 0:
-                        singleValuesList.append(solutionName)
+                    # then we need to print the un-printed result line before we go to next new problem.
+                    # Then reset the result line to empty indicating a new problem.
+                    # Need to add a winner field in CSV result.
+                    if len(singleValueLine) > 0:
+                        # show on screen
+                        print(f"{singleValueLine}"+f",{solutionIdx}"+f",{solutionName}")
+                        singleValueLine = ""
+                        # add to csv
+                        singleValuesList.extend([winner,solutionIdx,solutionName])
                         dd_output = defaultdict(str, zip(csvKeys, singleValuesList))
                         benchResultsList += [dd_output]
-                        print(f"{','.join(singleValuesList)}\n")
-                        csvKeys = []
+                        csvKeys = [] # may not be neccessary
+
+                    # The line should be: "Is supported X / Total solutions: Y"
+                    splitLine = line.split(' ')
+                    supportedSols = int(splitLine[2])
+                    isOfflineTuning = (supportedSols > 1) # when X > 1
+                    print(f'\nBench New Problem:')
+                    if isOfflineTuning:
+                        print(f'[Offline Tuning]:')
+                    else:
+                        print(f'[Bench Only One Solution]:')
+
+                elif line.startswith(startingToken):
+                    # show on screen if we have any un-printed bench result:
+                    # The previous "if line.startswith(newProbToken):" happens when we see a new problem
+                    # And this happends when --reqeusted_solution > 1,
+                    # so for one problem, we run many solutions, and each solution result starts with [SSN]
+                    # When we see a new solution start, we print the previous un-printed result if we have any.
+                    if len(singleValueLine) > 0:
+                        print(f"{singleValueLine}"+f",{solutionIdx}"+f",{solutionName}")
+                        singleValueLine = ""
+                        csvKeys = [] # may not be neccessary
+
+                    if printWinner:
+                        print(f'\n{winnerToken}')
+                        printWinner = False
 
                     line = line.replace('hipblaslt-Gflops', 'gflops')
                     line = line.replace('hipblaslt-GB/s', 'GB/s')
                     splitLine = line.split(':')
-                    # SSN = splitLine[0] # should be [0]
-                    keys = splitLine[1] + str(",solution-name")
-                    csvKeys = keys.split(',')
-                    print(f'\n{keys}')
-                    # print(f'\n{csvKeys}')
-                    capturingValues = True # Next line must be values
+                    SSN = splitLine[0] # should be [supported-sol-SSN] ([0], [1], [2],...etc, NOT sol-index)
+                    # shown on screen, for each solution, there is NO so-called "winner" included
+                    header = SSN + ":" + splitLine[1] + ",solution-idx,solution-name"
+                    print(f'\n{header}')
+
+                    # construct the header of csv: need to export "winner" field
+                    # (value is always "0" if not offline tuning)
+                    csvKeys = str(splitLine[1] + ",winner-idx,solution-idx,solution-name").split(',')
+                    # print(f'\n{csvKeys}') # debugging
+                    capturingValues = True # Next line must be bench result values
+                    winner = SSN.strip('[').strip(']') # always keep the last SSN until next problem
                 else:
-                    # if is "--Solution name:" (--print_kernel_info), then we capture this
+                    # if is "--Solution name:" or "--Solution index:" (--print_kernel_info),
+                    # then we capture this, otherwise they will be "N/A" and "-1"
                     if line.startswith(solNameToken):
                         splitLine = line.split(':')
                         solutionName = splitLine[1].strip()
+                    elif line.startswith(solIndexToken):
+                        splitLine = line.split(':')
+                        solutionIdx = splitLine[1].strip()
+                    elif line.startswith(winnerToken):
+                        printWinner = True
                     # simply ignore irrelative msg
                     else:
                         continue
 
-        # the last one result (for running .sh cmd with --yaml argument)
-        if len(csvKeys) > 0:
-            singleValuesList.append(solutionName)
+        # the last one bench result (since we won't see newProbToken nor startingToken anymore,
+        # so we must print the last bench result here)
+        if len(singleValueLine) > 0:
+            # show on screen
+            print(f"{singleValueLine}"+f",{solutionIdx}"+f",{solutionName}")
+            singleValueLine = ""
+            # add to csv
+            singleValuesList.extend([winner,solutionIdx,solutionName])
             dd_output = defaultdict(str, zip(csvKeys, singleValuesList))
             benchResultsList += [dd_output]
-            print(f"{','.join(singleValuesList)}\n")
 
         return await process.wait()  # Wait for the child process to exit
 

--- a/projects/hipblaslt/clients/scripts/performance/bench.py
+++ b/projects/hipblaslt/clients/scripts/performance/bench.py
@@ -54,8 +54,8 @@ def run_bench(benchExecutable,
         print('hipblaslt-perf: ' + ' '.join(cmd))
 
     startingToken = "["
-    csvKeys = ''
-    benchResultsList = []
+    csvKeys = []
+    benchResultsList = [] # a list with each elem is a {}
     capturingValues = False
     isAPIOverhead = False
 
@@ -138,7 +138,7 @@ def run_sh_cmd(cmdLine,
     startingToken = "["
     solNameToken = "--Solution name:"
     csvKeys = []
-    benchResultsList = {}
+    benchResultsList = [] # a list with each elem is a {}
     capturingValues = False
 
     async def run_command(*args, timeout=None):
@@ -180,13 +180,24 @@ def run_sh_cmd(cmdLine,
                     continue
 
                 if line.startswith(startingToken):
+                    # if we are encountering the next problem
+                    # (in a single hipblaslt-bench, this means it is called with --yaml containing multi-sizes)
+                    # then we complete the current problem and result
+                    # reset csvKeys to empty indicating a new problem
+                    if len(csvKeys) > 0:
+                        singleValuesList.append(solutionName)
+                        dd_output = defaultdict(str, zip(csvKeys, singleValuesList))
+                        benchResultsList += [dd_output]
+                        print(f"{','.join(singleValuesList)}\n")
+                        csvKeys = []
+
                     line = line.replace('hipblaslt-Gflops', 'gflops')
                     line = line.replace('hipblaslt-GB/s', 'GB/s')
                     splitLine = line.split(':')
                     # SSN = splitLine[0] # should be [0]
                     keys = splitLine[1] + str(",solution-name")
                     csvKeys = keys.split(',')
-                    # print(f'\n{keys}')
+                    print(f'\n{keys}')
                     # print(f'\n{csvKeys}')
                     capturingValues = True # Next line must be values
                 else:
@@ -198,8 +209,12 @@ def run_sh_cmd(cmdLine,
                     else:
                         continue
 
-        singleValuesList.append(solutionName)
-        benchResultsList = defaultdict(str, zip(csvKeys, singleValuesList))
+        # the last one result (for running .sh cmd with --yaml argument)
+        if len(csvKeys) > 0:
+            singleValuesList.append(solutionName)
+            dd_output = defaultdict(str, zip(csvKeys, singleValuesList))
+            benchResultsList += [dd_output]
+            print(f"{','.join(singleValuesList)}\n")
 
         return await process.wait()  # Wait for the child process to exit
 

--- a/projects/hipblaslt/clients/scripts/performance/generator.py
+++ b/projects/hipblaslt/clients/scripts/performance/generator.py
@@ -116,10 +116,6 @@ class ShellScriptProblemGenerator:
                     if cmd.count("verfiy") > 0 or cmd.count("-v") > 0:
                         print(f'--verify or -v is not supported, skip bench.')
                         continue
-                    # TODO- not supported for offline tuning
-                    if cmd.count("requested_solution") > 0:
-                        print(f'--requested_solution is not supported, skip bench.')
-                        continue
 
                     cmd = cmd.replace("./hipblaslt-bench", str(self.bench_exec))
                     # print("parsed cmd: " + cmd)

--- a/projects/hipblaslt/clients/scripts/performance/hipblaslt-perf
+++ b/projects/hipblaslt/clients/scripts/performance/hipblaslt-perf
@@ -193,12 +193,14 @@ def run_sh_bench(arguments):
     for singleCMD in generator.iterate_cmd():
         # print("singleCMD: " + singleCMD)
         csvKeys, benchResults, success = bench.run_sh_cmd(singleCMD, True)
-        content = extractProblemDescStr(benchResults, csvKeys) + '\n'
-        if writeHeader:
-            header = ','.join([str(key) for key in csvKeys]) + '\n'
-            csv_file.write(header)
-            writeHeader = False
-        csv_file.write(content)
+        for eachResult in benchResults:
+            # data in problem description
+            content = extractProblemDescStr(eachResult, csvKeys) + '\n'
+            if writeHeader:
+                header = ','.join([str(key) for key in csvKeys]) + '\n'
+                csv_file.write(header)
+                writeHeader = False
+            csv_file.write(content)
 
     print(f'\nResults written to {csv_file.name}')
     csv_file.close()


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
An extension of #1068 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
In the previous PR #1068, it says:

> The sh file looks like
> ```
> ./hipblaslt-bench [problems....m, n, k, type, ...]
> ./hipblaslt-bench [problems....m, n, k, type, ...]
> ./hipblaslt-bench [problems....m, n, k, type, ...]
> ./hipblaslt-bench [problems....m, n, k, type, ...]
> ```

Which means each -bench for each problem. 
One point I didn't mention in that PR is **`./hipblaslt-bench --yaml [problem-yaml-file]` is not supported.**
In fact, running 1000 problems with a **single ./hipblaslt-bench --yaml [100-problem-yaml-file] command** is way faster than **running ./hipblaslt-bench command 1000 times.**

So this PR added the support of running a .sh file with --yaml argument in it.
#### Example:
You have a yaml file "bbs_bench.yaml" looks like:
```
- {function: matmul, transA: N, transB: T, M: ......... }
- {function: matmul, transA: N, transB: T, M: ......... }
- {function: matmul, transA: N, transB: T, M: ......... }
- {function: matmul, transA: N, transB: T, M: ......... }
- {function: matmul, transA: N, transB: T, M: ......... }
...
- {function: matmul, transA: N, transB: T, M: ......... }
```
Then you can make your sh file, e.g. "bbs_bench.sh"
```
./hipblaslt-bench --yaml <abs-path-of-bbs_bench.yaml>
```
Or you can mix them all:
```
./hipblaslt-bench --yaml <abs-path-of-bbs_bench.yaml>
./hipblaslt-bench --yaml <abs-path-of-another-yaml>
./hipblaslt-bench [problems....m, n, k, type, ...]
./hipblaslt-bench [problems....m, n, k, type, ...]
```
When under projects/hipblaslt/
**`./clients/scripts/performance/hipblaslt-perf --run_sh <path-to-bbs_bench.sh>`**

By default, a csv file will be saved in **`projects/hipblaslt/hipBLASLt_benchmark/bench_output_csv/bbs_bench.csv`**
If you put optional argument `--csvfile my_custom_name`, then it would be saved as `my_custom_name.csv`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
This is a helper script/tool and is tested manually. 

## Test Result

<!-- Briefly summarize test outcomes. -->
Can correctly generate the csv file as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Supported --yaml [YamlFile]
- [x] Supported --requested_solution (1 or > 1)
- [x] Added WinnderIdx, SolutionIdx in the exported CSV file
