### PR TITLE
Auto-update rocWMMA doc dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,3 +58,15 @@ updates:
       - "ci:docs-only"
     reviewers:
       - "samjwu"
+
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "projects/rocwmma/docs/sphinx" # Location of package manifests
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    labels:
+      - "documentation"
+      - "dependencies"
+      - "ci:docs-only"
+    reviewers:
+      - "samjwu"


### PR DESCRIPTION
## Motivation

We should keep the documentation dependencies up to date.  This was enabled in the standalone rocWMMA repo; adding support here as well.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
