### PR TITLE
Re-enable large datatype perf tests on gfx950

### DIFF
--- a/shared/rocroller/scripts/lib/rrperf/rrsuites.py
+++ b/shared/rocroller/scripts/lib/rrperf/rrsuites.py
@@ -1738,14 +1738,14 @@ def all():
         yield from fp8_kernels()
         yield from mxfp8_kernels()
         yield from mx_gemms_f8f6f4()
-    else:
-        yield from sgemm()
-        yield from hgemm()
-        yield from hgemm_no_store_LDS()
-        yield from streamk()
-        yield from streamk_sweep()
-        yield from scalar_is_zero()
-        yield from codegen()
+
+    yield from sgemm()
+    yield from hgemm()
+    yield from hgemm_no_store_LDS()
+    yield from streamk()
+    yield from streamk_sweep()
+    yield from scalar_is_zero()
+    yield from codegen()
 
 
 def all_gfx120X():


### PR DESCRIPTION
## Motivation

This PR re-enables perf tests for large datatypes on gfx950. These tests were disabled on gfx950 in [#1294](https://github.com/ROCm/rocm-libraries/pull/1294/commits/b3726c92bdaeaba4045ab6741cecd89737e645fc) because they increased the length of the automated PR performance report comments past the GitHub comment character limit.  The performance report comments have been shortened thanks to #1987, so the tests can now be re-enabled.

## Technical Details

- Remove `else` which prevented large datatype tests in`rrsuites` from being run on gfx95* machines

## Test Plan

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
