### PR TITLE
[MIOpen] MIOpenDriver path fix for GTests

### DIFF
--- a/projects/miopen/test/gtest/miopendriver_common.hpp
+++ b/projects/miopen/test/gtest/miopendriver_common.hpp
@@ -69,16 +69,13 @@ static inline miopen::fs::path MIOpenDriverExePath()
 
 #ifdef __linux__
     miopen::fs::path path = {""};
-    Dl_info info;
 
-    if(dladdr(reinterpret_cast<void*>(miopenCreate), &info) != 0)
-    {
-        path = miopen::fs::canonical(miopen::fs::path{info.dli_fname});
-        if(path.empty())
-            return path;
+    path = miopen::fs::canonical("/proc/self/exe");
 
-        path = path.parent_path();
-    }
+    if(path.empty())
+        return path;
+
+    path = path.parent_path();
     return path /= MIOpenDriverExeName;
 #else
     return {MIOpenDriverExeName};

--- a/projects/miopen/test/gtest/miopendriver_common.hpp
+++ b/projects/miopen/test/gtest/miopendriver_common.hpp
@@ -68,9 +68,7 @@ static inline miopen::fs::path MIOpenDriverExePath()
     static const std::string MIOpenDriverExeName = "MIOpenDriver";
 
 #ifdef __linux__
-    miopen::fs::path path = {""};
-
-    path = miopen::fs::canonical("/proc/self/exe");
+    miopen::fs::path path = miopen::fs::canonical("/proc/self/exe");
 
     if(path.empty())
         return path;


### PR DESCRIPTION
I discovered pretty bad issue which we have in MIOpenDriverExePath() function.
We use this function from inside some GTests.

dladdr called with (miopenCreate) parameter which means that path to .so file should be returned. But due to bug in dladdr it returns test executable path and everything works because MIOpenDriver executable located in the same bin directory as test executable.

However, while running on theRock, dladdr function works correctly and returns .so file in lib folder. MIOpenDriver cannot be found in this case and tests fail.

Examples on what dladdr returns on MIOpen CI and theRock CI:

MIOpen Regular CI:
dladdr info.dli_fname: /home/jenkins/workspace/_libraries-folder_MIOpen_PR-2448/projects/miopen/build/bin/miopen_gtest

TheRock CI:
dladdr info.dli_fname: /__w/TheRock/TheRock/build/bin/../lib/libMIOpen.so.1

So, MIOpen CI works because of issue in dladdr function.

This PR fixes this: We should not look for a dynamic library folder - we should just take current test executable path and try to find MIOpenDriver there.