### PR TITLE
ChunkTransform Support

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
@@ -425,7 +425,8 @@ defaultBenchmarkCommonParameters = [
     {"MbskPrefetchMethod": [-1]},
     {"UseCustomMainLoopSchedule": [1]},
     {"SpaceFillingAlgo": [[]]},
-    {"SFCWGM": [[[1,1],[1,1]]]}
+    {"SFCWGM": [[[1,1],[1,1]]]},
+    {"CTChunkSize": [-1]}
 ]
 
 # dictionary of defaults comprised of default option for each parameter

--- a/projects/hipblaslt/tensilelite/Tensile/Common/RequiredParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/RequiredParameters.py
@@ -40,6 +40,7 @@ def getRequiredParametersMin() -> set:
         'AssertSummationElementMultiple',
         'ClusterLocalRead',
         'ConvertAfterDS',
+        'CTChunkSize',
         'DirectToVgprA',
         'DirectToVgprB',
         'DirectToLdsA',

--- a/projects/hipblaslt/tensilelite/Tensile/Common/ValidParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/ValidParameters.py
@@ -559,6 +559,12 @@ validParameters = { # we need to make sure this matches develop
     #  - Level1 grid dim 32x8
     #  - Level2 grid dim 1x16 (if enabled, otherwise last 16 bit values are ignored)
     "SFCWGM" : -1,
+    #
+    # CTChunkSize: Statically specify the chunk size used in chiplet_transform_chunked
+    # -1: Uses wgmxcc mapping when using classic wgm algo, uses chiplet_transform when using SFC algos
+    #  0: Sets chunksize = wgm * wgm
+    #  N: Sets chunksize = N
+    "CTChunkSize" : range(-1, 1024),
     "MaxOccupancy": list(
         range(1, 40 + 1)
     ),  # wg / CU; if cache thrashing is hurting performance, this allocates extra lds to artificially limit occupancy

--- a/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
@@ -94,6 +94,20 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
     module.addComment1("remap workgroup to XCCs")
 
     sgprWGM = "WGM"
+
+    # Use chiplet_transform_chunk, skip classic wgmxcc remapping
+    if kernel["CTChunkSize"] >= 0:
+        sgprIndex = "WorkGroup0"
+        sgprChunkSize = writer.sgprPool.checkOut(1)
+        if kernel["CTChunkSize"] == 0:
+            module.add(SAndB32(dst=sgpr(sgprChunkSize), src0=sgpr(sgprWGM), src1="0xffff", comment="Get WGM"))
+            module.add(SMulI32(dst=sgpr(sgprChunkSize), src0=sgpr(sgprChunkSize), src1=sgpr(sgprChunkSize), comment="Compute wgm**2"))
+        else:
+            module.add(module.add(SMovB32(dst=sgpr(sgprChunkSize), src=kernel["CTChunkSize"])))
+        module.add(chiplet_transform_chunked(writer, kernel, sgprIndex, tmpSgprNumWorkGroups, sgprChunkSize))
+        writer.sgprPool.checkIn(sgprChunkSize)
+        return module
+
     label_skipWGMXCC = Label(label="skip_WGMXCC", comment="skip WGMXCC if no enough WGs to remap")
 
     if(kernel["StreamK"] != 0 and kernel["WorkGroupMappingXCC"] == -1):
@@ -116,7 +130,7 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
             tmpSgpr = SgprWGMXCC
             group   = SgprQ
             # offset  = SgprR
-            
+
             tmpVgpr     = writer.vgprPool.checkOutAligned(4,2)
             tmpVgprRes  = ContinuousRegister(tmpVgpr, 4)
 
@@ -129,7 +143,7 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
             module.add(scalarUInt24DivideAndRemainder(qReg=SgprX, rReg=SgprG, dReg="WorkGroup0", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
             module.add(SWaitCnt(kmcnt=0, comment="wait for args to load"))
             module.addComment0("divmod(WG, WGMXCC)")
-            module.add(scalarUInt24DivideAndRemainder(qReg=SgprQ, rReg=SgprR, dReg="skGrid", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))            
+            module.add(scalarUInt24DivideAndRemainder(qReg=SgprQ, rReg=SgprR, dReg="skGrid", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
             writer.vgprPool.checkIn(tmpVgpr)
             # Check if current group requires a remainder WG or not
             module.add(SCmpLtU32(src0=sgpr(SgprG), src1=sgpr(SgprR)))
@@ -287,8 +301,69 @@ def DefaultWGM(writer, kernel, sgprWGM):
 
     return module
 
+
+def chiplet_transform_chunked(writer, kernel, sgprIndex, sgprNumWG, sgprChunkSize):
+
+    numXCC = 8
+    module = Module()
+
+    sgprNumXCC = writer.sgprPool.checkOut(1)
+    sgprTmp  = writer.sgprPool.checkOut(1)
+    sgprTmp2 = writer.sgprPool.checkOut(1)
+
+    sgprLocalId = writer.sgprPool.checkOut(1)
+    sgprChunkId = writer.sgprPool.checkOut(1)
+    sgprPosInChunk = writer.sgprPool.checkOut(1)
+    sgprXCC = writer.sgprPool.checkOut(1)
+
+    tmpVgpr = writer.vgprPool.checkOutAligned(6,2,"tmpVgpr")
+    tmpVgprRes = ContinuousRegister(tmpVgpr, 6)
+
+    labelEnd = Label(writer.labels.getUniqueNamePrefix("ChipletTransformChunkEnd"), comment="")
+
+    module.addComment0("Chiplet Transform Chunked")
+
+    # Hard-coded for now, needs to be a run-time param
+    module.add(SMovB32(dst=sgpr(sgprNumXCC), src=numXCC, comment=""))
+
+    # Compute sgprTmp = numWG, sgprTmp2 = numXCC * chunk_size
+    module.add(SMulI32(dst=sgpr(sgprTmp2), src0=sgpr(sgprNumXCC), src1=sgpr(sgprChunkSize), comment="Compute total number of tiles"))
+    # compute (numWG // (numXCC * chunkSize)) and localId = index // numXCC, note: sgprPosInChunk is not used
+    module.add(scalarUInt24DivideAndRemainderPair(qReg=[sgprLocalId,sgprTmp], dReg=[sgprIndex,sgprNumWG], \
+                                                  divReg=[sgprNumXCC,sgprTmp2], rReg=[sgprXCC, sgprPosInChunk], tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
+    # (numWG // (numXCC * chunkSize)) * (numXCC * chunkSize)
+    module.add(SMulI32(dst=sgpr(sgprTmp), src0=sgpr(sgprTmp), src1=sgpr(sgprTmp2), comment=""))
+    # check,     if index > (num_workgroups // (num_xcds * chunk_size)) * (num_xcds * chunk_size)
+    module.add(SCmpGtU32(src0=sgpr(sgprIndex), src1=sgpr(sgprTmp), comment=""))
+    module.add(SCBranchSCC1(labelEnd.getLabelName()))
+
+    # Calculate: index = chunk_idx * num_xcds * chunk_size + xcd * chunk_size + pos_in_chunk
+    # chunk ID, pos_in_chunk
+    module.add(scalarUInt24DivideAndRemainder(qReg=sgprChunkId, dReg=sgprLocalId, divReg=sgprChunkSize, rReg=sgprPosInChunk, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
+    # xcc * chunk_size
+    module.add(SMulI32(dst=sgpr(sgprTmp), src0=sgpr(sgprXCC), src1=sgpr(sgprChunkSize), comment=""))
+    # chunkId * numxcc * chunk_size
+    module.add(SMulI32(dst=sgpr(sgprTmp2), src0=sgpr(sgprChunkId), src1=sgpr(sgprTmp2), comment=""))
+    module.add(SAddU32(dst=sgpr(sgprTmp), src0=sgpr(sgprTmp), src1=sgpr(sgprPosInChunk), comment=""))
+    module.add(SAddU32(dst=sgpr(sgprIndex), src0=sgpr(sgprTmp), src1=sgpr(sgprTmp2), comment=""))
+
+    module.add(labelEnd)
+
+    writer.sgprPool.checkIn(sgprXCC)
+    writer.sgprPool.checkIn(sgprPosInChunk)
+    writer.sgprPool.checkIn(sgprChunkId)
+    writer.sgprPool.checkIn(sgprLocalId)
+    writer.sgprPool.checkIn(sgprTmp)
+    writer.sgprPool.checkIn(sgprTmp2)
+    writer.sgprPool.checkIn(sgprNumXCC)
+    writer.vgprPool.checkIn(tmpVgpr)
+
+
+    return module
+
+
 # Remap 1D workgroup ID
-def chiplet_transform(writer, kernel, sgprIndex, sgprNumTilesM, sgprNumTilesN):
+def chiplet_transform(writer, kernel, sgprIndex, sgprNumWG):
 
     numXCC = 8
     module = Module()
@@ -304,8 +379,9 @@ def chiplet_transform(writer, kernel, sgprIndex, sgprNumTilesM, sgprNumTilesN):
     tmpVgpr = writer.vgprPool.checkOutAligned(6,2,"tmpVgpr")
     tmpVgprRes = ContinuousRegister(tmpVgpr, 6)
 
+    module.addComment0("Chiplet Transform")
+
     module.add(SMovB32(dst=sgpr(sgprNumXCC), src=numXCC, comment=""))
-    module.add(SMulI32(dst=sgpr(sgprTmp), src0=sgpr(sgprNumTilesM), src1=sgpr(sgprNumTilesN), comment="Compute total number of tiles"))
 
     # POSINXCC = Index // NumXCC
     # - ID in XCC
@@ -314,7 +390,7 @@ def chiplet_transform(writer, kernel, sgprIndex, sgprNumTilesM, sgprNumTilesN):
     #
     # MinPerXCC = TotalNumTiles // NumXCC
     # ExtraWG = TotalNumTiles % NumXCC
-    module.add(scalarUInt24DivideAndRemainderPair(qReg=[sgprPOSINXCC,sgprMinPerXCC], dReg=[sgprIndex,sgprTmp], \
+    module.add(scalarUInt24DivideAndRemainderPair(qReg=[sgprPOSINXCC,sgprMinPerXCC], dReg=[sgprIndex,sgprNumWG], \
                                                   divReg=[sgprNumXCC,sgprNumXCC], rReg=[sgprXCC,sgprExtraWG], tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"]))
 
     module.add(SMulI32(dst=sgpr(sgprIndex), src0=sgpr(sgprXCC), src1=sgpr(sgprMinPerXCC), comment=""))
@@ -403,7 +479,19 @@ def SpaceFillingCurveWalk(writer, kernel, sgprWGM):
     # Apply a permtutation of all sgprIndex values. This will overwrite sgprIndex.
     useXCCRemap = len(kernel["SpaceFillingAlgo"])
     if useXCCRemap:
-      module.add(chiplet_transform(writer, kernel, sgprIndex, sgprNumTilesM, sgprNumTilesN))
+      sgprNumWG = writer.sgprPool.checkOut(1)
+      module.add(SMulI32(dst=sgpr(sgprNumWG), src0=sgpr(sgprNumTilesM), src1=sgpr(sgprNumTilesN), comment="Compute total number of tiles"))
+      if kernel["CTChunkSize"] >= 0:
+        sgprChunkSize = writer.sgprPool.checkOut(1)
+        if kernel["CTChunkSize"] == 0:
+          module.add(module.add(SMovB32(dst=sgpr(sgprChunkSize), src=kernel["WorkGroupMapping"]**2)))
+        else:
+          module.add(module.add(SMovB32(dst=sgpr(sgprChunkSize), src=kernel["CTChunkSize"])))
+        module.add(chiplet_transform_chunked(writer, kernel, sgprIndex, sgprNumWG, sgprChunkSize))
+        writer.sgprPool.checkIn(sgprChunkSize)
+      else:
+        module.add(chiplet_transform(writer, kernel, sgprIndex, sgprNumWG))
+      writer.sgprPool.checkIn(sgprNumWG)
 
 
     # Starting (M,N) tile offset

--- a/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
@@ -93,24 +93,27 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
     module = Module("WGMXCC")
     module.addComment1("remap workgroup to XCCs")
 
-    sgprWGM = "WGM"
-
-    # Use chiplet_transform_chunk, skip classic wgmxcc remapping
-    if kernel["CTChunkSize"] >= 0:
-        sgprIndex = "WorkGroup0"
-        sgprChunkSize = writer.sgprPool.checkOut(1)
-        if kernel["CTChunkSize"] == 0:
-            module.add(SAndB32(dst=sgpr(sgprChunkSize), src0=sgpr(sgprWGM), src1="0xffff", comment="Get WGM"))
-            module.add(SMulI32(dst=sgpr(sgprChunkSize), src0=sgpr(sgprChunkSize), src1=sgpr(sgprChunkSize), comment="Compute wgm**2"))
-        else:
-            module.add(module.add(SMovB32(dst=sgpr(sgprChunkSize), src=kernel["CTChunkSize"])))
-        module.add(chiplet_transform_chunked(writer, kernel, sgprIndex, tmpSgprNumWorkGroups, sgprChunkSize))
-        writer.sgprPool.checkIn(sgprChunkSize)
-        return module
-
+    sgprWGM   = "WGM"
     label_skipWGMXCC = Label(label="skip_WGMXCC", comment="skip WGMXCC if no enough WGs to remap")
 
     if(kernel["StreamK"] != 0 and kernel["WorkGroupMappingXCC"] == -1):
+        label_skipWGMCHUNK = Label(label="skip_WGMCHUNK", comment="skip WGMCHUNK if no enough WGs to remap")
+        """
+        Use chiplet_transform_chunk, skip classic wgmxcc remapping
+        """        
+        SgprIndex = "WorkGroup0"
+        SgprChunkSize = writer.sgprPool.checkOut(1)
+        module.add(SLShiftRightB32(dst=sgpr(SgprChunkSize), shiftHex=hex(22), src=sgpr(sgprWGM), comment="Get WGMCHUNK"))
+        module.add(SAndB32(dst=sgpr(SgprChunkSize), src0=sgpr(SgprChunkSize), src1=hex(1023), comment="Get WGMCHUNK"))
+        module.addComment0("remap WGs if WGMCHUNK > 1")
+        module.add(SCmpGtU32(src0=sgpr(SgprChunkSize), src1=1))
+        module.add(SCBranchSCC0(label_skipWGMCHUNK.getLabelName()))
+        module.add(chiplet_transform_chunked(writer, kernel, SgprIndex, tmpSgprNumWorkGroups, SgprChunkSize))
+        writer.sgprPool.checkIn(SgprChunkSize)
+        module.add(SBranch(label_skipWGMXCC.getLabelName()))
+        module.add(label_skipWGMCHUNK)
+
+
         """
         Formula:
         x, g   = divmod(old_wg, WGMXCC)
@@ -129,7 +132,6 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
             # Reuse some sgprs
             tmpSgpr = SgprWGMXCC
             group   = SgprQ
-            # offset  = SgprR
 
             tmpVgpr     = writer.vgprPool.checkOutAligned(4,2)
             tmpVgprRes  = ContinuousRegister(tmpVgpr, 4)
@@ -154,7 +156,7 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
             module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr(SgprX), src1=sgpr(SgprO)))
             module.add(SMulI32(dst=sgpr(tmpSgpr), src0=sgpr(SgprG), src1=sgpr(group)))
             module.add(SAddU32(dst=sgpr("WorkGroup0"), src0=sgpr("WorkGroup0"), src1=sgpr(tmpSgpr)))
-
+            # Skip
             module.add(label_skipWGMXCC)
     else:
         with writer.allocTmpSgpr(6, 2) as tmpSgprRes:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/general_wgm.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/general_wgm.yaml
@@ -78,6 +78,7 @@ BenchmarkProblems:
         - UseCustomMainLoopSchedule: [1]
         - SpaceFillingAlgo: [[],[0,1,2],[2,2,2], [0],[1,0],[2,3]]
         - SFCWGM: [[[5,5],[2,2]], [[8,1],[4,3]]]
+        - CTChunkSize: [-1,0,1,32,64]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/AMDGPU.hpp
@@ -230,6 +230,7 @@ namespace TensileLite
         int         skDynamicWGM     = 0;
         int         fixedWGM         = std::numeric_limits<int>::max();
         int         fixedWGMXCC      = std::numeric_limits<int>::max();
+        int         fixedWGMXCCCHUNK = std::numeric_limits<int>::max();
         int         skMaxCUs         = 0;
         int         skGridMultiplier = 1;
         int         skFixedGrid      = 0;
@@ -275,6 +276,13 @@ namespace TensileLite
         const int getFixedWGMXCC() const
         {
             static const char* envStr = std::getenv("TENSILE_FIXED_WGMXCC");
+            static const int   value  = (envStr == NULL ? std::numeric_limits<int>::max() : std::atoi(envStr));
+            return value;
+        }
+
+        const int getFixedWGMXCCCHUNK() const
+        {
+            static const char* envStr = std::getenv("TENSILE_FIXED_WGMXCCCHUNK");
             static const int   value  = (envStr == NULL ? std::numeric_limits<int>::max() : std::atoi(envStr));
             return value;
         }

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
@@ -183,7 +183,7 @@ namespace TensileLite
         using Problem       = ContractionProblemGemm;
         using Inputs        = ContractionInputs;
         using GroupedInputs = ContractionGroupedInputs;
-        using ParamsCache  = CacheMap<std::pair<int32_t, uint32_t>, Problem>;
+        using ParamsCache   = CacheMap<std::tuple<int32_t, uint32_t, uint32_t>, Problem>;
 
         /**
          * Indicate a solution is equally or estimatedly matched.
@@ -381,8 +381,9 @@ namespace TensileLite
                         uint32_t                            numWorkGroups,
                         Hardware const*                     hardware,
                         const ContractionProblemParameters& param,
-                        int32_t                             defaultWGM,
-                        uint32_t                            defaultWGMXCC,
+                        int32_t                             autoWGM,
+                        uint32_t                            autoWGMXCC,
+                        uint32_t                            autoWGMXCCCHUNK,
                         uint32_t                            autoGsuVal) const;
 
         template <typename KA>
@@ -532,7 +533,7 @@ namespace TensileLite
         bool                         debugKernel     = false;
         bool                         kernelArgsLog   = false;
         mutable int                  isFallbackCUSol = -1; // -1:unset, 0:false, 1:true
-        mutable ParamsCache paramsCache = ParamsCache(std::make_pair(0,0));
+        mutable ParamsCache paramsCache = ParamsCache(std::make_tuple(0, 0, 0));
 
         std::shared_ptr<Predicates::Predicate<Task>> taskPredicate
             = std::make_shared<Predicates::True<Task>>();
@@ -562,9 +563,9 @@ namespace TensileLite
         uint32_t magicNumber(int magicDivAlg, uint32_t x, uint32_t* magicShift) const;
         uint32_t smallMagicNumber(uint32_t x) const;
 
-        std::pair<int32_t, uint32_t> calculateAutoWGM(Problem const&  problem, 
-                                                      Hardware const* hardware, 
-                                                      uint32_t        skgrid) const;
+        std::tuple<int32_t, uint32_t, uint32_t> calculateAutoWGM(Problem const&  problem, 
+                                                                Hardware const* hardware, 
+                                                                uint32_t        skgrid) const;
         uint32_t calculateAutoGSU(Problem const& problem, Hardware const* hardware) const;
     };
 

--- a/projects/hipblaslt/tensilelite/src/AMDGPU.cpp
+++ b/projects/hipblaslt/tensilelite/src/AMDGPU.cpp
@@ -55,6 +55,7 @@ namespace TensileLite
         , skDynamicWGM(getSKDynamicWGM())
         , fixedWGM(getFixedWGM())
         , fixedWGMXCC(getFixedWGMXCC())
+        , fixedWGMXCCCHUNK(getFixedWGMXCCCHUNK())
         , skMaxCUs(getSKMaxCUs())
         , skGridMultiplier(getSKGridMultiplier())
         , skFixedGrid(getSKFixedGrid())

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -565,7 +565,7 @@ namespace TensileLite
         TensorDescriptor const& compressed = problem.compressed();
         TensorDescriptor const& metadata   = problem.metadata();
 
-        auto [autoWGM, autoWGMXCC] = calculateAutoWGM(problem, hardware, sk.grid);
+        auto [autoWGM, autoWGMXCC, autoWGMXCCCHUNK] = calculateAutoWGM(problem, hardware, sk.grid);
         uint32_t autoGsuVal = calculateAutoGSU(problem, hardware);
         uint32_t gsu = problem.getParams().gsu() > 0 ? problem.getParams().gsu() : autoGsuVal;
 
@@ -790,6 +790,7 @@ namespace TensileLite
                                           problem.getParams(),
                                           autoWGM,
                                           autoWGMXCC,
+                                          autoWGMXCCCHUNK,
                                           autoGsuVal);
 
         if(!problemType.useScaleAB.empty()) //kernel input data
@@ -955,8 +956,8 @@ namespace TensileLite
         return (double)(std::ceil(m / mt0) * std::ceil(n / mt1) * gsu / cuCount)
                / std::ceil(std::ceil(m / mt0) * std::ceil(n / mt1) * gsu / cuCount);
     }
-
-    std::pair<int32_t, uint32_t> ContractionSolution::calculateAutoWGM(
+    
+    std::tuple<int32_t, uint32_t, uint32_t> ContractionSolution::calculateAutoWGM(
         Problem const&  problem,
         Hardware const* hardware,
         uint32_t const  skgrid) const
@@ -968,6 +969,7 @@ namespace TensileLite
         // Default WGM
         int32_t defaultWGM;
         uint32_t defaultWGMXCC;
+        uint32_t defaultWGMXCCCHUNK;
 
         // Dynamically pick the values
         if(sizeMapping.streamK != 0
@@ -979,11 +981,12 @@ namespace TensileLite
         {
             int32_t c_wgm = 0;
             uint32_t c_wgmxcc = 0;
-            // Try to find cached WGM and WGMXCC
-            std::tie(c_wgm, c_wgmxcc) = paramsCache.find(problem);
+            uint32_t c_wgmxccchunk = 0;
+            // Try to find cached WGM and WGMXCC and WGMXCCCHUNK
+            std::tie(c_wgm, c_wgmxcc, c_wgmxccchunk) = paramsCache.find(problem);
 
-            if(!c_wgm && !c_wgmxcc)
-            {
+            if(!c_wgm && !c_wgmxcc && !c_wgmxccchunk)
+            { 
                 auto sizes = problem.problemSizes();
                 if(sizes.size() >= 4)
                 {
@@ -999,19 +1002,24 @@ namespace TensileLite
                                                             sizeMapping.nonTemporalB,
                                                             skgrid,
                                                             false);
-                    defaultWGMXCC = std::get<0>(wgm_pred);
-                    defaultWGM    = std::get<1>(wgm_pred);
+                    
+                    defaultWGMXCCCHUNK = std::get<0>(wgm_pred);
+                    defaultWGMXCC      = std::get<1>(wgm_pred);
+                    defaultWGM         = std::get<2>(wgm_pred);
 
                     // Add to cache only if dynamically calculated.
-                    paramsCache.add(std::make_pair(defaultWGM, defaultWGMXCC), problem);
+                    paramsCache.add(std::make_tuple(defaultWGM, defaultWGMXCC, defaultWGMXCCCHUNK), problem);
                     if(Debug::Instance().printPropertyEvaluation())
-                        std::cout << "Dynamic WGM "<< defaultWGM << ", WGMXCC " << defaultWGMXCC << std::endl;
+                        std::cout << "Dynamic WGM "<< defaultWGM 
+                                  << ", WGMXCC " << defaultWGMXCC
+                                  << ", WGMXCCCHUNK " << defaultWGMXCCCHUNK << std::endl;
                 }
             }
             else
             {
                 defaultWGM = c_wgm;
                 defaultWGMXCC = c_wgmxcc;
+                defaultWGMXCCCHUNK = c_wgmxccchunk;
             }
         }
         else
@@ -1034,6 +1042,9 @@ namespace TensileLite
             }
             else
                 defaultWGMXCC = sizeMapping.workGroupMappingXCC;
+
+            // Default WGMXCCCHUNK
+            defaultWGMXCCCHUNK = 0;
         }
 
 
@@ -1046,13 +1057,19 @@ namespace TensileLite
         {
             defaultWGMXCC = pAMDGPU->fixedWGMXCC;
         }
+        if(pAMDGPU->fixedWGMXCCCHUNK != std::numeric_limits<int>::max())
+        {
+            defaultWGMXCCCHUNK = pAMDGPU->fixedWGMXCCCHUNK;
+        }
 
         // WGM should be in this range: [-1023, -1022, ..., -1, 0, 1, ..., 1023]
         assert(std::fabs(defaultWGM) < 1024);
         // WGMXCC should be in this range: [1, 2, 3, ..., 63]
         assert(defaultWGMXCC > 0 && defaultWGMXCC < 64);
-
-        return std::make_pair(defaultWGM, defaultWGMXCC);
+        // WGMXCCCHUNK should be in this range: [0, 1, 2, 3, ..., 1023]
+        assert(defaultWGMXCCCHUNK < 1024);
+        
+        return std::make_tuple(defaultWGM, defaultWGMXCC, defaultWGMXCCCHUNK);
     }
 
     uint32_t ContractionSolution::calculateAutoGSU(Problem const&  problem,
@@ -1121,6 +1138,7 @@ namespace TensileLite
                                          const ContractionProblemParameters& param,
                                          int32_t                             autoWGM,
                                          uint32_t                            autoWGMXCC,
+                                         uint32_t                            autoWGMXCCCHUNK,
                                          uint32_t                            autoGsuVal) const
     {
         if constexpr(!Legacy)
@@ -1136,6 +1154,7 @@ namespace TensileLite
         bool           gsuwgmrr     = false; // initialized false
         int32_t        wgm          = param.wgm() != 0 ? param.wgm() : autoWGM;
         uint32_t       wgmxcc       = param.wgmxcc() != 0 ? param.wgmxcc() : autoWGMXCC;
+        uint32_t       wgmxccchunk  = autoWGMXCCCHUNK;
         int32_t        wgmxccg      = -1;
         const uint32_t mask16       = 0xFFFF;
         const uint32_t mask14       = 0x3FFF;
@@ -1170,6 +1189,10 @@ namespace TensileLite
                     AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(hardware);
                     assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
                     wgmxccg = pAMDGPU->computeUnitCount;
+                }
+                if(sizeMapping.workGroupMappingXCC == -1)
+                {
+                    wgmxccg = wgmxccchunk;
                 }
                 internalArg1 = internalArg1 | (wgmxccg << 22) | (wgmxcc << 16) | (mask16 & wgm);
             }
@@ -1314,14 +1337,15 @@ namespace TensileLite
 
         if(internalArgsSupport.useUniversalArgs)
         {
-            auto [autoWGM, autoWGMXCC] = calculateAutoWGM(problem, &hardware, sk.grid);
+            auto [autoWGM, autoWGMXCC, autoWGMXCCCHUNK] = calculateAutoWGM(problem, &hardware, sk.grid);
             if(T_Debug)
             {
                 std::cout << "AutoWGM: " << autoWGM << std::endl;
                 std::cout << "AutoWGMXCC: " << autoWGMXCC << std::endl;
+                std::cout << "AutoWGMXCCCHUNK: " << autoWGMXCCCHUNK << std::endl;
             }
             kernelArgs<T_Debug, false>(
-                1, 0, rv.args, getNumWorkGroups(rv), &hardware, problem.getParams(), autoWGM, autoWGMXCC, autoGsuVal);
+                1, 0, rv.args, getNumWorkGroups(rv), &hardware, problem.getParams(), autoWGM, autoWGMXCC, autoWGMXCCCHUNK, autoGsuVal);
         }
         singleCallArgs<T_Debug, true>(
             problem, inputs, 0, &hardware, problemNumGroupTiles, rv.numWorkGroups, rv.args, sk);
@@ -1485,7 +1509,7 @@ namespace TensileLite
 
         if constexpr(!std::is_same<KA, KernelArgumentsCounter>::value)
         {
-            auto [autoWGM, autoWGMXCC] = calculateAutoWGM(problems[0], &hardware, 0);
+            auto [autoWGM, autoWGMXCC, autoWGMXCCCHUNK] = calculateAutoWGM(problems[0], &hardware, 0);
 
             if(internalArgsSupport.useUniversalArgs)
             {
@@ -1502,6 +1526,7 @@ namespace TensileLite
                                            problems[0].getParams(),
                                            autoWGM,
                                            autoWGMXCC,
+                                           autoWGMXCCCHUNK,
                                            autoGsuVal);
                 // For user input
                 if(argType == KERNELARGTYPE::USERARGS)
@@ -1530,6 +1555,7 @@ namespace TensileLite
                                           problems[0].getParams(),
                                           autoWGM,
                                           autoWGMXCC,
+                                          autoWGMXCCCHUNK,
                                           autoGsuVal);
             }
 

--- a/shared/origami/include/origami/utils.hpp
+++ b/shared/origami/include/origami/utils.hpp
@@ -94,18 +94,18 @@ namespace origami
                                                         = {},
                                                         bool print = false);
 
-        std::tuple<size_t, int32_t> select_best_wgm(const hardware_t& hardware,
-                                                    size_t            M,
-                                                    size_t            N,
-                                                    size_t            K,
-                                                    size_t            batch,
-                                                    size_t            MT_M,
-                                                    size_t            MT_N,
-                                                    size_t            MT_K,
-                                                    int               nta,
-                                                    int               ntb,
-                                                    size_t            skGrid,
-                                                    bool              print);
+        std::tuple<size_t, size_t, int32_t> select_best_wgm(const hardware_t& hardware,
+                                                            size_t            M,
+                                                            size_t            N,
+                                                            size_t            K,
+                                                            size_t            batch,
+                                                            size_t            MT_M,
+                                                            size_t            MT_N,
+                                                            size_t            MT_K,
+                                                            int               nta,
+                                                            int               ntb,
+                                                            size_t            skGrid,
+                                                            bool              print);
 
         double compute_tflops_from_latency(double latency_cycles,
                                            size_t M,

--- a/shared/origami/src/origami/utils.cpp
+++ b/shared/origami/src/origami/utils.cpp
@@ -362,19 +362,28 @@ constexpr N safe_ceil_div(N n, D d) {
 }
 
 /*!
- * \brief Selects the best WGM (maximizing L2 hit rate) given fixed macro tile sizes.
- *
- * \param[in] hardware          - Hardware
- * \param[in] M, N, K, batch    - Problem
- * \param[in] MT_M, MT_N, MT_K  - Solution
- * \param[in] print             - whether to print the final best result
- *
- * \return best WGMXCC, WGM.
- */
-std::tuple<size_t, int32_t> select_best_wgm(const hardware_t& hardware, size_t M, size_t N,
-                                            size_t K, size_t batch, size_t MT_M, size_t MT_N,
-                                            size_t MT_K, int nta, int ntb, size_t skGrid,
-                                            bool print) {
+* \brief Selects the best WGM (maximizing L2 hit rate) given fixed macro tile sizes.
+*
+* \param[in] hardware          - Hardware
+* \param[in] M, N, K, batch    - Problem
+* \param[in] MT_M, MT_N, MT_K  - Solution
+* \param[in] print             - whether to print the final best result
+*
+* \return best WGMXCCCHUNK, WGMXCC, WGM.
+*/
+std::tuple<size_t, size_t, int32_t> select_best_wgm(const hardware_t& hardware,
+                                                    size_t            M,
+                                                    size_t            N,
+                                                    size_t            K,
+                                                    size_t            batch,
+                                                    size_t            MT_M,
+                                                    size_t            MT_N,
+                                                    size_t            MT_K,
+                                                    int               nta,
+                                                    int               ntb,
+                                                    size_t            skGrid,
+                                                    bool              print)
+{
     // Default is the closest we can get to a square
     size_t max_CU_XCD = hardware.N_CU / hardware.NUM_XCD;
     size_t defaultWGM = ceil(std::sqrt(max_CU_XCD));
@@ -392,13 +401,19 @@ std::tuple<size_t, int32_t> select_best_wgm(const hardware_t& hardware, size_t M
     // -------------------
     // NonTemporal Cases
     // -------------------
-    if (nta > 3 && ntb < 4)
-        return std::make_tuple(hardware.NUM_XCD, 1);
-    else if (nta < 4 && ntb > 3)
-        return std::make_tuple(hardware.NUM_XCD,
-                               std::min(max_CU_XCD, safe_ceil_div(numMTs, hardware.NUM_XCD)));
-    else if (nta > 3 && ntb > 3)
-        return std::make_tuple(hardware.NUM_XCD, 1);
+    if(nta > 3 && ntb < 4)
+        return std::make_tuple(0, hardware.NUM_XCD, 1);
+    else if(nta < 4 && ntb > 3)
+        return std::make_tuple(0, hardware.NUM_XCD, std::min(max_CU_XCD, safe_ceil_div(numMTs, hardware.NUM_XCD)));
+    else if(nta > 3 && ntb > 3)
+        return std::make_tuple(0, hardware.NUM_XCD, 1);
+
+    // -------------------
+    // WGMXCCCHUNK Prediction
+    // -------------------
+    auto defaultWGMXCCCHUNK = 0;
+    bool isWGMXCCCHUNKset = false;
+    size_t out_wgmxccchunk = defaultWGMXCCCHUNK;
 
     // -------------------
     // WGMXCC Prediction
@@ -553,8 +568,8 @@ std::tuple<size_t, int32_t> select_best_wgm(const hardware_t& hardware, size_t M
 
         out_wgm = bestWGM;
     }
-
-    return std::make_tuple(out_wgmxcc, out_wgm);
+    
+    return std::make_tuple(out_wgmxccchunk, out_wgmxcc, out_wgm);
 }
 
 // Logic to decide between two MT that are "tied"

--- a/shared/origami/tests/include/testing_origami.hpp
+++ b/shared/origami/tests/include/testing_origami.hpp
@@ -602,7 +602,7 @@ void BestWGM(const origami::hardware_t& hardware,
     // Assume DP
     auto skGrid = (M + MT_M - 1) / MT_M * (N + MT_N - 1) / MT_N;
 
-    auto [best_wgmxcc_large_tile, best_wgm_large_tile] = 
+    auto [best_wgmxccchunk_large_tile, best_wgmxcc_large_tile, best_wgm_large_tile] = 
         select_best_wgm(hardware,
                         M,
                         N,
@@ -616,7 +616,7 @@ void BestWGM(const origami::hardware_t& hardware,
                         skGrid,
                         false);
 
-    auto [best_wgmxcc_small_tile, best_wgm_small_tile] = 
+    auto [best_wgmxccchunk_small_tile, best_wgmxcc_small_tile, best_wgm_small_tile] = 
         select_best_wgm(hardware,
                         M / 4,
                         N / 4,
@@ -630,7 +630,7 @@ void BestWGM(const origami::hardware_t& hardware,
                         skGrid,
                         false);
 
-    auto [best_wgmxcc_nonsquare_tile, best_wgm_nonsquare_tile] = 
+    auto [best_wgmxccchunk_nonsquare_tile, best_wgmxcc_nonsquare_tile, best_wgm_nonsquare_tile] = 
         select_best_wgm(hardware,
                         1024,
                         5120,


### PR DESCRIPTION
## Motivation

This PR adds an extension to XCCMapping called ChunkTransform. 

## Technical Details

ChunkTransform code is generated for all kernels with WGMXCCn1. The right value for it will be determined at runtime on host-code through Origami. If it is passed as zero or one to the kernel, the kernel will skip that code and use the old WGMXCC code. Otherwise, the WGMXCC code is skipped and ChunkTransform is only used.
For experiments/sweeps, the env variable "TENSILE_FIXED_WGMXCCCHUNK" is introduced that will override the prediction and is passed directly to the kernel. 

## Test Plan

CI and locally.

## Test Result

No effect on performance at all with this PR.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
