### PR TITLE
[rocThrust] Adding docs to unique_ptr.h

### DIFF
--- a/projects/rocthrust/docs/conf.py
+++ b/projects/rocthrust/docs/conf.py
@@ -34,4 +34,4 @@ doxygen_project = {
     "path": "doxygen/xml",
 }
 
-cpp_id_attributes = ["__device__", "__host__", "THRUST_HOST_DEVICE", "THRUST_HOST", "THRUST_DEVICE", "THRUST_SUPPRESS_DEPRECATED_PUSH"]
+cpp_id_attributes = ["__device__", "__host__", "THRUST_HOST_DEVICE", "THRUST_HOST", "THRUST_DEVICE", "THRUST_SUPPRESS_DEPRECATED_PUSH", "THRUST_CONSTEXPR_SINCE_CXX23"]

--- a/projects/rocthrust/docs/doxygen/Doxyfile
+++ b/projects/rocthrust/docs/doxygen/Doxyfile
@@ -2403,7 +2403,9 @@ PREDEFINED             = THRUST_DOXYGEN_INVOKED \
                          THRUST_PREVENT_MACRO_SUBSTITUTION= \
                          THRUST_EXEC_CHECK_DISABLE= \
                          THRUST_ALIAS_ATTRIBUTE(x)= \
-                         THRUST_DEPRECATED_BECAUSE(x)=
+                         THRUST_DEPRECATED_BECAUSE(x)= \
+                         "__attribute__(x)=" \
+                         "[[no_unique_address]]="
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -413,6 +413,8 @@ public:
   //==========================================================================
   // Destructor
   //==========================================================================
+  /*! Destroys the \p unique_ptr, the managed object is destroyed via `get_deleter()(get())`. If get() == nullptr there are no effects.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 ~unique_ptr()
   {
     reset();

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -378,7 +378,7 @@ public:
   //==========================================================================
   // Assignment
   //==========================================================================
-  /*! Move assignment operator. Replaces the managed object with the one from \p u.
+  /*! \brief Move assignment operator. Replaces the managed object with the one from \p u.
    *  \param u The \p unique_ptr to move from.
    *  \return `*this`
    */
@@ -389,7 +389,7 @@ public:
     return *this;
   }
 
-  /*! Converting assignment operator.. Replaces the managed object with the one from \p u.
+  /*! \brief Converting assignment operator.. Replaces the managed object with the one from \p u.
    *  \param u The \p unique_ptr to move from.
    *  \return `*this`
    */
@@ -401,7 +401,7 @@ public:
     return *this;
   }
 
-  /*! Assigns a null pointer, deallocating the managed object. Effectively the same as calling reset().
+  /*! \brief Assigns a null pointer, deallocating the managed object. Effectively the same as calling reset().
    *  \return `*this`
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(std::nullptr_t) noexcept
@@ -413,7 +413,7 @@ public:
   //==========================================================================
   // Destructor
   //==========================================================================
-  /*! Destroys the \p unique_ptr, the managed object is destroyed via `get_deleter()(get())`. If get() == nullptr there are no effects.
+  /*! \brief Destroys the \p unique_ptr, the managed object is destroyed via `get_deleter()(get())`. If get() == nullptr there are no effects.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 ~unique_ptr()
   {
@@ -423,7 +423,7 @@ public:
   //==========================================================================
   // Observers
   //==========================================================================
-  /*! Returns a pointer to the managed object or `nullptr` if no object is owned.
+  /*! \brief Returns a pointer to the managed object or `nullptr` if no object is owned.
    *  \return Pointer to the managed object.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer get() const noexcept
@@ -431,7 +431,7 @@ public:
     return m_ptr;
   }
 
-  /*! Returns a raw pointer to the managed object or `nullptr` if no object is owned.
+  /*! \brief Returns a raw pointer to the managed object or `nullptr` if no object is owned.
    *  \return Raw pointer to the managed object.
    */
   template <bool Dummy = true, class = EnableIfDeleterDefaultDelete<Dummy>>
@@ -440,7 +440,7 @@ public:
     return raw_pointer_cast(m_ptr);
   }
 
-  /*! Returns a reference to the deleter object which would be used for destruction of the managed object.
+  /*! \brief Returns a reference to the deleter object which would be used for destruction of the managed object.
    *  \return A reference to the stored deleter.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 deleter_type& get_deleter() noexcept
@@ -448,7 +448,7 @@ public:
     return m_deleter;
   }
 
-  /*! Returns a reference to the deleter object which would be used for destruction of the managed object.
+  /*! \brief Returns a reference to the deleter object which would be used for destruction of the managed object.
    *  \return A reference to the stored deleter.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 const deleter_type& get_deleter() const noexcept
@@ -456,7 +456,7 @@ public:
     return m_deleter;
   }
 
-  /*! Checks if the \p unique_ptr owns an object.
+  /*! \brief Checks if the \p unique_ptr owns an object.
    *  \return `true` if an object is owned, `false` otherwise.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit operator bool() const noexcept
@@ -464,7 +464,7 @@ public:
     return m_ptr != nullptr;
   }
 
-  /*! Dereferences the stored pointer.
+  /*! \brief Dereferences the stored pointer.
    * 
    *  The default `unique_ptr` implementation uses `thrust::device_ptr`.
    *  Dereferencing this pointer in host code is a valid operation that
@@ -491,7 +491,7 @@ public:
   //==========================================================================
   // Modifiers
   //==========================================================================
-  /*! Releases ownership of the managed object, if any.
+  /*! \brief Releases ownership of the managed object, if any.
    *  \return A pointer to the released object.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer release() noexcept
@@ -501,7 +501,7 @@ public:
     return temp;
   }
 
-  /*! Replaces the managed object.
+  /*! \brief Replaces the managed object.
    *  \param p The new object to manage.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void reset(pointer p = pointer()) noexcept
@@ -514,7 +514,7 @@ public:
     }
   }
 
-  /*! Swaps the managed object and deleter with another \p unique_ptr.
+  /*! \brief Swaps the managed object and deleter with another \p unique_ptr.
    *  \param u The \p unique_ptr to swap with.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr& u) noexcept

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -600,17 +600,27 @@ public:
   // Constructors
   //==========================================================================
 
+  /*! \brief Constructs an empty \p unique_ptr that does not own an array.
+   */
   template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
   THRUST_HOST constexpr unique_ptr() noexcept
       : m_ptr()
       , m_deleter()
   {}
 
+  /*! \brief Constructs an empty \p unique_ptr that does not own an array.
+   */
   template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
   THRUST_HOST constexpr unique_ptr(std::nullptr_t) noexcept
       : unique_ptr()
   {}
 
+  /*! \brief Constructs a \p unique_ptr that owns the object pointed to by \p p.
+   *
+   *  This overload is only available for arrays of trivially-destructible types.
+   *
+   *  \param p A pointer to an array in device memory to manage.
+   */
   template <class Pp,
             bool Dummy = true,
             class      = EnableIfDeleterDefaultConstructible<Dummy>,
@@ -621,6 +631,12 @@ public:
       , m_deleter()
   {}
 
+  /*! \brief Constructs a \p unique_ptr from a raw device array pointer.
+   *
+   *  This overload is only available for arrays of trivially-destructible types.
+   * 
+   * \param raw_p A raw pointer to an array in device memory to manage.
+   */
   template <class Pp,
             bool Dummy = true,
             class      = EnableIfDeleterDefaultConstructible<Dummy>,
@@ -632,6 +648,14 @@ public:
       , m_deleter()
   {}
 
+  /*! \brief Constructs a \p unique_ptr that owns the object pointed to by \p p with known size. 
+   *
+   *  For arrays of non-trivially-destructible types, the size is required to ensure
+   *  all element destructors are properly called during deletion.
+   *
+   *  \param p A pointer to an array in device memory to manage.
+   *  \param size The number of elements in the array.
+   */
   template <class Pp,
             bool Dummy = true,
             class      = EnableIfDeleterDefaultConstructible<Dummy>,
