### PR TITLE
[hipFFTW] Enabling hipfftw guru plan creation functions and testing thereof + corresponding documentation updates

### DIFF
--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -50,16 +50,18 @@ struct hipfftw_trait;
 template <>
 struct hipfftw_trait<fft_precision_single>
 {
-    using plan_t    = fftwf_plan;
-    using complex_t = fftwf_complex;
-    using real_t    = float;
+    using plan_t                                 = fftwf_plan;
+    using complex_t                              = fftwf_complex;
+    using real_t                                 = float;
+    static constexpr std::string_view prec_label = R"(single)";
 };
 template <>
 struct hipfftw_trait<fft_precision_double>
 {
-    using plan_t    = fftw_plan;
-    using complex_t = fftw_complex;
-    using real_t    = double;
+    using plan_t                                 = fftw_plan;
+    using complex_t                              = fftw_complex;
+    using real_t                                 = double;
+    static constexpr std::string_view prec_label = R"(double)";
 };
 
 template <fft_precision prec>
@@ -583,7 +585,7 @@ public:
         }
         else if(plan)
         {
-            std::cerr << "WARNING: A " << (prec == fft_precision_single ? "single" : "double")
+            std::cerr << "WARNING: A " << hipfftw_trait<prec>::prec_label
                       << "-precision plan was seemingly created but its destructor cannot be used "
                       << std::endl;
         }
@@ -1103,7 +1105,9 @@ private:
         // cannot generate sensible "dims" from empty lengths and/or with invalid rank
         if(lengths.empty() || !rank_is_valid_for_hipfftw(rank))
             return nullptr;
-        if(lengths.size() != rank || istrides.size() != rank || ostrides.size() != rank)
+        if(lengths.size() != static_cast<size_t>(rank)
+           || istrides.size() != static_cast<size_t>(rank)
+           || ostrides.size() != static_cast<size_t>(rank))
             throw std::logic_error("hipfftw_helper::get_guru_dims(): size mismatch between "
                                    "lengths, istrides, and/or ostrides.");
         if constexpr(std::is_same_v<iodim, fftw_iodim>)
@@ -1132,7 +1136,9 @@ private:
         // cannot generate sensible "howmany_dims" from empty batches and/or with invalid batch_rank
         if(batches.empty() || !rank_is_valid_for_hipfftw(batch_rank))
             return nullptr;
-        if(batches.size() != batch_rank || idist.size() != batch_rank || odist.size() != batch_rank)
+        if(batches.size() != static_cast<size_t>(batch_rank)
+           || idist.size() != static_cast<size_t>(batch_rank)
+           || odist.size() != static_cast<size_t>(batch_rank))
             throw std::logic_error("hipfftw_helper::get_guru_dims(): size mismatch between "
                                    "batches, idist, and/or odist.");
         if constexpr(std::is_same_v<iodim, fftw_iodim>)
@@ -1380,6 +1386,22 @@ private:
                       || ifact * idist[batch_dim] == ofact * odist[batch_dim];
         }
         return ret;
+    }
+
+    static void create_temp_plan_from_token(const std::string& token)
+    {
+        hipfftw_helper<prec> temp;
+        temp.from_token(token);
+        hostbuf input;
+        input.alloc(temp.get_data_byte_size(fft_io::fft_io_in));
+        if(temp.plan_placement == fft_placement_inplace)
+            temp.create_plan(input.data(), input.data());
+        else
+        {
+            hostbuf output;
+            output.alloc(temp.get_data_byte_size(fft_io::fft_io_out));
+            temp.create_plan(input.data(), output.data());
+        }
     }
 
 public:
@@ -1846,10 +1868,7 @@ public:
         if(!rank_is_valid_for_hipfftw(rank) || lengths.empty())
             ret << "_rank" << (rank < 0 ? "_negative_" : "_") << std::abs(rank);
         append_vec("len", lengths);
-        if constexpr(prec == fft_precision_single)
-            ret << "_single";
-        else
-            ret << "_double";
+        ret << "_" << hipfftw_trait<prec>::prec_label;
         ret << (plan_placement == fft_placement_inplace ? "_ip" : "_op");
         if(batch_rank != 1)
             ret << "_batch_rank" << (batch_rank < 0 ? "_negative_" : "_") << std::abs(batch_rank);
@@ -1885,9 +1904,12 @@ public:
     {
         fft_params tmp;
         tmp.from_token(token);
+        if(tmp.precision != prec)
+            throw std::invalid_argument("hipfftw_helper::from_token: precision mismatch between "
+                                        "token and (specialization of) hipfftw_helper object");
         if(tmp.istride.size() != tmp.ostride.size() || tmp.istride.size() != tmp.length.size())
-            throw std::runtime_error("hipfftw_helper::from_token: unexpected mismatch of vector "
-                                     "sizes in hipfftw_helper::from_token");
+            throw std::runtime_error(
+                "unexpected mismatch of vector sizes in hipfftw_helper::from_token");
         dft_kind   = tmp.transform_type;
         rank       = tmp.length.size();
         batch_rank = 1;
@@ -2099,6 +2121,18 @@ public:
     {
         using std::runtime_error::runtime_error;
     };
+    friend void create_hipfftw_plan_from_token_using_temp_io(const std::string&, bool);
 };
+
+// trigger a plan creation via hipfftw, without user-defined I/O
+static void create_hipfftw_plan_from_token_using_temp_io(const std::string& token, bool verbose)
+{
+    if(token.find(hipfftw_trait<fft_precision_single>::prec_label) != std::string::npos)
+        hipfftw_helper<fft_precision_single>::create_temp_plan_from_token(token);
+    else if(token.find(hipfftw_trait<fft_precision_double>::prec_label) != std::string::npos)
+        hipfftw_helper<fft_precision_double>::create_temp_plan_from_token(token);
+    else if(verbose)
+        std::cout << "Unknown/unexpected precision from " << token << std::endl;
+}
 
 #endif

--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -243,84 +243,120 @@ struct hipfftw_funcs;
         = dynamically_loaded_function_t<decltype(prefix##func)>(HIPFFTW_STRINGIFY(prefix##func), \
                                                                 &(prefix##func));
 
-#define HIPFFTW_FUNCS_SPECIALIZATION(prefix, specialization)                           \
-    template <>                                                                        \
-    struct hipfftw_funcs<specialization>                                               \
-    {                                                                                  \
-    private:                                                                           \
-        hipfftw_funcs()                                                                \
-        {                                                                              \
-            load_implementations(malloc,                                               \
-                                 alloc_real,                                           \
-                                 alloc_complex,                                        \
-                                 free,                                                 \
-                                 destroy_plan,                                         \
-                                 cleanup,                                              \
-                                 execute,                                              \
-                                 plan_dft_1d,                                          \
-                                 plan_dft_2d,                                          \
-                                 plan_dft_3d,                                          \
-                                 plan_dft,                                             \
-                                 plan_dft_r2c_1d,                                      \
-                                 plan_dft_r2c_2d,                                      \
-                                 plan_dft_r2c_3d,                                      \
-                                 plan_dft_r2c,                                         \
-                                 plan_dft_c2r_1d,                                      \
-                                 plan_dft_c2r_2d,                                      \
-                                 plan_dft_c2r_3d,                                      \
-                                 plan_dft_c2r,                                         \
-                                 print_plan,                                           \
-                                 set_timelimit,                                        \
-                                 cost,                                                 \
-                                 flops,                                                \
-                                 execute_dft,                                          \
-                                 execute_dft_r2c,                                      \
-                                 execute_dft_c2r,                                      \
-                                 plan_many_dft,                                        \
-                                 plan_many_dft_r2c,                                    \
-                                 plan_many_dft_c2r);                                   \
-        }                                                                              \
-        /* disable copies and moves */                                                 \
-        hipfftw_funcs(const hipfftw_funcs&) = delete;                                  \
-        hipfftw_funcs& operator=(const hipfftw_funcs&) = delete;                       \
-        hipfftw_funcs(hipfftw_funcs&&)                 = delete;                       \
-        hipfftw_funcs& operator=(hipfftw_funcs&&) = delete;                            \
-                                                                                       \
-    public:                                                                            \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, malloc)            \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, alloc_real)        \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, alloc_complex)     \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, free)              \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, destroy_plan)      \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, cleanup)           \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, execute)           \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_1d)       \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_2d)       \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_3d)       \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft)          \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c_1d)   \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c_2d)   \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c_3d)   \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c)      \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r_1d)   \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r_2d)   \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r_3d)   \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r)      \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, print_plan)        \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, set_timelimit)     \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, cost)              \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, flops)             \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, execute_dft)       \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, execute_dft_r2c)   \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, execute_dft_c2r)   \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_many_dft)     \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_many_dft_r2c) \
-        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_many_dft_c2r) \
-        static const hipfftw_funcs& get_instance()                                     \
-        {                                                                              \
-            static const hipfftw_funcs instance;                                       \
-            return instance;                                                           \
-        }                                                                              \
+#define HIPFFTW_FUNCS_SPECIALIZATION(prefix, specialization)                             \
+    template <>                                                                          \
+    struct hipfftw_funcs<specialization>                                                 \
+    {                                                                                    \
+    private:                                                                             \
+        hipfftw_funcs()                                                                  \
+        {                                                                                \
+            load_implementations(malloc,                                                 \
+                                 alloc_real,                                             \
+                                 alloc_complex,                                          \
+                                 free,                                                   \
+                                 destroy_plan,                                           \
+                                 cleanup,                                                \
+                                 execute,                                                \
+                                 plan_dft_1d,                                            \
+                                 plan_dft_2d,                                            \
+                                 plan_dft_3d,                                            \
+                                 plan_dft,                                               \
+                                 plan_dft_r2c_1d,                                        \
+                                 plan_dft_r2c_2d,                                        \
+                                 plan_dft_r2c_3d,                                        \
+                                 plan_dft_r2c,                                           \
+                                 plan_dft_c2r_1d,                                        \
+                                 plan_dft_c2r_2d,                                        \
+                                 plan_dft_c2r_3d,                                        \
+                                 plan_dft_c2r,                                           \
+                                 print_plan,                                             \
+                                 set_timelimit,                                          \
+                                 cost,                                                   \
+                                 flops,                                                  \
+                                 execute_dft,                                            \
+                                 execute_dft_r2c,                                        \
+                                 execute_dft_c2r,                                        \
+                                 plan_many_dft,                                          \
+                                 plan_many_dft_r2c,                                      \
+                                 plan_many_dft_c2r,                                      \
+                                 plan_guru_dft,                                          \
+                                 plan_guru_dft_r2c,                                      \
+                                 plan_guru_dft_c2r,                                      \
+                                 plan_guru64_dft,                                        \
+                                 plan_guru64_dft_r2c,                                    \
+                                 plan_guru64_dft_c2r);                                   \
+        }                                                                                \
+        /* disable copies and moves */                                                   \
+        hipfftw_funcs(const hipfftw_funcs&) = delete;                                    \
+        hipfftw_funcs& operator=(const hipfftw_funcs&) = delete;                         \
+        hipfftw_funcs(hipfftw_funcs&&)                 = delete;                         \
+        hipfftw_funcs& operator=(hipfftw_funcs&&) = delete;                              \
+                                                                                         \
+    public:                                                                              \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, malloc)              \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, alloc_real)          \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, alloc_complex)       \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, free)                \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, destroy_plan)        \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, cleanup)             \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, execute)             \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_1d)         \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_2d)         \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_3d)         \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft)            \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c_1d)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c_2d)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c_3d)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_r2c)        \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r_1d)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r_2d)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r_3d)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_dft_c2r)        \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, print_plan)          \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, set_timelimit)       \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, cost)                \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, flops)               \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, execute_dft)         \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, execute_dft_r2c)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, execute_dft_c2r)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_many_dft)       \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_many_dft_r2c)   \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_many_dft_c2r)   \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_guru_dft)       \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_guru_dft_r2c)   \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_guru_dft_c2r)   \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_guru64_dft)     \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_guru64_dft_r2c) \
+        HIPFFTW_DECLARE_DYNAMICALLY_LOADED_FUNCTION_POINTER(prefix, plan_guru64_dft_c2r) \
+        static const hipfftw_funcs& get_instance()                                       \
+        {                                                                                \
+            static const hipfftw_funcs instance;                                         \
+            return instance;                                                             \
+        }                                                                                \
+        template <bool use_guru64>                                                       \
+        const auto& get_plan_guru_dft_r2c() const                                        \
+        {                                                                                \
+            if constexpr(use_guru64)                                                     \
+                return plan_guru64_dft_r2c;                                              \
+            else                                                                         \
+                return plan_guru_dft_r2c;                                                \
+        }                                                                                \
+        template <bool use_guru64>                                                       \
+        const auto& get_plan_guru_dft_c2r() const                                        \
+        {                                                                                \
+            if constexpr(use_guru64)                                                     \
+                return plan_guru64_dft_c2r;                                              \
+            else                                                                         \
+                return plan_guru_dft_c2r;                                                \
+        }                                                                                \
+        template <bool use_guru64>                                                       \
+        const auto& get_plan_guru_dft() const                                            \
+        {                                                                                \
+            if constexpr(use_guru64)                                                     \
+                return plan_guru64_dft;                                                  \
+            else                                                                         \
+                return plan_guru_dft;                                                    \
+        }                                                                                \
     }
 
 HIPFFTW_FUNCS_SPECIALIZATION(fftwf_, fft_precision_single);
