### PR TITLE
Porting OpTensorLeadingOnes kernels to HIP

### DIFF
--- a/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
+++ b/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2023-2025 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,8 @@
  *
  *******************************************************************************/
 #ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
-#include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
 #include <hip/hip_bfloat16.h>
 #endif
 
@@ -535,7 +535,6 @@ extern "C" __global__ void Op4dTensorGeneric(MIOPEN_TYPE* a,
         }
     }
 }
-
 #endif
 
 #ifdef USE_4D_TENSOR_LITE
@@ -630,4 +629,218 @@ extern "C" __global__ void Op4dTensorLite(const MIOPEN_TYPE* a,
         }
     }
 }
-#endif // USE_4D_TENSOR_LITE
+#endif
+
+#ifdef USE_LEADING_ONES
+extern "C" __global__ void OpTensorLeadingOnes(MIOPEN_TYPE* a,
+                                               MIOPEN_TYPE* b,
+                                               MIOPEN_TYPE* c,
+                                               const int c_c,
+                                               const int c_h,
+                                               const int c_w,
+                                               const int c_nstride,
+                                               const int c_cstride,
+                                               const int work_per_wg,
+                                               const MIOPEN_TYPE alpha0,
+                                               const MIOPEN_TYPE alpha1,
+                                               const MIOPEN_TYPE beta,
+                                               const uint64_t Aoffset,
+                                               const uint64_t Boffset,
+                                               const uint64_t Coffset,
+                                               const int num_wg,
+                                               const unsigned int bitmap)
+{
+    /* Special case for leading ones where the total no. of threads is the
+     * inner_product of the tensor dims. Each thread just updates one value
+     */
+
+    MIOPEN_TYPE* a_off = a + Aoffset;
+    MIOPEN_TYPE* b_off = b + Boffset;
+    MIOPEN_TYPE* c_off = c + Coffset;
+
+    int gid = (bitmap == 0xF) ? (blockIdx.x * blockDim.x + threadIdx.x) : blockIdx.x;
+
+    // num_wg: the number of workgroups should be launched
+    // MAX_NUM_WG: the maximum number of workgroups actually launched
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+    if(beta == static_cast<MIOPEN_TYPE>(0))
+#pragma clang diagnostic pop
+    {
+        for(; gid < num_wg; gid += MAX_NUM_WG)
+        {
+            int lid             = (bitmap == 0xF) ? 0 : threadIdx.x;
+            int lcl_sz          = (bitmap == 0xF) ? work_per_wg : blockDim.x;
+            MIOPEN_TYPE operand = b_off[gid] * alpha1;
+
+            int o_w = (bitmap & (1 << 0)) ? (gid % c_w) : 0;
+            int o_h = (bitmap & (1 << 1)) ? ((gid / ((bitmap & (1 << 0)) ? c_w : 1)) % c_h) : 0;
+            int o_c =
+                (bitmap & (1 << 2))
+                    ? ((gid / (((bitmap & (1 << 0)) ? c_w : 1) * ((bitmap & (1 << 1)) ? c_h : 1))) %
+                       c_c)
+                    : 0;
+            int o_n = gid / (((bitmap & (1 << 0)) ? c_w : 1) * ((bitmap & (1 << 1)) ? c_h : 1) *
+                             ((bitmap & (1 << 2)) ? c_c : 1));
+
+            while(lid < work_per_wg)
+            {
+                int index    = o_n * c_nstride + o_c * c_cstride + o_h * c_w + o_w + lid;
+                c_off[index] = MIOPEN_TENSOR_OP(a_off[index] * alpha0, operand);
+                lid += lcl_sz;
+            }
+        }
+    }
+    else
+    {
+        for(; gid < num_wg; gid += MAX_NUM_WG)
+        {
+            int lid             = (bitmap == 0xF) ? 0 : threadIdx.x;
+            int lcl_sz          = (bitmap == 0xF) ? work_per_wg : blockDim.x;
+            MIOPEN_TYPE operand = b_off[gid] * alpha1;
+
+            int o_w = (bitmap & (1 << 0)) ? (gid % c_w) : 0;
+            int o_h = (bitmap & (1 << 1)) ? ((gid / ((bitmap & (1 << 0)) ? c_w : 1)) % c_h) : 0;
+            int o_c =
+                (bitmap & (1 << 2))
+                    ? ((gid / (((bitmap & (1 << 0)) ? c_w : 1) * ((bitmap & (1 << 1)) ? c_h : 1))) %
+                       c_c)
+                    : 0;
+            int o_n = gid / (((bitmap & (1 << 0)) ? c_w : 1) * ((bitmap & (1 << 1)) ? c_h : 1) *
+                             ((bitmap & (1 << 2)) ? c_c : 1));
+
+            while(lid < work_per_wg)
+            {
+                int index = o_n * c_nstride + o_c * c_cstride + o_h * c_w + o_w + lid;
+                c_off[index] =
+                    MIOPEN_TENSOR_OP(a_off[index] * alpha0, operand) + beta * c_off[index];
+                lid += lcl_sz;
+            }
+        }
+    }
+}
+#endif
+
+#ifdef USE_LEADING_ONES_GENERIC
+extern "C" __global__ void OpTensorLeadingOnesGeneric(MIOPEN_TYPE* a,
+                                                      const int a_nstride,
+                                                      const int a_cstride,
+                                                      const int a_hstride,
+                                                      MIOPEN_TYPE* b,
+                                                      const int b_nstride,
+                                                      const int b_cstride,
+                                                      const int b_hstride,
+                                                      MIOPEN_TYPE* c,
+                                                      const int c_c,
+                                                      const int c_h,
+                                                      const int c_w,
+                                                      const int c_nstride,
+                                                      const int c_cstride,
+                                                      const int c_hstride,
+                                                      const MIOPEN_TYPE alpha0,
+                                                      const MIOPEN_TYPE alpha1,
+                                                      const MIOPEN_TYPE beta,
+                                                      const int work_per_wg,
+                                                      const uint64_t Aoffset,
+                                                      const uint64_t Boffset,
+                                                      const uint64_t Coffset,
+                                                      const int num_wg,
+                                                      const unsigned int bitmap)
+{
+    /* Special case for leading ones where the total no. of threads is the
+     * inner_product of the tensor dims. Each thread just updates one value
+     */
+    MIOPEN_TYPE* a_off = a + Aoffset;
+    MIOPEN_TYPE* b_off = b + Boffset;
+    MIOPEN_TYPE* c_off = c + Coffset;
+
+    int gid = (bitmap == 0xF) ? blockIdx.x * blockDim.x + threadIdx.x : blockIdx.x;
+
+    // num_wg: the number of workgroups should be launched
+    // MAX_NUM_WG: the maximum number of workgroups actually launched
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+    if(beta == static_cast<MIOPEN_TYPE>(0))
+#pragma clang diagnostic pop
+    {
+        for(; gid < num_wg; gid += MAX_NUM_WG)
+        {
+            int lid    = (bitmap == 0xF) ? 0 : threadIdx.x;
+            int lcl_sz = (bitmap == 0xF) ? work_per_wg : blockDim.x;
+
+            int o_w = (bitmap & (1 << 0)) ? (gid % c_w) : 0;
+            int o_h = (bitmap & (1 << 1)) ? ((gid / ((bitmap & (1 << 0)) ? c_w : 1)) % c_h) : 0;
+            int o_c =
+                (bitmap & (1 << 2))
+                    ? ((gid / (((bitmap & (1 << 0)) ? c_w : 1) * ((bitmap & (1 << 1)) ? c_h : 1))) %
+                       c_c)
+                    : 0;
+            int o_n = gid / (((bitmap & (1 << 0)) ? c_w : 1) * ((bitmap & (1 << 1)) ? c_h : 1) *
+                             ((bitmap & (1 << 2)) ? c_c : 1));
+
+            int bindex          = o_n * b_nstride + o_c * b_cstride + o_h * b_hstride + o_w;
+            MIOPEN_TYPE operand = b_off[bindex] * alpha1;
+
+            while(lid < work_per_wg)
+            {
+                o_c           = (bitmap & (1 << 2)) ? o_c : (lid % c_c);
+                o_h           = (bitmap & (1 << 1))
+                                    ? o_h
+                                    : ((bitmap & (1 << 2)) ? (lid / c_w) : ((lid / c_c) % c_h));
+                o_w           = (bitmap & (1 << 0))
+                                    ? o_w
+                                    : ((bitmap & (1 << 1))
+                                           ? lid
+                                           : ((bitmap & (1 << 2)) ? (lid % c_w) : ((lid / c_c) / c_h)));
+                int aindex    = o_n * a_nstride + o_c * a_cstride + o_h * a_hstride + o_w;
+                int cindex    = o_n * c_nstride + o_c * c_cstride + o_h * c_hstride + o_w;
+                c_off[cindex] = MIOPEN_TENSOR_OP(a_off[aindex] * alpha0, operand);
+
+                lid += lcl_sz;
+            }
+        }
+    }
+    else
+    {
+        for(; gid < num_wg; gid += MAX_NUM_WG)
+        {
+            int lid    = (bitmap == 0xF) ? 0 : threadIdx.x;
+            int lcl_sz = (bitmap == 0xF) ? work_per_wg : blockDim.x;
+
+            int o_w = (bitmap & (1 << 0)) ? (gid % c_w) : 0;
+            int o_h = (bitmap & (1 << 1)) ? ((gid / ((bitmap & (1 << 0)) ? c_w : 1)) % c_h) : 0;
+            int o_c =
+                (bitmap & (1 << 2))
+                    ? ((gid / (((bitmap & (1 << 0)) ? c_w : 1) * ((bitmap & (1 << 1)) ? c_h : 1))) %
+                       c_c)
+                    : 0;
+            int o_n = gid / (((bitmap & (1 << 0)) ? c_w : 1) * ((bitmap & (1 << 1)) ? c_h : 1) *
+                             ((bitmap & (1 << 2)) ? c_c : 1));
+
+            int bindex          = o_n * b_nstride + o_c * b_cstride + o_h * b_hstride + o_w;
+            MIOPEN_TYPE operand = b_off[bindex] * alpha1;
+
+            while(lid < work_per_wg)
+            {
+                o_c        = (bitmap & (1 << 2)) ? o_c : (lid % c_c);
+                o_h        = (bitmap & (1 << 1))
+                                 ? o_h
+                                 : ((bitmap & (1 << 2)) ? (lid / c_w) : ((lid / c_c) % c_h));
+                o_w        = (bitmap & (1 << 0))
+                                 ? o_w
+                                 : ((bitmap & (1 << 1))
+                                        ? lid
+                                        : ((bitmap & (1 << 2)) ? (lid % c_w) : ((lid / c_c) / c_h)));
+                int aindex = o_n * a_nstride + o_c * a_cstride + o_h * a_hstride + o_w;
+                int cindex = o_n * c_nstride + o_c * c_cstride + o_h * c_hstride + o_w;
+                c_off[cindex] =
+                    MIOPEN_TENSOR_OP(a_off[aindex] * alpha0, operand) + beta * c_off[cindex];
+
+                lid += lcl_sz;
+            }
+        }
+    }
+}
+#endif

