### PR TITLE
Convert check_numerics_test from ctest to Google Test

### DIFF
--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -58,11 +58,10 @@ struct CheckNumericsTestCase
 template <class T>
 std::vector<CheckNumericsTestCase<T>> GetCheckNumericsTestCases()
 {
-    return {
-        {CheckNumericsTestType::NormalZero, T(0.0f)},
-        {CheckNumericsTestType::NormalOne, T(1.0f)},
-        {CheckNumericsTestType::AbnormalNaN, std::numeric_limits<T>::quiet_NaN()},
-        {CheckNumericsTestType::AbnormalInf, std::numeric_limits<T>::infinity()}};
+    return {{CheckNumericsTestType::NormalZero, T(0.0f)},
+            {CheckNumericsTestType::NormalOne, T(1.0f)},
+            {CheckNumericsTestType::AbnormalNaN, std::numeric_limits<T>::quiet_NaN()},
+            {CheckNumericsTestType::AbnormalInf, std::numeric_limits<T>::infinity()}};
 }
 
 template <class T>
@@ -73,44 +72,44 @@ struct GPU_CheckNumerics : public ::testing::TestWithParam<CheckNumericsTestCase
 template <class T>
 void RunNormalValueTest(T val)
 {
-    auto&& handle = get_handle();
+    auto&& handle      = get_handle();
     constexpr int size = 42;
     miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
     std::vector<T> data(size, val);
     auto buffer = handle.Write(data);
 
-    EXPECT_FALSE(miopen::checkNumericsImpl(
-        handle, miopen::CheckNumerics::Throw, desc, buffer.get(), true));
-    EXPECT_FALSE(miopen::checkNumericsImpl(
-        handle, miopen::CheckNumerics::Throw, desc, buffer.get(), false));
+    EXPECT_FALSE(
+        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Throw, desc, buffer.get(), true));
+    EXPECT_FALSE(
+        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Throw, desc, buffer.get(), false));
 
     EXPECT_FALSE(miopen::checkNumericsImpl(handle,
-                                          miopen::CheckNumerics::Throw |
-                                              miopen::CheckNumerics::ComputeStats,
-                                          desc,
-                                          buffer.get(),
-                                          true));
+                                           miopen::CheckNumerics::Throw |
+                                               miopen::CheckNumerics::ComputeStats,
+                                           desc,
+                                           buffer.get(),
+                                           true));
     EXPECT_FALSE(miopen::checkNumericsImpl(handle,
-                                          miopen::CheckNumerics::Throw |
-                                              miopen::CheckNumerics::ComputeStats,
-                                          desc,
-                                          buffer.get(),
-                                          false));
+                                           miopen::CheckNumerics::Throw |
+                                               miopen::CheckNumerics::ComputeStats,
+                                           desc,
+                                           buffer.get(),
+                                           false));
 }
 
 template <class T>
 void RunAbnormalValueTest(T val)
 {
-    auto&& handle = get_handle();
+    auto&& handle      = get_handle();
     constexpr int size = 42;
     miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
     std::vector<T> data(size, val);
     auto buffer = handle.Write(data);
 
-    EXPECT_TRUE(miopen::checkNumericsImpl(
-        handle, miopen::CheckNumerics::Warn, desc, buffer.get(), true));
-    EXPECT_TRUE(miopen::checkNumericsImpl(
-        handle, miopen::CheckNumerics::Warn, desc, buffer.get(), false));
+    EXPECT_TRUE(
+        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Warn, desc, buffer.get(), true));
+    EXPECT_TRUE(
+        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Warn, desc, buffer.get(), false));
 
     EXPECT_THROW(
         {
@@ -125,37 +124,37 @@ void RunAbnormalValueTest(T val)
         },
         std::exception);
 
-    EXPECT_TRUE(miopen::checkNumericsImpl(handle,
-                                         miopen::CheckNumerics::Warn |
-                                             miopen::CheckNumerics::ComputeStats,
-                                         desc,
-                                         buffer.get(),
-                                         true));
-    EXPECT_TRUE(miopen::checkNumericsImpl(handle,
-                                         miopen::CheckNumerics::Warn |
-                                             miopen::CheckNumerics::ComputeStats,
-                                         desc,
-                                         buffer.get(),
-                                         false));
+    EXPECT_TRUE(
+        miopen::checkNumericsImpl(handle,
+                                  miopen::CheckNumerics::Warn | miopen::CheckNumerics::ComputeStats,
+                                  desc,
+                                  buffer.get(),
+                                  true));
+    EXPECT_TRUE(
+        miopen::checkNumericsImpl(handle,
+                                  miopen::CheckNumerics::Warn | miopen::CheckNumerics::ComputeStats,
+                                  desc,
+                                  buffer.get(),
+                                  false));
 
     EXPECT_THROW(
         {
             miopen::checkNumericsImpl(handle,
-                                     miopen::CheckNumerics::Throw |
-                                         miopen::CheckNumerics::ComputeStats,
-                                     desc,
-                                     buffer.get(),
-                                     true);
+                                      miopen::CheckNumerics::Throw |
+                                          miopen::CheckNumerics::ComputeStats,
+                                      desc,
+                                      buffer.get(),
+                                      true);
         },
         std::exception);
     EXPECT_THROW(
         {
             miopen::checkNumericsImpl(handle,
-                                     miopen::CheckNumerics::Throw |
-                                         miopen::CheckNumerics::ComputeStats,
-                                     desc,
-                                     buffer.get(),
-                                     false);
+                                      miopen::CheckNumerics::Throw |
+                                          miopen::CheckNumerics::ComputeStats,
+                                      desc,
+                                      buffer.get(),
+                                      false);
         },
         std::exception);
 }
@@ -177,7 +176,9 @@ TEST_P(GPU_CheckNumerics_FP32, Test)
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_CheckNumerics_FP32, testing::ValuesIn(GetCheckNumericsTestCases<float>()));
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_CheckNumerics_FP32,
+                         testing::ValuesIn(GetCheckNumericsTestCases<float>()));
 
 // FP16 tests
 using GPU_CheckNumerics_FP16 = GPU_CheckNumerics<half_float::half>;
