### PR TITLE
Fix compilation issue with -DBUILD_WITH_SPARSE=ON

### DIFF
--- a/projects/rocsolver/library/src/refact/rocsolver_rfinfo.cpp
+++ b/projects/rocsolver/library/src/refact/rocsolver_rfinfo.cpp
@@ -62,6 +62,7 @@
         }                                                          \
     } while(0)
 
+#ifndef HAVE_ROCSPARSE
 ROCSOLVER_BEGIN_NAMESPACE
 
 template <typename Fn>
@@ -216,6 +217,7 @@ static bool try_load_rocsparse()
 }
 
 ROCSOLVER_END_NAMESPACE
+#endif /* HAVE_ROCSPARSE */
 
 extern "C" rocblas_status rocsolver_create_rfinfo(rocsolver_rfinfo* rfinfo, rocblas_handle handle)
 {


### PR DESCRIPTION
## Motivation

As reported in https://github.com/ROCm/rocm-libraries/issues/2585, rocsolver fails to compile with -DBUILD_WITH_SPARSE=ON. This can be addressed by avoiding compilation of load_rocsparse and related code if rocsparse is a build dependency and not a runtime dependency.

## Technical Details

Adds conditional compilation for load_rocsparse and related code. Code calling these functions is already similarly conditionally compiled, so this should not affect rocsolver internally.

## Test Plan

Reproducer: attempt to build rocsolver with `./install.sh -i --sparse`, which sets `-DBUILD_WITH_SPARSE=ON`.

## Test Result

Before change: compilation error as reported in issue.
After change: compilation proceeds successfully.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
