### PR TITLE
[rocrand] Re-enable unrolling in mt19937.hpp

### DIFF
--- a/projects/rocrand/library/src/rng/mt19937.hpp
+++ b/projects/rocrand/library/src/rng/mt19937.hpp
@@ -570,9 +570,7 @@ void generate_long_mt19937(dim3 block_idx,
             mt19937_octo_engine& engine    = thread_engines[warp_lane];
             const unsigned int   thread_id = block_idx.x * block_size + thread_idx.x + warp_lane;
 #endif
-// Disabled for warning: optimizer failed to unroll when compiling
-// TODO: enable when the compiler successfully unrolls the loop
-// #pragma unroll
+#pragma unroll
             for(unsigned int j = 0; j < inputs_per_state; j++)
             {
 #pragma unroll
@@ -616,9 +614,7 @@ void generate_long_mt19937(dim3 block_idx,
             mt19937_octo_engine& engine    = thread_engines[warp_lane];
             const unsigned int   thread_id = block_idx.x * block_size + thread_idx.x + warp_lane;
 #endif
-// Disabled for warning: optimizer failed to unroll when compiling
-// TODO: enable when the compiler successfully unrolls the loop
-// #pragma unroll
+#pragma unroll
             for(unsigned int j = 0; j < inputs_per_state; j++)
             {
 #pragma unroll


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Performance drops on MI355 observed from a previous commit that commented out loop unrolling in mt19937.hpp. This PR reverts that.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
The previous commit is no longer needed due to the compiler updates which fix the issue that commit was supposed to resolve.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run benchmark_rocrand_host_api to verify the performance on MI355.

## Test Result

<!-- Briefly summarize test outcomes. -->
Confirmed the restore of the performance on MI355 from the mt19937 generator.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
