### PR TITLE
Remove WORKBUF_TRSM_B_CHNK environment variable mention in doxygen comment

### DIFF
--- a/projects/hipblas/library/include/hipblas.h
+++ b/projects/hipblas/library/include/hipblas.h
@@ -20884,11 +20884,10 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZtrmmStridedBatched_64(hipblasHandle_t    
     Note about memory allocation:
     When trsm is launched with a k evenly divisible by the internal block size of 128,
     and is no larger than 10 of these blocks, the API takes advantage of utilizing pre-allocated
-    memory found in the handle to increase overall performance. This memory can be managed by using
-    the environment variable WORKBUF_TRSM_B_CHNK. When this variable is not set the device memory
-    used for temporary storage will default to 1 MB and may result in chunking, which in turn may
-    reduce performance. Under these circumstances it is recommended that WORKBUF_TRSM_B_CHNK be set
-    to the desired chunk of right hand sides to be used at a time.
+    memory found in the handle to increase overall performance (where k is m when
+    HIPBLAS_SIDE_LEFT and is n when HIPBLAS_SIDE_RIGHT). For more information on
+    pre-allocated memory in the handle, see the Device Memory Allocation
+    in rocBLAS section of the rocBLAS API Reference.
 
     (where k is m when HIPBLAS_SIDE_LEFT and is n when HIPBLAS_SIDE_RIGHT)
 
@@ -21079,12 +21078,10 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZtrsm_64(hipblasHandle_t         handle,
     Note about memory allocation:
     When trsm is launched with a k evenly divisible by the internal block size of 128,
     and is no larger than 10 of these blocks, the API takes advantage of utilizing pre-allocated
-    memory found in the handle to increase overall performance. This memory can be managed by using
-    the environment variable WORKBUF_TRSM_B_CHNK. When this variable is not set the device memory
-    used for temporary storage will default to 1 MB and may result in chunking, which in turn may
-    reduce performance. Under these circumstances it is recommended that WORKBUF_TRSM_B_CHNK be set
-    to the desired chunk of right hand sides to be used at a time.
-    (where k is m when HIPBLAS_SIDE_LEFT and is n when HIPBLAS_SIDE_RIGHT)
+    memory found in the handle to increase overall performance (where k is m when
+    HIPBLAS_SIDE_LEFT and is n when HIPBLAS_SIDE_RIGHT). For more information on
+    pre-allocated memory in the handle, see the Device Memory Allocation
+    in rocBLAS section of the rocBLAS API Reference.
 
     - Supported precisions in rocBLAS : s,d,c,z
     - Supported precisions in cuBLAS  : s,d,c,z
@@ -21271,12 +21268,10 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZtrsmBatched_64(hipblasHandle_t           
     Note about memory allocation:
     When trsm is launched with a k evenly divisible by the internal block size of 128,
     and is no larger than 10 of these blocks, the API takes advantage of utilizing pre-allocated
-    memory found in the handle to increase overall performance. This memory can be managed by using
-    the environment variable WORKBUF_TRSM_B_CHNK. When this variable is not set the device memory
-    used for temporary storage will default to 1 MB and may result in chunking, which in turn may
-    reduce performance. Under these circumstances it is recommended that WORKBUF_TRSM_B_CHNK be set
-    to the desired chunk of right hand sides to be used at a time.
-    (where k is m when HIPBLAS_SIDE_LEFT and is n when HIPBLAS_SIDE_RIGHT)
+    memory found in the handle to increase overall performance (where k is m when
+    HIPBLAS_SIDE_LEFT and is n when HIPBLAS_SIDE_RIGHT). For more information on
+    pre-allocated memory in the handle, see the Device Memory Allocation
+    in rocBLAS section of the rocBLAS API Reference.
 
     - Supported precisions in rocBLAS : s,d,c,z
     - Supported precisions in cuBLAS  : No support


### PR DESCRIPTION
## Motivation

Remove WORKBUF_TRSM_B_CHNK environment variable mention in doxygen comment.

## Technical Details

Remove WORKBUF_TRSM_B_CHNK environment variable mention in doxygen comment.

## Test Plan

Not needed, will check the develop documentation.

## Test Result

Develop documentation.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
