### PR TITLE
Detect if kernel launch would overflow hip grid limits

### DIFF
--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -2125,6 +2125,23 @@ Tests:
   requested_solution_num: -1
   unit_check: 1
 
+# Test case for launch limits
+# Review: should this be enabled on CI?
+# It requires a lot of memory and takes a little while to run.
+# - name: matmul_launch_limits
+#   category: nightly
+#   function:
+#     matmul: *hpa_bf16_precision
+#   matrix_size:
+#     - { M:  262144,   N:  131072,    K:  1024 }
+#   algo_method: [1]
+#   transA: T
+#   transB: N
+#   alpha: 1
+#   beta: 0
+#   requested_solution_num: -1
+#   unit_check: 0
+
 - name: matmul_heuristic_all_solutions_real_1byte_fnuz
   category: nightly
   function:

--- a/projects/hipblaslt/tensilelite/Tensile/Contractions.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Contractions.py
@@ -415,8 +415,21 @@ class TaskPredicate(Properties.Predicate):
         return None
 
     @classmethod
+    def ExtraPredicates(cls, state):
+        rv = []
+
+        # LaunchLimits predicate checks that launch grid will not overflow hip API limits
+        # TODO This predicate could also verify limits on some kernel arguments
+        # Stream-k kernels currently do not need limit check since launch grid should be limited by the grid model
+        if ('StreamK' not in state) or (state['StreamK'] == 0):
+            rv += [cls('LaunchLimits')]
+
+        return rv
+
+    @classmethod
     def FromOriginalState(cls, d, problemType, morePreds=[]):
-        predicates = [p for p in map(cls.FromOriginalKeyPair, d.items()) if p is not None]
+        extraPredicates = cls.ExtraPredicates(d)
+        predicates = [p for p in map(cls.FromOriginalKeyPair, d.items()) if p is not None] + extraPredicates
         return cls.And(predicates)
 
 class ProblemPredicate(Properties.Predicate):

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
@@ -286,6 +286,9 @@ namespace TensileLite
 
         size_t requiredSynchronizerSize(Problem const& problem, Hardware const& hardware) const;
 
