### PR TITLE
[rocfft and hipfftw] avoiding false positives for hipfftw tests + adding known rocfft defects

### DIFF
--- a/projects/hipfft/clients/tests/hipfftw_test.cpp
+++ b/projects/hipfft/clients/tests/hipfftw_test.cpp
@@ -98,7 +98,30 @@ namespace
 
     std::ranlux24_base& get_pseudo_rng()
     {
-        static std::ranlux24_base gen(random_seed);
+        // The fully-randomized data layouts being tested via hipFFTW (generated in
+        // this unit) explore a wider scope of plan configurations than the rocFFT
+        // unit tests. That creates a significant risk for false-positives in hipFFTW
+        // tests, i.e., hipFFTW test failures actually triggered by a (unknown-yet)
+        // rocFFT defect under the hood.
+        // Restricting the possible test-generation seeds to a set of pre-verified (on
+        // gfx90a) values mitigates that risk w/o sacrificing hipFFTW code and feature
+        // coverage.
+        const std::vector<size_t> verified_seeds = {1884086845,
+                                                    3282587354,
+                                                    2802468591,
+                                                    2531043007,
+                                                    2913365592,
+                                                    334387271,
+                                                    3196785377,
+                                                    3518924498,
+                                                    3455844329,
+                                                    3390661914,
+                                                    2632016286,
+                                                    1664906633,
+                                                    3892674020};
+        static const auto         test_generation_seed
+            = verified_seeds[random_seed % verified_seeds.size()];
+        static std::ranlux24_base gen(test_generation_seed);
         return gen;
     }
 
@@ -2313,10 +2336,11 @@ namespace
             // rocfft can't create some plans with non-default strides for lengths
             // AxBxC wherein B, C are in
             const std::vector<std::array<ptrdiff_t, 2>> symptomatic_sub_len
-                = {{16, 4},  {4, 16},  {16, 16}, {27, 4}, {4, 27},  {25, 4}, {4, 25},
-                   {16, 25}, {25, 16}, {25, 25}, {8, 9},  {9, 8},   {8, 4},  {4, 8},
-                   {8, 8},   {4, 9},   {9, 4},   {4, 4},  {20, 10}, {10, 20}};
-            // (Note: failing lengths usually have a value of A involving a prime factor > 17)
+                = {{16, 4},  {4, 16},  {16, 16}, {27, 4}, {4, 27},  {25, 4},  {4, 25},
+                   {16, 25}, {25, 16}, {25, 25}, {8, 9},  {9, 8},   {8, 4},   {4, 8},
+                   {8, 8},   {4, 9},   {9, 4},   {4, 4},  {20, 10}, {10, 20}, {27, 27}};
+            // (Note: failing lengths usually have a value of A involving a prime factor > 17.
+            // See adhoc tokens in rocfft's disabled suite of adhoc accuracy tests)
             ret = ret
                   || std::any_of(symptomatic_sub_len.begin(),
                                  symptomatic_sub_len.end(),
@@ -2325,8 +2349,45 @@ namespace
                                          sub_len.begin(), sub_len.end(), len.begin() + 1);
                                  });
         }
+        if(helper.get_rank() > 1 && is_real(dft_kind) && !helper.is_using_default_strides())
+        {
+            // rocfft can't create some plans with non-default strides for real transforms of
+            // lengths in the following sets. See adhoc tokens in rocfft's disabled suite of
+            // adhoc accuracy tests.
+            // - 3D size Ax1xB
+            ret = ret || (helper.get_rank() == 3 && len[1] == 1);
+            // - 2D sizes in the following set
+            const std::vector<std::vector<ptrdiff_t>> symptomatic_real_lengths = {{25, 8},
+                                                                                  {9, 54},
+                                                                                  {81, 18},
+                                                                                  {25, 16},
+                                                                                  {8, 18},
+                                                                                  {64, 8},
+                                                                                  {64, 16},
+                                                                                  {27, 16},
+                                                                                  {25, 32},
+                                                                                  {9, 16},
+                                                                                  {8, 8},
+                                                                                  {9, 32},
+                                                                                  {20, 20},
+                                                                                  {16, 8},
+                                                                                  {32, 8},
+                                                                                  {81, 64},
+                                                                                  {16, 16},
+                                                                                  {4, 18},
+                                                                                  {9, 8}};
+
+            ret = ret
+                  || std::any_of(symptomatic_real_lengths.begin(),
+                                 symptomatic_real_lengths.end(),
+                                 [&](const std::vector<ptrdiff_t>& len_to_skip) {
+                                     return len_to_skip == len;
+                                 });
+        }
         if(is_real(dft_kind) && len.back() % 2 == 0
-           && (helper.get_nbatch() > 1 || product(len.begin(), len.end() - 1) > 1))
+           && (helper.get_nbatch() > 1 || product(len.begin(), len.end() - 1) > 1)
+           && helper.get_strides(fft_io::fft_io_in).back() == 1
+           && helper.get_strides(fft_io::fft_io_out).back() == 1)
         {
             // rocfft can't handle odd values of strides/distances between rows
             // with even values of lengths.back() for real transforms.
@@ -2340,20 +2401,59 @@ namespace
 
             ret = ret || fwd_row_dist % 2 == 1;
         }