@@ -641,6 +665,14 @@ public:
       , m_deleter(size)
   {}
 
+  /*! \brief Constructs a \p unique_ptr from a raw device array pointer with known size.
+   *
+   *  For arrays of non-trivially-destructible types, the size is required to ensure
+   *  all element destructors are properly called during deletion.
+   *
+   *  \param raw_p A raw pointer to an array in device memory to manage.
+   *  \param size The number of elements in the array.
+   */
   template <class Pp,
             bool Dummy = true,
             class      = EnableIfDeleterDefaultConstructible<Dummy>,
@@ -651,6 +683,11 @@ public:
       , m_deleter(size)
   {}
 
+  /*! \brief Constructs a \p unique_ptr with a custom deleter (lvalue reference).
+   *
+   *  \param p A pointer to the array in device memory to manage.
+   *  \param deleter The deleter to use for destroying the array.
+   */
   template <class Pp,
             bool Dummy = true,
             class      = EnableIfDeleterConstructible<LValRefType<Dummy>>,
@@ -660,12 +697,21 @@ public:
       , m_deleter(deleter)
   {}
 
+  /*! \brief Constructs an empty \p unique_ptr with a custom deleter (lvalue reference).
+   *
+   *  \param deleter The deleter to store.
+   */
   template <bool Dummy = true, class = EnableIfDeleterConstructible<LValRefType<Dummy>>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(std::nullptr_t, LValRefType<Dummy> deleter) noexcept
       : m_ptr(nullptr)
       , m_deleter(deleter)
   {}
 
+  /*! \brief Constructs a \p unique_ptr with a custom deleter (rvalue reference).
+   *
+   *  \param p A pointer to the array in device memory to manage.
+   *  \param deleter The deleter to use for destroying the array (moved).
+   */
   template <class Pp,
             bool Dummy = true,
             class      = EnableIfDeleterConstructible<GoodRValRefType<Dummy>>,
@@ -677,6 +723,10 @@ public:
     static_assert(!std::is_reference_v<deleter_type>, "rvalue deleter bound to reference");
   }
 
+  /*! \brief Constructs an empty \p unique_ptr with a custom deleter (rvalue reference).
+   *
+   *  \param deleter The deleter to store (moved).
+   */
   template <bool Dummy = true, class = EnableIfDeleterConstructible<GoodRValRefType<Dummy>>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(std::nullptr_t, GoodRValRefType<Dummy> deleter) noexcept
       : m_ptr(nullptr)
@@ -691,11 +741,24 @@ public:
             class      = EnableIfPointerConvertible<Pp>>
   THRUST_HOST unique_ptr(Pp ptr, BadRValRefType<Dummy> deleter) = delete;
 
+  /*! \brief Move constructor that transfers ownership from another array \p unique_ptr.
+   *
+   *  \param u The \p unique_ptr to move from.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& u) noexcept
       : m_ptr(u.release())
       , m_deleter(std::forward<deleter_type>(u.get_deleter()))
   {}
 
+  /*! \brief Converting move constructor from a compatible array \p unique_ptr.
+   *
+   *  Allows converting from \p unique_ptr<U[], E> to \p unique_ptr<T[], D> when
+   *  the array element types and deleter types are compatible (e.g., derived to base).
+   *
+   *  \tparam Up An array element type convertible to \p T.
+   *  \tparam Ep A deleter type convertible to \p D.
+   *  \param u The \p unique_ptr to move from.
+   */
   template <class Up,
             class Ep,
             class = EnableIfMoveConvertible<unique_ptr<Up, Ep>, Up>,

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -423,32 +423,55 @@ public:
   //==========================================================================
   // Observers
   //==========================================================================
+  /*! Returns a pointer to the managed object or `nullptr` if no object is owned.
+   *  \return Pointer to the managed object.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer get() const noexcept
   {
     return m_ptr;
   }
 
+  /*! Returns a raw pointer to the managed object or `nullptr` if no object is owned.
+   *  \return Raw pointer to the managed object.
+   */
   template <bool Dummy = true, class = EnableIfDeleterDefaultDelete<Dummy>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 T* get_raw() const noexcept
   {
     return raw_pointer_cast(m_ptr);
   }
 
+  /*! Returns a reference to the deleter object which would be used for destruction of the managed object.
+   *  \return A reference to the stored deleter.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 deleter_type& get_deleter() noexcept
   {
     return m_deleter;
   }
 
+  /*! Returns a reference to the deleter object which would be used for destruction of the managed object.
+   *  \return A reference to the stored deleter.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 const deleter_type& get_deleter() const noexcept
   {
     return m_deleter;
   }
 
+  /*! Checks if the \p unique_ptr owns an object.
+   *  \return `true` if an object is owned, `false` otherwise.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit operator bool() const noexcept
   {
     return m_ptr != nullptr;
   }
 
+  /*! Dereferences the stored pointer.
+   * 
+   *  The default `unique_ptr` implementation uses `thrust::device_ptr`.
+   *  Dereferencing this pointer in host code is a valid operation that
+   *  results in a copy of the object from device to host memory.
+   *
+   *  \return A reference to the managed object.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 auto operator*() const noexcept
   {
     return *m_ptr;

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -1,4 +1,4 @@
-/*! \file
+/*! \file unique_ptr.h
  *  \brief A smart pointer that owns and manages another object through a
  *         pointer and disposes of that object when the \p unique_ptr goes
  *         out of scope.
@@ -26,9 +26,28 @@ THRUST_NAMESPACE_BEGIN
  *  \{
  */
 
+/*! \brief Default deleter for \p unique_ptr.
+ *
+ *  The default deleter used by \p unique_ptr when no custom deleter is specified.
+ *  Uses \p thrust::device_free to deallocate memory. For non-trivially destructible
+ *  types, invokes destructors on the device before deallocation.
+ *
+ *  \tparam T The type of object to delete (single object form).
+ *
+ *  \see thrust::unique_ptr
+ *  \see thrust::device_free
+ */
 template <class T, class = void>
 struct default_delete;
 
+/*! \brief Default deleter specialization for single objects.
+ *
+ *  This specialization handles deletion of single objects allocated in device memory.
+ *  For non-trivially destructible types, the destructor is invoked on the device
+ *  before memory deallocation.
+ *
+ *  \tparam T The type of object to delete.
+ */
 template <class T>
 struct default_delete<T, std::enable_if_t<!std::is_array_v<T>>>
 {
@@ -70,6 +89,13 @@ struct default_delete<T, std::enable_if_t<!std::is_array_v<T>>>
   }
 };
 
+/*! \brief Default deleter specialization for arrays of non-trivially destructible types.
+ *
+ *  This specialization handles deletion of arrays where element destructors must be called.
+ *  Stores the array size to ensure all element destructors are properly invoked on the device.
+ *
+ *  \tparam T The array element type (non-trivially destructible).
+ */
 template <class T>
 struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>>>
 {
@@ -122,12 +148,16 @@ private:
   size_t m_size;
 };
 
-// For arrays of trivially destructible element types we intentionally do NOT
-// store the element count. Their destruction is a no-op, so only the raw
-// deallocation is required. Omitting the size keeps this deleter
-// specialization an empty (zero-size) type, allowing unique_ptr<T[]>
-// instantiations that use it to remain a zero-cost abstraction (the deleter
-// need not increase the overall object size).
+/*! \brief Default deleter specialization for arrays of trivially destructible types.
+ *
+ *  For arrays of trivially destructible element types, this specialization intentionally
+ *  does NOT store the element count. Their destruction is a no-op, so only the raw
+ *  deallocation is required. Omitting the size keeps this deleter specialization an
+ *  empty (zero-size) type, allowing \p unique_ptr<T[]> instantiations that use it to
+ *  remain a zero-cost abstraction (the deleter need not increase the overall object size).
+ *
+ *  \tparam T The array element type (trivially destructible).
+ */
 template <class T>
 struct default_delete<T[], std::enable_if_t<std::is_trivially_destructible_v<T>>>
 {
@@ -864,8 +894,8 @@ public:
     return m_deleter;
   }
 