+        void calculateGrid(dim3& workGroupSize,
+                           dim3& numWorkGroups,
+                           ContractionSolution::Problem const& problem) const;
         origami::streamk::reduction_type getSKReduction(Problem const& problem, Hardware const& hardware) const;
         size_t getSKGrid(Problem const& problem, Hardware const& hardware, size_t tiles, origami::streamk::reduction_type reductionStrat) const;
         size_t partialTileSize(size_t skGrid) const;

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionTaskPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionTaskPredicates.hpp
@@ -47,6 +47,66 @@ namespace TensileLite
  */
         namespace Contraction
         {
+            struct LaunchLimits : public Predicate_CRTP<LaunchLimits, Task>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = false
+                };
+
+                LaunchLimits() = default;
+
+                static std::string Type()
+                {
+                    return "LaunchLimits";
+                }
+
+                virtual bool operator()(Task const& task) const override
+                {
+                    if (task.solution.sizeMapping.streamK == 0)
+                    {
+                        // For non-stream-k kernels, check if the launch grid would overflow the maximum number of work items
+                        dim3 workGroupSize;
+                        dim3 numWorkGroups;
+                        task.solution.calculateGrid(workGroupSize, numWorkGroups, task.problem);
+                        uint64_t workItems = static_cast<uint64_t>(workGroupSize.x)
+                                           * static_cast<uint64_t>(workGroupSize.y)
+                                           * static_cast<uint64_t>(workGroupSize.z)
+                                           * static_cast<uint64_t>(numWorkGroups.x)
+                                           * static_cast<uint64_t>(numWorkGroups.y)
+                                           * static_cast<uint64_t>(numWorkGroups.z);
+                        return workItems <= std::numeric_limits<uint32_t>::max();
+                    }
+
+                    return true;
+                }
+
+                virtual bool debugEval(Task const& task, std::ostream& stream) const override
+                {
+                    if (task.solution.sizeMapping.streamK == 0)
+                    {
+                        // For non-stream-k kernels, check if the launch grid would overflow the maximum number of work items
+                        dim3 workGroupSize;
+                        dim3 numWorkGroups;
+                        task.solution.calculateGrid(workGroupSize, numWorkGroups, task.problem);
+                        uint64_t workItems = static_cast<uint64_t>(workGroupSize.x)
+                                           * static_cast<uint64_t>(workGroupSize.y)
+                                           * static_cast<uint64_t>(workGroupSize.z)
+                                           * static_cast<uint64_t>(numWorkGroups.x)
+                                           * static_cast<uint64_t>(numWorkGroups.y)
+                                           * static_cast<uint64_t>(numWorkGroups.z);
+                        bool rv = (workItems <= std::numeric_limits<uint32_t>::max());
+                        stream << "LaunchLimits " << rv << " (workItems = " << workItems << ")";
+                        return rv;
+                    }
+
+                    stream << "Launch limits for stream-k kernels handled by grid predictor";
+
+                    return true;
+                }
+            };
+
             struct WorkspaceCheck : public Predicate_CRTP<WorkspaceCheck, Task>
             {
                 enum

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/Predicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/Predicates.hpp
@@ -249,7 +249,9 @@ namespace TensileLite
 
             static SubclassMap GetSubclasses()
             {
-                SubclassMap rv({Base::template Pair<Predicates::Contraction::WorkspaceCheck>()});
+                SubclassMap rv(
+                    {Base::template Pair<Predicates::Contraction::LaunchLimits>(),
+                     Base::template Pair<Predicates::Contraction::WorkspaceCheck>()});
 
                 auto gmap = Generic::GetSubclasses();
                 rv.insert(gmap.begin(), gmap.end());
@@ -264,6 +266,12 @@ namespace TensileLite
         template <typename IO>
         const typename TaskPredicateSMT<IO>::SubclassMap SubclassMappingTraits<Predicates::Predicate<Task>,IO>::subclasses
             = TaskPredicateSMT<IO>::GetSubclasses();
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::LaunchLimits, IO>
+            : public AutoMappingTraits<Predicates::Contraction::LaunchLimits, IO>
+        {
+        };
 
         template <typename IO>
         struct MappingTraits<Predicates::Contraction::WorkspaceCheck, IO>

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -1056,7 +1056,7 @@ namespace TensileLite
     }
 
     uint32_t ContractionSolution::calculateAutoGSU(Problem const&  problem,
-                                               Hardware const* hardware) const
+                                                   Hardware const* hardware) const
     {
         // if original GSU is not -1
         if(sizeMapping.globalSplitU != -1)
@@ -1101,6 +1101,14 @@ namespace TensileLite
             uint32_t synchronizerUsage = sizeMapping.synchronizerSizePerWG * problem.getNumTiles(sizeMapping, 1) * B;
             gsuVal = synchronizerUsage > 409600 ? 1 : gsuVal;
         }
+
+        // Avoid selecting a gsu value that would make launch grid over the limit
+        uint32_t tiles0 = CeilDivide(M, MT0);
+        uint32_t tiles1 = CeilDivide(N, MT1);
+        uint32_t tiles = tiles0 * tiles1 * B;
+        uint32_t workGroupSize = sizeMapping.workGroupSize.x * sizeMapping.workGroupSize.y * sizeMapping.workGroupSize.z;
+        uint32_t maxGsuValue = (std::numeric_limits<uint32_t>::max() / workGroupSize) / tiles;
+        gsuVal = min(gsuVal, maxGsuValue);
 
         // avoid gsu < 1
         gsuVal = max(gsuVal, 1);
@@ -1215,6 +1223,45 @@ namespace TensileLite
         }
     }
 