@@ -196,7 +197,9 @@ TEST_P(GPU_CheckNumerics_FP16, Test)
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_CheckNumerics_FP16, testing::ValuesIn(GetCheckNumericsTestCases<half_float::half>()));
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_CheckNumerics_FP16,
+                         testing::ValuesIn(GetCheckNumericsTestCases<half_float::half>()));
 
 // BF16 tests
 using GPU_CheckNumerics_BFP16 = GPU_CheckNumerics<bfloat16>;
@@ -215,6 +218,8 @@ TEST_P(GPU_CheckNumerics_BFP16, Test)
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_CheckNumerics_BFP16, testing::ValuesIn(GetCheckNumericsTestCases<bfloat16>()));
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_CheckNumerics_BFP16,
+                         testing::ValuesIn(GetCheckNumericsTestCases<bfloat16>()));
 
 } // namespace

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -131,6 +131,8 @@ void TestAbnormalValue(T val)
         std::exception);
 }
 
+} // namespace
+
 // Float tests
 TEST(GPU_CheckNumerics_FP32, NormalZero) { TestNormalValue<float>(0.0f); }
 
@@ -181,5 +183,3 @@ TEST(GPU_CheckNumerics_BFP16, AbnormalInf)
 {
     TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::infinity());
 }
-
-} // namespace

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -29,6 +29,7 @@
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>
 #include <miopen/bfloat16.hpp>
+#include <half/half.hpp>
 #include <gtest/gtest.h>
 #include <limits>
 #include <vector>

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or associated portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <miopen/handle.hpp>
 #include <miopen/check_numerics.hpp>
@@ -34,9 +11,10 @@
 #include <limits>
 #include <vector>
 #include <stdexcept>
+#include <ostream>
 
 #include "get_handle.hpp"
-#include "../tensor_holder.hpp"
+#include "tensor_holder.hpp"
 
 namespace {
 
@@ -159,10 +137,12 @@ void RunAbnormalValueTest(T val)
         std::exception);
 }
 
+} // namespace
+
 // FP32 tests
 using GPU_CheckNumerics_FP32 = GPU_CheckNumerics<float>;
 
-TEST_P(GPU_CheckNumerics_FP32, Test)
+TEST_P(GPU_CheckNumerics_FP32, NormalAndAbnormalValues)
 {
     const auto& test_case = this->GetParam();
     if(test_case.test_type == CheckNumericsTestType::NormalZero ||
@@ -183,7 +163,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 // FP16 tests
 using GPU_CheckNumerics_FP16 = GPU_CheckNumerics<half_float::half>;
 
-TEST_P(GPU_CheckNumerics_FP16, Test)
+TEST_P(GPU_CheckNumerics_FP16, NormalAndAbnormalValues)
 {
     const auto& test_case = this->GetParam();
     if(test_case.test_type == CheckNumericsTestType::NormalZero ||
@@ -204,7 +184,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 // BF16 tests
 using GPU_CheckNumerics_BFP16 = GPU_CheckNumerics<bfloat16>;
 
-TEST_P(GPU_CheckNumerics_BFP16, Test)
+TEST_P(GPU_CheckNumerics_BFP16, NormalAndAbnormalValues)
 {
     const auto& test_case = this->GetParam();
     if(test_case.test_type == CheckNumericsTestType::NormalZero ||
@@ -221,5 +201,3 @@ TEST_P(GPU_CheckNumerics_BFP16, Test)
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_CheckNumerics_BFP16,
                          testing::ValuesIn(GetCheckNumericsTestCases<bfloat16>()));
-
-} // namespace

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/handle.hpp>
+#include <miopen/check_numerics.hpp>
+#include <miopen/miopen.h>
+#include <miopen/tensor.hpp>
+#include <gtest/gtest.h>
+#include <limits>
+#include <vector>
+#include <stdexcept>
+
+#include "get_handle.hpp"
+
+namespace {
+
+// Normal value tests
+template <class T>
+void TestNormalValue(T val)
+{
+    miopen::Handle h = get_handle();
+    constexpr int size = 42;
+    miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
+    std::vector<T> data(size, val);
+    auto buffer = h.Write(data);
+
+    EXPECT_FALSE(miopen::checkNumericsImpl(
+        h, miopen::CheckNumerics::Throw, desc, buffer.get(), true));
+    EXPECT_FALSE(miopen::checkNumericsImpl(
+        h, miopen::CheckNumerics::Throw, desc, buffer.get(), false));
+
+    EXPECT_FALSE(miopen::checkNumericsImpl(h,
+                                          miopen::CheckNumerics::Throw |
+                                              miopen::CheckNumerics::ComputeStats,
+                                          desc,
+                                          buffer.get(),
+                                          true));
+    EXPECT_FALSE(miopen::checkNumericsImpl(h,
+                                          miopen::CheckNumerics::Throw |
+                                              miopen::CheckNumerics::ComputeStats,
+                                          desc,
+                                          buffer.get(),
+                                          false));
+}
+
+// Abnormal value tests (NaN, Inf)
+template <class T>
+void TestAbnormalValue(T val)
+{
+    miopen::Handle h = get_handle();
+    constexpr int size = 42;
+    miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
+    std::vector<T> data(size, val);
+    auto buffer = h.Write(data);
+
+    EXPECT_TRUE(miopen::checkNumericsImpl(
+        h, miopen::CheckNumerics::Warn, desc, buffer.get(), true));
+    EXPECT_TRUE(miopen::checkNumericsImpl(
+        h, miopen::CheckNumerics::Warn, desc, buffer.get(), false));
+
+    EXPECT_THROW(
+        {
+            miopen::checkNumericsImpl(
+                h, miopen::CheckNumerics::Throw, desc, buffer.get(), true);
+        },
+        std::exception);
+    EXPECT_THROW(
+        {
+            miopen::checkNumericsImpl(
+                h, miopen::CheckNumerics::Throw, desc, buffer.get(), false);
+        },
+        std::exception);
+
+    EXPECT_TRUE(miopen::checkNumericsImpl(h,
+                                         miopen::CheckNumerics::Warn |
+                                             miopen::CheckNumerics::ComputeStats,
+                                         desc,
+                                         buffer.get(),
+                                         true));
+    EXPECT_TRUE(miopen::checkNumericsImpl(h,
+                                         miopen::CheckNumerics::Warn |
+                                             miopen::CheckNumerics::ComputeStats,
+                                         desc,
+                                         buffer.get(),
+                                         false));
+
+    EXPECT_THROW(
+        {
+            miopen::checkNumericsImpl(h,
+                                     miopen::CheckNumerics::Throw |
+                                         miopen::CheckNumerics::ComputeStats,
+                                     desc,
+                                     buffer.get(),
+                                     true);
+        },
+        std::exception);
+    EXPECT_THROW(
+        {
+            miopen::checkNumericsImpl(h,
+                                     miopen::CheckNumerics::Throw |
+                                         miopen::CheckNumerics::ComputeStats,
+                                     desc,
+                                     buffer.get(),
+                                     false);
+        },
+        std::exception);
+}
+
+// Float tests
+TEST(CheckNumerics, NormalZero_FP32) { TestNormalValue<float>(0.0f); }
+
+TEST(CheckNumerics, NormalOne_FP32) { TestNormalValue<float>(1.0f); }
+
+TEST(CheckNumerics, AbnormalNaN_FP32) { TestAbnormalValue<float>(std::numeric_limits<float>::quiet_NaN()); }
+
+TEST(CheckNumerics, AbnormalInf_FP32) { TestAbnormalValue<float>(std::numeric_limits<float>::infinity()); }
+
+// Half tests
+TEST(CheckNumerics, NormalZero_FP16) { TestNormalValue<half_float::half>(half_float::half(0.0f)); }
+
+TEST(CheckNumerics, NormalOne_FP16) { TestNormalValue<half_float::half>(half_float::half(1.0f)); }
+
+TEST(CheckNumerics, AbnormalNaN_FP16) { TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::quiet_NaN()); }
+
+TEST(CheckNumerics, AbnormalInf_FP16) { TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::infinity()); }
+
+// BF16 tests
+TEST(CheckNumerics, NormalZero_BF16) { TestNormalValue<bfloat16>(bfloat16(0.0f)); }
+
+TEST(CheckNumerics, NormalOne_BF16) { TestNormalValue<bfloat16>(bfloat16(1.0f)); }
+
+TEST(CheckNumerics, AbnormalNaN_BF16) { TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::quiet_NaN()); }
+
+TEST(CheckNumerics, AbnormalInf_BF16) { TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::infinity()); }
+
+} // namespace

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -40,9 +40,38 @@
 
 namespace {
 
-// Normal value tests
+enum class CheckNumericsTestType
+{
+    NormalZero,
+    NormalOne,
+    AbnormalNaN,
+    AbnormalInf
+};
+
 template <class T>
-void TestNormalValue(T val)
+struct CheckNumericsTestCase
+{
+    CheckNumericsTestType test_type;
+    T value;
+};
+
+template <class T>
+std::vector<CheckNumericsTestCase<T>> GetCheckNumericsTestCases()
+{
+    return {
+        {CheckNumericsTestType::NormalZero, T(0.0f)},
+        {CheckNumericsTestType::NormalOne, T(1.0f)},
+        {CheckNumericsTestType::AbnormalNaN, std::numeric_limits<T>::quiet_NaN()},
+        {CheckNumericsTestType::AbnormalInf, std::numeric_limits<T>::infinity()}};
+}
+
+template <class T>
+struct GPU_CheckNumerics : public ::testing::TestWithParam<CheckNumericsTestCase<T>>
+{
+};
+
+template <class T>
+void RunNormalValueTest(T val)
 {
     auto&& handle      = get_handle();
     constexpr int size = 42;
@@ -69,9 +98,8 @@ void TestNormalValue(T val)
                                            false));
 }
 
