### PR TITLE
[hipsparse] Dont compile fortran documentation examples on windows

### DIFF
--- a/projects/hipsparse/clients/samples/CMakeLists.txt
+++ b/projects/hipsparse/clients/samples/CMakeLists.txt
@@ -98,9 +98,17 @@ if(NOT USE_CUDA)
   FILE(GLOB_RECURSE DOCUMENTATION_EXAMPLES_C documentation_examples/*.c)
   FILE(GLOB_RECURSE DOCUMENTATION_EXAMPLES_F90 documentation_examples/*.f90)
   
-  set(DOCUMENTATION_EXAMPLES ${DOCUMENTATION_EXAMPLES_CPP} ${DOCUMENTATION_EXAMPLES_C} ${DOCUMENTATION_EXAMPLES_F90})
-
-  foreach(file ${DOCUMENTATION_EXAMPLES})
+  foreach(file ${DOCUMENTATION_EXAMPLES_CPP})
       add_hipsparse_example(${file})
   endforeach()
+
+  foreach(file ${DOCUMENTATION_EXAMPLES_C})
+      add_hipsparse_example(${file})
+  endforeach()
+
+  if (NOT WIN32)
+    foreach(file ${DOCUMENTATION_EXAMPLES_F90})
+        add_hipsparse_example(${file})
+    endforeach()
+  endif()
 endif()


### PR DESCRIPTION
## Motivation

Don't compile fortran documentation examples on windows as we dont build the hipsparse_fortran target on windows
