### PR TITLE
[hipDNN] [AIMIOPEN-158] Check data type is set in validate() functions for Node and TensorAttributes

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -248,37 +248,9 @@ private:
         }
     }
 
-public:
-    Graph()
-        : INode(GraphAttributes{})
+    static Error checkNoDuplicateTensorIdsImpl(
+        std::unordered_set<std::shared_ptr<TensorAttributes>> const& allTensors)
     {
-        HIPDNN_FE_LOG_INFO("Creating new Graph instance");
-    }
-
-    Error validate()
-    {
-        HIPDNN_FE_LOG_INFO("Validating graph {}", graph_attributes.get_name());
-
-        auto result = checkNoDuplicateTensorIds();
-        if(result.code != ErrorCode::OK)
-        {
-            return result;
-        }
-
-        result = topologicallySortGraph();
-        if(result.code != ErrorCode::OK)
-        {
-            return result;
-        }
-
-        return validateSubtree();
-    }
-
-    Error checkNoDuplicateTensorIds()
-    {
-        std::unordered_set<std::shared_ptr<TensorAttributes>> allTensors;
-        gatherHipdnnTensorsSubtree(allTensors);
-
         std::unordered_set<int64_t> seenUids;
         std::unordered_set<int64_t> duplicateUids;
 
@@ -306,6 +278,58 @@ public:
         }
 
         return {ErrorCode::OK, ""};
+    }
+
+public:
+    Graph()
+        : INode(GraphAttributes{})
+    {
+        HIPDNN_FE_LOG_INFO("Creating new Graph instance");
+    }
+
+    Error validate()
+    {
+        HIPDNN_FE_LOG_INFO("Validating graph {}", graph_attributes.get_name());
+
+        std::unordered_set<std::shared_ptr<TensorAttributes>> allTensors;
+        gatherHipdnnTensorsSubtree(allTensors);
+
+        auto result = checkNoDuplicateTensorIdsImpl(allTensors);
+        if(result.code != ErrorCode::OK)
+        {
+            return result;
+        }
+
+        result = topologicallySortGraph();
+        if(result.code != ErrorCode::OK)
+        {
+            return result;
+        }
+
+        result = validateSubtree();
+        if(result.code != ErrorCode::OK)
+        {
+            return result;
+        }
+
+        for(const auto& tensor : allTensors)
+        {
+            result = tensor->validate();
+            if(result.code != ErrorCode::OK)
+            {
+                return result;
+            }
+        }
+
+        return {ErrorCode::OK, ""};
+    }
+
+    Error checkNoDuplicateTensorIds()
+    {
+        std::unordered_set<std::shared_ptr<TensorAttributes>> allTensors;
+        gatherHipdnnTensorsSubtree(allTensors);
+
+        return checkNoDuplicateTensorIdsImpl(allTensors);
     }
 
     Error topologicallySortGraph()

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/TensorAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/TensorAttributes.hpp
@@ -4,6 +4,7 @@
 
 #include "GraphAttributes.hpp"
 #include <flatbuffers/flatbuffers.h>
+#include <hipdnn_frontend/Error.hpp>
 #include <hipdnn_frontend/Types.hpp>
 #include <hipdnn_sdk/data_objects/graph_generated.h>
 #include <hipdnn_sdk/data_objects/tensor_attributes_generated.h>
@@ -184,6 +185,17 @@ public:
         }
 
         return *this;
+    }
+
+    Error validate() const
+    {
+        if(_dataType == DataType::NOT_SET)
+        {
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
+                    "Tensor " + _name + " does not have a data type set"};
+        }
+
+        return {ErrorCode::OK, ""};
     }
 
     bool validate_dims_set_and_positive() const // NOLINT(readability-identifier-naming

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/Node.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/Node.hpp
@@ -159,6 +159,16 @@ public:
         }
     }
 