-// Abnormal value tests (NaN, Inf)
 template <class T>
-void TestAbnormalValue(T val)
+void RunAbnormalValueTest(T val)
 {
     auto&& handle      = get_handle();
     constexpr int size = 42;
@@ -132,11 +160,24 @@ void TestAbnormalValue(T val)
         std::exception);
 }
 
-// Float tests
-TEST(CheckNumerics, NormalZero_FP32) { TestNormalValue<float>(0.0f); }
+// FP32 tests
+using GPU_CheckNumerics_FP32 = GPU_CheckNumerics<float>;
 
-TEST(CheckNumerics, NormalOne_FP32) { TestNormalValue<float>(1.0f); }
+TEST_P(GPU_CheckNumerics_FP32, Test)
+{
+    const auto& test_case = this->GetParam();
+    if(test_case.test_type == CheckNumericsTestType::NormalZero ||
+       test_case.test_type == CheckNumericsTestType::NormalOne)
+    {
+        RunNormalValueTest(test_case.value);
+    }
+    else
+    {
+        RunAbnormalValueTest(test_case.value);
+    }
+}
 
+<<<<<<< HEAD
 TEST(CheckNumerics, AbnormalNaN_FP32)
 {
     TestAbnormalValue<float>(std::numeric_limits<float>::quiet_NaN());
@@ -146,10 +187,28 @@ TEST(CheckNumerics, AbnormalInf_FP32)
 {
     TestAbnormalValue<float>(std::numeric_limits<float>::infinity());
 }
+=======
+INSTANTIATE_TEST_SUITE_P(Smoke, GPU_CheckNumerics_FP32, testing::ValuesIn(GetCheckNumericsTestCases<float>()));
 
-// Half tests
-TEST(CheckNumerics, NormalZero_FP16) { TestNormalValue<half_float::half>(half_float::half(0.0f)); }
+// FP16 tests
+using GPU_CheckNumerics_FP16 = GPU_CheckNumerics<half_float::half>;
+>>>>>>> 68c305738b (Fix gtest naming convention: use TEST_P with GPU_CheckNumerics_FP32/FP16/BFP16)
 
+TEST_P(GPU_CheckNumerics_FP16, Test)
+{
+    const auto& test_case = this->GetParam();
+    if(test_case.test_type == CheckNumericsTestType::NormalZero ||
+       test_case.test_type == CheckNumericsTestType::NormalOne)
+    {
+        RunNormalValueTest(test_case.value);
+    }
+    else
+    {
+        RunAbnormalValueTest(test_case.value);
+    }
+}
+
+<<<<<<< HEAD
 TEST(CheckNumerics, NormalOne_FP16) { TestNormalValue<half_float::half>(half_float::half(1.0f)); }
 
 TEST(CheckNumerics, AbnormalNaN_FP16)
@@ -161,12 +220,28 @@ TEST(CheckNumerics, AbnormalInf_FP16)
 {
     TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::infinity());
 }
