### PR TITLE
Support Runtime Configurable StaggerU

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -35843,7 +35843,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -37867,7 +37867,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -42158,7 +42158,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -42382,7 +42382,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -42606,7 +42606,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -42830,7 +42830,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -43983,7 +43983,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bjlk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
@@ -471,7 +471,7 @@
     StoreVectorWidth: 4
     StreamK: 3
     StreamKAtomic: 0
-    StreamKXCCMapping: 0
+    StreamKXCCMapping: 8
     SubGroup0: 8
     SubGroup1: 32
     SubGroupA: 8
@@ -504,8 +504,8 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 06
-    WorkGroupMappingXCC: -1
+    WorkGroupMapping: 6
+    WorkGroupMappingXCC: 1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
     WorkspaceCheck: [4, 0, 0]

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -19224,7 +19224,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -21928,7 +21928,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -48499,7 +48499,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [128, 2, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -49395,7 +49395,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -52851,7 +52851,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -47687,7 +47687,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
@@ -246,7 +246,7 @@
     StoreVectorWidth: 4
     StreamK: 3
     StreamKAtomic: 0
-    StreamKXCCMapping: 0
+    StreamKXCCMapping: 8
     SubGroup0: 8
     SubGroup1: 32
     SubGroupA: 8
@@ -280,8 +280,8 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 06
-    WorkGroupMappingXCC: -1
+    WorkGroupMapping: 6
+    WorkGroupMappingXCC: 1
     WorkgroupMappingXCCGroup: 256
     WorkGroupReduction: false
     WorkspaceCheck: [4, 0, 0]

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bjlk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -18287,7 +18287,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -18304,7 +18304,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -46032,7 +46032,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -51897,7 +51897,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -53249,7 +53249,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8B8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -287,7 +287,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_F8BS_BH_BiasSB_HAS_SAB_SAV_UserArgs.yaml
@@ -287,7 +287,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_HHS_BH_BiasSH_HAS_SAV_UserArgs.yaml
@@ -18287,7 +18287,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -51810,7 +51810,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
@@ -52034,7 +52034,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_SB_BiasS_HAS_SAV_UserArgs.yaml
@@ -51357,7 +51357,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Origami/gfx950_Cijk_Alik_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
@@ -246,7 +246,7 @@
     StoreVectorWidth: 4
     StreamK: 3
     StreamKAtomic: 0
-    StreamKXCCMapping: 0
+    StreamKXCCMapping: 8
     SubGroup0: 8
     SubGroup1: 32
     SubGroupA: 8
@@ -280,8 +280,8 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [16, 16, 1]
-    WorkGroupMapping: 06
-    WorkGroupMappingXCC: -1
+    WorkGroupMapping: 6
+    WorkGroupMappingXCC: 1
     WorkgroupMappingXCCGroup: 256
     WorkGroupReduction: false
     WorkspaceCheck: [4, 0, 0]
@@ -19097,7 +19097,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [64, 4, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkgroupMappingXCCGroup: 256
     WorkGroupReduction: false
@@ -20217,7 +20217,7 @@
     WaveSplitK: false
     WavefrontSize: 64
     WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 06
+    WorkGroupMapping: 0
     WorkGroupMappingXCC: -1
     WorkgroupMappingXCCGroup: 256
     WorkGroupReduction: false

--- a/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
@@ -227,7 +227,7 @@ namespace TensileLite
         int         simdPerCu        = 4;
         int         computeUnitCount = 0;
         int         skDynamicGrid    = 6;
-        int         skDynamicWGM     = 0;
+        int         fixedSU          = std::numeric_limits<int>::max();
         int         fixedWGM         = std::numeric_limits<int>::max();
         int         fixedWGMXCC      = std::numeric_limits<int>::max();
         int         skMaxCUs         = 0;
@@ -258,10 +258,10 @@ namespace TensileLite
             return value;
         }
 
-        const int getSKDynamicWGM() const
+        const int getFixedSU() const
         {
-            static const char* envStr = std::getenv("TENSILE_STREAMK_DYNAMIC_WGM");
-            static const int   value  = (envStr == NULL ? 0 : std::atoi(envStr));
+            static const char* envStr = std::getenv("TENSILE_FIXED_SU");
+            static const int   value  = (envStr == NULL ? std::numeric_limits<int>::max() : std::atoi(envStr));
             return value;
         }
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
@@ -381,8 +381,9 @@ namespace TensileLite
                         uint32_t                            numWorkGroups,
                         Hardware const*                     hardware,
                         const ContractionProblemParameters& param,
-                        int32_t                             defaultWGM,
-                        uint32_t                            defaultWGMXCC,
+                        uint32_t                            autoSU,
+                        int32_t                             autoWGM,
+                        uint32_t                            autoWGMXCC,
                         uint32_t                            autoGsuVal) const;
 
         template <typename KA>