-        if(is_complex(dft_kind) && helper.get_rank() == 2 && helper.is_using_default_strides()
-           && !helper.is_using_default_distances())
+        // incorrect results may be produced by rocfft for some of the following cases
+        if(is_complex(dft_kind))
         {
-            // incorrect results generated for the following lengths
-            const std::vector<std::array<ptrdiff_t, 2>> symptomatic_lengths = {{81, 74}};
-
-            ret = ret
-                  || std::any_of(symptomatic_lengths.begin(),
-                                 symptomatic_lengths.end(),
-                                 [&](const std::array<ptrdiff_t, 2>& failing_lengths) {
-                                     return std::equal(failing_lengths.begin(),
-                                                       failing_lengths.end(),
-                                                       len.begin());
-                                 });
+            // see adhoc tokens in rocfft's disabled suite of adhoc accuracy tests
+            if(helper.is_using_default_strides())
+            {
+                ret = ret
+                      || (helper.get_rank() == 2 && len[0] == 81 && len[1] == 74
+                          && !helper.is_using_default_distances());
+            }
+            else
+            {
+                ret = ret || (helper.get_rank() == 2 && len[0] == 50 && len[1] == 129);
+            }
+        }
+        else
+        {
+            if(helper.get_rank() == 1 && helper.get_nbatch() > 1
+               && helper.get_distance(fft_io::fft_io_in) == 1
+               && helper.get_distance(fft_io::fft_io_out) == 1)
+            {
+                // inner batch 1D: see adhoc token in rocfft's disabled suite of adhoc accuracy tests
+                ret = ret || len[0] == 486;
+            }
+            if(helper.get_rank() > 1 && !helper.is_using_default_strides())
+            {
+                if(helper.get_rank() == 2)
+                {
+                    ret = ret || (len[0] == 26 && len[1] == 52);
+                }
+                if(helper.get_rank() == 3)
+                {
+                    // may fail if the last length is a multiple of a prime larger than 16. Examples
+                    // of failing lengths: 15x12x76, 7x14x76, 11x12x38, 20x8x38, 5x12x38, 6x24x38,
+                    // 6x25x38, 26x26x134, 2x40x62, 36x13x46, 2x5x46, 6x12x46, 2x14x46 (see adhoc
+                    // tokens in rocfft's disabled suite of adhoc accuracy tests)
+                    auto tmp = helper.get_lengths().back();
+                    if(tmp % 2 == 0)
+                    {
+                        auto largest_prime_factor = 2;
+                        while(tmp != 1)
+                        {
+                            while(tmp % largest_prime_factor == 0)
+                            {
+                                tmp /= largest_prime_factor;
+                            }
+                            if(tmp != 1)
+                                largest_prime_factor++;
+                        }
+                        ret = ret || largest_prime_factor > 16;
+                    }
+                }
+            }
         }
         return ret;
     }

--- a/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
+++ b/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
@@ -364,8 +364,9 @@ INSTANTIATE_TEST_SUITE_P(adhoc_token,
                          ::testing::ValuesIn(param_generator_token(test_prob, adhoc_tokens)),
                          accuracy_test::TestName);
 