--- a/projects/miopen/test/gtest/bn_infer_fused_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/bn_infer_fused_ocl_hip.cpp
@@ -57,7 +57,7 @@ void BatchNormFusedInferencGPU(const miopen::Handle& handle,
                                ConstData_t estimatedMean,
                                ConstData_t estimatedVariance,
                                double epsilon,
-                               PerfHelper<float>& perf_helper,
+                               PerfHelper& perf_helper,
                                bool use_hip)
 {
     int n, c, h, w;
@@ -352,8 +352,7 @@ protected:
     const float activ_beta  = static_cast<float>(0.5f);
     const float activ_gamma = static_cast<float>(0.5f);
     double epsilon          = 1.0e-5;
-    // GetKernelTime returns time in float
-    PerfHelper<float> perf_helper;
+    PerfHelper perf_helper;
 };
 
 template <typename XDataType,

--- a/projects/miopen/test/gtest/perf_helper.hpp
+++ b/projects/miopen/test/gtest/perf_helper.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,36 +29,32 @@
 #define NUM_PERF_RUNS 5
 #define NUM_WARMUP_RUNS 3
 
-template <typename T>
 struct PerfHelper
 {
-    std::vector<std::tuple<std::string, T, T, double, double, double>> kernelTestStats;
+    std::vector<std::tuple<std::string, double, double, double, double, double>> kernelTestStats;
 
-    // hold the min, max, mean, median, and standard deviation
-    std::tuple<T, T, double, double, double> gpuStats;
-
-    static T perf_min(const std::vector<T>& data)
+    static double perf_min(const std::vector<double>& data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
         return *std::min_element(data.begin(), data.end());
     }
 
-    static T perf_max(const std::vector<T>& data)
+    static double perf_max(const std::vector<double>& data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
         return *std::max_element(data.begin(), data.end());
     }
 
-    static double perf_mean(const std::vector<T>& data)
+    static double perf_mean(const std::vector<double>& data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
         return std::accumulate(data.begin(), data.end(), 0.0) / data.size();
     }
 
-    static double perf_median(std::vector<T> data)
+    static double perf_median(std::vector<double> data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
@@ -74,26 +70,29 @@ struct PerfHelper
         }
     }
 
