### PR TITLE
Clean usage of device target arch in rocprim

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -527,12 +527,6 @@ auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
     return Config::template architecture_config<target_arch::unknown>::params;
 }
 
-template<typename Config>
-constexpr auto device_params()
-{
-    return Config::template architecture_config<device_target_arch()>::params;
-}
-
 inline target_arch parse_gcn_arch(const char* arch_name)
 {
     static constexpr auto length = sizeof(hipDeviceProp_t::gcnArchName);

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -1052,7 +1052,7 @@ template<typename LookbackScanState>
 constexpr bool is_lookback_kernel_runnable()
 {
 #if !defined(ROCPRIM_TARGET_SPIRV) || ROCPRIM_TARGET_SPIRV == 0
-    if(device_target_arch() == target_arch::gfx908)
+    if constexpr(__builtin_amdgcn_processor_is("gfx908"))
     {
         // For gfx908 kernels with both version of lookback_scan_state can run: with and without
         // sleep

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/lookback_scan_state.hpp
@@ -1051,7 +1051,7 @@ hipError_t is_sleep_scan_state_used(const hipStream_t stream, bool& use_sleep)
 template<typename LookbackScanState>
 constexpr bool is_lookback_kernel_runnable()
 {
-#if !defined(ROCPRIM_TARGET_SPIRV) || ROCPRIM_TARGET_SPIRV == 0
+#if (!defined(ROCPRIM_TARGET_SPIRV) || ROCPRIM_TARGET_SPIRV == 0) && __has_builtin(__builtin_amdgcn_processor_is)
     if constexpr(__builtin_amdgcn_processor_is("gfx908"))
     {
         // For gfx908 kernels with both version of lookback_scan_state can run: with and without

--- a/projects/rocprim/test/rocprim/test_config_dispatch.cpp
+++ b/projects/rocprim/test/rocprim/test_config_dispatch.cpp
@@ -30,10 +30,17 @@
 
 using rocprim::detail::target_arch;
 
-__global__ void write_target_arch(target_arch* dest_arch)
+__global__
+void write_target_arch([[maybe_unused]] target_arch host_arch,
+                       int* __restrict__ result)
 {
+#if !defined(ROCPRIM_TARGET_SPIRV)
     static constexpr auto arch = rocprim::detail::device_target_arch();
-    *dest_arch                 = arch;
+
+    *result = arch == host_arch;
+#else
+    *result = -1;
+#endif
 }
 
 // If this compile then
@@ -76,16 +83,27 @@ TEST(RocprimConfigDispatchTests, HostMatchesDevice)
     {
         target_arch host_arch;
         HIP_CHECK(rocprim::detail::host_target_arch(stream, host_arch));
+        
+        int* result_ptr = nullptr;
+        HIP_CHECK(common::hipMallocHelper(&result_ptr, sizeof(result_ptr)));
 
-        common::device_ptr<target_arch> device_arch_ptr(1);
-
-        hipLaunchKernelGGL(write_target_arch, dim3(1), dim3(1), 0, stream, device_arch_ptr.get());
+        hipLaunchKernelGGL(write_target_arch, dim3(1), dim3(1), 0, stream, host_arch, result_ptr);
         HIP_CHECK(hipGetLastError());
 
-        const auto device_arch = device_arch_ptr.load_value_at(0);
+        int result = -1;
+        HIP_CHECK(hipMemcpy(&result, result_ptr, sizeof(result), hipMemcpyDeviceToHost));
 
-        ASSERT_NE(host_arch, target_arch::invalid);
-        ASSERT_EQ(host_arch, device_arch);
+        if(result != -1)
+        {
+            ASSERT_NE(host_arch, target_arch::invalid);
+            ASSERT_EQ(result, 1);
+        }
+        else
+        {
+            GTEST_SKIP() << "SPIR-V build: result is null; skipping arch match assertion.";
+        }
+
+        HIP_CHECK(hipFree(result_ptr));
     }
 }
 

--- a/projects/rocprim/test/rocprim/test_config_dispatch.cpp
+++ b/projects/rocprim/test/rocprim/test_config_dispatch.cpp
@@ -31,8 +31,7 @@
 using rocprim::detail::target_arch;
 
 __global__
-void write_target_arch([[maybe_unused]] target_arch host_arch,
-                       int* __restrict__ result)
+void write_target_arch([[maybe_unused]] target_arch host_arch, int* __restrict__ result)
 {
 #if !defined(ROCPRIM_TARGET_SPIRV)
     static constexpr auto arch = rocprim::detail::device_target_arch();
@@ -83,7 +82,7 @@ TEST(RocprimConfigDispatchTests, HostMatchesDevice)
     {
         target_arch host_arch;
         HIP_CHECK(rocprim::detail::host_target_arch(stream, host_arch));
-        
+
         int* result_ptr = nullptr;
         HIP_CHECK(common::hipMallocHelper(&result_ptr, sizeof(result_ptr)));
 


### PR DESCRIPTION
## Motivation

With the new config system, the `device_target_arch` should not be exposed to public namespace, and `device_params` is no longer used, and `test_config_dispatch` needs some modification to pass when targetting SPIR-V.
