### PR TITLE
[hipblaslt] Make LR wait optional for CMS

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -42,7 +42,7 @@ from copy import deepcopy
 class ScheduleInfo:
     numCodePaths: int
     numMfma: int
-    def __init__(self, numCodePaths, numMfma, optSchedule, syncCode, nglshift, nllshift, mfmaReorder = []):
+    def __init__(self, numCodePaths, numMfma, optSchedule, syncCode, nglshift, nllshift, mfmaReorder = [], waitLR = True):
         self.numCodePaths = numCodePaths
         self.numMfma = numMfma
         self.optSchedule = optSchedule
@@ -50,6 +50,8 @@ class ScheduleInfo:
         self.nglshift = nglshift # vmcnt shift for noglobalload loop
         self.nllshift = nllshift # vmcnt shift for nolocalload loop
         self.mfmaReorder = mfmaReorder
+        # Wait for all LR in pre-loop to complete before we start main loop
+        self.waitLR = waitLR
 
 
 def removeComments(module):
@@ -279,7 +281,7 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
                     macro.add(ValueEndif(comment="EndIf \\ID checks"))
 
     module.add(macro)
-    return module, numCodePath
+    return module, numCodePath, opt1.waitLR
 
 
 @CallableGuard

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -2845,13 +2845,13 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
 
     if kernel["UseCustomMainLoopSchedule"]:
-      optSchedule, numCodePath = customMainLoopSchedule(self, kernel, tensorParametersA, tensorParametersB, globalReadIncACode, globalReadIncBCode, \
+      optSchedule, numCodePath, waitLR = customMainLoopSchedule(self, kernel, tensorParametersA, tensorParametersB, globalReadIncACode, globalReadIncBCode, \
                                                    LRCodeAAllIters, PackCodeAAllIters, LRCodeBAllIters, PackCodeBAllIters, \
                                                    LRSwapAAllIters, LRSwapBAllIters, self.codes.globalReadA, self.codes.globalReadB, \
                                                    LWSwapAAllIters, LWSwapBAllIters, MfmaCodeAllIters, \
                                                    self.closeLoop(kernel, tensorParametersA, tensorParametersB, self.states.unrollIdx, False))
       module.add(optSchedule)
-      module.add(self.simdSpecDispatch(kernel, numCodePath))
+      module.add(self.simdSpecDispatch(kernel, numCodePath, waitLR))
 
     # close unrolled loop
     endStr = ""

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -14024,7 +14024,7 @@ class KernelWriterAssembly(KernelWriter):
     module.addSpaceLine()
     return module
 
-  def simdSpecDispatch(self, kernel, numCodePath):
+  def simdSpecDispatch(self, kernel, numCodePath, waitLR):
     module = Module()
 
     loopLabelBegin = []
@@ -14033,7 +14033,8 @@ class KernelWriterAssembly(KernelWriter):
     loopChar = self.states.indexChars[kernel["ProblemType"]["IndicesSummation"][self.states.unrollIdx]]
 
     # Wait for all LR in pre-loop to complete before we start main loop
-    module.add(SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for all LR in pre-loop to complete"))
+    if waitLR:
+      module.add(SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for all LR in pre-loop to complete"))
 
     if numCodePath == 1:
       module.add(MacroInstruction(name="MAINLOOP", args=[0]))


### PR DESCRIPTION
## Motivation

By default, an s_waitcnt lgkmcnt(0) is inserted at the end of the MAINLOOP macro to wait for the pre-loop LR. This PR makes the insertion optional (to avoid breaking the previous CMS implementation) and allows the new CMS implementations to disable it and handle the lgkmcnt count manually.