-const auto adhoc_nondefault_nembed_tokens = {
+const auto adhoc_nondefault_layout_tokens = {
     // clang-format off
+    // plan creation failures:
     "complex_forward_len_29_4_16_double_op_batch_233_istride_540_135_5_CI_ostride_1540_140_4_CI_idist_20520_odist_55440_ioffset_0_0_ooffset_0_0",
     "complex_forward_len_23_16_4_single_op_batch_253_istride_450_10_2_CI_ostride_1376_32_4_CI_idist_16650_odist_41280_ioffset_0_0_ooffset_0_0",
     "complex_forward_len_19_16_4_double_ip_batch_376_istride_384_16_4_CI_ostride_384_16_4_CI_idist_10752_odist_10752_ioffset_0_0_ooffset_0_0",
@@ -397,11 +398,55 @@ const auto adhoc_nondefault_nembed_tokens = {
     "complex_inverse_len_29_27_4_double_op_batch_1358_istride_216_8_1_CI_ostride_672_24_2_CI_idist_6480_odist_22176_ioffset_0_0_ooffset_0_0",
     "complex_inverse_len_29_4_27_double_op_batch_1358_istride_216_27_1_CI_ostride_672_56_2_CI_idist_6480_odist_22176_ioffset_0_0_ooffset_0_0",
     "complex_forward_len_19_16_16_single_ip_batch_3_istride_342_18_1_CI_ostride_342_18_1_CI_idist_6840_odist_6840_ioffset_0_0_ooffset_0_0",
+    "complex_inverse_len_19_27_27_double_op_batch_600_istride_1624_58_2_CI_ostride_3780_140_4_CI_idist_34104_odist_128520_ioffset_0_0_ooffset_0_0"
+    "real_inverse_len_25_8_double_ip_batch_7851_istride_11_1_HI_ostride_22_1_R_idist_825_odist_1650_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_9_54_single_ip_batch_2976_istride_106_1_HI_ostride_212_1_R_idist_3286_odist_6572_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_81_18_double_ip_batch_2790_istride_12_1_HI_ostride_24_1_R_idist_1884_odist_3768_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_25_16_double_ip_batch_5802_istride_13_1_HI_ostride_26_1_R_idist_650_odist_1300_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_8_18_single_ip_batch_904_istride_27_1_HI_ostride_54_1_R_idist_2052_odist_4104_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_64_8_double_ip_batch_2663_istride_20_1_HI_ostride_40_1_R_idist_2780_odist_5560_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_27_16_double_ip_batch_5966_istride_47_1_HI_ostride_94_1_R_idist_2303_odist_4606_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_25_32_double_ip_batch_4876_istride_56_1_HI_ostride_112_1_R_idist_4256_odist_8512_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_9_54_single_ip_batch_2468_istride_143_1_HI_ostride_286_1_R_idist_5005_odist_10010_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_9_16_single_ip_batch_7730_istride_22_1_HI_ostride_44_1_R_idist_396_odist_792_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_8_8_double_ip_batch_4302_istride_31_1_HI_ostride_62_1_R_idist_4402_odist_8804_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_9_32_single_ip_batch_5591_istride_20_1_HI_ostride_40_1_R_idist_1160_odist_2320_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_4_1_18_double_ip_batch_2265_istride_28_14_1_HI_ostride_56_28_1_R_idist_588_odist_1176_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_20_20_single_ip_batch_4737_istride_113_1_HI_ostride_226_1_R_idist_3729_odist_7458_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_16_8_double_ip_batch_2683_istride_13_1_HI_ostride_26_1_R_idist_442_odist_884_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_16_1_18_double_ip_batch_2970_istride_98_14_1_HI_ostride_196_28_1_R_idist_1568_odist_3136_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_20_20_single_ip_batch_6342_istride_99_1_HI_ostride_198_1_R_idist_3366_odist_6732_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_8_1_8_double_ip_batch_5635_istride_125_5_1_HI_ostride_250_10_1_R_idist_1375_odist_2750_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_32_8_double_ip_batch_1752_istride_35_1_HI_ostride_70_1_R_idist_8225_odist_16450_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_81_64_single_ip_batch_7187_istride_48_1_HI_ostride_96_1_R_idist_5088_odist_10176_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_64_16_double_ip_batch_7289_istride_46_1_HI_ostride_92_1_R_idist_3128_odist_6256_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_16_16_single_ip_batch_6600_istride_19_1_HI_ostride_38_1_R_idist_798_odist_1596_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_4_18_double_ip_batch_7484_istride_64_1_HI_ostride_128_1_R_idist_8192_odist_16384_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_9_8_double_ip_batch_6908_istride_7_1_HI_ostride_14_1_R_idist_462_odist_924_ioffset_0_0_ooffset_0_0",
+    // plan can be created but inaccurate results are produced:
+    "complex_forward_len_81_74_single_ip_batch_2_istride_74_1_CI_ostride_74_1_CI_idist_7696_odist_7696_ioffset_0_0_ooffset_0_0",
+    "complex_forward_len_50_129_single_op_batch_3189_istride_1432_8_CI_ostride_129_1_CI_idist_81624_odist_24252_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_486_double_op_batch_7014_istride_7014_R_ostride_7014_HI_idist_1_odist_1_ioffset_0_0_ooffset_0_0_flags_64",
+    "real_forward_len_486_double_op_batch_910_istride_910_R_ostride_910_HI_idist_1_odist_1_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_15_12_76_single_ip_batch_125_istride_1280_80_1_R_ostride_640_40_1_HI_idist_32000_odist_16000_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_11_12_38_single_ip_batch_1253_istride_2128_56_1_R_ostride_1064_28_1_HI_idist_23408_odist_11704_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_36_13_46_single_ip_batch_91_istride_1170_39_1_HI_ostride_2340_78_1_R_idist_45630_odist_91260_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_20_8_38_double_ip_batch_846_istride_696_24_1_HI_ostride_1392_48_1_R_idist_33408_odist_66816_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_2_5_46_double_ip_batch_281_istride_4340_70_1_R_ostride_2170_35_1_HI_idist_30380_odist_15190_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_5_12_38_single_ip_batch_2725_istride_1012_44_1_R_ostride_506_22_1_HI_idist_17204_odist_8602_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_6_24_38_single_ip_batch_830_istride_2688_64_1_R_ostride_1344_32_1_HI_idist_48384_odist_24192_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_6_25_38_single_ip_batch_2006_istride_1360_40_1_R_ostride_680_20_1_HI_idist_13600_odist_6800_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_26_26_134_double_ip_batch_41_istride_5934_138_1_R_ostride_2967_69_1_HI_idist_231426_odist_115713_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_2_40_62_single_op_batch_922_istride_62_124_1_R_ostride_1280_32_1_HI_idist_4960_odist_2560_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_6_12_46_single_op_batch_2312_istride_288_24_1_HI_ostride_46_276_1_R_idist_1728_odist_3312_ioffset_0_0_ooffset_0_0",
+    "real_inverse_len_7_14_76_double_ip_batch_202_istride_1794_39_1_HI_ostride_3588_78_1_R_idist_75348_odist_150696_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_2_14_46_single_ip_batch_499_istride_2050_50_1_R_ostride_1025_25_1_HI_idist_71750_odist_35875_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_26_52_double_op_batch_3899_istride_240_4_R_ostride_224_7_HI_idist_15600_odist_8960_ioffset_0_0_ooffset_0_0"
     // clang-format on
 };
 
-INSTANTIATE_TEST_SUITE_P(DISABLED_adhoc_nondefault_nembed,
+INSTANTIATE_TEST_SUITE_P(DISABLED_adhoc_nondefault_layout,
                          accuracy_test,
                          ::testing::ValuesIn(param_generator_token(test_prob,
-                                                                   adhoc_nondefault_nembed_tokens)),
+                                                                   adhoc_nondefault_layout_tokens)),
                          accuracy_test::TestName);


### PR DESCRIPTION
## Motivation & technical details

More rocFFT defects have been unveiled via extensive hipFFTW functional tests (investigated manually). This PR suggests to
- document them (by adding them to the disabled test suite on the `rocfft-test` side);
- identify (and skip) possible such cases at runtime in the hipFFTW functional tests;
- mitigate the risk for future false positive in hipfftw tests by reducing the randomness for the generated test configurations for the hipFFTW tests: only a subset of test-generation seeds would be considered for the randomly-generated hipFFTW tests.

These changes should make testing (and maintenance) more manageable for hipFFTW without sacrificing code and feature coverage.

## Test Plan

Existing tests suffice.

## Test Result

Manual tests pass reliably on `gfx90a` for all the suggested values in `verified_seeds`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