-  /*! \brief Returns a constreference to the deleter object which would be used for destruction of the managed array.
-   *  \return A reference to the stored deleter.
+  /*! \brief Returns a const reference to the deleter object which would be used for destruction of the managed array.
+   *  \return A const reference to the stored deleter.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 const deleter_type& get_deleter() const noexcept
   {

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -104,7 +104,6 @@ struct default_delete<T, std::enable_if_t<!std::is_array_v<T>>>
 /*! \brief Default deleter specialization for arrays of non-trivially destructible types.
  *
  *  This specialization handles deletion of arrays where element destructors must be called.
- *  Stores the array size to ensure all element destructors are properly invoked on the device.
  *
  *  \tparam T The array element type (non-trivially destructible).
  */

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -264,11 +264,22 @@ template <class T, class D = default_delete<T>>
 class __attribute__((trivial_abi)) unique_ptr
 {
 public:
+  /*! \typedef pointer
+   *  \brief The type of the stored pointer (defaults to `thrust::device_ptr<T>`).
+   */
   using pointer      = typename thrust::detail::pointer_detector<T, D>::type;
+  
+  /*! \typedef element_type
+   *  \brief The type of the managed object (`T`).
+   */
   using element_type = T;
+  
+  /*! \typedef deleter_type
+   *  \brief The type of the deleter (`D`).
+   */
   using deleter_type = D;
 
-  // TODO: When a standard “trivially relocatable” facility lands, add an
+  // TODO: When a standard "trivially relocatable" facility lands, add an
   // annotation/macro here to advertise that unique_ptr can be bitwise relocated
 
 private:
@@ -582,43 +593,23 @@ public:
   }
 };
 
-/*! \brief Array specialization of \p unique_ptr for managing dynamically-allocated arrays.
- *
- *  This specialization manages arrays allocated in device memory. The array form
- *  provides `operator[]` for element access.
- *
- *  \par Array Destruction Behavior
- *  The array form has different constructor requirements and performance characteristics
- *  based on the element type's destructibility:
- *
- *  **Trivially-destructible types** (e.g., `int`, `float`, POD types):
- *  - Constructors do NOT require array size parameter
- *  - Deleter is zero-size (no memory overhead)
- *  - Destruction only deallocates memory (no destructors to call)
- *  - Example: `unique_ptr<int[]> ptr(device_malloc<int>(100));`
- *
- *  **Non-trivially-destructible types** (e.g., types with custom destructors):
- *  - Constructors REQUIRE array size parameter
- *  - Deleter stores the size (small memory overhead: one `size_t`)
- *  - Destruction calls destructor for each element on device before deallocation
- *  - Example: `unique_ptr<MyClass[]> ptr(device_new<MyClass>(100), 100);`
- *
- *  This design ensures zero overhead for simple types while properly handling
- *  complex types that require cleanup.
- *
- *  \tparam T The array element type.
- *  \tparam D The type of the deleter.
- *
- *  \see thrust::default_delete
- *  \see thrust::make_unique
- *  \see https://en.cppreference.com/w/cpp/memory/unique_ptr
- */
 template <class T, class D>
 class __attribute__((trivial_abi)) unique_ptr<T[], D>
 {
 public:
+  /*! \typedef pointer
+   *  \brief The type of the stored pointer (defaults to `thrust::device_ptr<T>`).
+   */
   using pointer      = typename thrust::detail::pointer_detector<T, D>::type;
+  
+  /*! \typedef element_type
+   *  \brief The type of the array elements (`T`).
+   */
   using element_type = T;
+  
+  /*! \typedef deleter_type
+   *  \brief The type of the deleter (`D`).
+   */
   using deleter_type = D;
 
 private:

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -192,6 +192,34 @@ struct unique_ptr_deleter_sfinae<Deleter&>
 
 } // namespace detail
 
+/*! \p thrust::unique_ptr is a smart pointer that owns and manages another object,
+ *  allocated in device memory, via a pointer and subsequently disposes of that
+ *  object when the \p unique_ptr goes out of scope.
+ *
+ *  The object is disposed of using the associated `Deleter` when either of the
+ *  following happens:
+ *  - the managing `unique_ptr` object is destroyed.
+ *  - the managing `unique_ptr` object is assigned another pointer via `operator=` or `reset()`.
+ *
+ *  The object is disposed of by calling `get_deleter()(get())`. The default deleter,
+ *  `thrust::default_delete`, deallocates the memory using `thrust::device_free`.
+ *  For non-trivially destructible types, Deleter invokes the destructor of the
+ *  managed object on the device before deallocation.
+ *
+ *  A `unique_ptr` may alternatively own no object, in which case it is described as
+ *  *empty*.
+ *
+ *  There are two versions of `thrust::unique_ptr`:
+ *  1. Manages a single object
+ *  2. Manages a dynamically-allocated array of objects
+ *
+ *
+ *  \tparam T The type of the managed object.
+ *  \tparam D The type of the deleter.
+ *
+ *  \see https://en.cppreference.com/w/cpp/memory/unique_ptr
+ */
+
 template <class T, class D = default_delete<T>>
 class __attribute__((trivial_abi)) unique_ptr
 {

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -988,6 +988,9 @@ public:
    *  For device arrays, accessing an element from host code triggers a copy
    *  from device to host memory.
    *
+   *  \warning Using this operator when iterating over the array is STRONGLY discouraged
+   *  as the excessive number of single-element copies usually results in poor performance.
+   *
    *  \param i The index of the element to access.
    *  \return A reference to (or copy of) the element at index \p i.
    */
@@ -1346,7 +1349,7 @@ template <class T, class D>
 //==============================================================================
 /*! \brief Constructs an object of type \p T in device memory and wraps it in a \p unique_ptr.
  *
- *  Allocates device memory for a single object of type \p T, constructs the object
+ *  Allocates device memory for a single object of type \p T, direct-initializes the object
  *  by forwarding the provided arguments, and returns a \p unique_ptr managing the
  *  allocated object.
  *
@@ -1367,7 +1370,7 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique(Args&&
 /*! \brief Constructs an array of objects of type \p T in device memory and wraps it in a \p unique_ptr.
  *
  *  Allocates device memory for an array of \p n objects of type \p U (where \p T is \p U[]),
- *  and returns a \p unique_ptr managing the allocated array.
+ *  default-initializes each element, and returns a \p unique_ptr managing the allocated array.
  *
  *  This overload participates in overload resolution only if \p T is an array of unknown
  *  bound (e.g., \p T[]).

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -865,8 +865,8 @@ public:
     return *this;
   }
 
-  /*! \brief Converting assignment operator. Replaces the managed object with the one from \p u.
-   *  \param u The \p unique_ptr to move from.
+  /*! \brief Converting assignment operator. Replaces the managed object with the one from \p p.
+   *  \param p The \p unique_ptr to move from.
    *  \return `*this`
    */
   template <class Up,
@@ -1011,6 +1011,13 @@ public:
   }
 };
 
+/*! \brief Swaps two \p unique_ptr objects.
+ *
+ *  Exchanges the contents of \p x and \p y by calling `x.swap(y)`.
+ *
+ *  \param x The first \p unique_ptr.
+ *  \param y The second \p unique_ptr.
+ */
 template <class T, class D, std::enable_if_t<std::is_swappable_v<D>, void>>
 inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept
 {
@@ -1066,18 +1073,36 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<
   return std::less<CTP>()(thrust::raw_pointer_cast(x.get()), thrust::raw_pointer_cast(y.get()));
 }
 
