### PR TITLE
[hipblaslt] gfx12 Fix ttmp init workaround

### DIFF
--- a/projects/hipblaslt/clients/tests/data/matmul_common.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_common.yaml
@@ -57,7 +57,7 @@ Definitions:
     - { M: 24000, N: 256, K: 256, lda: 24010, ldb: 256, ldc: 24000, ldd: 24000 }
     - { M: 24000, N: 256, K: 256, lda: 24000, ldb: 256, ldc: 24020, ldd: 24020 }
 
-  - &grid_limit_matrix_size_single
+  - &grid_limit_matrix_size_real
     - { M: 2, N: 2097152, K:1 }
     - { M: 64, N: 1048576, K: 1 }
     - { M: 256, N: 1048576, K: 1 }

--- a/projects/hipblaslt/clients/tests/data/matmul_common.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_common.yaml
@@ -48,6 +48,17 @@ Definitions:
     - { M: 16, N: 16, K: 16, lda: 16, ldb: 16, ldc: 16, ldd: 16 }
     - { M: 128, N: 128, K: 64, lda: 128, ldb: 128, ldc: 128, ldd: 128 }
 
+  - &large_matrix_size_range
+    - { M: 16385, N: 3, K: 3 }
+    - { M: 524289, N: 3, K: 3 }
+    - { M: 2097153, N: 3, K: 3 }
+    - { M: 3, N: 16385, K: 3 }
+    - { M: 3, N: 524289, K: 3 }
+    - { M: 3, N: 2097153, K: 3 }
+    - { M: 3, N: 3, K: 16385 }
+    - { M: 3, N: 3, K: 524289 }
+    - { M: 3, N: 3, K: 2097153 }
+
   - &smoke_matrix_size_range
     - { M: 8, N: 8, K: 8, lda: 8, ldb: 8, ldc: 8, ldd: 8 }
     - { M: 16, N: 16, K: 16, lda: 16, ldb: 16, ldc: 16, ldd: 16 }

--- a/projects/hipblaslt/clients/tests/data/matmul_common.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_common.yaml
@@ -48,17 +48,6 @@ Definitions:
     - { M: 16, N: 16, K: 16, lda: 16, ldb: 16, ldc: 16, ldd: 16 }
     - { M: 128, N: 128, K: 64, lda: 128, ldb: 128, ldc: 128, ldd: 128 }
 
-  - &large_matrix_size_range
-    - { M: 16385, N: 3, K: 3 }
-    - { M: 524289, N: 3, K: 3 }
-    - { M: 2097153, N: 3, K: 3 }
-    - { M: 3, N: 16385, K: 3 }
-    - { M: 3, N: 524289, K: 3 }
-    - { M: 3, N: 2097153, K: 3 }
-    - { M: 3, N: 3, K: 16385 }
-    - { M: 3, N: 3, K: 524289 }
-    - { M: 3, N: 3, K: 2097153 }
-
   - &smoke_matrix_size_range
     - { M: 8, N: 8, K: 8, lda: 8, ldb: 8, ldc: 8, ldd: 8 }
     - { M: 16, N: 16, K: 16, lda: 16, ldb: 16, ldc: 16, ldd: 16 }

--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -132,18 +132,28 @@ Tests:
   alpha: 2
   beta: 3
 
-- name: matmul_grid_limit_single
-  category: pre_checkin
+- name: matmul_grid_limit_real
+  category: nightly
   function:
-    matmul: *single_precision
-  matrix_size: *grid_limit_matrix_size_single
+    matmul: *real_precisions
+  matrix_size: *grid_limit_matrix_size_real
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: 0
+  gpu_arch: '120[0-1]'
+
+- name: matmul_grid_limit_real_1b
+  category: nightly
+  function:
+    matmul: *real_precisions_1b
+  matrix_size: *grid_limit_matrix_size_real
   transA_transB: *transA_transB_range
   alpha: 1
   beta: 0
   gpu_arch: '120[0-1]'
 
 - name: matmul_grid_limit_double
-  category: pre_checkin
+  category: nightly
   function:
     matmul: *double_precision
   matrix_size: *grid_limit_matrix_size_double
@@ -2144,23 +2154,6 @@ Tests:
   beta: [0,1]
   requested_solution_num: -1
   unit_check: 1
-
-# Test case for launch limits
-# Review: should this be enabled on CI?
-# It requires a lot of memory and takes a little while to run.
-# - name: matmul_launch_limits
-#   category: nightly
-#   function:
-#     matmul: *hpa_bf16_precision
-#   matrix_size:
-#     - { M:  262144,   N:  131072,    K:  1024 }
-#   algo_method: [1]
-#   transA: T
-#   transB: N
-#   alpha: 1
-#   beta: 0
-#   requested_solution_num: -1
-#   unit_check: 0
 
 - name: matmul_heuristic_all_solutions_real_1byte_fnuz
   category: nightly

--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -100,6 +100,14 @@ Tests:
   transA_transB: *transA_transB_range
   alpha_beta: *alpha_beta_range
 
