### PR TITLE
Update CK commit hash for MI Open

### DIFF
--- a/projects/miopen/requirements.txt
+++ b/projects/miopen/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.22
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@38c52448b1a4996b3e0e435a877d02441098b1dd
-ROCm/composable_kernel@515e28309153ae8ab6fa3cbed81b44e2c01c43cd -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@0be0288f58879123c228373525c4b438d354694f -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0


### PR DESCRIPTION
This PR updates the CK commit hash in MI Open's requirements.txt.