### PR TITLE
[hipsparse] Fix hipsparseXgemvi documentation example

### DIFF
--- a/projects/hipsparse/clients/samples/documentation_examples/level2/example_hipsparse_gemvi.cpp
+++ b/projects/hipsparse/clients/samples/documentation_examples/level2/example_hipsparse_gemvi.cpp
@@ -48,9 +48,9 @@
 //! [doc example]
 int main(int argc, char* argv[])
 {
-    hipsparseOperation_t opA = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    hipsparseOperation_t opA     = HIPSPARSE_OPERATION_NON_TRANSPOSE;
     hipsparseIndexBase_t idxBase = HIPSPARSE_INDEX_BASE_ZERO;
-    
+
     // Scalar alpha and beta
     float alpha = 1.0f;
     float beta  = 1.0f;
@@ -63,12 +63,27 @@ int main(int argc, char* argv[])
     //     5 6 7 8
     //     2 4 6 8
     //     4 3 2 1
-    std::vector<float> hA = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 2.0f, 4.0f, 6.0f, 8.0f, 4.0f, 3.0f, 2.0f, 1.0f};
-    
+    std::vector<float> hA = {1.0f,
+                             2.0f,
+                             3.0f,
+                             4.0f,
+                             5.0f,
+                             6.0f,
+                             7.0f,
+                             8.0f,
+                             2.0f,
+                             4.0f,
+                             6.0f,
+                             8.0f,
+                             4.0f,
+                             3.0f,
+                             2.0f,
+                             1.0f};
+
     // Sparse vector x
-    int nnz = 2;
-    std::vector<int> hxInd = {0, 2};
-    std::vector<float> hx = {10.0f, 11.0f};
+    int                nnz   = 2;
+    std::vector<int>   hxInd = {0, 2};
+    std::vector<float> hx    = {10.0f, 11.0f};
 
     // Dense vector y
     std::vector<float> hy = {1.0f, 2.0f, 3.0f, 4.0f};
@@ -77,8 +92,8 @@ int main(int argc, char* argv[])
     float* dA = nullptr;
     HIP_CHECK(hipMalloc((void**)&dA, sizeof(float) * m * n));
 
-    int* dxInd = nullptr;
-    float* dx = nullptr;
+    int*   dxInd = nullptr;
+    float* dx    = nullptr;
     HIP_CHECK(hipMalloc((void**)&dxInd, sizeof(int) * nnz));
     HIP_CHECK(hipMalloc((void**)&dx, sizeof(float) * nnz));
 