-    static double perf_standardDeviation(const std::vector<T>& data)
+    static double perf_standardDeviation(const std::vector<double>& data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
         double data_mean = perf_mean(data);
         double sq_sum    = std::inner_product(
-            data.begin(), data.end(), data.begin(), 0.0, std::plus<>(), [data_mean](T a, T b) {
-                return (a - data_mean) * (b - data_mean);
-            });
+            data.begin(),
+            data.end(),
+            data.begin(),
+            0.0,
+            std::plus<>(),
+            [data_mean](double a, double b) { return (a - data_mean) * (b - data_mean); });
         return std::sqrt(sq_sum / data.size());
     }
 
-    static std::tuple<T, T, double, double, double> calcStats(const std::vector<T>& data)
+    static auto calcStats(const std::vector<double>& data)
     {
-        T min_val         = perf_min(data);
-        T max_val         = perf_max(data);
+        double min_val    = perf_min(data);
+        double max_val    = perf_max(data);
         double mean_val   = perf_mean(data);
         double median_val = perf_median(data); // Note: This modifies the data(sorts it)
         double sd_val     = perf_standardDeviation(data);
-        return {min_val, max_val, mean_val, median_val, sd_val};
+        return std::make_tuple(min_val, max_val, mean_val, median_val, sd_val);
     }
 
     void writeStatsToCSV(const std::string& filename, std::string test_info)
