### PR TITLE
[hipCUB] Build rocm-cmake from source

### DIFF
--- a/projects/hipcub/cmake/ROCmCMakeBuildToolsDependency.cmake
+++ b/projects/hipcub/cmake/ROCmCMakeBuildToolsDependency.cmake
@@ -39,6 +39,20 @@ if(NOT ROCmCMakeBuildTools_FOUND)
     GIT_TAG        rocm-6.4.4
     ${SOURCE_SUBDIR_ARG}
   )
+  FetchContent_GetProperties(rocm-cmake)
+  if(NOT rocm-cmake_POPULATED)
+    # rocm-cmake 0.12.0 and higher needs to built from source
+    FetchContent_Populate(rocm-cmake)
+    message("Populated: ${rocm-cmake_SOURCE_DIR}")
+    execute_process(
+      WORKING_DIRECTORY ${rocm-cmake_SOURCE_DIR}
+      COMMAND ${CMAKE_COMMAND} ${rocm-cmake_SOURCE_DIR} -DCMAKE_INSTALL_PREFIX=.
+    )
+    execute_process(
+      WORKING_DIRECTORY ${rocm-cmake_SOURCE_DIR}
+      COMMAND ${CMAKE_COMMAND} --build ${rocm-cmake_SOURCE_DIR} --target install
+    )
+  endif()
   FetchContent_MakeAvailable(rocm-cmake)
   find_package(ROCmCMakeBuildTools CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
 else()


### PR DESCRIPTION
## Motivation

We recently started using ROCmCMakeBuildTools (since the previous ROCM package is now deprecated). This package needs to be built from source in some situations. rocPRIM's cmake files were updated to do this, but hipCUB's were not. This can result in build errors when the package is not already installed.

## Technical Details

This change copies the existing rocPRIM cmake code that builds the package from source into hipCUB. This fixes build issues that can be encountered when the package is not already available.

## Test Plan

The easiest way to test this fix is to build hipCUB on Windows, where the package is not already pre-installed. Verify that the build succeeds. You should see a message from cmake that says "Populated: <path/to/rocm-cmake-src/>".

## Test Result

The builds succeeds.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