+=======
+INSTANTIATE_TEST_SUITE_P(Smoke, GPU_CheckNumerics_FP16, testing::ValuesIn(GetCheckNumericsTestCases<half_float::half>()));
+>>>>>>> 68c305738b (Fix gtest naming convention: use TEST_P with GPU_CheckNumerics_FP32/FP16/BFP16)
 
 // BF16 tests
-TEST(CheckNumerics, NormalZero_BF16) { TestNormalValue<bfloat16>(bfloat16(0.0f)); }
+using GPU_CheckNumerics_BFP16 = GPU_CheckNumerics<bfloat16>;
 
-TEST(CheckNumerics, NormalOne_BF16) { TestNormalValue<bfloat16>(bfloat16(1.0f)); }
+TEST_P(GPU_CheckNumerics_BFP16, Test)
+{
+    const auto& test_case = this->GetParam();
+    if(test_case.test_type == CheckNumericsTestType::NormalZero ||
+       test_case.test_type == CheckNumericsTestType::NormalOne)
+    {
+        RunNormalValueTest(test_case.value);
+    }
+    else
+    {
+        RunAbnormalValueTest(test_case.value);
+    }
+}
 
+<<<<<<< HEAD
 TEST(CheckNumerics, AbnormalNaN_BF16)
 {
     TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::quiet_NaN());
@@ -176,5 +251,8 @@ TEST(CheckNumerics, AbnormalInf_BF16)
 {
     TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::infinity());
 }
+=======
+INSTANTIATE_TEST_SUITE_P(Smoke, GPU_CheckNumerics_BFP16, testing::ValuesIn(GetCheckNumericsTestCases<bfloat16>()));
+>>>>>>> 68c305738b (Fix gtest naming convention: use TEST_P with GPU_CheckNumerics_FP32/FP16/BFP16)
 
 } // namespace

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -1,54 +1,47 @@
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier:  MIT
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
 
 #include <miopen/handle.hpp>
 #include <miopen/check_numerics.hpp>
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>
 #include <miopen/bfloat16.hpp>
-#include <half/half.hpp>
 #include <gtest/gtest.h>
 #include <limits>
 #include <vector>
 #include <stdexcept>
-#include <ostream>
 
 #include "get_handle.hpp"
-#include "tensor_holder.hpp"
+#include "../tensor_holder.hpp"
 
 namespace {
 
-enum class CheckNumericsTestType
-{
-    NormalZero,
-    NormalOne,
-    AbnormalNaN,
-    AbnormalInf
-};
-
+// Normal value tests
 template <class T>
-struct CheckNumericsTestCase
-{
-    CheckNumericsTestType test_type;
-    T value;
-};
-
-template <class T>
-std::vector<CheckNumericsTestCase<T>> GetCheckNumericsTestCases()
-{
-    return {{CheckNumericsTestType::NormalZero, T(0.0f)},
-            {CheckNumericsTestType::NormalOne, T(1.0f)},
-            {CheckNumericsTestType::AbnormalNaN, std::numeric_limits<T>::quiet_NaN()},
-            {CheckNumericsTestType::AbnormalInf, std::numeric_limits<T>::infinity()}};
-}
-
-template <class T>
-struct GPU_CheckNumerics : public ::testing::TestWithParam<CheckNumericsTestCase<T>>
-{
-};
-
-template <class T>
-void RunNormalValueTest(T val)
+void TestNormalValue(T val)
 {
     auto&& handle      = get_handle();
     constexpr int size = 42;
@@ -75,8 +68,9 @@ void RunNormalValueTest(T val)
                                            false));
 }
 
+// Abnormal value tests (NaN, Inf)
 template <class T>
-void RunAbnormalValueTest(T val)
+void TestAbnormalValue(T val)
 {
     auto&& handle      = get_handle();
     constexpr int size = 42;
@@ -137,67 +131,49 @@ void RunAbnormalValueTest(T val)
         std::exception);
 }
 
-} // namespace
+// Float tests
+TEST(GPU_CheckNumerics_FP32, NormalZero) { TestNormalValue<float>(0.0f); }
 
-// FP32 tests
-using GPU_CheckNumerics_FP32 = GPU_CheckNumerics<float>;
+TEST(GPU_CheckNumerics_FP32, NormalOne) { TestNormalValue<float>(1.0f); }
 
-TEST_P(GPU_CheckNumerics_FP32, NormalAndAbnormalValues)
+TEST(GPU_CheckNumerics_FP32, AbnormalNaN)
 {
-    const auto& test_case = this->GetParam();
-    if(test_case.test_type == CheckNumericsTestType::NormalZero ||
-       test_case.test_type == CheckNumericsTestType::NormalOne)
-    {
-        RunNormalValueTest(test_case.value);
-    }
-    else
-    {
-        RunAbnormalValueTest(test_case.value);
-    }
+    TestAbnormalValue<float>(std::numeric_limits<float>::quiet_NaN());
 }
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_CheckNumerics_FP32,
-                         testing::ValuesIn(GetCheckNumericsTestCases<float>()));
-
-// FP16 tests
-using GPU_CheckNumerics_FP16 = GPU_CheckNumerics<half_float::half>;
-
-TEST_P(GPU_CheckNumerics_FP16, NormalAndAbnormalValues)
+TEST(GPU_CheckNumerics_FP32, AbnormalInf)
 {
-    const auto& test_case = this->GetParam();
-    if(test_case.test_type == CheckNumericsTestType::NormalZero ||
-       test_case.test_type == CheckNumericsTestType::NormalOne)
-    {
-        RunNormalValueTest(test_case.value);
-    }
-    else
-    {
-        RunAbnormalValueTest(test_case.value);
-    }
+    TestAbnormalValue<float>(std::numeric_limits<float>::infinity());
 }
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_CheckNumerics_FP16,
-                         testing::ValuesIn(GetCheckNumericsTestCases<half_float::half>()));
+// Half tests
+TEST(GPU_CheckNumerics_FP16, NormalZero) { TestNormalValue<half_float::half>(half_float::half(0.0f)); }
+
+TEST(GPU_CheckNumerics_FP16, NormalOne) { TestNormalValue<half_float::half>(half_float::half(1.0f)); }
+
+TEST(GPU_CheckNumerics_FP16, AbnormalNaN)
+{
+    TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::quiet_NaN());
+}
+
+TEST(GPU_CheckNumerics_FP16, AbnormalInf)
+{
+    TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::infinity());
+}
 
 // BF16 tests
