### PR TITLE
[rocSOLVER] Increase hegvdx test tolerance

### DIFF
--- a/projects/rocsolver/clients/common/lapack/testing_sygvdx_hegvdx.hpp
+++ b/projects/rocsolver/clients/common/lapack/testing_sygvdx_hegvdx.hpp
@@ -515,7 +515,7 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
     // calls to the solver should look for computed eigenvalues in the range
     // (vl - tol, vu + tol], where `tol = C * n * ulp * ||A||`.
     //
-    S C = 4;
+    S C = 5;
     std::vector<S> tols(bc, 0);
     std::vector<S> norms(bc, 0);
     S tol = 0;

--- a/projects/rocsolver/clients/common/lapack/testing_sygvdx_hegvdx.hpp
+++ b/projects/rocsolver/clients/common/lapack/testing_sygvdx_hegvdx.hpp
@@ -515,7 +515,7 @@ void sygvdx_hegvdx_getError(const rocblas_handle handle,
     // calls to the solver should look for computed eigenvalues in the range
     // (vl - tol, vu + tol], where `tol = C * n * ulp * ||A||`.
     //
-    S C = 5;
+    S C = 10;
     std::vector<S> tols(bc, 0);
     std::vector<S> norms(bc, 0);
     S tol = 0;


### PR DESCRIPTION
## Motivation
The tolerance in checking the eigenvalues from HEGVDX is too strict which is causing some test failures. SWDEV-562867

## Technical Details
Increase HEGVDX tolerance parameter slightly.

## Test Plan
Run failing test and and SYGVDX/HEGVDX test suite.

## Test Result
Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
