### PR TITLE
[hipblaslt] Reduced GetHeuristic overhead 

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
@@ -1848,6 +1848,8 @@ rocblaslt_status
         {
             // set excluded lib here: if the #-returned < #-requested, we'll call getAll.
             // But in that case, we don't need to get GridBased or Prediction which are already returned here
+            static std::mutex mtx;
+            std::lock_guard<std::mutex> lock(mtx);
             TensileLite::Debug::Instance().setExcludedLibFromGetAll(defExcludedSet);
 
             std::vector<rocblaslt_matmul_heuristic_result> allSolutionsResults;
@@ -2098,6 +2100,8 @@ rocblaslt_status
         {
             // set excluded lib here: if the #-returned < #-requested, we'll call getAll.
             // But in that case, we don't need to get GridBased or Prediction which are already returned here
+            static std::mutex mtx;
+            std::lock_guard<std::mutex> lock(mtx);
             TensileLite::Debug::Instance().setExcludedLibFromGetAll(defExcludedSet);
 
             std::vector<rocblaslt_matmul_heuristic_result> allSolutionsResults;

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
@@ -49,6 +49,8 @@
 #include "tensile_host.hpp"
 #include "utility.hpp"
 
+#include <Tensile/Debug.hpp>
+
 #include <hip/hip_runtime_api.h>
 #include <map>
 #include <utility>
@@ -100,14 +102,19 @@ inline bool
                                      int&                               AlgoCount,
                                      bool                               override_option)
 {
+    log_api(__func__, "Entering function");
 
     int index = -1;
+    int duplicated_counts = 0;
 
     for(int i = 0; i < AlgoCount; i++)
     {
         if(*(int*)(heuristicResultsArray[i].algo.data)
            == *(int*)(SolutionsResult->algo.data)) //solution index
+        {
+            ++duplicated_counts;
             index = i;
+        }
     }
 
     if(override_option && index != -1)
@@ -117,6 +124,8 @@ inline bool
             heuristicResultsArray[i] = heuristicResultsArray[i + 1];
         }
     }
+
+    log_api(__func__, "Done: duplicated counts", duplicated_counts);
 
     return (index == -1) ? false : true;
 }
@@ -1831,9 +1840,16 @@ rocblaslt_status
             matmul_desc->bias = nullptr;
         log_api(__func__, "returnAlgoCount", *returnAlgoCount);
 
-        //Try to get size independent solutions from getAllSolutions()
+        static TensileLite::StringSet emptySet({});
+        static TensileLite::StringSet defExcludedSet({"GridBasedMatching", "PredictionMatching"});
+
+        // Try to get size independent solutions from getAllSolutions()
         if(requestedAlgoCount > *returnAlgoCount)
         {
+            // set excluded lib here: if the #-returned < #-requested, we'll call getAll.
+            // But in that case, we don't need to get GridBased or Prediction which are already returned here
+            TensileLite::Debug::Instance().setExcludedLibFromGetAll(defExcludedSet);
+
             std::vector<rocblaslt_matmul_heuristic_result> allSolutionsResults;
             if(rocblaslt_status_success
                == getAllSolutions(prob, handle, allSolutionsResults, pref->max_workspace_bytes))
@@ -1866,6 +1882,9 @@ rocblaslt_status
 
                 log_api(__func__, "final returnAlgoCount", *returnAlgoCount);
             }
+
+            // reset
+            TensileLite::Debug::Instance().setExcludedLibFromGetAll(emptySet);
         }
 
         if(status != rocblaslt_status_success)
@@ -2069,9 +2088,18 @@ rocblaslt_status
         {
             throw status;
         }
