### PR TITLE
[rocWMMA] Add --gc-sections flag to clean up number of ELF sections

### DIFF
--- a/projects/rocwmma/test/CMakeLists.txt
+++ b/projects/rocwmma/test/CMakeLists.txt
@@ -36,7 +36,7 @@ if(ROCWMMA_CODE_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
     add_link_options(-fprofile-instr-generate)
 endif()
-add_link_options(-mcmodel=large)
+add_link_options(-mcmodel=large -Wl,--gc-sections)
 
 # Test/benchmark requires additional dependencies
 if(ROCWMMA_USE_SYSTEM_GOOGLETEST)


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/rocm-libraries/issues/2769. Currently when TheRock is building python packages, it is using the `patchelf --print-rpath` utility to normalize rpaths. Because the generated test binaries have over 64k ELF sections, this is failing, so this fix is aimed at cleaning up the binaries. 

The two failing binaries were:
`gemm_PGR1_LB2_MP0_MB_CP_WG-validate`: ~66k -> ~44k sections
`gemm_PGR1_LB2_MP0_MB_CP_WV-validate` ~66k -> ~43k sections

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Add the `--gc-sections` flag when building the rocWMMA tests
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Verify that rocWMMA builds correctly
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

rocWMMA builds with the resultant test binaries having fewer ELF sections
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
