### PR TITLE
[rocSPARSE] fix documentation build

### DIFF
--- a/projects/rocsparse/docs/reference/api.rst
+++ b/projects/rocsparse/docs/reference/api.rst
@@ -544,6 +544,10 @@ documentation for details about the supported data types and compute types.
 +-----------------------------------------------------+
 |:cpp:func:`rocsparse_v2_spmv()`                      |
 +-----------------------------------------------------+
+|:cpp:func:`rocsparse_spmv_set_extra()`               |
++-----------------------------------------------------+
+|:cpp:func:`rocsparse_spmv_clear_extra()`             |
++-----------------------------------------------------+
 |:cpp:func:`rocsparse_spsv()`                         |
 +-----------------------------------------------------+
 |:cpp:func:`rocsparse_sptrsv_buffer_size()`           |

--- a/projects/rocsparse/docs/reference/generic.rst
+++ b/projects/rocsparse/docs/reference/generic.rst
@@ -56,6 +56,16 @@ rocsparse_v2_spmv()
 
 .. doxygenfunction:: rocsparse_v2_spmv
 
+rocsparse_spmv_set_extra()
+--------------------------
+
+.. doxygenfunction:: rocsparse_spmv_set_extra
+
+rocsparse_spmv_clear_extra()
+----------------------------
+
+.. doxygenfunction:: rocsparse_spmv_clear_extra
+
 rocsparse_spsv()
 ----------------
 

