### PR TITLE
[rocblas] Fix schedule name for gfx1103 logics

### DIFF
--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_BBS_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_BBS_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_BBS_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_BBS_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_HB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_HB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_HB_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_HB_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_HHS_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_HHS_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_HHS_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_HHS_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_I8II_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_I8II_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_I8II_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_I8II_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_SB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bjlk_SB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.33.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_BBS_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_BBS_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_BBS_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_BBS_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_HB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_HB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_HB_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_HB_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_HHS_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_HHS_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_HHS_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_HHS_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_I8II_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_I8II_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_I8II_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_I8II_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_SB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Ailk_Bljk_SB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.33.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_BBS_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_BBS_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_BBS_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_BBS_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_HB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_HB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_HB_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_HB_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_HHS_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_HHS_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_HHS_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_HHS_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_I8II_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_I8II_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_I8II_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_I8II_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_SB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bjlk_SB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.33.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_BBS_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_BBS_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_BBS_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_BBS_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_HB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_HB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_HB_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_HB_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_HHS_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_HHS_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_HHS_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_HHS_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_I8II_BH.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_I8II_BH.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_I8II_BH_GB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_I8II_BH_GB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.35.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false

--- a/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_SB.yaml
+++ b/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full/gfx1103/gfx1103_Cijk_Alik_Bljk_SB.yaml
@@ -1,5 +1,5 @@
 - {MinimumRequiredVersion: 4.33.0}
-- navi33
+- gfx1103
 - gfx1103
 - [Device 15bf]
 - AllowNoFreeDims: false


### PR DESCRIPTION
## Motivation

The `gfx1103` logic files used an incorrect reference to `navi33`, which has been exposed due to the recent inclusion of new logic file consistency checks in #2162.

## Technical Details

Update the schedule name in the rocblas logic files to properly map to `gfx1103` which is consistent with the architectureMap in Common.py

## Test Plan

Local testing before and after this change shows the following outputs

Command:
```
Tensile/bin/TensileCreateLibrary [...] --architecture=gfx1103 /path/to/Tensile/Logic/asm_full build_gfx1103 HIP
```

Result (before; develop)
```
ValueError: Architecture mismatch: gfx1103 does not match  navi33. Review the library logic file
```

Result (after)
```
# Reading logic files: 32 thread(s), 144 tasks .............................. 100.0% (took 4.0 secs)
# Generating kernels: 32 thread(s), 2690 tasks .............................. 100.0% (took 23.1 secs)
# Compiling source kernels .............................. 100.0% (took 0.0 secs)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
