### PR TITLE
Fix python/python3 selection on Windows

### DIFF
--- a/projects/hipblas/CMakeLists.txt
+++ b/projects/hipblas/CMakeLists.txt
@@ -44,8 +44,10 @@ endif()
 
 project( hipblas LANGUAGES CXX )
 
-if (NOT python)
-    set(python "python3") # default for linux
+if(WIN32)
+  set(python "python") # default for windows
+else()
+  set(python "python3") # default for linux
 endif()
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)

--- a/projects/hipsparse/CMakeLists.txt
+++ b/projects/hipsparse/CMakeLists.txt
@@ -23,8 +23,10 @@
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
-if (NOT python)
-    set(python "python3") # default for linux
+if (WIN32)
+  set(python "python") # default for windows
+else()
+  set(python "python3") # default for linux
 endif()
 
 # Consider removing this in the future


### PR DESCRIPTION
## Technical Details

Added additional logic to hipBLAS and hipSPARSE to differentiate python invocation on Windows from Linux


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
