### PR TITLE
Fix incorrect event waiting logic in `test_wait_event`

### DIFF
--- a/projects/rocthrust/test/test_event.cpp
+++ b/projects/rocthrust/test/test_event.cpp
@@ -162,7 +162,7 @@ TEST(EventTests, test_event_when_all)
 
   ASSERT_EQ(e0_stream, e8.stream().native_handle());
 
-  e8.wait();
+  TEST_EVENT_WAIT(e8);
 
   ASSERT_EQ(false, e0.ready());
   ASSERT_EQ(false, e1.ready());
@@ -173,8 +173,7 @@ TEST(EventTests, test_event_when_all)
   ASSERT_EQ(false, e6.ready());
   ASSERT_EQ(false, e7.ready());
 
-  // // FIXME: Temporarily disabled due to observed failure in AMD CI.
-  // ASSERT_EQ(true, e8.ready());
+  ASSERT_EQ(true, e8.ready());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/projects/rocthrust/testing/event.cu
+++ b/projects/rocthrust/testing/event.cu
@@ -154,7 +154,7 @@ THRUST_HOST void test_event_when_all()
 
   ASSERT_EQUAL(e0_stream, e8.stream().native_handle());
 
-  e8.wait();
+  TEST_EVENT_WAIT(e8);
 
   ASSERT_EQUAL(false, e0.ready());
   ASSERT_EQUAL(false, e1.ready());

--- a/projects/rocthrust/testing/unittest/util_async.h
+++ b/projects/rocthrust/testing/unittest/util_async.h
@@ -40,7 +40,10 @@ THRUST_HOST void test_event_wait(Event&& e, std::string const& filename = "unkno
   ASSERT_EQUAL_WITH_FILE_AND_LINE(true, e.valid_stream(), filename, lineno);
 
   e.wait();
-  e.wait();
+  while (!e.ready())
+  {
+    e.wait();
+  }
 
   ASSERT_EQUAL_WITH_FILE_AND_LINE(true, e.valid_stream(), filename, lineno);
   ASSERT_EQUAL_WITH_FILE_AND_LINE(true, e.ready(), filename, lineno);


### PR DESCRIPTION
## Motivation

Test failures were observed in cccl thrust `async_transform`, `event` and `future`.

## Technical Details

The problem was with the faulty [test_wait_event](https://github.com/ROCm/rocm-libraries/blob/29f4e1dc10930abf88d333232730115b65c6e548/projects/rocthrust/testing/unittest/util_async.h#L43) util function of cccl thrust tests, the correct one could be seen in hip thrust [test_wait_event](https://github.com/ROCm/rocm-libraries/blob/29f4e1dc10930abf88d333232730115b65c6e548/projects/rocthrust/test/test_utils.hpp#L321), where we check if the event if ready, then actually wait for the event.

Failed tests in async_transform and future were directly fixed with the correct util function. As for event, the same logic of `check if ready first, then wait` still holds, so they are corrected accordingly. Now the tests all pass.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
