### PR TITLE
Fix workspace minimum bug in rocblaslt_mat

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -157,8 +157,9 @@ rocblaslt_status rocblaslt_matmul_impl(const rocblaslt_handle       handle,
     //     return rocblaslt_status_invalid_size;
     // }
 
-    if(algo)
-        workspaceSizeInBytes = min(workspaceSizeInBytes, algo->max_workspace_bytes);
+    if(algo) {
+        workspaceSizeInBytes = std::min<size_t>(workspaceSizeInBytes, algo->max_workspace_bytes);
+    }
     RocblasltContractionProblem problem{opA,
                                         opB,
                                         m,


### PR DESCRIPTION
Motivation
Avoid potential overload/macros from using an unqualified min(). Use std::min<size_t> for correct and consistent workspace clamping.

Technical Details
```
if (algo) {
    workspaceSizeInBytes = std::min<size_t>(workspaceSizeInBytes, algo->max_workspace_bytes);
}
```
No functional behavior change. Only ensures type-safe clamp.

Before
[Info][rocblaslt_matmul_impl] Before min: workspaceSizeInBytes=3164160, algo->max_workspace_bytes=4294967296
[Info][rocblaslt_matmul_impl] After min: workspaceSizeInBytes=0
[Info][runContractionProblem] Input workspace size 0 is less than the required workspace size 3164160

After
[Info][rocblaslt_matmul_impl] Before min: workspaceSizeInBytes=3164160, algo->max_workspace_bytes=4294967296
[Info][rocblaslt_matmul_impl] After min: workspaceSizeInBytes=3164160
[Info][runContractionProblem] problem.workspaceSize=3164160 (correct)

This shows that the incorrect min() usage resulted in workspace size becoming 0, while std::min<size_t> preserves the correct intended size.

Test Plan
Build hipBLASLt and run existing matmul tests.

Test Result
Build and tests pass. No correctness or performance changes observed. Workspace is now clamped correctly.

ROCM-22111