### PR TITLE
Prevent zero size allocation for keys during HMM and test_device_find_first_of

### DIFF
--- a/projects/rocprim/test/rocprim/test_device_find_first_of.cpp
+++ b/projects/rocprim/test/rocprim/test_device_find_first_of.cpp
@@ -159,7 +159,7 @@ TYPED_TEST(RocprimDeviceFindFirstOfTests, FindFirstOf)
             SCOPED_TRACE(testing::Message() << "with size = " << size);
 
             const size_t keys_size
-                = std::sqrt(test_utils::get_random_value<size_t>(0, size, seed_value));
+                = std::sqrt(test_utils::get_random_value<size_t>(common::use_hmm() ? 1 : 0, size, seed_value));
 
             // Starting point is an appoximate position of the first match we want to test for
             for(double starting_point : {0.0, 0.234, 0.876, 1.0, 100.0})


### PR DESCRIPTION
## Motivation

hipMallocManaged() does not work with zero-size allocations.  The device_find_first_of test can potentially try to do this.  

## Technical Details

I've added a simple check to ensure we don't allocate 0 bytes when using HMM - the minimum is 1 element.

## Test Plan

Run tests.

## Test Result

Test executes properly when using HMM.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
