### PR TITLE
[hipsparse] Fix compilation failure in documentation example for sddmm on fedora and centos

### DIFF
--- a/projects/hipsparse/clients/samples/documentation_examples/generic/example_hipsparse_sddmm_cpp.cpp
+++ b/projects/hipsparse/clients/samples/documentation_examples/generic/example_hipsparse_sddmm_cpp.cpp
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
 
         for(int j = 0; j < n; j++)
         {
-            std::cout << temp[j] << " ";
+            std::cout << static_cast<float>(temp[j]) << " ";
         }
         std::cout << std::endl;
     }


### PR DESCRIPTION
## Motivation

Fixes compilation failure seen when building hipsparse from source on fedora43 rawhide centos 10

## Technical Details

Fixes ambiguous operator overload errors related to using `__half`:

example_hipsparse_sddmm_cpp.cpp:185:23: error: use of overloaded operator '<<' is ambiguous

## Test Plan

Ensure compilation passes
