### PR TITLE
[rocsparse] use existing codecov executable instead of downloading

### DIFF
--- a/projects/rocsparse/.jenkins/common.groovy
+++ b/projects/rocsparse/.jenkins/common.groovy
@@ -117,9 +117,7 @@ def runCoverageCommand (platform, project, gfilter, String dirmode = "release")
                     cd ${project.paths.project_build_prefix}/build/${dirmode}
                     export LD_LIBRARY_PATH=/opt/rocm/lib/
                     GTEST_LISTENER=NO_PASS_LINE_IN_LOG make coverage_cleanup coverage GTEST_FILTER=${gfilter}-*known_bug*
-                    curl -Os https://uploader.codecov.io/latest/linux/codecov
-                    chmod +x codecov
-                    ./codecov -v -U \$http_proxy -t ${CODECOV_TOKEN} --file lcoverage/main_coverage.info --name rocm-libraries --flags rocSPARSE --sha ${commitSha}
+                    /usr/local/bin/codecov -v -U \$http_proxy -t ${CODECOV_TOKEN} --file lcoverage/main_coverage.info --name rocm-libraries --flags rocSPARSE --sha ${commitSha}
                 """
 
         platform.runCommand(this, command)


### PR DESCRIPTION
## Motivation

Use the existing `codecov` executable that exists in container rather than downloading every time, which can cause failures

## Test Plan

We just need a pass on the codecov job for this PR