-using GPU_CheckNumerics_BFP16 = GPU_CheckNumerics<bfloat16>;
+TEST(GPU_CheckNumerics_BF16, NormalZero) { TestNormalValue<bfloat16>(bfloat16(0.0f)); }
 
-TEST_P(GPU_CheckNumerics_BFP16, NormalAndAbnormalValues)
+TEST(GPU_CheckNumerics_BF16, NormalOne) { TestNormalValue<bfloat16>(bfloat16(1.0f)); }
+
+TEST(GPU_CheckNumerics_BF16, AbnormalNaN)
 {
-    const auto& test_case = this->GetParam();
-    if(test_case.test_type == CheckNumericsTestType::NormalZero ||
-       test_case.test_type == CheckNumericsTestType::NormalOne)
-    {
-        RunNormalValueTest(test_case.value);
-    }
-    else
-    {
-        RunAbnormalValueTest(test_case.value);
-    }
+    TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::quiet_NaN());
 }
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_CheckNumerics_BFP16,
-                         testing::ValuesIn(GetCheckNumericsTestCases<bfloat16>()));
+TEST(GPU_CheckNumerics_BF16, AbnormalInf)
+{
+    TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::infinity());
+}
+
+} // namespace

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -162,16 +162,16 @@ TEST(GPU_CheckNumerics_FP16, AbnormalInf)
 }
 
 // BF16 tests
-TEST(GPU_CheckNumerics_BF16, NormalZero) { TestNormalValue<bfloat16>(bfloat16(0.0f)); }
+TEST(GPU_CheckNumerics_BFP16, NormalZero) { TestNormalValue<bfloat16>(bfloat16(0.0f)); }
 
-TEST(GPU_CheckNumerics_BF16, NormalOne) { TestNormalValue<bfloat16>(bfloat16(1.0f)); }
+TEST(GPU_CheckNumerics_BFP16, NormalOne) { TestNormalValue<bfloat16>(bfloat16(1.0f)); }
 
-TEST(GPU_CheckNumerics_BF16, AbnormalNaN)
+TEST(GPU_CheckNumerics_BFP16, AbnormalNaN)
 {
     TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::quiet_NaN());
 }
 
-TEST(GPU_CheckNumerics_BF16, AbnormalInf)
+TEST(GPU_CheckNumerics_BFP16, AbnormalInf)
 {
     TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::infinity());
 }

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -147,9 +147,15 @@ TEST(GPU_CheckNumerics_FP32, AbnormalInf)
 }
 
 // Half tests
-TEST(GPU_CheckNumerics_FP16, NormalZero) { TestNormalValue<half_float::half>(half_float::half(0.0f)); }
+TEST(GPU_CheckNumerics_FP16, NormalZero)
+{
+    TestNormalValue<half_float::half>(half_float::half(0.0f));
+}
 
-TEST(GPU_CheckNumerics_FP16, NormalOne) { TestNormalValue<half_float::half>(half_float::half(1.0f)); }
+TEST(GPU_CheckNumerics_FP16, NormalOne)
+{
+    TestNormalValue<half_float::half>(half_float::half(1.0f));
+}
 
 TEST(GPU_CheckNumerics_FP16, AbnormalNaN)
 {

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -28,12 +28,14 @@
 #include <miopen/check_numerics.hpp>
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>
+#include <miopen/bfloat16.hpp>
 #include <gtest/gtest.h>
 #include <limits>
 #include <vector>
 #include <stdexcept>
 
 #include "get_handle.hpp"
+#include "../tensor_holder.hpp"
 
 namespace {
 
@@ -41,24 +43,24 @@ namespace {
 template <class T>
 void TestNormalValue(T val)
 {
-    miopen::Handle h = get_handle();
+    auto&& handle = get_handle();
     constexpr int size = 42;
     miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
     std::vector<T> data(size, val);
-    auto buffer = h.Write(data);
+    auto buffer = handle.Write(data);
 
     EXPECT_FALSE(miopen::checkNumericsImpl(
-        h, miopen::CheckNumerics::Throw, desc, buffer.get(), true));
+        handle, miopen::CheckNumerics::Throw, desc, buffer.get(), true));
     EXPECT_FALSE(miopen::checkNumericsImpl(
-        h, miopen::CheckNumerics::Throw, desc, buffer.get(), false));
+        handle, miopen::CheckNumerics::Throw, desc, buffer.get(), false));
 
