### PR TITLE
Set MbskPrefetchMethod to 1

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
@@ -422,7 +422,7 @@ defaultBenchmarkCommonParameters = [
     {"ForceDisableShadowInit": [False]},
     {"LDSTrInst": [False]},
     {"WaveSplitK": [ False ]},
-    {"MbskPrefetchMethod": [-1]},
+    {"MbskPrefetchMethod": [1]},
     {"UseCustomMainLoopSchedule": [1]},
     {"SpaceFillingAlgo": [[]]},
     {"SFCWGM": [[[1,1],[1,1]]]}


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Enhance performance on big MT and small GSU problems.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Enabling MbskPrefetchMethod  to 1 has no big performance difference for small MT problems but it has big performance gain for big MT and small GSU problems. Therefore, set MbskPrefetchMethod to 1.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
hipblaslt-test and tensilelite test pass

## Test Result

<!-- Briefly summarize test outcomes. -->
hipblaslt-test and tensilelite test pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