-        //Try to get size independent solutions from getAllSolutions()
+
+        int duplicated_counts = 0;
+        static TensileLite::StringSet emptySet({});
+        static TensileLite::StringSet defExcludedSet({"GridBasedMatching", "PredictionMatching"});
+
+        // Try to get size independent solutions from getAllSolutions()
         if(requestedAlgoCount > results.size())
         {
+            // set excluded lib here: if the #-returned < #-requested, we'll call getAll.
+            // But in that case, we don't need to get GridBased or Prediction which are already returned here
+            TensileLite::Debug::Instance().setExcludedLibFromGetAll(defExcludedSet);
+
             std::vector<rocblaslt_matmul_heuristic_result> allSolutionsResults;
             size_t                                         workspaceSizeInBytes = 0;
             if(rocblaslt_status_success
@@ -2087,7 +2115,10 @@ rocblaslt_status
                     for(int j = 0; j < oriReturnAlgoCount; j++)
                         if(*(int*)(results[j].algo.data)
                            == *(int*)(allSolutionsResults[i].algo.data)) //solution index
+                        {
+                            ++duplicated_counts;
                             duplicated_sol = true;
+                        }
                     rocblaslt::RocTuningV2* tuning = nullptr;
                     if(duplicated_sol == true
                        || rocblaslt_status_success
@@ -2105,7 +2136,12 @@ rocblaslt_status
 
                 log_api(__func__, "final returnAlgoCount", results.size());
             }
+
+            // reset
+            TensileLite::Debug::Instance().setExcludedLibFromGetAll(emptySet);
         }
+
+        log_api(__func__, "duplicated counts from getAll", duplicated_counts);
     }
     catch(const rocblaslt_status& status)
     {

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -3628,6 +3628,18 @@ rocblaslt_status getBestSolutions(RocblasltContractionProblem const& prob,
 
     auto algoCount = min(static_cast<size_t>(requestedAlgoCount), solutions.size());
     memset(heuristicResultsArray, 0, sizeof(rocblaslt_matmul_heuristic_result) * algoCount);
+
+    if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+    {
+        std::ostringstream msg;
+        for(size_t i = 0; i < algoCount; ++i)
+        {
+            auto& solution = solutions[i];
+            msg << "getBestSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
+        }
+        log_info(__func__, msg.str());
+    }
+
     _convertToHeuristicResultArray(solutions,
                                    requestedAlgoCount,
                                    heuristicResultsArray,
@@ -3725,8 +3737,13 @@ rocblaslt_status getAllSolutions(MyProblem&                                     
         else
             heuristicResults[i].workspaceSize = 0;
 
-        // debug
-        // std::cout << "getAllSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
+        if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+        {
+            std::ostringstream msg;
+            msg << "getAllSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
+            log_info(__func__, msg.str());
+        }
+
         i++;
     }
     heuristicResults.resize(i);
@@ -4204,12 +4221,16 @@ rocblaslt_status getBestSolutions(rocblaslt_handle       handle,
         heuristicResults.clear();
         heuristicResults.resize(algoCount);
 
-        // debug
-        // for(size_t i = 0; i < algoCount; ++i)
-        // {
-        //     auto& solution = solutions[i];
-        //     std::cout << "getBestSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
-        // }
+        if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+        {
+            std::ostringstream msg;
+            for(size_t i = 0; i < algoCount; ++i)
+            {
+                auto& solution = solutions[i];
+                msg << "getBestSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
+            }
+            log_info(__func__, msg.str());
+        }
 
         _convertToHeuristicResultArray(solutions,
                                        algoCount,

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -890,7 +890,7 @@ namespace
                     "algo_method",
                     2,
                     "solution_index",
-                    solutionIndex,                                          
+                    solutionIndex,
                     "activation_type",
                     tensileActivationtType_to_bench_string(problem.getParams().activationEnum()),
                     "flush",
@@ -1283,7 +1283,7 @@ namespace
             "algo_method",
             2,
             "solution_index",
-            solutionIndex,                                          
+            solutionIndex,
             "activation_type",
             tensileActivationtType_to_bench_string(problem.gemms[0].getParams().activationEnum()),
             "flush",
@@ -3626,8 +3626,8 @@ rocblaslt_status getBestSolutions(RocblasltContractionProblem const& prob,
             prob, library, hardware, data->problem, enableEpilogue, requestedAlgoCount);
     }
 
-    memset(
-        heuristicResultsArray, 0, sizeof(rocblaslt_matmul_heuristic_result) * requestedAlgoCount);
+    auto algoCount = min(static_cast<size_t>(requestedAlgoCount), solutions.size());
+    memset(heuristicResultsArray, 0, sizeof(rocblaslt_matmul_heuristic_result) * algoCount);
     _convertToHeuristicResultArray(solutions,
                                    requestedAlgoCount,
                                    heuristicResultsArray,
@@ -3645,6 +3645,8 @@ rocblaslt_status getAllSolutions(MyProblem&                                     
                                  std::vector<rocblaslt_matmul_heuristic_result>& heuristicResults,
                                  size_t                                          maxWorkSpaceBytes)
 {
+    log_api(__func__, "Entering function");
+
     std::shared_ptr<TensileLite::MasterSolutionLibrary<TensileLite::ContractionProblemGemm>>
                                            library;
     std::shared_ptr<hipDeviceProp_t>       deviceProp;
@@ -3698,6 +3700,7 @@ rocblaslt_status getAllSolutions(MyProblem&                                     
     heuristicResults.resize(solutions.size());
 
     int i = 0;
+    int duplicated_counts = 0;
     for(auto solution : solutions)
     {
         //workaround: findAllSolutions should get all solutions without duplications
@@ -3706,7 +3709,10 @@ rocblaslt_status getAllSolutions(MyProblem&                                     
             if(*(int*)(heuristicResults[j].algo.data) == solution->index)
                 duplicated_sol = true;
         if(duplicated_sol)
+        {
+            ++duplicated_counts;
             continue;
+        }
         memset(&heuristicResults[i], 0, sizeof(rocblaslt_matmul_heuristic_result));
         memset(heuristicResults[i].algo.data, 0, sizeof(heuristicResults[i].algo.data));
         int* solutionIndex                           = (int*)(heuristicResults[i].algo.data);
@@ -3718,10 +3724,14 @@ rocblaslt_status getAllSolutions(MyProblem&                                     
             heuristicResults[i].workspaceSize = solution->requiredWorkspaceSize(prob, *hardware);
         else
             heuristicResults[i].workspaceSize = 0;
+
+        // debug
+        // std::cout << "getAllSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
         i++;
     }
     heuristicResults.resize(i);
     log_api(__func__, "Final hardware solutions: ", heuristicResults.size());
+    log_api(__func__, "Leaving function, duplicated counts: ", duplicated_counts);
 
     return rocblaslt_status_success;
 }
@@ -4149,6 +4159,8 @@ rocblaslt_status getBestSolutions(rocblaslt_handle       handle,
                                   const int              requestedAlgoCount,
                                   std::vector<rocblaslt_matmul_heuristic_result>& heuristicResults)
 {
+    log_api(__func__, "Entering function");
+
     std::shared_ptr<TensileLite::MasterSolutionLibrary<TensileLite::ContractionProblemGemm>>
                                            library;
     std::shared_ptr<hipDeviceProp_t>       deviceProp;
@@ -4191,6 +4203,14 @@ rocblaslt_status getBestSolutions(rocblaslt_handle       handle,
         int  returnAlgoCount = 0;
         heuristicResults.clear();
         heuristicResults.resize(algoCount);
+
+        // debug
+        // for(size_t i = 0; i < algoCount; ++i)
+        // {
+        //     auto& solution = solutions[i];
+        //     std::cout << "getBestSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
+        // }
+
         _convertToHeuristicResultArray(solutions,
                                        algoCount,
                                        heuristicResults.data(),

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionLibrary.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionLibrary.py
@@ -419,7 +419,7 @@ class MasterSolutionLibrary:
                 elif d["Library"]["distance"] == "Range":
                     predicate = Properties.Predicate(tag="RangeMatching")
                 else:
-                    predicate = Properties.Predicate(tag="TruePred")
+                    predicate = Properties.Predicate(tag="GridBasedMatching") # to make different from TruePred
 
                 matchingLib = MatchingLibrary.FromOriginalState(d["Library"], solutions)
                 library = PredicateLibrary(tag="Problem")
@@ -431,7 +431,7 @@ class MasterSolutionLibrary:
                 library = PredicateLibrary(tag="Problem")
                 library.rows.append({"predicate": predicate, "library": freesizeLib})
             elif d["LibraryType"] == "Prediction":
-                predicate = Properties.Predicate(tag="FreeSizeMatching") # TODO Do we need a new predicate here?
+                predicate = Properties.Predicate(tag="PredictionMatching") # So that FreeSize / Prediction can co-exist
 
                 predictionLib = PredictionLibrary.FromOriginalState(d["Library"], solutions)
                 library = PredicateLibrary(tag="Problem")

--- a/projects/hipblaslt/tensilelite/include/Tensile/CachingLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/CachingLibrary.hpp
@@ -135,7 +135,12 @@ namespace TensileLite
         template <typename SubMap, typename K>
         void add_impl(SubMap& map, Value const& value, K const& key)
         {
-            map.emplace(key, value);
+            // use faster emplace entry when key is new, otherwise update value with []
+            if(!map.count(key))
+                map.emplace(key, value);
+            else
+                map[key] = value;
+
         }
 
         template <typename SubMap, typename K, typename... Ks>
@@ -160,6 +165,8 @@ namespace TensileLite
         using Library = SolutionLibrary<MyProblem, MySolution>;
         using Cache  = CacheMap<std::tuple<std::shared_ptr<MySolution>, double>, AMDGPU, MyProblem>;
         using Caches = CacheMap<SolutionVector<MySolution>, AMDGPU, MyProblem>;
+        using CachesAllSolsFlag
+            = CacheMap<bool, AMDGPU, MyProblem>;
         using CachesGroupedGemm
             = CacheMap<SolutionVector<MySolution>, AMDGPU, std::vector<MyProblem>>;
 
@@ -167,6 +174,7 @@ namespace TensileLite
             : m_subLibrary(subLibrary)
             , m_cache(std::make_tuple(nullptr, std::numeric_limits<double>::max()))
             , m_caches(SolutionVector<MySolution>{})
+            , m_cachesAllSolutions(false)
             , m_cachesGroupedGemm(SolutionVector<MySolution>{})
         {
         }
@@ -255,22 +263,41 @@ namespace TensileLite
             {
                 auto const&                amdgpu = dynamic_cast<AMDGPU const&>(hardware);
                 SolutionVector<MySolution> solutions;
+                bool                       cacheAlreadyContainAll;
                 solutions = m_caches.find(problem, amdgpu);
+                cacheAlreadyContainAll = m_cachesAllSolutions.find(problem, amdgpu);
+                // set flag in case of early return
+                lastFindTopRetAll = cacheAlreadyContainAll;
 
-                if(solutions.size() != 0)
+                if(solutions.size() >= numSolutions || cacheAlreadyContainAll)
                     return solutions;
 
                 solutions = m_subLibrary->findTopSolutions(problem, hardware, numSolutions);
                 if(solutions.size() != 0)
+                {
+                    bool alreadyRetAll = m_subLibrary->lastFindTopAlreadyRetAll();
                     m_caches.add(solutions, problem, amdgpu);
+                    m_cachesAllSolutions.add(alreadyRetAll, problem, amdgpu);
+                    // debug
+                    // std::cout << "m_cachesAllSolutions.add() with solution.size() = " << solutions.size()
+                    //           << " and alreadyRetAll: " << (alreadyRetAll? "True" : "False") << std::endl;
+                }
 
+                // can't reach the requested number, means findTop already done its best
+                lastFindTopRetAll = (solutions.size() < numSolutions);
                 return solutions;
             }
             catch(std::bad_cast const& exc)
             {
                 return m_subLibrary->findTopSolutions(problem, hardware, numSolutions);
             }
+            // TODO- redundant ??
             return m_subLibrary->findTopSolutions(problem, hardware, numSolutions);
+        }
+
+        virtual bool lastFindTopAlreadyRetAll() const override
+        {
+            return lastFindTopRetAll;
         }
 
         virtual SolutionVector<MySolution>
@@ -305,7 +332,9 @@ namespace TensileLite
         std::shared_ptr<Library>  m_subLibrary;
         mutable Cache             m_cache;
         mutable Caches            m_caches;
+        mutable CachesAllSolsFlag m_cachesAllSolutions;
         mutable CachesGroupedGemm m_cachesGroupedGemm;
+        mutable bool              lastFindTopRetAll;
     };
 
 #if 0

--- a/projects/hipblaslt/tensilelite/include/Tensile/CachingLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/CachingLibrary.hpp
@@ -334,7 +334,7 @@ namespace TensileLite
         mutable Caches            m_caches;
         mutable CachesAllSolsFlag m_cachesAllSolutions;
         mutable CachesGroupedGemm m_cachesGroupedGemm;
-        mutable bool              lastFindTopRetAll;
+        mutable std::atomic<bool> lastFindTopRetAll = false;
     };
 
 #if 0

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1975,6 +1975,65 @@ namespace TensileLite
                 }
             };
 
+            struct PredictionMatching : public Predicate_CRTP<PredictionMatching, ContractionProblemGemm>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = false
+                };
+
+                PredictionMatching() = default;
+
+                static std::string Type()
+                {
+                    return "PredictionMatching";
+                }
+
+                virtual bool operator()(ContractionProblemGemm const& problem) const override
+                {
+                    return true;
+                }
+
+                virtual bool debugEval(ContractionProblemGemm const& problem,
+                                       std::ostream&                 stream) const override
+                {
+                    bool rv = (*this)(problem);
+                    stream << rv << ": " << this->type() << std::endl;
+                    return rv;
+                }
+            };
+
+            struct GridBasedMatching
+                : public Predicate_CRTP<GridBasedMatching, ContractionProblemGemm>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = false
+                };
+
+                GridBasedMatching() = default;
+
+                static std::string Type()
+                {
+                    return "GridBasedMatching";
+                }
+
+                virtual bool operator()(ContractionProblemGemm const& problem) const override
+                {
+                    return true;
+                }
+
+                virtual bool debugEval(ContractionProblemGemm const& problem,
+                                       std::ostream&                 stream) const override
+                {
+                    bool rv = (*this)(problem);
+                    stream << rv << ": " << this->type() << std::endl;
+                    return rv;
+                }
+            };
+
             struct UseGradientEqual
                 : public Predicate_CRTP<UseGradientEqual, ContractionProblemGemm>
             {

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
@@ -187,12 +187,17 @@ namespace TensileLite
         using ParamsCache  = CacheMap<std::pair<int32_t, int32_t>, Problem>;
 
         /**
-         * Indicate a solution is equally or estimatedly matched.
+         * Indicate a solution's matching type
          */
         enum class MatchingTag
         {
-            Equal,
-            Estimated
+            Equal,        // EqualityMatching
+            Range,        // RangeMatching
+            FreeSize,     // FreeSizeMatching
+            GridBased,    // GridBasedMatching
+            Prediction,   // PredictionMatching
+            Experimental, // ExperimentalStreamK or ExperimentalMLP
+            Others,       // Default
         };
 
         static std::string Type()
@@ -217,12 +222,21 @@ namespace TensileLite
         {
             return kernelName;
         }
+
         virtual bool isFallbackForHW(Hardware const&) const;
 
         bool isStreamK() const
         {
             return sizeMapping.streamK > 0;
         }
+
+        /**
+         * @brief Returns the string representation of the solution's matching type.
+         *
+         * This tag is used to identify or categorize the solution for matching purposes.
+         * @return A string representing the matching type of the solution.
+         */
+        virtual std::string matchingTag() const;
 
         //! Estimates based on problem size, solution tile, and  machine hardware
         //! charz:
@@ -565,7 +579,7 @@ namespace TensileLite
         int32_t               libraryLogicIndex = -1;
         std::map<int, double> ideals;
         LinearModel           linearModel;
-        MatchingTag           tag{MatchingTag::Estimated};
+        MatchingTag           tag{MatchingTag::Others};
 
         uint32_t magicNumberAlg1(uint32_t x, uint32_t* magicShift) const;
         uint32_t magicNumberAlg2(uint32_t x, uint32_t* magicShift) const;

--- a/projects/hipblaslt/tensilelite/include/Tensile/Debug.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Debug.hpp
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <set>
 #include <string>
 #ifdef Tensile_ENABLE_MARKER
 #include <roctracer/roctx.h>
@@ -36,6 +37,8 @@
 
 namespace TensileLite
 {
+    using StringSet = std::set<std::string>;
+
     /**
      * @brief Common place for defining flags which enable debug behaviour.
      */
@@ -83,6 +86,10 @@ namespace TensileLite
         bool gridBasedBatchExp() const;
 
         bool disableStaggerU() const;
+
+        StringSet excludedLibFromGetAll() const;
+
+        void setExcludedLibFromGetAll(StringSet& excludedSet);
 
         __attribute__((always_inline)) inline void markerStart(const char* name) const
         {
@@ -133,6 +140,7 @@ namespace TensileLite
         bool        m_gridbasedBatchExp   = false;
         bool        m_printMarker         = false;
         bool        m_disableStaggerU     = false;
+        StringSet   m_excludedFromGetAll;
 
         Debug();
     };

--- a/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
@@ -55,8 +55,8 @@ namespace TensileLite
     struct ExactLogicLibrary : public SolutionLibrary<MyProblem, MySolution>
     {
         using Row = LibraryRow<MyProblem, MySolution, MyPredicate>;
-        std::vector<Row> rows;
-        mutable bool     lastFindTopRetAll;
+        std::vector<Row>          rows;
+        mutable std::atomic<bool> lastFindTopRetAll = false;
 
         ExactLogicLibrary() = default;
         ExactLogicLibrary(std::initializer_list<Row> init)

--- a/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include <Tensile/ContractionProblemPredicates.hpp>
 #include <Tensile/Debug.hpp>
 #include <Tensile/Predicates.hpp>

--- a/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -56,6 +56,7 @@ namespace TensileLite
     {
         using Row = LibraryRow<MyProblem, MySolution, MyPredicate>;
         std::vector<Row> rows;
+        mutable bool     lastFindTopRetAll;
 
         ExactLogicLibrary() = default;
         ExactLogicLibrary(std::initializer_list<Row> init)
@@ -129,9 +130,14 @@ namespace TensileLite
         {
             SolutionSet<MySolution> rv;
             const bool              streamK = Debug::Instance().useExperimentalSelection() == 2;
+            const auto&             excludedLib = Debug::Instance().excludedLibFromGetAll();
 
             for(auto const& row : rows)
             {
+                // we want to exclude this lib from getAll
+                if(excludedLib.count(row.first.value->type()))
+                    continue;
+
                 if(row.first.value->type() == "ExperimentalStreamK" && !streamK)
                     continue;
 
@@ -139,6 +145,34 @@ namespace TensileLite
                     continue;
 
                 auto rowSolutions = row.second->findAllSolutions(problem, hardware, searchType);
+
+                if(dynamic_cast<Predicates::Contraction::EqualityMatching*>(row.first.value.get()))
+                {
+                    for(auto& sol : rowSolutions)
+                        sol->tag = MySolution::MatchingTag::Equal;
+                }
+                else if(dynamic_cast<Predicates::Contraction::GridBasedMatching*>(row.first.value.get()))
+                {
+                    for(auto& sol : rowSolutions)
+                        sol->tag = MySolution::MatchingTag::GridBased;
+                }
+                else if(dynamic_cast<Predicates::Contraction::RangeMatching*>(row.first.value.get()))
+                {
+                    for(auto& sol : rowSolutions)
+                        sol->tag = MySolution::MatchingTag::Range;
+                }
+                else if(dynamic_cast<Predicates::Contraction::FreeSizeMatching*>(row.first.value.get()))
+                {
+                    for(auto& sol : rowSolutions)
+                        sol->tag = MySolution::MatchingTag::FreeSize;
+                }
+                else if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(row.first.value.get()))
+                {
+                    for(auto& sol : rowSolutions)
+                        sol->tag = MySolution::MatchingTag::Prediction;
+                }
+                // TODO- Experimental?
+
                 rv.insert(rowSolutions.begin(), rowSolutions.end());
             }
 
@@ -179,12 +213,15 @@ namespace TensileLite
             const bool                 streamK = Debug::Instance().useExperimentalSelection() == 2;
             const bool                 predictionLib = Debug::Instance().usePredictionLibrary();
 
+            // false in case of early return;
+            lastFindTopRetAll = false;
+
             for(auto const& row : rows)
             {
                 if(row.first.value->type() == "ExperimentalStreamK" && !streamK)
                     continue;
 
-                if(predictionLib && ((row.first.value->type() == "EqualityMatching") 
+                if(predictionLib && ((row.first.value->type() == "EqualityMatching")
                                      || (row.first.value->type() == "RangeMatching")))
                     continue;
 
@@ -193,10 +230,32 @@ namespace TensileLite
                     solutions
                         = row.second->findTopSolutions(problem, hardware, numSolutions - rv.size());
 
-                    if(dynamic_cast<Predicates::Contraction::EqualityMatching*>(
-                           row.first.value.get()))
+                    if(dynamic_cast<Predicates::Contraction::EqualityMatching*>(row.first.value.get()))
+                    {
                         for(auto& sol : solutions)
                             sol->tag = MySolution::MatchingTag::Equal;
+                    }
+                    else if(dynamic_cast<Predicates::Contraction::GridBasedMatching*>(row.first.value.get()))
+                    {
+                        for(auto& sol : solutions)
+                            sol->tag = MySolution::MatchingTag::GridBased;
+                    }
+                    else if(dynamic_cast<Predicates::Contraction::RangeMatching*>(row.first.value.get()))
+                    {
+                        for(auto& sol : solutions)
+                            sol->tag = MySolution::MatchingTag::Range;
+                    }
+                    else if(dynamic_cast<Predicates::Contraction::FreeSizeMatching*>(row.first.value.get()))
+                    {
+                        for(auto& sol : solutions)
+                            sol->tag = MySolution::MatchingTag::FreeSize;
+                    }
+                    else if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(row.first.value.get()))
+                    {
+                        for(auto& sol : solutions)
+                            sol->tag = MySolution::MatchingTag::Prediction;
+                    }
+                    // TODO- Experimental
 
                     rv.insert(std::end(rv), std::begin(solutions), std::end(solutions));
                     if(rv.size() == numSolutions)
@@ -204,7 +263,14 @@ namespace TensileLite
                 }
             }
 
+            // can't reach the requested number, means findTop already done its best
+            lastFindTopRetAll = (rv.size() < numSolutions);
             return rv;
+        }
+
+        virtual bool lastFindTopAlreadyRetAll() const override
+        {
+            return lastFindTopRetAll;
         }
 
         virtual SolutionVector<MySolution>

--- a/projects/hipblaslt/tensilelite/include/Tensile/FreeSizeLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/FreeSizeLibrary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -140,6 +140,10 @@ namespace TensileLite
                                                             Hardware const&  hardware,
                                                             int numSolutions) const override
         {
+            // TODO-
+            //   Can remove this override since the base SolutionLibrary has done the same thing
+            // FreeSize pool is simply a table, no ranking information.
+            // Return empty to indicate not supported for heuristic.
             SolutionVector<MySolution> solutions;
             return solutions;
         }

--- a/projects/hipblaslt/tensilelite/include/Tensile/MLPClassificationLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MLPClassificationLibrary.hpp
@@ -53,9 +53,10 @@ namespace TensileLite
         using ProblemFeatures  = std::vector<std::shared_ptr<MLFeatures::MLFeature<MyProblem>>>;
 
         std::map<int, std::shared_ptr<MySolution>> solutionmap;
-        std::shared_ptr<MLPNet>                   model;
+        std::shared_ptr<MLPNet>                    model;
         SolutionFeatures                           solFeatures;
         ProblemFeatures                            probFeatures;
+        mutable bool                               lastFindTopRetAll;
 
         static std::string Type()
         {
@@ -155,7 +156,15 @@ namespace TensileLite
                         numToSort--;
                     }
             }
+
+            // can't reach the requested number, means findTop already done its best
+            lastFindTopRetAll = (rv.size() < numSolutions);
             return rv;
+        }
+
+        virtual bool lastFindTopAlreadyRetAll() const override
+        {
+            return lastFindTopRetAll;
         }
 
         virtual SolutionSet<MySolution>

--- a/projects/hipblaslt/tensilelite/include/Tensile/MLPClassificationLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MLPClassificationLibrary.hpp
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <queue>
 #include <set>
 #include <vector>

--- a/projects/hipblaslt/tensilelite/include/Tensile/MLPClassificationLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MLPClassificationLibrary.hpp
@@ -56,7 +56,7 @@ namespace TensileLite
         std::shared_ptr<MLPNet>                    model;
         SolutionFeatures                           solFeatures;
         ProblemFeatures                            probFeatures;
-        mutable bool                               lastFindTopRetAll;
+        mutable std::atomic<bool>                  lastFindTopRetAll = false;
 
         static std::string Type()
         {

--- a/projects/hipblaslt/tensilelite/include/Tensile/MapLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MapLibrary.hpp
@@ -186,17 +186,28 @@ namespace TensileLite
 
         std::shared_ptr<Property<MyProblem, Key>> property;
         LibraryMap<MyProblem, MySolution, Key>    map;
+        mutable bool                              lastFindTopRetAll;
 
         virtual SolutionVector<MySolution> findTopSolutions(MyProblem const& problem,
                                                             Hardware const&  hardware,
                                                             int numSolutions) const override
         {
+            // false in case of early return
+            lastFindTopRetAll = false;
             auto library = lookup(problem, hardware);
 
             if(library == nullptr)
                 return SolutionVector<MySolution>();
 
-            return library->findTopSolutions(problem, hardware, numSolutions);
+            const auto& rv = library->findTopSolutions(problem, hardware, numSolutions);
+            lastFindTopRetAll = library->lastFindTopAlreadyRetAll();
+
+            return rv;
+        }
+
+        virtual bool lastFindTopAlreadyRetAll() const override
+        {
+            return lastFindTopRetAll;
         }
 
         virtual SolutionVector<MySolution>

--- a/projects/hipblaslt/tensilelite/include/Tensile/MapLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MapLibrary.hpp
@@ -186,7 +186,7 @@ namespace TensileLite
 
         std::shared_ptr<Property<MyProblem, Key>> property;
         LibraryMap<MyProblem, MySolution, Key>    map;
-        mutable bool                              lastFindTopRetAll;
+        mutable std::atomic<bool>                 lastFindTopRetAll = false;
 
         virtual SolutionVector<MySolution> findTopSolutions(MyProblem const& problem,
                                                             Hardware const&  hardware,

--- a/projects/hipblaslt/tensilelite/include/Tensile/MapLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MapLibrary.hpp
@@ -26,8 +26,9 @@
 
 #pragma once
 
-#include <Tensile/SolutionLibrary.hpp>
+#include <atomic>
 
+#include <Tensile/SolutionLibrary.hpp>
 #include <Tensile/PropertyMatching.hpp>
 
 namespace TensileLite

--- a/projects/hipblaslt/tensilelite/include/Tensile/MasterSolutionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MasterSolutionLibrary.hpp
@@ -103,6 +103,7 @@ namespace TensileLite
         mutable SolutionMap<MySolution>                         solutions;
         std::string                                             version;
         mutable std::mutex                                      solutionsGuard;
+        mutable bool                                            lastFindTopRetAll;
 
         MasterSolutionLibrary() = default;
 
@@ -320,13 +321,22 @@ namespace TensileLite
                 auto   end    = std::chrono::steady_clock::now();
                 double time   = std::chrono::duration<double, std::micro>(end - start).count();
                 std::cout << "Solution selection time: " << time << " us" << std::endl;
+                lastFindTopRetAll = library->lastFindTopAlreadyRetAll();
 
                 return result;
             }
             else
             {
-                return library->findTopSolutions(problem, hardware, numSolutions);
+                const auto& result = library->findTopSolutions(problem, hardware, numSolutions);
+                lastFindTopRetAll = library->lastFindTopAlreadyRetAll();
+
+                return result;
             }
+        }
+
+        virtual bool lastFindTopAlreadyRetAll() const override
+        {
+            return lastFindTopRetAll;
         }
 
         virtual SolutionVector<MySolution>

--- a/projects/hipblaslt/tensilelite/include/Tensile/MasterSolutionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MasterSolutionLibrary.hpp
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <map>

--- a/projects/hipblaslt/tensilelite/include/Tensile/MasterSolutionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MasterSolutionLibrary.hpp
@@ -103,7 +103,7 @@ namespace TensileLite
         mutable SolutionMap<MySolution>                         solutions;
         std::string                                             version;
         mutable std::mutex                                      solutionsGuard;
-        mutable bool                                            lastFindTopRetAll;
+        mutable std::atomic<bool>                               lastFindTopRetAll = false;
 
         MasterSolutionLibrary() = default;
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/MatchingLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MatchingLibrary.hpp
@@ -47,6 +47,7 @@ namespace TensileLite
         using Element = std::shared_ptr<SolutionLibrary<MyProblem, MySolution>>;
         using Table   = Matching::MatchingTable<MyProblem, Element, std::shared_ptr<MySolution>>;
         std::shared_ptr<Table> table;
+        mutable bool           lastFindTopRetAll;
 
         static std::string Type()
         {
@@ -176,7 +177,15 @@ namespace TensileLite
                 else
                     std::cout << "No solution found" << std::endl;
             }
+
+            // can't reach the requested number, means findTop already done its best
+            lastFindTopRetAll = (solutions.size() < numSolutions);
             return solutions;
+        }
+
+        virtual bool lastFindTopAlreadyRetAll() const override
+        {
+            return lastFindTopRetAll;
         }
 
         virtual SolutionVector<MySolution>

--- a/projects/hipblaslt/tensilelite/include/Tensile/MatchingLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MatchingLibrary.hpp
@@ -46,8 +46,8 @@ namespace TensileLite
     {
         using Element = std::shared_ptr<SolutionLibrary<MyProblem, MySolution>>;
         using Table   = Matching::MatchingTable<MyProblem, Element, std::shared_ptr<MySolution>>;
-        std::shared_ptr<Table> table;
-        mutable bool           lastFindTopRetAll;
+        std::shared_ptr<Table>    table;
+        mutable std::atomic<bool> lastFindTopRetAll = false;
 
         static std::string Type()
         {

--- a/projects/hipblaslt/tensilelite/include/Tensile/MatchingLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MatchingLibrary.hpp
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <set>
 #include <vector>
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/PlaceholderLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PlaceholderLibrary.hpp
@@ -149,6 +149,7 @@ namespace TensileLite
         std::string                                                     filePrefix;
         std::string                                                     suffix;
         std::string                                                     libraryDirectory;
+        mutable bool                                                    lastFindTopRetAll;
 
         mutable std::map<std::string, std::shared_ptr<SolutionLibrary<MyProblem, MySolution>>>*
             indexLoadedLibraries;
@@ -303,7 +304,15 @@ namespace TensileLite
             {
                 solution->codeObjectFilename = getCodeObjectFileName();
             }
+
+            // can't reach the requested number, means findTop already done its best
+            lastFindTopRetAll = (solutions.size() < numSolutions);
             return solutions;
+        }
+
+        virtual bool lastFindTopAlreadyRetAll() const override
+        {
+            return lastFindTopRetAll;
         }
 
         virtual SolutionVector<MySolution>

--- a/projects/hipblaslt/tensilelite/include/Tensile/PlaceholderLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PlaceholderLibrary.hpp
@@ -149,7 +149,7 @@ namespace TensileLite
         std::string                                                     filePrefix;
         std::string                                                     suffix;
         std::string                                                     libraryDirectory;
-        mutable bool                                                    lastFindTopRetAll;
+        mutable std::atomic<bool>                                       lastFindTopRetAll = false;
 
         mutable std::map<std::string, std::shared_ptr<SolutionLibrary<MyProblem, MySolution>>>*
             indexLoadedLibraries;

--- a/projects/hipblaslt/tensilelite/include/Tensile/PlaceholderLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PlaceholderLibrary.hpp
@@ -31,6 +31,7 @@
 #include <Tensile/SolutionLibrary.hpp>
 #include <Tensile/Tensile.hpp>
 
+#include <atomic>
 #include <algorithm>
 #include <map>
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
@@ -49,6 +49,8 @@ namespace TensileLite
         std::vector<origami::config_t>                       origami_config_list;
         std::unordered_map<origami::config_t, int>           origami_config_map;
 
+        mutable bool lastFindTopRetAll = false;
+
         static std::string Type()
         {
             return "Prediction";
@@ -198,7 +200,15 @@ namespace TensileLite
                     }
                 }
             }
