### PR TITLE
[hipsparse] Add cuda deprecation notices to the doxygen documentation

### DIFF
--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_bsr2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_bsr2csr.h
@@ -110,9 +110,8 @@ extern "C" {
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
 *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p descrC, \p bsrValA,
-*          \p bsrRowPtrA, \p bsrColIndA, \p csrValC, \p csrRowPtrC or \p csrColIndC is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb or \p nb is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is invalid.
+*          \p bsrRowPtrA, \p bsrColIndA, \p csrValC, \p csrRowPtrC or \p csrColIndC is nullptr,
+*          \p mb or \p nb is negative, or \p blockDim is invalid.
 *
 *  \par Example
 *  \snippet example_hipsparse_bsr2csr.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_bsr2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_bsr2csr.h
@@ -79,11 +79,11 @@ extern "C" {
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  dirA        the storage format of the blocks, \ref HIPSPARSE_DIRECTION_ROW or \ref HIPSPARSE_DIRECTION_COLUMN
+*  dirA        the storage format of the blocks, \ref HIPSPARSE_DIRECTION_ROW or \ref HIPSPARSE_DIRECTION_COLUMN.
 *  @param[in]
-*  mb          number of block rows in the sparse BSR matrix.
+*  mb          number of block rows in the sparse BSR matrix. Must be non-negative.
 *  @param[in]
-*  nb          number of block columns in the sparse BSR matrix.
+*  nb          number of block columns in the sparse BSR matrix. Must be non-negative.
 *  @param[in]
 *  descrA      descriptor of the sparse BSR matrix. Currently, only
 *              \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
@@ -95,7 +95,7 @@ extern "C" {
 *  @param[in]
 *  bsrColIndA  array of \p nnzb elements containing the block column indices of the sparse BSR matrix.
 *  @param[in]
-*  blockDim    size of the blocks in the sparse BSR matrix.
+*  blockDim    size of the blocks in the sparse BSR matrix. Must be positive.
 *  @param[in]
 *  descrC      descriptor of the sparse CSR matrix. Currently, only
 *              \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
@@ -107,9 +107,12 @@ extern "C" {
 *  @param[out]
 *  csrColIndC  array of \p nnzb*blockDim*blockDim elements containing the column indices of the sparse CSR matrix.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nb, \p blockDim, \p bsrValA,
-*              \p bsrRowPtrA, \p bsrColIndA, \p csrValC, \p csrRowPtrC or \p csrColIndC pointer is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p descrC, \p bsrValA,
+*          \p bsrRowPtrA, \p bsrColIndA, \p csrValC, \p csrRowPtrC or \p csrColIndC is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb or \p nb is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is invalid.
 *
 *  \par Example
 *  \snippet example_hipsparse_bsr2csr.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_coo2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_coo2csr.h
@@ -77,11 +77,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p cooRowInd or \p csrRowPtr is nullptr when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
-*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p m or \p nnz is negative,
+*          \p cooRowInd or \p csrRowPtr is nullptr when \p nnz is greater than zero, or
+*          \p idxBase is neither \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_coo2csr.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_coo2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_coo2csr.h
@@ -65,18 +65,23 @@ extern "C" {
 *  cooRowInd   array of \p nnz elements containing the row indices of the sparse COO
 *              matrix.
 *  @param[in]
-*  nnz         number of non-zero entries of the sparse CSR matrix.
+*  nnz         number of non-zero entries of the sparse CSR matrix. Must be non-negative.
 *  @param[in]
-*  m           number of rows of the sparse CSR matrix.
+*  m           number of rows of the sparse CSR matrix. Must be non-negative.
 *  @param[out]
 *  csrRowPtr   array of \p m+1 elements that point to the start of every row of the
 *              sparse CSR matrix.
 *  @param[in]
-*  idxBase    \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase     index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*              \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nnz, \p cooRowInd or \p csrRowPtr
-*              pointer is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p cooRowInd or \p csrRowPtr is nullptr when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_coo2csr.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csc2dense.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csc2dense.h
@@ -94,10 +94,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p cscVal, \p cscColPtr, 
-*          \p cscRowInd or \p A is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ld is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p cscVal, \p cscColPtr,
+*          \p cscRowInd or \p A is nullptr, \p m or \p n is negative, or \p ld is invalid.
 */
 /**@{*/
 DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csc2dense.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csc2dense.h
@@ -69,8 +69,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csc2dense.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csc2dense.h
@@ -67,12 +67,17 @@ extern "C" {
 *  It is executed asynchronously with respect to the host and may return control to the application
 *  on the host before the entire result is ready.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  m           number of rows of the dense matrix \p A.
+*  m           number of rows of the dense matrix \p A. Must be non-negative.
 *  @param[in]
-*  n           number of columns of the dense matrix \p A.
+*  n           number of columns of the dense matrix \p A. Must be non-negative.
 *  @param[in]
 *  descr       the descriptor of the dense matrix \p A, the supported matrix type is \ref HIPSPARSE_MATRIX_TYPE_GENERAL and also
 *              any valid value of the \ref hipsparseIndexBase_t.
@@ -83,13 +88,16 @@ extern "C" {
 *  @param[in]
 *  cscColPtr   integer array of \p n+1 elements that contains the start of every column and the end of the last column plus one.
 *  @param[out]
-*  A           array of dimensions (\p ld, \p n)
-*  @param[out]
-*  ld          leading dimension of dense array \p A.
+*  A           array of dimensions (\p ld, \p n).
+*  @param[in]
+*  ld          leading dimension of dense array \p A. Must be at least \p m.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p ld, \p A, \p cscVal \p cscColPtr
-*              or \p cscRowInd pointer is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p cscVal, \p cscColPtr, 
+*          \p cscRowInd or \p A is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ld is invalid.
 */
 /**@{*/
 DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2bsr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2bsr.h
@@ -135,7 +135,7 @@ extern "C" {
 *  dirA        direction that specified whether to count nonzero elements by \ref HIPSPARSE_DIRECTION_ROW or by
 *              \ref HIPSPARSE_DIRECTION_COLUMN.
 *  @param[in]
-*  m           number of rows of the sparse CSR matrix.
+*  m           number of rows of the sparse CSR matrix. Must be non-negative.
 *  @param[in]
 *  n           number of columns of the sparse CSR matrix.
 *  @param[in]

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2coo.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2coo.h
@@ -64,19 +64,24 @@ extern "C" {
 *  csrRowPtr   array of \p m+1 elements that point to the start of every row
 *              of the sparse CSR matrix.
 *  @param[in]
-*  nnz         number of non-zero entries of the sparse CSR matrix.
+*  nnz         number of non-zero entries of the sparse CSR matrix. Must be non-negative.
 *  @param[in]
-*  m           number of rows of the sparse CSR matrix.
+*  m           number of rows of the sparse CSR matrix. Must be non-negative.
 *  @param[out]
 *  cooRowInd   array of \p nnz elements containing the row indices of the sparse COO
 *              matrix.
 *  @param[in]
-*  idxBase    \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase     index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*              \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nnz, \p csrRowPtr or \p cooRowInd
-*              pointer is invalid.
-*  \retval     HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrRowPtr or \p cooRowInd is nullptr when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
 */
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseXcsr2coo(hipsparseHandle_t    handle,

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2coo.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2coo.h
@@ -76,11 +76,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrRowPtr or \p cooRowInd is nullptr when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
-*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p m or \p nnz is negative,
+*          \p csrRowPtr or \p cooRowInd is nullptr when \p nnz is greater than zero, or
+*          \p idxBase is neither \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
 */
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2csc.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2csc.h
@@ -75,14 +75,19 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle          handle to the hipsparse library context queue.
 *  @param[in]
-*  m               number of rows of the sparse CSR matrix.
+*  m               number of rows of the sparse CSR matrix. Must be non-negative.
 *  @param[in]
-*  n               number of columns of the sparse CSR matrix.
+*  n               number of columns of the sparse CSR matrix. Must be non-negative.
 *  @param[in]
-*  nnz             number of non-zero entries of the sparse CSR matrix.
+*  nnz             number of non-zero entries of the sparse CSR matrix. Must be non-negative.
 *  @param[in]
 *  csrSortedVal    array of \p nnz elements of the sparse CSR matrix.
 *  @param[in]
@@ -102,13 +107,21 @@ extern "C" {
 *  @param[in]
 *  copyValues      \ref HIPSPARSE_ACTION_SYMBOLIC or \ref HIPSPARSE_ACTION_NUMERIC.
 *  @param[in]
-*  idxBase         \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase         index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*                  \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p nnz, \p csrSortedVal, \p csrSortedRowPtr,
-*              \p csrSortedColInd, \p cscSortedVal, \p cscSortedRowInd or \p cscSortedColPtr pointer is invalid.
-*  \retval     HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n or \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrSortedVal, \p csrSortedRowPtr, \p csrSortedColInd,
+*          \p cscSortedVal, \p cscSortedRowInd or \p cscSortedColPtr is nullptr when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p copyValues is neither \ref HIPSPARSE_ACTION_SYMBOLIC 
+*          nor \ref HIPSPARSE_ACTION_NUMERIC.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither \ref HIPSPARSE_INDEX_BASE_ZERO 
+*          nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 *
 *  \par Example
 *  \snippet example_hipsparse_csr2csc.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2csc.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2csc.h
@@ -112,14 +112,11 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n or \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrSortedVal, \p csrSortedRowPtr, \p csrSortedColInd,
-*          \p cscSortedVal, \p cscSortedRowInd or \p cscSortedColPtr is nullptr when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p copyValues is neither \ref HIPSPARSE_ACTION_SYMBOLIC 
-*          nor \ref HIPSPARSE_ACTION_NUMERIC.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither \ref HIPSPARSE_INDEX_BASE_ZERO 
-*          nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p m, \p n or \p nnz is negative,
+*          \p csrSortedVal, \p csrSortedRowPtr, \p csrSortedColInd, \p cscSortedVal, \p cscSortedRowInd
+*          or \p cscSortedColPtr is nullptr when \p nnz is greater than zero, \p copyValues is neither
+*          \ref HIPSPARSE_ACTION_SYMBOLIC nor \ref HIPSPARSE_ACTION_NUMERIC, or \p idxBase is neither
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 *

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2csc.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2csc.h
@@ -77,8 +77,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle          handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2dense.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2dense.h
@@ -94,10 +94,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p csrVal, \p csrRowPtr, 
-*          \p csrColInd or \p A is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ld is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p csrVal, \p csrRowPtr,
+*          \p csrColInd or \p A is nullptr, \p m or \p n is negative, or \p ld is invalid.
 *
 *  \par Example
 *  \snippet example_hipsparse_csr2dense.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2dense.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2dense.h
@@ -69,8 +69,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2dense.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2dense.h
@@ -67,12 +67,17 @@ extern "C" {
 *  It is executed asynchronously with respect to the host and may return control to the application
 *  on the host before the entire result is ready.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  m           number of rows of the dense matrix \p A.
+*  m           number of rows of the dense matrix \p A. Must be non-negative.
 *  @param[in]
-*  n           number of columns of the dense matrix \p A.
+*  n           number of columns of the dense matrix \p A. Must be non-negative.
 *  @param[in]
 *  descr       the descriptor of the dense matrix \p A, the supported matrix type is \ref HIPSPARSE_MATRIX_TYPE_GENERAL and
 *              also any valid value of the \ref hipsparseIndexBase_t.
@@ -83,13 +88,16 @@ extern "C" {
 *  @param[in]
 *  csrColInd   integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column indices of the non-zero elements of matrix \p A.
 *  @param[out]
-*  A           array of dimensions (\p ld, \p n)
-*  @param[out]
-*  ld          leading dimension of dense array \p A.
+*  A           array of dimensions (\p ld, \p n).
+*  @param[in]
+*  ld          leading dimension of dense array \p A. Must be at least \p m.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p ld, \p A, \p csrVal, \p csrRowPtr or \p csrColInd
-*              pointer is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p csrVal, \p csrRowPtr, 
+*          \p csrColInd or \p A is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ld is invalid.
 *
 *  \par Example
 *  \snippet example_hipsparse_csr2dense.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2hyb.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2hyb.h
@@ -44,12 +44,17 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle            handle to the hipsparse library context queue.
 *  @param[in]
-*  m                 number of rows of the sparse CSR matrix.
+*  m                 number of rows of the sparse CSR matrix. Must be non-negative.
 *  @param[in]
-*  n                 number of columns of the sparse CSR matrix.
+*  n                 number of columns of the sparse CSR matrix. Must be non-negative.
 *  @param[in]
 *  descrA            descriptor of the sparse CSR matrix. Currently, only
 *                    \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
@@ -64,20 +69,21 @@ extern "C" {
 *  hybA              sparse matrix in HYB format.
 *  @param[in]
 *  userEllWidth      width of the ELL part of the HYB matrix (only required if
-*                    \p partitionType == \ref HIPSPARSE_HYB_PARTITION_USER).
+*                    \p partitionType == \ref HIPSPARSE_HYB_PARTITION_USER). Must be non-negative.
 *  @param[in]
 *  partitionType     \ref HIPSPARSE_HYB_PARTITION_AUTO (recommended),
 *                    \ref HIPSPARSE_HYB_PARTITION_USER or
 *                    \ref HIPSPARSE_HYB_PARTITION_MAX.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p userEllWidth, \p partitionType,
-*              \p descrA, \p hybA, \p csrSortedValA, \p csrSortedRowPtrA or \p csrSortedColIndA pointer is invalid.
-*  \retval     HIPSPARSE_STATUS_ALLOC_FAILED the buffer for the HYB matrix could not be
-*              allocated.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
-*              \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p hybA, \p csrSortedValA, 
+*          \p csrSortedRowPtrA or \p csrSortedColIndA is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p userEllWidth or \p partitionType is invalid.
+*  \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer for the HYB matrix could not be allocated.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 *
 *  \par Example
 *  \snippet example_hipsparse_csr2hyb.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2hyb.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2hyb.h
@@ -46,8 +46,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle            handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2hyb.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_csr2hyb.h
@@ -77,10 +77,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p hybA, \p csrSortedValA, 
-*          \p csrSortedRowPtrA or \p csrSortedColIndA is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p userEllWidth or \p partitionType is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p hybA, \p csrSortedValA,
+*          \p csrSortedRowPtrA or \p csrSortedColIndA is nullptr, \p m or \p n is negative, or
+*          \p userEllWidth or \p partitionType is invalid.
 *  \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer for the HYB matrix could not be allocated.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csc.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csc.h
@@ -103,10 +103,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p A, \p nnzPerColumn, \p cscVal, 
-*          \p cscColPtr or \p cscRowInd is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ld is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p A, \p nnzPerColumn, \p cscVal,
+*          \p cscColPtr or \p cscRowInd is nullptr, \p m or \p n is negative, or \p ld is invalid.
 */
 /**@{*/
 DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csc.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csc.h
@@ -74,19 +74,24 @@ extern "C" {
 *  It is executed asynchronously with respect to the host and may return control to the
 *  application on the host before the entire result is ready.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle       handle to the hipsparse library context queue.
 *  @param[in]
-*  m            number of rows of the dense matrix \p A.
+*  m            number of rows of the dense matrix \p A. Must be non-negative.
 *  @param[in]
-*  n            number of columns of the dense matrix \p A.
+*  n            number of columns of the dense matrix \p A. Must be non-negative.
 *  @param[in]
 *  descr        the descriptor of the dense matrix \p A, the supported matrix type is  \ref HIPSPARSE_MATRIX_TYPE_GENERAL and also
 *               any valid value of the \ref hipsparseIndexBase_t.
 *  @param[in]
-*  A            array of dimensions (\p ld, \p n)
+*  A            array of dimensions (\p ld, \p n).
 *  @param[in]
-*  ld           leading dimension of dense array \p A.
+*  ld           leading dimension of dense array \p A. Must be at least \p m.
 *  @param[in]
 *  nnzPerColumn array of size \p n containing the number of non-zero elements per column.
 *  @param[out]
@@ -96,9 +101,12 @@ extern "C" {
 *  @param[out]
 *  cscColPtr    integer array of \p n+1 elements that contains the start of every column and the end of the last column plus one.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p ld, \p A, \p nnzPerColumn or \p cscVal \p cscColPtr
-*              or \p cscRowInd pointer is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p A, \p nnzPerColumn, \p cscVal, 
+*          \p cscColPtr or \p cscRowInd is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ld is invalid.
 */
 /**@{*/
 DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csc.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csc.h
@@ -76,8 +76,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle       handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csr.h
@@ -69,18 +69,18 @@ extern "C" {
 *  @param[in]
 *  handle       handle to the hipsparse library context queue.
 *  @param[in]
-*  m            number of rows of the dense matrix \p A.
+*  m            number of rows of the dense matrix \p A. Must be non-negative.
 *  @param[in]
-*  n            number of columns of the dense matrix \p A.
+*  n            number of columns of the dense matrix \p A. Must be non-negative.
 *  @param[in]
 *  descr        the descriptor of the dense matrix \p A, the supported matrix type is  \ref HIPSPARSE_MATRIX_TYPE_GENERAL and also
 *               any valid value of the \ref hipsparseIndexBase_t.
 *  @param[in]
-*  A            array of dimensions (\p ld, \p n)
+*  A            array of dimensions (\p ld, \p n).
 *  @param[in]
-*  ld           leading dimension of dense array \p A.
+*  ld           leading dimension of dense array \p A. Must be at least \p m.
 *  @param[in]
-*  nnzPerRow    array of size \p n containing the number of non-zero elements per row.
+*  nnzPerRow    array of size \p m containing the number of non-zero elements per row.
 *  @param[out]
 *  csrVal       array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) nonzero elements of matrix \p A.
 *  @param[out]
@@ -88,9 +88,12 @@ extern "C" {
 *  @param[out]
 *  csrColInd    integer array of nnz ( = \p csrRowPtr[m] - \p csrRowPtr[0] ) column indices of the non-zero elements of matrix \p A.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p ld, \p A, \p nnzPerRow, \p csrVal \p csrRowPtr or \p csrColInd
-*              pointer is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p A, \p nnzPerRow, \p csrVal, 
+*          \p csrRowPtr or \p csrColInd is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ld is invalid.
 *
 *  \par Example
 *  \snippet example_hipsparse_dense2csr.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_dense2csr.h
@@ -90,10 +90,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p A, \p nnzPerRow, \p csrVal, 
-*          \p csrRowPtr or \p csrColInd is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ld is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p A, \p nnzPerRow, \p csrVal,
+*          \p csrRowPtr or \p csrColInd is nullptr, \p m or \p n is negative, or \p ld is invalid.
 *
 *  \par Example
 *  \snippet example_hipsparse_dense2csr.cpp doc example

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_hyb2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_hyb2csr.h
@@ -41,8 +41,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle            handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_hyb2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_hyb2csr.h
@@ -39,6 +39,11 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle            handle to the hipsparse library context queue.
 *  @param[in]
@@ -54,12 +59,12 @@ extern "C" {
 *  @param[out]
 *  csrSortedColIndA  array containing the column indices of the sparse CSR matrix.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p hybA, \p csrSortedValA,
-*              \p csrSortedRowPtrA or \p csrSortedColIndA pointer is invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
-*              \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p hybA, \p csrSortedValA,
+*          \p csrSortedRowPtrA or \p csrSortedColIndA is nullptr.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 */
 /**@{*/
 DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11")

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_nnz.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_nnz.h
@@ -94,10 +94,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p A, \p nnzPerRowColumn 
-*          or \p nnzTotalDevHostPtr is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p lda is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p A, \p nnzPerRowColumn
+*          or \p nnzTotalDevHostPtr is nullptr, \p m or \p n is negative, or \p lda is invalid.
 */
 /**@{*/
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_nnz.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_nnz.h
@@ -73,28 +73,31 @@ extern "C" {
 *  The routine does support asynchronous execution if the pointer mode is set to device.
 *
 *  @param[in]
-*  handle             handle to the rocsparse library context queue.
+*  handle             handle to the hipsparse library context queue.
 *  @param[in]
 *  dirA               direction that specified whether to count nonzero elements by \ref HIPSPARSE_DIRECTION_ROW
 *                     or by \ref HIPSPARSE_DIRECTION_COLUMN.
 *  @param[in]
-*  m                  number of rows of the dense matrix \p A.
+*  m                  number of rows of the dense matrix \p A. Must be non-negative.
 *  @param[in]
-*  n                  number of columns of the dense matrix \p A.
+*  n                  number of columns of the dense matrix \p A. Must be non-negative.
 *  @param[in]
 *  descrA             the descriptor of the dense matrix \p A.
 *  @param[in]
-*  A                  array of dimensions (\p lda, \p n)
+*  A                  array of dimensions (\p lda, \p n).
 *  @param[in]
-*  lda                leading dimension of dense array \p A.
+*  lda                leading dimension of dense array \p A. Must be at least \p m.
 *  @param[out]
 *  nnzPerRowColumn    array of size \p m or \p n containing the number of nonzero elements per row or column, respectively.
 *  @param[out]
 *  nnzTotalDevHostPtr total number of nonzero elements in device or host memory.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p lda, \p A or \p nnzPerRowColumn or
-*              \p nnzTotalDevHostPtr pointer is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p A, \p nnzPerRowColumn 
+*          or \p nnzTotalDevHostPtr is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p lda is invalid.
 */
 /**@{*/
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_prune_dense2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_prune_dense2csr.h
@@ -83,8 +83,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p pBufferSizeInBytes is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p pBufferSizeInBytes is nullptr,
+*          or \p m or \p n is negative.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 */
 /**@{*/

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_prune_dense2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_prune_dense2csr.h
@@ -50,16 +50,21 @@ extern "C" {
 *
 *  See hipsparseSpruneDense2csr() for a full code example.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle             handle to the hipsparse library context queue.
 *  @param[in]
-*  m                  number of rows of the dense matrix \p A.
+*  m                  number of rows of the dense matrix \p A. Must be non-negative.
 *  @param[in]
-*  n                  number of columns of the dense matrix \p A.
+*  n                  number of columns of the dense matrix \p A. Must be non-negative.
 *  @param[in]
-*  A                  array of dimensions (\p lda, \p n)
+*  A                  array of dimensions (\p lda, \p n).
 *  @param[in]
-*  lda                leading dimension of dense array \p A.
+*  lda                leading dimension of dense array \p A. Must be at least \p m.
 *  @param[in]
 *  threshold          pointer to the pruning non-negative threshold which can exist in either host or device memory.
 *  @param[in]
@@ -76,9 +81,11 @@ extern "C" {
 *                     hipsparseSpruneDense2csrNnz(), hipsparseDpruneDense2csrNnz(),
 *                     hipsparseSpruneDense2csr() and hipsparseDpruneDense2csr().
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p pBufferSizeInBytes pointer is invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p pBufferSizeInBytes is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 */
 /**@{*/
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")

--- a/projects/hipsparse/library/include/internal/conversion/hipsparse_prune_dense2csr.h
+++ b/projects/hipsparse/library/include/internal/conversion/hipsparse_prune_dense2csr.h
@@ -52,8 +52,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
-*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle             handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/extra/hipsparse_csrgeam.h
+++ b/projects/hipsparse/library/include/internal/extra/hipsparse_csrgeam.h
@@ -95,9 +95,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p descrB or \p descrC is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n, \p nnzA or \p nnzB is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrRowPtrA, \p csrColIndA, \p csrRowPtrB, 
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p descrB or \p descrC is nullptr,
+*          \p m, \p n, \p nnzA or \p nnzB is negative, or \p csrRowPtrA, \p csrColIndA, \p csrRowPtrB, 
 *          \p csrColIndB, \p csrRowPtrC or \p nnzTotalDevHostPtr is nullptr.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
 *          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.

--- a/projects/hipsparse/library/include/internal/extra/hipsparse_csrgeam.h
+++ b/projects/hipsparse/library/include/internal/extra/hipsparse_csrgeam.h
@@ -52,8 +52,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle          handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/extra/hipsparse_csrgeam.h
+++ b/projects/hipsparse/library/include/internal/extra/hipsparse_csrgeam.h
@@ -50,17 +50,22 @@ extern "C" {
 *  \note
 *  Currently, only \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle          handle to the hipsparse library context queue.
 *  @param[in]
-*  m               number of rows of the sparse CSR matrix \f$A\f$, \f$B\f$ and \f$C\f$.
+*  m               number of rows of the sparse CSR matrix \f$A\f$, \f$B\f$ and \f$C\f$. Must be non-negative.
 *  @param[in]
-*  n               number of columns of the sparse CSR matrix \f$A\f$, \f$B\f$ and \f$C\f$.
+*  n               number of columns of the sparse CSR matrix \f$A\f$, \f$B\f$ and \f$C\f$. Must be non-negative.
 *  @param[in]
 *  descrA          descriptor of the sparse CSR matrix \f$A\f$. Currently, only
 *                  \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
 *  @param[in]
-*  nnzA            number of non-zero entries of the sparse CSR matrix \f$A\f$.
+*  nnzA            number of non-zero entries of the sparse CSR matrix \f$A\f$. Must be non-negative.
 *  @param[in]
 *  csrRowPtrA      array of \p m+1 elements that point to the start of every row of the
 *                  sparse CSR matrix \f$A\f$.
@@ -71,7 +76,7 @@ extern "C" {
 *  descrB          descriptor of the sparse CSR matrix \f$B\f$. Currently, only
 *                  \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
 *  @param[in]
-*  nnzB            number of non-zero entries of the sparse CSR matrix \f$B\f$.
+*  nnzB            number of non-zero entries of the sparse CSR matrix \f$B\f$. Must be non-negative.
 *  @param[in]
 *  csrRowPtrB      array of \p m+1 elements that point to the start of every row of the
 *                  sparse CSR matrix \f$B\f$.
@@ -89,11 +94,13 @@ extern "C" {
 *                     matrix \f$C\f$. \p nnzTotalDevHostPtr can be a host or device pointer.
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p nnzA, \p nnzB, \p descrA,
-*          \p csrRowPtrA, \p csrColIndA, \p descrB, \p csrRowPtrB, \p csrColIndB, \p descrC,
-*          \p csrRowPtrC or \p nnzTotalDevHostPtr is invalid.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED
-*          \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p descrB or \p descrC is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n, \p nnzA or \p nnzB is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrRowPtrA, \p csrColIndA, \p csrRowPtrB, 
+*          \p csrColIndB, \p csrRowPtrC or \p nnzTotalDevHostPtr is nullptr.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
+*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 */
 DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11")
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/extra/hipsparse_csrgemm.h
+++ b/projects/hipsparse/library/include/internal/extra/hipsparse_csrgemm.h
@@ -110,16 +110,12 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p descrB or \p descrC is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n, \p k, \p nnzA or \p nnzB is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrRowPtrA, \p csrColIndA, \p csrRowPtrB, 
-*          \p csrColIndB, \p csrRowPtrC or \p nnzTotalDevHostPtr is nullptr.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not 
-*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transB is not 
-*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
-*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p descrB or \p descrC is nullptr,
+*          \p m, \p n, \p k, \p nnzA or \p nnzB is negative, or \p csrRowPtrA, \p csrColIndA,
+*          \p csrRowPtrB, \p csrColIndB, \p csrRowPtrC or \p nnzTotalDevHostPtr is nullptr.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not \ref HIPSPARSE_OPERATION_NON_TRANSPOSE,
+*          \p transB is not \ref HIPSPARSE_OPERATION_NON_TRANSPOSE, or
+*          \ref hipsparseMatrixType_t is not \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 */
 DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11")
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/extra/hipsparse_csrgemm.h
+++ b/projects/hipsparse/library/include/internal/extra/hipsparse_csrgemm.h
@@ -55,6 +55,11 @@ extern "C" {
 *  \note
 *  Currently, only \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle          handle to the hipsparse library context queue.
 *  @param[in]
@@ -62,18 +67,18 @@ extern "C" {
 *  @param[in]
 *  transB          matrix \f$B\f$ operation type.
 *  @param[in]
-*  m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$.
+*  m               number of rows of the sparse CSR matrix \f$op(A)\f$ and \f$C\f$. Must be non-negative.
 *  @param[in]
 *  n               number of columns of the sparse CSR matrix \f$op(B)\f$ and
-*                  \f$C\f$.
+*                  \f$C\f$. Must be non-negative.
 *  @param[in]
 *  k               number of columns of the sparse CSR matrix \f$op(A)\f$ and number of
-*                  rows of the sparse CSR matrix \f$op(B)\f$.
+*                  rows of the sparse CSR matrix \f$op(B)\f$. Must be non-negative.
 *  @param[in]
 *  descrA          descriptor of the sparse CSR matrix \f$A\f$. Currently, only
 *                  \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
 *  @param[in]
-*  nnzA            number of non-zero entries of the sparse CSR matrix \f$A\f$.
+*  nnzA            number of non-zero entries of the sparse CSR matrix \f$A\f$. Must be non-negative.
 *  @param[in]
 *  csrRowPtrA      array of \p m+1 elements (\f$op(A) == A\f$, \p k+1 otherwise)
 *                  that point to the start of every row of the sparse CSR matrix
@@ -85,7 +90,7 @@ extern "C" {
 *  descrB          descriptor of the sparse CSR matrix \f$B\f$. Currently, only
 *                  \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
 *  @param[in]
-*  nnzB            number of non-zero entries of the sparse CSR matrix \f$B\f$.
+*  nnzB            number of non-zero entries of the sparse CSR matrix \f$B\f$. Must be non-negative.
 *  @param[in]
 *  csrRowPtrB      array of \p k+1 elements (\f$op(B) == B\f$, \p m+1 otherwise)
 *                  that point to the start of every row of the sparse CSR matrix
@@ -104,13 +109,17 @@ extern "C" {
 *                     matrix \f$C\f$. \p nnzTotalDevHostPtr can be a host or device pointer.
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p k, \p nnzA, \p nnzB, \p nnzC,
-*          \p descrA, \p csrRowPtrA, \p csrColIndA, \p descrB, \p csrRowPtrB, \p csrColIndB,
-*          \p descrC, \p csrRowPtrC or \p nnzTotalDevHostPtr is invalid.
-*  \retval HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED
-*          \p transA != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE,
-*          \p transB != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE, or
-*          \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p descrB or \p descrC is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n, \p k, \p nnzA or \p nnzB is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrRowPtrA, \p csrColIndA, \p csrRowPtrB, 
+*          \p csrColIndB, \p csrRowPtrC or \p nnzTotalDevHostPtr is nullptr.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not 
+*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transB is not 
+*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
+*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 */
 DEPRECATED_CUDA_10000("The routine will be removed in CUDA 11")
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/extra/hipsparse_csrgemm.h
+++ b/projects/hipsparse/library/include/internal/extra/hipsparse_csrgemm.h
@@ -57,8 +57,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle          handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_axpby.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_axpby.h
@@ -85,8 +85,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p vecX, \p beta or \p vecY is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE the vector sizes or data types are incompatible.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p vecX, \p beta or \p vecY is nullptr,
+*          or the vector sizes or data types are incompatible.
 *
 *  \par Example
 *  \snippet example_hipsparse_axpby.cpp doc example

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_axpby.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_axpby.h
@@ -77,15 +77,16 @@ extern "C" {
 *  @param[in]
 *  alpha       scalar \f$\alpha\f$.
 *  @param[in]
-*  vecX        sparse matrix descriptor.
+*  vecX        sparse vector descriptor.
 *  @param[in]
 *  beta        scalar \f$\beta\f$.
 *  @param[inout]
-*  vecY        dense matrix descriptor.
+*  vecY        dense vector descriptor.
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p vecX, \p beta or \p vecY pointer is
-*          invalid.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p vecX, \p beta or \p vecY is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE the vector sizes or data types are incompatible.
 *
 *  \par Example
 *  \snippet example_hipsparse_axpby.cpp doc example

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_gather.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_gather.h
@@ -65,8 +65,10 @@ extern "C" {
 *  @param[out]
 *  vecX         sparse vector descriptor \f$x\f$.
 *
-*  \retval      HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval      HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX or \p vecY pointer is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX or \p vecY is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE the vector sizes or data types are incompatible.
 *
 *  \par Example
 *  \snippet example_hipsparse_gather.cpp doc example

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_gather.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_gather.h
@@ -67,8 +67,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX or \p vecY is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE the vector sizes or data types are incompatible.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX or \p vecY is nullptr,
+*          or the vector sizes or data types are incompatible.
 *
 *  \par Example
 *  \snippet example_hipsparse_gather.cpp doc example

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_rot.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_rot.h
@@ -62,6 +62,11 @@ extern "C" {
 *  <tr><td>HIP_C_64F
 *  </table>
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using alternative rotation APIs.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
@@ -73,9 +78,10 @@ extern "C" {
 *  @param[inout]
 *  vecY        dense vector descriptor \f$y\f$.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p c_coeff, \p s_coeff, \p vecX or \p vecY pointer is
-*              invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p c_coeff, \p s_coeff, \p vecX or \p vecY is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE the vector sizes or data types are incompatible.
 *
 *  \par Example
 *  \snippet example_hipsparse_rot.cpp doc example

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_rot.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_rot.h
@@ -64,8 +64,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
-*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using alternative rotation APIs.
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_rot.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_rot.h
@@ -80,8 +80,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p c_coeff, \p s_coeff, \p vecX or \p vecY is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE the vector sizes or data types are incompatible.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p c_coeff, \p s_coeff, \p vecX or \p vecY is nullptr,
+*          or the vector sizes or data types are incompatible.
 *
 *  \par Example
 *  \snippet example_hipsparse_rot.cpp doc example

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_scatter.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_scatter.h
@@ -67,8 +67,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX or \p vecY is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE the vector sizes or data types are incompatible.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX or \p vecY is nullptr,
+*          or the vector sizes or data types are incompatible.
 *
 *  \par Example
 *  \snippet example_hipsparse_scatter.cpp doc example

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_scatter.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_scatter.h
@@ -65,8 +65,10 @@ extern "C" {
 *  @param[out]
 *  vecY         dense vector descriptor \f$y\f$.
 *
-*  \retval      HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval      HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX or \p vecY pointer is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX or \p vecY is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE the vector sizes or data types are incompatible.
 *
 *  \par Example
 *  \snippet example_hipsparse_scatter.cpp doc example

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_sddmm.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_sddmm.h
@@ -65,10 +65,11 @@ extern "C" {
 *  pBufferSizeInBytes  number of bytes of the temporary storage buffer.
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p beta, \p A, \p B, \p D, \p C or
-*          \p pBufferSizeInBytes pointer is invalid or the value of \p opA or \p opB is incorrect
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED
-*          \p opA == \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE or
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p beta, \p A, \p B, \p C or
+*          \p pBufferSizeInBytes is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA or \p opB is invalid.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA == \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE or
 *          \p opB == \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_sddmm.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_sddmm.h
@@ -67,8 +67,7 @@ extern "C" {
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
 *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p beta, \p A, \p B, \p C or
-*          \p pBufferSizeInBytes is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA or \p opB is invalid.
+*          \p pBufferSizeInBytes is nullptr, or \p opA or \p opB is invalid.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA == \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE or
 *          \p opB == \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE.
 */

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spgemm.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spgemm.h
@@ -94,8 +94,7 @@ hipsparseStatus_t hipsparseSpGEMM_destroyDescr(hipsparseSpGEMMDescr_t descr);
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
 *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p beta, \p matA, \p matB, \p matC,
-*          \p spgemmDescr or \p bufferSize1 is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA or \p opB is invalid.
+*          \p spgemmDescr or \p bufferSize1 is nullptr, or \p opA or \p opB is invalid.
 *  \retval HIPSPARSE_STATUS_ALLOC_FAILED additional buffer for long rows could not be allocated.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE or
 *          \p opB != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spgemm.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spgemm.h
@@ -92,12 +92,12 @@ hipsparseStatus_t hipsparseSpGEMM_destroyDescr(hipsparseSpGEMMDescr_t descr);
 *  externalBuffer1  temporary storage buffer allocated by the user.
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p beta, \p matA, \p matB, \p matC
-*                                         or \p bufferSize1 pointer is invalid.
-*  \retval HIPSPARSE_STATUS_ALLOC_FAILED additional buffer for long rows could not be
-*          allocated.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED
-*          \p opA != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE or
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p beta, \p matA, \p matB, \p matC,
+*          \p spgemmDescr or \p bufferSize1 is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA or \p opB is invalid.
+*  \retval HIPSPARSE_STATUS_ALLOC_FAILED additional buffer for long rows could not be allocated.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE or
 *          \p opB != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
 *
 *  \par Example (See full example below)

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spmm.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spmm.h
@@ -67,8 +67,7 @@ extern "C" {
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
 *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p matB, \p matC, \p beta, or
-*          \p pBufferSizeInBytes is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA or \p opB is invalid.
+*          \p pBufferSizeInBytes is nullptr, or \p opA or \p opB is invalid.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA, \p opB, \p computeType or \p alg is currently not supported.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spmm.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spmm.h
@@ -50,13 +50,13 @@ extern "C" {
 *  @param[in]
 *  alpha               scalar \f$\alpha\f$.
 *  @param[in]
-*  matA                matrix descriptor.
+*  matA                sparse matrix descriptor.
 *  @param[in]
-*  matB                matrix descriptor.
+*  matB                dense matrix descriptor.
 *  @param[in]
 *  beta                scalar \f$\beta\f$.
 *  @param[in]
-*  matC                matrix descriptor.
+*  matC                dense matrix descriptor.
 *  @param[in]
 *  computeType         floating point precision for the SpMM computation.
 *  @param[in]
@@ -64,11 +64,12 @@ extern "C" {
 *  @param[out]
 *  pBufferSizeInBytes  number of bytes of the temporary storage buffer.
 *
-*  \retval      HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval      HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p matB, \p matC, \p beta, or
-*               \p pBufferSizeInBytes pointer is invalid.
-*  \retval      HIPSPARSE_STATUS_NOT_SUPPORTED \p opA, \p opB, \p computeType or \p alg is
-*               currently not supported.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p matB, \p matC, \p beta, or
+*          \p pBufferSizeInBytes is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA or \p opB is invalid.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA, \p opB, \p computeType or \p alg is currently not supported.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spmv.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spmv.h
@@ -48,13 +48,13 @@ extern "C" {
 *  @param[in]
 *  alpha               scalar \f$\alpha\f$.
 *  @param[in]
-*  matA                matrix descriptor.
+*  matA                sparse matrix descriptor.
 *  @param[in]
-*  vecX                vector descriptor.
+*  vecX                dense vector descriptor.
 *  @param[in]
 *  beta                scalar \f$\beta\f$.
 *  @param[inout]
-*  vecY                vector descriptor.
+*  vecY                dense vector descriptor.
 *  @param[in]
 *  computeType         floating point precision for the SpMV computation.
 *  @param[in]
@@ -62,11 +62,13 @@ extern "C" {
 *  @param[out]
 *  pBufferSizeInBytes  number of bytes of the temporary storage buffer.
 *
-*  \retval      HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval      HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p x, \p beta, \p y or
-*               \p pBufferSizeInBytes pointer is invalid or if \p opA, \p computeType, \p alg is incorrect.
-*  \retval      HIPSPARSE_STATUS_NOT_SUPPORTED \p computeType or \p alg is
-*               currently not supported.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p vecX, \p beta, 
+*          \p vecY or \p pBufferSizeInBytes is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE the matrix or vector dimensions are incompatible.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p computeType or \p alg is currently not supported.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spmv.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spmv.h
@@ -65,9 +65,8 @@ extern "C" {
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
 *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p vecX, \p beta, 
-*          \p vecY or \p pBufferSizeInBytes is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA is invalid.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE the matrix or vector dimensions are incompatible.
+*          \p vecY or \p pBufferSizeInBytes is nullptr, \p opA is invalid, or the matrix 
+*          or vector dimensions are incompatible.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p computeType or \p alg is currently not supported.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spsm.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spsm.h
@@ -83,11 +83,12 @@ hipsparseStatus_t hipsparseSpSM_destroyDescr(hipsparseSpSMDescr_t descr);
 *  @param[out]
 *  pBufferSizeInBytes  number of bytes of the temporary storage buffer.
 *
-*  \retval      HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval      HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p matB, \p matC, \p spsmDescr or
-*               \p pBufferSizeInBytes pointer is invalid.
-*  \retval      HIPSPARSE_STATUS_NOT_SUPPORTED \p opA, \p opB, \p computeType or \p alg is
-*               currently not supported.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p matB, \p matC, \p spsmDescr or
+*          \p pBufferSizeInBytes is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA or \p opB is invalid.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA, \p opB, \p computeType or \p alg is currently not supported.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spsm.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spsm.h
@@ -86,8 +86,7 @@ hipsparseStatus_t hipsparseSpSM_destroyDescr(hipsparseSpSMDescr_t descr);
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
 *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p matB, \p matC, \p spsmDescr or
-*          \p pBufferSizeInBytes is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA or \p opB is invalid.
+*          \p pBufferSizeInBytes is nullptr, or \p opA or \p opB is invalid.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA, \p opB, \p computeType or \p alg is currently not supported.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spsv.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spsv.h
@@ -84,8 +84,7 @@ hipsparseStatus_t hipsparseSpSV_destroyDescr(hipsparseSpSVDescr_t descr);
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
 *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p x, \p y, \p spsvDescr or
-*          \p pBufferSizeInBytes is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA is invalid.
+*          \p pBufferSizeInBytes is nullptr, or \p opA is invalid.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA, \p computeType or \p alg is currently not supported.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spsv.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spsv.h
@@ -67,11 +67,11 @@ hipsparseStatus_t hipsparseSpSV_destroyDescr(hipsparseSpSVDescr_t descr);
 *  @param[in]
 *  alpha               scalar \f$\alpha\f$.
 *  @param[in]
-*  matA                matrix descriptor.
+*  matA                sparse matrix descriptor.
 *  @param[in]
-*  x                   vector descriptor.
+*  x                   dense vector descriptor.
 *  @param[inout]
-*  y                   vector descriptor.
+*  y                   dense vector descriptor.
 *  @param[in]
 *  computeType         floating point precision for the SpSV computation.
 *  @param[in]
@@ -81,11 +81,12 @@ hipsparseStatus_t hipsparseSpSV_destroyDescr(hipsparseSpSVDescr_t descr);
 *  @param[out]
 *  pBufferSizeInBytes  number of bytes of the temporary storage buffer.
 *
-*  \retval      HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval      HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p x, \p y, \p spsvDescr or
-*               \p pBufferSizeInBytes pointer is invalid.
-*  \retval      HIPSPARSE_STATUS_NOT_SUPPORTED \p opA, \p computeType or \p alg is
-*               currently not supported.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha, \p matA, \p x, \p y, \p spsvDescr or
+*          \p pBufferSizeInBytes is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p opA is invalid.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p opA, \p computeType or \p alg is currently not supported.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spvv.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spvv.h
@@ -48,17 +48,17 @@ extern "C" {
 *  @param[in]
 *  vecY                dense vector descriptor.
 *  @param[out]
-*  result              pointer to the result, can be host or device memory
+*  result              pointer to the result, can be host or device memory.
 *  @param[in]
 *  computeType         floating point precision for the SpVV computation.
 *  @param[out]
 *  pBufferSizeInBytes  number of bytes of the temporary storage buffer.
 *
-*  \retval      HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval      HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX, \p vecY, \p result or \p pBufferSizeInBytes
-*               pointer is invalid.
-*  \retval      HIPSPARSE_STATUS_NOT_SUPPORTED \p computeType is currently not
-*               supported.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p vecX, \p vecY, \p result or 
+*          \p pBufferSizeInBytes is nullptr.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p computeType is currently not supported.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 12000)
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_axpyi.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_axpyi.h
@@ -81,12 +81,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p alpha, \p xVal, \p xInd or \p y is nullptr 
-*          when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
-*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p nnz is negative, 
+*          \p alpha, \p xVal, \p xInd or \p y is nullptr when \p nnz is greater than zero, 
+*          or \p idxBase is neither \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_axpyi.cpp doc example

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_axpyi.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_axpyi.h
@@ -58,8 +58,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_axpyi.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_axpyi.h
@@ -51,25 +51,42 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
-
+*  \note
+*  If \p nnz is zero, the function returns successfully without modifying \p y.
+*  Duplicate indices in \p xInd will result in the corresponding values being added
+*  multiple times to the same location in \p y.
+*
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  nnz         number of non-zero entries of vector \f$x\f$.
+*  nnz         number of non-zero entries of vector \f$x\f$. Must be non-negative.
 *  @param[in]
 *  alpha       scalar \f$\alpha\f$.
 *  @param[in]
-*  xVal       array of \p nnz elements containing the values of \f$x\f$.
+*  xVal        array of \p nnz elements containing the values of \f$x\f$.
 *  @param[in]
-*  xInd       array of \p nnz elements containing the indices of the non-zero
+*  xInd        array of \p nnz elements containing the indices of the non-zero
 *              values of \f$x\f$.
 *  @param[inout]
-*  y           array of values in dense format.
+*  y           array of values in dense format. Must be pre-allocated with sufficient
+*              size to accommodate all indices specified in \p xInd.
 *  @param[in]
-*  idxBase    \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase     index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*              \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p idxBase, \p nnz, \p alpha, \p xVal, \p xInd or \p y is invalid.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p alpha, \p xVal, \p xInd or \p y is nullptr 
+*          when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_axpyi.cpp doc example

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_dotci.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_dotci.h
@@ -52,25 +52,40 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \note
+*  If \p nnz is zero, the function returns successfully with result set to zero.
+*
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  nnz         number of non-zero entries of vector \f$x\f$.
+*  nnz         number of non-zero entries of vector \f$x\f$. Must be non-negative.
 *  @param[in]
-*  xVal       array of \p nnz values.
+*  xVal        array of \p nnz values containing the elements of \f$x\f$.
 *  @param[in]
-*  xInd       array of \p nnz elements containing the indices of the non-zero
+*  xInd        array of \p nnz elements containing the indices of the non-zero
 *              values of \f$x\f$.
 *  @param[in]
-*  y           array of values in dense format.
+*  y           array of values in dense format. Must be pre-allocated with sufficient
+*              size to accommodate all indices specified in \p xInd.
 *  @param[out]
-*  result      pointer to the result, can be host or device memory
+*  result      pointer to the result, can be host or device memory.
 *  @param[in]
-*  idxBase    \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase     index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*              \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p idxBase, \p nnz, \p xVal,
-*          \p xInd, \p y or \p result is invalid.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p result is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p xVal, \p xInd or \p y is nullptr 
+*          when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *  \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer for the dot product reduction
 *          could not be allocated.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_dotci.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_dotci.h
@@ -57,8 +57,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_dotci.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_dotci.h
@@ -80,12 +80,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p result is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p xVal, \p xInd or \p y is nullptr 
-*          when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
-*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p result is nullptr, \p nnz is negative,
+*          \p xVal, \p xInd or \p y is nullptr when \p nnz is greater than zero, or \p idxBase 
+*          is neither \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *  \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer for the dot product reduction
 *          could not be allocated.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_doti.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_doti.h
@@ -79,12 +79,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p result is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p xVal, \p xInd or \p y is nullptr 
-*          when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
-*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p result is nullptr, \p nnz is negative,
+*          \p xVal, \p xInd or \p y is nullptr when \p nnz is greater than zero, or \p idxBase 
+*          is neither \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *  \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer for the dot product reduction
 *          could not be allocated.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_doti.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_doti.h
@@ -51,25 +51,40 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \note
+*  If \p nnz is zero, the function returns successfully with result set to zero.
+*
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  nnz         number of non-zero entries of vector \f$x\f$.
+*  nnz         number of non-zero entries of vector \f$x\f$. Must be non-negative.
 *  @param[in]
-*  xVal       array of \p nnz values.
+*  xVal        array of \p nnz values containing the elements of \f$x\f$.
 *  @param[in]
-*  xInd       array of \p nnz elements containing the indices of the non-zero
+*  xInd        array of \p nnz elements containing the indices of the non-zero
 *              values of \f$x\f$.
 *  @param[in]
-*  y           array of values in dense format.
+*  y           array of values in dense format. Must be pre-allocated with sufficient
+*              size to accommodate all indices specified in \p xInd.
 *  @param[out]
-*  result      pointer to the result, can be host or device memory
+*  result      pointer to the result, can be host or device memory.
 *  @param[in]
-*  idxBase    \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase     index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*              \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p idxBase, \p nnz, \p xVal,
-*          \p xInd, \p y or \p result is invalid.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle or \p result is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p xVal, \p xInd or \p y is nullptr 
+*          when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *  \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer for the dot product reduction
 *          could not be allocated.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_doti.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_doti.h
@@ -56,8 +56,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_gthr.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_gthr.h
@@ -73,12 +73,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p y, \p xVal or \p xInd is nullptr 
-*          when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
-*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p nnz is negative,
+*          \p y, \p xVal or \p xInd is nullptr when \p nnz is greater than zero, or \p idxBase 
+*          is neither \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_gthr.cpp doc example

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_gthr.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_gthr.h
@@ -52,8 +52,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_gthr.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_gthr.h
@@ -47,23 +47,38 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \note
+*  If \p nnz is zero, the function returns successfully without modifying \p xVal.
+*
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  nnz         number of non-zero entries of \f$x\f$.
+*  nnz         number of non-zero entries of \f$x\f$. Must be non-negative.
 *  @param[in]
-*  y           array of values in dense format.
+*  y           array of values in dense format. Must be pre-allocated with sufficient
+*              size to accommodate all indices specified in \p xInd.
 *  @param[out]
-*  xVal       array of \p nnz elements containing the values of \f$x\f$.
+*  xVal        array of \p nnz elements that will contain the gathered values of \f$x\f$.
 *  @param[in]
-*  xInd       array of \p nnz elements containing the indices of the non-zero
+*  xInd        array of \p nnz elements containing the indices of the non-zero
 *              values of \f$x\f$.
 *  @param[in]
-*  idxBase    \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase     index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*              \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p idxBase, \p nnz, \p y, \p xVal or \p xInd is
-*              invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p y, \p xVal or \p xInd is nullptr 
+*          when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_gthr.cpp doc example

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_gthrz.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_gthrz.h
@@ -77,12 +77,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p y, \p xVal or \p xInd is nullptr 
-*          when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
-*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p nnz is negative,
+*          \p y, \p xVal or \p xInd is nullptr when \p nnz is greater than zero, or \p idxBase 
+*          is neither \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 */
 /**@{*/
 DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_gthrz.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_gthrz.h
@@ -50,23 +50,39 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \note
+*  If \p nnz is zero, the function returns successfully without modifying \p xVal or \p y.
+*
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  nnz         number of non-zero entries of \f$x\f$.
+*  nnz         number of non-zero entries of \f$x\f$. Must be non-negative.
 *  @param[inout]
-*  y           array of values in dense format.
+*  y           array of values in dense format. Must be pre-allocated with sufficient
+*              size to accommodate all indices specified in \p xInd. Gathered elements
+*              are set to zero.
 *  @param[out]
-*  xVal       array of \p nnz elements containing the non-zero values of \f$x\f$.
+*  xVal        array of \p nnz elements that will contain the gathered values of \f$x\f$.
 *  @param[in]
-*  xInd       array of \p nnz elements containing the indices of the non-zero
+*  xInd        array of \p nnz elements containing the indices of the non-zero
 *              values of \f$x\f$.
 *  @param[in]
-*  idxBase    \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase     index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*              \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p idxBase, \p nnz, \p y, \p xVal
-*              or \p xInd is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p y, \p xVal or \p xInd is nullptr 
+*          when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 */
 /**@{*/
 DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_gthrz.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_gthrz.h
@@ -55,8 +55,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_roti.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_roti.h
@@ -54,27 +54,42 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \note
+*  If \p nnz is zero, the function returns successfully without modifying \p xVal or \p y.
+*
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  nnz         number of non-zero entries of \f$x\f$.
+*  nnz         number of non-zero entries of \f$x\f$. Must be non-negative.
 *  @param[inout]
-*  xVal       array of \p nnz elements containing the non-zero values of \f$x\f$.
+*  xVal        array of \p nnz elements containing the non-zero values of \f$x\f$.
 *  @param[in]
-*  xInd       array of \p nnz elements containing the indices of the non-zero
+*  xInd        array of \p nnz elements containing the indices of the non-zero
 *              values of \f$x\f$.
 *  @param[inout]
-*  y           array of values in dense format.
+*  y           array of values in dense format. Must be pre-allocated with sufficient
+*              size to accommodate all indices specified in \p xInd.
 *  @param[in]
 *  c           pointer to the cosine element of \f$G\f$, can be on host or device.
 *  @param[in]
 *  s           pointer to the sine element of \f$G\f$, can be on host or device.
 *  @param[in]
-*  idxBase    \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase     index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*              \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p idxBase, \p nnz, \p c, \p s, \p xVal, \p xInd
-*              or \p y is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p c or \p s is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p xVal, \p xInd or \p y is nullptr 
+*          when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_roti.cpp doc example

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_roti.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_roti.h
@@ -84,12 +84,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p c or \p s is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p xVal, \p xInd or \p y is nullptr 
-*          when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
-*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p c or \p s is nullptr, \p nnz is negative,
+*          \p xVal, \p xInd or \p y is nullptr when \p nnz is greater than zero, or \p idxBase 
+*          is neither \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_roti.cpp doc example

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_roti.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_roti.h
@@ -59,8 +59,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_sctr.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_sctr.h
@@ -54,8 +54,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_sctr.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_sctr.h
@@ -75,12 +75,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p xVal, \p xInd or \p y is nullptr 
-*          when \p nnz is greater than zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
-*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr, \p nnz is negative,
+*          \p xVal, \p xInd or \p y is nullptr when \p nnz is greater than zero, or \p idxBase 
+*          is neither \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_sctr.cpp doc example

--- a/projects/hipsparse/library/include/internal/level1/hipsparse_sctr.h
+++ b/projects/hipsparse/library/include/internal/level1/hipsparse_sctr.h
@@ -48,23 +48,39 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \note
+*  If \p nnz is zero, the function returns successfully without modifying \p y.
+*  Duplicate indices in \p xInd will result in the last value being written to \p y.
+*
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  nnz         number of non-zero entries of \f$x\f$.
+*  nnz         number of non-zero entries of \f$x\f$. Must be non-negative.
 *  @param[in]
-*  xVal       array of \p nnz elements containing the non-zero values of \f$x\f$.
+*  xVal        array of \p nnz elements containing the non-zero values of \f$x\f$.
 *  @param[in]
-*  xInd       array of \p nnz elements containing the indices of the non-zero
-*              values of x.
+*  xInd        array of \p nnz elements containing the indices of the non-zero
+*              values of \f$x\f$.
 *  @param[inout]
-*  y           array of values in dense format.
+*  y           array of values in dense format. Must be pre-allocated with sufficient
+*              size to accommodate all indices specified in \p xInd.
 *  @param[in]
-*  idxBase    \ref HIPSPARSE_INDEX_BASE_ZERO or \ref HIPSPARSE_INDEX_BASE_ONE.
+*  idxBase     index base. \ref HIPSPARSE_INDEX_BASE_ZERO for zero-based indexing or
+*              \ref HIPSPARSE_INDEX_BASE_ONE for one-based indexing.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p idxBase, \p nnz, \p xVal, \p xInd
-*              or \p y is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p xVal, \p xInd or \p y is nullptr 
+*          when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p idxBase is neither 
+*          \ref HIPSPARSE_INDEX_BASE_ZERO nor \ref HIPSPARSE_INDEX_BASE_ONE.
 *
 *  \par Example
 *  \snippet example_hipsparse_sctr.cpp doc example

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_bsrmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_bsrmv.h
@@ -56,49 +56,53 @@ extern "C" {
 *  Currently, only \p transA == \ref HIPSPARSE_OPERATION_NON_TRANSPOSE is supported.
 *
 *  @param[in]
-*  handle      handle to the hipsparse library context queue.
+*  handle          handle to the hipsparse library context queue.
 *  @param[in]
-*  dirA        matrix storage of BSR blocks.
+*  dirA            matrix storage of BSR blocks.
 *  @param[in]
-*  transA      matrix operation type.
+*  transA          matrix operation type.
 *  @param[in]
-*  mb          number of block rows of the sparse BSR matrix.
+*  mb              number of block rows of the sparse BSR matrix. Must be non-negative.
 *  @param[in]
-*  nb          number of block columns of the sparse BSR matrix.
+*  nb              number of block columns of the sparse BSR matrix. Must be non-negative.
 *  @param[in]
-*  nnzb        number of non-zero blocks of the sparse BSR matrix.
+*  nnzb            number of non-zero blocks of the sparse BSR matrix. Must be non-negative.
 *  @param[in]
-*  alpha       scalar \f$\alpha\f$.
+*  alpha           scalar \f$\alpha\f$.
 *  @param[in]
-*  descrA      descriptor of the sparse BSR matrix. Currently, only
-*              \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
+*  descrA          descriptor of the sparse BSR matrix. Currently, only
+*                  \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
 *  @param[in]
-*  bsrSortedValA array of \p nnzb blocks of the sparse BSR matrix.
+*  bsrSortedValA   array of \p nnzb blocks of the sparse BSR matrix.
 *  @param[in]
 *  bsrSortedRowPtrA array of \p mb+1 elements that point to the start of every block row of
-*              the sparse BSR matrix.
+*                  the sparse BSR matrix.
 *  @param[in]
 *  bsrSortedColIndA array of \p nnzb elements containing the block column indices of the sparse
-*              BSR matrix.
+*                  BSR matrix.
 *  @param[in]
-*  blockDim     block dimension of the sparse BSR matrix.
+*  blockDim        block dimension of the sparse BSR matrix. Must be positive.
 *  @param[in]
-*  x           array of \p nb*blockDim elements (\f$op(A) = A\f$) or \p mb*blockDim
-*              elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
+*  x               array of \p nb*blockDim elements (\f$op(A) = A\f$) or \p mb*blockDim
+*                  elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
 *  @param[in]
-*  beta        scalar \f$\beta\f$.
+*  beta            scalar \f$\beta\f$.
 *  @param[inout]
-*  y           array of \p mb*blockDim elements (\f$op(A) = A\f$) or \p nb*blockDim
-*              elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
+*  y               array of \p mb*blockDim elements (\f$op(A) = A\f$) or \p nb*blockDim
+*                  elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nb, \p nnzb,
-*              \p blockDim, \p descr, \p alpha, \p bsrSortedValA, \p bsrSortedRowPtrA,
-*              \p bsrSortedColIndA, \p x, \p beta or \p y is invalid.
-*  \retval     HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
-*  \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
-*              \p trans != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE or
-*              \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb, \p nb or \p nnzb is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is less than or equal to zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p bsrSortedValA, \p bsrSortedRowPtrA, 
+*          \p bsrSortedColIndA, \p x or \p y is nullptr.
+*  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not 
+*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
+*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 *
 *  \par Example
 *  \snippet example_hipsparse_bsrmv.cpp doc example

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_bsrmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_bsrmv.h
@@ -93,16 +93,12 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb, \p nb or \p nnzb is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is less than or equal to zero.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p bsrSortedValA, \p bsrSortedRowPtrA, 
-*          \p bsrSortedColIndA, \p x or \p y is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr,
+*          \p mb, \p nb or \p nnzb is negative, \p blockDim is less than or equal to zero, or
+*          \p bsrSortedValA, \p bsrSortedRowPtrA, \p bsrSortedColIndA, \p x or \p y is nullptr.
 *  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not 
-*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
-*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not \ref HIPSPARSE_OPERATION_NON_TRANSPOSE,
+*          or \ref hipsparseMatrixType_t is not \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 *
 *  \par Example
 *  \snippet example_hipsparse_bsrmv.cpp doc example

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_bsrsv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_bsrsv.h
@@ -43,6 +43,11 @@ extern "C" {
 *  \note \p hipsparseXbsrsv2_zeroPivot is a blocking function. It might influence
 *  performance negatively.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
@@ -50,11 +55,11 @@ extern "C" {
 *  @param[inout]
 *  position    pointer to zero pivot \f$j\f$, can be in host or device memory.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is
-*              invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval     HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is nullptr.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
 */
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_bsrsv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_bsrsv.h
@@ -45,8 +45,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
-*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_bsrxmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_bsrxmv.h
@@ -115,17 +115,13 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p alpha or \p beta is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb, \p nb, \p nnzb or \p sizeOfMask is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p sizeOfMask is greater than \p mb.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is less than or equal to 1.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p bsrVal, \p bsrMaskPtr, \p bsrRowPtr, 
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p alpha or \p beta is nullptr,
+*          \p mb, \p nb, \p nnzb or \p sizeOfMask is negative, \p sizeOfMask is greater than \p mb,
+*          \p blockDim is less than or equal to 1, or \p bsrVal, \p bsrMaskPtr, \p bsrRowPtr,
 *          \p bsrEndPtr, \p bsrColInd, \p x or \p y is nullptr.
 *  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p trans is not 
-*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
-*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p trans is not \ref HIPSPARSE_OPERATION_NON_TRANSPOSE,
+*          or \ref hipsparseMatrixType_t is not \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 */
 /**@{*/
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_bsrxmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_bsrxmv.h
@@ -64,6 +64,11 @@ extern "C" {
 *  Currently, only \p trans == \ref HIPSPARSE_OPERATION_NON_TRANSPOSE is supported.
 *  Currently, \p blockDim == 1 is not supported.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
@@ -71,13 +76,14 @@ extern "C" {
 *  @param[in]
 *  trans       matrix operation type.
 *  @param[in]
-*  sizeOfMask  number of updated block rows of the array \p y.
+*  sizeOfMask  number of updated block rows of the array \p y. Must be non-negative and
+*              not greater than \p mb.
 *  @param[in]
-*  mb          number of block rows of the sparse BSR matrix.
+*  mb          number of block rows of the sparse BSR matrix. Must be non-negative.
 *  @param[in]
-*  nb          number of block columns of the sparse BSR matrix.
+*  nb          number of block columns of the sparse BSR matrix. Must be non-negative.
 *  @param[in]
-*  nnzb        number of non-zero blocks of the sparse BSR matrix.
+*  nnzb        number of non-zero blocks of the sparse BSR matrix. Must be non-negative.
 *  @param[in]
 *  alpha       scalar \f$\alpha\f$.
 *  @param[in]
@@ -85,10 +91,8 @@ extern "C" {
 *              \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
 *  @param[in]
 *  bsrVal      array of \p nnzb blocks of the sparse BSR matrix.
-*
 *  @param[in]
 *  bsrMaskPtr  array of \p sizeOfMask elements that give the indices of the updated block rows.
-*
 *  @param[in]
 *  bsrRowPtr   array of \p mb elements that point to the start of every block row of
 *              the sparse BSR matrix.
@@ -99,7 +103,7 @@ extern "C" {
 *  bsrColInd   array of \p nnzb elements containing the block column indices of the sparse
 *              BSR matrix.
 *  @param[in]
-*  blockDim    block dimension of the sparse BSR matrix.
+*  blockDim    block dimension of the sparse BSR matrix. Must be greater than 1.
 *  @param[in]
 *  x           array of \p nb*blockDim elements (\f$op(A) = A\f$) or \p mb*blockDim
 *              elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
@@ -109,15 +113,19 @@ extern "C" {
 *  y           array of \p mb*blockDim elements (\f$op(A) = A\f$) or \p nb*blockDim
 *              elements (\f$op(A) = A^T\f$ or \f$op(A) = A^H\f$).
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nb, \p nnzb, \p blockDim,
-*              \p sizeOfMask, \p descr, \p alpha, \p bsrVal, \p bsrRowPtr, \p bsrEndPtr,
-*              \p bsrColInd, \p x, \p beta or \p y is invalid or if \p sizeOfMask is greater
-*              than \p mb.
-*  \retval     HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
-*  \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
-*              \p blockDim==1, \p trans != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE or
-*              \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descr, \p alpha or \p beta is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb, \p nb, \p nnzb or \p sizeOfMask is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p sizeOfMask is greater than \p mb.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is less than or equal to 1.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p bsrVal, \p bsrMaskPtr, \p bsrRowPtr, 
+*          \p bsrEndPtr, \p bsrColInd, \p x or \p y is nullptr.
+*  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p trans is not 
+*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
+*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 */
 /**@{*/
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_bsrxmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_bsrxmv.h
@@ -66,8 +66,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
-*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_csrmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_csrmv.h
@@ -109,9 +109,8 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n or \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrSortedValA, \p csrSortedRowPtrA, 
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr,
+*          \p m, \p n or \p nnz is negative, or \p csrSortedValA, \p csrSortedRowPtrA,
 *          \p csrSortedColIndA, \p x or \p y is nullptr.
 *  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_csrmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_csrmv.h
@@ -72,8 +72,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle              handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_csrmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_csrmv.h
@@ -70,45 +70,52 @@ extern "C" {
 *  \note
 *  Currently, only \p transA == \ref HIPSPARSE_OPERATION_NON_TRANSPOSE is supported.
 *
-*  @param[in]
-*  handle      handle to the hipsparse library context queue.
-*  @param[in]
-*  transA      matrix operation type.
-*  @param[in]
-*  m           number of rows of the sparse CSR matrix.
-*  @param[in]
-*  n           number of columns of the sparse CSR matrix.
-*  @param[in]
-*  nnz         number of non-zero entries of the sparse CSR matrix.
-*  @param[in]
-*  alpha       scalar \f$\alpha\f$.
-*  @param[in]
-*  descrA      descriptor of the sparse CSR matrix. Currently, only
-*              \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
-*  @param[in]
-*  csrSortedValA array of \p nnz elements of the sparse CSR matrix.
-*  @param[in]
-*  csrSortedRowPtrA array of \p m+1 elements that point to the start
-*              of every row of the sparse CSR matrix.
-*  @param[in]
-*  csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
-*              CSR matrix.
-*  @param[in]
-*  x           array of \p n elements (\f$op(A) == A\f$) or \p m elements
-*              (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
-*  @param[in]
-*  beta        scalar \f$\beta\f$.
-*  @param[inout]
-*  y           array of \p m elements (\f$op(A) == A\f$) or \p n elements
-*              (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n or \p nnz, \p descr,
-*              \p alpha, \p csrSortedValA, \p csrSortedRowPtrA, \p csrSortedColIndA, \p x,
-*              \p beta or \p y is invalid.
-*  \retval     HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
-*  \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
-*              \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  @param[in]
+*  handle              handle to the hipsparse library context queue.
+*  @param[in]
+*  transA              matrix operation type.
+*  @param[in]
+*  m                   number of rows of the sparse CSR matrix. Must be non-negative.
+*  @param[in]
+*  n                   number of columns of the sparse CSR matrix. Must be non-negative.
+*  @param[in]
+*  nnz                 number of non-zero entries of the sparse CSR matrix. Must be non-negative.
+*  @param[in]
+*  alpha               scalar \f$\alpha\f$.
+*  @param[in]
+*  descrA              descriptor of the sparse CSR matrix. Currently, only
+*                      \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
+*  @param[in]
+*  csrSortedValA       array of \p nnz elements of the sparse CSR matrix.
+*  @param[in]
+*  csrSortedRowPtrA    array of \p m+1 elements that point to the start
+*                      of every row of the sparse CSR matrix.
+*  @param[in]
+*  csrSortedColIndA    array of \p nnz elements containing the column indices of the sparse
+*                      CSR matrix.
+*  @param[in]
+*  x                   array of \p n elements (\f$op(A) == A\f$) or \p m elements
+*                      (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
+*  @param[in]
+*  beta                scalar \f$\beta\f$.
+*  @param[inout]
+*  y                   array of \p m elements (\f$op(A) == A\f$) or \p n elements
+*                      (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
+*
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n or \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrSortedValA, \p csrSortedRowPtrA, 
+*          \p csrSortedColIndA, \p x or \p y is nullptr.
+*  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
+*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 *
 *  \par Example
 *  \snippet example_hipsparse_csrmv.cpp doc example

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_csrsv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_csrsv.h
@@ -43,6 +43,11 @@ extern "C" {
 *  \note \p hipsparseXcsrsv2_zeroPivot is a blocking function. It might influence
 *  performance negatively.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
@@ -50,10 +55,11 @@ extern "C" {
 *  @param[inout]
 *  position    pointer to zero pivot \f$j\f$, can be in host or device memory.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle \p info or \p position is invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval     HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is nullptr.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
 */
 DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_csrsv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_csrsv.h
@@ -45,8 +45,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_hybmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_hybmv.h
@@ -83,15 +83,13 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha, \p beta or \p hybA is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p x or \p y is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha, \p beta or \p hybA is nullptr,
+*          or \p x or \p y is nullptr.
 *  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
 *  \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer could not be allocated.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not 
-*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
-*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
-*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not \ref HIPSPARSE_OPERATION_NON_TRANSPOSE,
+*          or \ref hipsparseMatrixType_t is not \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 *
 *  \par Example
 *  \snippet example_hipsparse_hybmv.cpp doc example

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_hybmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_hybmv.h
@@ -56,6 +56,11 @@ extern "C" {
 *  \note
 *  Currently, only \p transA == \ref HIPSPARSE_OPERATION_NON_TRANSPOSE is supported.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
@@ -76,15 +81,17 @@ extern "C" {
 *  y           array of \p m elements (\f$op(A) == A\f$) or \p n elements
 *              (\f$op(A) == A^T\f$ or \f$op(A) == A^H\f$).
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha,
-*              \p hybA, \p x, \p beta or \p y is invalid.
-*  \retval     HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
-*  \retval     HIPSPARSE_STATUS_ALLOC_FAILED the buffer could not be allocated.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
-*              \p transA != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE or
-*              \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha, \p beta or \p hybA is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p x or \p y is nullptr.
+*  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
+*  \retval HIPSPARSE_STATUS_ALLOC_FAILED the buffer could not be allocated.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not 
+*          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
+*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 *
 *  \par Example
 *  \snippet example_hipsparse_hybmv.cpp doc example

--- a/projects/hipsparse/library/include/internal/level2/hipsparse_hybmv.h
+++ b/projects/hipsparse/library/include/internal/level2/hipsparse_hybmv.h
@@ -58,8 +58,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_bsrmm.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_bsrmm.h
@@ -75,13 +75,13 @@ extern "C" {
  *  transB      matrix \f$B\f$ operation type. Currently, only \ref HIPSPARSE_OPERATION_NON_TRANSPOSE and \ref HIPSPARSE_OPERATION_TRANSPOSE
  *              are supported.
  *  @param[in]
- *  mb          number of block rows of the sparse BSR matrix \f$A\f$.
+ *  mb          number of block rows of the sparse BSR matrix \f$A\f$. Must be non-negative.
  *  @param[in]
- *  n           number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$.
+ *  n           number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$. Must be non-negative.
  *  @param[in]
- *  kb          number of block columns of the sparse BSR matrix \f$A\f$.
+ *  kb          number of block columns of the sparse BSR matrix \f$A\f$. Must be non-negative.
  *  @param[in]
- *  nnzb        number of non-zero blocks of the sparse BSR matrix \f$A\f$.
+ *  nnzb        number of non-zero blocks of the sparse BSR matrix \f$A\f$. Must be non-negative.
  *  @param[in]
  *  alpha       scalar \f$\alpha\f$.
  *  @param[in]
@@ -96,7 +96,7 @@ extern "C" {
  *  bsrColIndA  array of \p nnzb elements containing the block column indices of the sparse
  *              BSR matrix \f$A\f$.
  *  @param[in]
- *  blockDim    size of the blocks in the sparse BSR matrix.
+ *  blockDim    size of the blocks in the sparse BSR matrix. Must be positive.
  *  @param[in]
  *  B           array of dimension \p ldb*n (\f$op(B) == B\f$),
  *              \p ldb*k otherwise.
@@ -111,15 +111,21 @@ extern "C" {
  *  ldc         leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$ (\f$ op(A) == A\f$) where \p m=blockDim*mb,
  *              \f$\max{(1, k)}\f$ where \p k=blockDim*kb otherwise.
  *
- *  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
- *  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p n, \p kb, \p nnzb, \p ldb,
- *              \p ldc, \p descr, \p alpha, \p bsrValA, \p bsrRowPtrA, \p bsrColIndA,
- *              \p B, \p beta or \p C is invalid.
- *  \retval     HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
- *  \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
- *              \p transA != \ref HIPSPARSE_OPERATION_NON_TRANSPOSE or
- *              \p transB == \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE or
- *              \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+ *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+ *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb, \p n, \p kb or \p nnzb is negative.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ldb or \p ldc is invalid.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is less than or equal to zero.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p bsrValA, \p bsrRowPtrA, \p bsrColIndA, 
+ *          \p B or \p C is nullptr.
+ *  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
+ *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not 
+ *          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
+ *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transB is 
+ *          \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE.
+ *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
+ *          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
  *
  *  \par Example
  *  \snippet example_hipsparse_bsrmm.cpp doc example

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_bsrmm.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_bsrmm.h
@@ -113,19 +113,14 @@ extern "C" {
  *
  *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
  *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
- *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr.
- *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb, \p n, \p kb or \p nnzb is negative.
- *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ldb or \p ldc is invalid.
- *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is less than or equal to zero.
- *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p bsrValA, \p bsrRowPtrA, \p bsrColIndA, 
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr,
+ *          \p mb, \p n, \p kb or \p nnzb is negative, \p ldb or \p ldc is invalid,
+ *          \p blockDim is less than or equal to zero, or \p bsrValA, \p bsrRowPtrA, \p bsrColIndA,
  *          \p B or \p C is nullptr.
  *  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
- *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not 
- *          \ref HIPSPARSE_OPERATION_NON_TRANSPOSE.
- *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transB is 
- *          \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE.
- *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
- *          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+ *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \p transA is not \ref HIPSPARSE_OPERATION_NON_TRANSPOSE,
+ *          \p transB is \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE, or
+ *          \ref hipsparseMatrixType_t is not \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
  *
  *  \par Example
  *  \snippet example_hipsparse_bsrmm.cpp doc example

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_bsrsm.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_bsrsm.h
@@ -42,6 +42,11 @@ extern "C" {
 *  \note \p hipsparseXbsrsm2_zeroPivot is a blocking function. It might influence
 *  performance negatively.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
@@ -49,11 +54,11 @@ extern "C" {
 *  @param[inout]
 *  position    pointer to zero pivot \f$j\f$, can be in host or device memory.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is
-*              invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval     HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is nullptr.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
 */
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_bsrsm.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_bsrsm.h
@@ -44,8 +44,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
-*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_csrmm.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_csrmm.h
@@ -66,56 +66,64 @@ extern "C" {
 *      }
 *  \endcode
 *
-*  \note
+ *  \note
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
-*  @param[in]
-*  handle      handle to the hipsparse library context queue.
-*  @param[in]
-*  transA      matrix \f$A\f$ operation type.
-*  @param[in]
-*  m           number of rows of the sparse CSR matrix \f$A\f$.
-*  @param[in]
-*  n           number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$.
-*  @param[in]
-*  k           number of columns of the sparse CSR matrix \f$A\f$.
-*  @param[in]
-*  nnz         number of non-zero entries of the sparse CSR matrix \f$A\f$.
-*  @param[in]
-*  alpha       scalar \f$\alpha\f$.
-*  @param[in]
-*  descrA      descriptor of the sparse CSR matrix \f$A\f$. Currently, only
-*              \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
-*  @param[in]
-*  csrSortedValA array of \p nnz elements of the sparse CSR matrix \f$A\f$.
-*  @param[in]
-*  csrSortedRowPtrA array of \p m+1 elements that point to the start of every row of the
-*              sparse CSR matrix \f$A\f$.
-*  @param[in]
-*  csrSortedColIndA array of \p nnz elements containing the column indices of the sparse
-*              CSR matrix \f$A\f$.
-*  @param[in]
-*  B           array of dimension \p ldb*n (\f$op(B) == B\f$),
-*              \p ldb*k otherwise.
-*  @param[in]
-*  ldb         leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$
-*              (\f$op(B) == B\f$), \f$\max{(1, n)}\f$ otherwise.
-*  @param[in]
-*  beta        scalar \f$\beta\f$.
-*  @param[inout]
-*  C           array of dimension \p ldc*n.
-*  @param[in]
-*  ldc         leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$
-*              (\f$op(A) == A\f$), \f$\max{(1, k)}\f$ otherwise.
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p k, \p nnz, \p ldb, \p ldc
-*              \p descrA, \p alpha, \p csrSortedValA, \p csrSortedRowPtrA, \p csrSortedColIndA,
-*              \p B, \p beta or \p C is invalid.
-*  \retval     HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
-*  \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
-*              \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+*  @param[in]
+*  handle              handle to the hipsparse library context queue.
+*  @param[in]
+*  transA              matrix \f$A\f$ operation type.
+*  @param[in]
+*  m                   number of rows of the sparse CSR matrix \f$A\f$. Must be non-negative.
+*  @param[in]
+*  n                   number of columns of the dense matrix \f$op(B)\f$ and \f$C\f$. Must be non-negative.
+*  @param[in]
+*  k                   number of columns of the sparse CSR matrix \f$A\f$. Must be non-negative.
+*  @param[in]
+*  nnz                 number of non-zero entries of the sparse CSR matrix \f$A\f$. Must be non-negative.
+*  @param[in]
+*  alpha               scalar \f$\alpha\f$.
+*  @param[in]
+*  descrA              descriptor of the sparse CSR matrix \f$A\f$. Currently, only
+*                      \ref HIPSPARSE_MATRIX_TYPE_GENERAL is supported.
+*  @param[in]
+*  csrSortedValA       array of \p nnz elements of the sparse CSR matrix \f$A\f$.
+*  @param[in]
+*  csrSortedRowPtrA    array of \p m+1 elements that point to the start of every row of the
+*                      sparse CSR matrix \f$A\f$.
+*  @param[in]
+*  csrSortedColIndA    array of \p nnz elements containing the column indices of the sparse
+*                      CSR matrix \f$A\f$.
+*  @param[in]
+*  B                   array of dimension \p ldb*n (\f$op(B) == B\f$),
+*                      \p ldb*k otherwise.
+*  @param[in]
+*  ldb                 leading dimension of \f$B\f$, must be at least \f$\max{(1, k)}\f$
+*                      (\f$op(B) == B\f$), \f$\max{(1, n)}\f$ otherwise.
+*  @param[in]
+*  beta                scalar \f$\beta\f$.
+*  @param[inout]
+*  C                   array of dimension \p ldc*n.
+*  @param[in]
+*  ldc                 leading dimension of \f$C\f$, must be at least \f$\max{(1, m)}\f$
+*                      (\f$op(A) == A\f$), \f$\max{(1, k)}\f$ otherwise.
+*
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n, \p k or \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ldb or \p ldc is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrSortedValA, \p csrSortedRowPtrA, 
+*          \p csrSortedColIndA, \p B or \p C is nullptr.
+*  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
+*  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
+*          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
 *
 *  \par Example
 *  \snippet example_hipsparse_csrmm.cpp doc example

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_csrmm.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_csrmm.h
@@ -116,11 +116,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n, \p k or \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ldb or \p ldc is invalid.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrSortedValA, \p csrSortedRowPtrA, 
-*          \p csrSortedColIndA, \p B or \p C is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p alpha or \p beta is nullptr,
+*          \p m, \p n, \p k or \p nnz is negative, \p ldb or \p ldc is invalid, or
+*          \p csrSortedValA, \p csrSortedRowPtrA, \p csrSortedColIndA, \p B or \p C is nullptr.
 *  \retval HIPSPARSE_STATUS_ARCH_MISMATCH the device is not supported.
 *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t is not 
 *          \ref HIPSPARSE_MATRIX_TYPE_GENERAL.

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_csrmm.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_csrmm.h
@@ -72,8 +72,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 10.0+) and will be 
-*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 11.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle              handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_csrsm.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_csrsm.h
@@ -45,8 +45,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_csrsm.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_csrsm.h
@@ -43,6 +43,11 @@ extern "C" {
 *  \note \p hipsparseXcsrsm2_zeroPivot is a blocking function. It might influence
 *  performance negatively.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
@@ -50,10 +55,11 @@ extern "C" {
 *  @param[inout]
 *  position    pointer to zero pivot \f$j\f$, can be in host or device memory.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval     HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is nullptr.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
 */
 DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_gemmi.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_gemmi.h
@@ -45,16 +45,21 @@ extern "C" {
 *  This function is non blocking and executed asynchronously with respect to the host.
 *  It may return before the actual computation has finished.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
-*  m           number of rows of the dense matrix \f$A\f$.
+*  m           number of rows of the dense matrix \f$A\f$. Must be non-negative.
 *  @param[in]
-*  n           number of columns of the sparse CSC matrix \f$op(B)\f$ and \f$C\f$.
+*  n           number of columns of the sparse CSC matrix \f$op(B)\f$ and \f$C\f$. Must be non-negative.
 *  @param[in]
-*  k           number of columns of the dense matrix \f$A\f$.
+*  k           number of columns of the dense matrix \f$A\f$. Must be non-negative.
 *  @param[in]
-*  nnz         number of non-zero entries of the sparse CSC matrix \f$B\f$.
+*  nnz         number of non-zero entries of the sparse CSC matrix \f$B\f$. Must be non-negative.
 *  @param[in]
 *  alpha       scalar \f$\alpha\f$.
 *  @param[in]
@@ -79,10 +84,13 @@ extern "C" {
 *  @param[in]
 *  ldc         leading dimension of \f$C\f$, must be at least \f$m\f$.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p k, \p nnz,
-*              \p lda, \p ldc, \p alpha, \p A, \p cscValB, \p cscColPtrB, \p cscRowIndB,
-*              \p beta or \p C is invalid.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha or \p beta is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n, \p k or \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p lda or \p ldc is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p A, \p cscValB, \p cscColPtrB, 
+*          \p cscRowIndB or \p C is nullptr.
 *
 *  \par Example
 *  \snippet example_hipsparse_gemmi.cpp doc example

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_gemmi.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_gemmi.h
@@ -86,11 +86,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha or \p beta is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m, \p n, \p k or \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p lda or \p ldc is invalid.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p A, \p cscValB, \p cscColPtrB, 
-*          \p cscRowIndB or \p C is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p alpha or \p beta is nullptr,
+*          \p m, \p n, \p k or \p nnz is negative, \p lda or \p ldc is invalid, or
+*          \p A, \p cscValB, \p cscColPtrB, \p cscRowIndB or \p C is nullptr.
 *
 *  \par Example
 *  \snippet example_hipsparse_gemmi.cpp doc example

--- a/projects/hipsparse/library/include/internal/level3/hipsparse_gemmi.h
+++ b/projects/hipsparse/library/include/internal/level3/hipsparse_gemmi.h
@@ -47,8 +47,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 11.0+) and will be 
-*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 12.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_bsric0.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_bsric0.h
@@ -112,9 +112,8 @@ hipsparseStatus_t
  *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
  *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
  *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p bsrValA, \p bsrRowPtrA,
- *          \p bsrColIndA, \p info or \p pBufferSizeInBytes is nullptr.
- *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb or \p nnzb is negative.
- *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is invalid.
+ *          \p bsrColIndA, \p info or \p pBufferSizeInBytes is nullptr, \p mb or \p nnzb is negative,
+ *          or \p blockDim is invalid.
  *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
  *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
  */

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_bsric0.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_bsric0.h
@@ -50,8 +50,7 @@ extern "C" {
  *
  *  \deprecated
  *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
- *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
- *  For portable code across backends, consider using the generic sparse APIs instead.
+ *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
  *
  *  @param[in]
  *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_bsric0.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_bsric0.h
@@ -48,6 +48,11 @@ extern "C" {
  *  \note \p hipsparseXbsric02_zeroPivot is a blocking function. It might influence
  *  performance negatively.
  *
+ *  \deprecated
+ *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+ *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+ *  For portable code across backends, consider using the generic sparse APIs instead.
+ *
  *  @param[in]
  *  handle      handle to the hipsparse library context queue.
  *  @param[in]
@@ -55,11 +60,11 @@ extern "C" {
  *  @param[inout]
  *  position    pointer to zero pivot \f$j\f$, can be in host or device memory.
  *
- *  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
- *  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position pointer is
- *              invalid.
- *  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
- *  \retval     HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+ *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+ *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is nullptr.
+ *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+ *  \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
  */
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")
 HIPSPARSE_EXPORT
@@ -81,9 +86,9 @@ hipsparseStatus_t
  *  dirA               direction that specifies whether to count nonzero elements by \ref HIPSPARSE_DIRECTION_ROW
  *                     or by \ref HIPSPARSE_DIRECTION_COLUMN.
  *  @param[in]
- *  mb                 number of block rows in the sparse BSR matrix.
+ *  mb                 number of block rows in the sparse BSR matrix. Must be non-negative.
  *  @param[in]
- *  nnzb               number of non-zero block entries of the sparse BSR matrix.
+ *  nnzb               number of non-zero block entries of the sparse BSR matrix. Must be non-negative.
  *  @param[in]
  *  descrA             descriptor of the sparse BSR matrix.
  *  @param[in]
@@ -94,7 +99,7 @@ hipsparseStatus_t
  *  @param[in]
  *  bsrColIndA         array of \p nnzb elements containing the block column indices of the sparse BSR matrix.
  *  @param[in]
- *  blockDim           the block dimension of the BSR matrix. Between 1 and m where \p m=mb*blockDim.
+ *  blockDim           the block dimension of the BSR matrix. Must be positive. Between 1 and m where \p m=mb*blockDim.
  *  @param[out]
  *  info               structure that holds the information collected during the analysis step.
  *  @param[out]
@@ -104,13 +109,14 @@ hipsparseStatus_t
  *                     hipsparseSbsric02(), hipsparseDbsric02(), hipsparseCbsric02()
  *                     and hipsparseZbsric02().
  *
- *  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
- *  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p mb, \p nnzb, \p blockDim, \p descrA,
- *              \p bsrValA, \p bsrRowPtrA, \p bsrColIndA, \p info or \p pBufferSizeInBytes pointer
- *              is invalid.
- *  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
- *  \retval     HIPSPARSE_STATUS_NOT_SUPPORTED
- *              \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
+ *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+ *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p bsrValA, \p bsrRowPtrA,
+ *          \p bsrColIndA, \p info or \p pBufferSizeInBytes is nullptr.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p mb or \p nnzb is negative.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p blockDim is invalid.
+ *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+ *  \retval HIPSPARSE_STATUS_NOT_SUPPORTED \ref hipsparseMatrixType_t != \ref HIPSPARSE_MATRIX_TYPE_GENERAL.
  */
 /**@{*/
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_bsrilu0.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_bsrilu0.h
@@ -50,8 +50,7 @@ extern "C" {
  *
  *  \deprecated
  *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
- *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
- *  For portable code across backends, consider using the generic sparse APIs instead.
+ *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
  *
  *  @param[in]
  *  handle      handle to the hipsparse library context queue.
@@ -87,8 +86,7 @@ hipsparseStatus_t
  *
  *  \deprecated
  *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
- *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
- *  For portable code across backends, consider using the generic sparse APIs instead.
+ *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
  *
  *  @param[in]
  *  handle        handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_bsrilu0.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_bsrilu0.h
@@ -48,6 +48,11 @@ extern "C" {
  *  \note \p hipsparseXbsrilu02_zeroPivot is a blocking function. It might influence
  *  performance negatively.
  *
+ *  \deprecated
+ *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+ *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+ *  For portable code across backends, consider using the generic sparse APIs instead.
+ *
  *  @param[in]
  *  handle      handle to the hipsparse library context queue.
  *  @param[in]
@@ -55,11 +60,11 @@ extern "C" {
  *  @param[inout]
  *  position    pointer to zero pivot \f$j\f$, can be in host or device memory.
  *
- *  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
- *  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position pointer is
- *              invalid.
- *  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
- *  \retval     HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+ *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+ *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is nullptr.
+ *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+ *  \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
  */
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")
 HIPSPARSE_EXPORT
@@ -80,6 +85,11 @@ hipsparseStatus_t
  *
  *  \note \p tol and \p boost_val can be in host or device memory.
  *
+ *  \deprecated
+ *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+ *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+ *  For portable code across backends, consider using the generic sparse APIs instead.
+ *
  *  @param[in]
  *  handle        handle to the hipsparse library context queue.
  *  @param[in]
@@ -91,10 +101,10 @@ hipsparseStatus_t
  *  @param[in]
  *  boost_val     boost value to replace a numerical value.
  *
- *  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
- *  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info, \p tol or \p boost_val pointer
- *              is invalid.
- *  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+ *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+ *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info, \p tol or \p boost_val is nullptr.
+ *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 */
 /**@{*/
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_csric0.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_csric0.h
@@ -45,8 +45,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
-*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_csric0.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_csric0.h
@@ -43,6 +43,11 @@ extern "C" {
 *  \note \p hipsparseXcsric02_zeroPivot is a blocking function. It might influence
 *  performance negatively.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
@@ -50,11 +55,11 @@ extern "C" {
 *  @param[inout]
 *  position    pointer to zero pivot \f$j\f$, can be in host or device memory.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position pointer is
-*              invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval     HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is nullptr.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
 */
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_csrilu0.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_csrilu0.h
@@ -44,8 +44,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
-*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
@@ -81,8 +80,7 @@ hipsparseStatus_t
  *
  *  \deprecated
  *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
- *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
- *  For portable code across backends, consider using the generic sparse APIs instead.
+ *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
  *
  *  @param[in]
  *  handle          handle to the hipsparse library context queue.

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_csrilu0.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_csrilu0.h
@@ -42,6 +42,11 @@ extern "C" {
 *  \note \p hipsparseXcsrilu02_zeroPivot is a blocking function. It might influence
 *  performance negatively.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle      handle to the hipsparse library context queue.
 *  @param[in]
@@ -49,11 +54,11 @@ extern "C" {
 *  @param[inout]
 *  position    pointer to zero pivot \f$j\f$, can be in host or device memory.
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position pointer is
-*              invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
-*  \retval     HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info or \p position is nullptr.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_ZERO_PIVOT zero pivot has been found.
 */
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")
 HIPSPARSE_EXPORT
@@ -74,6 +79,11 @@ hipsparseStatus_t
  *
  *  \note \p tol and \p boost_val can be in host or device memory.
  *
+ *  \deprecated
+ *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+ *  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+ *  For portable code across backends, consider using the generic sparse APIs instead.
+ *
  *  @param[in]
  *  handle          handle to the hipsparse library context queue.
  *  @param[in]
@@ -85,10 +95,10 @@ hipsparseStatus_t
  *  @param[in]
  *  boost_val       boost value to replace a numerical value.
  *
- *  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
- *  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info, \p tol or \p boost_val pointer
- *              is invalid.
- *  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+ *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+ *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+ *  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p info, \p tol or \p boost_val is nullptr.
+ *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
  */
 /**@{*/
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_gtsv.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_gtsv.h
@@ -42,11 +42,11 @@ extern "C" {
 *  This routine supports execution in a hipGraph context.
 *
 *  @param[in]
-*  handle             handle to the hipSPARSE library context queue.
+*  handle             handle to the hipsparse library context queue.
 *  @param[in]
-*  m                  size of the tri-diagonal linear system (must be >= 2).
+*  m                  size of the tri-diagonal linear system. Must be at least 2.
 *  @param[in]
-*  n                  number of columns in the dense matrix B.
+*  n                  number of columns in the dense matrix B. Must be non-negative.
 *  @param[in]
 *  dl                 lower diagonal of tri-diagonal system. First entry must be zero.
 *  @param[in]
@@ -54,17 +54,19 @@ extern "C" {
 *  @param[in]
 *  du                 upper diagonal of tri-diagonal system. Last entry must be zero.
 *  @param[in]
-*  B                  Dense matrix of size ( \p ldb, \p n ).
+*  B                  dense matrix of size ( \p ldb, \p n ).
 *  @param[in]
-*  ldb                Leading dimension of B. Must satisfy \p ldb >= max(1, m).
+*  ldb                leading dimension of B. Must satisfy \p ldb >= max(1, m).
 *  @param[out]
 *  pBufferSizeInBytes number of bytes of the temporary storage buffer required by
 *                     \ref hipsparseSgtsv2 "hipsparseXgtsv2()".
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p ldb, \p dl, \p d, \p du,
-*              \p B or \p pBufferSizeInBytes pointer is invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p dl, \p d, \p du, \p B or \p pBufferSizeInBytes is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m is less than 2 or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ldb is invalid.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 */
 /**@{*/
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_gtsv.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_gtsv.h
@@ -63,9 +63,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p dl, \p d, \p du, \p B or \p pBufferSizeInBytes is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m is less than 2 or \p n is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ldb is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p dl, \p d, \p du, \p B or
+*          \p pBufferSizeInBytes is nullptr, \p m is less than 2 or \p n is negative,
+*          or \p ldb is invalid.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 */
 /**@{*/

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_gtsv_nopivot.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_gtsv_nopivot.h
@@ -37,9 +37,9 @@ extern "C" {
 *  @param[in]
 *  handle             handle to the hipsparse library context queue.
 *  @param[in]
-*  m                  size of the tri-diagonal linear system (must be >= 2).
+*  m                  size of the tri-diagonal linear system. Must be >= 2.
 *  @param[in]
-*  n                  number of columns in the dense matrix B.
+*  n                  number of columns in the dense matrix B. Must be non-negative.
 *  @param[in]
 *  dl                 lower diagonal of tri-diagonal system. First entry must be zero.
 *  @param[in]
@@ -54,10 +54,13 @@ extern "C" {
 *  pBufferSizeInBytes number of bytes of the temporary storage buffer required by
 *                     hipsparseSgtsv2_nopivot "hipsparseXgtsv2_nopivot()".
 *
-*  \retval     HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval     HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p n, \p ldb, \p dl, \p d, \p du,
-*              \p B or \p pBufferSizeInBytes pointer is invalid.
-*  \retval     HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
+*  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p dl, \p d, \p du, \p B or 
+*          \p pBufferSizeInBytes is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m is less than 2 or \p n is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ldb is invalid.
+*  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 */
 /**@{*/
 HIPSPARSE_EXPORT

--- a/projects/hipsparse/library/include/internal/precond/hipsparse_gtsv_nopivot.h
+++ b/projects/hipsparse/library/include/internal/precond/hipsparse_gtsv_nopivot.h
@@ -56,10 +56,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p dl, \p d, \p du, \p B or 
-*          \p pBufferSizeInBytes is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m is less than 2 or \p n is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p ldb is invalid.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p dl, \p d, \p du, \p B or
+*          \p pBufferSizeInBytes is nullptr, \p m is less than 2 or \p n is negative,
+*          or \p ldb is invalid.
 *  \retval HIPSPARSE_STATUS_INTERNAL_ERROR an internal error occurred.
 */
 /**@{*/

--- a/projects/hipsparse/library/include/internal/reorder/hipsparse_csrcolor.h
+++ b/projects/hipsparse/library/include/internal/reorder/hipsparse_csrcolor.h
@@ -41,12 +41,17 @@ extern "C" {
 *  must be stored as a general matrix with a symmetric sparsity pattern, and if the matrix \f$A\f$ is non-symmetric
 *  then the user is responsible to provide the symmetric part \f$\frac{A+A^T}{2}\f$.
 *
+*  \deprecated
+*  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
+*  For portable code across backends, consider using the generic sparse APIs instead.
+*
 *  @param[in]
 *  handle          handle to the hipsparse library context queue.
 *  @param[in]
-*  m               number of rows of sparse matrix \f$A\f$.
+*  m               number of rows of sparse matrix \f$A\f$. Must be non-negative.
 *  @param[in]
-*  nnz             number of non-zero entries of sparse matrix \f$A\f$.
+*  nnz             number of non-zero entries of sparse matrix \f$A\f$. Must be non-negative.
 *  @param[in]
 *  descrA          sparse matrix descriptor.
 *  @param[in]
@@ -70,8 +75,12 @@ extern "C" {
 *  info            structure that holds the information collected during the coloring algorithm.
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p m, \p nnz, \p descrA, \p csrValA, \p csrRowPtrA, \p csrColIndA,
-*                                         \p fractionToColor, \p ncolors, \p coloring or \p info pointer is invalid.
+*  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p fractionToColor, 
+*          \p ncolors, \p coloring or \p info is nullptr.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p nnz is negative.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrValA, \p csrRowPtrA or \p csrColIndA is nullptr 
+*          when \p nnz is greater than zero.
 */
 /**@{*/
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")

--- a/projects/hipsparse/library/include/internal/reorder/hipsparse_csrcolor.h
+++ b/projects/hipsparse/library/include/internal/reorder/hipsparse_csrcolor.h
@@ -76,11 +76,9 @@ extern "C" {
 *
 *  \retval HIPSPARSE_STATUS_SUCCESS the operation completed successfully.
 *  \retval HIPSPARSE_STATUS_NOT_INITIALIZED \p handle is not initialized.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p fractionToColor, 
-*          \p ncolors, \p coloring or \p info is nullptr.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p m or \p nnz is negative.
-*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p csrValA, \p csrRowPtrA or \p csrColIndA is nullptr 
-*          when \p nnz is greater than zero.
+*  \retval HIPSPARSE_STATUS_INVALID_VALUE \p handle, \p descrA, \p fractionToColor,
+*          \p ncolors, \p coloring or \p info is nullptr, \p m or \p nnz is negative, or
+*          \p csrValA, \p csrRowPtrA or \p csrColIndA is nullptr when \p nnz is greater than zero.
 */
 /**@{*/
 DEPRECATED_CUDA_12000("The routine will be removed in CUDA 13")

--- a/projects/hipsparse/library/include/internal/reorder/hipsparse_csrcolor.h
+++ b/projects/hipsparse/library/include/internal/reorder/hipsparse_csrcolor.h
@@ -43,8 +43,7 @@ extern "C" {
 *
 *  \deprecated
 *  This function is deprecated when using the CUDA backend (CUDA 12.0+) and will be 
-*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend. 
-*  For portable code across backends, consider using the generic sparse APIs instead.
+*  removed in CUDA 13.0. This deprecation does not apply to the ROCm backend.
 *
 *  @param[in]
 *  handle          handle to the hipsparse library context queue.


### PR DESCRIPTION
## Motivation

1. Add documentation indicating each routines support when using cuda backends
2. Add other improvements like indicating what parameters must be positive etc.
3. Fix other minor typos

## Technical Details

Because hipSPARSE is a wrapper library that supports both using cusparse and rocsparse backends, many routines that hipSPARSE has are now deprecated in cusparse. This means that when using the cusparse backend, these functions are no longer supported. To let users know what versions of cusparse a routine is supported, I have added deprecation warnings indicating when a routine has been deprecated in cusparse and when it has been removed in cusparse.
