### PR TITLE
[hipSPARSELt] fix README GPU target

### DIFF
--- a/projects/hipsparselt/README.md
+++ b/projects/hipsparselt/README.md
@@ -93,7 +93,7 @@ cmake --build _build --target coverage
 
 ### Using CMake variables directly
 
-**Full build for gfx1201**
+**Full build for gfx942**
 
 ```bash
 # configure
@@ -102,7 +102,7 @@ cmake -B build -S .                                  \
       -D CMAKE_CXX_COMPILER=/opt/rocm/bin/amdclang++ \
       -D CMAKE_C_COMPILER=/opt/rocm/bin/amdclang     \
       -D CMAKE_PREFIX_PATH=/opt/rocm                 \
-      -D GPU_TARGETS=gfx1201
+      -D GPU_TARGETS=gfx942
 # build
 cmake --build build --parallel
 ```
@@ -127,8 +127,8 @@ Refer to the available build options using `./install.sh --help`
 
 # build and install all libraries and clients, and fetch dependencies
 ./install.sh -idc
-# build for gfx1201 only without installation
-./install.sh -c -a gfx1201
+# build for gfx942 only without installation
+./install.sh -c -a gfx942
 ```
 
 ### Options


### PR DESCRIPTION
## Motivation

gfx1201 is not currently supported, change README build instructions to target gfx942 instead

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
