### PR TITLE
[hipsparselt] Update client package deps

### DIFF
--- a/projects/hipsparselt/CMakeLists.txt
+++ b/projects/hipsparselt/CMakeLists.txt
@@ -182,7 +182,8 @@ endif()
 # --- Packaging and installation ---
 
 if(HIPSPARSELT_ENABLE_CLIENT)
-    include(ROCmClientPackages)
+    include(rocm_client_prerequisites)
+    rocm_set_client_package_prerequisites()
     rocm_package_setup_component(clients)
     rocm_package_setup_client_component(clients-common)
 endif()

--- a/projects/hipsparselt/cmake/rocm_client_prerequisites.cmake
+++ b/projects/hipsparselt/cmake/rocm_client_prerequisites.cmake
@@ -66,7 +66,7 @@ macro(rocm_setup_posix_gfortran_packages)
 endmacro()
 
 # Macro to set up all client package variables
-macro(rocm_setup_client_packages)
+macro(rocm_set_client_package_prerequisites)
     _rocm_detect_os()
     message(STATUS "Detected OS: ${HOST_OS} ${HOST_OS_VERSION}")
 
@@ -76,10 +76,3 @@ macro(rocm_setup_client_packages)
     message(STATUS "OpenMP packages: RPM=${OPENMP_RPM}, DEB=${OPENMP_DEB}")
     message(STATUS "GFortran packages: RPM=${GFORTRAN_RPM}, DEB=${GFORTRAN_DEB}")
 endmacro()
-
-# Convenience function that also sets up standard components
-function(rocm_setup_client_components component_name client_component_name)
-    rocm_setup_client_packages()
-    rocm_package_setup_component(${component_name})
-    rocm_package_setup_client_component(${client_component_name})
-endfunction()


### PR DESCRIPTION
## Motivation

Missing OPENMP and Fortran variables that established DEB and RPM dependencies existed prior to the new build system were missed in the refactor.

## Technical Details

Use the new helper macros to set variables for the client packages to support various distros.

## Test Plan

Low risk, standard CI testing is sufficient.

## Test Result

See CI checks in PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
