### PR TITLE
[MIOpen] Fix broken nightly tests

### DIFF
--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -924,7 +924,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        runDbSyncJob()
+                        runDbSyncJob(gfx908_flags)
                     }
                     post {
                         always {


### PR DESCRIPTION
## Motivation

Our nightly broke as a result of me improperly resolving a recent merge conflict in our Jenkinsfile.

## Technical Details

We're attempting to call runDbSyncJob with no arguments, this fix adds the approrpriate flags for this platform.

## Test Plan

* Full test pass

## Test Result

* Test pass pending

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