@@ -921,16 +957,82 @@ private:
         }
         break;
         case hipfftw_plan_creation_func::PLAN_GURU:
-            [[fallthrough]];
+            return create_guru_plan<make_reference_plan, /* use_guru64 = */ false>(in, out);
+            break;
         case hipfftw_plan_creation_func::PLAN_GURU64:
-            throw std::runtime_error(
-                "hipfftw_helper::make_plan: enforced plan creation is not implemented yet");
+            return create_guru_plan<make_reference_plan, /* use_guru64 = */ true>(in, out);
             break;
         default:
             throw std::runtime_error("hipfftw_helper::make_plan: unknown kind of plan creation");
             break;
         }
         // unreachable
+    }
+
+    template <bool make_reference_plan, bool use_guru64>
+    hipfftw_plan_t<prec> create_guru_plan(void* in, void* out) const
+    {
+        if constexpr(use_guru64)
+        {
+            if(!can_use_creation_options(hipfftw_plan_creation_func::PLAN_GURU64))
+                throw std::runtime_error("hipfftw_helper::create_guru_plan: "
+                                         "hipfftw_plan_creation_func::PLAN_GURU64 cannot be used.");
+        }
+        else
+        {
+            if(!can_use_creation_options(hipfftw_plan_creation_func::PLAN_GURU))
+                throw std::runtime_error("hipfftw_helper::create_guru_plan: "
+                                         "hipfftw_plan_creation_func::PLAN_GURU cannot be used.");
+        }
+        // NOTE: fftw_iodim (resp. fftw_iodim64) and fftwf_iodim (resp. fftwf_iodim64) are actually
+        // the same types
+        static_assert(
+            std::is_same_v<fftw_iodim64, fftwf_iodim64> && std::is_same_v<fftw_iodim, fftwf_iodim>);
+        using io_dim_t           = std::conditional_t<use_guru64, fftw_iodim64, fftw_iodim>;
+        const auto& hipfftw_impl = hipfftw_funcs<prec>::get_instance();
+        const auto* dims         = get_guru_dims<io_dim_t>();
+        const auto* howmany_dims = get_guru_howmany_dims<io_dim_t>();
+
+        if(dft_kind == fft_transform_type_real_forward)
+        {
+            const auto& plan_creation_functor
+                = hipfftw_impl.template get_plan_guru_dft_r2c<use_guru64>();
+            return plan_creation_functor.template call<make_reference_plan>(
+                rank,
+                dims,
+                batch_rank,
+                howmany_dims,
+                static_cast<hipfftw_real_t<prec>*>(in),
+                static_cast<hipfftw_complex_t<prec>*>(out),
+                flags);
+        }
+        else if(dft_kind == fft_transform_type_real_inverse)
+        {
+            const auto& plan_creation_functor
+                = hipfftw_impl.template get_plan_guru_dft_c2r<use_guru64>();
+            return plan_creation_functor.template call<make_reference_plan>(
+                rank,
+                dims,
+                batch_rank,
+                howmany_dims,
+                static_cast<hipfftw_complex_t<prec>*>(in),
+                static_cast<hipfftw_real_t<prec>*>(out),
+                flags);
+        }
+        else
+        {
+            const auto& plan_creation_functor
+                = hipfftw_impl.template get_plan_guru_dft<use_guru64>();
+            return plan_creation_functor.template call<make_reference_plan>(
+                rank,
+                dims,
+                batch_rank,
+                howmany_dims,
+                static_cast<hipfftw_complex_t<prec>*>(in),
+                static_cast<hipfftw_complex_t<prec>*>(out),
+                sign,
+                flags);
+        }
     }
 
     // converts vec to an std::vector<T> if it can be done so without underflow/overflow
@@ -985,6 +1087,71 @@ private:
             // cannot use ionembed
             ionembed.reset();
         }
+    }
+
+    struct cannot_use_guru : std::runtime_error
+    {
+        cannot_use_guru()
+            : std::runtime_error(
+                "guru plan creation functions cannot be used (integral value out of range)."){};
+    };
+
+    template <typename iodim>
+    const iodim* get_guru_dims() const
+    {
+        static_assert(std::is_same_v<iodim, fftw_iodim> || std::is_same_v<iodim, fftw_iodim64>);
+        // cannot generate sensible "dims" from empty lengths and/or with invalid rank
+        if(lengths.empty() || !rank_is_valid_for_hipfftw(rank))
+            return nullptr;
+        if(lengths.size() != rank || istrides.size() != rank || ostrides.size() != rank)
+            throw std::logic_error("hipfftw_helper::get_guru_dims(): size mismatch between "
+                                   "lengths, istrides, and/or ostrides.");
+        if constexpr(std::is_same_v<iodim, fftw_iodim>)
+        {
+            for(const auto& vec : {lengths, istrides, ostrides})
+                if(!vector_has_valid_values_as<int>(vec, vec.size()))
+                {
+                    throw cannot_use_guru();
+                }
+        }
+        static std::vector<iodim> dims_vec;
+        dims_vec.resize(rank);
+        for(auto dim = 0; dim < rank; dim++)
+        {
+            dims_vec[dim].n  = lengths[dim];
+            dims_vec[dim].is = istrides[dim];
+            dims_vec[dim].os = ostrides[dim];
+        }
+        return dims_vec.data();
+    }
+
+    template <typename iodim>
+    const iodim* get_guru_howmany_dims() const
+    {
+        static_assert(std::is_same_v<iodim, fftw_iodim> || std::is_same_v<iodim, fftw_iodim64>);
+        // cannot generate sensible "howmany_dims" from empty batches and/or with invalid batch_rank
+        if(batches.empty() || !rank_is_valid_for_hipfftw(batch_rank))
+            return nullptr;
+        if(batches.size() != batch_rank || idist.size() != batch_rank || odist.size() != batch_rank)
+            throw std::logic_error("hipfftw_helper::get_guru_dims(): size mismatch between "
+                                   "batches, idist, and/or odist.");
+        if constexpr(std::is_same_v<iodim, fftw_iodim>)
+        {
+            for(const auto& vec : {batches, idist, odist})
+                if(!vector_has_valid_values_as<int>(vec, vec.size()))
+                {
+                    throw cannot_use_guru();
+                }
+        }
+        static std::vector<iodim> howmany_dims_vec;
+        howmany_dims_vec.resize(batch_rank);
+        for(auto batch_dim = 0; batch_dim < batch_rank; batch_dim++)
+        {
+            howmany_dims_vec[batch_dim].n  = batches[batch_dim];
+            howmany_dims_vec[batch_dim].is = idist[batch_dim];
+            howmany_dims_vec[batch_dim].os = odist[batch_dim];
+        }
+        return howmany_dims_vec.data();
     }
 
     // (private) validity checks
@@ -1167,11 +1334,16 @@ private:
                 ret = valid_io_nembed;
             }
             break;
-            case hipfftw_plan_creation_func::PLAN_GURU64:
-                [[fallthrough]];
             case hipfftw_plan_creation_func::PLAN_GURU:
-                ret = false; // for now... to be defined when guru apis are enabled
-                break;
+            {
+                ret = vector_has_valid_values_as<int>(strides, rank);
+            }
+            break;
+            case hipfftw_plan_creation_func::PLAN_GURU64:
+            {
+                ret = vector_has_valid_values_as<ptrdiff_t>(strides, rank);
+            }
+            break;
             default:
                 throw std::runtime_error("hipfftw_helper::has_valid_strides: internal error "
                                          "encountered (unexpected value for creation_func)");
@@ -1515,9 +1687,22 @@ public:
             return true;
         }
         case hipfftw_plan_creation_func::PLAN_GURU:
-            [[fallthrough]];
+        {
+            // anything goes provided it can be represented as regular integer(s)
+            try
+            {
+                auto tmp = get_guru_dims<fftw_iodim>();
+                tmp      = get_guru_howmany_dims<fftw_iodim>();
+            }
+            catch(const cannot_use_guru& e)
+            {
+                return false;
+            }
+            return true;
+        }
         case hipfftw_plan_creation_func::PLAN_GURU64:
-            return false;
+            // anything goes!
+            return true;
         default:
             throw std::runtime_error("hipfftw_helper::can_use_creation_options: internal error "
                                      "encountered (unexpected value for creation_options)");
@@ -1571,8 +1756,8 @@ public:
     {
         return is_valid_for_creation_with(hipfftw_plan_creation_func::ANY);
     }
-    // check expected support by (any of) the given option(s)
-    bool has_unsupported_args_for(hipfftw_plan_creation_func creation_options) const
+    // check expected support
+    bool has_unsupported_args() const
     {
         // extra conditions for valid configurations that are not supported by hipfftw:
         if(rank > 3)
@@ -1599,7 +1784,7 @@ public:
 
         if(!is_valid_for_creation_with(creation_options))
             return false;
-        if(has_unsupported_args_for(creation_options))
+        if(has_unsupported_args())
             return false;
         return true;
     }
@@ -1667,7 +1852,7 @@ public:
             ret << "_double";
         ret << (plan_placement == fft_placement_inplace ? "_ip" : "_op");
         if(batch_rank != 1)
-            ret << "_batch_rank_" << (batch_rank < 0 ? "_negative_" : "_") << std::abs(batch_rank);
+            ret << "_batch_rank" << (batch_rank < 0 ? "_negative_" : "_") << std::abs(batch_rank);
         append_vec("batch", batches);
         append_vec("istride", istrides);
         if(!is_real(dft_kind))

--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -39,6 +39,7 @@
 #include "../../shared/sys_mem.h"
 #include "../../shared/work_queue.h"
 #include "../hipfft_params.h"
+#include "../hipfftw_helper.h"
 #include "hipfft/hipfft.h"
 #include "hipfft_accuracy_test.h"
 
@@ -160,12 +161,18 @@ void init_gtest_flags()
 void precompile_test_kernels(const std::string& precompile_file)
 {
     std::cout << "precompiling test kernels...\n";
-    WorkQueue<std::string> tokenQueue;
 
     init_gtest_flags();
 
-    std::vector<std::string> tokens;
-    auto                     ut = testing::UnitTest::GetInstance();
+    enum class lib_under_test
+    {
+        HIPFFT,
+        HIPFFTW
+    };
+
+    std::map<lib_under_test, std::vector<std::string>> tokens;
+
+    auto ut = testing::UnitTest::GetInstance();
     for(int ts_index = 0; ts_index < ut->total_test_suite_count(); ++ts_index)
     {
         const auto ts = ut->GetTestSuite(ts_index);
@@ -196,66 +203,97 @@ void precompile_test_kernels(const std::string& precompile_file)
                     continue;
                 name.replace(idx, end - idx, "1");
 
-                tokens.emplace_back(std::move(name));
+                if(name.find("hipfftw") != std::string::npos)
+                    tokens[lib_under_test::HIPFFTW].emplace_back(std::move(name));
+                else
+                    tokens[lib_under_test::HIPFFT].emplace_back(std::move(name));
             }
         }
     }
 
     std::random_device dev;
     std::mt19937       dist(dev());
