### PR TITLE
[rocPRIM][hipCUB] Add minimum version in find_package call for Google Benchmark

### DIFF
--- a/projects/hipcub/cmake/Dependencies.cmake
+++ b/projects/hipcub/cmake/Dependencies.cmake
@@ -336,6 +336,7 @@ if(USER_BUILD_TEST)
 endif(USER_BUILD_TEST)
 
 if(USER_BUILD_BENCHMARK)
+  set(BENCHMARK_VERSION 1.8.0)
   if(NOT EXTERNAL_DEPS_FORCE_DOWNLOAD)
     find_package(benchmark CONFIG QUIET)
   endif()
@@ -346,7 +347,7 @@ if(USER_BUILD_BENCHMARK)
     FetchContent_Declare(
       googlebench
       GIT_REPOSITORY https://github.com/google/benchmark.git
-      GIT_TAG        v1.8.0
+      GIT_TAG        v${BENCHMARK_VERSION}
     )
     FetchContent_MakeAvailable(googlebench)
     if(NOT TARGET benchmark::benchmark)

--- a/projects/rocprim/cmake/Dependencies.cmake
+++ b/projects/rocprim/cmake/Dependencies.cmake
@@ -120,8 +120,9 @@ if(BUILD_TEST)
 endif(BUILD_TEST)
 
 if(BUILD_BENCHMARK)
+  set(BENCHMARK_VERSION 1.8.0)
   if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
-    find_package(benchmark CONFIG QUIET)
+    find_package(benchmark ${BENCHMARK_VERSION} CONFIG QUIET)
   endif()
   if(NOT TARGET benchmark::benchmark)
     message(STATUS "Google Benchmark not found. Fetching...")
@@ -130,7 +131,7 @@ if(BUILD_BENCHMARK)
     FetchContent_Declare(
       googlebench
       GIT_REPOSITORY https://github.com/google/benchmark.git
-      GIT_TAG        v1.8.0
+      GIT_TAG        v${BENCHMARK_VERSION}
     )
     set(HAVE_STD_REGEX ON)
     set(RUN_HAVE_STD_REGEX 1)


### PR DESCRIPTION
## Motivation

In the rocPRIM and hipCUB cmake dependencies files, no minimum Google Benchmark version is specified in the call to find_package. This can cause CMake to grab an incompatible version of the library, causing the build to fail.
rocThrust and rocRAND already do this.

## Technical Details

This change adds a minimum version. I've set it to the version that's downloaded when the library isn't present.

## Test Plan

Install Google Benchmark < 1.8.0 from the github repo here: https://github.com/google/benchmark. 
Build rocPRIM and hipCUB with -DBENCHMARK=ON.
Verify that there are no build errors.

## Test Result

No build errors observed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
