### PR TITLE
[rocfft & hipfft] Make all ad-hoc client exceptions inherit from std::exception and catch one such in hipfftw tests' SetUp

### DIFF
--- a/projects/hipfft/clients/bench/bench.cpp
+++ b/projects/hipfft/clients/bench/bench.cpp
@@ -258,7 +258,7 @@ int main(int argc, char* argv[])
     }
     catch(ROCFFT_SKIP& e)
     {
-        std::cout << "SKIPPED: " << e.msg << "\n";
+        std::cout << "SKIPPED: " << e.what() << "\n";
         return EXIT_SUCCESS;
     }
     if(!vram_fits_problem(vram_footprint, free))

--- a/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
+++ b/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
@@ -118,11 +118,11 @@ TEST_P(accuracy_test, vs_fftw)
         {
             // explicitly clear cache
             last_cpu_fft_data = last_cpu_fft_cache();
-            GTEST_SKIP() << e.msg;
+            GTEST_SKIP() << e.what();
         }
         catch(ROCFFT_SKIP& e)
         {
-            GTEST_SKIP() << e.msg;
+            GTEST_SKIP() << e.what();
         }
         catch(const fft_params::unimplemented_exception& e)
         {
@@ -130,7 +130,7 @@ TEST_P(accuracy_test, vs_fftw)
         }
         catch(ROCFFT_FAIL& e)
         {
-            GTEST_FAIL() << e.msg;
+            GTEST_FAIL() << e.what();
         }
         break;
     }

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -1366,65 +1366,72 @@ namespace
     protected:
         void SetUp() override
         {
-            const hipfftw_input_validation_params<prec>& params = this->GetParam();
+            try
+            {
+                const hipfftw_input_validation_params<prec>& params = this->GetParam();
 
-            if(!params.can_be_tested())
-                GTEST_FAIL() << "invalid parameters which cannot be tested";
-            safe_to_touch_nonnull_io = true;
+                if(!params.can_be_tested())
+                    GTEST_FAIL() << "invalid parameters which cannot be tested";
+                safe_to_touch_nonnull_io = true;
 
-            // get_data_byte_size requires valid ranks and lengths to be calculated (of course)
-            // --> make sure the I/O data sizes are not zero for test consistency w.r.t. testing
-            // for nullptr data args I/O
-            auto compute_io_size = [&](fft_io io) {
-                try
+                // get_data_byte_size requires valid ranks and lengths to be calculated (of course)
+                // --> make sure the I/O data sizes are not zero for test consistency w.r.t. testing
+                // for nullptr data args I/O
+                auto compute_io_size = [&](fft_io io) {
+                    try
+                    {
+                        return params.plan_helper.get_data_byte_size(io);
+                    }
+                    catch(const typename hipfftw_helper<prec>::num_elements_calc_exception& e)
+                    {
+                        safe_to_touch_nonnull_io = false;
+                        return sizeof(hipfftw_complex_t<prec>); // some nonzero value
+                    }
+                };
+                const size_t input_data_size  = compute_io_size(fft_io::fft_io_in);
+                const size_t output_data_size = compute_io_size(fft_io::fft_io_out);
+                if(input_data_size > max_byte_size_for_hipfftw_tests()
+                   || output_data_size > max_byte_size_for_hipfftw_tests())
                 {
-                    return params.plan_helper.get_data_byte_size(io);
+                    GTEST_SKIP()
+                        << "Skipping test due to excessive I/O byte size (max of I/O byte size: "
+                        << std::max(input_data_size, output_data_size)
+                        << " vs limit: " << max_byte_size_for_hipfftw_tests() << ")";
                 }
-                catch(const typename hipfftw_helper<prec>::num_elements_calc_exception& e)
-                {
-                    safe_to_touch_nonnull_io = false;
-                    return sizeof(hipfftw_complex_t<prec>); // some nonzero value
-                }
-            };
-            const size_t input_data_size  = compute_io_size(fft_io::fft_io_in);
-            const size_t output_data_size = compute_io_size(fft_io::fft_io_out);
-            if(input_data_size > max_byte_size_for_hipfftw_tests()
-               || output_data_size > max_byte_size_for_hipfftw_tests())
-            {
-                GTEST_SKIP()
-                    << "Skipping test due to excessive I/O byte size (max of I/O byte size: "
-                    << std::max(input_data_size, output_data_size)
-                    << " vs limit: " << max_byte_size_for_hipfftw_tests() << ")";
-            }
 
-            if(params.creation_io_is_null.first)
-                plan_creation_input.free();
-            else
-                plan_creation_input.alloc(input_data_size);
-
-            if(params.creation_placement() == fft_placement_inplace
-               || params.creation_io_is_null.second)
-                plan_creation_output.free();
-            else
-                plan_creation_output.alloc(output_data_size);
-
-            if(params.use_creation_io_at_execution())
-            {
-                plan_execution_input.free();
-                plan_execution_output.free();
-            }
-            else
-            {
-                if(!params.is_execution_arg_null(fft_io::fft_io_in))
-                    plan_execution_input.alloc(input_data_size);
+                if(params.creation_io_is_null.first)
+                    plan_creation_input.free();
                 else
+                    plan_creation_input.alloc(input_data_size);
+
+                if(params.creation_placement() == fft_placement_inplace
+                   || params.creation_io_is_null.second)
+                    plan_creation_output.free();
+                else
+                    plan_creation_output.alloc(output_data_size);
+
+                if(params.use_creation_io_at_execution())
+                {
                     plan_execution_input.free();
-
-                if(params.execution_placement() == fft_placement_inplace
-                   || params.is_execution_arg_null(fft_io::fft_io_out))
                     plan_execution_output.free();
+                }
                 else
-                    plan_execution_output.alloc(output_data_size);
+                {
+                    if(!params.is_execution_arg_null(fft_io::fft_io_in))
+                        plan_execution_input.alloc(input_data_size);
+                    else
+                        plan_execution_input.free();
+
+                    if(params.execution_placement() == fft_placement_inplace
+                       || params.is_execution_arg_null(fft_io::fft_io_out))
+                        plan_execution_output.free();
+                    else
+                        plan_execution_output.alloc(output_data_size);
+                }
+            }
+            catch(const HOSTBUF_MEM_USAGE& e)
+            {
+                GTEST_SKIP() << e.what();
             }
         }
         void TearDown() override
@@ -2032,6 +2039,10 @@ namespace
                     GTEST_SKIP() << e.what() << "\nError code: " << e.hip_error << ".";
                 else
                     GTEST_FAIL() << e.what() << "\nError code: " << e.hip_error << ".";
+            }
+            catch(const HOSTBUF_MEM_USAGE& e)
+            {
+                GTEST_SKIP() << e.what();
             }
         }
         void TearDown() override