@@ -562,6 +563,9 @@ namespace TensileLite
         uint32_t magicNumber(int magicDivAlg, uint32_t x, uint32_t* magicShift) const;
         uint32_t smallMagicNumber(uint32_t x) const;
 
+        uint32_t calculateAutoStaggerU(Problem const&  problem, 
+                                       Hardware const* hardware, 
+                                       uint32_t        skgrid) const;
         std::pair<int32_t, uint32_t> calculateAutoWGM(Problem const&  problem, 
                                                       Hardware const* hardware, 
                                                       uint32_t        skgrid) const;

--- a/projects/hipblaslt/tensilelite/src/AMDGPU.cpp
+++ b/projects/hipblaslt/tensilelite/src/AMDGPU.cpp
@@ -52,7 +52,7 @@ namespace TensileLite
         , computeUnitCount(cus)
         , deviceName(name)
         , skDynamicGrid(getSKDynamicGrid())
-        , skDynamicWGM(getSKDynamicWGM())
+        , fixedSU(getFixedSU())
         , fixedWGM(getFixedWGM())
         , fixedWGMXCC(getFixedWGMXCC())
         , skMaxCUs(getSKMaxCUs())

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -565,8 +565,9 @@ namespace TensileLite
         TensorDescriptor const& compressed = problem.compressed();
         TensorDescriptor const& metadata   = problem.metadata();
 
+        auto autoSU                = calculateAutoStaggerU(problem, hardware, sk.grid);
         auto [autoWGM, autoWGMXCC] = calculateAutoWGM(problem, hardware, sk.grid);
-        uint32_t autoGsuVal = calculateAutoGSU(problem, hardware);
+        uint32_t autoGsuVal        = calculateAutoGSU(problem, hardware);
         uint32_t gsu = problem.getParams().gsu() > 0 ? problem.getParams().gsu() : autoGsuVal;
 
         {
@@ -788,6 +789,7 @@ namespace TensileLite
                                           0,
                                           hardware,
                                           problem.getParams(),
+                                          autoSU,
                                           autoWGM,
                                           autoWGMXCC,
                                           autoGsuVal);
@@ -956,6 +958,43 @@ namespace TensileLite
                / std::ceil(std::ceil(m / mt0) * std::ceil(n / mt1) * gsu / cuCount);
     }
 
+    uint32_t ContractionSolution::calculateAutoStaggerU(Problem const&  problem,
+                                                        Hardware const* hardware,
+                                                        uint32_t const  skgrid) const
+    {
+        // Constants
+        constexpr uint32_t mask8        = 0xFF;
+        constexpr uint32_t staggerMask1 = 0x1F00;
+
+        // Hardware
+        AMDGPU const* pAMDGPU           = dynamic_cast<AMDGPU const*>(hardware);
+        hip::HipAMDGPU const* hipAMDGPU = dynamic_cast<hip::HipAMDGPU const*>(hardware);
+       
+        // Default SU
+        uint32_t staggerU;
+        uint32_t staggerUMapping = (sizeMapping.staggerUMapping << 13);
+        uint32_t staggerUShift   = staggerMask1 & ((sizeMapping.staggerStrideShift) << 8);
+
+        staggerU = mask8 & sizeMapping.staggerU;
+        staggerU = staggerU | staggerUShift;
+        staggerU = staggerU | staggerUMapping;
+        
+        // If SU is explicitly specified at runtime, they override default and predictions
+        if(pAMDGPU->fixedSU != std::numeric_limits<int>::max())
+        {
+            staggerU = pAMDGPU->fixedSU;
+        }
+
+        // SU should be in this range: 
+        // assert(std::fabs(staggerU) < ???);
+        
+        // 
+        if(Debug::Instance().printPropertyEvaluation())
+            std::cout << "Dynamic StaggerU " << staggerU << std::endl;
+        
+        return staggerU;
+    }
+    
     std::pair<int32_t, uint32_t> ContractionSolution::calculateAutoWGM(
         Problem const&  problem,
         Hardware const* hardware,
@@ -1119,6 +1158,7 @@ namespace TensileLite
                                          uint32_t                            numWorkGroups,
                                          Hardware const*                     hardware,
                                          const ContractionProblemParameters& param,
+                                         uint32_t                            autoSU,
                                          int32_t                             autoWGM,
                                          uint32_t                            autoWGMXCC,
                                          uint32_t                            autoGsuVal) const