+    Error post_validate_node() const override // NOLINT(readability-identifier-naming)
+    {
+        if(self().attributes.compute_data_type == DataType::NOT_SET)
+        {
+            return {ErrorCode::ATTRIBUTE_NOT_SET,
+                    "Node " + self().attributes.name + " does not have a compute_data_type set"};
+        }
+        return {ErrorCode::OK, ""};
+    }
+
     std::vector<std::shared_ptr<TensorAttributes>> getNodeInputTensorAttributes() const override
     {
         std::vector<std::shared_ptr<TensorAttributes>> inputAttributes;

--- a/projects/hipdnn/frontend/tests/CMakeLists.txt
+++ b/projects/hipdnn/frontend/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
     TestGraphAttributes.cpp
     TestGraphGenerated.cpp
     TestINode.cpp
+    TestNode.cpp
     TestPointwiseAttributes.cpp
     TestPointwiseNode.cpp
     TestScopedHipdnnBackendDescriptor.cpp

--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -120,6 +120,29 @@ TEST_F(TestGraph, ValidateFailsOnUnsetNodeComputeDataType)
     EXPECT_FALSE(validationResult.is_good()) << validationResult.get_message();
 }
 
+TEST_F(TestGraph, ValidateSucceedsOnUnsetNodeComputeDataTypeWithSetGraph)
+{
+    Graph graph;
+
+    graph.set_name("TestGraph")
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
+
+    auto in0 = std::make_shared<TensorAttributes>();
+    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
+
+    PointwiseAttributes attributes;
+    attributes.set_name("PointwiseNode");
+    attributes.set_mode(PointwiseMode::RELU_FWD);
+
+    auto out0 = graph.pointwise(in0, attributes);
+
+    auto validationResult = graph.validate();
+
+    EXPECT_TRUE(validationResult.is_good()) << validationResult.get_message();
+}
+
 TEST_F(TestGraph, ValidateFailsOnUnsetTensorDataType)
 {
     Graph graph;
@@ -141,6 +164,29 @@ TEST_F(TestGraph, ValidateFailsOnUnsetTensorDataType)
     auto validationResult = graph.validate();
 
     EXPECT_FALSE(validationResult.is_good()) << validationResult.get_message();
+}
+
+TEST_F(TestGraph, ValidateSucceedsOnUnsetTensorDataTypeWithSetGraph)
+{
+    Graph graph;
+
+    graph.set_name("TestGraph")
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
+
+    auto in0 = std::make_shared<TensorAttributes>();
+    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::NOT_SET);
+
+    PointwiseAttributes attributes;
+    attributes.set_name("PointwiseNode");
+    attributes.set_mode(PointwiseMode::RELU_FWD);
+
+    auto out0 = graph.pointwise(in0, attributes);
+
+    auto validationResult = graph.validate();
+
+    EXPECT_TRUE(validationResult.is_good()) << validationResult.get_message();
 }
 
 TEST_F(TestGraph, SetAndGetAttributes)

--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -166,7 +166,31 @@ TEST_F(TestGraph, ValidateUnsetTensorDataTypeUnsetGraphIoType)
     EXPECT_FALSE(validationResult.is_good()) << validationResult.get_message();
 }
 
-TEST_F(TestGraph, ValidateUnsetTensorDataTypeSetGraphDataType)
+TEST_F(TestGraph, ValidateUnsetTensorDataTypeUnsetGraphIntermediateType)
+{
+    Graph graph;
+
+    graph.set_name("TestGraph")
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::NOT_SET)
+        .set_io_data_type(DataType::FLOAT);
+
+    auto in0 = std::make_shared<TensorAttributes>();
+    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::NOT_SET);
+    in0->set_is_virtual(true);
+
+    PointwiseAttributes attributes;
+    attributes.set_name("PointwiseNode");
+    attributes.set_mode(PointwiseMode::RELU_FWD);
+
+    auto out0 = graph.pointwise(in0, attributes);
+
+    auto validationResult = graph.validate();
+
+    EXPECT_FALSE(validationResult.is_good()) << validationResult.get_message();
+}
+
+TEST_F(TestGraph, ValidateUnsetTensorDataTypeSetGraphDataTypes)
 {
     Graph graph;
 
@@ -177,12 +201,17 @@ TEST_F(TestGraph, ValidateUnsetTensorDataTypeSetGraphDataType)
 
     auto in0 = std::make_shared<TensorAttributes>();
     in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::NOT_SET);
+    auto in1 = std::make_shared<TensorAttributes>();
+    in1->set_dim({1, 2, 3, 4})
+        .set_stride({5, 6, 7, 8})
+        .set_data_type(DataType::NOT_SET)
+        .set_is_virtual(true);
 
     PointwiseAttributes attributes;
     attributes.set_name("PointwiseNode");
