### PR TITLE
[hipcub] Fix the benchmark_warp_reduce symbol resolution issue

### DIFF
--- a/projects/hipcub/benchmark/benchmark_warp_reduce.cpp
+++ b/projects/hipcub/benchmark/benchmark_warp_reduce.cpp
@@ -29,9 +29,8 @@
 const size_t DEFAULT_N = 1024 * 1024 * 32;
 #endif
 
-template<class T, unsigned int WarpSize, unsigned int Trials>
-__global__ __launch_bounds__(64)
-auto warp_reduce_kernel(const T* d_input, T* d_output)
+template<unsigned int WarpSize, unsigned int Trials, class T>
+__device__ auto warp_reduce_benchmark(const T* d_input, T* d_output)
     -> std::enable_if_t<benchmark_utils::device_test_enabled_for_warp_size_v<WarpSize>>
 {
     const unsigned int i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -50,15 +49,20 @@ auto warp_reduce_kernel(const T* d_input, T* d_output)
     d_output[i] = value;
 }
 
-template<class T, unsigned int WarpSize, unsigned int Trials>
-__global__ __launch_bounds__(64)
-auto warp_reduce_kernel(const T* /*d_input*/, T* /*d_output*/)
+template<unsigned int WarpSize, unsigned int Trials, class T>
+__device__ auto warp_reduce_benchmark(const T* /*d_input*/, T* /*d_output*/)
     -> std::enable_if_t<!benchmark_utils::device_test_enabled_for_warp_size_v<WarpSize>>
 {}
 
-template<class T, class Flag, unsigned int WarpSize, unsigned int Trials>
+template<unsigned int WarpSize, unsigned int Trials, class T>
 __global__ __launch_bounds__(64)
-auto segmented_warp_reduce_kernel(const T* d_input, Flag* d_flags, T* d_output)
+void warp_reduce_kernel(const T* d_input, T* d_output)
+{
+    warp_reduce_benchmark<WarpSize, Trials>(d_input, d_output);
+}
+
+template<unsigned int WarpSize, unsigned int Trials, class T, class Flag>
+__device__ auto segmented_warp_reduce_benchmark(const T* d_input, Flag* d_flags, T* d_output)
     -> std::enable_if_t<benchmark_utils::device_test_enabled_for_warp_size_v<WarpSize>>
 {
     const unsigned int i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
@@ -77,11 +81,17 @@ auto segmented_warp_reduce_kernel(const T* d_input, Flag* d_flags, T* d_output)
     d_output[i] = value;
 }
 
-template<class T, class Flag, unsigned int WarpSize, unsigned int Trials>
-__global__ __launch_bounds__(64)
-auto segmented_warp_reduce_kernel(const T* /*d_input*/, Flag* /*d_flags*/, T* /*d_output*/)
+template<unsigned int WarpSize, unsigned int Trials, class T, class Flag>
+__device__ auto segmented_warp_reduce_benchmark(const T* /*d_input*/, Flag* /*d_flags*/, T* /*d_output*/)
     -> std::enable_if_t<!benchmark_utils::device_test_enabled_for_warp_size_v<WarpSize>>
 {}
+
+template<unsigned int WarpSize, unsigned int Trials, class T, class Flag>
+__global__ __launch_bounds__(64)
+void segmented_warp_reduce_kernel(const T* d_input, Flag* d_flags, T* d_output)
+{
+    segmented_warp_reduce_benchmark<WarpSize, Trials>(d_input, d_flags, d_output);
+}
 
 template<bool         Segmented,
          unsigned int WarpSize,
@@ -93,7 +103,7 @@ inline auto execute_warp_reduce_kernel(
     T* input, T* output, Flag* /* flags */, size_t size, hipStream_t stream) ->
     typename std::enable_if<!Segmented>::type
 {
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(warp_reduce_kernel<T, WarpSize, Trials>),
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(warp_reduce_kernel<WarpSize, Trials, T>),
                        dim3(size / BlockSize),
                        dim3(BlockSize),
                        0,
@@ -113,7 +123,7 @@ inline auto
     execute_warp_reduce_kernel(T* input, T* output, Flag* flags, size_t size, hipStream_t stream) ->
     typename std::enable_if<Segmented>::type
 {
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_warp_reduce_kernel<T, Flag, WarpSize, Trials>),
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(segmented_warp_reduce_kernel<WarpSize, Trials, T, Flag>),
                        dim3(size / BlockSize),
                        dim3(BlockSize),
                        0,


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Following the other benchmark code, wrap the benchmark_warp_reduce code in device functions rather than directly exposing kernels to std::enable_if_t conditions. This fixes the "Cannot find symbol with name" error observed on some Windows systems.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Apply the  std::enable_if_t conditions on device functions instead of on warp_reduce_kernel. This follows the pattern used in all other benchmarks.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
This should fix the "Cannot find symbol with name" error on reported Windows systems. And everything should still work on Linux.

## Test Result

<!-- Briefly summarize test outcomes. -->
Fixed the issue on tested Windows system.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