@@ -1131,12 +1171,13 @@ namespace TensileLite
             args.template append<uint32_t>("gemm_count", gemmCount);
         }
 
-        uint32_t       gsu          = param.gsu() > 0 ? param.gsu() : autoGsuVal;
-        bool           gsuc         = false; // initialized false
-        bool           gsuwgmrr     = false; // initialized false
+        uint32_t       staggerU     = autoSU;
         int32_t        wgm          = param.wgm() != 0 ? param.wgm() : autoWGM;
         uint32_t       wgmxcc       = param.wgmxcc() != 0 ? param.wgmxcc() : autoWGMXCC;
         int32_t        wgmxccg      = -1;
+        uint32_t       gsu          = param.gsu() > 0 ? param.gsu() : autoGsuVal;
+        bool           gsuc         = false; // initialized false
+        bool           gsuwgmrr     = false; // initialized false
         const uint32_t mask16       = 0xFFFF;
         const uint32_t mask14       = 0x3FFF;
         const uint32_t mask8        = 0xFF;
@@ -1193,14 +1234,6 @@ namespace TensileLite
         // StaggerU
         if(internalArgsSupport.staggerU)
         {
-            const uint32_t staggerMask1    = 0x1F00;
-            uint32_t       staggerUMapping = (sizeMapping.staggerUMapping << 13);
-            uint32_t       staggerUShift   = staggerMask1 & ((sizeMapping.staggerStrideShift) << 8);
-            uint32_t       staggerU        = mask8 & sizeMapping.staggerU;
-            if(Debug::Instance().disableStaggerU())
-                staggerU = 0;
-            staggerU                       = staggerU | staggerUShift;
-            staggerU                       = staggerU | staggerUMapping;
             internalArg0                   = internalArg0 | (staggerU << 16);
         }
         else if(T_Debug && Debug::Instance().disableStaggerU())
@@ -1314,14 +1347,16 @@ namespace TensileLite
 
         if(internalArgsSupport.useUniversalArgs)
         {
+            auto autoSU                = calculateAutoStaggerU(problem, &hardware, sk.grid);
             auto [autoWGM, autoWGMXCC] = calculateAutoWGM(problem, &hardware, sk.grid);
             if(T_Debug)
             {
+                std::cout << "AutoSU: " << autoSU << std::endl;
                 std::cout << "AutoWGM: " << autoWGM << std::endl;
                 std::cout << "AutoWGMXCC: " << autoWGMXCC << std::endl;
             }
             kernelArgs<T_Debug, false>(
-                1, 0, rv.args, getNumWorkGroups(rv), &hardware, problem.getParams(), autoWGM, autoWGMXCC, autoGsuVal);
+                1, 0, rv.args, getNumWorkGroups(rv), &hardware, problem.getParams(), autoSU, autoWGM, autoWGMXCC, autoGsuVal);
         }
         singleCallArgs<T_Debug, true>(
             problem, inputs, 0, &hardware, problemNumGroupTiles, rv.numWorkGroups, rv.args, sk);
@@ -1485,6 +1520,7 @@ namespace TensileLite
 
         if constexpr(!std::is_same<KA, KernelArgumentsCounter>::value)
         {
+            auto autoSU                = calculateAutoStaggerU(problems[0], &hardware, 0);
             auto [autoWGM, autoWGMXCC] = calculateAutoWGM(problems[0], &hardware, 0);
 
             if(internalArgsSupport.useUniversalArgs)
@@ -1500,6 +1536,7 @@ namespace TensileLite
                                            getNumWorkGroups(rv),
                                            &hardware,
                                            problems[0].getParams(),
+                                           autoSU,
                                            autoWGM,
                                            autoWGMXCC,
                                            autoGsuVal);
@@ -1528,6 +1565,7 @@ namespace TensileLite
                                           0,
                                           &hardware,
                                           problems[0].getParams(),
+                                          autoSU,
                                           autoWGM,
                                           autoWGMXCC,
                                           autoGsuVal);


### PR DESCRIPTION
## Motivation

StaggerU is another parameter that we can predict at runtime. With this PR, there is a new env variable (`TENSILE_FIXED_SU`) to sweep over different values for StaggerU.
Moreover, there were some inconsistencies in the current Origami libraries for supporting autoWGM which is also addressed in this PR.

## Technical Details

No change in perf is expected with this PR. This is just an env variable that fallbacks to what we have in libraries for StaggerU if it is not set at runtime.

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