+- name: matmul_large
+  category: pre_checkin
+  function:
+    matmul: *real_precisions
+  matrix_size: *large_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha_beta: *alpha_beta_range
+
 - name: matmul_batch_medium
   category: pre_checkin
   function:

--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -100,14 +100,6 @@ Tests:
   transA_transB: *transA_transB_range
   alpha_beta: *alpha_beta_range
 
-- name: matmul_large
-  category: pre_checkin
-  function:
-    matmul: *real_precisions
-  matrix_size: *large_matrix_size_range
-  transA_transB: *transA_transB_range
-  alpha_beta: *alpha_beta_range
-
 - name: matmul_batch_medium
   category: pre_checkin
   function:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/StreamK.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/StreamK.py
@@ -1729,12 +1729,6 @@ class StreamKOff(StreamK):
 
     def graWorkGroup(self, writer, kernel, tPA, tPB):
         module = Module("StreamK Off graWorkGroup")
-
-        if writer.states.archCaps["WorkGroupIdFromTTM"]:
-            module.add(SMovB32(dst=sgpr("WorkGroup0"), src="ttmp9", comment="workaround"))
-            module.add(SAndB32(dst=sgpr("WorkGroup1"), src0=hex(0xFFFF), src1="ttmp7", comment="workaround"))
-            module.add(SLShiftRightB32(dst=sgpr("WorkGroup2"), shiftHex=hex(0x10), src="ttmp7"))
-
         return module
 
     def computeLoadSrd(self, writer, kernel, tc, sTmp):

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -1587,13 +1587,6 @@ class KernelWriterAssembly(KernelWriter):
     # FIXME: Here does not support UseBatch: False
     if "WorkGroup2" in self.sgprs:
       with self.allocTmpSgpr(2) as tmpSgpr:
-        # init workgroup id from ttmp
-        if self.states.archCaps["WorkGroupIdFromTTM"]:
-          module.addComment1("Init workgroup id from ttmp")
-          module.add(SMovB32(dst=sgpr("WorkGroup0"), src="ttmp9"))
-          module.add(SAndB32(dst=sgpr("WorkGroup1"), src0=hex(0xFFFF), src1="ttmp7"))
-          module.add(SLShiftRightB32(dst=sgpr("WorkGroup2"), shiftHex=hex(0x10), src="ttmp7"))
-
         module.addComment1("remap wg from 1D(idxWG012) to 3D(wg2,wg1,wg0)")
         module.addComment0("wg2 = idxWG012 * smallMagicNumber(1/(numWG0*numWG1))")
         tmpVgpr     = self.vgprPool.checkOut(2)
@@ -1803,6 +1796,13 @@ class KernelWriterAssembly(KernelWriter):
         for i in range(1, self.states.totalVgprs):
           moduleRegInit.add(VMovB32(dst=vgpr(i), src=hex(self.consts.initVgprValue), comment="InitVgpr&0x1"))
         moduleRegInit.addSpaceLine()