-    attributes.set_mode(PointwiseMode::RELU_FWD);
+    attributes.set_mode(PointwiseMode::ADD);
 
-    auto out0 = graph.pointwise(in0, attributes);
+    auto out0 = graph.pointwise(in0, in1, attributes);
 
     auto validationResult = graph.validate();
 

--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -97,7 +97,7 @@ protected:
     }
 };
 
-TEST_F(TestGraph, ValidateFailsOnUnsetNodeComputeDataType)
+TEST_F(TestGraph, ValidateUnsetNodeComputeTypeUnsetGraphComputeType)
 {
     Graph graph;
 
@@ -120,7 +120,7 @@ TEST_F(TestGraph, ValidateFailsOnUnsetNodeComputeDataType)
     EXPECT_FALSE(validationResult.is_good()) << validationResult.get_message();
 }
 
-TEST_F(TestGraph, ValidateSucceedsOnUnsetNodeComputeDataTypeWithSetGraph)
+TEST_F(TestGraph, ValidateUnsetNodeComputeTypeSetGraphComputeType)
 {
     Graph graph;
 
@@ -143,7 +143,7 @@ TEST_F(TestGraph, ValidateSucceedsOnUnsetNodeComputeDataTypeWithSetGraph)
     EXPECT_TRUE(validationResult.is_good()) << validationResult.get_message();
 }
 
-TEST_F(TestGraph, ValidateFailsOnUnsetTensorDataType)
+TEST_F(TestGraph, ValidateUnsetTensorDataTypeUnsetGraphIoType)
 {
     Graph graph;
 
@@ -166,7 +166,7 @@ TEST_F(TestGraph, ValidateFailsOnUnsetTensorDataType)
     EXPECT_FALSE(validationResult.is_good()) << validationResult.get_message();
 }
 
-TEST_F(TestGraph, ValidateSucceedsOnUnsetTensorDataTypeWithSetGraph)
+TEST_F(TestGraph, ValidateUnsetTensorDataTypeSetGraphDataType)
 {
     Graph graph;
 

--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -97,6 +97,52 @@ protected:
     }
 };
 
