### PR TITLE
[MIOPEN][GTEST] Filter out BFP16 gtests from FP16

### DIFF
--- a/projects/miopen/test/gtest/CMakeLists.txt
+++ b/projects/miopen/test/gtest/CMakeLists.txt
@@ -109,7 +109,7 @@ function(add_gtest TEST_NAME TEST_CPP)
         add_gtest_negative_filter("*GPU*")
     endif()
 
-    if(MIOPEN_TEST_HALF AND NOT (MIOPEN_TEST_BFLOAT16))
+    if(MIOPEN_TEST_HALF AND NOT MIOPEN_TEST_BFLOAT16)
         add_gtest_negative_filter("*BFP16*")
     endif()
 
@@ -168,6 +168,10 @@ function(add_gtest TEST_NAME TEST_CPP)
         add_gtest_negative_filter("Smoke/GPU_BNFWDTrainLargeFusedActivation2D_FP32.BnV2LargeFWD_TrainCKfp32Activation/NCHW_BNSpatial_testBNAPIV1_Dim_2_test_id_32") # Temporarily disabled until gfx1151 CI nodes have fw 31 or higher installed
         add_gtest_negative_filter("Smoke/GPU_BNFWDTrainLarge2D_FP32.BnV2LargeFWD_TrainCKfp32/NCHW_BNSpatial_testBNAPIV2_Dim_2_test_id_64") # Temporarily disabled until gfx1151 CI nodes have fw 31 or higher installed
         add_gtest_negative_filter("*SerialRun3D*") # These FP32 SerialRun3D tests use so much memory that they have a risk of timing out the machine during tests
+    endif()
+
+    if(MIOPEN_TEST_HALF AND NOT MIOPEN_TEST_BFLOAT16)
+        add_gtest_negative_filter("*BFP16*")
     endif()
 
     # when building the single gtest, add them in a sharded manner

--- a/projects/miopen/test/gtest/CMakeLists.txt
+++ b/projects/miopen/test/gtest/CMakeLists.txt
@@ -109,6 +109,10 @@ function(add_gtest TEST_NAME TEST_CPP)
         add_gtest_negative_filter("*GPU*")
     endif()
 
+    if(MIOPEN_TEST_HALF AND NOT (MIOPEN_TEST_BFLOAT16))
+        add_gtest_negative_filter("*BFP16*")
+    endif()
+
     # NONE datatype is explicitly enabled for all the state, all the NONE tests take 4 seconds to complete.
     set(MIOPEN_GTEST_FILTER "${MIOPEN_GTEST_PREFIX}*${MIOPEN_GTEST_SUFFIX}*:${MIOPEN_GTEST_PREFIX}*NONE*${MIOPEN_GTEST_FILTER_NEGATIVE}")
 


### PR DESCRIPTION
## Motivation

Current gtest filter for fp16 allows also all tests for bfp16. We have a dedicated bfp16 CI stage and don't need to run the tests twice. Filtering bfp16 tests out should reduce the CI time.

## Technical Details

## Test Plan

- [x] Check execution time
- [ ] Check if there are missing tests

## Test Result

CI has been passed. Gtests are executed in 4 shards, here are the time they took for the stages we expected to be affected.

* Full Tests / Fp16 Hip Install All gfx90a
  * 1776370 ms -> 1758196 ms
  * 1787945 ms -> 1776269 ms
  * 1662049 ms -> 1604081 ms
  * 1879561 ms -> 1790730 ms
* Full Tests / Fp16 Hip Install All gfx942
  * 1240221 ms -> 996162 ms
  * 1260974 ms -> 962194 ms
  * 1295105 ms -> 979199 ms
  * 1178628 ms -> 865118 ms

We see the execution time decreased for gfx90a by ~1% which is not enough for merging this PR. For gfx942 it is about 20-25% which can be taken into consideration.

In this gfx942 stage `make install check` step overall time changed from ~40 min to ~30 min.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
