### PR TITLE
Fix version check in test_config_dispatch

### DIFF
--- a/projects/rocprim/test/rocprim/test_config_dispatch.cpp
+++ b/projects/rocprim/test/rocprim/test_config_dispatch.cpp
@@ -143,7 +143,7 @@ TEST(RocprimConfigDispatchTests, DeviceIdFromStream)
     ASSERT_EQ(result, device_id);
 
     // hipStreamLegacy support was added in ROCm 6.2.0
-#if (HIP_VERSION_MAJOR >= 6 && HIP_VERSION_MINOR >= 2)
+#if (HIP_VERSION_MAJOR > 6 || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 2))
     HIP_CHECK(get_device_from_stream(hipStreamLegacy, result));
     ASSERT_EQ(result, device_id);
 #endif


### PR DESCRIPTION
## Motivation

This PR fixes #2524.  

## Technical Details

The original fix https://github.com/ROCm/rocm-libraries/commit/42ae90cba6d73a7eedfe61df3923f7a9ac6b4ace fixed the header but omitted the unit test.  This PR adds the correct check to the unit test for ROCm 7.0, 7.1.

## Test Plan

Test in CI

## Test Result

Test passes

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