--- a/projects/hipfft/shared/client_except.h
+++ b/projects/hipfft/shared/client_except.h
@@ -24,31 +24,15 @@
 #include <string>
 
 // exception type to throw when we want to skip a problem
-struct ROCFFT_SKIP
+struct ROCFFT_SKIP : public std::runtime_error
 {
-    const std::string msg;
-    ROCFFT_SKIP(std::string&& s)
-        : msg(std::move(s))
-    {
-    }
-    ROCFFT_SKIP(const std::string& s)
-        : msg(s)
-    {
-    }
+    using std::runtime_error::runtime_error;
 };
 
 // exception type to throw when we want to consider a problem failed
-struct ROCFFT_FAIL
+struct ROCFFT_FAIL : public std::runtime_error
 {
-    const std::string msg;
-    ROCFFT_FAIL(std::string&& s)
-        : msg(std::move(s))
-    {
-    }
-    ROCFFT_FAIL(const std::string& s)
-        : msg(s)
-    {
-    }
+    using std::runtime_error::runtime_error;
 };
 
 #endif

--- a/projects/hipfft/shared/hostbuf.h
+++ b/projects/hipfft/shared/hostbuf.h
@@ -34,9 +34,9 @@
 #include <sys/mman.h>
 #endif
 
-struct HOSTBUF_MEM_USAGE
+struct HOSTBUF_MEM_USAGE : public std::runtime_error
 {
-    const std::string msg;
+    using std::runtime_error::runtime_error;
 };
 
 // Simple RAII class for host buffers.  T is the type of pointer that

--- a/projects/rocfft/clients/tests/bitwise_repro/bitwise_repro_test.cpp
+++ b/projects/rocfft/clients/tests/bitwise_repro/bitwise_repro_test.cpp
@@ -63,15 +63,15 @@ TEST(bitwise_repro_test, compare_precisions)
     }
     catch(HOSTBUF_MEM_USAGE& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_SKIP& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_FAIL& e)
     {
-        GTEST_FAIL() << e.msg;
+        GTEST_FAIL() << e.what();
     }
     SUCCEED();
 }
@@ -108,15 +108,15 @@ TEST(bitwise_repro_test, compare_lengths)
     }
     catch(HOSTBUF_MEM_USAGE& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_SKIP& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_FAIL& e)
     {
-        GTEST_FAIL() << e.msg;
+        GTEST_FAIL() << e.what();
     }
     SUCCEED();
 }
@@ -153,15 +153,15 @@ TEST(bitwise_repro_test, compare_transform_types)
     }
     catch(HOSTBUF_MEM_USAGE& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_SKIP& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_FAIL& e)
     {
-        GTEST_FAIL() << e.msg;
+        GTEST_FAIL() << e.what();
     }
     SUCCEED();
 }
@@ -201,15 +201,15 @@ TEST_P(bitwise_repro_test, compare_to_reference)
     }
     catch(HOSTBUF_MEM_USAGE& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_SKIP& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_FAIL& e)
     {
-        GTEST_FAIL() << e.msg;
+        GTEST_FAIL() << e.what();
     }
     SUCCEED();
 }

--- a/projects/rocfft/clients/tests/buffer_hash_test.cpp
+++ b/projects/rocfft/clients/tests/buffer_hash_test.cpp
@@ -373,7 +373,7 @@ TEST(rocfft_UnitTest, buffer_hashing_half)
     }
     catch(HOSTBUF_MEM_USAGE& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
 }
 