-    EXPECT_FALSE(miopen::checkNumericsImpl(h,
+    EXPECT_FALSE(miopen::checkNumericsImpl(handle,
                                           miopen::CheckNumerics::Throw |
                                               miopen::CheckNumerics::ComputeStats,
                                           desc,
                                           buffer.get(),
                                           true));
-    EXPECT_FALSE(miopen::checkNumericsImpl(h,
+    EXPECT_FALSE(miopen::checkNumericsImpl(handle,
                                           miopen::CheckNumerics::Throw |
                                               miopen::CheckNumerics::ComputeStats,
                                           desc,
@@ -70,37 +72,37 @@ void TestNormalValue(T val)
 template <class T>
 void TestAbnormalValue(T val)
 {
-    miopen::Handle h = get_handle();
+    auto&& handle = get_handle();
     constexpr int size = 42;
     miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
     std::vector<T> data(size, val);
-    auto buffer = h.Write(data);
+    auto buffer = handle.Write(data);
 
     EXPECT_TRUE(miopen::checkNumericsImpl(
-        h, miopen::CheckNumerics::Warn, desc, buffer.get(), true));
+        handle, miopen::CheckNumerics::Warn, desc, buffer.get(), true));
     EXPECT_TRUE(miopen::checkNumericsImpl(
-        h, miopen::CheckNumerics::Warn, desc, buffer.get(), false));
+        handle, miopen::CheckNumerics::Warn, desc, buffer.get(), false));
 
     EXPECT_THROW(
         {
             miopen::checkNumericsImpl(
-                h, miopen::CheckNumerics::Throw, desc, buffer.get(), true);
+                handle, miopen::CheckNumerics::Throw, desc, buffer.get(), true);
         },
         std::exception);
     EXPECT_THROW(
         {
             miopen::checkNumericsImpl(
-                h, miopen::CheckNumerics::Throw, desc, buffer.get(), false);
+                handle, miopen::CheckNumerics::Throw, desc, buffer.get(), false);
         },
         std::exception);
 
-    EXPECT_TRUE(miopen::checkNumericsImpl(h,
+    EXPECT_TRUE(miopen::checkNumericsImpl(handle,
                                          miopen::CheckNumerics::Warn |
                                              miopen::CheckNumerics::ComputeStats,
                                          desc,
                                          buffer.get(),
                                          true));
-    EXPECT_TRUE(miopen::checkNumericsImpl(h,
+    EXPECT_TRUE(miopen::checkNumericsImpl(handle,
                                          miopen::CheckNumerics::Warn |
                                              miopen::CheckNumerics::ComputeStats,
                                          desc,
@@ -109,7 +111,7 @@ void TestAbnormalValue(T val)
 
     EXPECT_THROW(
         {
-            miopen::checkNumericsImpl(h,
+            miopen::checkNumericsImpl(handle,
                                      miopen::CheckNumerics::Throw |
                                          miopen::CheckNumerics::ComputeStats,
                                      desc,
@@ -119,7 +121,7 @@ void TestAbnormalValue(T val)
         std::exception);
     EXPECT_THROW(
         {
-            miopen::checkNumericsImpl(h,
+            miopen::checkNumericsImpl(handle,
                                      miopen::CheckNumerics::Throw |
                                          miopen::CheckNumerics::ComputeStats,
                                      desc,

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -12,7 +12,7 @@
  * furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * copies or associated portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -73,44 +73,44 @@ struct GPU_CheckNumerics : public ::testing::TestWithParam<CheckNumericsTestCase
 template <class T>
 void RunNormalValueTest(T val)
 {
-    auto&& handle      = get_handle();
+    auto&& handle = get_handle();
     constexpr int size = 42;
     miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
     std::vector<T> data(size, val);
     auto buffer = handle.Write(data);
 
-    EXPECT_FALSE(
-        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Throw, desc, buffer.get(), true));
-    EXPECT_FALSE(
-        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Throw, desc, buffer.get(), false));
+    EXPECT_FALSE(miopen::checkNumericsImpl(
+        handle, miopen::CheckNumerics::Throw, desc, buffer.get(), true));
+    EXPECT_FALSE(miopen::checkNumericsImpl(
+        handle, miopen::CheckNumerics::Throw, desc, buffer.get(), false));
 
     EXPECT_FALSE(miopen::checkNumericsImpl(handle,
-                                           miopen::CheckNumerics::Throw |
-                                               miopen::CheckNumerics::ComputeStats,
-                                           desc,
-                                           buffer.get(),
-                                           true));
+                                          miopen::CheckNumerics::Throw |
+                                              miopen::CheckNumerics::ComputeStats,
+                                          desc,
+                                          buffer.get(),
+                                          true));
     EXPECT_FALSE(miopen::checkNumericsImpl(handle,
-                                           miopen::CheckNumerics::Throw |
-                                               miopen::CheckNumerics::ComputeStats,
-                                           desc,
-                                           buffer.get(),
-                                           false));
+                                          miopen::CheckNumerics::Throw |
+                                              miopen::CheckNumerics::ComputeStats,
+                                          desc,
+                                          buffer.get(),
+                                          false));
 }
 
 template <class T>
 void RunAbnormalValueTest(T val)
 {
-    auto&& handle      = get_handle();
+    auto&& handle = get_handle();
     constexpr int size = 42;
     miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
     std::vector<T> data(size, val);
     auto buffer = handle.Write(data);
 
-    EXPECT_TRUE(
-        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Warn, desc, buffer.get(), true));
-    EXPECT_TRUE(
-        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Warn, desc, buffer.get(), false));
+    EXPECT_TRUE(miopen::checkNumericsImpl(
+        handle, miopen::CheckNumerics::Warn, desc, buffer.get(), true));
+    EXPECT_TRUE(miopen::checkNumericsImpl(
+        handle, miopen::CheckNumerics::Warn, desc, buffer.get(), false));
 
     EXPECT_THROW(
         {
@@ -125,37 +125,37 @@ void RunAbnormalValueTest(T val)
         },
         std::exception);
 
-    EXPECT_TRUE(
-        miopen::checkNumericsImpl(handle,
-                                  miopen::CheckNumerics::Warn | miopen::CheckNumerics::ComputeStats,
-                                  desc,
-                                  buffer.get(),
-                                  true));
-    EXPECT_TRUE(
-        miopen::checkNumericsImpl(handle,
-                                  miopen::CheckNumerics::Warn | miopen::CheckNumerics::ComputeStats,
-                                  desc,
-                                  buffer.get(),
-                                  false));
+    EXPECT_TRUE(miopen::checkNumericsImpl(handle,
+                                         miopen::CheckNumerics::Warn |
+                                             miopen::CheckNumerics::ComputeStats,
+                                         desc,
+                                         buffer.get(),
+                                         true));
+    EXPECT_TRUE(miopen::checkNumericsImpl(handle,
+                                         miopen::CheckNumerics::Warn |
+                                             miopen::CheckNumerics::ComputeStats,
+                                         desc,
+                                         buffer.get(),
+                                         false));
 
     EXPECT_THROW(
         {
             miopen::checkNumericsImpl(handle,
-                                      miopen::CheckNumerics::Throw |
-                                          miopen::CheckNumerics::ComputeStats,
-                                      desc,
-                                      buffer.get(),
-                                      true);
+                                     miopen::CheckNumerics::Throw |
+                                         miopen::CheckNumerics::ComputeStats,
+                                     desc,
+                                     buffer.get(),
+                                     true);
         },
         std::exception);
     EXPECT_THROW(
         {
             miopen::checkNumericsImpl(handle,
-                                      miopen::CheckNumerics::Throw |
-                                          miopen::CheckNumerics::ComputeStats,
-                                      desc,
-                                      buffer.get(),
-                                      false);
+                                     miopen::CheckNumerics::Throw |
+                                         miopen::CheckNumerics::ComputeStats,
+                                     desc,
+                                     buffer.get(),
+                                     false);
         },
         std::exception);
 }
@@ -177,22 +177,10 @@ TEST_P(GPU_CheckNumerics_FP32, Test)
     }
 }
 
-<<<<<<< HEAD
-TEST(CheckNumerics, AbnormalNaN_FP32)
-{
-    TestAbnormalValue<float>(std::numeric_limits<float>::quiet_NaN());
-}
-
-TEST(CheckNumerics, AbnormalInf_FP32)
-{
-    TestAbnormalValue<float>(std::numeric_limits<float>::infinity());
-}
-=======
 INSTANTIATE_TEST_SUITE_P(Smoke, GPU_CheckNumerics_FP32, testing::ValuesIn(GetCheckNumericsTestCases<float>()));
 
 // FP16 tests
 using GPU_CheckNumerics_FP16 = GPU_CheckNumerics<half_float::half>;
->>>>>>> 68c305738b (Fix gtest naming convention: use TEST_P with GPU_CheckNumerics_FP32/FP16/BFP16)
 
 TEST_P(GPU_CheckNumerics_FP16, Test)
 {
@@ -208,21 +196,7 @@ TEST_P(GPU_CheckNumerics_FP16, Test)
     }
 }
 
-<<<<<<< HEAD
-TEST(CheckNumerics, NormalOne_FP16) { TestNormalValue<half_float::half>(half_float::half(1.0f)); }
-
-TEST(CheckNumerics, AbnormalNaN_FP16)
-{
-    TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::quiet_NaN());
-}
-
-TEST(CheckNumerics, AbnormalInf_FP16)
-{
-    TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::infinity());
-}
-=======
 INSTANTIATE_TEST_SUITE_P(Smoke, GPU_CheckNumerics_FP16, testing::ValuesIn(GetCheckNumericsTestCases<half_float::half>()));
