### PR TITLE
[hipDNN] Removing warnings as error to check CI

### DIFF
--- a/projects/hipdnn/.clang-tidy
+++ b/projects/hipdnn/.clang-tidy
@@ -23,7 +23,6 @@ Checks: >
   -readability-use-anyofallof,
   -readability-function-cognitive-complexity
 
-WarningsAsErrors: "*"
 HeaderFileExtensions: ['h','hpp']
 
 # This regex is a inclusion filter for the files to be checked. Its a Posix regex and


### PR DESCRIPTION
Checking code_coverage with warnings off due to clang tidy mismatch. 

<DO NOT MERGE>