### PR TITLE
Auto-update hipTensor doc dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,3 +70,15 @@ updates:
       - "ci:docs-only"
     reviewers:
       - "samjwu"
+
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "projects/hiptensor/docs/sphinx" # Location of package manifests
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    labels:
+      - "documentation"
+      - "dependencies"
+      - "ci:docs-only"
+    reviewers:
+      - "samjwu"


### PR DESCRIPTION
## Motivation

Auto-updating hipTensor documentation dependencies as previously done for the standalone repo.

## Technical Details

## Test Plan

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