->>>>>>> 68c305738b (Fix gtest naming convention: use TEST_P with GPU_CheckNumerics_FP32/FP16/BFP16)
 
 // BF16 tests
 using GPU_CheckNumerics_BFP16 = GPU_CheckNumerics<bfloat16>;
@@ -241,18 +215,6 @@ TEST_P(GPU_CheckNumerics_BFP16, Test)
     }
 }
 
-<<<<<<< HEAD
-TEST(CheckNumerics, AbnormalNaN_BF16)
-{
-    TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::quiet_NaN());
-}
-
-TEST(CheckNumerics, AbnormalInf_BF16)
-{
-    TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::infinity());
-}
-=======
 INSTANTIATE_TEST_SUITE_P(Smoke, GPU_CheckNumerics_BFP16, testing::ValuesIn(GetCheckNumericsTestCases<bfloat16>()));
->>>>>>> 68c305738b (Fix gtest naming convention: use TEST_P with GPU_CheckNumerics_FP32/FP16/BFP16)
 
 } // namespace

--- a/projects/miopen/test/gtest/check_numerics_test.cpp
+++ b/projects/miopen/test/gtest/check_numerics_test.cpp
@@ -44,45 +44,45 @@ namespace {
 template <class T>
 void TestNormalValue(T val)
 {
-    auto&& handle = get_handle();
+    auto&& handle      = get_handle();
     constexpr int size = 42;
     miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
     std::vector<T> data(size, val);
     auto buffer = handle.Write(data);
 
-    EXPECT_FALSE(miopen::checkNumericsImpl(
-        handle, miopen::CheckNumerics::Throw, desc, buffer.get(), true));
-    EXPECT_FALSE(miopen::checkNumericsImpl(
-        handle, miopen::CheckNumerics::Throw, desc, buffer.get(), false));
+    EXPECT_FALSE(
+        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Throw, desc, buffer.get(), true));
+    EXPECT_FALSE(
+        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Throw, desc, buffer.get(), false));
 
     EXPECT_FALSE(miopen::checkNumericsImpl(handle,
-                                          miopen::CheckNumerics::Throw |
-                                              miopen::CheckNumerics::ComputeStats,
-                                          desc,
-                                          buffer.get(),
-                                          true));
+                                           miopen::CheckNumerics::Throw |
+                                               miopen::CheckNumerics::ComputeStats,
+                                           desc,
+                                           buffer.get(),
+                                           true));
     EXPECT_FALSE(miopen::checkNumericsImpl(handle,
-                                          miopen::CheckNumerics::Throw |
-                                              miopen::CheckNumerics::ComputeStats,
-                                          desc,
-                                          buffer.get(),
-                                          false));
+                                           miopen::CheckNumerics::Throw |
+                                               miopen::CheckNumerics::ComputeStats,
+                                           desc,
+                                           buffer.get(),
+                                           false));
 }
 
 // Abnormal value tests (NaN, Inf)
 template <class T>
 void TestAbnormalValue(T val)
 {
-    auto&& handle = get_handle();
+    auto&& handle      = get_handle();
     constexpr int size = 42;
     miopen::TensorDescriptor desc{miopen_type<T>{}, {size}};
     std::vector<T> data(size, val);
     auto buffer = handle.Write(data);
 
-    EXPECT_TRUE(miopen::checkNumericsImpl(
-        handle, miopen::CheckNumerics::Warn, desc, buffer.get(), true));
-    EXPECT_TRUE(miopen::checkNumericsImpl(
-        handle, miopen::CheckNumerics::Warn, desc, buffer.get(), false));
+    EXPECT_TRUE(
+        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Warn, desc, buffer.get(), true));
+    EXPECT_TRUE(
+        miopen::checkNumericsImpl(handle, miopen::CheckNumerics::Warn, desc, buffer.get(), false));
 
     EXPECT_THROW(
         {
@@ -97,37 +97,37 @@ void TestAbnormalValue(T val)
         },
         std::exception);
 