-    std::shuffle(tokens.begin(), tokens.end(), dist);
-    auto precompile_begin = std::chrono::steady_clock::now();
-    std::cout << "precompiling kernels for " << tokens.size() << " tokens...\n";
-
-    for(auto&& t : tokens)
-        tokenQueue.push(std::move(t));
-
-    EnvironmentSetTemp       env_compile_only{"ROCFFT_INTERNAL_COMPILE_ONLY", "1"};
-    const size_t             NUM_THREADS = rocfft_concurrency();
-    std::vector<std::thread> threads;
-    for(size_t i = 0; i < NUM_THREADS; ++i)
+    auto               precompile_begin = std::chrono::steady_clock::now();
+    std::cout << "precompiling kernels for "
+              << std::accumulate(tokens.begin(),
+                                 tokens.end(),
+                                 static_cast<size_t>(0),
+                                 [](size_t& acc, const decltype(tokens)::value_type& tok) {
+                                     return acc += tok.second.size();
+                                 })
+              << " tokens...\n";
+    EnvironmentSetTemp env_compile_only{"ROCFFT_INTERNAL_COMPILE_ONLY", "1"};
+    const size_t       NUM_THREADS = rocfft_concurrency();
+    for(auto& pair : tokens)
     {
-        threads.emplace_back([&tokenQueue]() {
-            for(;;)
-            {
-                std::string token{tokenQueue.pop()};
-                if(token.empty())
-                    break;
+        const auto             lib       = pair.first;
+        auto&                  lib_token = pair.second;
+        WorkQueue<std::string> tokenQueue;
+        std::shuffle(lib_token.begin(), lib_token.end(), dist);
+        for(auto&& t : lib_token)
+            tokenQueue.push(std::move(t));
 
-                try
+        std::vector<std::thread> threads;
+        for(size_t i = 0; i < NUM_THREADS; ++i)
+        {
+            threads.emplace_back([&tokenQueue, lib]() {
+                for(;;)
                 {
-                    hipfft_params params;
-                    params.from_token(token);
-                    params.validate();
-                    params.create_plan();
-                    if(params.is_forward())
+                    std::string token{tokenQueue.pop()};
+                    if(token.empty())
+                        break;
+
+                    try
                     {
-                        hipfft_params inverse_params;
-                        inverse_params.inverse_from_forward(params);
-                        inverse_params.validate();
-                        inverse_params.create_plan();
+                        switch(lib)
+                        {
+                        case(lib_under_test::HIPFFT):
+                        {
+                            hipfft_params params;
+                            params.from_token(token);
+                            params.validate();
+                            params.create_plan();
+                            if(params.is_forward())
+                            {
+                                hipfft_params inverse_params;
+                                inverse_params.inverse_from_forward(params);
+                                inverse_params.validate();
+                                inverse_params.create_plan();
+                            }
+                        }
+                        break;
+                        case(lib_under_test::HIPFFTW):
+                        {
+                            create_hipfftw_plan_from_token_using_temp_io(token, verbose);
+                        }
+                        break;
+                        default:
+                            throw std::runtime_error(
+                                "unexpected lib encountered in precompile_test_kernels");
+                            break;
+                        }
+                    }
+                    catch(fft_params::work_buffer_alloc_failure&)
+                    {
+                        continue;
+                    }
+                    catch(std::exception& e)
+                    {
+                        // failed to create a plan, abort
+                        //
+                        // we could continue on, but the test should just
+                        // fail later anyway in the same way.  so report
+                        // which token failed early and get out
+                        throw std::runtime_error(token + " plan creation failure: " + e.what());
                     }
                 }
-                catch(fft_params::work_buffer_alloc_failure&)
-                {
-                    continue;
-                }
-                catch(std::exception& e)
-                {
-                    // failed to create a plan, abort
-                    //
-                    // we could continue on, but the test should just
-                    // fail later anyway in the same way.  so report
-                    // which token failed early and get out
-                    throw std::runtime_error(token + " plan creation failure: " + e.what());
-                }
-            }
-        });
-        // insert empty tokens to tell threads to stop
-        tokenQueue.push({});
+            });
+            // insert empty tokens to tell threads to stop
+            tokenQueue.push({});
+        }
+        for(auto& t : threads)
+            t.join();
     }
-    for(auto& t : threads)
-        t.join();
 
     auto                                      precompile_end = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::milli> precompile_ms  = precompile_end - precompile_begin;
@@ -267,7 +305,7 @@ int main(int argc, char* argv[])
 {
     CLI::App app{
         "\n"
-        "hipFFT Runtime Test command line options\n"
+        "hipFFT/hipFFTW Runtime Test command line options\n"
         "NB: input parameters are row-major.\n"
         "\n"
         "FFTW accuracy test cases are named using these identifiers:\n"

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -3423,8 +3423,7 @@ namespace
         }
         // always add the manually-provided test, if matching target test's precision
         if(!manual_token.empty()
-           && manual_token.find(prec == fft_precision_single ? "single" : "double")
-                  != std::string::npos)
+           && manual_token.find(hipfftw_trait<prec>::prec_label) != std::string::npos)
         {
             insert_into_unique_sorted_params(
                 ret, hipfftw_functional_validation_params<prec>(manual_token));

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -1223,7 +1223,7 @@ namespace
                 // plan cannot be created and arguments were invalid...
                 // We may however have a mixed bag of some invalid and other unsupported args.
                 // In such cases, the specific exception to expect would be ill-defined
-                if(!plan_helper.has_unsupported_args_for(creation_options))
+                if(!plan_helper.has_unsupported_args())
                     return hipfftw_internal_exception::invalid_args;
                 else
                     return hipfftw_internal_exception::ill_defined;
@@ -1286,14 +1286,13 @@ namespace
         }
     };
 
+    template <int min_unsupported = 4, std::enable_if_t<(min_unsupported > 1), bool> = true>
     std::vector<int> arg_validation_runtime_rank_range()
     {
-        constexpr int min_unsupported_rank = 4;
-
         std::vector<int> ret = {
             get_random_rank<!valid_value>(), // invalid
-            get_random_rank<valid_value, min_unsupported_rank>(), // valid but unsupported
-            get_random_rank<valid_value, 1, min_unsupported_rank - 1>() // valid and supported
+            get_random_rank<valid_value, min_unsupported>(), // valid but unsupported
+            get_random_rank<valid_value, 1, min_unsupported - 1>() // valid and supported
         };
         return ret;
     }
@@ -1395,7 +1394,6 @@ namespace
         {
             ret.push_back(1);
         }
-
         return ret;
     }
 
@@ -1581,6 +1579,170 @@ namespace
         return ret;
     }
 
+    void shuffle_vectors(std::vector<ptrdiff_t>& len,
+                         std::vector<ptrdiff_t>& is,
+                         std::vector<ptrdiff_t>& os,
+                         bool                    all_but_last_dim = false)
+    {
+        if(len.size() != is.size() || len.size() != os.size())
+            throw std::invalid_argument("shuffle_vectors: inconsistent vector sizes.");
+        if(len.size() <= 1 || (len.size() == 2 && all_but_last_dim))
+            return;
+        std::vector<fftw_iodim64> layout(len.size());
+        for(auto idx = len.size(); idx-- > 0;)
+        {
+            layout[idx].n  = len[idx];
+            layout[idx].is = is[idx];
+            layout[idx].os = os[idx];
+        }
+        std::shuffle(layout.begin(), layout.end() - (all_but_last_dim ? 1 : 0), get_pseudo_rng());
+        for(auto idx = layout.size(); idx-- > 0;)
+        {
+            len[idx] = layout[idx].n;
+            is[idx]  = layout[idx].is;
+            os[idx]  = layout[idx].os;
+        }
+    }
+
+    template <fft_precision prec, bool use_guru64>
+    std::vector<hipfftw_helper<prec>> test_scope_for_arg_validation_of_plan_guru_dft()
+    {
+        constexpr int       min_unsupported_batch_rank = 2;
+        constexpr ptrdiff_t max_guru_val
+            = use_guru64 ? static_cast<ptrdiff_t>(std::numeric_limits<int>::max())
+                         : std::numeric_limits<ptrdiff_t>::max();
+
+        auto range_of_strides = [](const std::vector<ptrdiff_t>& lengths,
+                                   fft_transform_type            dft_kind,
+                                   fft_result_placement          placement,
+                                   fft_io                        io) {
+            std::vector<std::vector<ptrdiff_t>> ret;
+            if(lengths.empty())
+            {
+                ret.emplace_back(std::vector<ptrdiff_t>());
+                return ret;
+            }
+            std::vector<ptrdiff_t> abs_len = lengths;
+            std::for_each(abs_len.begin(), abs_len.end(), [](ptrdiff_t& x) { x = std::abs(x); });
+            auto strides_to_add = default_strides(dft_kind, placement, io, abs_len);
+            ret.push_back(strides_to_add);
+            // add some invalid strides (for nontrivial corresponding lengths)
+            decltype(strides_to_add)::value_type tmp      = 0;
+            auto                                 rand_idx = get_random_idx(strides_to_add.size());
+            std::swap(strides_to_add[rand_idx], tmp);
+            ret.push_back(strides_to_add);
+            std::swap(strides_to_add[rand_idx], tmp);
+            // add some unsupported strides
+            rand_idx = get_random_idx(strides_to_add.size());
+            strides_to_add[rand_idx] *= -1;
+            ret.push_back(strides_to_add);
+            return ret;
+        };
+
+        auto range_of_distances = [](const std::vector<ptrdiff_t>& batches,
+                                     const std::vector<ptrdiff_t>& lengths,
+                                     fft_transform_type            dft_kind,
+                                     fft_result_placement          placement,
+                                     fft_io                        io) {
+            std::vector<std::vector<ptrdiff_t>> ret;
+            if(batches.empty())
+            {
+                ret.emplace_back(std::vector<ptrdiff_t>());
+                return ret;
+            }
+            std::vector<ptrdiff_t> abs_batches = batches;
+            std::vector<ptrdiff_t> abs_lengths = lengths;
+            std::for_each(
+                abs_lengths.begin(), abs_lengths.end(), [](ptrdiff_t& x) { x = std::abs(x); });
+            std::for_each(
+                abs_batches.begin(), abs_batches.end(), [](ptrdiff_t& x) { x = std::abs(x); });
+            auto distances_to_add
+                = default_distances(dft_kind, placement, io, abs_lengths, abs_batches);
+            ret.push_back(distances_to_add);
+            // add some invalid distances (for nontrivial corresponding batch sizes)
+            decltype(distances_to_add)::value_type tmp = 0;
+            auto rand_idx                              = get_random_idx(distances_to_add.size());
+            std::swap(distances_to_add[rand_idx], tmp);
+            ret.push_back(distances_to_add);
+            std::swap(distances_to_add[rand_idx], tmp);
+            // add some unsupported distances
+            rand_idx = get_random_idx(distances_to_add.size());
+            distances_to_add[rand_idx] *= -1;
+            ret.push_back(distances_to_add);
+            return ret;
+        };
+
+        std::vector<hipfftw_helper<prec>> ret;
+
+        while(ret.size() < max_num_arg_validation_tests_per_hipfftw_plan_type)
+        {
+            const auto dft_kind   = get_random_element_in(trans_type_range_full);
+            const auto rank       = get_random_element_in(arg_validation_runtime_rank_range());
+            const auto batch_rank = get_random_element_in(
+                arg_validation_runtime_rank_range<min_unsupported_batch_rank>());
+            // rough limit for product(batches.begin(), batches.end()) <= max_nbatch_for_hipfftw_test
+            const auto batch_max_val = std::min(
+                max_guru_val,
+                std::max(static_cast<ptrdiff_t>(1),
+                         static_cast<ptrdiff_t>(std::pow(max_nbatch_for_hipfftw_test,
+                                                         1.0 / std::max(batch_rank, 1)))));
+            auto batches_range
+                = arg_validation_strictly_positive_vec_range(batch_rank, batch_max_val);
+            // --> test for empty batches/distances, too
+            batches_range.emplace_back(std::vector<ptrdiff_t>());
+            auto       batches = get_random_element_in(batches_range);
+            const auto nbatch_bound
+                = std::accumulate(batches.begin(),
+                                  batches.end(),
+                                  static_cast<ptrdiff_t>(1),
+                                  [](ptrdiff_t& acc, ptrdiff_t x) {
+                                      return acc * std::max(ptrdiff_t(1), std::abs(x));
+                                  });
+            const auto placement = get_random_element_in(place_range);
+            ptrdiff_t  max_len   = std::min(max_guru_val / nbatch_bound,
+                                         static_cast<ptrdiff_t>(max_length_for_hipfftw_test));
+            if(rank_is_valid_for_hipfftw(rank))
+            {
+                max_len = std::min(
+                    max_len,
+                    find_threshold_length_for_byte_size<prec>(
+                        max_byte_size_for_hipfftw_tests() / nbatch_bound, rank, is_real(dft_kind)));
+            }
+            auto len_range = arg_validation_strictly_positive_vec_range(rank, max_len);
+            // --> test for empty lengths/strides, too
+            len_range.emplace_back(std::vector<ptrdiff_t>());
+            auto lengths  = get_random_element_in(len_range);
+            auto istrides = get_random_element_in(
+                range_of_strides(lengths, dft_kind, placement, fft_io::fft_io_in));
+            auto ostrides = get_random_element_in(
+                range_of_strides(lengths, dft_kind, placement, fft_io::fft_io_out));
+            auto idist = get_random_element_in(
+                range_of_distances(batches, lengths, dft_kind, placement, fft_io::fft_io_in));
+            auto odist = get_random_element_in(
+                range_of_distances(batches, lengths, dft_kind, placement, fft_io::fft_io_out));
+            const auto sign  = get_random_element_in(arg_validation_sign_range(dft_kind));
+            const auto flags = get_random_element_in(arg_validation_flags_range(dft_kind, rank));
+
+            shuffle_vectors(lengths, istrides, ostrides, is_real(dft_kind));
+            shuffle_vectors(batches, idist, odist);
+            hipfftw_helper<prec> helper_to_add;
+            helper_to_add.set_creation_args(dft_kind,
+                                            rank,
+                                            lengths,
+                                            placement,
+                                            sign,
+                                            flags,
+                                            istrides,
+                                            ostrides,
+                                            batch_rank,
+                                            batches,
+                                            idist,
+                                            odist);
+            ret.emplace_back(helper_to_add);
+        }
+        return ret;
+    }
+
     // broad scope of hipfftw_helpers structs compatible with using a specific
     // plan creation function and configured with (zero or possibly many)
     // invalid/unsupported parameter value(s)
