### PR TITLE
[hipsparse] Use std::filesystem when manipulating paths in get_filename function

### DIFF
--- a/projects/hipsparse/clients/benchmarks/CMakeLists.txt
+++ b/projects/hipsparse/clients/benchmarks/CMakeLists.txt
@@ -52,6 +52,11 @@ endif()
 # Target link libraries
 target_link_libraries(hipsparse-bench PRIVATE roc::hipsparse)
 
+# Link against stdc++fs for std::experimental::filesystem support
+if(NOT WIN32)
+  target_link_libraries(hipsparse-bench PRIVATE stdc++fs)
+endif()
+
 # Add OpenMP if available
 if(OPENMP_FOUND AND THREADS_FOUND)
   target_link_libraries(hipsparse-bench PRIVATE OpenMP::OpenMP_CXX ${OpenMP_CXX_FLAGS})

--- a/projects/hipsparse/clients/common/utility.cpp
+++ b/projects/hipsparse/clients/common/utility.cpp
@@ -34,14 +34,6 @@
 #define strSUITEcmp(A, B) _stricmp(A, B)
 #endif
 
-#ifdef __cpp_lib_filesystem
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
-
 /* ============================================================================================ */
 // Return path of this executable
 std::string hipsparse_exepath()

--- a/projects/hipsparse/clients/include/utility.hpp
+++ b/projects/hipsparse/clients/include/utility.hpp
@@ -46,6 +46,15 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+
+#ifdef __cpp_lib_filesystem
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
 /*! \brief Return path of this executable */
 std::string hipsparse_exepath();
 /*! \brief Return path where the test data file (hipsparse_test.data) is located */
@@ -103,20 +112,20 @@ inline std::string get_filename(const std::string& matrix_filename)
         matrices_dir = getenv("HIPSPARSE_CLIENTS_MATRICES_DIR");
     }
 
-    std::string r;
+    fs::path r;
     if(matrices_dir != nullptr)
     {
-        r = std::string(matrices_dir) + "/" + matrix_filename_with_ext;
+        r = fs::path(matrices_dir) / matrix_filename_with_ext;
     }
     else
     {
-        r = hipsparse_exepath() + "../matrices/" + matrix_filename_with_ext;
+        r = fs::path(hipsparse_exepath()) / ".." / "matrices" / matrix_filename_with_ext;
     }
 
-    FILE* tmpf = fopen(r.c_str(), "r");
+    FILE* tmpf = fopen(r.string().c_str(), "r");
     if(!tmpf)
     {
-        missing_file_error_message(r.c_str());
+        missing_file_error_message(r.string().c_str());
         std::cerr << "exit(HIPSPARSE_STATUS_INTERNAL_ERROR)" << std::endl;
         exit(HIPSPARSE_STATUS_INTERNAL_ERROR);
     }
@@ -124,7 +133,7 @@ inline std::string get_filename(const std::string& matrix_filename)
     {
         fclose(tmpf);
     }
-    return r;
+    return r.string();
 }
 
 /*!\file

--- a/projects/hipsparse/clients/samples/CMakeLists.txt
+++ b/projects/hipsparse/clients/samples/CMakeLists.txt
@@ -44,6 +44,11 @@ function(add_hipsparse_example EXAMPLE_SOURCE)
   # Linker dependencies
   target_link_libraries(${EXAMPLE_TARGET} PRIVATE roc::hipsparse)
 
+  # Link against stdc++fs for std::experimental::filesystem support
+  if(NOT WIN32)
+    target_link_libraries(${EXAMPLE_TARGET} PRIVATE stdc++fs)
+  endif()
+
   if(NOT USE_CUDA)
     target_link_libraries(${EXAMPLE_TARGET} PRIVATE hip::host)
   else()

--- a/projects/hipsparse/clients/tests/CMakeLists.txt
+++ b/projects/hipsparse/clients/tests/CMakeLists.txt
@@ -195,6 +195,11 @@ endif()
 # Target link libraries
 target_link_libraries(hipsparse-test PRIVATE GTest::gtest roc::hipsparse)
 
+# Link against stdc++fs for std::experimental::filesystem support
+if(NOT WIN32)
+  target_link_libraries(hipsparse-test PRIVATE stdc++fs)
+endif()
+
 # Add OpenMP if available
 if(OPENMP_FOUND AND THREADS_FOUND)
   target_link_libraries(hipsparse-test PRIVATE OpenMP::OpenMP_CXX ${OpenMP_CXX_FLAGS})


### PR DESCRIPTION
## Motivation

We were hard coding the slashes when concatenating paths which resulted in forward/back slashes mixed together on windows
