### PR TITLE
[hipblaslt] Remove SWaitCnt(dscnt=0) from CMS MAINLOOP when using a single codepath

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -14036,8 +14036,9 @@ class KernelWriterAssembly(KernelWriter):
     module.add(SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for all LR in pre-loop to complete"))
 
     if numCodePath == 1:
+      module.add(Label("LoopBegin%s_0"%(loopChar), "" ))
       module.add(MacroInstruction(name="MAINLOOP", args=[0]))
-      module.add(SCBranchSCC0(labelName="label_LoopBegin%s"%(loopChar), comment="" ))
+      module.add(SCBranchSCC0(labelName="label_LoopBegin%s_0"%(loopChar), comment="" ))
       module.add(Label("LoopEnd%s"%(loopChar), "" ))
       return module
 


### PR DESCRIPTION
## Motivation

When using a single code path with CMS, the pre-loop wait on LR is included within the loop, which can lead to unnecessary waits. To avoid this, this PR adds a label just before calling the MAINLOOP macro.

This issue affected only the CMS implementation with a single code path. The codebase contains only one such case, and an SWaitCnt(dscnt=0) is already manually performed at the end of the loop.