@@ -395,7 +395,7 @@ TEST(rocfft_UnitTest, buffer_hashing_single)
     }
     catch(HOSTBUF_MEM_USAGE& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
 }
 
@@ -417,6 +417,6 @@ TEST(rocfft_UnitTest, buffer_hashing_double)
     }
     catch(HOSTBUF_MEM_USAGE& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
 }

--- a/projects/rocfft/clients/tests/callback_change_type.cpp
+++ b/projects/rocfft/clients/tests/callback_change_type.cpp
@@ -230,6 +230,6 @@ TEST_P(change_type, short_to_float)
     }
     catch(HOSTBUF_MEM_USAGE& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
 }

--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -821,15 +821,15 @@ TEST(manual, vs_fftw) // MANUAL TESTS HERE
     {
         // explicitly clear test cache
         last_cpu_fft_data = last_cpu_fft_cache();
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_SKIP& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_FAIL& e)
     {
-        GTEST_FAIL() << e.msg;
+        GTEST_FAIL() << e.what();
     }
 }
 
@@ -863,11 +863,11 @@ TEST(manual, bitwise_reproducibility) // MANUAL TESTS HERE
     }
     catch(ROCFFT_SKIP& e)
     {
-        GTEST_SKIP() << e.msg;
+        GTEST_SKIP() << e.what();
     }
     catch(ROCFFT_FAIL& e)
     {
-        GTEST_FAIL() << e.msg;
+        GTEST_FAIL() << e.what();
     }
     SUCCEED();
 }

--- a/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
+++ b/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
@@ -94,15 +94,15 @@ TEST_P(accuracy_test, vs_fftw)
         {
             // explicitly clear cache
             last_cpu_fft_data = last_cpu_fft_cache();
-            GTEST_SKIP() << e.msg;
+            GTEST_SKIP() << e.what();
         }
         catch(ROCFFT_SKIP& e)
         {
-            GTEST_SKIP() << e.msg;
+            GTEST_SKIP() << e.what();
         }
         catch(ROCFFT_FAIL& e)
         {
-            GTEST_FAIL() << e.msg;
+            GTEST_FAIL() << e.what();
         }
         break;
     }

--- a/projects/rocfft/shared/client_except.h
+++ b/projects/rocfft/shared/client_except.h
@@ -24,31 +24,15 @@
 #include <string>
 
 // exception type to throw when we want to skip a problem
-struct ROCFFT_SKIP
+struct ROCFFT_SKIP : public std::runtime_error
 {
-    const std::string msg;
-    ROCFFT_SKIP(std::string&& s)
-        : msg(std::move(s))
-    {
-    }
-    ROCFFT_SKIP(const std::string& s)
-        : msg(s)
-    {
-    }
+    using std::runtime_error::runtime_error;
 };
 
 // exception type to throw when we want to consider a problem failed
-struct ROCFFT_FAIL
+struct ROCFFT_FAIL : public std::runtime_error
 {
-    const std::string msg;
-    ROCFFT_FAIL(std::string&& s)
-        : msg(std::move(s))
-    {
-    }
-    ROCFFT_FAIL(const std::string& s)
-        : msg(s)
-    {
-    }
+    using std::runtime_error::runtime_error;
 };
 
 #endif

--- a/projects/rocfft/shared/hostbuf.h
+++ b/projects/rocfft/shared/hostbuf.h
@@ -34,9 +34,9 @@
 #include <sys/mman.h>
 #endif
 
-struct HOSTBUF_MEM_USAGE
+struct HOSTBUF_MEM_USAGE : public std::runtime_error
 {
-    const std::string msg;
+    using std::runtime_error::runtime_error;
 };
 
 // Simple RAII class for host buffers.  T is the type of pointer that


### PR DESCRIPTION
## Motivation

- The ad-hoc client exceptions `ROCFFT_SKIP`, `ROCFFT_FAIL`, and `HOSTBUF_MEM_USAGE` do not inherit from `std::exception`. As a result, their nature (and the informative message they carry) is unknown in contexts that are not aware of their exact definition. If leaking out of the clients code base (_e.g._, if omitted to be caught in newly-developed tests), any relevant and/or helpful information they carry is no longer accessible practically.
- In their current form, the argument-validation and functional hipFFTW tests may require more host memory than available on the system, thereby triggering a `HOSTBUF_MEM_USAGE` to be thrown. Such exceptions are not caught as of now, which may result in failures with "Unknown C++ exception thrown in SetUp()" [being reported](https://github.com/google/googletest/blob/b2b9072ecbe874f5937054653ef8f2731eb0f010/googletest/src/gtest.cc#L2635).

## Technical Details

- Changing the definitions of `ROCFFT_SKIP`, `ROCFFT_FAIL`, and `HOSTBUF_MEM_USAGE` to make them all inherit form `std::runtime_error` and use the inherited constructors.
- Catch possible `HOSTBUF_MEM_USAGE` in hipfftw tests' `SetUp` and skip tests in such cases.

## Test Plan

Current test base suffices to cover the suggested changes.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