+    void ContractionSolution::calculateGrid(dim3& workGroupSize,
+                                            dim3& numWorkGroups,
+                                            ContractionSolution::Problem const& problem) const
+    {
+        workGroupSize.x = sizeMapping.workGroupSize.x * sizeMapping.workGroupSize.y
+            * sizeMapping.workGroupSize.z;
+        workGroupSize.y = 1;
+        workGroupSize.z = 1;
+
+        numWorkGroups.x = 1;
+        numWorkGroups.y = 1;
+
+        for(size_t i = 0; i < problem.freeIndicesA().size(); i++)
+        {
+            numWorkGroups.x *= problem.freeSizeA(i);
+        }
+        for(size_t i = 0; i < problem.freeIndicesB().size(); i++)
+        {
+            numWorkGroups.y *= problem.freeSizeB(i);
+        }
+
+        numWorkGroups.z = 1;
+        for(size_t i = 0; i < problem.batchIndices().size(); i++)
+        {
+            if(sizeMapping.packBatchDims & 0x1)
+                numWorkGroups.x *= problem.batchSize(i);
+            if(sizeMapping.packBatchDims & 0x2)
+                numWorkGroups.y *= problem.batchSize(i);
+            if(!sizeMapping.packBatchDims)
+                numWorkGroups.z *= problem.batchSize(i);
+        }
+
+        if(problem.transposeC01())
+            std::swap(numWorkGroups.x, numWorkGroups.y);
+
+        numWorkGroups.x = CeilDivide(numWorkGroups.x, sizeMapping.macroTile.x);
+        numWorkGroups.y = CeilDivide(numWorkGroups.y, sizeMapping.macroTile.y);
+    }
+
     template <bool T_Debug>
     KernelInvocation
         ContractionSolution::generateSingleCall(ContractionSolution::Problem const& problem,
@@ -1232,39 +1279,7 @@ namespace TensileLite
 
         rv.kernelName = kernelName;
 
-        rv.workGroupSize.x = sizeMapping.workGroupSize.x * sizeMapping.workGroupSize.y
-                             * sizeMapping.workGroupSize.z;
-        rv.workGroupSize.y = 1;
-        rv.workGroupSize.z = 1;
-
-        rv.numWorkGroups.x = 1;
-        rv.numWorkGroups.y = 1;
-
-        for(size_t i = 0; i < problem.freeIndicesA().size(); i++)
-        {
-            rv.numWorkGroups.x *= problem.freeSizeA(i);
-        }
-        for(size_t i = 0; i < problem.freeIndicesB().size(); i++)
-        {
-            rv.numWorkGroups.y *= problem.freeSizeB(i);
-        }
-
-        rv.numWorkGroups.z = 1;
-        for(size_t i = 0; i < problem.batchIndices().size(); i++)
-        {
-            if(sizeMapping.packBatchDims & 0x1)
-                rv.numWorkGroups.x *= problem.batchSize(i);
-            if(sizeMapping.packBatchDims & 0x2)
-                rv.numWorkGroups.y *= problem.batchSize(i);
-            if(!sizeMapping.packBatchDims)
-                rv.numWorkGroups.z *= problem.batchSize(i);
-        }
-
-        if(problem.transposeC01())
-            std::swap(rv.numWorkGroups.x, rv.numWorkGroups.y);
-
-        rv.numWorkGroups.x = CeilDivide(rv.numWorkGroups.x, sizeMapping.macroTile.x);
-        rv.numWorkGroups.y = CeilDivide(rv.numWorkGroups.y, sizeMapping.macroTile.y);
+        calculateGrid(rv.workGroupSize, rv.numWorkGroups, problem);
 
         dim3 problemNumGroupTiles = rv.numWorkGroups;
 


### PR DESCRIPTION
## Motivation

The hip launch grid limit is 2^32 work items. When running algo method all on a large problem, you can end up with a small MT kernel that results in a large number of tiles that might overflow hip's limits.

## Technical Details

This change adds a new predicate that detects if a solution would overflow hip's launch limits. When using algo method all, isSolutionSupported will now accurately indicate that the kernel will not be able to solve the problem due to exceeding grid limits.

## Test Plan

Fixes the affected test case locally. A new test case to exercise the feature is added with this PR, but is currently disable since it requires a lot of memory, and a little longer to run that the average test case. Need reviewer comments on whether this test case should be enabled on CI or not.

## Test Result

Local tests for the issue passed. Awaiting CI results.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- ROCM-9844