+/*! \brief Compares two \p unique_ptr objects using greater-than ordering.
+ *
+ *  \param x The first \p unique_ptr to compare.
+ *  \param y The second \p unique_ptr to compare.
+ *  \return `true` if \p x is greater than \p y, `false` otherwise.
+ */
 template <class T1, class D1, class T2, class D2>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   return y < x;
 }
 
+/*! \brief Compares two \p unique_ptr objects using less-than-or-equal ordering.
+ *
+ *  \param x The first \p unique_ptr to compare.
+ *  \param y The second \p unique_ptr to compare.
+ *  \return `true` if \p x is less than or equal to \p y, `false` otherwise.
+ */
 template <class T1, class D1, class T2, class D2>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   return !(y < x);
 }
 
+/*! \brief Compares two \p unique_ptr objects using greater-than-or-equal ordering.
+ *
+ *  \param x The first \p unique_ptr to compare.
+ *  \param y The second \p unique_ptr to compare.
+ *  \return `true` if \p x is greater than or equal to \p y, `false` otherwise.
+ */
 template <class T1, class D1, class T2, class D2>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
@@ -1093,6 +1118,11 @@ template <class T1, class D1, class T2, class D2>
 }
 #endif
 
+/*! \brief Compares a \p unique_ptr with nullptr for equality.
+ *
+ *  \param x The \p unique_ptr to compare.
+ *  \return `true` if \p x is empty, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr<T, D>& x, std::nullptr_t) noexcept
 {
@@ -1100,18 +1130,33 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr
 }
 
 #if THRUST_STD_VER <= 17
+/*! \brief Compares nullptr with a \p unique_ptr for equality (C++17 and earlier).
+ *
+ *  \param y The \p unique_ptr to compare.
+ *  \return `true` if \p y is empty, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
 {
   return !y;
 }
 
+/*! \brief Compares a \p unique_ptr with nullptr for inequality (C++17 and earlier).
+ *
+ *  \param x The \p unique_ptr to compare.
+ *  \return `true` if \p x is not empty, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(const unique_ptr<T, D>& x, std::nullptr_t) noexcept
 {
   return static_cast<bool>(x);
 }
 
+/*! \brief Compares nullptr with a \p unique_ptr for inequality (C++17 and earlier).
+ *
+ *  \param y The \p unique_ptr to compare.
+ *  \return `true` if \p y is not empty, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(std::nullptr_t, const unique_ptr<T, D>& y) noexcept
 {
@@ -1119,48 +1164,88 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(std::nullptr_t, 
 }
 #endif
 
+/*! \brief Compares a \p unique_ptr with nullptr using less-than ordering.
+ *
+ *  \param x The \p unique_ptr to compare.
+ *  \return `true` if the pointer in \p x is less than nullptr, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<T, D>& x, std::nullptr_t)
 {
   return std::less<typename unique_ptr<T, D>::pointer>()(x.get(), nullptr); // x.get() < nullptr;
 }
 
+/*! \brief Compares nullptr with a \p unique_ptr using less-than ordering.
+ *
+ *  \param y The \p unique_ptr to compare.
+ *  \return `true` if nullptr is less than the pointer in \p y, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(std::nullptr_t, const unique_ptr<T, D>& y)
 {
   return std::less<typename unique_ptr<T, D>::pointer>()(nullptr, y.get()); // nullptr < y.get();
 }
 
+/*! \brief Compares a \p unique_ptr with nullptr using greater-than ordering.
+ *
+ *  \param x The \p unique_ptr to compare.
+ *  \return `true` if the pointer in \p x is greater than nullptr, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(const unique_ptr<T, D>& x, std::nullptr_t)
 {
   return nullptr < x;
 }
 
+/*! \brief Compares nullptr with a \p unique_ptr using greater-than ordering.
+ *
+ *  \param y The \p unique_ptr to compare.
+ *  \return `true` if nullptr is greater than the pointer in \p y, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>(std::nullptr_t, const unique_ptr<T, D>& y)
 {
   return y < nullptr;
 }
 
+/*! \brief Compares a \p unique_ptr with nullptr using less-than-or-equal ordering.
+ *
+ *  \param x The \p unique_ptr to compare.
+ *  \return `true` if the pointer in \p x is less than or equal to nullptr, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(const unique_ptr<T, D>& x, std::nullptr_t)
 {
   return !(nullptr < x);
 }
 
+/*! \brief Compares nullptr with a \p unique_ptr using less-than-or-equal ordering.
+ *
+ *  \param y The \p unique_ptr to compare.
+ *  \return `true` if nullptr is less than or equal to the pointer in \p y, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<=(std::nullptr_t, const unique_ptr<T, D>& y)
 {
   return !(y < nullptr);
 }
 
+/*! \brief Compares a \p unique_ptr with nullptr using greater-than-or-equal ordering.
+ *
+ *  \param x The \p unique_ptr to compare.
+ *  \return `true` if the pointer in \p x is greater than or equal to nullptr, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(const unique_ptr<T, D>& x, std::nullptr_t)
 {
   return !(x < nullptr);
 }
 
+/*! \brief Compares nullptr with a \p unique_ptr using greater-than-or-equal ordering.
+ *
+ *  \param y The \p unique_ptr to compare.
+ *  \return `true` if nullptr is greater than or equal to the pointer in \p y, `false` otherwise.
+ */
 template <class T, class D>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator>=(std::nullptr_t, const unique_ptr<T, D>& y)
 {

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -487,6 +487,9 @@ public:
   }
 
   /*! \brief Checks if the \p unique_ptr owns an object.
+   *
+   *  Equivalent to `get() != nullptr`.
+   *
    *  \return `true` if an object is owned, `false` otherwise.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit operator bool() const noexcept
@@ -507,8 +510,18 @@ public:
     return *m_ptr;
   }
 
-  // In host code, attempting to use this will produce a clear diagnostic
-  // instead of silently allowing an invalid dereference of device memory.
+  /*! \brief Disabled for device pointers - cannot dereference device memory from host.
+   *
+   *  \warning This operator is intentionally disabled because dereferencing
+   *  device memory from host code is invalid. Use `operator*()` to copy the
+   *  object to host first (`T host_obj = *ptr`), or access members inside
+   *  device code.
+   *
+   *  Attempting to use this operator will produce a compile-time error with
+   *  a clear diagnostic message.
+   *
+   *  \return This function does not return; it triggers a compile-time error.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer operator->() const noexcept
   {
     static_assert(false,
@@ -545,6 +558,10 @@ public:
   }
 
   /*! \brief Swaps the managed object and deleter with another \p unique_ptr.
+   *
+   *  Exchanges the contents of `*this` and \p u. This operation is `noexcept`
+   *  and swaps both the stored pointer and the deleter.
+   *
    *  \param u The \p unique_ptr to swap with.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr& u) noexcept

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -771,6 +771,14 @@ public:
   //==========================================================================
   // Assignment
   //==========================================================================
+  /*! \brief Move assignment operator. Replaces the managed object with the one from \p u.
+   *
+   *  Releases the currently managed array (if any) and takes ownership of
+   *  the array managed by \p p.
+   *
+   *  \param p The \p unique_ptr to move from.
+   *  \return `*this`
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr&& p) noexcept
   {
     reset(p.release());
@@ -778,6 +786,10 @@ public:
     return *this;
   }
 
+  /*! \brief Converting assignment operator. Replaces the managed object with the one from \p u.
+   *  \param u The \p unique_ptr to move from.
+   *  \return `*this`
+   */
   template <class Up,
             class Ep,
             class = EnableIfMoveConvertible<unique_ptr<Up, Ep>, Up>,
@@ -789,6 +801,9 @@ public:
     return *this;
   }
 