+TEST_F(TestGraph, ValidateFailsOnUnsetNodeComputeDataType)
+{
+    Graph graph;
+
+    graph.set_name("TestGraph")
+        .set_compute_data_type(DataType::NOT_SET)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
+
+    auto in0 = std::make_shared<TensorAttributes>();
+    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
+
+    PointwiseAttributes attributes;
+    attributes.set_name("PointwiseNode");
+    attributes.set_mode(PointwiseMode::RELU_FWD);
+
+    auto out0 = graph.pointwise(in0, attributes);
+
+    auto validationResult = graph.validate();
+
+    EXPECT_FALSE(validationResult.is_good()) << validationResult.get_message();
+}
+
+TEST_F(TestGraph, ValidateFailsOnUnsetTensorDataType)
+{
+    Graph graph;
+
+    graph.set_name("TestGraph")
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::NOT_SET);
+
+    auto in0 = std::make_shared<TensorAttributes>();
+    in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::NOT_SET);
+
+    PointwiseAttributes attributes;
+    attributes.set_name("PointwiseNode");
+    attributes.set_mode(PointwiseMode::RELU_FWD);
+
+    auto out0 = graph.pointwise(in0, attributes);
+
+    auto validationResult = graph.validate();
+
+    EXPECT_FALSE(validationResult.is_good()) << validationResult.get_message();
+}
+
 TEST_F(TestGraph, SetAndGetAttributes)
 {
     Graph graph;
@@ -118,6 +164,9 @@ TEST_F(TestGraph, SetAndGetAttributes)
 TEST_F(TestGraph, BatchnormNodeCreation)
 {
     Graph graph;
+    graph.set_io_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
@@ -151,6 +200,9 @@ TEST_F(TestGraph, BatchnormNodeCreation)
 TEST_F(TestGraph, BatchnormBackwardNodeCreation)
 {
     Graph graph;
+    graph.set_io_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT);
 
     auto dy = std::make_shared<TensorAttributes>();
     auto x = std::make_shared<TensorAttributes>();
@@ -180,6 +232,9 @@ TEST_F(TestGraph, BatchnormBackwardNodeCreation)
 TEST_F(TestGraph, BatchnormInferenceNodeCreation)
 {
     Graph graph;
+    graph.set_io_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
@@ -204,6 +259,9 @@ TEST_F(TestGraph, BatchnormInferenceNodeCreation)
 TEST_F(TestGraph, PointwiseNodeCreationSingleInput)
 {
     Graph graph;
+    graph.set_io_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT);
 
     auto in0 = std::make_shared<TensorAttributes>();
     in0->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
@@ -224,6 +282,9 @@ TEST_F(TestGraph, PointwiseNodeCreationSingleInput)
 TEST_F(TestGraph, PointwiseNodeCreationTwoInputs)
 {
     Graph graph;
+    graph.set_io_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT);
 
     auto in0 = std::make_shared<TensorAttributes>();
     auto in1 = std::make_shared<TensorAttributes>();
@@ -247,6 +308,9 @@ TEST_F(TestGraph, PointwiseNodeCreationTwoInputs)
 TEST_F(TestGraph, PointwiseNodeCreationThreeInputs)
 {
     Graph graph;
+    graph.set_io_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT);
 
     auto in0 = std::make_shared<TensorAttributes>();
     auto in1 = std::make_shared<TensorAttributes>();
@@ -272,6 +336,9 @@ TEST_F(TestGraph, PointwiseNodeCreationThreeInputs)
 TEST_F(TestGraph, ConvolutionFwdNodeCreation)
 {
     Graph graph;
+    graph.set_io_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_dim({1, 3, 32, 32}).set_stride({3072, 1024, 32, 1}).set_data_type(DataType::FLOAT);
@@ -298,6 +365,9 @@ TEST_F(TestGraph, ConvolutionFwdNodeCreation)
 TEST_F(TestGraph, ConvolutionDgradNodeCreation)
 {
     Graph graph;
+    graph.set_io_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT);
 
     auto dy = std::make_shared<TensorAttributes>();
     dy->set_dim({1, 64, 32, 32}).set_stride({65536, 1024, 32, 1}).set_data_type(DataType::FLOAT);
@@ -335,6 +405,9 @@ TEST_F(TestGraph, BuildAndSerializeBatchnormInferenceGraph)
 {
     ::testing::FLAGS_gmock_verbose = "error";
     Graph graph;
+    graph.set_io_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT);
 
     graph.set_name("SerializedGraphTest")
         .set_compute_data_type(DataType::FLOAT)
@@ -1838,6 +1911,9 @@ TEST_F(TestGraph, TopologicalSortFailsOnCircularDependency)
 TEST_F(TestGraph, ValidateSortsNodesTopologically)
 {
     GraphTestUtils graph;
+    graph.set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
 
     auto x = std::make_shared<TensorAttributes>();
     x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
@@ -1929,6 +2005,10 @@ TEST_F(TestGraph, ValidateSortsNodesTopologically)
 TEST_F(TestGraph, ValidateFailsWithDuplicateTensorUids)
 {
     GraphTestUtils graph;
+    graph.set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::HALF)
+        .set_io_data_type(DataType::FLOAT);
+
     auto x = std::make_shared<TensorAttributes>();
     x->set_dim({1, 2, 3, 4}).set_stride({5, 6, 7, 8}).set_data_type(DataType::FLOAT);
     x->set_uid(1);

--- a/projects/hipdnn/frontend/tests/TestNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestNode.cpp
@@ -1,0 +1,54 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <hipdnn_frontend/attributes/Attributes.hpp>
+#include <hipdnn_frontend/node/Node.hpp>
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_frontend::graph;
+using namespace ::testing;
+
+namespace hipdnn_frontend
+{
+
+struct FakeAttributes : public Attributes<FakeAttributes>
+{
+    std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>> inputs;
+    std::unordered_map<int64_t, std::shared_ptr<TensorAttributes>> outputs;
+};
+
+class FakeNode : public NodeCRTP<FakeNode>
+{
+public:
+    FakeNode(FakeAttributes&& fakeAttrs, GraphAttributes const& graphAttrs)
+        : NodeCRTP<FakeNode>(graphAttrs)
+        , attributes(std::move(fakeAttrs))
+    {
+    }
+    FakeAttributes attributes;
+};
+
+TEST(TestNode, PostValidateNodeComputeDataType)
+{
+    GraphAttributes graphAttributes;
+    FakeNode node(FakeAttributes{}, graphAttributes);
+
+    std::vector<std::pair<DataType, ErrorCode>> expectedResults
+        = {{DataType::NOT_SET, ErrorCode::ATTRIBUTE_NOT_SET},
+           {DataType::FLOAT, ErrorCode::OK},
+           {DataType::HALF, ErrorCode::OK},
+           {DataType::BFLOAT16, ErrorCode::OK},
+           {DataType::DOUBLE, ErrorCode::OK},
+           {DataType::UINT8, ErrorCode::OK},
+           {DataType::INT32, ErrorCode::OK}};
+
+    for(auto [dataType, errorCode] : expectedResults)
+    {
+        node.attributes.set_compute_data_type(dataType);
+        auto result = node.post_validate_node();
+        EXPECT_EQ(result.code, errorCode) << "For " + std::string(to_string(dataType));
+    }
+}
+
+} // namespace hipdnn_frontend

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -322,10 +322,25 @@ TEST(TestTensorAttributes, ValidateDimsSetAndPositive5DValidCase)
     EXPECT_TRUE(tensor.validate_dims_set_and_positive());
 }
 
-TEST(TestTensorAttributes, ValidateDimsSetAndPositiveWithStridesIgnored)
+TEST(TestTensorAttributes, ValidateDataType)
 {
     TensorAttributes tensor;
     tensor.set_dim({4, 5, 6});
-    tensor.set_stride({0, -1, 2}); // Invalid strides should be ignored
-    EXPECT_TRUE(tensor.validate_dims_set_and_positive());
+    tensor.set_stride({0, 1, 2}); // Invalid strides should be ignored
+
+    std::vector<std::pair<DataType, ErrorCode>> expectedResults
+        = {{DataType::NOT_SET, ErrorCode::ATTRIBUTE_NOT_SET},
+           {DataType::FLOAT, ErrorCode::OK},
+           {DataType::HALF, ErrorCode::OK},
+           {DataType::BFLOAT16, ErrorCode::OK},
+           {DataType::DOUBLE, ErrorCode::OK},
+           {DataType::UINT8, ErrorCode::OK},
+           {DataType::INT32, ErrorCode::OK}};
+
+    for(auto [dataType, errorCode] : expectedResults)
+    {
+        tensor.set_data_type(dataType);
+        auto result = tensor.validate();
+        EXPECT_EQ(result.code, errorCode) << "For " + std::string(to_string(dataType));
+    }
 }

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -322,11 +322,19 @@ TEST(TestTensorAttributes, ValidateDimsSetAndPositive5DValidCase)
     EXPECT_TRUE(tensor.validate_dims_set_and_positive());
 }
 
+TEST(TestTensorAttributes, ValidateDimsSetAndPositiveWithStridesIgnored)
+{
+    TensorAttributes tensor;
+    tensor.set_dim({4, 5, 6});
+    tensor.set_stride({0, -1, 2}); // Invalid strides should be ignored
+    EXPECT_TRUE(tensor.validate_dims_set_and_positive());
+}
+
 TEST(TestTensorAttributes, ValidateDataType)
 {
     TensorAttributes tensor;
     tensor.set_dim({4, 5, 6});
-    tensor.set_stride({0, 1, 2}); // Invalid strides should be ignored
+    tensor.set_stride({0, 1, 2});
 
     std::vector<std::pair<DataType, ErrorCode>> expectedResults
         = {{DataType::NOT_SET, ErrorCode::ATTRIBUTE_NOT_SET},

--- a/projects/hipdnn/tests/frontend/IntegrationBatchnormForwardInference.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationBatchnormForwardInference.cpp
@@ -155,19 +155,22 @@ protected:
         bool useManualUids)
     {
         auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
-        graph->set_name(graphName);
+        graph->set_name(graphName)
+            .set_io_data_type(DataType::FLOAT)
+            .set_intermediate_data_type(DataType::FLOAT)
+            .set_compute_data_type(DataType::FLOAT);
 
         int64_t uid = 1;
         BatchnormTestTensors tensors;
 
-        auto xAttr = makeTensorAttributes("X", DataType_t::FLOAT, tensorBundle.xTensor);
+        auto xAttr = makeTensorAttributes("X", DataType::FLOAT, tensorBundle.xTensor);
         if(useManualUids)
         {
             xAttr.set_uid(uid++);
         }
         tensors.x = std::make_shared<TensorAttributes>(std::move(xAttr));
 
-        auto meanAttr = makeTensorAttributes("mean", DataType_t::FLOAT, tensorBundle.meanTensor);
+        auto meanAttr = makeTensorAttributes("mean", DataType::FLOAT, tensorBundle.meanTensor);
         if(useManualUids)
         {
             meanAttr.set_uid(uid++);
@@ -175,21 +178,21 @@ protected:
         tensors.mean = std::make_shared<TensorAttributes>(std::move(meanAttr));
 
         auto invVarianceAttr
-            = makeTensorAttributes("inv_variance", DataType_t::FLOAT, tensorBundle.varianceTensor);
+            = makeTensorAttributes("inv_variance", DataType::FLOAT, tensorBundle.varianceTensor);
         if(useManualUids)
         {
             invVarianceAttr.set_uid(uid++);
         }
         tensors.invVariance = std::make_shared<TensorAttributes>(std::move(invVarianceAttr));
 
-        auto scaleAttr = makeTensorAttributes("scale", DataType_t::FLOAT, tensorBundle.scaleTensor);
+        auto scaleAttr = makeTensorAttributes("scale", DataType::FLOAT, tensorBundle.scaleTensor);
         if(useManualUids)
         {
             scaleAttr.set_uid(uid++);
         }
         tensors.scale = std::make_shared<TensorAttributes>(std::move(scaleAttr));
 
-        auto biasAttr = makeTensorAttributes("bias", DataType_t::FLOAT, tensorBundle.biasTensor);
+        auto biasAttr = makeTensorAttributes("bias", DataType::FLOAT, tensorBundle.biasTensor);
         if(useManualUids)
         {
             biasAttr.set_uid(uid++);
@@ -206,7 +209,7 @@ protected:
         {
             tensors.y->set_uid(uid++);
         }
-        tensors.y->set_data_type(DataType_t::FLOAT);
+        tensors.y->set_data_type(DataType::FLOAT);
 
         return {graph, tensors};
     }

--- a/projects/hipdnn/tests/frontend/IntegrationConvForward.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvForward.cpp
@@ -147,7 +147,10 @@ protected:
                                     bool useManualUids)
     {
         auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
-        graph->set_name(graphName);
+        graph->set_name(graphName)
+            .set_io_data_type(DataType::FLOAT)
+            .set_intermediate_data_type(DataType::FLOAT)
+            .set_compute_data_type(DataType::FLOAT);
 
         int64_t uid = 1;
         ConvolutionTestTensors tensors;

--- a/projects/hipdnn/tests/frontend/IntegrationConvolutionBackwardData.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvolutionBackwardData.cpp
@@ -145,7 +145,10 @@ protected:
             bool useManualUids)
     {
         auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
-        graph->set_name(graphName);
+        graph->set_name(graphName)
+            .set_io_data_type(DataType::FLOAT)
+            .set_intermediate_data_type(DataType::FLOAT)
+            .set_compute_data_type(DataType::FLOAT);
 
         int64_t uid = 1;
         ConvolutionTestTensors tensors;

--- a/projects/hipdnn/tests/frontend/IntegrationConvolutionBackwardWeight.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvolutionBackwardWeight.cpp
@@ -146,7 +146,10 @@ protected:
             bool useManualUids)
     {
         auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
-        graph->set_name(graphName);
+        graph->set_name(graphName)
+            .set_io_data_type(DataType::FLOAT)
+            .set_intermediate_data_type(DataType::FLOAT)
+            .set_compute_data_type(DataType::FLOAT);
 
         int64_t uid = 1;
         ConvolutionTestTensors tensors;


### PR DESCRIPTION
## Motivation

Have graph::validate() return an error if a TensorAttributes has an unset data type, or if a Node has an unset compute_data_type