### PR TITLE
[rocsolver] update code coverage proces to use llvm-cov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -48,3 +48,6 @@ coverage:
       hipSOLVER:
         flags: [hipSOLVER]
         target: 80%
+      rocSOLVER:
+        flags: [rocSOLVER]
+        target: 80%

--- a/projects/rocsolver/CMakeLists.txt
+++ b/projects/rocsolver/CMakeLists.txt
@@ -306,36 +306,46 @@ rocm_create_package(
 #   make coverage_analysis GTEST_FILTER=<> (analyze tests)
 #   make coverage_output (generate html documentation)
 if(BUILD_CODE_COVERAGE)
-  # Run coverage analysis
-  add_custom_target(coverage_analysis
+  set(coverage_test ./clients/staging/rocsolver-test)
+
+  add_custom_target(
+    coverage_analysis
+    DEPENDS rocsolver-test
     COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
-    COMMAND ./clients/staging/rocsolver-test --gtest_filter=\"\${GTEST_FILTER}\"
+    COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
+    COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
+    COMMAND ${CMAKE_COMMAND} -E env LLVM_PROFILE_FILE="./coverage-report/profraw/rocSOLVER-coverage_%p.profraw" GTEST_LISTENER=NO_PASS_LINE_IN_LOG ${coverage_test} --gtest_filter=\"\${GTEST_FILTER}\"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
-  add_dependencies(coverage_analysis rocsolver)
 
-  # Generate gcov-tool script
-  # This little script is generated because the option '--gcov-tool <program name>' of lcov cannot take arguments.
-  add_custom_target(coverage_output
+  find_program(
+    LLVM_PROFDATA
+    llvm-profdata
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+
+  find_program(
+    LLVM_COV
+    llvm-cov
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+
+  add_custom_target(
+    coverage
     DEPENDS coverage_analysis
-    COMMAND mkdir -p lcoverage
-    COMMAND echo "\\#!/bin/bash" > llvm-gcov.sh
-    COMMAND echo "\\# THIS FILE HAS BEEN GENERATED" >> llvm-gcov.sh
-    COMMAND printf "exec /opt/rocm/llvm/bin/llvm-cov gcov $$\\@" >> llvm-gcov.sh
-    COMMAND chmod +x llvm-gcov.sh
-  )
-
-  # Generate code coverage report
-  add_custom_command(TARGET coverage_output
-    COMMAND lcov --directory . --base-directory . --gcov-tool ${CMAKE_BINARY_DIR}/llvm-gcov.sh --capture -o lcoverage/raw_main_coverage.info
-    COMMAND lcov --remove lcoverage/raw_main_coverage.info "'/opt/*'" "'/usr/*'" -o lcoverage/main_coverage.info
-    COMMAND genhtml --ignore-errors source lcoverage/main_coverage.info --output-directory lcoverage
-  )
-  add_custom_target(coverage DEPENDS coverage_output)
-
-  # Delete gcov data files
-  add_custom_target(coverage_cleanup
-    COMMAND find ${CMAKE_BINARY_DIR} -name *.gcda -delete
+    COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/rocSOLVER-coverage_*.profraw -o ./coverage-report/rocSOLVER.profdata
+    COMMAND ${LLVM_COV} report -object ./library/src/librocsolver.so -instr-profile=./coverage-report/rocSOLVER.profdata
+    COMMAND ${LLVM_COV} show -object ./library/src/librocsolver.so -instr-profile=./coverage-report/rocSOLVER.profdata -format=html -output-dir=coverage-report
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+  # Coverage cleanup
+  add_custom_target(coverage_cleanup
+      COMMAND find ${CMAKE_BINARY_DIR} -name *.gcda -delete
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 endif()

--- a/projects/rocsolver/CMakeLists.txt
+++ b/projects/rocsolver/CMakeLists.txt
@@ -340,6 +340,7 @@ if(BUILD_CODE_COVERAGE)
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/rocSOLVER-coverage_*.profraw -o ./coverage-report/rocSOLVER.profdata
     COMMAND ${LLVM_COV} report -object ./library/src/librocsolver.so -instr-profile=./coverage-report/rocSOLVER.profdata
     COMMAND ${LLVM_COV} show -object ./library/src/librocsolver.so -instr-profile=./coverage-report/rocSOLVER.profdata -format=html -output-dir=coverage-report
+    COMMAND ${LLVM_COV} export -object ./library/src/librocsolver.so -instr-profile=./coverage-report/rocSOLVER.profdata -format=lcov > ./coverage-report/coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
 

--- a/projects/rocsolver/CMakeLists.txt
+++ b/projects/rocsolver/CMakeLists.txt
@@ -343,10 +343,4 @@ if(BUILD_CODE_COVERAGE)
     COMMAND ${LLVM_COV} export -object ./library/src/librocsolver.so -instr-profile=./coverage-report/rocSOLVER.profdata -format=lcov > ./coverage-report/coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
-
-  # Coverage cleanup
-  add_custom_target(coverage_cleanup
-      COMMAND find ${CMAKE_BINARY_DIR} -name *.gcda -delete
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
 endif()

--- a/projects/rocsolver/common/CMakeLists.txt
+++ b/projects/rocsolver/common/CMakeLists.txt
@@ -71,10 +71,14 @@ endif()
 
 if(BUILD_CODE_COVERAGE)
   target_compile_options(rocsolver-common INTERFACE
-    -fprofile-arcs
-    -ftest-coverage
+    -g
+    -O0
+    -fprofile-instr-generate
+    -fcoverage-mapping
   )
-  target_link_options(rocsolver-common INTERFACE --coverage)
+  target_link_options(rocsolver-common INTERFACE
+    -fprofile-instr-generate
+  )
 endif()
 
 if(BUILD_COMPRESSED_DBG)


### PR DESCRIPTION
## Motivation

Updated the code coverage process so that it works with CI.

## Technical Details

We need to use llvm-cov for generating coverage reports for clang compiled code; gov/lcov do not work.  With this process, we simply run `make coverage` and it will generate the report in the correct directory for CI to grab an eventually upload to codecov.io

## Test Plan

```bash
mkdir build && cd build
cmake -DBUILD_CLIENTS_EXTRA_TESTS=ON -DCMAKE_CXX_COMPILER=amdclang++ -DCMAKE_C_COMPILER=amdclang -DBUILD_CLIENTS_TESTS=ON  -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CODE_COVERAGE=ON -DGPU_TARGETS=gfx942 -DBUILD_TESTING=ON -DBUILD_CLIENTS_BENCHMARKS=ON ..
make -j$(nproc) coverage
```

## Test Result

<img width="901" height="332" alt="image" src="https://github.com/user-attachments/assets/2edd9555-db32-4c82-bfcd-f5d594298992" />

