### PR TITLE
[hipsparselt] ASAN device support forward-compat

### DIFF
--- a/projects/hipsparselt/cmake/hipsparselt_supported_architectures.cmake
+++ b/projects/hipsparselt/cmake/hipsparselt_supported_architectures.cmake
@@ -7,17 +7,17 @@ set(BASE_ARCHITECTURES "")
 # All supported architectures including xnack variants - used for validation of GPU_TARGETS
 set(SUPPORTED_ARCHITECTURES "")
 
-if(NOT BUILD_ADDRESS_SANITIZER)
+if(HIPSPARSELT_ENABLE_ASAN OR BUILD_ADDRESS_SANITIZER)
+    # For address sanitizer builds, base and supported are the same
+    list(APPEND BASE_ARCHITECTURES "gfx942:xnack+" "gfx950:xnack+")
+    set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
+else()
     list(APPEND BASE_ARCHITECTURES "gfx942" "gfx950")
 
     set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
     list(APPEND SUPPORTED_ARCHITECTURES "gfx942:xnack+" "gfx942:xnack-" "gfx950:xnack+"
          "gfx950:xnack-"
     )
-else()
-    # For address sanitizer builds, base and supported are the same
-    list(APPEND BASE_ARCHITECTURES "gfx942:xnack+" "gfx950:xnack+")
-    set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
 endif()
 
 # .rst: Validates that all specified GPU targets are supported.


### PR DESCRIPTION
## Motivation

ASAN architecture selection should be enableable with `HIPSPARSELT_ENABLE_ASAN`.

## Technical Details

Add the flag to hipsparselt_supported_architectures.cmake.

## Test Plan

Low risk, standard CI testing is sufficient.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
