### PR TITLE
[hipBLASLt] Allow getIndexFromAlgo to work with rocRoller kernels.

### DIFF
--- a/projects/hipblaslt/library/include/hipblaslt/hipblaslt-ext.hpp
+++ b/projects/hipblaslt/library/include/hipblaslt/hipblaslt-ext.hpp
@@ -1070,9 +1070,8 @@ namespace hipblaslt_ext
      *  algo    The algorithm.
      *
      *  \retval int The index of the algorithm, can be used to get heuristic
-     * results from \ref getAlgosFromIndex. Returns -1 if the index stored
-     * in algo < 0. Note that the index may not be valid if the algo struct
-     * is not initialized properly.
+     * results from \ref getAlgosFromIndex. Note that the index may not be valid
+     * if the algo struct is not initialized properly.
      */
     HIPBLASLT_EXPORT int getIndexFromAlgo(hipblasLtMatmulAlgo_t& algo);
 

--- a/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/hipblaslt-ext.cpp
@@ -1413,10 +1413,7 @@ namespace hipblaslt_ext
     int getIndexFromAlgo(hipblasLtMatmulAlgo_t& algo)
     {
         int* algo_ptr = (int*)algo.data;
-        if(*algo_ptr < 0)
-        {
-            return -1;
-        }
+
         return *algo_ptr;
     }
 


### PR DESCRIPTION
## Motivation

getIndexFromAlgo currently returns an error if an index is negative, but rocRoller kernels use negative indices.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