+
+            // can't reach the requested number, means findTop already done its best
+            lastFindTopRetAll = (rv.size() < numSolutions);
             return rv;
+        }
+
+        virtual bool lastFindTopAlreadyRetAll() const override
+        {
+            return lastFindTopRetAll;
         }
 
         virtual SolutionVector<MySolution>

--- a/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <set>
 #include <vector>
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
@@ -49,7 +49,7 @@ namespace TensileLite
         std::vector<origami::config_t>                       origami_config_list;
         std::unordered_map<origami::config_t, int>           origami_config_map;
 
-        mutable bool lastFindTopRetAll = false;
+        mutable std::atomic<bool> lastFindTopRetAll = false;
 
         static std::string Type()
         {

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/ContractionPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/ContractionPredicates.hpp
@@ -105,6 +105,8 @@ namespace TensileLite
                      Base::template Pair<Predicates::Contraction::EqualityMatching>(),
                      Base::template Pair<Predicates::Contraction::RangeMatching>(),
                      Base::template Pair<Predicates::Contraction::FreeSizeMatching>(),
+                     Base::template Pair<Predicates::Contraction::PredictionMatching>(),
+                     Base::template Pair<Predicates::Contraction::GridBasedMatching>(),
                      Base::template Pair<Predicates::Contraction::UseGradientEqual>(),
                      Base::template Pair<Predicates::Contraction::ActivationCheck>(),
                      Base::template Pair<Predicates::Contraction::ActivationComputeTypeEqual>(),
@@ -415,6 +417,18 @@ namespace TensileLite
         template <typename IO>
         struct MappingTraits<Predicates::Contraction::FreeSizeMatching, IO>
             : public AutoMappingTraits<Predicates::Contraction::FreeSizeMatching, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::PredictionMatching, IO>
+            : public AutoMappingTraits<Predicates::Contraction::PredictionMatching, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::GridBasedMatching, IO>
+            : public AutoMappingTraits<Predicates::Contraction::GridBasedMatching, IO>
         {
         };
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/SolutionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/SolutionLibrary.hpp
@@ -194,6 +194,12 @@ namespace TensileLite
         {
             return SolutionVector<MySolution>();
         }
+
+        virtual bool lastFindTopAlreadyRetAll() const
+        {
+            return true;
+        }
+
         virtual SolutionVector<MySolution>
             findTopSolutionsGroupedGemm(std::vector<MyProblem> const& problems,
                                         Hardware const&               hardware,

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -48,6 +48,9 @@
 #include <roctracer/roctx.h>
 #endif
 
+#define TENSILELITE_TO_STR(x) #x
+#define TENSILELITE_ENUMSTR(x) x, TENSILELITE_TO_STR(x)
+
 namespace TensileLite
 {
     enum class KERNELARGTYPE
@@ -310,6 +313,24 @@ namespace TensileLite
                                  DeviceUserArguments<float>*                      args);
 
     PerfModel perf;
+
+    static const std::map<ContractionSolution::MatchingTag, const char*>& MatchingTag2StringMap()
+    {
+        static const std::map<ContractionSolution::MatchingTag, const char*> MatchingTag2String
+            = {{TENSILELITE_ENUMSTR(ContractionSolution::MatchingTag::Equal)},
+               {TENSILELITE_ENUMSTR(ContractionSolution::MatchingTag::GridBased)},
+               {TENSILELITE_ENUMSTR(ContractionSolution::MatchingTag::Range)},
+               {TENSILELITE_ENUMSTR(ContractionSolution::MatchingTag::FreeSize)},
+               {TENSILELITE_ENUMSTR(ContractionSolution::MatchingTag::Prediction)},
+               {TENSILELITE_ENUMSTR(ContractionSolution::MatchingTag::Experimental)},
+               {TENSILELITE_ENUMSTR(ContractionSolution::MatchingTag::Others)}};
+        return MatchingTag2String;
+    }
+
+    std::string ContractionSolution::matchingTag() const
+    {
+        return MatchingTag2StringMap().at(tag);
+    }
 
     // check if this solution is a CU-Fallback solution for current hardware
     bool ContractionSolution::isFallbackForHW(Hardware const& hardware) const

--- a/projects/hipblaslt/tensilelite/src/Debug.cpp
+++ b/projects/hipblaslt/tensilelite/src/Debug.cpp
@@ -165,6 +165,16 @@ namespace TensileLite
         return m_disableStaggerU;
     }
 
+    StringSet Debug::excludedLibFromGetAll() const
+    {
+        return m_excludedFromGetAll;
+    }
+
+    void Debug::setExcludedLibFromGetAll(StringSet& excludedSet)
+    {
+        m_excludedFromGetAll = excludedSet;
+    }
+
     Debug::Debug()
         : m_value(DEBUG_SM)
         , m_value2(DEBUG_SM2)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Reduce the overhead of some APIs, without changing the returned results.

in PR #3103 

> - [x] Added a "num_sols" field to check if the follow-up PR can still return correct solutions
> - [x] GetHeuristic with requested_solution = 100
> - [x] GetHeuristic with requested_solution = -1
> 
> After the first two GetHeuristic (get only one solution, both in c/cpp API), "CachingLibrary" will contain only one solution.
> In this case, I'd like to know if we bench the same problem but request 100 solutions again, what is the behavior ?
> 
> When I'm tracing the code, I found that the GetHeuristic( get 100 ) only return one solution from cache, and the rest of 99 solutions are from "getAll" (even if 100 solutions can be returned from findTopSolutions without getAll)
> This situation is similar as when setting requested_solution = -1, getAll is always called.

The results of getHeuristic[100] and getHeuristic[-1] is the main motivation.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
1. Improving CachingLibrary by making it able to update
2. Extending MatchingTag to make solutions' matching type more precise.
3. From GetHeuristic to GetAll, we can exclude some matching type (i.e. GridBased, Prediction) 

**Other details, please see my self-review in the conversation**

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
CI Test

## Test Result

<!-- Briefly summarize test outcomes. -->
CI Test and PTS to see if overhead is reduced

Compared with #3103 

> ### [overhead]:function,api_name,num_sols,us/iter,best_us
> api_overhead,hipblasLtMatmulAlgoGetHeuristic,1,15.111134,14.859000
> api_overhead,hipblaslt_ext::algoGetHeuristic,1,7.788060,7.558000
> api_overhead,hipblaslt_ext::getAllAlgos,1505,144378.582950,141457.371000
> api_overhead,hipblasLtMatmulAlgoGetHeuristic[100],100,**144179.146080**,142785.777000
> api_overhead,hipblaslt_ext::algoGetHeuristic[100],100,**143197.977740**,141912.436000
> api_overhead,hipblasLtMatmulAlgoGetHeuristic[Neg1],1505,**161085.538430**,159418.012000
> api_overhead,hipblaslt_ext::algoGetHeuristic[Neg1],1505,**150868.661910**,149525.587000

Below is the result of this PR:

> ### [overhead]:function,api_name,num_sols,us/iter,best_us
> api_overhead,hipblasLtMatmulAlgoGetHeuristic,1,20.141360,19.735000
> api_overhead,hipblaslt_ext::algoGetHeuristic,1,12.287753,11.894000
> api_overhead,hipblaslt_ext::getAllAlgos,1505,153778.685300,150340.943000
> api_overhead,hipblasLtMatmulAlgoGetHeuristic[100],100,**45.903910**,45.358000
> api_overhead,hipblaslt_ext::algoGetHeuristic[100],100,**41.973360**,40.059000
> api_overhead,hipblasLtMatmulAlgoGetHeuristic[Neg1],1505,**11561.851830**,11212.520000
> api_overhead,hipblaslt_ext::algoGetHeuristic[Neg1],1505,**8509.848810**,8451.583000

* **num_sols is still correct, no solutions are missing.**
* getAllAlgos remains slow, it's expected
* GetHeuristic[100] from [143000 ~ 144000] us to [41 ~ 45] us. **3000x faster**
* GetHeuristic[Neg1] from [150000 ~ 161000] us to [8500 ~ 11500] us **14x~18x faster**


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