--- a/projects/hipsparse/clients/samples/documentation_examples/level2/example_hipsparse_gemvi.cpp
+++ b/projects/hipsparse/clients/samples/documentation_examples/level2/example_hipsparse_gemvi.cpp
@@ -25,6 +25,7 @@
 #include <hipsparse/hipsparse.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
 
 #define HIP_CHECK(stat)                                               \
     {                                                                 \
@@ -47,93 +48,83 @@
 //! [doc example]
 int main(int argc, char* argv[])
 {
-    // // hipSPARSE handle
-    // hipsparseHandle_t handle;
-    // HIPSPARSE_CHECK(hipsparseCreate(&handle));
+    hipsparseOperation_t opA = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    hipsparseIndexBase_t idxBase = HIPSPARSE_INDEX_BASE_ZERO;
+    
+    // Scalar alpha and beta
+    float alpha = 1.0f;
+    float beta  = 1.0f;
 
-    // // Define a sparse matrix A (CSR format) and vectors x and y
-    // // For sgemvi: y = alpha * A * x + beta * y
-    // // M x N matrix, where M is number of rows, N is number of columns.
-    // // In this example, we'll assume a square matrix for simplicity, M = N = 4.
-    // // However, hipsparseSgemvi supports M != N.
+    const int m   = 4; // Number of rows of A
+    const int n   = 4; // Number of columns of A
+    const int lda = m; // leading dimension of A
 
-    // const int m   = 4; // Number of rows of A
-    // const int n   = 4; // Number of columns of A
-    // const int nnz = 13; // Number of non-zero elements in A
+    // A = 1 2 3 4
+    //     5 6 7 8
+    //     2 4 6 8
+    //     4 3 2 1
+    std::vector<float> hA = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 2.0f, 4.0f, 6.0f, 8.0f, 4.0f, 3.0f, 2.0f, 1.0f};
+    
+    // Sparse vector x
+    int nnz = 2;
+    std::vector<int> hxInd = {0, 2};
+    std::vector<float> hx = {10.0f, 11.0f};
 
-    // hipsparseOperation_t op = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    // Dense vector y
+    std::vector<float> hy = {1.0f, 2.0f, 3.0f, 4.0f};
 
-    // // CSR row pointers
-    // int hcsrRowPtr[m + 1] = {0, 2, 6, 10, 13};
+    // Device data
+    float* dA = nullptr;
+    HIP_CHECK(hipMalloc((void**)&dA, sizeof(float) * m * n));
 
-    // // CSR column indices
-    // int hcsrColInd[nnz] = {0, 2, 0, 1, 2, 3, 0, 1, 2, 3, 0, 2, 3};
+    int* dxInd = nullptr;
+    float* dx = nullptr;
+    HIP_CHECK(hipMalloc((void**)&dxInd, sizeof(int) * nnz));
+    HIP_CHECK(hipMalloc((void**)&dx, sizeof(float) * nnz));
 
-    // // CSR values (single precision float for 'S'gemvi)
-    // float hcsrVal[nnz]
-    //     = {1.0f, 2.0f, 3.0f, 2.0f, 4.0f, 1.0f, 5.0f, 6.0f, 1.0f, 3.0f, 7.0f, 8.0f, 0.6f};
+    float* dy = nullptr;
+    HIP_CHECK(hipMalloc((void**)&dy, sizeof(float) * m));
 
-    // // Scalar alpha and beta
-    // float alpha = 1.0f;
-    // float beta  = 0.0f; // For y = A * x (effectively)
+    // Copy data from host to device
+    HIP_CHECK(hipMemcpy(dA, hA.data(), sizeof(float) * m * n, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dxInd, hxInd.data(), sizeof(int) * nnz, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dx, hx.data(), sizeof(float) * nnz, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dy, hy.data(), sizeof(float) * m, hipMemcpyHostToDevice));
 
-    // // Input vector x and initial y (output vector)
-    // float hx[n] = {1.0f, 2.0f, 3.0f, 4.0f}; // Example input x
-    // float hy[m] = {0.0f, 0.0f, 0.0f, 0.0f}; // Initialize y to zeros for y = A * x
+    // hipSPARSE handle
+    hipsparseHandle_t handle;
+    HIPSPARSE_CHECK(hipsparseCreate(&handle));
 
-    // // Matrix descriptor
-    // hipsparseMatDescr_t descr;
-    // HIPSPARSE_CHECK(hipsparseCreateMatDescr(&descr));
+    // Call hipsparseSgemvi to perform y = alpha * A * x + beta * y
+    int bufferSize = 0;
+    HIPSPARSE_CHECK(hipsparseSgemvi_bufferSize(handle, opA, m, n, nnz, &bufferSize));
 
-    // // Set index base on descriptor
-    // HIPSPARSE_CHECK(hipsparseSetMatIndexBase(descr, HIPSPARSE_INDEX_BASE_ZERO));
+    void* dbuffer = nullptr;
+    HIP_CHECK(hipMalloc((void**)&dbuffer, bufferSize));
 
-    // // Offload data to device
-    // int*   dcsrRowPtr;
-    // int*   dcsrColInd;
-    // float* dcsrVal;
-    // float* dx;
-    // float* dy;
+    HIPSPARSE_CHECK(hipsparseSgemvi(
+        handle, opA, m, n, &alpha, dA, lda, nnz, dx, dxInd, &beta, dy, idxBase, dbuffer));
 
-    // HIP_CHECK(hipMalloc((void**)&dcsrRowPtr, sizeof(int) * (m + 1)));
-    // HIP_CHECK(hipMalloc((void**)&dcsrColInd, sizeof(int) * nnz));
-    // HIP_CHECK(hipMalloc((void**)&dcsrVal, sizeof(float) * nnz));
-    // HIP_CHECK(hipMalloc((void**)&dx, sizeof(float) * n)); // x has 'n' elements
-    // HIP_CHECK(hipMalloc((void**)&dy, sizeof(float) * m)); // y has 'm' elements
+    // Copy result back to host
+    HIP_CHECK(hipMemcpy(hy.data(), dy, sizeof(float) * m, hipMemcpyDeviceToHost));
 
-    // HIP_CHECK(hipMemcpy(dcsrRowPtr, hcsrRowPtr, sizeof(int) * (m + 1), hipMemcpyHostToDevice));
-    // HIP_CHECK(hipMemcpy(dcsrColInd, hcsrColInd, sizeof(int) * nnz, hipMemcpyHostToDevice));
-    // HIP_CHECK(hipMemcpy(dcsrVal, hcsrVal, sizeof(float) * nnz, hipMemcpyHostToDevice));
-    // HIP_CHECK(hipMemcpy(dx, hx, sizeof(float) * n, hipMemcpyHostToDevice));
-    // HIP_CHECK(hipMemcpy(dy, hy, sizeof(float) * m, hipMemcpyHostToDevice));
+    // Print the result (optional)
+    std::cout << "hy" << std::endl;
+    for(int i = 0; i < m; i++)
+    {
+        std::cout << hy[i] << " ";
+    }
+    std::cout << "" << std::endl;
 
-    // // Call hipsparseSgemvi to perform y = alpha * A * x + beta * y
-    // // hipsparseSgemvi does not require a bufferSize or analysis phase.
+    // Clear hipSPARSE
+    HIPSPARSE_CHECK(hipsparseDestroy(handle));
 
-    // HIPSPARSE_CHECK(hipsparseSgemvi(
-    //     handle, op, m, n, &alpha, A, lda, nnz, dx, dxInd, &beta, dy, indBase, buffer));
-
-    // // Copy result back to host
-    // HIP_CHECK(hipMemcpy(hy, dy, sizeof(float) * m, hipMemcpyDeviceToHost));
-
-    // // Print the result (optional)
-    // std::cout << "hy" << std::endl;
-    // for(int i = 0; i < m; i++)
-    // {
-    //     std::cout << hy[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
-    // // Clear hipSPARSE
-    // HIPSPARSE_CHECK(hipsparseDestroyMatDescr(descr));
-    // HIPSPARSE_CHECK(hipsparseDestroy(handle));
-
-    // // Clear device memory
-    // HIP_CHECK(hipFree(dcsrRowPtr));
-    // HIP_CHECK(hipFree(dcsrColInd));
-    // HIP_CHECK(hipFree(dcsrVal));
-    // HIP_CHECK(hipFree(dx));
-    // HIP_CHECK(hipFree(dy));
+    // Clear device memory
+    HIP_CHECK(hipFree(dA));
+    HIP_CHECK(hipFree(dxInd));
+    HIP_CHECK(hipFree(dx));
+    HIP_CHECK(hipFree(dy));
+    HIP_CHECK(hipFree(dbuffer));
 
     return 0;
 }


### PR DESCRIPTION
## Motivation

The example using hipsparseSgemvi included in the documentation was incorrect. This PR fixes it. 