@@ -1588,6 +1750,7 @@ namespace
     std::vector<hipfftw_helper<prec>>
         test_scope_for_arg_validation_of(hipfftw_plan_creation_func creation_func)
     {
+        constexpr bool use_guru64 = true; // for readability
         switch(creation_func)
         {
         case hipfftw_plan_creation_func::PLAN_DFT_ND:
@@ -1597,10 +1760,9 @@ namespace
         case hipfftw_plan_creation_func::PLAN_MANY:
             return test_scope_for_arg_validation_of_plan_many_dft<prec>();
         case hipfftw_plan_creation_func::PLAN_GURU:
-            [[fallthrough]];
+            return test_scope_for_arg_validation_of_plan_guru_dft<prec, !use_guru64>();
         case hipfftw_plan_creation_func::PLAN_GURU64:
-            throw std::runtime_error("PLAN_GURU, and PLAN_GURU64 are not implemented yet for "
-                                     "test_scope_for_arg_validation_of");
+            return test_scope_for_arg_validation_of_plan_guru_dft<prec, use_guru64>();
         default:
             throw std::invalid_argument(
                 "creation_func unknown to test_scope_for_arg_validation_of");
@@ -1666,7 +1828,9 @@ namespace
 
         for(auto creation_func : {hipfftw_plan_creation_func::PLAN_DFT_ND,
                                   hipfftw_plan_creation_func::PLAN_DFT,
-                                  hipfftw_plan_creation_func::PLAN_MANY})
+                                  hipfftw_plan_creation_func::PLAN_MANY,
+                                  hipfftw_plan_creation_func::PLAN_GURU,
+                                  hipfftw_plan_creation_func::PLAN_GURU64})
         {
             for(const auto& helper : test_scope_for_arg_validation_of<prec>(creation_func))
             {
@@ -2389,17 +2553,20 @@ namespace
            && helper.get_strides(fft_io::fft_io_in).back() == 1
            && helper.get_strides(fft_io::fft_io_out).back() == 1)
         {
-            // rocfft can't handle odd values of strides/distances between rows
-            // with even values of lengths.back() for real transforms.
+            // rocfft can't handle odd values of (non-elementary) strides/distances
+            // in real domain, with even values of lengths.back() for real transforms.
             // Incorrect results are generated
-            const auto rank = helper.get_rank();
-            const auto fwd_strides
+            auto tmp
                 = helper.get_strides(is_fwd(dft_kind) ? fft_io::fft_io_in : fft_io::fft_io_out);
-            const auto fwd_dist
-                = helper.get_distance(is_fwd(dft_kind) ? fft_io::fft_io_in : fft_io::fft_io_out);
-            const auto fwd_row_dist = rank > 1 ? fwd_strides[rank - 2] : fwd_dist;
+            tmp.erase(tmp.end() - 1); // remove elementary strides from considerations
+            tmp.push_back(
+                helper.get_distance(is_fwd(dft_kind) ? fft_io::fft_io_in : fft_io::fft_io_out));
 
-            ret = ret || fwd_row_dist % 2 == 1;
+            ret = ret
+                  || std::any_of(
+                      tmp.begin(), tmp.end(), [](const typename decltype(tmp)::value_type& val) {
+                          return val % 2 == 1;
+                      });
         }
         // incorrect results may be produced by rocfft for some of the following cases
         if(is_complex(dft_kind))
@@ -2868,7 +3035,6 @@ namespace
             batches,
             default_distances(dft_kind, placement, fft_io::fft_io_in, lengths, batches),
             default_distances(dft_kind, placement, fft_io::fft_io_out, lengths, batches));
-        return;
     }
 
     template <fft_precision prec>
@@ -2992,6 +3158,151 @@ namespace
                                  dist);
     }
 
+    // guru-/guru64-compatible plan (only).
+    // plan configurations with packed layouts but shuffling the natural
+    // dimension ordering, e.g., using column-major layouts
+    template <fft_precision prec>
+    void setup_nondefault_dim_ordering_plan(hipfftw_helper<prec>& helper)
+    {
+        constexpr int batch_rank = 1; // nothing else is supported
+
+        auto get_random_shuffling_indices = [](int rank, bool is_real_in_place) {
+            if(rank < 1)
+                throw std::invalid_argument("setup_nondefault_dim_ordering_plan::get_random_"
+                                            "shuffling_indices: unexpected rank.");
+            // shuffle the natural ordering:
+            std::vector<size_t> dimension_ordering(rank);
+            std::iota(dimension_ordering.begin(), dimension_ordering.end(), 0);
+            std::shuffle(dimension_ordering.begin(),
+                         dimension_ordering.end() - (is_real_in_place ? 1 : 0),
+                         get_pseudo_rng());
+            return dimension_ordering;
+        };
+
+        // 1D cases are never guru-only cases
+        const int  rank     = get_random_rank<valid_value, 2, 3>();
+        const auto dft_kind = get_random_element_in(trans_type_range_full);
+        // real in-place requires unit elementary strides, so rule it out for 2D real cases
+        const auto placement  = rank == 2 && is_real(dft_kind) ? fft_placement_notinplace
+                                                               : get_random_element_in(place_range);
+        const auto is_real_ip = is_real(dft_kind) && placement == fft_placement_inplace;
+        const auto batches
+            = get_random_vector<valid_value, ptrdiff_t>(batch_rank, max_nbatch_for_hipfftw_test, 1);
+        const size_t    max_data_size_per_batch = max_byte_size_for_hipfftw_tests() / batches[0];
+        const ptrdiff_t max_len = std::min(static_cast<ptrdiff_t>(max_length_for_hipfftw_test),
+                                           find_threshold_length_for_byte_size<prec>(
+                                               max_data_size_per_batch, rank, is_real(dft_kind)));
+        const auto      lengths = get_random_vector<valid_value, ptrdiff_t>(rank, max_len, 1);
+        auto            shuffling_indices = get_random_shuffling_indices(rank, is_real_ip);
+        const auto      istrides
+            = default_strides(dft_kind, placement, fft_io::fft_io_in, lengths, shuffling_indices);
+        const auto idist = default_distances(
+            dft_kind, placement, fft_io::fft_io_in, lengths, batches, shuffling_indices);
+        if(placement == fft_placement_notinplace)
+        {
+            // can use different shuffling on output
+            shuffling_indices = get_random_shuffling_indices(rank, is_real_ip);
+        }
+        const auto ostrides
+            = default_strides(dft_kind, placement, fft_io::fft_io_out, lengths, shuffling_indices);
+        const auto odist = default_distances(
+            dft_kind, placement, fft_io::fft_io_out, lengths, batches, shuffling_indices);
+
+        helper.set_creation_args(dft_kind,
+                                 rank,
+                                 lengths,
+                                 placement,
+                                 is_fwd(dft_kind) ? FFTW_FORWARD : FFTW_BACKWARD,
+                                 FFTW_ESTIMATE,
+                                 istrides,
+                                 ostrides,
+                                 batch_rank,
+                                 batches,
+                                 idist,
+                                 odist);
+    }
+
+    // guru-/guru64-compatible plan (only).
+    // plan configurations with not-quite-default 3D layouts: slowest-dimension's stride is
+    // added some arbitrary values making the layout nembed-incompatible (3D only since lesser
+    // similar rank cases are always nembed-compatible)
+    template <fft_precision prec>
+    void setup_tweaked_default_batched_plan(hipfftw_helper<prec>& helper)
+    {
+        constexpr int rank       = 3;
+        constexpr int batch_rank = 1;
+        const auto    dft_kind   = get_random_element_in(trans_type_range_full);
+        const auto    placement  = get_random_element_in(place_range);
+        const bool    is_real_ip = is_real(dft_kind) && placement == fft_placement_inplace;
+        // min original batch value of 2 (halved afterwards)
+        auto batches
+            = get_random_vector<valid_value, int>(batch_rank, max_nbatch_for_hipfftw_test, 2);
+        const size_t    max_data_size_per_batch = max_byte_size_for_hipfftw_tests() / batches[0];
+        const ptrdiff_t max_len = std::min(static_cast<ptrdiff_t>(max_length_for_hipfftw_test),
+                                           find_threshold_length_for_byte_size<prec>(
+                                               max_data_size_per_batch, rank, is_real(dft_kind)));
+        auto            lengths = get_random_vector<valid_value, int>(rank, max_len);
+        while(lengths[rank - 1] == 1)
+        {
+            // AxBx1 cannot be made nembed-incompatible by simply
+            // tweaking the slowest dimension's (A's) stride
+            lengths = get_random_vector<valid_value, int>(rank, max_len);
+        }
+        // parameters to tweak (initialized to default values)
+        auto istrides = default_strides(dft_kind, placement, fft_io::fft_io_in, lengths);
+        auto ostrides = default_strides(dft_kind, placement, fft_io::fft_io_out, lengths);
+        auto idist    = default_distances(dft_kind, placement, fft_io::fft_io_in, lengths, batches);
+        auto odist = default_distances(dft_kind, placement, fft_io::fft_io_out, lengths, batches);
+        // buy some wiggle room: double distances and halve the batch size
+        idist[0] *= 2;
+        odist[0] *= 2;
+        batches[0] /= 2;
+        // tweak slowest dimension's stride
+        const auto min_slow_dim_istride
+            = istrides.front() + (is_real_ip && is_fwd(dft_kind) ? 2 : 1);
+        const auto min_slow_dim_ostride
+            = ostrides.front() + (is_real_ip && is_bwd(dft_kind) ? 2 : 1);
+        const auto                    max_slow_dim_istride = 2 * istrides.front();
+        const auto                    max_slow_dim_ostride = 2 * ostrides.front();
+        std::uniform_int_distribution i_stride_gen(min_slow_dim_istride, max_slow_dim_istride);
+        std::uniform_int_distribution o_stride_gen(min_slow_dim_ostride, max_slow_dim_ostride);
+        while(istrides[0] % istrides[1] == 0 && ostrides[0] % ostrides[1] == 0)
+        {
+            istrides[0] = i_stride_gen(get_pseudo_rng());
+            if(placement == fft_placement_inplace)
+            {
+                if(is_real(dft_kind))
+                {
+                    if(is_fwd(dft_kind))
+                    {
+                        if(istrides[0] % 2 == 1)
+                            istrides[0]--;
+                        ostrides[0] = istrides[0] / 2;
+                    }
+                    else
+                        ostrides[0] = 2 * istrides[0];
+                }
+                else
+                    ostrides[0] = istrides[0];
+            }
+            else
+                ostrides[0] = o_stride_gen(get_pseudo_rng());
+        }
+
+        helper.set_creation_args(dft_kind,
+                                 rank,
+                                 lengths,
+                                 placement,
+                                 is_fwd(dft_kind) ? FFTW_FORWARD : FFTW_BACKWARD,
+                                 FFTW_ESTIMATE,
+                                 istrides,
+                                 ostrides,
+                                 batch_rank,
+                                 batches,
+                                 idist,
+                                 odist);
+    }
+
     template <fft_precision prec>
     std::vector<hipfftw_functional_validation_params<prec>>
         params_for_functional_tests(size_t desired_full_suite_size, const std::string& manual_token)