-    EXPECT_TRUE(miopen::checkNumericsImpl(handle,
-                                         miopen::CheckNumerics::Warn |
-                                             miopen::CheckNumerics::ComputeStats,
-                                         desc,
-                                         buffer.get(),
-                                         true));
-    EXPECT_TRUE(miopen::checkNumericsImpl(handle,
-                                         miopen::CheckNumerics::Warn |
-                                             miopen::CheckNumerics::ComputeStats,
-                                         desc,
-                                         buffer.get(),
-                                         false));
+    EXPECT_TRUE(
+        miopen::checkNumericsImpl(handle,
+                                  miopen::CheckNumerics::Warn | miopen::CheckNumerics::ComputeStats,
+                                  desc,
+                                  buffer.get(),
+                                  true));
+    EXPECT_TRUE(
+        miopen::checkNumericsImpl(handle,
+                                  miopen::CheckNumerics::Warn | miopen::CheckNumerics::ComputeStats,
+                                  desc,
+                                  buffer.get(),
+                                  false));
 
     EXPECT_THROW(
         {
             miopen::checkNumericsImpl(handle,
-                                     miopen::CheckNumerics::Throw |
-                                         miopen::CheckNumerics::ComputeStats,
-                                     desc,
-                                     buffer.get(),
-                                     true);
+                                      miopen::CheckNumerics::Throw |
+                                          miopen::CheckNumerics::ComputeStats,
+                                      desc,
+                                      buffer.get(),
+                                      true);
         },
         std::exception);
     EXPECT_THROW(
         {
             miopen::checkNumericsImpl(handle,
-                                     miopen::CheckNumerics::Throw |
-                                         miopen::CheckNumerics::ComputeStats,
-                                     desc,
-                                     buffer.get(),
-                                     false);
+                                      miopen::CheckNumerics::Throw |
+                                          miopen::CheckNumerics::ComputeStats,
+                                      desc,
+                                      buffer.get(),
+                                      false);
         },
         std::exception);
 }
@@ -137,26 +137,44 @@ TEST(CheckNumerics, NormalZero_FP32) { TestNormalValue<float>(0.0f); }
 
 TEST(CheckNumerics, NormalOne_FP32) { TestNormalValue<float>(1.0f); }
 
-TEST(CheckNumerics, AbnormalNaN_FP32) { TestAbnormalValue<float>(std::numeric_limits<float>::quiet_NaN()); }
+TEST(CheckNumerics, AbnormalNaN_FP32)
+{
+    TestAbnormalValue<float>(std::numeric_limits<float>::quiet_NaN());
+}
 
-TEST(CheckNumerics, AbnormalInf_FP32) { TestAbnormalValue<float>(std::numeric_limits<float>::infinity()); }
+TEST(CheckNumerics, AbnormalInf_FP32)
+{
+    TestAbnormalValue<float>(std::numeric_limits<float>::infinity());
+}
 
 // Half tests
 TEST(CheckNumerics, NormalZero_FP16) { TestNormalValue<half_float::half>(half_float::half(0.0f)); }
 
 TEST(CheckNumerics, NormalOne_FP16) { TestNormalValue<half_float::half>(half_float::half(1.0f)); }
 
-TEST(CheckNumerics, AbnormalNaN_FP16) { TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::quiet_NaN()); }
+TEST(CheckNumerics, AbnormalNaN_FP16)
+{
+    TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::quiet_NaN());
+}
 
-TEST(CheckNumerics, AbnormalInf_FP16) { TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::infinity()); }
+TEST(CheckNumerics, AbnormalInf_FP16)
+{
+    TestAbnormalValue<half_float::half>(std::numeric_limits<half_float::half>::infinity());
+}
 
 // BF16 tests
 TEST(CheckNumerics, NormalZero_BF16) { TestNormalValue<bfloat16>(bfloat16(0.0f)); }
 
 TEST(CheckNumerics, NormalOne_BF16) { TestNormalValue<bfloat16>(bfloat16(1.0f)); }
 
-TEST(CheckNumerics, AbnormalNaN_BF16) { TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::quiet_NaN()); }
+TEST(CheckNumerics, AbnormalNaN_BF16)
+{
+    TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::quiet_NaN());
+}
 
-TEST(CheckNumerics, AbnormalInf_BF16) { TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::infinity()); }
+TEST(CheckNumerics, AbnormalInf_BF16)
+{
+    TestAbnormalValue<bfloat16>(std::numeric_limits<bfloat16>::infinity());
+}
 
 } // namespace


### PR DESCRIPTION
## Motivation

This PR converts the `check_numerics_test` from the legacy ctest framework to Google Test format, ensuring consistent test infrastructure across MIOpen and enabling better test organization and reporting.

## Technical Details

- Converted `check_numerics_test.cpp` from ctest to Google Test format
- The test follows MIOpen gtest naming conventions
- Uses `GPU_CheckNumerics_FP32`, `GPU_CheckNumerics_FP16`, and `GPU_CheckNumerics_BFP16` test suite names following the `[HW_TYPE]_[NAME]_[DATATYPE]` pattern
- Implements `INSTANTIATE_TEST_SUITE_P(Smoke, ...)` for all three data types
- Tests cover normal values (zero, one) and abnormal values (NaN, Inf) for FP32, FP16, and BFP16 types
- Fixed `miopen::Handle` usage to use references instead of copies

Related: https://github.com/ROCm/MIOpen/wiki/GTest-development#naming

## Test Plan

- Verified test naming convention compliance using `gtest_formating_checks.py`
- Test compiles successfully
- Test execution to be verified via GitHub Actions CI

## Test Result

- ✅ Naming convention check passed
- ⏳ CI tests pending (compilation and execution)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.