### PR TITLE
[hipblas] corrections to test client memory counting

### DIFF
--- a/projects/hipblas/clients/common/host_alloc.cpp
+++ b/projects/hipblas/clients/common/host_alloc.cpp
@@ -42,7 +42,7 @@ static size_t                  mem_used{0};
 static std::map<void*, size_t> mem_allocated;
 static std::mutex              mem_mutex;
 
-inline void alloc_ptr_use(void* ptr, size_t size)
+void alloc_ptr_use(void* ptr, size_t size)
 {
     std::lock_guard<std::mutex> lock(mem_mutex);
     if(ptr)
@@ -52,7 +52,7 @@ inline void alloc_ptr_use(void* ptr, size_t size)
     }
 }
 
-inline void free_ptr_use(void* ptr)
+void free_ptr_use(void* ptr, bool call_free)
 {
     std::lock_guard<std::mutex> lock(mem_mutex);
     if(ptr && mem_allocated[ptr])
@@ -60,7 +60,8 @@ inline void free_ptr_use(void* ptr)
         mem_used -= mem_allocated[ptr];
         mem_allocated.erase(ptr);
     }
-    free(ptr);
+    if(call_free)
+        free(ptr);
 }
 
 size_t host_bytes_allocated()
@@ -126,7 +127,7 @@ ptrdiff_t host_bytes_available()
 #endif
 }
 
-inline bool host_mem_safe(size_t n_bytes)
+bool host_mem_safe(size_t n_bytes)
 {
 #if defined(HIPBLAS_BENCH)
     return true; // roll out to hipblas-bench when CI does perf testing
@@ -225,5 +226,5 @@ void* host_calloc(size_t nmemb, size_t size)
 
 void host_free(void* ptr)
 {
-    free_ptr_use(ptr);
+    free_ptr_use(ptr, true);
 }

--- a/projects/hipblas/clients/include/device_batch_matrix.hpp
+++ b/projects/hipblas/clients/include/device_batch_matrix.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "d_vector.hpp"
+#include "host_alloc.hpp"
 
 //
 // Local declaration of the host batch matrix.
@@ -72,6 +73,7 @@ public:
         if(false == this->try_initialize_memory())
         {
             this->free_memory();
+            throw std::bad_alloc{};
         }
     }
 
@@ -263,7 +265,7 @@ private:
         if(success)
         {
             success = (nullptr
-                       != (m_data = !this->use_HMM ? (hipblas_internal_type<T>**)calloc(
+                       != (m_data = !this->use_HMM ? (hipblas_internal_type<T>**)host_calloc(
                                         m_batch_count, sizeof(hipblas_internal_type<T>*))
                                                    : m_device_data));
             if(success)
@@ -332,7 +334,7 @@ private:
 
             if(!this->use_HMM)
             {
-                free(m_data);
+                host_free(m_data);
             }
             // else this is just a copy of m_device_data
 

--- a/projects/hipblas/clients/include/device_batch_vector.hpp
+++ b/projects/hipblas/clients/include/device_batch_vector.hpp
@@ -66,6 +66,7 @@ public:
         if(false == try_initialize_memory())
         {
             free_memory();
+            throw std::bad_alloc{};
         }
     }
 

--- a/projects/hipblas/clients/include/device_matrix.hpp
+++ b/projects/hipblas/clients/include/device_matrix.hpp
@@ -63,6 +63,8 @@ public:
         , m_lda{lda}
         , m_data{this->device_vector_setup()}
     {
+        if(!m_data)
+            throw std::bad_alloc{};
     }
 
     //!

--- a/projects/hipblas/clients/include/device_strided_batch_matrix.hpp
+++ b/projects/hipblas/clients/include/device_strided_batch_matrix.hpp
@@ -70,6 +70,8 @@ public:
         if(valid_parameters)
         {
             this->m_data = this->device_vector_setup();
+            if(!this->m_data)
+                throw std::bad_alloc{};
         }
     }
 

--- a/projects/hipblas/clients/include/device_strided_batch_vector.hpp
+++ b/projects/hipblas/clients/include/device_strided_batch_vector.hpp
@@ -65,6 +65,8 @@ public:
         , m_batch_count(batch_count)
     {
         m_data = this->device_vector_setup();
+        if(!m_data)
+            throw std::bad_alloc{};
     }
 
     //!

--- a/projects/hipblas/clients/include/device_vector.hpp
+++ b/projects/hipblas/clients/include/device_vector.hpp
@@ -61,6 +61,8 @@ public:
         , m_inc{inc ? inc : 1}
         , m_data{this->device_vector_setup()}
     {
+        if(!m_data)
+            throw std::bad_alloc{};
     }
 
     //!

--- a/projects/hipblas/clients/include/host_alloc.hpp
+++ b/projects/hipblas/clients/include/host_alloc.hpp
@@ -35,6 +35,16 @@ ptrdiff_t host_bytes_available();
 size_t host_bytes_allocated();
 
 //!
+//! @brief Count external memory towards limits
+//!
+void alloc_ptr_use(void* ptr, size_t size);
+
+//!
+//! @brief Release counted external memory
+//!
+void free_ptr_use(void* ptr, bool call_free = false);
+
+//!
 //! @brief Allocates memory which can be freed with free.  Returns nullptr if swap required.
 //!
 void* host_malloc(size_t size);
@@ -76,7 +86,7 @@ inline void* host_calloc_throw(size_t nmemb, size_t size)
 void host_free(void* ptr);
 
 //!
-//! @brief  Allocator which allocates with host_calloc
+//! @brief  Allocator which allocates with host_malloc_throw
 //!
 template <class T>
 struct host_memory_allocator

--- a/projects/hipblas/clients/include/host_batch_matrix.hpp
+++ b/projects/hipblas/clients/include/host_batch_matrix.hpp
@@ -67,6 +67,7 @@ public:
         if(false == this->try_initialize_memory())
         {
             this->free_memory();
+            throw std::bad_alloc{};
         }
     }
 