@@ -3004,13 +3315,17 @@ namespace
             default_unbatched,
             default_batched,
             random_nembed_compatible,
-            inner_batched
+            inner_batched,
+            nondefault_dim_ordering,
+            tweaked_default_batched
         };
         const std::vector<test_layout> possible_test_layouts
             = {test_layout::default_unbatched,
                test_layout::default_batched,
                test_layout::random_nembed_compatible,
-               test_layout::inner_batched};
+               test_layout::inner_batched,
+               test_layout::nondefault_dim_ordering,
+               test_layout::tweaked_default_batched};
         std::uniform_int_distribution<int> coin_toss(0, 1);
         const auto&                        possible_mem_types = get_possible_data_mem_types();
         while(full_list.size() < desired_full_suite_size)
@@ -3032,6 +3347,12 @@ namespace
                 break;
             case test_layout::inner_batched:
                 setup_inner_batched_plan(to_add.plan_helper);
+                break;
+            case test_layout::nondefault_dim_ordering:
+                setup_nondefault_dim_ordering_plan(to_add.plan_helper);
+                break;
+            case test_layout::tweaked_default_batched:
+                setup_tweaked_default_batched_plan(to_add.plan_helper);
                 break;
             default:
                 throw std::runtime_error(
@@ -3070,7 +3391,17 @@ namespace
             }
             // skip params if they can't be tested for some reason
             if(!to_add.can_be_tested())
+            {
+                if(verbose)
+                {
+                    // Likely some bug/mistake in one of the above setup_* functions.
+                    // That should be avoided as it can slow down test generation if
+                    // the failure to generate testable parameters happens frequently
+                    std::cout << to_add.to_string()
+                              << " rejected as a functional test (cannot be tested)." << std::endl;
+                }
                 continue;
+            }
             insert_into_unique_sorted_params(full_list, to_add);
         }
         std::vector<hipfftw_functional_validation_params<prec>> ret;

