### PR TITLE
[hipDNN] Re-enable BatchNorm bwd tests after MIOpen fix

### DIFF
--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackward.cpp
@@ -223,9 +223,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
                          IntegrationGpuBatchnormBackwardNhwcFp32,
                          testing::ValuesIn(getBnBwdFullTestCases()));
 
-// MIOpen segfaults for this case, re-enable when fix is released:
-// https://github.com/ROCm/rocm-libraries/pull/1197
-TEST_P(IntegrationGpuBatchnormBackwardNhwcBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormBackwardNhwcBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceBackward<hip_bfloat16>(), TensorLayout::NHWC);
 }
@@ -238,9 +236,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
                          IntegrationGpuBatchnormBackwardNhwcBfp16,
                          testing::ValuesIn(getBnBwdFullTestCases()));
 
-// MIOpen segfaults for this case, re-enable when fix is released:
-// https://github.com/ROCm/rocm-libraries/pull/1197
-TEST_P(IntegrationGpuBatchnormBackwardNhwcFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormBackwardNhwcFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceBackward<half>(), TensorLayout::NHWC);
 }
@@ -289,8 +285,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          IntegrationGpuBatchnormBackwardNdhwcFp32,
                          testing::ValuesIn(getBnBwd3dTestCases()));
 
-// MIOpen may have issues with NDHWC layout for certain data types
-TEST_P(IntegrationGpuBatchnormBackwardNdhwcBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormBackwardNdhwcBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceBackward<hip_bfloat16>(), TensorLayout::NDHWC);
 }
@@ -299,8 +294,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          IntegrationGpuBatchnormBackwardNdhwcBfp16,
                          testing::ValuesIn(getBnBwd3dTestCases()));
 
-// MIOpen may have issues with NDHWC layout for certain data types
-TEST_P(IntegrationGpuBatchnormBackwardNdhwcFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormBackwardNdhwcFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceBackward<half>(), TensorLayout::NDHWC);
 }

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/BatchnormCommon.hpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/BatchnormCommon.hpp
@@ -94,9 +94,7 @@ inline std::vector<BatchnormTestCase> getBnBwdTestCases()
 
     return {
         {{1, 3, 14, 14}, seed},
-        // MIOpen segfaults for this case, re-enable when fix is released:
-        // https://github.com/ROCm/rocm-libraries/pull/1197
-        // {1, 256, 1, 1, seed}, // Would produce near-zero variance in theory
+        {{1, 256, 1, 1}, seed},
         {{2, 3, 1, 1}, seed},
         {{32, 1, 14, 14}, seed},
         {{32, 3, 1, 14}, seed},


### PR DESCRIPTION
## Motivation

These tests were disabled due to a bug fixed by this [PR](https://github.com/ROCm/rocm-libraries/pull/1197). It is merged, so we can re-enable these tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
