### PR TITLE
Avoid parallel reduction for large LDD problems, WS required would not be practical

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_reduction.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_reduction.yaml
@@ -218,3 +218,62 @@ BenchmarkProblems:
           - Exact: [32, 8, 1, 34320]
           - Exact: [32, 8, 1, 34576]
           - Exact: [32, 8, 1, 34832]
+
+  - # Leading dimensions
+    - # HHS NT
+      OperationType: GEMM
+      DataType: s
+      DestDataType: s
+      ComputeDataType: s
+      # HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+
+    - # Grid
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ['Assembly']
+      ForkParameters:
+        - MatrixInstruction:
+          - [16,16,4,1, 1, 4,4, 2,2]
+        - 1LDSBuffer: [-1]
+        - ClusterLocalRead: [True]
+        - DepthU: [16]
+        - ExpandPointerSwap: [0]
+        - GlobalReadVectorWidthA: [4]
+        - GlobalReadVectorWidthB: [4]
+        # - LdsBlockSizePerPadA: [-1]
+        # - LdsBlockSizePerPadB: [-1]
+        # - LdsPadA: [0]
+        # - LdsPadB: [0]
+        - LocalReadVectorWidth: [4]
+        # - NonTemporalC: [0, 3, 4, 7]
+        # - NonTemporalD: [0, 3, 4, 7]
+        # - NumElementsPerBatchStore: [0, 16]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ScheduleIterAlg: [3]
+        - SourceSwap: [True]
+        - StaggerU: [0]
+        # - StaggerU: [0, 32]
+        # - StaggerUStride: [-1]
+        # - StaggerUMapping: [0, 1, 3]
+        # - StorePriorityOpt: [False, True]
+        # - StoreRemapVectorWidth: [0, 1, 2, 4, 8]
+        - StoreVectorWidth: [-1]
+        - StreamK: [3]
+        - StreamKFixupTreeReduction: [0] # TODO also test Tree=1 when bug fix is merged
+        # - StreamKXCCMapping: [8]
+        - TransposeLDS: [-1]
+        # - UnrollLoopSwapGlobalReadOrder: [0, 1]
+        - UseSgprForGRO: [0]
+        # - VectorWidthA: [1, 2, 4, 8]
+        # - VectorWidthB: [1, 2, 4, 8]
+        # - WaveSeparateGlobalReadA: [0, 1]
+        # - WaveSeparateGlobalReadB: [0, 1]
+        - WorkGroupMapping: [6]
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [320, 1024, 1, 29280, 138080, 138080, 29280, 29280]

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -2978,6 +2978,7 @@ namespace TensileLite
                 ReductionType reductionStrat = getSKReduction(problem, hardware);
                 size_t skGrid = getSKGrid(problem, hardware, tiles, reductionStrat);
                 // Get space required for partial tiles=
+                // TODO Revise parallel reduction WS to account for LDD
                 if(skGrid > 0 && (reductionStrat == ReductionType::Parallel || (tiles % skGrid != 0 && !streamKDP)))
                 {
                     // Check ideal amount of workspace for optimal performance
@@ -3144,6 +3145,11 @@ namespace TensileLite
         if(!sizeMapping.customKernelName.empty())
         {
             // Custom kernel currently only supports single-kernel reduction
+            reductionStrat = ReductionType::Tree;
+        }
+        else if (problem.d().totalAllocatedElements() > problem.d().totalLogicalElements())
+        {
+            // If LDD > M, fall back to tree reduction
             reductionStrat = ReductionType::Tree;
         }
         else if(pAMDGPU->skDynamicGrid > 0)


### PR DESCRIPTION
## Motivation

For problems with small M/N and large K, ideal reduction strategy would be parallel reduction. But if LDD is large, then the required workspace may be unrealistically large. This change falls back to tree reduction if LDD > M.

## Technical Details

This change prevents write-out-of-bounds due to incorrect WS estimate. As future work, the required workspace should account for LDD if parallel reduction is selected, then cases where LDD > M but still relatively small could still use parallel reduction.

## Test Plan

Passed in local tests. I will update this PR with a new test case for this issue shortly.

## Test Result

Local test passed, waiting for CI results

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