@@ -154,25 +153,17 @@ struct PerfHelper
     void perfTest(const miopen::Handle& handle,
                   const std::string& kernel_name,
                   const std::string& network_config,
-                  bool append,
                   Args&&... args)
     {
+        miopen::AutoEnableProfiling autoProfiling(handle);
+
         // Get kernels matching the kernel_name and network_config from the cache
         auto&& kernels = handle.GetKernels(kernel_name, network_config);
         // Ensure we have at least one kernel
         assert(!kernels.empty());
-        // Vector to hold the execution times
-        std::vector<T> elapsedTime_ms;
 
-        if(handle.IsProfilingEnabled())
-        { // If profiling was enabled elsewhere, reset the kernel time
-            handle.ResetKernelTime();
-        }
-        else
-        {
-            handle.EnableProfiling(); // Enable profiling
-            handle.ResetKernelTime(); // for good measure?
-        }
+        // Vector to hold the execution times
+        std::vector<double> elapsedTime_ms;
         // Optionally ignore the first few runs to allow for warm-up
         for(size_t i = 0; i < NUM_PERF_RUNS + NUM_WARMUP_RUNS; i++)
         {
@@ -184,9 +175,8 @@ struct PerfHelper
             handle.ResetKernelTime();
         }
 
-        handle.EnableProfiling(false); // Disable profiling
-
-        gpuStats = calcStats(elapsedTime_ms);
+        // Calculate the min, max, mean, median, and standard deviation
+        auto gpuStats = calcStats(elapsedTime_ms);
         kernelTestStats.push_back({kernel_name,
                                    std::get<0>(gpuStats),
                                    std::get<1>(gpuStats),

--- a/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
@@ -565,7 +565,7 @@ protected:
     TensorsConfig tensorsConfig;
     float alpha0, alpha1, beta;
 
-    PerfHelper<T> ph;
+    PerfHelper ph;
 };
 
 struct GPU_Op4dTensorGenericTest_FP32 : Op4DTensorGenericTest<float>


### PR DESCRIPTION
## Motivation
Port OpTensorLeadingOnes  and OpTensorLeadingOnesGeneric from OpenCL to HIP

## Test Result
Performance tests are presented in files 'tensor_leading_ones_ocl_hip.cpp' and 'tensor_leading_ones_generic_ocl_hip.cpp'
[tensor_leading_ones_generic_ocl_hip.cpp](https://github.com/user-attachments/files/23573895/tensor_leading_ones_generic_ocl_hip.cpp.txt)
[tensor_leading_ones_ocl_hip.cpp](https://github.com/user-attachments/files/23573901/tensor_leading_ones_ocl_hip.cpp.txt)