--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -2498,20 +2498,29 @@ namespace
         if(helper.get_rank() == 3 && is_complex(dft_kind) && !helper.is_using_default_strides())
         {
             // rocfft can't create some plans with non-default strides for lengths
-            // AxBxC wherein B, C are in
-            const std::vector<std::array<ptrdiff_t, 2>> symptomatic_sub_len
-                = {{16, 4},  {4, 16},  {16, 16}, {27, 4}, {4, 27},  {25, 4},  {4, 25},
-                   {16, 25}, {25, 16}, {25, 25}, {8, 9},  {9, 8},   {8, 4},   {4, 8},
-                   {8, 8},   {4, 9},   {9, 4},   {4, 4},  {20, 10}, {10, 20}, {27, 27}};
-            // (Note: failing lengths usually have a value of A involving a prime factor > 17.
-            // See adhoc tokens in rocfft's disabled suite of adhoc accuracy tests)
-            ret = ret
-                  || std::any_of(symptomatic_sub_len.begin(),
-                                 symptomatic_sub_len.end(),
-                                 [&](const std::array<ptrdiff_t, 2>& sub_len) {
-                                     return std::equal(
-                                         sub_len.begin(), sub_len.end(), len.begin() + 1);
-                                 });
+            // AxBxC wherein the two lengths of smallest input or output strides are in
+            const std::vector<std::vector<ptrdiff_t>> symptomatic_sub_len
+                = {{16, 4},  {4, 16},  {16, 16}, {27, 4},  {4, 27},  {25, 4},  {4, 25},
+                   {16, 25}, {25, 16}, {25, 25}, {8, 9},   {9, 8},   {8, 4},   {4, 8},
+                   {8, 8},   {4, 9},   {9, 4},   {4, 4},   {20, 10}, {10, 20}, {27, 27},
+                   {32, 9},  {9, 32},  {32, 4},  {4, 32},  {32, 8},  {8, 32},  {27, 9},
+                   {9, 27},  {16, 9},  {9, 16},  {25, 32}, {32, 25}, {9, 9},   {25, 9},
+                   {9, 25},  {16, 8},  {8, 16},  {16, 32}, {32, 16}, {25, 8},  {8, 25}};
+            // (Note: failing lengths usually have a value of length involving a prime factor > 17
+            // along the slowest dimension.  See adhoc tokens in rocfft's disabled suite of adhoc
+            // accuracy tests)
+            for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+            {
+                const auto& strides = helper.get_strides(io);
+                // get the sub-lengths corresponding of the fastest-varying dimensions
+                auto sub_len = len;
+                sub_len.erase(sub_len.begin()
+                              + std::distance(strides.begin(),
+                                              std::max_element(strides.begin(), strides.end())));
+                ret = ret
+                      || std::find(symptomatic_sub_len.begin(), symptomatic_sub_len.end(), sub_len)
+                             != symptomatic_sub_len.end();
+            }
         }
         if(helper.get_rank() > 1 && is_real(dft_kind) && !helper.is_using_default_strides())
         {
@@ -2521,25 +2530,10 @@ namespace
             // - 3D size Ax1xB
             ret = ret || (helper.get_rank() == 3 && len[1] == 1);
             // - 2D sizes in the following set
-            const std::vector<std::vector<ptrdiff_t>> symptomatic_real_lengths = {{25, 8},
-                                                                                  {9, 54},
-                                                                                  {81, 18},
-                                                                                  {25, 16},
-                                                                                  {8, 18},
-                                                                                  {64, 8},
-                                                                                  {64, 16},
-                                                                                  {27, 16},
-                                                                                  {25, 32},
-                                                                                  {9, 16},
-                                                                                  {8, 8},
-                                                                                  {9, 32},
-                                                                                  {20, 20},
-                                                                                  {16, 8},
-                                                                                  {32, 8},
-                                                                                  {81, 64},
-                                                                                  {16, 16},
-                                                                                  {4, 18},
-                                                                                  {9, 8}};
+            const std::vector<std::vector<ptrdiff_t>> symptomatic_real_lengths
+                = {{25, 8},  {9, 54},  {81, 18}, {25, 16}, {8, 18}, {64, 8},  {64, 16},
+                   {27, 16}, {25, 32}, {9, 16},  {8, 8},   {9, 32}, {20, 20}, {16, 8},
+                   {32, 8},  {81, 64}, {16, 16}, {4, 18},  {9, 8},  {32, 18}};
 
             ret = ret
                   || std::any_of(symptomatic_real_lengths.begin(),

--- a/projects/hipfft/docs/reference/hipfftw-api-usage.rst
+++ b/projects/hipfft/docs/reference/hipfftw-api-usage.rst
@@ -26,6 +26,14 @@ Similarly to FFTW_, hipFFTW uses the following specific types.
 
 .. doxygentypedef:: fftwf_plan
 
+.. doxygentypedef:: fftw_iodim
+
+.. doxygentypedef:: fftwf_iodim
+
+.. doxygentypedef:: fftw_iodim64
+
+.. doxygentypedef:: fftwf_iodim64
+
 Constant values
 ===============
 
@@ -139,7 +147,7 @@ input and output buffers are used when the plan is created. The plan is configur
 .. note::
   - hipFFTW does not support split complex formats, real-to-real transforms, nor distributed transforms;
   - hipFFTW does not support transforms of more than 3 dimensions, that is, ``rank > 3`` is not supported;
-  - hipFFTW does not support transforms of more than 1 batch dimension, that is, ``batch_rank > 1`` is not supported.
+  - hipFFTW does not support transforms of more than 1 batch dimension, that is, ``howmany_rank > 1`` is not supported.
 
 .. _hipfftw-basic-plan-creation:
 
@@ -238,7 +246,42 @@ The following functions can be used for creating advanced hipFFTW plans.
 Arbitrary plans
 ---------------
 
-.. TBD
+Arbitrary plans support batched transforms with arbitrary data layouts.
+
+Considering a :math:`d`-dimensional transform (:math:`d > 0`) of lengths ``n[0] x n[1] x ... x n[d-1]``
+batched ``m[0] x m[1] x ... x m[q-1]`` times (:math:`q > 0`), arbitrary input and output data layouts
+can be set via the ``dims`` and ``howmany_dims`` arguments of the plan creation functions below. Their
+``rank`` and ``howmany_rank`` arguments capture the (strictly positive) values of :math:`d` and
+:math:`q`, respectively.
+
+Specifically, ``dims`` must be an array of :math:`d` ``fftw_iodim`` (or ``fftw_iodim64``) values such
+that, for all :math:`0 \leq i < d`,
+
+- ``dims[i].n`` is equal to ``n[i]`` (must be strictly positive);
+- ``dims[i].is`` is the input stride along the ``i``-th data dimension;
+- ``dims[i].os`` is the output stride along the ``i``-th data dimension.
+
+Similarly, ``howmany_dims`` must be an array of :math:`q` ``fftw_iodim`` (or ``fftw_iodim64``) values
+such that, for all :math:`0 \leq j < q`,
+
+- ``howmany_dims[j].n`` is equal to ``m[j]`` (must be strictly positive);
+- ``howmany_dims[j].is`` is the input distance along the ``j``-th batch dimension;
+- ``howmany_dims[j].os`` is the output distance along the ``j``-th batch dimension.
+
+The following functions can be used for creating arbitrary hipFFTW plans.
+
+.. doxygenfunction:: fftw_plan_guru_dft
+.. doxygenfunction:: fftwf_plan_guru_dft
+.. doxygenfunction:: fftw_plan_guru_dft_r2c
+.. doxygenfunction:: fftwf_plan_guru_dft_r2c
+.. doxygenfunction:: fftw_plan_guru_dft_c2r
+.. doxygenfunction:: fftwf_plan_guru_dft_c2r
+.. doxygenfunction:: fftw_plan_guru64_dft
+.. doxygenfunction:: fftwf_plan_guru64_dft
+.. doxygenfunction:: fftw_plan_guru64_dft_r2c
+.. doxygenfunction:: fftwf_plan_guru64_dft_r2c
+.. doxygenfunction:: fftw_plan_guru64_dft_c2r
+.. doxygenfunction:: fftwf_plan_guru64_dft_c2r
 
 .. _hipfftw-data-layout-requirements:
 

--- a/projects/hipfft/library/include/hipfft/hipfftw.h
+++ b/projects/hipfft/library/include/hipfft/hipfftw.h
@@ -61,6 +61,47 @@ typedef struct fftw_plan_s* fftw_plan;
  */
 typedef struct fftwf_plan_s* fftwf_plan;
 
+typedef struct
+{
+    int n;
+    int is;
+    int os;
+} hipfftw_iodim;
+typedef struct
+{
+    ptrdiff_t n;
+    ptrdiff_t is;
+    ptrdiff_t os;
+} hipfftw_iodim64;
+
+/**
+ * @brief Structure type describing lengths (or batch sizes) and input/output
+ * strides (or distances) along a dimension for generalized data layouts.
+ * Structure members are:
+ * - ``n`` length (or batch size);
+ * - ``is`` input stride (or distance);
+ * - ``os`` output stride (or distance).
+ *
+ * All the above members are of type ``int``.
+ */
+typedef hipfftw_iodim fftw_iodim;
+
+/**
+ * @brief This type is strictly equivalent to ``fftw_iodim``.
+ */
+typedef hipfftw_iodim fftwf_iodim;
+
+/**
+ * @brief This structure type is the equivalent of ``fftw_iodim`` using
+ * ``ptrdiff_t`` for members' type instead of ``int``.
+ */
+typedef hipfftw_iodim64 fftw_iodim64;
+
+/**
+ * @brief This type is strictly equivalent to ``fftw_iodim64``.
+ */
+typedef hipfftw_iodim64 fftwf_iodim64;
+
 /**
  * @brief Flag value allowing hipFFTW to compute (possibly many) FFTs at plan creation
  * to find the optimal configuration, using the input and output data buffers set at plan
@@ -512,6 +553,172 @@ HIPFFT_EXPORT fftwf_plan fftwf_plan_many_dft_c2r(int            rank,
                                                  int            ostride,
                                                  int            odist,
                                                  unsigned       flags);
+// guru plans
+/**
+ * @brief Creates an arbitrary plan for a multidimensional, double-precision, complex
+ * discrete Fourier transform of lengths ``dims[0].n x dims[1].n x ... x dims[rank-1].n``
+ * and batch sizes ``howmany_dims[0].n x howmany_dims[1].n x ... x howmany_dims[howmany_rank-1].n``.
+ * 
+ * @param[in] rank strictly positive rank of the transform;
+ * @param[in] dims array of ``rank`` ``fftw_iodim`` values;
+ * @param[in] howmany_rank strictly positive rank of the transform's batch sizes;
+ * @param[in] howmany_dims array of ``howmany_rank`` ``fftw_iodim`` values;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] sign exponent sign defining the desired complex transform (``FFTW_FORWARD`` or ``FFTW_BACKWARD``);
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
+HIPFFT_EXPORT fftw_plan fftw_plan_guru_dft(int               rank,
+                                           const fftw_iodim* dims,
+                                           int               howmany_rank,
+                                           const fftw_iodim* howmany_dims,
+                                           fftw_complex*     in,
+                                           fftw_complex*     out,
+                                           int               sign,
+                                           unsigned          flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_guru_dft.
+ */
+HIPFFT_EXPORT fftwf_plan fftwf_plan_guru_dft(int                rank,
+                                             const fftwf_iodim* dims,
+                                             int                howmany_rank,
+                                             const fftwf_iodim* howmany_dims,
+                                             fftwf_complex*     in,
+                                             fftwf_complex*     out,
+                                             int                sign,
+                                             unsigned           flags);
+/**
+ * @brief Creates an arbitrary plan for a multidimensional, double-precision, real forward
+ * discrete Fourier transform of lengths ``dims[0].n x dims[1].n x ... x dims[rank-1].n``
+ * and batch sizes ``howmany_dims[0].n x howmany_dims[1].n x ... x howmany_dims[howmany_rank-1].n``.
+ * 
+ * @param[in] rank strictly positive rank of the transform;
+ * @param[in] dims array of ``rank`` ``fftw_iodim`` values;
+ * @param[in] howmany_rank strictly positive rank of the transform's batch sizes;
+ * @param[in] howmany_dims array of ``howmany_rank`` ``fftw_iodim`` values;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
+HIPFFT_EXPORT fftw_plan fftw_plan_guru_dft_r2c(int               rank,
+                                               const fftw_iodim* dims,
+                                               int               howmany_rank,
+                                               const fftw_iodim* howmany_dims,
+                                               double*           in,
+                                               fftw_complex*     out,
+                                               unsigned          flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_guru_dft_r2c.
+ */
+HIPFFT_EXPORT fftwf_plan fftwf_plan_guru_dft_r2c(int                rank,
+                                                 const fftwf_iodim* dims,
+                                                 int                howmany_rank,
+                                                 const fftwf_iodim* howmany_dims,
+                                                 float*             in,
+                                                 fftwf_complex*     out,
+                                                 unsigned           flags);
+/**
+ * @brief Creates an arbitrary plan for a multidimensional, double-precision, real backward
+ * (inverse) discrete Fourier transform of lengths ``dims[0].n x dims[1].n x ... x dims[rank-1].n``
+ * and batch sizes ``howmany_dims[0].n x howmany_dims[1].n x ... x howmany_dims[howmany_rank-1].n``.
+ * 
+ * @param[in] rank strictly positive rank of the transform;
+ * @param[in] dims array of ``rank`` ``fftw_iodim`` values;
+ * @param[in] howmany_rank strictly positive rank of the transform's batch sizes;
+ * @param[in] howmany_dims array of ``howmany_rank`` ``fftw_iodim`` values;
+ * @param[in] in pointer to the input buffer for the transform;
+ * @param[in] out pointer to the output buffer for the transform;
+ * @param[in] flags bitwise OR (``|``) combination of zero or more constant flag values.
+ * @return a valid double-precision hipFFTW plan ready for execution upon success (``nullptr`` otherwise).
+ */
+HIPFFT_EXPORT fftw_plan fftw_plan_guru_dft_c2r(int               rank,
+                                               const fftw_iodim* dims,
+                                               int               howmany_rank,
+                                               const fftw_iodim* howmany_dims,
+                                               fftw_complex*     in,
+                                               double*           out,
+                                               unsigned          flags);
+/**
+ * @brief Single-precision equivalent of \ref fftw_plan_guru_dft_c2r.
+ */
+HIPFFT_EXPORT fftwf_plan fftwf_plan_guru_dft_c2r(int                rank,
+                                                 const fftwf_iodim* dims,
+                                                 int                howmany_rank,
+                                                 const fftwf_iodim* howmany_dims,
+                                                 fftwf_complex*     in,
+                                                 float*             out,
+                                                 unsigned           flags);
+// guru64 plans
+/**
+ * @brief Equivalent of \ref fftw_plan_guru_dft using layout-describing values of type
+ * ``fftw_iodim64`` instead of ``fftw_iodim``.
+ */
+HIPFFT_EXPORT fftw_plan fftw_plan_guru64_dft(int                 rank,
+                                             const fftw_iodim64* dims,
+                                             int                 howmany_rank,
+                                             const fftw_iodim64* howmany_dims,
+                                             fftw_complex*       in,
+                                             fftw_complex*       out,
+                                             int                 sign,
+                                             unsigned            flags);
+/**
+ * @brief Equivalent of \ref fftwf_plan_guru_dft using layout-describing values of type
+ * ``fftwf_iodim64`` instead of ``fftwf_iodim``.
+ */
+HIPFFT_EXPORT fftwf_plan fftwf_plan_guru64_dft(int                  rank,
+                                               const fftwf_iodim64* dims,
+                                               int                  howmany_rank,
+                                               const fftwf_iodim64* howmany_dims,
+                                               fftwf_complex*       in,
+                                               fftwf_complex*       out,
+                                               int                  sign,
+                                               unsigned             flags);
+/**
+ * @brief Equivalent of \ref fftw_plan_guru_dft_r2c using layout-describing values of type
+ * ``fftw_iodim64`` instead of ``fftw_iodim``.
+ */
+HIPFFT_EXPORT fftw_plan fftw_plan_guru64_dft_r2c(int                 rank,
+                                                 const fftw_iodim64* dims,
+                                                 int                 howmany_rank,
+                                                 const fftw_iodim64* howmany_dims,
+                                                 double*             in,
+                                                 fftw_complex*       out,
+                                                 unsigned            flags);
+/**
+ * @brief Equivalent of \ref fftwf_plan_guru_dft_r2c using layout-describing values of type
+ * ``fftwf_iodim64`` instead of ``fftwf_iodim``.
+ */
+HIPFFT_EXPORT fftwf_plan fftwf_plan_guru64_dft_r2c(int                  rank,
+                                                   const fftwf_iodim64* dims,
+                                                   int                  howmany_rank,
+                                                   const fftwf_iodim64* howmany_dims,
+                                                   float*               in,
+                                                   fftwf_complex*       out,
+                                                   unsigned             flags);
+/**
+ * @brief Equivalent of \ref fftw_plan_guru_dft_c2r using layout-describing values of type
+ * ``fftw_iodim64`` instead of ``fftw_iodim``.
+ */
+HIPFFT_EXPORT fftw_plan fftw_plan_guru64_dft_c2r(int                 rank,
+                                                 const fftw_iodim64* dims,
+                                                 int                 howmany_rank,
+                                                 const fftw_iodim64* howmany_dims,
+                                                 fftw_complex*       in,
+                                                 double*             out,
+                                                 unsigned            flags);
+/**
+ * @brief Equivalent of \ref fftwf_plan_guru_dft_c2r using layout-describing values of type
+ * ``fftwf_iodim64`` instead of ``fftwf_iodim``.
+ */
+HIPFFT_EXPORT fftwf_plan fftwf_plan_guru64_dft_c2r(int                  rank,
+                                                   const fftwf_iodim64* dims,
+                                                   int                  howmany_rank,
+                                                   const fftwf_iodim64* howmany_dims,
+                                                   fftwf_complex*       in,
+                                                   float*               out,
+                                                   unsigned             flags);
 
 // Plan execution
 /**

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -869,6 +869,32 @@ namespace
         return ret;
     }
 
+    template <size_t rank,
+              typename iodim,
+              std::enable_if_t<
+                  std::is_same_v<iodim, hipfftw_iodim> || std::is_same_v<iodim, hipfftw_iodim64>,
+                  bool> = true>
+    hipfftw_general_layout_data<rank, 1> hipfftw_get_data_layout(const iodim* dims,
+                                                                 const iodim* howmany_dims)
+    {
+        if(!dims)
+            throw hipfftw_invalid_arg("dims argument must not be nullptr.");
+        if(!howmany_dims)
+            throw hipfftw_invalid_arg("howmany_dims argument must not be nullptr.");
+
+        hipfftw_general_layout_data<rank, 1> ret;
+        for(auto dim = rank; dim-- > 0;)
+        {
+            ret.lengths[dim]  = dims[dim].n;
+            ret.istrides[dim] = dims[dim].is;
+            ret.ostrides[dim] = dims[dim].os;
+        }
+        ret.batches[0] = howmany_dims[0].n;
+        ret.idist[0]   = howmany_dims[0].is;
+        ret.odist[0]   = howmany_dims[0].os;
+        return ret;
+    }
+
     inline void hipfftw_validate_sign(int sign)
     {
         if(sign != FFTW_FORWARD && sign != FFTW_BACKWARD)
@@ -1226,6 +1252,64 @@ static hipfftw_plan_t<prec>* hipfftw_create_advanced_complex_plan(int        ran
     else
         return hipfftw_create_advanced_plan<rocfft_transform_type_complex_inverse, prec>(
             rank, n, howmany, in, inembed, istride, idist, out, onembed, ostride, odist, flags);
+}
+
+template <rocfft_transform_type dft_type, rocfft_precision prec, typename iodim>
+static hipfftw_plan_t<prec>*
+    hipfftw_create_guru_plan(int                                                      rank,
+                             const iodim*                                             dims,
+                             int                                                      howmany_rank,
+                             const iodim*                                             howmany_dims,
+                             hipfftw_user_data_t<dft_type, prec, fft_io::fft_io_in>*  in,
+                             hipfftw_user_data_t<dft_type, prec, fft_io::fft_io_out>* out,
+                             unsigned                                                 flags)
+{
+    static_assert(std::is_same_v<iodim, hipfftw_iodim> || std::is_same_v<iodim, hipfftw_iodim64>);
+    if(rank <= 0 || howmany_rank <= 0)
+        throw hipfftw_invalid_arg("rank and howmany_rank values must be strictly positive.");
+    if(howmany_rank != 1)
+        throw hipfftw_unsupported("howmany_rank values larger than 1 are not supported.");
+    // rank == 1, 2, 3, or unsupported
+    switch(rank)
+    {
+    case 1:
+    {
+        const auto data_layout = hipfftw_get_data_layout<1, iodim>(dims, howmany_dims);
+        return hipfftw_create_plan<dft_type, prec>(data_layout, in, out, flags);
+    }
+    case 2:
+    {
+        const auto data_layout = hipfftw_get_data_layout<2, iodim>(dims, howmany_dims);
+        return hipfftw_create_plan<dft_type, prec>(data_layout, in, out, flags);
+    }
+    case 3:
+    {
+        const auto data_layout = hipfftw_get_data_layout<3, iodim>(dims, howmany_dims);
+        return hipfftw_create_plan<dft_type, prec>(data_layout, in, out, flags);
+    }
+    default:
+        throw hipfftw_unsupported("rank values larger than 3 are not supported.");
+    }
+    // unreachable
+}
+
+template <rocfft_precision prec, typename iodim>
+static hipfftw_plan_t<prec>* hipfftw_create_guru_complex_plan(int          rank,
+                                                              const iodim* dims,
+                                                              int          howmany_rank,
+                                                              const iodim* howmany_dims,
+                                                              hipfftw_complex_data_t<prec>* in,
+                                                              hipfftw_complex_data_t<prec>* out,
+                                                              int                           sign,
+                                                              unsigned                      flags)
+{
+    hipfftw_validate_sign(sign);
+    if(sign == FFTW_FORWARD)
+        return hipfftw_create_guru_plan<rocfft_transform_type_complex_forward, prec, iodim>(
+            rank, dims, howmany_rank, howmany_dims, in, out, flags);
+    else
+        return hipfftw_create_guru_plan<rocfft_transform_type_complex_inverse, prec, iodim>(
+            rank, dims, howmany_rank, howmany_dims, in, out, flags);
 }
 
 void* fftw_malloc(size_t n)
@@ -1959,6 +2043,242 @@ try
     constexpr auto dft_type = rocfft_transform_type_real_inverse;
     return hipfftw_create_advanced_plan<dft_type, prec>(
         rank, n, howmany, in, inembed, istride, idist, out, onembed, ostride, odist, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+/* ------------------------------------------------------------------------- */
+/*                      GURU PLAN CREATION FUNCTIONS                         */
+/* ------------------------------------------------------------------------- */
+
+fftw_plan fftw_plan_guru_dft(int               rank,
+                             const fftw_iodim* dims,
+                             int               howmany_rank,
+                             const fftw_iodim* howmany_dims,
+                             fftw_complex*     in,
+                             fftw_complex*     out,
+                             int               sign,
+                             unsigned          flags)
+try
+{
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_guru_complex_plan<prec, hipfftw_iodim>(
+        rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_guru_dft(int                rank,
+                               const fftwf_iodim* dims,
+                               int                howmany_rank,
+                               const fftwf_iodim* howmany_dims,
+                               fftwf_complex*     in,
+                               fftwf_complex*     out,
+                               int                sign,
+                               unsigned           flags)
+try
+{
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_guru_complex_plan<prec, hipfftw_iodim>(
+        rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_guru_dft_r2c(int               rank,
+                                 const fftw_iodim* dims,
+                                 int               howmany_rank,
+                                 const fftw_iodim* howmany_dims,
+                                 double*           in,
+                                 fftw_complex*     out,
+                                 unsigned          flags)
+try
+{
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_guru_plan<rocfft_transform_type_real_forward, prec, hipfftw_iodim>(
+        rank, dims, howmany_rank, howmany_dims, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_guru_dft_r2c(int                rank,
+                                   const fftwf_iodim* dims,
+                                   int                howmany_rank,
+                                   const fftwf_iodim* howmany_dims,
+                                   float*             in,
+                                   fftwf_complex*     out,
+                                   unsigned           flags)
+try
+{
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_guru_plan<rocfft_transform_type_real_forward, prec, hipfftw_iodim>(
+        rank, dims, howmany_rank, howmany_dims, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_guru_dft_c2r(int               rank,
+                                 const fftw_iodim* dims,
+                                 int               howmany_rank,
+                                 const fftw_iodim* howmany_dims,
+                                 fftw_complex*     in,
+                                 double*           out,
+                                 unsigned          flags)
+try
+{
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_guru_plan<rocfft_transform_type_real_inverse, prec, hipfftw_iodim>(
+        rank, dims, howmany_rank, howmany_dims, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_guru_dft_c2r(int                rank,
+                                   const fftwf_iodim* dims,
+                                   int                howmany_rank,
+                                   const fftwf_iodim* howmany_dims,
+                                   fftwf_complex*     in,
+                                   float*             out,
+                                   unsigned           flags)
+try
+{
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_guru_plan<rocfft_transform_type_real_inverse, prec, hipfftw_iodim>(
+        rank, dims, howmany_rank, howmany_dims, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_guru64_dft(int                 rank,
+                               const fftw_iodim64* dims,
+                               int                 howmany_rank,
+                               const fftw_iodim64* howmany_dims,
+                               fftw_complex*       in,
+                               fftw_complex*       out,
+                               int                 sign,
+                               unsigned            flags)
+try
+{
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_guru_complex_plan<prec, hipfftw_iodim64>(
+        rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_guru64_dft(int                  rank,
+                                 const fftwf_iodim64* dims,
+                                 int                  howmany_rank,
+                                 const fftwf_iodim64* howmany_dims,
+                                 fftwf_complex*       in,
+                                 fftwf_complex*       out,
+                                 int                  sign,
+                                 unsigned             flags)
+try
+{
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_guru_complex_plan<prec, hipfftw_iodim64>(
+        rank, dims, howmany_rank, howmany_dims, in, out, sign, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_guru64_dft_r2c(int                 rank,
+                                   const fftw_iodim64* dims,
+                                   int                 howmany_rank,
+                                   const fftw_iodim64* howmany_dims,
+                                   double*             in,
+                                   fftw_complex*       out,
+                                   unsigned            flags)
+try
+{
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_guru_plan<rocfft_transform_type_real_forward, prec, hipfftw_iodim64>(
+        rank, dims, howmany_rank, howmany_dims, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_guru64_dft_r2c(int                  rank,
+                                     const fftwf_iodim64* dims,
+                                     int                  howmany_rank,
+                                     const fftwf_iodim64* howmany_dims,
+                                     float*               in,
+                                     fftwf_complex*       out,
+                                     unsigned             flags)
+try
+{
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_guru_plan<rocfft_transform_type_real_forward, prec, hipfftw_iodim64>(
+        rank, dims, howmany_rank, howmany_dims, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftw_plan fftw_plan_guru64_dft_c2r(int                 rank,
+                                   const fftw_iodim64* dims,
+                                   int                 howmany_rank,
+                                   const fftw_iodim64* howmany_dims,
+                                   fftw_complex*       in,
+                                   double*             out,
+                                   unsigned            flags)
+try
+{
+    constexpr auto prec = rocfft_precision_double;
+    return hipfftw_create_guru_plan<rocfft_transform_type_real_inverse, prec, hipfftw_iodim64>(
+        rank, dims, howmany_rank, howmany_dims, in, out, flags);
+}
+catch(...)
+{
+    hipfftw_exception_handler(__func__);
+    return nullptr;
+}
+
+fftwf_plan fftwf_plan_guru64_dft_c2r(int                  rank,
+                                     const fftwf_iodim64* dims,
+                                     int                  howmany_rank,
+                                     const fftwf_iodim64* howmany_dims,
+                                     fftwf_complex*       in,
+                                     float*               out,
+                                     unsigned             flags)
+try
+{
+    constexpr auto prec = rocfft_precision_single;
+    return hipfftw_create_guru_plan<rocfft_transform_type_real_inverse, prec, hipfftw_iodim64>(
+        rank, dims, howmany_rank, howmany_dims, in, out, flags);
 }
 catch(...)
 {

--- a/projects/hipfft/shared/data_layout.h
+++ b/projects/hipfft/shared/data_layout.h
@@ -43,7 +43,7 @@ struct is_std_array<std::array<T, N>> : std::true_type
 };
 
 /**
- * @brief calculates the default strides for a given Discrete Fourier transform (row-major convention).
+ * @brief calculates the default strides for a given Discrete Fourier transform (observing row-major convention by default).
  * @note This function assumes interleaved complex representation for hermitian-symmetric data.
  * @note Empty strides are returned for empty lengths.
  * 
@@ -52,21 +52,39 @@ struct is_std_array<std::array<T, N>> : std::true_type
  * @param[in] dft_type type of transform
  * @param[in] placement placement of the transform
  * @param[in] io input/output flag
- * @param[in] lengths container of lengths for the transform of interest (row-major ordering convention)
+ * @param[in] lengths container of lengths for the transform of interest
+ * @param[in] dim_order optional vector of dimension ordering for ``lengths``. If used, the content
+ * of this vector must be a permutation of {0, 1, ..., lengths.size() - 1} (:= default natural order)
+ * and the corresponding dimension ordering is observed when generating the strides. For instance,
+ * column-major ordering is observed when setting ``dim_order`` to {lengths.size()-1, ..., 1, 0}.
  * @return desired default strides (same type as ``lengths`` input argument)
  */
 template <typename C, std::enable_if_t<std::is_integral_v<typename C::value_type>, bool> = true>
-static C default_strides(fft_transform_type   dft_type,
-                         fft_result_placement placement,
-                         fft_io               io,
-                         const C&             lengths)
+static C default_strides(fft_transform_type                        dft_type,
+                         fft_result_placement                      placement,
+                         fft_io                                    io,
+                         const C&                                  lengths,
+                         const std::optional<std::vector<size_t>>& dim_order = std::nullopt)
 {
     validate_enums_or_throw("default_strides", dft_type, placement, io);
+    if(dim_order)
+    {
+        if(dim_order->size() != lengths.size())
+            throw std::invalid_argument(
+                "default_strides: size mismatch between dim_order and lengths");
+        std::vector<size_t> natural_order(lengths.size());
+        std::iota(natural_order.begin(), natural_order.end(), 0);
+        if(!std::is_permutation(dim_order->begin(), dim_order->end(), natural_order.begin()))
+            throw std::invalid_argument("default_strides: invalid dim_order (not a permutation of "
+                                        "{0, 1, ..., lengths.size() - 1}");
+    }
+
     C                      ret(lengths);
     typename C::value_type def_stride = 1;
-    for(auto dim_idx = lengths.size(); dim_idx-- > 0;)
+    for(auto l_idx = lengths.size(); l_idx-- > 0;)
     {
-        ret[dim_idx] = def_stride;
+        const auto dim_idx = dim_order ? dim_order->at(l_idx) : l_idx;
+        ret[dim_idx]       = def_stride;
         if(dim_idx == lengths.size() - 1 && is_real(dft_type))
         {
             if((io == fft_io_out) == is_fwd(dft_type))
@@ -87,31 +105,53 @@ static C default_strides(fft_transform_type   dft_type,
 
 /**
  * @brief calculates the default distances for a given Discrete Fourier transform,
- * batched possibly multiple times (row-major convention).
+ * batched possibly multiple times (observing row-major convention by default).
  * @note This function assumes interleaved complex representation for hermitian-symmetric data.
- * @note Empty distances are returned for empty lengths or empty batches.
+ * @note Empty distances are returned for empty batches.
  * 
  * @tparam T integral value type for lengths and batches, the same type is used for the returned distances
  * @param[in] dft_type type of transform
  * @param[in] placement placement of the transform
  * @param[in] io input/output flag
- * @param[in] lengths vector of lengths for the transform of interest (row-major ordering convention)
+ * @param[in] lengths vector of lengths for the transform of interest
  * @param[in] batches vector of (possibly many) batch sizes for the transform of interest
+ * @param[in] len_dim_order optional vector of dimension ordering for ``lengths``. If used, the content
+ * of this vector must be a permutation of {0, 1, ..., lengths.size() - 1} (:= default natural order)
+ * and the corresponding dimension ordering is observed when generating the strides. For instance,
+ * column-major ordering is observed when setting ``len_dim_order`` to {lengths.size()-1, ..., 1, 0}.
  * @return std::vector<T> desired default distances (of size batches.size())
  */
 template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
-static std::vector<T> default_distances(fft_transform_type    dft_type,
-                                        fft_result_placement  placement,
-                                        fft_io                io,
-                                        const std::vector<T>& lengths,
-                                        const std::vector<T>& batches)
+static std::vector<T> default_distances(fft_transform_type                        dft_type,
+                                        fft_result_placement                      placement,
+                                        fft_io                                    io,
+                                        const std::vector<T>&                     lengths,
+                                        const std::vector<T>&                     batches,
+                                        const std::optional<std::vector<size_t>>& len_dim_order
+                                        = std::nullopt)
 {
     validate_enums_or_throw("default_distances", dft_type, placement, io);
-    if(batches.empty() || lengths.empty())
+    if(batches.empty())
         return std::vector<T>(); // empty as well
     auto temp_lengths = lengths;
     temp_lengths.insert(temp_lengths.begin(), batches.begin(), batches.end());
-    auto ret = default_strides(dft_type, placement, io, temp_lengths);
+    std::vector<T> ret;
+    if(!len_dim_order)
+    {
+        ret = default_strides(dft_type, placement, io, temp_lengths);
+    }
+    else
+    {
+        if(len_dim_order->size() != lengths.size())
+            throw std::invalid_argument(
+                "default_distances: size mismatch between len_dim_order and lengths");
+        std::vector<size_t> dim_order(batches.size() + lengths.size());
+        std::iota(dim_order.begin(), dim_order.begin() + batches.size(), 0);
+        for(size_t len_idx = 0; len_idx < lengths.size(); len_idx++)
+            dim_order[batches.size() + len_idx] = batches.size() + len_dim_order->at(len_idx);
+        ret = default_strides(dft_type, placement, io, temp_lengths, dim_order);
+    }
+
     ret.resize(batches.size());
     return ret;
 }
@@ -119,17 +159,18 @@ static std::vector<T> default_distances(fft_transform_type    dft_type,
  * @brief equivalent of default_distances for one-dimensional batches 
  */
 template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
-static T default_distance(fft_transform_type    dft_type,
-                          fft_result_placement  placement,
-                          fft_io                io,
-                          const std::vector<T>& lengths,
-                          const T&              batch_sz)
+static T default_distance(fft_transform_type                        dft_type,
+                          fft_result_placement                      placement,
+                          fft_io                                    io,
+                          const std::vector<T>&                     lengths,
+                          const T&                                  batch_sz,
+                          const std::optional<std::vector<size_t>>& len_dim_order = std::nullopt)
 {
     validate_enums_or_throw("default_distance", dft_type, placement, io);
     if(lengths.empty())
         throw std::invalid_argument("empty lengths rejected by default_distance");
-    const auto tmp
-        = default_distances(dft_type, placement, io, lengths, std::vector<T>(1, batch_sz));
+    const auto tmp = default_distances(
+        dft_type, placement, io, lengths, std::vector<T>(1, batch_sz), len_dim_order);
     return tmp.front();
 }
 

--- a/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
+++ b/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
@@ -492,6 +492,7 @@ const auto adhoc_nondefault_layout_real_tokens = {
     "real_inverse_len_16_16_single_ip_batch_6600_istride_19_1_HI_ostride_38_1_R_idist_798_odist_1596_ioffset_0_0_ooffset_0_0",
     "real_inverse_len_4_18_double_ip_batch_7484_istride_64_1_HI_ostride_128_1_R_idist_8192_odist_16384_ioffset_0_0_ooffset_0_0",
     "real_inverse_len_9_8_double_ip_batch_6908_istride_7_1_HI_ostride_14_1_R_idist_462_odist_924_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_32_18_double_ip_batch_7083_istride_15_1_HI_ostride_30_1_R_idist_915_odist_1830_ioffset_0_0_ooffset_0_0",
     // plan can be created but inaccurate results are produced:
     "real_forward_len_486_double_op_batch_7014_istride_7014_R_ostride_7014_HI_idist_1_odist_1_ioffset_0_0_ooffset_0_0_flags_64",
     "real_forward_len_486_double_op_batch_910_istride_910_R_ostride_910_HI_idist_1_odist_1_ioffset_0_0_ooffset_0_0",

--- a/projects/rocfft/shared/data_layout.h
+++ b/projects/rocfft/shared/data_layout.h
@@ -43,7 +43,7 @@ struct is_std_array<std::array<T, N>> : std::true_type
 };
 
 /**
- * @brief calculates the default strides for a given Discrete Fourier transform (row-major convention).
+ * @brief calculates the default strides for a given Discrete Fourier transform (observing row-major convention by default).
  * @note This function assumes interleaved complex representation for hermitian-symmetric data.
  * @note Empty strides are returned for empty lengths.
  * 
@@ -52,21 +52,39 @@ struct is_std_array<std::array<T, N>> : std::true_type
  * @param[in] dft_type type of transform
  * @param[in] placement placement of the transform
  * @param[in] io input/output flag
- * @param[in] lengths container of lengths for the transform of interest (row-major ordering convention)
+ * @param[in] lengths container of lengths for the transform of interest
+ * @param[in] dim_order optional vector of dimension ordering for ``lengths``. If used, the content
+ * of this vector must be a permutation of {0, 1, ..., lengths.size() - 1} (:= default natural order)
+ * and the corresponding dimension ordering is observed when generating the strides. For instance,
+ * column-major ordering is observed when setting ``dim_order`` to {lengths.size()-1, ..., 1, 0}.
  * @return desired default strides (same type as ``lengths`` input argument)
  */
 template <typename C, std::enable_if_t<std::is_integral_v<typename C::value_type>, bool> = true>
-static C default_strides(fft_transform_type   dft_type,
-                         fft_result_placement placement,
-                         fft_io               io,
-                         const C&             lengths)
+static C default_strides(fft_transform_type                        dft_type,
+                         fft_result_placement                      placement,
+                         fft_io                                    io,
+                         const C&                                  lengths,
+                         const std::optional<std::vector<size_t>>& dim_order = std::nullopt)
 {
     validate_enums_or_throw("default_strides", dft_type, placement, io);
+    if(dim_order)
+    {
+        if(dim_order->size() != lengths.size())
+            throw std::invalid_argument(
+                "default_strides: size mismatch between dim_order and lengths");
+        std::vector<size_t> natural_order(lengths.size());
+        std::iota(natural_order.begin(), natural_order.end(), 0);
+        if(!std::is_permutation(dim_order->begin(), dim_order->end(), natural_order.begin()))
+            throw std::invalid_argument("default_strides: invalid dim_order (not a permutation of "
+                                        "{0, 1, ..., lengths.size() - 1}");
+    }
+
     C                      ret(lengths);
     typename C::value_type def_stride = 1;
-    for(auto dim_idx = lengths.size(); dim_idx-- > 0;)
+    for(auto l_idx = lengths.size(); l_idx-- > 0;)
     {
-        ret[dim_idx] = def_stride;
+        const auto dim_idx = dim_order ? dim_order->at(l_idx) : l_idx;
+        ret[dim_idx]       = def_stride;
         if(dim_idx == lengths.size() - 1 && is_real(dft_type))
         {
             if((io == fft_io_out) == is_fwd(dft_type))
@@ -87,31 +105,53 @@ static C default_strides(fft_transform_type   dft_type,
 
 /**
  * @brief calculates the default distances for a given Discrete Fourier transform,
- * batched possibly multiple times (row-major convention).
+ * batched possibly multiple times (observing row-major convention by default).
  * @note This function assumes interleaved complex representation for hermitian-symmetric data.
- * @note Empty distances are returned for empty lengths or empty batches.
+ * @note Empty distances are returned for empty batches.
  * 
  * @tparam T integral value type for lengths and batches, the same type is used for the returned distances
  * @param[in] dft_type type of transform
  * @param[in] placement placement of the transform
  * @param[in] io input/output flag
- * @param[in] lengths vector of lengths for the transform of interest (row-major ordering convention)
+ * @param[in] lengths vector of lengths for the transform of interest
  * @param[in] batches vector of (possibly many) batch sizes for the transform of interest
+ * @param[in] len_dim_order optional vector of dimension ordering for ``lengths``. If used, the content
+ * of this vector must be a permutation of {0, 1, ..., lengths.size() - 1} (:= default natural order)
+ * and the corresponding dimension ordering is observed when generating the strides. For instance,
+ * column-major ordering is observed when setting ``len_dim_order`` to {lengths.size()-1, ..., 1, 0}.
  * @return std::vector<T> desired default distances (of size batches.size())
  */
 template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
-static std::vector<T> default_distances(fft_transform_type    dft_type,
-                                        fft_result_placement  placement,
-                                        fft_io                io,
-                                        const std::vector<T>& lengths,
-                                        const std::vector<T>& batches)
+static std::vector<T> default_distances(fft_transform_type                        dft_type,
+                                        fft_result_placement                      placement,
+                                        fft_io                                    io,
+                                        const std::vector<T>&                     lengths,
+                                        const std::vector<T>&                     batches,
+                                        const std::optional<std::vector<size_t>>& len_dim_order
+                                        = std::nullopt)
 {
     validate_enums_or_throw("default_distances", dft_type, placement, io);
-    if(batches.empty() || lengths.empty())
+    if(batches.empty())
         return std::vector<T>(); // empty as well
     auto temp_lengths = lengths;
     temp_lengths.insert(temp_lengths.begin(), batches.begin(), batches.end());
-    auto ret = default_strides(dft_type, placement, io, temp_lengths);
+    std::vector<T> ret;
+    if(!len_dim_order)
+    {
+        ret = default_strides(dft_type, placement, io, temp_lengths);
+    }
+    else
+    {
+        if(len_dim_order->size() != lengths.size())
+            throw std::invalid_argument(
+                "default_distances: size mismatch between len_dim_order and lengths");
+        std::vector<size_t> dim_order(batches.size() + lengths.size());
+        std::iota(dim_order.begin(), dim_order.begin() + batches.size(), 0);
+        for(size_t len_idx = 0; len_idx < lengths.size(); len_idx++)
+            dim_order[batches.size() + len_idx] = batches.size() + len_dim_order->at(len_idx);
+        ret = default_strides(dft_type, placement, io, temp_lengths, dim_order);
+    }
+
     ret.resize(batches.size());
     return ret;
 }
@@ -119,17 +159,18 @@ static std::vector<T> default_distances(fft_transform_type    dft_type,
  * @brief equivalent of default_distances for one-dimensional batches 
  */
 template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
-static T default_distance(fft_transform_type    dft_type,
-                          fft_result_placement  placement,
-                          fft_io                io,
-                          const std::vector<T>& lengths,
-                          const T&              batch_sz)
+static T default_distance(fft_transform_type                        dft_type,
+                          fft_result_placement                      placement,
+                          fft_io                                    io,
+                          const std::vector<T>&                     lengths,
+                          const T&                                  batch_sz,
+                          const std::optional<std::vector<size_t>>& len_dim_order = std::nullopt)
 {
     validate_enums_or_throw("default_distance", dft_type, placement, io);
     if(lengths.empty())
         throw std::invalid_argument("empty lengths rejected by default_distance");
-    const auto tmp
-        = default_distances(dft_type, placement, io, lengths, std::vector<T>(1, batch_sz));
+    const auto tmp = default_distances(
+        dft_type, placement, io, lengths, std::vector<T>(1, batch_sz), len_dim_order);
     return tmp.front();
 }
 


### PR DESCRIPTION
## Motivation

This PR continues and completes the development of `hipfftw` with the implementation of the `guru` plan creation functions `{fftw,fftwf}_{guru,guru64}_{dft,dft_r2c,dft_c2r}`. These functions allow users to set up most general plans, using arbitrary data layouts for multi-dimensional batched cases.
The relevant documentation parts are augmented accordingly.

## Technical Details

- The pre-existing `hipfftw` implementation details were almost entirely ready for this addition.
- `hipfftw_helper`'s logic is expanded accordingly.
- These functions enable usage for data layouts that may not be configurable via any of the hipFFT plan creation functions. As a consequence, the pre-compilation steps are modified to use the same library as the upcoming test's to trigger the required kernel compilation for all relevant test token.

## Test Plan

Argument validation and functional tests are expanded to cover the expanded `hipfftw` plan configuration set. For functional tests, random configurations of the following types are considered:
- default batched data layout with non-standard dimension ordering, _e.g._, using column-major dimension ordering instead of the natural row-major ordering;
- batched 3D data layouts tweaked compared to default layouts in such a way that they can only be configured via the new functions enabled herein.

## Test Result

Pre-existing and new tests are expected to pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
