### PR TITLE
Fix hipblaslt `rocm_export_targets` overwriting DEPENDS argument

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -333,8 +333,7 @@ if(HIPBLASLT_ENABLE_HOST)
 
     rocm_export_targets(
         TARGETS roc::hipblaslt
-        DEPENDS PACKAGE hip
-        DEPENDS PACKAGE ${hipblas_target}
+        DEPENDS PACKAGE hip PACKAGE ${hipblas_target}
         NAMESPACE roc::
     )
 


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/rocm-libraries/issues/2556

## Technical Details

From what I can tell in https://github.com/ROCm/rocm-cmake/blob/develop/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake#L322, `DEPENDS` should have a list of arguments, another keywords will overwrite the existing list.

## Test Plan

Need to test but this should just be following how MIOpen already uses the CMake function https://github.com/ROCm/rocm-libraries/blob/develop/projects/miopen/src/CMakeLists.txt#L1079.

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
