### PR TITLE
[Ex CI] Update Generate token step in Azure CI Dispatch

### DIFF
--- a/.github/workflows/azure-ci-dispatcher.yml
+++ b/.github/workflows/azure-ci-dispatcher.yml
@@ -65,7 +65,6 @@ jobs:
         fi
     - name: Generate a token
       id: generate-token
-      if: steps.branch-check.outputs.should-run == 'true'
       uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
       with:
         app-id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Motivation
The generate token step is needed for the Azure CI Summary. Thus removing the branch check in the generate token step
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
