### PR TITLE
[rocthrust] Namespace change from thrust::hip to thrust::system::hip

### DIFF
--- a/projects/rocthrust/thrust/system/hip/detail/assign_value.h
+++ b/projects/rocthrust/thrust/system/hip/detail/assign_value.h
@@ -41,19 +41,19 @@ namespace hip_rocprim
 
 template <typename DerivedPolicy, typename Pointer1, typename Pointer2>
 inline THRUST_HOST_DEVICE void
-assign_value(thrust::hip::execution_policy<DerivedPolicy>& exec, Pointer1 dst, Pointer2 src)
+assign_value(thrust::system::hip::execution_policy<DerivedPolicy>& exec, Pointer1 dst, Pointer2 src)
 {
   // XXX war nvbugs/881631
   struct war_nvbugs_881631
   {
     THRUST_HOST inline static void
-    host_path(thrust::hip::execution_policy<DerivedPolicy>& exec, Pointer1 dst, Pointer2 src)
+    host_path(thrust::system::hip::execution_policy<DerivedPolicy>& exec, Pointer1 dst, Pointer2 src)
     {
       hip_rocprim::copy(exec, src, src + 1, dst);
     }
 
     THRUST_DEVICE inline static void
-    device_path(thrust::hip::execution_policy<DerivedPolicy>&, Pointer1 dst, Pointer2 src)
+    device_path(thrust::system::hip::execution_policy<DerivedPolicy>&, Pointer1 dst, Pointer2 src)
     {
       *thrust::raw_pointer_cast(dst) = *thrust::raw_pointer_cast(src);
     }
@@ -82,7 +82,7 @@ inline THRUST_HOST_DEVICE void assign_value(cross_system<System1, System2>& syst
     {
       // XXX forward the true hip::execution_policy inside systems here
       //     instead of materializing a tag
-      thrust::hip::tag hip_tag;
+      thrust::system::hip::tag hip_tag;
       thrust::hip_rocprim::assign_value(hip_tag, dst, src);
     }
   };

--- a/projects/rocthrust/thrust/system/hip/detail/cross_system.h
+++ b/projects/rocthrust/thrust/system/hip/detail/cross_system.h
@@ -150,56 +150,56 @@ constexpr THRUST_HOST_DEVICE auto is_device_to_device_copy(ExecutionPolicy const
 
 // Device to host.
 template <class Sys1, class Sys2>
-THRUST_HOST_DEVICE auto select_device_system(thrust::hip::execution_policy<Sys1>& sys1, thrust::execution_policy<Sys2>&)
+THRUST_HOST_DEVICE auto select_device_system(thrust::system::hip::execution_policy<Sys1>& sys1, thrust::execution_policy<Sys2>&)
   THRUST_DECLTYPE_RETURNS(sys1)
 
   // Device to host.
   template <class Sys1, class Sys2>
-  THRUST_HOST_DEVICE auto select_device_system(thrust::hip::execution_policy<Sys1> const& sys1,
+  THRUST_HOST_DEVICE auto select_device_system(thrust::system::hip::execution_policy<Sys1> const& sys1,
                                                thrust::execution_policy<Sys2> const&) THRUST_DECLTYPE_RETURNS(sys1)
 
   // Host to device.
   template <class Sys1, class Sys2>
   THRUST_HOST_DEVICE auto select_device_system(thrust::execution_policy<Sys1>&,
-                                               thrust::hip::execution_policy<Sys2>& sys2) THRUST_DECLTYPE_RETURNS(sys2)
+                                               thrust::system::hip::execution_policy<Sys2>& sys2) THRUST_DECLTYPE_RETURNS(sys2)
 
   // Host to device.
   template <class Sys1, class Sys2>
   THRUST_HOST_DEVICE auto select_device_system(thrust::execution_policy<Sys1> const&,
-                                               thrust::hip::execution_policy<Sys2> const& sys2)
+                                               thrust::system::hip::execution_policy<Sys2> const& sys2)
     THRUST_DECLTYPE_RETURNS(sys2)
 
   // Device to device.
   template <class Sys1, class Sys2>
-  THRUST_HOST_DEVICE auto select_device_system(thrust::hip::execution_policy<Sys1>& sys1,
-                                               thrust::hip::execution_policy<Sys2>&) THRUST_DECLTYPE_RETURNS(sys1)
+  THRUST_HOST_DEVICE auto select_device_system(thrust::system::hip::execution_policy<Sys1>& sys1,
+                                               thrust::system::hip::execution_policy<Sys2>&) THRUST_DECLTYPE_RETURNS(sys1)
 
   // Device to device.
   template <class Sys1, class Sys2>
-  THRUST_HOST_DEVICE auto select_device_system(thrust::hip::execution_policy<Sys1> const& sys1,
-                                               thrust::hip::execution_policy<Sys2> const&) THRUST_DECLTYPE_RETURNS(sys1)
+  THRUST_HOST_DEVICE auto select_device_system(thrust::system::hip::execution_policy<Sys1> const& sys1,
+                                               thrust::system::hip::execution_policy<Sys2> const&) THRUST_DECLTYPE_RETURNS(sys1)
 
   /////////////////////////////////////////////////////////////////////////////
 
   // Device to host.
   template <class Sys1, class Sys2>
-  THRUST_HOST_DEVICE auto select_host_system(thrust::hip::execution_policy<Sys1>&, thrust::execution_policy<Sys2>& sys2)
+  THRUST_HOST_DEVICE auto select_host_system(thrust::system::hip::execution_policy<Sys1>&, thrust::execution_policy<Sys2>& sys2)
     THRUST_DECLTYPE_RETURNS(sys2)
 
   // Device to host.
   template <class Sys1, class Sys2>
-  THRUST_HOST_DEVICE auto select_host_system(thrust::hip::execution_policy<Sys1> const&,
+  THRUST_HOST_DEVICE auto select_host_system(thrust::system::hip::execution_policy<Sys1> const&,
                                              thrust::execution_policy<Sys2> const& sys2) THRUST_DECLTYPE_RETURNS(sys2)
 
   // Host to device.
   template <class Sys1, class Sys2>
-  THRUST_HOST_DEVICE auto select_host_system(thrust::execution_policy<Sys1>& sys1, thrust::hip::execution_policy<Sys2>&)
+  THRUST_HOST_DEVICE auto select_host_system(thrust::execution_policy<Sys1>& sys1, thrust::system::hip::execution_policy<Sys2>&)
     THRUST_DECLTYPE_RETURNS(sys1)
 
   // Host to device.
   template <class Sys1, class Sys2>
   THRUST_HOST_DEVICE auto select_host_system(thrust::execution_policy<Sys1> const& sys1,
-                                             thrust::hip::execution_policy<Sys2> const&) THRUST_DECLTYPE_RETURNS(sys1)
+                                             thrust::system::hip::execution_policy<Sys2> const&) THRUST_DECLTYPE_RETURNS(sys1)
 
   // Device to device.
   template <class Sys1, class Sys2>

--- a/projects/rocthrust/thrust/system/hip/detail/iter_swap.h
+++ b/projects/rocthrust/thrust/system/hip/detail/iter_swap.h
@@ -41,7 +41,7 @@ namespace hip_rocprim
 {
 
 template <typename DerivedPolicy, typename Pointer1, typename Pointer2>
-inline THRUST_HOST_DEVICE void iter_swap(thrust::hip::execution_policy<DerivedPolicy>&, Pointer1 a, Pointer2 b)
+inline THRUST_HOST_DEVICE void iter_swap(thrust::system::hip::execution_policy<DerivedPolicy>&, Pointer1 a, Pointer2 b)
 {
   // XXX war nvbugs/881631
   struct war_nvbugs_881631

--- a/projects/rocthrust/thrust/system/hip/memory_resource.h
+++ b/projects/rocthrust/thrust/system/hip/memory_resource.h
@@ -92,9 +92,9 @@ inline hipError_t hipHostMalloc(void** ptr, std::size_t bytes)
 
 using device_memory_resource = detail::hip_memory_resource<hipMalloc, hipFree, thrust::hip_rocprim::pointer<void>>;
 using managed_memory_resource =
-  detail::hip_memory_resource<detail::hipMallocManaged, hipFree, thrust::hip::universal_pointer<void>>;
+  detail::hip_memory_resource<detail::hipMallocManaged, hipFree, thrust::system::hip::universal_pointer<void>>;
 using pinned_memory_resource =
-  detail::hip_memory_resource<hipHostMalloc, hipHostFree, thrust::hip::universal_pointer<void>>;
+  detail::hip_memory_resource<hipHostMalloc, hipHostFree, thrust::system::hip::universal_pointer<void>>;
 
 } // namespace detail
 //! \endcond


### PR DESCRIPTION
## Technical Details

This PR changes thrust::hip to thrust::system::hip in certain files to prevent compilation errors. Depends on https://github.com/ROCm/xgboost/pull/12. Closes https://github.com/ROCm/rocm-libraries/issues/1922

## Test Result

Xgboost compiles and runs on ROCm 7.1.0, Ubuntu 24.04, Python 3.12. Test was done by modifying header files in already installed ROCm instead of compiling ROCm with the change.