+  /*! \brief Assigns a null pointer, deallocating the managed object. Effectively the same as calling reset().
+   *  \return `*this`
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(std::nullptr_t) noexcept
   {
     reset();

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -51,16 +51,32 @@ struct default_delete;
 template <class T>
 struct default_delete<T, std::enable_if_t<!std::is_array_v<T>>>
 {
+  /*! \typedef pointer
+   *  \brief The pointer type (`thrust::device_ptr<T>`).
+   */
   using pointer = thrust::device_ptr<T>;
 
   THRUST_HOST constexpr default_delete() noexcept = default;
 
+  /*! \brief Converting constructor from compatible deleter.
+   *
+   *  Allows construction from a deleter for a convertible type.
+   *
+   *  \tparam U A type convertible to \p T.
+   */
   template <class U>
   THRUST_HOST default_delete(
     const default_delete<U>&,
     std::enable_if_t<std::is_convertible_v<thrust::device_ptr<U>, pointer>>* = nullptr) noexcept
   {}
 
+  /*! \brief Deletes the object pointed to by \p ptr.
+   *
+   *  For non-trivially destructible types, invokes the destructor on the device
+   *  before deallocating memory.
+   *
+   *  \param ptr Pointer to the object to delete.
+   */
   THRUST_HOST void operator()(pointer ptr) const noexcept
   {
     if (ptr.get() == nullptr)
@@ -99,11 +115,25 @@ struct default_delete<T, std::enable_if_t<!std::is_array_v<T>>>
 template <class T>
 struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>>>
 {
+  /*! \typedef pointer
+   *  \brief The pointer type (`thrust::device_ptr<T>`).
+   */
   using pointer = thrust::device_ptr<T>;
 
+  /*! \brief Constructs a deleter with the specified array size.
+   *
+   *  \param n The number of elements in the array (default: 0).
+   */
   THRUST_HOST constexpr default_delete(size_t n = 0) noexcept
       : m_size(n){};
 
+  /*! \brief Converting constructor from compatible array deleter.
+   *
+   *  Copies the size from another deleter for a convertible array type.
+   *
+   *  \tparam U An array element type convertible to \p T.
+   *  \param other The deleter to copy from.
+   */
   template <class U>
   THRUST_HOST
   default_delete(const default_delete<U[]>& other,
@@ -111,6 +141,12 @@ struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>
       : m_size(other.size())
   {}
 
+  /*! \brief Deletes the array pointed to by \p ptr.
+   *
+   *  Invokes the destructor for each element on the device before deallocating memory.
+   *
+   *  \param ptr Pointer to the array to delete.
+   */
   THRUST_HOST void operator()(pointer ptr) const noexcept
   {
     if (ptr.get() == nullptr)
@@ -139,6 +175,10 @@ struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>
     thrust::device_free(ptr);
   }
 
+  /*! \brief Returns the number of elements in the array.
+   *
+   *  \return The array size.
+   */
   THRUST_HOST size_t size() const
   {
     return m_size;
@@ -161,16 +201,36 @@ private:
 template <class T>
 struct default_delete<T[], std::enable_if_t<std::is_trivially_destructible_v<T>>>
 {
+  /*! \typedef pointer
+   *  \brief The pointer type (`thrust::device_ptr<T>`).
+   */
   using pointer = thrust::device_ptr<T>;
 
+  /*! \brief Constructs a deleter (size parameter ignored for trivially destructible types).
+   *
+   *  The size parameter is accepted but ignored since trivially destructible types
+   *  don't require element-wise destruction.
+   */
   THRUST_HOST constexpr default_delete(size_t = 0) noexcept {};
 
+  /*! \brief Converting constructor from compatible deleter.
+   *
+   *  Allows construction from a deleter for a convertible type.
+   *
+   *  \tparam U A type convertible to \p T.
+   */
   template <class U>
   THRUST_HOST default_delete(
     const default_delete<U>&,
     std::enable_if_t<std::is_convertible_v<thrust::device_ptr<U>, pointer>>* = nullptr) noexcept
   {}
 
+  /*! \brief Deletes the array pointed to by \p ptr.
+   *
+   *  Only deallocates memory (no destructors called for trivially destructible types).
+   *
+   *  \param ptr Pointer to the array to delete.
+   */
   THRUST_HOST void operator()(pointer ptr) const noexcept
   {
     thrust::device_free(ptr);

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -294,23 +294,33 @@ public:
   // Constructors
   //==========================================================================
 
+  /*! Constructs a \p unique_ptr that does not own an object.
+   */
   template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
   THRUST_HOST constexpr unique_ptr() noexcept
       : m_ptr()
       , m_deleter()
   {}
 
+  /*! Constructs a \p unique_ptr that does not own an object.
+   */
   template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
   THRUST_HOST constexpr unique_ptr(std::nullptr_t) noexcept
       : unique_ptr()
   {}
 
+  /*! Constructs a \p unique_ptr that owns the object pointed to by \p p.
+   *  \param p A pointer to the object in device memory to manage.
+   */
   template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit unique_ptr(pointer p) noexcept
       : m_ptr(p)
       , m_deleter()
   {}
 
+  /*! Constructs a \p unique_ptr that owns the object pointed to by \p raw_p.
+   *  \param raw_p A raw pointer to the object in device memory to manage.
+   */
   template <bool Dummy = true,
             class      = EnableIfDeleterDefaultConstructible<Dummy>,
             class      = EnableIfDeleterDefaultDelete<Dummy>>
@@ -319,12 +329,22 @@ public:
       , m_deleter()
   {}
 
+  /*! Constructs a \p unique_ptr that owns the object pointed to by \p p and
+   *  uses \p d as the deleter.
+   *  \param p A pointer to the object in device memory to manage.
+   *  \param d The deleter to use.
+   */
   template <bool Dummy = true, class = EnableIfDeleterConstructible<LValRefType<Dummy>>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer p, LValRefType<Dummy> d) noexcept
       : m_ptr(p)
       , m_deleter(d)
   {}
 
+  /*! Constructs a \p unique_ptr that owns the object pointed to by \p p and
+   *  uses \p d as the deleter.
+   *  \param p A pointer to the object in device memory to manage.
+   *  \param d The deleter to use.
+   */
   template <bool Dummy = true, class = EnableIfDeleterConstructible<GoodRValRefType<Dummy>>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(pointer p, GoodRValRefType<Dummy> d) noexcept
       : m_ptr(p)
@@ -336,11 +356,19 @@ public:
   template <bool Dummy = true, class = EnableIfDeleterConstructible<BadRValRefType<Dummy>>>
   unique_ptr(pointer p, BadRValRefType<Dummy> d) = delete;
 
+  /*! Move constructor. Constructs a \p unique_ptr by taking ownership of the
+   *  object managed by \p u.
+   *  \param u The \p unique_ptr to move from.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& u) noexcept
       : m_ptr(u.release())
       , m_deleter(std::forward<deleter_type>(u.get_deleter()))
   {}
 
+  /*! Move constructor. Constructs a \p unique_ptr by taking ownership of the
+   *  object managed by \p u.
+   *  \param u The \p unique_ptr to move from.
+   */
   template <class U, class E, class = EnableIfMoveConvertible<unique_ptr<U, E>, U>, class = EnableIfDeleterConvertible<E>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr<U, E>&& u) noexcept
       : m_ptr(u.release())

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -823,6 +823,15 @@ inline THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr<T, D>& x, unique_ptr<T,
 //==============================================================================
 // Comparison Operators
 //==============================================================================
+/*! \brief Compares two \p unique_ptr objects for equality.
+ *
+ *  Two \p unique_ptr objects are considered equal if they point to the same
+ *  memory address or are both null.
+ *
+ *  \param x The first \p unique_ptr to compare.
+ *  \param y The second \p unique_ptr to compare.
+ *  \return `true` if the pointers are equal, `false` otherwise.
+ */
 template <class T1, class D1, class T2, class D2>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
@@ -831,12 +840,26 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator==(const unique_ptr
 
 #if THRUST_STD_VER <= 17
 template <class T1, class D1, class T2, class D2>
+/*! \brief Compares two \p unique_ptr objects for inequality (C++17 and earlier).
+ *
+ *  \param x The first \p unique_ptr to compare.
+ *  \param y The second \p unique_ptr to compare.
+ *  \return `true` if the pointers are not equal, `false` otherwise.
+ */
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator!=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
   return !(x == y);
 }
 #endif
 
+/*! \brief Compares two \p unique_ptr objects using less-than ordering.
+ *
+ *  \param x The first \p unique_ptr to compare.
+ *  \param y The second \p unique_ptr to compare.
+ *  \return `true` if the pointer stored in \p x is less than the pointer stored in \p y, `false` otherwise.
+ *  
+ *  \note Operators `>`, `<=`, and `>=` are also provided and defined in terms of this operator.
+ */
 template <class T1, class D1, class T2, class D2>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 {
@@ -959,6 +982,19 @@ template <class T, class D>
 //==============================================================================
 // Make unique
 //==============================================================================
+/*! \brief Constructs an object of type \p T in device memory and wraps it in a \p unique_ptr.
+ *
+ *  Allocates device memory for a single object of type \p T, constructs the object
+ *  by forwarding the provided arguments, and returns a \p unique_ptr managing the
+ *  allocated object.
+ *
+ *  This overload participates in overload resolution only if \p T is not an array type.
+ *
+ *  \tparam T The type of object to construct (must not be an array).
+ *  \tparam Args The types of arguments to forward to the constructor of \p T.
+ *  \param args Arguments to forward to the constructor of \p T.
+ *  \return A \p unique_ptr<T> managing the newly created object.
+ */
 template <class T, class... Args, class = std::enable_if_t<!std::is_array_v<T>>>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique(Args&&... args)
 {
@@ -966,6 +1002,18 @@ THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique(Args&&
   return unique_ptr<T>(thrust::device_new<T>(p, T(std::forward<Args>(args)...), 1));
 }
 
+/*! \brief Constructs an array of objects of type \p T in device memory and wraps it in a \p unique_ptr.
+ *
+ *  Allocates device memory for an array of \p n objects of type \p U (where \p T is \p U[]),
+ *  and returns a \p unique_ptr managing the allocated array.
+ *
+ *  This overload participates in overload resolution only if \p T is an array of unknown
+ *  bound (e.g., \p T[]).
+ *
+ *  \tparam T The array type (e.g., \p int[], \p MyClass[]).
+ *  \param n The number of elements in the array.
+ *  \return A \p unique_ptr<T> managing the newly created array.
+ */
 template <class T, class = std::enable_if_t<thrust::detail::is_unbounded_array<T>::value>>
 THRUST_HOST inline THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique(size_t n)
 {
@@ -978,12 +1026,36 @@ THRUST_HOST void make_unique(Args&&...) = delete;
 
 #if THRUST_STD_VER >= 20
 
+/*! \brief Constructs an object of type \p T in device memory without initialization (C++20).
+ *
+ *  Allocates device memory for a single object of type \p T without initializing it,
+ *  and returns a \p unique_ptr managing the allocated memory. The object has
+ *  indeterminate value.
+ *
+ *  This overload participates in overload resolution only if \p T is not an array type.
+ *
+ *  \tparam T The type of object to allocate (must not be an array).
+ *  \return A \p unique_ptr<T> managing the uninitialized memory.
+ */
 template <class T, class = std::enable_if_t<!std::is_array_v<T>>>
 THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique_for_overwrite()
 {
   return unique_ptr<T>(thrust::device_malloc<T>(1));
 }
 
+/*! \brief Constructs an array without initialization (C++20).
+ *
+ *  Allocates device memory for an array of \p n objects of type \p U (where \p T is \p U[])
+ *  without initializing the elements, and returns a \p unique_ptr managing the allocated
+ *  array. The elements have indeterminate values.
+ *
+ *  This overload participates in overload resolution only if \p T is an array of unknown
+ *  bound (e.g., \p T[]).
+ * 
+ *  \tparam T The array type (e.g., \p int[], \p MyClass[]).
+ *  \param n The number of elements in the array.
+ *  \return A \p unique_ptr<T> managing the uninitialized array.
+ */
 template <class T, class = std::enable_if_t<thrust::detail::is_unbounded_array<T>::value>>
 THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr<T> make_unique_for_overwrite(size_t n)
 {

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -883,6 +883,9 @@ public:
   //==========================================================================
   // Modifiers
   //==========================================================================
+  /*! \brief Releases ownership of the managed array, if any.
+   *  \return A pointer to the released array.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer release() noexcept
   {
     pointer temp = m_ptr;
@@ -890,6 +893,9 @@ public:
     return temp;
   }
 
+  /*! \brief Replaces the managed array.
+   *  \param p The new array to manage.
+   */
   template <class Pp, class = EnableIfPointerConvertible<Pp>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void reset(Pp p) noexcept
   {
@@ -901,6 +907,10 @@ public:
     }
   }
 
+  /*! \brief Replaces the managed array with \p nullptr.
+   *
+   *  Destroys the currently managed array (if any) and resets to empty state.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void reset(std::nullptr_t = nullptr) noexcept
   {
     pointer temp = m_ptr;
@@ -911,6 +921,9 @@ public:
     }
   }
 
+  /*! \brief Swaps the managed array and deleter with another array \p unique_ptr.
+   *  \param u The \p unique_ptr to swap with.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr& u) noexcept
   {
     using std::swap;

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -243,10 +243,20 @@ struct unique_ptr_deleter_sfinae<Deleter&>
  *  1. Manages a single object
  *  2. Manages a dynamically-allocated array of objects
  *
+ *  \par Nested Types
+ *  - `pointer` - The type of the stored pointer (defaults to `thrust::device_ptr<T>`)
+ *  - `element_type` - The type of the managed object (`T`)
+ *  - `deleter_type` - The type of the deleter (`D`)
  *
  *  \tparam T The type of the managed object.
  *  \tparam D The type of the deleter.
  *
+ *  \see thrust::default_delete
+ *  \see thrust::make_unique
+ *  \see thrust::device_ptr
+ *  \see thrust::device_malloc
+ *  \see thrust::device_new
+ *  \see thrust::device_free
  *  \see https://en.cppreference.com/w/cpp/memory/unique_ptr
  */
 

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -29,8 +29,7 @@ THRUST_NAMESPACE_BEGIN
 /*! \brief Default deleter for \p unique_ptr.
  *
  *  The default deleter used by \p unique_ptr when no custom deleter is specified.
- *  Uses \p thrust::device_free to deallocate memory. For non-trivially destructible
- *  types, invokes destructors on the device before deallocation.
+ *  Calls the destructor (if needed) and deallocates memory using \p thrust::device_free.
  *
  *  \tparam T The type of object to delete (single object form).
  *
@@ -43,8 +42,6 @@ struct default_delete;
 /*! \brief Default deleter specialization for single objects.
  *
  *  This specialization handles deletion of single objects allocated in device memory.
- *  For non-trivially destructible types, the destructor is invoked on the device
- *  before memory deallocation.
  *
  *  \tparam T The type of object to delete.
  */
@@ -72,8 +69,7 @@ struct default_delete<T, std::enable_if_t<!std::is_array_v<T>>>
 
   /*! \brief Deletes the object pointed to by \p ptr.
    *
-   *  For non-trivially destructible types, invokes the destructor on the device
-   *  before deallocating memory.
+   *  Calls the destructor (if needed) and deallocates memory using thrust::device_free.
    *
    *  \param ptr Pointer to the object to delete.
    */
@@ -143,7 +139,7 @@ struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>
 
   /*! \brief Deletes the array pointed to by \p ptr.
    *
-   *  Invokes the destructor for each element on the device before deallocating memory.
+   *  Calls destructors (if needed) and deallocates memory using thrust::device_free.
    *
    *  \param ptr Pointer to the array to delete.
    */
@@ -227,7 +223,7 @@ struct default_delete<T[], std::enable_if_t<std::is_trivially_destructible_v<T>>
 
   /*! \brief Deletes the array pointed to by \p ptr.
    *
-   *  Only deallocates memory (no destructors called for trivially destructible types).
+   *  Deallocates memory using thrust::device_free.
    *
    *  \param ptr Pointer to the array to delete.
    */
@@ -292,10 +288,9 @@ struct unique_ptr_deleter_sfinae<Deleter&>
  *  - the managing `unique_ptr` object is assigned another pointer via `operator=` or `reset()`.
  *
  *  The object is disposed of by calling `get_deleter()(get())`. The default deleter,
- *  `thrust::default_delete`, deallocates the memory using `thrust::device_free`.
- *  For non-trivially destructible types, Deleter invokes the destructor of the
- *  managed object on the device before deallocation.
- *
+ *  `thrust::default_delete`, calls the destructor (if needed) and deallocates memory
+ *  using `thrust::device_free`.
+ * 
  *  A `unique_ptr` may alternatively own no object, in which case it is described as
  *  *empty*.
  *
@@ -984,7 +979,6 @@ public:
   // Destructor
   //==========================================================================
   /*! \brief Destroys the \p unique_ptr, the managed array is destroyed via `get_deleter()(get())`. If get() == nullptr there are no effects.
-   *  For non-trivially-destructible types, this calls the destructor for each element.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 ~unique_ptr()
   {

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -294,7 +294,7 @@ public:
   // Constructors
   //==========================================================================
 
-  /*! Constructs a \p unique_ptr that does not own an object.
+  /*! \brief Constructs a \p unique_ptr that does not own an object.
    */
   template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
   THRUST_HOST constexpr unique_ptr() noexcept
@@ -302,14 +302,14 @@ public:
       , m_deleter()
   {}
 
-  /*! Constructs a \p unique_ptr that does not own an object.
+  /*! \brief Constructs a \p unique_ptr that does not own an object.
    */
   template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
   THRUST_HOST constexpr unique_ptr(std::nullptr_t) noexcept
       : unique_ptr()
   {}
 
-  /*! Constructs a \p unique_ptr that owns the object pointed to by \p p.
+  /*! \brief Constructs a \p unique_ptr that owns the object pointed to by \p p.
    *  \param p A pointer to the object in device memory to manage.
    */
   template <bool Dummy = true, class = EnableIfDeleterDefaultConstructible<Dummy>>
@@ -318,7 +318,7 @@ public:
       , m_deleter()
   {}
 
-  /*! Constructs a \p unique_ptr that owns the object pointed to by \p raw_p.
+  /*! \brief Constructs a \p unique_ptr that owns the object pointed to by \p raw_p.
    *  \param raw_p A raw pointer to the object in device memory to manage.
    */
   template <bool Dummy = true,
@@ -329,8 +329,7 @@ public:
       , m_deleter()
   {}
 
-  /*! Constructs a \p unique_ptr that owns the object pointed to by \p p and
-   *  uses \p d as the deleter.
+  /*! \brief Constructs a \p unique_ptr that owns the object pointed to by \p p and uses \p d as the deleter.
    *  \param p A pointer to the object in device memory to manage.
    *  \param d The deleter to use.
    */
@@ -340,8 +339,7 @@ public:
       , m_deleter(d)
   {}
 
-  /*! Constructs a \p unique_ptr that owns the object pointed to by \p p and
-   *  uses \p d as the deleter.
+  /*! \brief Constructs a \p unique_ptr that owns the object pointed to by \p p and uses \p d as the deleter.
    *  \param p A pointer to the object in device memory to manage.
    *  \param d The deleter to use.
    */
@@ -356,8 +354,7 @@ public:
   template <bool Dummy = true, class = EnableIfDeleterConstructible<BadRValRefType<Dummy>>>
   unique_ptr(pointer p, BadRValRefType<Dummy> d) = delete;
 
-  /*! Move constructor. Constructs a \p unique_ptr by taking ownership of the
-   *  object managed by \p u.
+  /*! \brief Move constructor. Constructs a \p unique_ptr by taking ownership of the object managed by \p u.
    *  \param u The \p unique_ptr to move from.
    */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr(unique_ptr&& u) noexcept
@@ -365,8 +362,11 @@ public:
       , m_deleter(std::forward<deleter_type>(u.get_deleter()))
   {}
 
-  /*! Move constructor. Constructs a \p unique_ptr by taking ownership of the
-   *  object managed by \p u.
+  /*! \brief Converting move constructor. Constructs a \p unique_ptr by taking ownership of the object managed by \p u.
+   *
+   *  Allows converting from \p unique_ptr<U, E> to \p unique_ptr<T, D> when
+   *  the pointer and deleter types are compatible.
+   * 
    *  \param u The \p unique_ptr to move from.
    */
   template <class U, class E, class = EnableIfMoveConvertible<unique_ptr<U, E>, U>, class = EnableIfDeleterConvertible<E>>

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -378,6 +378,10 @@ public:
   //==========================================================================
   // Assignment
   //==========================================================================
+  /*! Move assignment operator. Replaces the managed object with the one from \p u.
+   *  \param u The \p unique_ptr to move from.
+   *  \return `*this`
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr&& u) noexcept
   {
     reset(u.release());
@@ -385,6 +389,10 @@ public:
     return *this;
   }
 
+  /*! Converting assignment operator.. Replaces the managed object with the one from \p u.
+   *  \param u The \p unique_ptr to move from.
+   *  \return `*this`
+   */
   template <class U, class E, class = EnableIfMoveConvertible<unique_ptr<U, E>, U>, class = EnableIfDeleterAssignable<E>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept
   {
@@ -393,6 +401,9 @@ public:
     return *this;
   }
 
+  /*! Assigns a null pointer, deallocating the managed object. Effectively the same as calling reset().
+   *  \return `*this`
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 unique_ptr& operator=(std::nullptr_t) noexcept
   {
     reset();

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -582,6 +582,37 @@ public:
   }
 };
 
+/*! \brief Array specialization of \p unique_ptr for managing dynamically-allocated arrays.
+ *
+ *  This specialization manages arrays allocated in device memory. The array form
+ *  provides `operator[]` for element access.
+ *
+ *  \par Array Destruction Behavior
+ *  The array form has different constructor requirements and performance characteristics
+ *  based on the element type's destructibility:
+ *
+ *  **Trivially-destructible types** (e.g., `int`, `float`, POD types):
+ *  - Constructors do NOT require array size parameter
+ *  - Deleter is zero-size (no memory overhead)
+ *  - Destruction only deallocates memory (no destructors to call)
+ *  - Example: `unique_ptr<int[]> ptr(device_malloc<int>(100));`
+ *
+ *  **Non-trivially-destructible types** (e.g., types with custom destructors):
+ *  - Constructors REQUIRE array size parameter
+ *  - Deleter stores the size (small memory overhead: one `size_t`)
+ *  - Destruction calls destructor for each element on device before deallocation
+ *  - Example: `unique_ptr<MyClass[]> ptr(device_new<MyClass>(100), 100);`
+ *
+ *  This design ensures zero overhead for simple types while properly handling
+ *  complex types that require cleanup.
+ *
+ *  \tparam T The array element type.
+ *  \tparam D The type of the deleter.
+ *
+ *  \see thrust::default_delete
+ *  \see thrust::make_unique
+ *  \see https://en.cppreference.com/w/cpp/memory/unique_ptr
+ */
 template <class T, class D>
 class __attribute__((trivial_abi)) unique_ptr<T[], D>
 {

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -116,6 +116,10 @@ struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>
    */
   using pointer = thrust::device_ptr<T>;
 
+  // Allow other instantiations to access private members for converting constructor
+  template <class U, class>
+  friend struct default_delete;
+
   /*! \brief Constructs a deleter with the specified array size.
    *
    *  \param n The number of elements in the array (default: 0).
@@ -134,7 +138,7 @@ struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>
   THRUST_HOST
   default_delete(const default_delete<U[]>& other,
                  std::enable_if_t<std::is_convertible_v<U (*)[], T (*)[]>>* = nullptr) noexcept
-      : m_size(other.size())
+      : m_size(other.m_size)
   {}
 
   /*! \brief Deletes the array pointed to by \p ptr.
@@ -169,15 +173,6 @@ struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>
       });
     }
     thrust::device_free(ptr);
-  }
-
-  /*! \brief Returns the number of elements in the array.
-   *
-   *  \return The array size.
-   */
-  THRUST_HOST size_t size() const
-  {
-    return m_size;
   }
 
 private:

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -813,6 +813,9 @@ public:
   //==========================================================================
   // Destructor
   //==========================================================================
+  /*! \brief Destroys the \p unique_ptr, the managed array is destroyed via `get_deleter()(get())`. If get() == nullptr there are no effects.
+   *  For non-trivially-destructible types, this calls the destructor for each element.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 ~unique_ptr()
   {
     reset();
@@ -821,33 +824,57 @@ public:
   //==========================================================================
   // Observers
   //==========================================================================
-
+  /*! \brief Accesses an element of the managed array.
+   *
+   *  For device arrays, accessing an element from host code triggers a copy
+   *  from device to host memory.
+   *
+   *  \param i The index of the element to access.
+   *  \return A reference to (or copy of) the element at index \p i.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 auto operator[](size_t i) const noexcept
   {
     return m_ptr[i];
   }
 
+  /*! \brief Returns a pointer to the managed array or `nullptr` if no object is owned.
+   *  
+   *  \return Pointer to the managed array.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer get() const noexcept
   {
     return m_ptr;
   }
 
+  /*! \brief Returns a raw pointer to the managed array or `nullptr` if no object is owned.
+   *  
+   *  \return Pointer to the managed array.
+   */
   template <bool Dummy = true, class = EnableIfDeleterDefaultDelete<Dummy>>
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 T* get_raw() const noexcept
   {
     return raw_pointer_cast(m_ptr);
   }
 
+  /*! \brief Returns a reference to the deleter object which would be used for destruction of the managed array.
+   *  \return A reference to the stored deleter.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 deleter_type& get_deleter() noexcept
   {
     return m_deleter;
   }
 
+  /*! \brief Returns a constreference to the deleter object which would be used for destruction of the managed array.
+   *  \return A reference to the stored deleter.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 const deleter_type& get_deleter() const noexcept
   {
     return m_deleter;
   }
 
+  /*! \brief Checks if the \p unique_ptr owns an array.
+   *  \return `true` if an array is owned, `false` otherwise.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 explicit operator bool() const noexcept
   {
     return m_ptr != nullptr;

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -1,3 +1,9 @@
+/*! \file
+ *  \brief A smart pointer that owns and manages another object through a
+ *         pointer and disposes of that object when the \p unique_ptr goes
+ *         out of scope.
+ */
+
 #pragma once
 
 #include <thrust/detail/config.h>
@@ -15,6 +21,10 @@
 #include <utility>
 
 THRUST_NAMESPACE_BEGIN
+
+/*! \addtogroup memory_management Memory Management
+ *  \{
+ */
 
 template <class T, class = void>
 struct default_delete;
@@ -885,5 +895,8 @@ template <class T, class... Args, class = std::enable_if_t<thrust::detail::is_bo
 THRUST_HOST void make_unique_for_overwrite(Args&&...) = delete;
 
 #endif
+
+/*! \} // end smart_pointers
+ */
 
 THRUST_NAMESPACE_END

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -491,6 +491,9 @@ public:
   //==========================================================================
   // Modifiers
   //==========================================================================
+  /*! Releases ownership of the managed object, if any.
+   *  \return A pointer to the released object.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 pointer release() noexcept
   {
     pointer temp = m_ptr;
@@ -498,6 +501,9 @@ public:
     return temp;
   }
 
+  /*! Replaces the managed object.
+   *  \param p The new object to manage.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void reset(pointer p = pointer()) noexcept
   {
     pointer temp = m_ptr;
@@ -508,6 +514,9 @@ public:
     }
   }
 
+  /*! Swaps the managed object and deleter with another \p unique_ptr.
+   *  \param u The \p unique_ptr to swap with.
+   */
   THRUST_HOST THRUST_CONSTEXPR_SINCE_CXX23 void swap(unique_ptr& u) noexcept
   {
     using std::swap;

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -653,6 +653,37 @@ public:
   }
 };
 
+/*! \brief Array specialization of \p unique_ptr for managing dynamically-allocated arrays.
+ *
+ *  This specialization manages arrays allocated in device memory. The array form
+ *  provides `operator[]` for element access.
+ *
+ *  \par Array Destruction Behavior
+ *  The array form has different constructor requirements and performance characteristics
+ *  based on the element type's destructibility:
+ *
+ *  **Trivially-destructible types** (e.g., `int`, `float`, POD types):
+ *  - Constructors do NOT require array size parameter
+ *  - Deleter is zero-size (no memory overhead)
+ *  - Destruction only deallocates memory (no destructors to call)
+ *  - Example: `unique_ptr<int[]> ptr(device_malloc<int>(100));`
+ *
+ *  **Non-trivially-destructible types** (e.g., types with custom destructors):
+ *  - Constructors REQUIRE array size parameter
+ *  - Deleter stores the size (small memory overhead: one `size_t`)
+ *  - Destruction calls destructor for each element on device before deallocation
+ *  - Example: `unique_ptr<MyClass[]> ptr(device_new<MyClass>(100), 100);`
+ *
+ *  This design ensures zero overhead for simple types while properly handling
+ *  complex types that require cleanup.
+ *
+ *  \tparam T The array element type.
+ *  \tparam D The type of the deleter.
+ *
+ *  \see thrust::default_delete
+ *  \see thrust::make_unique
+ *  \see https://en.cppreference.com/w/cpp/memory/unique_ptr
+ */
 template <class T, class D>
 class __attribute__((trivial_abi)) unique_ptr<T[], D>
 {

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -127,7 +127,7 @@ struct default_delete<T[], std::enable_if_t<!std::is_trivially_destructible_v<T>
   THRUST_HOST constexpr default_delete(size_t n = 0) noexcept
       : m_size(n){};
 
-  /*! \brief Converting constructor from compatible array deleter.
+  /*! \brief Copy and converting constructor from compatible array deleter.
    *
    *  Copies the size from another deleter for a convertible array type.
    *
@@ -205,7 +205,7 @@ struct default_delete<T[], std::enable_if_t<std::is_trivially_destructible_v<T>>
    */
   THRUST_HOST constexpr default_delete(size_t = 0) noexcept {};
 
-  /*! \brief Converting constructor from compatible deleter.
+  /*! \brief Copy and converting constructor from compatible deleter.
    *
    *  Allows construction from a deleter for a convertible type.
    *

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -185,7 +185,8 @@ private:
  *  does NOT store the element count. Their destruction is a no-op, so only the raw
  *  deallocation is required. Omitting the size keeps this deleter specialization an
  *  empty (zero-size) type, allowing \p unique_ptr<T[]> instantiations that use it to
- *  remain a zero-cost abstraction (the deleter need not increase the overall object size).
+ *  remain a low/zero-cost abstraction (the default deleter need not increase the overall
+ *  size of unique_ptr<T[]> above the size of a simple pointer `T *`).
  *
  *  \tparam T The array element type (trivially destructible).
  */


### PR DESCRIPTION
## Motivation

Add documentation for `thrust::unique_ptr` to improve API usability and maintainability. The documentation follows the structure and style of cppreference.com (https://en.cppreference.com/w/cpp/memory/unique_ptr.html) while incorporating rocThrust-specific details about device memory management.

## Test Plan

Documentation changes only - no functional changes to test.