### PR TITLE
tox environment pip installs rocisa/

### DIFF
--- a/projects/hipblaslt/tensilelite/tox.ini
+++ b/projects/hipblaslt/tensilelite/tox.ini
@@ -23,6 +23,7 @@ setenv =
     PYTHONPATH = {envdir}/build_tmp/tensilelite/rocisa/lib
     TENSILELITE_CLIENT_ARGS = {env:TENSILELITE_CLIENT_ARGS:}
 commands =
+    pip install --no-build-isolation {toxinidir}/rocisa/
     pip install --upgrade pip
     pip install pytest-cov
     invoke build-client --build-dir {envdir}/build_tmp {env:TENSILELITE_CLIENT_ARGS}


### PR DESCRIPTION

## Motivation

- With the default test targets in tox, we have instructions for setting up the Python environment under test (e.g. install pytest) and for building the tensilelite-client. However, we don't explicity `pip install rocisa` which appears to be necessary to get Tensile to run.

- Update tox.ini to `pip install rocisa/` before running the tests. Without this command, the typical user experience when running tox is to get an import error on rocisa imports when using Tensile.

## Technical Details


## Test Plan

TENSILELITE_CLIENT_ARGS="--build-type Debug --gpu-targets gfx950 --clean" tox -e py39 -- Tensile/Tests -k custom_mainloop_scheduling.yaml


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
