### PR TITLE
[rocsparse] Revert deprecation of SpSM and SpSV generic routines

### DIFF
--- a/projects/rocsparse/library/include/internal/generic/rocsparse_spsm.h
+++ b/projects/rocsparse/library/include/internal/generic/rocsparse_spsm.h
@@ -148,20 +148,18 @@ extern "C" {
 *  \par Example
 *  \snippet example_rocsparse_spsm.cpp doc example
 */
-__attribute__((deprecated("This function is deprecated and will be removed in a future release. "
-                          "Use rocsparse_sptrsm instead."))) ROCSPARSE_EXPORT rocsparse_status
-    rocsparse_spsm(rocsparse_handle            handle,
-                   rocsparse_operation         trans_A,
-                   rocsparse_operation         trans_B,
-                   const void*                 alpha,
-                   rocsparse_const_spmat_descr matA,
-                   rocsparse_const_dnmat_descr matB,
-                   const rocsparse_dnmat_descr matC,
-                   rocsparse_datatype          compute_type,
-                   rocsparse_spsm_alg          alg,
-                   rocsparse_spsm_stage        stage,
-                   size_t*                     buffer_size,
-                   void*                       temp_buffer);
+ROCSPARSE_EXPORT rocsparse_status rocsparse_spsm(rocsparse_handle            handle,
+                                                 rocsparse_operation         trans_A,
+                                                 rocsparse_operation         trans_B,
+                                                 const void*                 alpha,
+                                                 rocsparse_const_spmat_descr matA,
+                                                 rocsparse_const_dnmat_descr matB,
+                                                 const rocsparse_dnmat_descr matC,
+                                                 rocsparse_datatype          compute_type,
+                                                 rocsparse_spsm_alg          alg,
+                                                 rocsparse_spsm_stage        stage,
+                                                 size_t*                     buffer_size,
+                                                 void*                       temp_buffer);
 #ifdef __cplusplus
 }
 #endif

--- a/projects/rocsparse/library/include/internal/generic/rocsparse_spsv.h
+++ b/projects/rocsparse/library/include/internal/generic/rocsparse_spsv.h
@@ -127,19 +127,17 @@ extern "C" {
 *  \par Example
 *  \snippet example_rocsparse_spsv.cpp doc example
 */
-__attribute__((deprecated("This function is deprecated and will be removed in a future release. "
-                          "Use rocsparse_sptrsv instead."))) ROCSPARSE_EXPORT rocsparse_status
-    rocsparse_spsv(rocsparse_handle            handle,
-                   rocsparse_operation         trans,
-                   const void*                 alpha,
-                   rocsparse_const_spmat_descr mat,
-                   rocsparse_const_dnvec_descr x,
-                   const rocsparse_dnvec_descr y,
-                   rocsparse_datatype          compute_type,
-                   rocsparse_spsv_alg          alg,
-                   rocsparse_spsv_stage        stage,
-                   size_t*                     buffer_size,
-                   void*                       temp_buffer);
+ROCSPARSE_EXPORT rocsparse_status rocsparse_spsv(rocsparse_handle            handle,
+                                                 rocsparse_operation         trans,
+                                                 const void*                 alpha,
+                                                 rocsparse_const_spmat_descr mat,
+                                                 rocsparse_const_dnvec_descr x,
+                                                 const rocsparse_dnvec_descr y,
+                                                 rocsparse_datatype          compute_type,
+                                                 rocsparse_spsv_alg          alg,
+                                                 rocsparse_spsv_stage        stage,
+                                                 size_t*                     buffer_size,
+                                                 void*                       temp_buffer);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Motivation
Revert premature deprecation of spsm and spsv generic routines. These routines were not deprecated in the 7.1 release, but were deprecated temporarily but this should be undone before the 7.2 release.