### PR TITLE
[hipDNN] Fix checking for miopen-plugin -> miopen_plugin

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -36,7 +36,7 @@ jobs:
 
       # We only want to build MIOpen HEAD against CK HEAD, not applicable for other projects
       - name: Checkout composable_kernel repository
-        if: ${{ contains(inputs.project_to_test, 'miopen') || contains(inputs.project_to_test, 'miopen-plugin') }}
+        if: ${{ contains(inputs.project_to_test, 'miopen') || contains(inputs.project_to_test, 'miopen_plugin') }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/composable_kernel"

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build
     runs-on: azure-windows-scale-rocm
     # Skip hipDNN & plugin build on Windows since it's not supported yet https://github.com/ROCm/TheRock/issues/1822
-    if: ${{ !contains(inputs.project_to_test, 'hipdnn') && !contains(inputs.project_to_test, 'miopen-plugin') }}
+    if: ${{ !contains(inputs.project_to_test, 'hipdnn') && !contains(inputs.project_to_test, 'miopen_plugin') }}
     outputs:
       AMDGPU_FAMILIES: ${{ env.AMDGPU_FAMILIES }}
     permissions:
@@ -44,7 +44,7 @@ jobs:
 
        # We only want to build MIOpen HEAD against CK HEAD, not applicable for other projects
       - name: Checkout composable_kernel repository
-        if: ${{ contains(inputs.project_to_test, 'miopen') || contains(inputs.project_to_test, 'miopen-plugin') }}
+        if: ${{ contains(inputs.project_to_test, 'miopen') || contains(inputs.project_to_test, 'miopen_plugin') }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/composable_kernel"
@@ -166,7 +166,7 @@ jobs:
     name: "Test"
     needs: [therock-build-windows]
     # Skip hipDNN & plugin tests on Windows since it's not supported yet https://github.com/ROCm/TheRock/issues/1822
-    if: ${{ !contains(inputs.project_to_test, 'hipdnn') && !contains(inputs.project_to_test, 'miopen-plugin') }}
+    if: ${{ !contains(inputs.project_to_test, 'hipdnn') && !contains(inputs.project_to_test, 'miopen_plugin') }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       project_to_test: ${{ inputs.project_to_test }}


### PR DESCRIPTION
## Motivation

#2309 added miopen-plugin testing, but after updating the project to be miopen_plugin instead of miopen-plugin (due to matching project naming in [TheRock](https://github.com/ROCm/TheRock/pull/1811/files#diff-e9b6090803ee2e3d395eeec96bba30b24e418907e6e8d03b065377af65d2df64R191)) the checks of project_to_test were not updated properly.

For the Windows checks this was already covered since both hipDNN & miopen_plugin will be tested together, but for the Linux checks this was missing leading to using the pinned CK hash instead of head CK hash (like MIOpen currently uses). 

--- 

Fixing these checks for now, and updated #2316 to also include details about renaming the project.