--- a/projects/rocsparse/library/include/internal/generic/rocsparse_v2_spmv.h
+++ b/projects/rocsparse/library/include/internal/generic/rocsparse_v2_spmv.h
@@ -247,10 +247,10 @@ rocsparse_status rocsparse_v2_spmv(rocsparse_handle            handle,
  *  \p rocsparse_spmv_set_extra sets a gamma dnvec vector and z vectors
  *  appended to the spmv computation. The computation will be:
  *  \f$y = \alpha * op(A) * x + \beta * y + \sum_{i=1}^{n} \gamma_i z_i\f$
- *  where $n$ is the number of extra terms set by \p num_extras.
+ *  where \f$n\f$ is the number of extra terms set by \p num_extras.
  * 
  *  This feature can be used to implement residual calculations of the form
- *  $r = b - A * x$ within the SpMV call by setting \f$\gamma = 1\f$ and $z = b$.
+ *  \f$r = b - A * x\f$ within the SpMV call by setting \f$\gamma = 1\f$ and \f$z = b\f$.
  *
  *  \par Datatype Requirements
  *  The following datatype requirements must be satisfied:

--- a/projects/rocsparse/library/include/internal/generic/rocsparse_v2_spmv.h
+++ b/projects/rocsparse/library/include/internal/generic/rocsparse_v2_spmv.h
@@ -246,11 +246,11 @@ rocsparse_status rocsparse_v2_spmv(rocsparse_handle            handle,
  *  \details
  *  \p rocsparse_spmv_set_extra sets a gamma dnvec vector and z vectors
  *  appended to the spmv computation. The computation will be:
- *  $y = alpha * op(A) * x + beta * y + \sum_{i=1}^{n} \gamma_i z_i$
+ *  \f$y = \alpha * op(A) * x + \beta * y + \sum_{i=1}^{n} \gamma_i z_i\f$
  *  where $n$ is the number of extra terms set by \p num_extras.
  * 
  *  This feature can be used to implement residual calculations of the form
- *  $r = b - A * x$ within the SpMV call by setting $\gamma = 1$ and $z = b$.
+ *  $r = b - A * x$ within the SpMV call by setting \f$\gamma = 1\f$ and $z = b$.
  *
  *  \par Datatype Requirements
  *  The following datatype requirements must be satisfied:
@@ -318,18 +318,6 @@ rocsparse_status rocsparse_spmv_clear_extra(rocsparse_handle     handle,
 
 #ifdef __cplusplus
 }
-#endif
-
-// Helper functions for accessing pre-extracted arrays (C++ functions)
-#ifdef __cplusplus
-bool rocsparse_spmv_has_device_arrays(void* spmv_descr_ptr);
-
-// Template functions for accessing pre-extracted arrays
-template <typename T>
-T* rocsparse_spmv_get_gamma_device_array(void* spmv_descr_ptr);
-
-template <typename Z>
-const Z** rocsparse_spmv_get_z_array(void* spmv_descr_ptr);
 #endif
 
 #endif

--- a/projects/rocsparse/library/src/level2/rocsparse_csrmv_template_adaptive.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_csrmv_template_adaptive.cpp
@@ -656,11 +656,10 @@ rocsparse_status rocsparse::csrmv_adaptive_template_dispatch(rocsparse_handle   
     // Check if pre-extracted arrays are available in spmv descriptor
     if(num_extra > 0)
     {
-        if(handle && handle->temp_spmv_descr
-           && rocsparse_spmv_has_device_arrays(handle->temp_spmv_descr))
+        if(handle && handle->temp_spmv_descr && spmv_has_device_arrays(handle->temp_spmv_descr))
         {
-            gamma_device_array = rocsparse::get_gamma_array_helper<T>(handle->temp_spmv_descr);
-            z_array            = rocsparse::get_z_array_helper<Z>(handle->temp_spmv_descr);
+            gamma_device_array = rocsparse::spmv_get_gamma_device_array<T>(handle->temp_spmv_descr);
+            z_array            = rocsparse::spmv_get_z_array<Z>(handle->temp_spmv_descr);
         }
         else
         {

--- a/projects/rocsparse/library/src/level2/rocsparse_csrmv_template_lrb.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_csrmv_template_lrb.cpp
@@ -496,11 +496,10 @@ rocsparse_status rocsparse::csrmv_lrb_template_dispatch(rocsparse_handle        
     // Check if pre-extracted arrays are available in spmv descriptor
     if(num_extra > 0)
     {
-        if(handle && handle->temp_spmv_descr
-           && rocsparse_spmv_has_device_arrays(handle->temp_spmv_descr))
+        if(handle && handle->temp_spmv_descr && spmv_has_device_arrays(handle->temp_spmv_descr))
         {
-            gamma_device_array = rocsparse::get_gamma_array_helper<T>(handle->temp_spmv_descr);
-            z_array            = rocsparse::get_z_array_helper<Z>(handle->temp_spmv_descr);
+            gamma_device_array = rocsparse::spmv_get_gamma_device_array<T>(handle->temp_spmv_descr);
+            z_array            = rocsparse::spmv_get_z_array<Z>(handle->temp_spmv_descr);
         }
         else
         {

--- a/projects/rocsparse/library/src/level2/rocsparse_csrmv_template_nnzsplit.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_csrmv_template_nnzsplit.cpp
@@ -484,11 +484,10 @@ rocsparse_status rocsparse::csrmv_nnzsplit_template_dispatch(rocsparse_handle   
     // Check if pre-extracted arrays are available in spmv descriptor
     if(num_extra > 0)
     {
-        if(handle && handle->temp_spmv_descr
-           && rocsparse_spmv_has_device_arrays(handle->temp_spmv_descr))
+        if(handle && handle->temp_spmv_descr && spmv_has_device_arrays(handle->temp_spmv_descr))
         {
-            gamma_device_array = rocsparse::get_gamma_array_helper<T>(handle->temp_spmv_descr);
-            z_array            = rocsparse::get_z_array_helper<Z>(handle->temp_spmv_descr);
+            gamma_device_array = rocsparse::spmv_get_gamma_device_array<T>(handle->temp_spmv_descr);
+            z_array            = rocsparse::spmv_get_z_array<Z>(handle->temp_spmv_descr);
         }
         else
         {

--- a/projects/rocsparse/library/src/level2/rocsparse_csrmv_template_rowsplit.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_csrmv_template_rowsplit.cpp
@@ -232,11 +232,10 @@ rocsparse_status rocsparse::csrmv_rowsplit_template_dispatch(rocsparse_handle   
     // Check if pre-extracted arrays are available in spmv descriptor
     if(num_extra > 0)
     {
-        if(handle && handle->temp_spmv_descr
-           && rocsparse_spmv_has_device_arrays(handle->temp_spmv_descr))
+        if(handle && handle->temp_spmv_descr && spmv_has_device_arrays(handle->temp_spmv_descr))
         {
-            gamma_device_array = rocsparse::get_gamma_array_helper<T>(handle->temp_spmv_descr);
-            z_array            = rocsparse::get_z_array_helper<Z>(handle->temp_spmv_descr);
+            gamma_device_array = rocsparse::spmv_get_gamma_device_array<T>(handle->temp_spmv_descr);
+            z_array            = rocsparse::spmv_get_z_array<Z>(handle->temp_spmv_descr);
         }
         else
         {

--- a/projects/rocsparse/library/src/level2/rocsparse_spmv_helpers.h
+++ b/projects/rocsparse/library/src/level2/rocsparse_spmv_helpers.h
@@ -29,18 +29,14 @@
 
 namespace rocsparse
 {
+    bool spmv_has_device_arrays(void* spmv_descr_ptr);
+
     // Template helpers that directly call the template functions from v2_spmv.cpp
     template <typename T>
-    inline T* get_gamma_array_helper(void* spmv_descr_ptr)
-    {
-        return rocsparse_spmv_get_gamma_device_array<T>(spmv_descr_ptr);
-    }
+    T* spmv_get_gamma_device_array(void* spmv_descr_ptr);
 
     template <typename Z>
-    inline const Z** get_z_array_helper(void* spmv_descr_ptr)
-    {
-        return rocsparse_spmv_get_z_array<Z>(spmv_descr_ptr);
-    }
+    const Z** spmv_get_z_array(void* spmv_descr_ptr);
 }
 
 #endif // ROCSPARSE_SPMV_HELPERS_H

--- a/projects/rocsparse/library/src/level2/rocsparse_v2_spmv.cpp
+++ b/projects/rocsparse/library/src/level2/rocsparse_v2_spmv.cpp
@@ -35,6 +35,7 @@
 #include "rocsparse_ellmv.hpp"
 #include "rocsparse_sellmv.hpp"
 #include "rocsparse_spmv.hpp"
+#include "rocsparse_spmv_helpers.h"
 
 // Include the helper function
 #include "rocsparse_csrmv_helpers.cpp"
@@ -1376,7 +1377,7 @@ catch(...)
 // LCOV_EXCL_STOP
 
 // Helper functions for accessing pre-extracted arrays from template files
-bool rocsparse_spmv_has_device_arrays(void* spmv_descr_ptr)
+bool rocsparse::spmv_has_device_arrays(void* spmv_descr_ptr)
 {
     ROCSPARSE_ROUTINE_TRACE;
 
@@ -1389,7 +1390,7 @@ bool rocsparse_spmv_has_device_arrays(void* spmv_descr_ptr)
 
 // Template helper functions for accessing pre-extracted arrays from template files
 template <typename T>
-T* rocsparse_spmv_get_gamma_device_array(void* spmv_descr_ptr)
+T* rocsparse::spmv_get_gamma_device_array(void* spmv_descr_ptr)
 {
     if(!spmv_descr_ptr)
         return nullptr;
@@ -1399,7 +1400,7 @@ T* rocsparse_spmv_get_gamma_device_array(void* spmv_descr_ptr)
 }
 
 template <typename Z>
-const Z** rocsparse_spmv_get_z_array(void* spmv_descr_ptr)
+const Z** rocsparse::spmv_get_z_array(void* spmv_descr_ptr)
 {
     if(!spmv_descr_ptr)
         return nullptr;
@@ -1410,10 +1411,10 @@ const Z** rocsparse_spmv_get_z_array(void* spmv_descr_ptr)
 
 // Macro for gamma device array ETI
 #define INSTANTIATE_GAMMA_DEVICE_ARRAY(T) \
-    template T* rocsparse_spmv_get_gamma_device_array<T>(void*);
+    template T* rocsparse::spmv_get_gamma_device_array<T>(void*);
 
 // Macro for z array ETI
-#define INSTANTIATE_Z_ARRAY(T) template const T** rocsparse_spmv_get_z_array<T>(void*);
+#define INSTANTIATE_Z_ARRAY(T) template const T** rocsparse::spmv_get_z_array<T>(void*);
 
 // ETI for gamma device array
 INSTANTIATE_GAMMA_DEVICE_ARRAY(float)


### PR DESCRIPTION
The documentation was broken by #2242 . This PR fixes it by:
- Removing functions that should not be in the public API,
- Fixing the doxygen.