@@ -222,7 +223,7 @@ private:
 
     bool try_initialize_memory()
     {
-        bool success = (nullptr != (m_data = (T**)host_calloc_throw(m_batch_count, sizeof(T*))));
+        bool success = (nullptr != (m_data = (T**)host_calloc(m_batch_count, sizeof(T*))));
         if(success)
         {
             for(int64_t batch_index = 0; batch_index < m_batch_count; ++batch_index)
@@ -231,7 +232,7 @@ private:
                 {
                     success = (nullptr
                                != (m_data[batch_index]
-                                   = (T*)host_calloc_throw(m_nmemb * m_batch_count, sizeof(T))));
+                                   = (T*)host_calloc(m_nmemb * m_batch_count, sizeof(T))));
                     if(false == success)
                     {
                         break;

--- a/projects/hipblas/clients/include/host_batch_vector.hpp
+++ b/projects/hipblas/clients/include/host_batch_vector.hpp
@@ -66,6 +66,7 @@ public:
         if(false == this->try_initialize_memory())
         {
             this->free_memory();
+            throw std::bad_alloc{};
         }
     }
 
@@ -236,7 +237,7 @@ private:
     bool try_initialize_memory()
     {
         bool success
-            = (nullptr != (this->m_data = (T**)host_calloc_throw(this->m_batch_count, sizeof(T*))));
+            = (nullptr != (this->m_data = (T**)host_calloc(this->m_batch_count, sizeof(T*))));
         if(success)
         {
             size_t nmemb = size_t(this->m_n) * std::abs(this->m_inc);
@@ -246,7 +247,7 @@ private:
                 {
                     success = (nullptr
                                != (m_data[batch_index]
-                                   = (T*)host_calloc_throw(m_nmemb * m_batch_count, sizeof(T))));
+                                   = (T*)host_calloc(m_nmemb * m_batch_count, sizeof(T))));
                     if(false == success)
                     {
                         break;
@@ -269,7 +270,7 @@ private:
             {
                 if(batch_index == 0 && nullptr != this->m_data[batch_index])
                 {
-                    free(this->m_data[batch_index]);
+                    host_free(this->m_data[batch_index]);
                     this->m_data[batch_index] = nullptr;
                 }
                 else
@@ -278,7 +279,7 @@ private:
                 }
             }
 
-            free(this->m_data);
+            host_free(this->m_data);
             this->m_data = nullptr;
         }
     }

--- a/projects/hipblas/clients/include/host_strided_batch_matrix.hpp
+++ b/projects/hipblas/clients/include/host_strided_batch_matrix.hpp
@@ -79,7 +79,7 @@ public:
     {
         if(nullptr != this->m_data)
         {
-            free(this->m_data);
+            host_free(this->m_data);
             this->m_data = nullptr;
         }
     }


### PR DESCRIPTION
## Motivation

Match fixes in rocblas client memory counting that allows environment variable RAM limiter

## Technical Details

Throwing std::bad_alloc for memory limit rejection of allocation but left additional check macros
rocblas now wraps allocators on same line with check macro so slightly different design.  Could move to that later or just delete the later macros as now double checks