+
+      # init workgroup id from ttmp
+      if self.states.archCaps["WorkGroupIdFromTTM"]:
+        module.addComment1("Init workgroup id from ttmp")
+        module.add(SMovB32(dst=sgpr("WorkGroup0"), src="ttmp9"))
+        module.add(SAndB32(dst=sgpr("WorkGroup1"), src0=hex(0xFFFF), src1="ttmp7"))
+        module.add(SLShiftRightB32(dst=sgpr("WorkGroup2"), shiftHex=hex(0x10), src="ttmp7"))
 
       # set m0
       moduleRegInit.add(SMovB32(dst=mgpr(0), src=hex(kernel["LdsNumBytes"]),

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -1587,6 +1587,13 @@ class KernelWriterAssembly(KernelWriter):
     # FIXME: Here does not support UseBatch: False
     if "WorkGroup2" in self.sgprs:
       with self.allocTmpSgpr(2) as tmpSgpr:
+        # init workgroup id from ttmp
+        if self.states.archCaps["WorkGroupIdFromTTM"]:
+          module.addComment1("Init workgroup id from ttmp")
+          module.add(SMovB32(dst=sgpr("WorkGroup0"), src="ttmp9"))
+          module.add(SAndB32(dst=sgpr("WorkGroup1"), src0=hex(0xFFFF), src1="ttmp7"))
+          module.add(SLShiftRightB32(dst=sgpr("WorkGroup2"), shiftHex=hex(0x10), src="ttmp7"))
+
         module.addComment1("remap wg from 1D(idxWG012) to 3D(wg2,wg1,wg0)")
         module.addComment0("wg2 = idxWG012 * smallMagicNumber(1/(numWG0*numWG1))")
         tmpVgpr     = self.vgprPool.checkOut(2)

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/f32_grid_limit_size.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/f32_grid_limit_size.yaml
@@ -3,21 +3,15 @@ TestParameters:
 
 GlobalParameters:
   MinimumRequiredVersion: 5.0.0
-  PrintLevel: 1
-  PrintSolutionRejectionReason: True
-  Device: 0
-  CMakeBuildType: Release
-  KernelTime: True
-  MaxWorkspaceSize: 13421772800
-  DataInitTypeA: 21
-  DataInitTypeB: 21
-  DataInitTypeC: 21
+  SleepPercent: 50
+  NumElementsToValidate: 128
+  DataInitTypeBeta: 0
   DataInitTypeAlpha: 1
-  DataInitTypeBeta: 1
-  DataInitTypeBias: 21
-  DataInitTypeScaleAlphaVec: 21
-  NumElementsToValidate: -1
-  BoundsCheck: 2
+  NewClient: 2
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  Device: 0
+  PrintSolutionRejectionReason: True
 
 BenchmarkProblems:
   ########################################
@@ -68,12 +62,10 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16385, 3, 1, 3]
-          - Exact: [524289, 3, 1, 3]
-          - Exact: [2097153, 3, 1, 3]
-          - Exact: [3, 16385, 1, 3]
-          - Exact: [3, 524289, 1, 3]
-          - Exact: [3, 2097153, 1, 3]
-          - Exact: [3, 3, 1, 16385]
-          - Exact: [3, 3, 1, 524289]
-          - Exact: [3, 3, 1, 2097153]
+          - Exact: [2, 2097152, 1, 1]
+          - Exact: [64, 1048576, 1, 1]
+          - Exact: [256, 1048576, 1, 1]
+          - Exact: [1024, 524288, 1, 1]
+          - Exact: [2048, 262144, 1, 1]
+          - Exact: [3072, 131072, 1, 1]
+          - Exact: [4096, 131072, 1, 1]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/f32_large_size.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx12/f32_large_size.yaml
@@ -1,0 +1,79 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx950, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+
+GlobalParameters:
+  MinimumRequiredVersion: 5.0.0
+  PrintLevel: 1
+  PrintSolutionRejectionReason: True
+  Device: 0
+  CMakeBuildType: Release
+  KernelTime: True
+  MaxWorkspaceSize: 13421772800
+  DataInitTypeA: 21
+  DataInitTypeB: 21
+  DataInitTypeC: 21
+  DataInitTypeAlpha: 1
+  DataInitTypeBeta: 1
+  DataInitTypeBias: 21
+  DataInitTypeScaleAlphaVec: 21
+  NumElementsToValidate: -1
+  BoundsCheck: 2
+
+BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      ComputeDataType: s
+      TransposeA: true
+      TransposeB: false
+      # UseScaleAlphaVec: 1
+      # UseBeta: true
+      # UseBias: 1
+      Batched: true
+      # Activation: true
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: [Assembly]
+      ForkParameters:
+        - PrefetchGlobalRead: [0]
+        - PrefetchLocalRead: [0]
+        - WavefrontSize: [32]
+        - ThreadTile:
+          - [1, 1]
+          # - [2, 2]
+          # - [4, 4]
+          #- [8, 8]
+        - WorkGroup:
+          # - [4, 8, 1]
+          #- [8, 4, 1]
+          - [8, 8, 1]
+          # - [2, 16, 1]
+          # - [16, 2, 1]
+        - DepthU: [32]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - LocalReadVectorWidth: [1]
+        - GlobalReadVectorWidthA: [1]
+        - GlobalReadVectorWidthB: [1]
+        - ScheduleIterAlg: [1]
+        - WorkGroupMapping: [1]
+        - GlobalSplitU: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [16385, 3, 1, 3]
+          - Exact: [524289, 3, 1, 3]
+          - Exact: [2097153, 3, 1, 3]
+          - Exact: [3, 16385, 1, 3]
+          - Exact: [3, 524289, 1, 3]
+          - Exact: [3, 2097153, 1, 3]
+          - Exact: [3, 3, 1, 16385]
+          - Exact: [3, 3, 1, 524289]
+          - Exact: [3, 3, 1, 2097153]

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -1313,14 +1313,11 @@ namespace TensileLite
         static_cast<void>(hipGetDevice(&deviceId));
         static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
         auto gpu_arch_no_prefix = removePrefix(deviceProperties.gcnArchName);
-        if(stoi(gpu_arch_no_prefix) / 100 != 12)
+        if(internalArgsSupport.version >= 1)
         {
-            if(internalArgsSupport.version >= 1)
-            {
-                rv.numWorkGroups.x *= (rv.numWorkGroups.y * rv.numWorkGroups.z);
-                rv.numWorkGroups.y = 1;
-                rv.numWorkGroups.z = 1;
-            }
+            rv.numWorkGroups.x *= (rv.numWorkGroups.y * rv.numWorkGroups.z);
+            rv.numWorkGroups.y = 1;
+            rv.numWorkGroups.z = 1;
         }
 
         rv.numWorkItems.x = rv.workGroupSize.x * rv.numWorkGroups.x;


### PR DESCRIPTION
## Motivation

Fix workaround to support wg id larger than 2^15.

## Technical Details

1. WorkGroup ID is init by 1D at host side.
2. gfx12 kernels launch with wg id stored in ttmp
3. At kernel side, wg id is retrieved from ttmp and restored back to 3d id.

## Test Plan

add large skinny size to gtest and tox for gfx12

## Test Result

## Submission Checklist

