### PR TITLE
Remove addDownstreamBarrierInLoop in AddDeallocate

### DIFF
--- a/shared/rocroller/lib/include/rocRoller/KernelGraph/Transforms/AddDeallocate_detail.hpp
+++ b/shared/rocroller/lib/include/rocRoller/KernelGraph/Transforms/AddDeallocate_detail.hpp
@@ -38,30 +38,15 @@ namespace rocRoller
         namespace AddDeallocateDetail
         {
             /**
-             * @brief Add the next downstream Barrier to the list of dependencies.
-             *
-             * @param dependencies The set of dependencies for the Deallocate operation.
-             * @param coordinate The coordinate for which to add the Deallocate operation.
-             * @param lastRWOps The last read/write operations for the coordinate.
-             * @param original The original kernel graph.
-             * @param compare The topological comparison function (original).
-             */
-            void addDownstreamBarrierInLoop(std::set<int>&            dependencies,
-                                            int                       coordinate,
-                                            std::set<int> const&      lastRWOps,
-                                            KernelGraph const&        original,
-                                            TopologicalCompare const& compare);
-
-            /**
              * @brief Simplify dependencies by removing unnecessary ones.
-	     *
-	     * For example, if x and y are in the set of dependencies,
-	     * and x is `NodeOrdering::LeftFirst` of y, then x can be
-	     * removed from the dependencies.
-	     *
-	     * The set of dependencies is modified in-place.
-	     *
-	     * All dependencies must have the same body-parent.
+         *
+         * For example, if x and y are in the set of dependencies,
+         * and x is `NodeOrdering::LeftFirst` of y, then x can be
+         * removed from the dependencies.
+         *
+         * The set of dependencies is modified in-place.
+         *
+         * All dependencies must have the same body-parent.
              *
              * @param graph The kernel graph.
              * @param deps The set of dependencies to simplify.

--- a/shared/rocroller/lib/source/KernelGraph/Transformations/AddDeallocate.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Transformations/AddDeallocate.cpp
@@ -45,36 +45,6 @@ namespace rocRoller::KernelGraph
 
     namespace AddDeallocateDetail
     {
-        void addDownstreamBarrierInLoop(std::set<int>&            dependencies,
-                                        int                       coordinate,
-                                        std::set<int> const&      lastRWOps,
-                                        KernelGraph const&        original,
-                                        TopologicalCompare const& compare)
-        {
-            std::optional<int> maybeForLoop;
-            for(auto control : lastRWOps)
-            {
-                maybeForLoop = findContainingOperation<ForLoopOp>(control, original);
-                if(maybeForLoop)
-                    break;
-            }
-            if(not maybeForLoop)
-                return;
-
-            auto lastDependency = std::ranges::max(lastRWOps, compare);
-
-            auto downstreamBarriers = filter(original.control.isElemType<Barrier>(),
-                                             original.control.depthFirstVisit(lastDependency))
-                                          .to<std::vector>();
-
-            if(downstreamBarriers.empty())
-            {
-                dependencies = {*maybeForLoop};
-                return;
-            }
-
-            dependencies.insert(std::ranges::min(downstreamBarriers, compare));
-        }
 
         std::set<int> getContainingForLoops(std::set<int> controls, KernelGraph const& graph)
         {
@@ -248,12 +218,6 @@ namespace rocRoller::KernelGraph
         for(auto& [coordinate, controls] : locations)
         {
             auto dependencies = controls;
-
-            auto maybeLDS = graph.coordinates.get<LDS>(coordinate);
-            if(maybeLDS)
-            {
-                addDownstreamBarrierInLoop(dependencies, coordinate, controls, graph, topo);
-            }
 
             simplifyDependencies(graph, dependencies);
 

--- a/shared/rocroller/test/catch/AddDeallocateTest.cpp
+++ b/shared/rocroller/test/catch/AddDeallocateTest.cpp
@@ -86,45 +86,6 @@ namespace AddDeallocateTest
         for(auto& t : transforms)
             kgraph = kgraph.transform(t);
 
-        SECTION("Downstream Barriers")
-        {
-            auto topo
-                = TopologicalCompare(std::make_shared<rocRoller::KernelGraph::KernelGraph>(kgraph));
-
-            auto graph  = kgraph;
-            auto tracer = LastRWTracer(graph);
-
-            for(auto& [coordinate, controls] : tracer.lastRWLocations())
-            {
-                auto dependencies = controls;
-
-                auto maybeLDS = graph.coordinates.get<LDS>(coordinate);
-                if(maybeLDS)
-                {
-                    AddDeallocateDetail::addDownstreamBarrierInLoop(
-                        dependencies, coordinate, controls, kgraph, topo);
-                    CHECK(dependencies.size() >= 1);
-                    if(dependencies.size() == 1)
-                    {
-                        // If there is only one dependency, it should be a ForLoop
-                        CHECK(
-                            kgraph.control.get<ForLoopOp>(only(dependencies).value()).has_value());
-                    }
-                    else if(dependencies.size() > 1)
-                    {
-                        // If there are multiple dependencies, we should have an extra barrier
-                        for(auto& tag : dependencies)
-                        {
-                            if(controls.contains(tag))
-                                continue;
-
-                            CHECK(graph.control.get<Barrier>(tag).has_value());
-                        }
-                    }
-                }
-            }
-        }
-
         SECTION("Placement of LDS Deallocates")
         {
             kgraph = kgraph.transform(std::make_shared<NopExtraScopes>());


### PR DESCRIPTION
## Motivation

The `addDownstreamBarrierInLoop` is used to find the associated downstream Barrier operation for the target LDS coordinate and add it to the control stack. It is not required anymore because the tracer is able to track the Barrier operation via its mapper connection to the LDS coordinate.

## Technical Details

Remove the helper `addDownstreamBarrierInLoop` and the unit test for the helper.

## Test Plan

This PR should not change the kernel graph and the generated code. 

## Test Result

All existing tests should pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
