### PR TITLE
[rocPRIM] Add check to prevent std::uniform_int_distribution creation for single byte integer types

### DIFF
--- a/projects/rocprim/benchmark/benchmark_utils.hpp
+++ b/projects/rocprim/benchmark/benchmark_utils.hpp
@@ -464,9 +464,17 @@ std::vector<T>
     common::uniform_int_distribution<size_t> segment_length_distribution(
         std::numeric_limits<size_t>::min(),
         max_segment_length);
-    // std::uniform_real_distribution cannot handle rocprim::half, use float instead
+    // std::uniform_real_distribution cannot handle:
+    //   - rocprim::half, use float instead.
+    //   - single byte integer-based types (char, unsigned char, int8_t, uint8_t), use int instead
     using dis_type =
-        typename std::conditional<std::is_same<rocprim::half, T>::value, float, T>::type;
+        typename std::conditional<std::is_same<rocprim::half, T>::value,
+                                  float,
+                                  typename std::conditional<rocprim::is_integral<T>::value
+                                                   && !common::is_valid_for_int_distribution<T>::value,
+                                                   typename std::conditional<std::is_signed<T>::value, int, unsigned int>::type,
+                                                   T>::type>::type;
+
     using key_distribution_type = std::conditional_t<rocprim::is_integral<T>::value,
                                                      common::uniform_int_distribution<dis_type>,
                                                      std::uniform_real_distribution<dis_type>>;


### PR DESCRIPTION
## Motivation

Some benchmarks call common::get_random_segments to generate their random data. This function creates a std::uniform_int_distribution using the type it is passed. According to the standard library docs, this distribution does not work with single byte integer types like char, int8_t, etc.

While this compiles fine on Linux, it hits a static assert in the standard library on Windows.

## Technical Details

This change adds a check to determine if get_random_segments is being called with a type that won't work with std::uniform_int_distribution. If it won't work, it uses int/unsigned int as the distribution type instead. Then we cast back to the original type after we've generated the data.

Note: Other benchmarks (eg. benchmark_device_merge_inplace) already follow this approach.

## Test Plan

Build rocPRIM with benchmarks enabled on Windows. Verify that there are no build errors.

## Test Result

No build errors observed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
