### PR TITLE
[rocblas] spirv one target to rule them all

### DIFF
--- a/projects/rocblas/CMakeLists.txt
+++ b/projects/rocblas/CMakeLists.txt
@@ -218,7 +218,10 @@ if(NOT SKIP_LIBRARY)
   endif()
 endif()
 
-message(STATUS "Using GPU_TARGETS: ${GPU_TARGETS}")
+message(STATUS "Initial GPU_TARGETS: ${GPU_TARGETS}")
+# the one and only target
+set( GPU_TARGETS "amdgcnspirv" CACHE STRING "List of GPUs (gfx targets) to support" FORCE )
+message(STATUS "Forcing GPU_TARGETS: ${GPU_TARGETS}")
 
 # Find HIP dependencies
 if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )

--- a/projects/rocblas/CMakeLists.txt
+++ b/projects/rocblas/CMakeLists.txt
@@ -232,10 +232,7 @@ if(NOT SKIP_LIBRARY)
   endif()
 endif()
 
-message(STATUS "Initial GPU_TARGETS: ${GPU_TARGETS}")
-# the one and only target
-set( GPU_TARGETS "amdgcnspirv" CACHE STRING "List of GPUs (gfx targets) to support" FORCE )
-message(STATUS "Forcing GPU_TARGETS: ${GPU_TARGETS}")
+message(STATUS "Using GPU_TARGETS: ${GPU_TARGETS}")
 
 # Find HIP dependencies
 if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )

--- a/projects/rocblas/library/src/blas1/rocblas_asum_nrm2_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_asum_nrm2_kernels.hpp
@@ -94,7 +94,7 @@ rocblas_reduction_kernel_part1(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto* x = load_ptr_batch(xvec, batch, shiftx, stridex);
@@ -112,7 +112,7 @@ rocblas_reduction_kernel_part1(rocblas_int    n,
         if(threadIdx.x == 0)
             workspace[batch * nblocks + blockIdx.x] = sum;
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_asum_nrm2_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_asum_nrm2_kernels.hpp
@@ -93,7 +93,8 @@ rocblas_reduction_kernel_part1(rocblas_int    n,
 
     uint32_t batch = blockIdx.z;
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto* x = load_ptr_batch(xvec, batch, shiftx, stridex);
@@ -111,7 +112,7 @@ rocblas_reduction_kernel_part1(rocblas_int    n,
         if(threadIdx.x == 0)
             workspace[batch * nblocks + blockIdx.x] = sum;
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_axpy_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_axpy_kernels.hpp
@@ -50,7 +50,8 @@ rocblas_axpy_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto alpha = load_scalar(alpha_device_host, batch, stride_alpha);
@@ -66,7 +67,7 @@ rocblas_axpy_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -92,7 +93,8 @@ rocblas_saxpy_2_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -119,7 +121,7 @@ rocblas_saxpy_2_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -156,7 +158,8 @@ rocblas_axpy_kernel_batched(rocblas_int    n,
         int64_t iy = tid * incy;
 
 #if DEVICE_GRID_YZ_16BIT
-        for(; batch < batch_count; batch += gridDim.z * DIM_Y * 4)
+        // note non-standard looping for batch so no DEVICE_GRID_SETUP
+        do
         {
 #endif
 
@@ -178,7 +181,7 @@ rocblas_axpy_kernel_batched(rocblas_int    n,
             }
 
 #if DEVICE_GRID_YZ_16BIT
-        }
+        } while((batch += gridDim.z * DIM_Y * 4) < batch_count);
 #endif
     }
 }
@@ -204,7 +207,8 @@ rocblas_haxpy_mod_8_kernel(rocblas_int    n_mod_8,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -220,7 +224,7 @@ rocblas_haxpy_mod_8_kernel(rocblas_int    n_mod_8,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -244,7 +248,8 @@ rocblas_haxpy_mlt_8_kernel(rocblas_int    n_mlt_8,
 
     uint32_t batch = blockIdx.z;
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -311,7 +316,7 @@ rocblas_haxpy_mlt_8_kernel(rocblas_int    n_mlt_8,
             }
         }
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_axpy_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_axpy_kernels.hpp
@@ -51,7 +51,7 @@ rocblas_axpy_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto alpha = load_scalar(alpha_device_host, batch, stride_alpha);
@@ -67,7 +67,7 @@ rocblas_axpy_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -94,7 +94,7 @@ rocblas_saxpy_2_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -121,7 +121,7 @@ rocblas_saxpy_2_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -208,7 +208,7 @@ rocblas_haxpy_mod_8_kernel(rocblas_int    n_mod_8,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -224,7 +224,7 @@ rocblas_haxpy_mod_8_kernel(rocblas_int    n_mod_8,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -249,7 +249,7 @@ rocblas_haxpy_mlt_8_kernel(rocblas_int    n_mlt_8,
     uint32_t batch = blockIdx.z;
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -316,7 +316,7 @@ rocblas_haxpy_mlt_8_kernel(rocblas_int    n_mlt_8,
             }
         }
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_copy_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_copy_kernels.hpp
@@ -46,7 +46,7 @@ rocblas_copy_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -59,7 +59,7 @@ rocblas_copy_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -81,7 +81,7 @@ rocblas_scopy_2_kernel(rocblas_int n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -98,7 +98,7 @@ rocblas_scopy_2_kernel(rocblas_int n,
             y[tid] = x[tid];
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_copy_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_copy_kernels.hpp
@@ -45,7 +45,8 @@ rocblas_copy_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -58,7 +59,7 @@ rocblas_copy_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -79,7 +80,8 @@ rocblas_scopy_2_kernel(rocblas_int n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -96,7 +98,7 @@ rocblas_scopy_2_kernel(rocblas_int n,
             y[tid] = x[tid];
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_dot_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_dot_kernels.hpp
@@ -75,7 +75,7 @@ rocblas_dot_kernel_inc1(rocblas_int n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto* x = load_ptr_batch(xa, batch, shiftx, stridex);
@@ -98,7 +98,7 @@ rocblas_dot_kernel_inc1(rocblas_int n,
         rocblas_dot_save_sum<ONE_BLOCK>(sum, batch, workspace, out);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -120,7 +120,7 @@ rocblas_dot_kernel_inc1by2(rocblas_int n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -169,7 +169,7 @@ rocblas_dot_kernel_inc1by2(rocblas_int n,
         rocblas_dot_save_sum<ONE_BLOCK>(sum, batch, workspace, out);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -200,7 +200,7 @@ rocblas_dot_kernel(rocblas_int n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -224,7 +224,7 @@ rocblas_dot_kernel(rocblas_int n,
         rocblas_dot_save_sum<ONE_BLOCK>(sum, batch, workspace, out);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -299,7 +299,7 @@ rocblas_dot_kernel_magsq(rocblas_int n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -322,7 +322,7 @@ rocblas_dot_kernel_magsq(rocblas_int n,
         rocblas_dot_save_sum<ONE_BLOCK>(sum, batch, workspace, out);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_dot_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_dot_kernels.hpp
@@ -74,7 +74,8 @@ rocblas_dot_kernel_inc1(rocblas_int n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto* x = load_ptr_batch(xa, batch, shiftx, stridex);
@@ -97,7 +98,7 @@ rocblas_dot_kernel_inc1(rocblas_int n,
         rocblas_dot_save_sum<ONE_BLOCK>(sum, batch, workspace, out);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -118,7 +119,8 @@ rocblas_dot_kernel_inc1by2(rocblas_int n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -167,7 +169,7 @@ rocblas_dot_kernel_inc1by2(rocblas_int n,
         rocblas_dot_save_sum<ONE_BLOCK>(sum, batch, workspace, out);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -197,7 +199,8 @@ rocblas_dot_kernel(rocblas_int n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -221,7 +224,7 @@ rocblas_dot_kernel(rocblas_int n,
         rocblas_dot_save_sum<ONE_BLOCK>(sum, batch, workspace, out);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -240,7 +243,7 @@ rocblas_dot_kernel_gfx942_float_double(rocblas_int n,
                                        T* __restrict__ out)
 {
 // gfx942 kernels
-#if defined(__gfx942__)
+#if defined(__SPIRV__) || defined(__gfx942__)
     int         i = blockIdx.x * NB + threadIdx.x;
     const auto* x = load_ptr_batch(xa, blockIdx.z, shiftx, stridex);
     const auto* y = load_ptr_batch(ya, blockIdx.z, shifty, stridey);
@@ -295,7 +298,8 @@ rocblas_dot_kernel_magsq(rocblas_int n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -318,7 +322,7 @@ rocblas_dot_kernel_magsq(rocblas_int n,
         rocblas_dot_save_sum<ONE_BLOCK>(sum, batch, workspace, out);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_iamax_iamin_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_iamax_iamin_kernels.hpp
@@ -92,7 +92,8 @@ rocblas_iamax_iamin_kernel_part1(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -113,7 +114,7 @@ rocblas_iamax_iamin_kernel_part1(rocblas_int    n,
             workspace[batch * nblocks + blockIdx.x] = sum;
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_iamax_iamin_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_iamax_iamin_kernels.hpp
@@ -93,7 +93,7 @@ rocblas_iamax_iamin_kernel_part1(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -114,7 +114,7 @@ rocblas_iamax_iamin_kernel_part1(rocblas_int    n,
             workspace[batch * nblocks + blockIdx.x] = sum;
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_rot_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_rot_kernels.hpp
@@ -122,7 +122,8 @@ rocblas_rot_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -134,6 +135,6 @@ rocblas_rot_kernel(rocblas_int    n,
         rocblas_rot_kernel_calc<API_INT, Tex>(n, x, incx, y, incy, c, s);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }

--- a/projects/rocblas/library/src/blas1/rocblas_rot_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_rot_kernels.hpp
@@ -123,7 +123,7 @@ rocblas_rot_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -135,6 +135,6 @@ rocblas_rot_kernel(rocblas_int    n,
         rocblas_rot_kernel_calc<API_INT, Tex>(n, x, incx, y, incy, c, s);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }

--- a/projects/rocblas/library/src/blas1/rocblas_rotm_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_rotm_kernels.hpp
@@ -98,7 +98,8 @@ rocblas_rotm_kernel_batched(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -125,7 +126,7 @@ rocblas_rotm_kernel_batched(rocblas_int    n,
                                  batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_rotm_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_rotm_kernels.hpp
@@ -99,7 +99,7 @@ rocblas_rotm_kernel_batched(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -126,7 +126,7 @@ rocblas_rotm_kernel_batched(rocblas_int    n,
                                  batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_scal_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_scal_kernels.hpp
@@ -39,7 +39,7 @@ rocblas_scal_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -54,7 +54,7 @@ rocblas_scal_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -77,7 +77,7 @@ rocblas_sscal_2_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -105,7 +105,7 @@ rocblas_sscal_2_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -130,7 +130,7 @@ rocblas_hscal_mlt_4_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -178,7 +178,7 @@ rocblas_hscal_mlt_4_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_scal_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_scal_kernels.hpp
@@ -38,7 +38,8 @@ rocblas_scal_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -53,7 +54,7 @@ rocblas_scal_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -75,7 +76,8 @@ rocblas_sscal_2_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -103,7 +105,7 @@ rocblas_sscal_2_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -127,7 +129,8 @@ rocblas_hscal_mlt_4_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -175,7 +178,7 @@ rocblas_hscal_mlt_4_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_swap_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_swap_kernels.hpp
@@ -53,7 +53,8 @@ rocblas_swap_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -66,7 +67,7 @@ rocblas_swap_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -88,7 +89,8 @@ rocblas_sswap_2_kernel(rocblas_int n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -107,7 +109,7 @@ rocblas_sswap_2_kernel(rocblas_int n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas1/rocblas_swap_kernels.hpp
+++ b/projects/rocblas/library/src/blas1/rocblas_swap_kernels.hpp
@@ -54,7 +54,7 @@ rocblas_swap_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -67,7 +67,7 @@ rocblas_swap_kernel(rocblas_int    n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -90,7 +90,7 @@ rocblas_sswap_2_kernel(rocblas_int n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -109,7 +109,7 @@ rocblas_sswap_2_kernel(rocblas_int n,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/gemv_device.hpp
+++ b/projects/rocblas/library/src/blas2/gemv_device.hpp
@@ -636,12 +636,13 @@ rocblas_gemvt_row_vectorized_kernel(rocblas_int    m,
                                     rocblas_int    batch_count)
 {
 // gfx90a gfx942 kernels
-#if defined(__gfx90a__) || defined(__gfx942__)
+#if defined(__SPIRV__) || defined(__gfx90a__) || defined(__SPIRV__) || defined(__gfx942__)
 
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -657,7 +658,7 @@ rocblas_gemvt_row_vectorized_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 
 #endif
@@ -697,7 +698,8 @@ rocblas_gemv_scal_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -715,7 +717,7 @@ rocblas_gemv_scal_kernel(rocblas_int    n,
         rocblas_gemv_scal_kernel_calc<NB>(n, beta, stride_beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -1557,7 +1559,8 @@ rocblas_gemvn_double_buffered_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -1581,7 +1584,7 @@ rocblas_gemvn_double_buffered_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -1614,7 +1617,8 @@ rocblas_gemvt_double_buffered_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -1638,7 +1642,7 @@ rocblas_gemvt_double_buffered_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -1671,7 +1675,8 @@ rocblas_gemvn_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -1696,7 +1701,7 @@ rocblas_gemvn_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -1727,7 +1732,8 @@ rocblas_gemvt_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -1751,7 +1757,7 @@ rocblas_gemvt_kernel(rocblas_int    m,
         rocblas_gemvt_kernel_calc<CONJ, NB_X>(m, n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -1780,7 +1786,8 @@ rocblas_gemvt_warp_reduce_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto alpha = load_scalar(alpha_device_host, batch, stride_alpha);
@@ -1804,7 +1811,7 @@ rocblas_gemvt_warp_reduce_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -1828,7 +1835,8 @@ rocblas_gemvt_sn_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -1841,7 +1849,7 @@ rocblas_gemvt_sn_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, workspace, batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -1860,7 +1868,8 @@ rocblas_gemvt_sn_reduce(rocblas_int    n_sums,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -1870,7 +1879,7 @@ rocblas_gemvt_sn_reduce(rocblas_int    n_sums,
         rocblas_gemvt_sn_reduce_calc<NB, WIN>(n_sums, beta, y, incy, workspace, batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -1992,7 +2001,7 @@ rocblas_gemvn_sm_mn_batched_kernel(rocblas_int    m,
                                    rocblas_int    batch_count)
 {
 // gfx90a gfx942 kernels
-#if defined(__gfx90a__) || defined(__gfx942__)
+#if defined(__SPIRV__) || defined(__gfx90a__) || defined(__SPIRV__) || defined(__gfx942__)
 
     const int b = blockIdx.x * blockDim.y + threadIdx.y;
     if(b >= batch_count)

--- a/projects/rocblas/library/src/blas2/gemv_device.hpp
+++ b/projects/rocblas/library/src/blas2/gemv_device.hpp
@@ -642,7 +642,7 @@ rocblas_gemvt_row_vectorized_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -658,7 +658,7 @@ rocblas_gemvt_row_vectorized_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 
 #endif
@@ -699,7 +699,7 @@ rocblas_gemv_scal_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -717,7 +717,7 @@ rocblas_gemv_scal_kernel(rocblas_int    n,
         rocblas_gemv_scal_kernel_calc<NB>(n, beta, stride_beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -1560,7 +1560,7 @@ rocblas_gemvn_double_buffered_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -1584,7 +1584,7 @@ rocblas_gemvn_double_buffered_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -1618,7 +1618,7 @@ rocblas_gemvt_double_buffered_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -1642,7 +1642,7 @@ rocblas_gemvt_double_buffered_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -1676,7 +1676,7 @@ rocblas_gemvn_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -1701,7 +1701,7 @@ rocblas_gemvn_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -1733,7 +1733,7 @@ rocblas_gemvt_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -1757,7 +1757,7 @@ rocblas_gemvt_kernel(rocblas_int    m,
         rocblas_gemvt_kernel_calc<CONJ, NB_X>(m, n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -1787,7 +1787,7 @@ rocblas_gemvt_warp_reduce_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto alpha = load_scalar(alpha_device_host, batch, stride_alpha);
@@ -1811,7 +1811,7 @@ rocblas_gemvt_warp_reduce_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -1836,7 +1836,7 @@ rocblas_gemvt_sn_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -1849,7 +1849,7 @@ rocblas_gemvt_sn_kernel(rocblas_int    m,
             m, n, alpha, A, lda, x, incx, workspace, batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -1869,7 +1869,7 @@ rocblas_gemvt_sn_reduce(rocblas_int    n_sums,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -1879,7 +1879,7 @@ rocblas_gemvt_sn_reduce(rocblas_int    n_sums,
         rocblas_gemvt_sn_reduce_calc<NB, WIN>(n_sums, beta, y, incy, workspace, batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_gbmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_gbmv_kernels.cpp
@@ -216,7 +216,8 @@ rocblas_gbmvn_kernel(bool           host_ptr_mode,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -242,7 +243,7 @@ rocblas_gbmvn_kernel(bool           host_ptr_mode,
         rocblas_gbmvn_kernel_calc<WARP, DIM_Y>(m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -273,7 +274,8 @@ rocblas_gbmvt_kernel(bool              host_ptr_mode,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -298,7 +300,7 @@ rocblas_gbmvt_kernel(bool              host_ptr_mode,
             transA, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_gbmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_gbmv_kernels.cpp
@@ -217,7 +217,7 @@ rocblas_gbmvn_kernel(bool           host_ptr_mode,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -243,7 +243,7 @@ rocblas_gbmvn_kernel(bool           host_ptr_mode,
         rocblas_gbmvn_kernel_calc<WARP, DIM_Y>(m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -275,7 +275,7 @@ rocblas_gbmvt_kernel(bool              host_ptr_mode,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -300,7 +300,7 @@ rocblas_gbmvt_kernel(bool              host_ptr_mode,
             transA, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_ger_kernels.hpp
+++ b/projects/rocblas/library/src/blas2/rocblas_ger_kernels.hpp
@@ -71,7 +71,7 @@ rocblas_ger_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -116,7 +116,7 @@ rocblas_ger_kernel(rocblas_int    m,
             }
         }
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -213,7 +213,7 @@ rocblas_sger_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -249,7 +249,7 @@ rocblas_sger_kernel(rocblas_int    m,
             A[i] += res_y * x[(tx + i) * int64_t(incx)];
         }
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -295,7 +295,7 @@ rocblas_ger_double_buffered_kernel(bool           host_ptr_mode,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -370,7 +370,7 @@ rocblas_ger_double_buffered_kernel(bool           host_ptr_mode,
             A[(DIM_X / 2) + j + k * size_t(lda)] = areg_lower[k];
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_ger_kernels.hpp
+++ b/projects/rocblas/library/src/blas2/rocblas_ger_kernels.hpp
@@ -70,7 +70,8 @@ rocblas_ger_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -115,7 +116,7 @@ rocblas_ger_kernel(rocblas_int    m,
             }
         }
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -140,7 +141,7 @@ rocblas_sger_gfx942_kernel(rocblas_int    m,
                            rocblas_stride strideA)
 {
 // gfx942 kernels
-#if defined(__gfx942__)
+#if defined(__SPIRV__) || defined(__gfx942__)
 
     rocblas_int tx  = (blockIdx.x * DIM_X + threadIdx.x) * 2;
     rocblas_int col = blockIdx.y;
@@ -211,7 +212,8 @@ rocblas_sger_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -247,7 +249,7 @@ rocblas_sger_kernel(rocblas_int    m,
             A[i] += res_y * x[(tx + i) * int64_t(incx)];
         }
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -292,7 +294,8 @@ rocblas_ger_double_buffered_kernel(bool           host_ptr_mode,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -367,7 +370,7 @@ rocblas_ger_double_buffered_kernel(bool           host_ptr_mode,
             A[(DIM_X / 2) + j + k * size_t(lda)] = areg_lower[k];
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hbmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hbmv_kernels.cpp
@@ -187,7 +187,8 @@ rocblas_hbmvn_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto* A = cond_load_ptr_batch(alpha, Aa, batch, shifta, strideA);
@@ -199,7 +200,7 @@ rocblas_hbmvn_kernel(bool           is_upper,
             is_upper, n, k, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hbmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hbmv_kernels.cpp
@@ -188,7 +188,7 @@ rocblas_hbmvn_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto* A = cond_load_ptr_batch(alpha, Aa, batch, shifta, strideA);
@@ -200,7 +200,7 @@ rocblas_hbmvn_kernel(bool           is_upper,
             is_upper, n, k, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hemv_symv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hemv_symv_kernels.cpp
@@ -624,7 +624,7 @@ rocblas_hemvn_kernel_upper_block_sum(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
         W* saved_workspace_address
             = workspace; //Saving the address of the workspace memory to assign it after the computation
@@ -678,7 +678,7 @@ rocblas_hemvn_kernel_upper_block_sum(rocblas_int    n,
 #if DEVICE_GRID_YZ_16BIT
         workspace
             = saved_workspace_address; // Assigning back the saved address of the workspace memory to do the next batch computation
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 // end hemvn_kernel_upper_block_sum_calc
@@ -1172,7 +1172,7 @@ rocblas_hemvn_kernel_lower_block_sum(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
         W* saved_workspace_address
             = workspace; //Saving the address of the workspace memory to assign it after the computation
@@ -1227,7 +1227,7 @@ rocblas_hemvn_kernel_lower_block_sum(rocblas_int    n,
 #if DEVICE_GRID_YZ_16BIT
         workspace
             = saved_workspace_address; // Assigning back the saved address of the workspace memory to do the next batch computation
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 // end hemvn_kernel_lower_block_sum_calc
@@ -2577,7 +2577,7 @@ rocblas_hemvn_kernel_upper(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -2604,7 +2604,7 @@ rocblas_hemvn_kernel_upper(rocblas_int    n,
                                         T_index>(n, alpha, A, lda, x, incx, workspace, batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2644,7 +2644,7 @@ rocblas_hemvn_kernel_lower(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -2667,7 +2667,7 @@ rocblas_hemvn_kernel_lower(rocblas_int    n,
             n, alpha, A, lda, x, incx, workspace, batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2697,7 +2697,7 @@ rocblas_symv_kernel_upper_double_buffered_diagonal(bool           host_ptr_mode,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -2722,7 +2722,7 @@ rocblas_symv_kernel_upper_double_buffered_diagonal(bool           host_ptr_mode,
             n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2755,7 +2755,7 @@ rocblas_symv_kernel_upper_double_buffered_non_diagonal(bool           host_ptr_m
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -2781,7 +2781,7 @@ rocblas_symv_kernel_upper_double_buffered_non_diagonal(bool           host_ptr_m
             n, alpha, A, lda, x, incx, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2812,7 +2812,7 @@ rocblas_symv_kernel_upper_double_buffered_diagonal_generic(bool           host_p
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -2838,7 +2838,7 @@ rocblas_symv_kernel_upper_double_buffered_diagonal_generic(bool           host_p
             n, alpha, A, lda, x, incx, beta, y, incy, mod);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2873,7 +2873,7 @@ rocblas_symv_kernel_upper_double_buffered_non_diagonal_generic(bool           ho
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -2899,7 +2899,7 @@ rocblas_symv_kernel_upper_double_buffered_non_diagonal_generic(bool           ho
             n, alpha, A, lda, x, incx, y, incy, mod);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2929,7 +2929,7 @@ rocblas_symv_kernel_lower_double_buffered_diagonal(bool           host_ptr_mode,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -2955,7 +2955,7 @@ rocblas_symv_kernel_lower_double_buffered_diagonal(bool           host_ptr_mode,
             n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2988,7 +2988,7 @@ rocblas_symv_kernel_lower_double_buffered_non_diagonal(bool           host_ptr_m
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -3014,7 +3014,7 @@ rocblas_symv_kernel_lower_double_buffered_non_diagonal(bool           host_ptr_m
             n, alpha, A, lda, x, incx, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -3045,7 +3045,7 @@ rocblas_symv_kernel_lower_double_buffered_diagonal_generic(bool           host_p
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -3070,7 +3070,7 @@ rocblas_symv_kernel_lower_double_buffered_diagonal_generic(bool           host_p
             n, alpha, A, lda, x, incx, beta, y, incy, mod);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -3104,7 +3104,7 @@ rocblas_symv_kernel_lower_double_buffered_non_diagonal_generic(bool           ho
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -3129,7 +3129,7 @@ rocblas_symv_kernel_lower_double_buffered_non_diagonal_generic(bool           ho
             n, alpha, A, lda, x, incx, y, incy, mod);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hemv_symv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hemv_symv_kernels.cpp
@@ -623,7 +623,8 @@ rocblas_hemvn_kernel_upper_block_sum(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
         W* saved_workspace_address
             = workspace; //Saving the address of the workspace memory to assign it after the computation
@@ -677,7 +678,7 @@ rocblas_hemvn_kernel_upper_block_sum(rocblas_int    n,
 #if DEVICE_GRID_YZ_16BIT
         workspace
             = saved_workspace_address; // Assigning back the saved address of the workspace memory to do the next batch computation
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 // end hemvn_kernel_upper_block_sum_calc
@@ -1170,7 +1171,8 @@ rocblas_hemvn_kernel_lower_block_sum(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
         W* saved_workspace_address
             = workspace; //Saving the address of the workspace memory to assign it after the computation
@@ -1225,7 +1227,7 @@ rocblas_hemvn_kernel_lower_block_sum(rocblas_int    n,
 #if DEVICE_GRID_YZ_16BIT
         workspace
             = saved_workspace_address; // Assigning back the saved address of the workspace memory to do the next batch computation
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 // end hemvn_kernel_lower_block_sum_calc
@@ -2574,7 +2576,8 @@ rocblas_hemvn_kernel_upper(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -2601,7 +2604,7 @@ rocblas_hemvn_kernel_upper(rocblas_int    n,
                                         T_index>(n, alpha, A, lda, x, incx, workspace, batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2640,7 +2643,8 @@ rocblas_hemvn_kernel_lower(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -2663,7 +2667,7 @@ rocblas_hemvn_kernel_lower(rocblas_int    n,
             n, alpha, A, lda, x, incx, workspace, batch);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2692,7 +2696,8 @@ rocblas_symv_kernel_upper_double_buffered_diagonal(bool           host_ptr_mode,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -2717,7 +2722,7 @@ rocblas_symv_kernel_upper_double_buffered_diagonal(bool           host_ptr_mode,
             n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2749,7 +2754,8 @@ rocblas_symv_kernel_upper_double_buffered_non_diagonal(bool           host_ptr_m
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -2775,7 +2781,7 @@ rocblas_symv_kernel_upper_double_buffered_non_diagonal(bool           host_ptr_m
             n, alpha, A, lda, x, incx, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2805,7 +2811,8 @@ rocblas_symv_kernel_upper_double_buffered_diagonal_generic(bool           host_p
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -2831,7 +2838,7 @@ rocblas_symv_kernel_upper_double_buffered_diagonal_generic(bool           host_p
             n, alpha, A, lda, x, incx, beta, y, incy, mod);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2865,7 +2872,8 @@ rocblas_symv_kernel_upper_double_buffered_non_diagonal_generic(bool           ho
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -2891,7 +2899,7 @@ rocblas_symv_kernel_upper_double_buffered_non_diagonal_generic(bool           ho
             n, alpha, A, lda, x, incx, y, incy, mod);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2920,7 +2928,8 @@ rocblas_symv_kernel_lower_double_buffered_diagonal(bool           host_ptr_mode,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -2946,7 +2955,7 @@ rocblas_symv_kernel_lower_double_buffered_diagonal(bool           host_ptr_mode,
             n, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2978,7 +2987,8 @@ rocblas_symv_kernel_lower_double_buffered_non_diagonal(bool           host_ptr_m
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -3004,7 +3014,7 @@ rocblas_symv_kernel_lower_double_buffered_non_diagonal(bool           host_ptr_m
             n, alpha, A, lda, x, incx, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -3034,7 +3044,8 @@ rocblas_symv_kernel_lower_double_buffered_diagonal_generic(bool           host_p
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -3059,7 +3070,7 @@ rocblas_symv_kernel_lower_double_buffered_diagonal_generic(bool           host_p
             n, alpha, A, lda, x, incx, beta, y, incy, mod);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -3092,7 +3103,8 @@ rocblas_symv_kernel_lower_double_buffered_non_diagonal_generic(bool           ho
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto alpha = host_ptr_mode ? alpha_device_host.value
@@ -3117,7 +3129,7 @@ rocblas_symv_kernel_lower_double_buffered_non_diagonal_generic(bool           ho
             n, alpha, A, lda, x, incx, y, incy, mod);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_her2_kernels.hpp
+++ b/projects/rocblas/library/src/blas2/rocblas_her2_kernels.hpp
@@ -101,7 +101,8 @@ rocblas_her2_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto*       A = load_ptr_batch(Aa, batch, shift_A, stride_A);
@@ -111,7 +112,7 @@ rocblas_her2_kernel(bool           is_upper,
         rocblas_her2_kernel_calc(is_upper, n, area, alpha, x, incx, y, incy, A, lda);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_her2_kernels.hpp
+++ b/projects/rocblas/library/src/blas2/rocblas_her2_kernels.hpp
@@ -102,7 +102,7 @@ rocblas_her2_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto*       A = load_ptr_batch(Aa, batch, shift_A, stride_A);
@@ -112,7 +112,7 @@ rocblas_her2_kernel(bool           is_upper,
         rocblas_her2_kernel_calc(is_upper, n, area, alpha, x, incx, y, incy, A, lda);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_her_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_her_kernels.cpp
@@ -97,7 +97,7 @@ rocblas_her_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -117,7 +117,7 @@ rocblas_her_kernel(bool           is_upper,
         rocblas_her_kernel_calc<DIM_X>(is_upper, n, alpha, x, incx, A, lda);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_her_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_her_kernels.cpp
@@ -96,7 +96,8 @@ rocblas_her_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -116,7 +117,7 @@ rocblas_her_kernel(bool           is_upper,
         rocblas_her_kernel_calc<DIM_X>(is_upper, n, alpha, x, incx, A, lda);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hpmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hpmv_kernels.cpp
@@ -149,7 +149,7 @@ rocblas_hpmv_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto AP = cond_load_ptr_batch(alpha, APa, batch, shifta, strideA);
@@ -160,7 +160,7 @@ rocblas_hpmv_kernel(bool           is_upper,
         rocblas_hpmv_kernel_calc<DIM_X, DIM_Y>(is_upper, n, alpha, AP, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hpmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hpmv_kernels.cpp
@@ -148,7 +148,8 @@ rocblas_hpmv_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto AP = cond_load_ptr_batch(alpha, APa, batch, shifta, strideA);
@@ -159,7 +160,7 @@ rocblas_hpmv_kernel(bool           is_upper,
         rocblas_hpmv_kernel_calc<DIM_X, DIM_Y>(is_upper, n, alpha, AP, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hpr2_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hpr2_kernels.cpp
@@ -82,7 +82,8 @@ rocblas_hpr2_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto* x  = load_ptr_batch(xa, batch, shift_x, stride_x);
@@ -92,7 +93,7 @@ rocblas_hpr2_kernel(bool           is_upper,
         rocblas_hpr2_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, y, incy, AP);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hpr2_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hpr2_kernels.cpp
@@ -83,7 +83,7 @@ rocblas_hpr2_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto* x  = load_ptr_batch(xa, batch, shift_x, stride_x);
@@ -93,7 +93,7 @@ rocblas_hpr2_kernel(bool           is_upper,
         rocblas_hpr2_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, y, incy, AP);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hpr_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hpr_kernels.cpp
@@ -69,7 +69,7 @@ rocblas_hpr_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         const auto* x  = load_ptr_batch(xa, batch, shift_x, stride_x);
@@ -78,7 +78,7 @@ rocblas_hpr_kernel(bool           is_upper,
         rocblas_hpr_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, AP);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_hpr_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_hpr_kernels.cpp
@@ -68,7 +68,8 @@ rocblas_hpr_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         const auto* x  = load_ptr_batch(xa, batch, shift_x, stride_x);
@@ -77,7 +78,7 @@ rocblas_hpr_kernel(bool           is_upper,
         rocblas_hpr_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, AP);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_sbmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_sbmv_kernels.cpp
@@ -181,7 +181,7 @@ rocblas_sbmv_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -204,7 +204,7 @@ rocblas_sbmv_kernel(rocblas_int    n,
         rocblas_sbmv_kernel_calc<UPPER, DIM_X, DIM_Y>(n, k, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_sbmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_sbmv_kernels.cpp
@@ -180,7 +180,8 @@ rocblas_sbmv_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -203,7 +204,7 @@ rocblas_sbmv_kernel(rocblas_int    n,
         rocblas_sbmv_kernel_calc<UPPER, DIM_X, DIM_Y>(n, k, alpha, A, lda, x, incx, beta, y, incy);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_spmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_spmv_kernels.cpp
@@ -136,7 +136,8 @@ rocblas_spmv_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -158,7 +159,7 @@ rocblas_spmv_kernel(bool           is_upper,
 
         rocblas_spmv_kernel_calc<DIM_X, DIM_Y>(is_upper, n, alpha, AP, x, incx, beta, y, incy);
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_spmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_spmv_kernels.cpp
@@ -137,7 +137,7 @@ rocblas_spmv_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -159,7 +159,7 @@ rocblas_spmv_kernel(bool           is_upper,
 
         rocblas_spmv_kernel_calc<DIM_X, DIM_Y>(is_upper, n, alpha, AP, x, incx, beta, y, incy);
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_spr2_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_spr2_kernels.cpp
@@ -80,7 +80,8 @@ rocblas_spr2_kernel(bool           host_ptr_mode,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto*       AP = load_ptr_batch(APa, batch, shift_AP, stride_AP);
@@ -90,7 +91,7 @@ rocblas_spr2_kernel(bool           host_ptr_mode,
         rocblas_spr2_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, y, incy, AP);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_spr2_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_spr2_kernels.cpp
@@ -81,7 +81,7 @@ rocblas_spr2_kernel(bool           host_ptr_mode,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto*       AP = load_ptr_batch(APa, batch, shift_AP, stride_AP);
@@ -91,7 +91,7 @@ rocblas_spr2_kernel(bool           host_ptr_mode,
         rocblas_spr2_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, y, incy, AP);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_spr_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_spr_kernels.cpp
@@ -94,7 +94,8 @@ rocblas_spr_kernel(bool           host_ptr_mode,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto*       AP = load_ptr_batch(APa, batch, shift_A, stride_A);
@@ -103,7 +104,7 @@ rocblas_spr_kernel(bool           host_ptr_mode,
         rocblas_spr_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, AP);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_spr_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_spr_kernels.cpp
@@ -95,7 +95,7 @@ rocblas_spr_kernel(bool           host_ptr_mode,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto*       AP = load_ptr_batch(APa, batch, shift_A, stride_A);
@@ -104,7 +104,7 @@ rocblas_spr_kernel(bool           host_ptr_mode,
         rocblas_spr_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, AP);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_syr2_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_syr2_kernels.cpp
@@ -76,7 +76,7 @@ rocblas_syr2_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto*       A = load_ptr_batch(Aa, batch, shift_A, stride_A);
@@ -86,7 +86,7 @@ rocblas_syr2_kernel(bool           is_upper,
         rocblas_syr2_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, y, incy, A, lda);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_syr2_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_syr2_kernels.cpp
@@ -75,7 +75,8 @@ rocblas_syr2_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto*       A = load_ptr_batch(Aa, batch, shift_A, stride_A);
@@ -85,7 +86,7 @@ rocblas_syr2_kernel(bool           is_upper,
         rocblas_syr2_kernel_calc<DIM_X, DIM_Y, N_TX>(is_upper, n, alpha, x, incx, y, incy, A, lda);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_syr_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_syr_kernels.cpp
@@ -42,7 +42,7 @@ rocblas_syr_kernel_inc1(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto alpha = load_scalar(alpha_device_host, batch, stride_alpha);
@@ -88,7 +88,7 @@ rocblas_syr_kernel_inc1(rocblas_int    n,
         // if(uplo == rocblas_fill_lower ? tx < n && ty <= tx : ty < n && tx <= ty)
         // A[tx + size_t(lda) * ty] += alpha * x[tx] * x[ty];
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -112,7 +112,7 @@ rocblas_syr_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto alpha = load_scalar(alpha_device_host, batch, stride_alpha);
@@ -155,7 +155,7 @@ rocblas_syr_kernel(rocblas_int    n,
         A[tx + lda * ty] += alpha * x[tx * incx] * x[ty * incx];
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_syr_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_syr_kernels.cpp
@@ -41,7 +41,8 @@ rocblas_syr_kernel_inc1(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto alpha = load_scalar(alpha_device_host, batch, stride_alpha);
@@ -87,7 +88,7 @@ rocblas_syr_kernel_inc1(rocblas_int    n,
         // if(uplo == rocblas_fill_lower ? tx < n && ty <= tx : ty < n && tx <= ty)
         // A[tx + size_t(lda) * ty] += alpha * x[tx] * x[ty];
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -110,7 +111,8 @@ rocblas_syr_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto alpha = load_scalar(alpha_device_host, batch, stride_alpha);
@@ -153,7 +155,7 @@ rocblas_syr_kernel(rocblas_int    n,
         A[tx + lda * ty] += alpha * x[tx * incx] * x[ty * incx];
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_tbmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tbmv_kernels.cpp
@@ -275,7 +275,7 @@ rocblas_tbmvx_kernel(rocblas_operation transA,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -287,7 +287,7 @@ rocblas_tbmvx_kernel(rocblas_operation transA,
             transA, is_upper, is_unit_diag, n, k, A, lda, w_x_copy, x, incx);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_tbmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tbmv_kernels.cpp
@@ -274,7 +274,8 @@ rocblas_tbmvx_kernel(rocblas_operation transA,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -286,7 +287,7 @@ rocblas_tbmvx_kernel(rocblas_operation transA,
             transA, is_upper, is_unit_diag, n, k, A, lda, w_x_copy, x, incx);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_tbsv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tbsv_kernels.cpp
@@ -228,7 +228,8 @@ rocblas_tbsv_kernel(rocblas_operation transA,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -252,7 +253,7 @@ rocblas_tbsv_kernel(rocblas_operation transA,
                 is_unit_diag, n, k, A, lda, x, incx);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_tbsv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tbsv_kernels.cpp
@@ -229,7 +229,7 @@ rocblas_tbsv_kernel(rocblas_operation transA,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -253,7 +253,7 @@ rocblas_tbsv_kernel(rocblas_operation transA,
                 is_unit_diag, n, k, A, lda, x, incx);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_tpmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tpmv_kernels.cpp
@@ -197,7 +197,8 @@ rocblas_tpmvn_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         rocblas_tpmvn_kernel_calc<NB>(is_upper,
@@ -209,7 +210,7 @@ rocblas_tpmvn_kernel(bool           is_upper,
                                       load_ptr_batch(workspace, batch, shift_w, stride_w));
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -234,7 +235,8 @@ rocblas_tpmvt_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -246,7 +248,7 @@ rocblas_tpmvt_kernel(bool           is_upper,
                                       incx,
                                       load_ptr_batch(workspace, batch, shift_w, stride_w));
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -271,7 +273,8 @@ rocblas_tpmvc_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         rocblas_tpmvc_kernel_calc<NB>(is_upper,
@@ -282,7 +285,7 @@ rocblas_tpmvc_kernel(bool           is_upper,
                                       incx,
                                       load_ptr_batch(workspace, batch, shift_w, stride_w));
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_tpmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tpmv_kernels.cpp
@@ -198,7 +198,7 @@ rocblas_tpmvn_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         rocblas_tpmvn_kernel_calc<NB>(is_upper,
@@ -210,7 +210,7 @@ rocblas_tpmvn_kernel(bool           is_upper,
                                       load_ptr_batch(workspace, batch, shift_w, stride_w));
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -236,7 +236,7 @@ rocblas_tpmvt_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -248,7 +248,7 @@ rocblas_tpmvt_kernel(bool           is_upper,
                                       incx,
                                       load_ptr_batch(workspace, batch, shift_w, stride_w));
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -274,7 +274,7 @@ rocblas_tpmvc_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         rocblas_tpmvc_kernel_calc<NB>(is_upper,
@@ -285,7 +285,7 @@ rocblas_tpmvc_kernel(bool           is_upper,
                                       incx,
                                       load_ptr_batch(workspace, batch, shift_w, stride_w));
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_trmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_trmv_kernels.cpp
@@ -141,7 +141,8 @@ rocblas_trmvn_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -154,7 +155,7 @@ rocblas_trmvn_kernel(rocblas_int    n,
             load_ptr_batch(workspace, batch, shiftw, stride_w));
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -184,7 +185,8 @@ rocblas_trmvt_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -197,7 +199,7 @@ rocblas_trmvt_kernel(rocblas_int    n,
             load_ptr_batch(workspace, batch, shiftw, stride_w));
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_trmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_trmv_kernels.cpp
@@ -142,7 +142,7 @@ rocblas_trmvn_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -155,7 +155,7 @@ rocblas_trmvn_kernel(rocblas_int    n,
             load_ptr_batch(workspace, batch, shiftw, stride_w));
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -186,7 +186,7 @@ rocblas_trmvt_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -199,7 +199,7 @@ rocblas_trmvt_kernel(rocblas_int    n,
             load_ptr_batch(workspace, batch, shiftw, stride_w));
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_trsv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_trsv_kernels.cpp
@@ -503,7 +503,8 @@ rocblas_trsv_device(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -786,7 +787,7 @@ rocblas_trsv_device(rocblas_int    n,
         __threadfence();
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas2/rocblas_trsv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_trsv_kernels.cpp
@@ -504,7 +504,7 @@ rocblas_trsv_device(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -787,7 +787,7 @@ rocblas_trsv_device(rocblas_int    n,
         __threadfence();
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/herk_syrk_device.hpp
+++ b/projects/rocblas/library/src/blas3/herk_syrk_device.hpp
@@ -110,11 +110,11 @@ rocblas_syrkx_herkx_small_kernel(rocblas_int    N,
                                  rocblas_stride stride_c,
                                  rocblas_int    batch_count)
 {
-    int thx   = threadIdx.x; // thread's m position
-    int thy   = threadIdx.y; // thread's n position
-    int blx   = blockIdx.x; // block's m position
-    int bly   = blockIdx.y; // block's n position
-    int batch = blockIdx.z; // block's matrix in the batch
+    int      thx   = threadIdx.x; // thread's m position
+    int      thy   = threadIdx.y; // thread's n position
+    int      blx   = blockIdx.x; // block's m position
+    int      bly   = blockIdx.y; // block's n position
+    uint32_t batch = blockIdx.z; // block's matrix in the batch
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
@@ -217,11 +217,11 @@ rocblas_syrkx_herkx_small_restrict_kernel(rocblas_int    N,
                                           rocblas_stride stride_c,
                                           rocblas_int    batch_count)
 {
-    int thx   = threadIdx.x; // thread's m position
-    int thy   = threadIdx.y; // thread's n position
-    int blx   = blockIdx.x; // block's m position
-    int bly   = blockIdx.y; // block's n position
-    int batch = blockIdx.z; // block's matrix in the batch
+    int      thx   = threadIdx.x; // thread's m position
+    int      thy   = threadIdx.y; // thread's n position
+    int      blx   = blockIdx.x; // block's m position
+    int      bly   = blockIdx.y; // block's n position
+    uint32_t batch = blockIdx.z; // block's matrix in the batch
 
     auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
     auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);
@@ -304,16 +304,17 @@ rocblas_syrkx_herkx_general_kernel(rocblas_int    N,
                                    rocblas_stride stride_c,
                                    rocblas_int    batch_count)
 {
-    int thx   = threadIdx.x; // thread's m position in C
-    int thy   = threadIdx.y; // thread's n position in C
-    int idt   = DIM_N * thy + thx; // thread's number
-    int blx   = blockIdx.x; // block's m position
-    int bly   = blockIdx.y; // block's n position
-    int batch = blockIdx.z; // block's matrix in the batch
-    int thxA  = idt % BLK_N; // thread's m position for loading A
-    int thyA  = idt / BLK_N; // thread's n position for loading A
-    int thxB  = idt % BLK_K; // thread's m position for loading B
-    int thyB  = idt / BLK_K; // thread's n position for loading B
+    int      thx   = threadIdx.x; // thread's m position in C
+    int      thy   = threadIdx.y; // thread's n position in C
+    int      idt   = DIM_N * thy + thx; // thread's number
+    int      blx   = blockIdx.x; // block's m position
+    int      bly   = blockIdx.y; // block's n position
+    uint32_t batch = blockIdx.z; // block's matrix in the batch
+
+    int thxA = idt % BLK_N; // thread's m position for loading A
+    int thyA = idt / BLK_N; // thread's n position for loading A
+    int thxB = idt % BLK_K; // thread's m position for loading B
+    int thyB = idt / BLK_K; // thread's n position for loading B
 
     auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
     auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);
@@ -429,16 +430,17 @@ rocblas_syrkx_herkx_restricted_kernel(rocblas_int    N,
                                       rocblas_stride stride_c,
                                       rocblas_int    batch_count)
 {
-    int thx   = threadIdx.x; // thread's m position in C
-    int thy   = threadIdx.y; // thread's n position in C
-    int idt   = DIM_N * thy + thx; // thread's number
-    int blx   = blockIdx.x; // block's m position
-    int bly   = blockIdx.y; // block's n position
-    int batch = blockIdx.z; // block's matrix in the batch
-    int thxA  = idt % BLK_N; // thread's m position for loading A
-    int thyA  = idt / BLK_N; // thread's n position for loading A
-    int thxB  = idt % BLK_K; // thread's m position for loading B
-    int thyB  = idt / BLK_K; // thread's n position for loading B
+    int      thx   = threadIdx.x; // thread's m position in C
+    int      thy   = threadIdx.y; // thread's n position in C
+    int      idt   = DIM_N * thy + thx; // thread's number
+    int      blx   = blockIdx.x; // block's m position
+    int      bly   = blockIdx.y; // block's n position
+    uint32_t batch = blockIdx.z; // block's matrix in the batch
+
+    int thxA = idt % BLK_N; // thread's m position for loading A
+    int thyA = idt / BLK_N; // thread's n position for loading A
+    int thxB = idt % BLK_K; // thread's m position for loading B
+    int thyB = idt / BLK_K; // thread's n position for loading B
 
     auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
     auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);
@@ -548,16 +550,17 @@ rocblas_syrkx_herkx_restricted_kernel(rocblas_int    N,
                                       rocblas_stride stride_c,
                                       rocblas_int    batch_count)
 {
-    int thx   = threadIdx.x; // thread's m position in C
-    int thy   = threadIdx.y; // thread's n position in C
-    int idt   = DIM_N * thy + thx; // thread's number
-    int blx   = blockIdx.x; // block's m position
-    int bly   = blockIdx.y; // block's n position
-    int batch = blockIdx.z; // block's matrix in the batch
-    int thxA  = idt % BLK_N; // thread's m position for loading A
-    int thyA  = idt / BLK_N; // thread's n position for loading A
-    int thxB  = idt % BLK_K; // thread's m position for loading B
-    int thyB  = idt / BLK_K; // thread's n position for loading B
+    int      thx   = threadIdx.x; // thread's m position in C
+    int      thy   = threadIdx.y; // thread's n position in C
+    int      idt   = DIM_N * thy + thx; // thread's number
+    int      blx   = blockIdx.x; // block's m position
+    int      bly   = blockIdx.y; // block's n position
+    uint32_t batch = blockIdx.z; // block's matrix in the batch
+
+    int thxA = idt % BLK_N; // thread's m position for loading A
+    int thyA = idt / BLK_N; // thread's n position for loading A
+    int thxB = idt % BLK_K; // thread's m position for loading B
+    int thyB = idt / BLK_K; // thread's n position for loading B
 
     auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
     auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);

--- a/projects/rocblas/library/src/blas3/herk_syrk_device.hpp
+++ b/projects/rocblas/library/src/blas3/herk_syrk_device.hpp
@@ -72,7 +72,8 @@ rocblas_syr2k_scale_kernel(bool           is_upper,
 
     uint32_t batch = blockIdx.z;
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -80,7 +81,7 @@ rocblas_syr2k_scale_kernel(bool           is_upper,
         rocblas_syr2k_scale_device<API_INT, HERK>(is_upper, n, beta, C, ldc);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -109,19 +110,20 @@ rocblas_syrkx_herkx_small_kernel(rocblas_int    N,
                                  rocblas_stride stride_c,
                                  rocblas_int    batch_count)
 {
-    int thx = threadIdx.x; // thread's m position
-    int thy = threadIdx.y; // thread's n position
-    int blx = blockIdx.x; // block's m position
-    int bly = blockIdx.y; // block's n position
-    int blz = blockIdx.z; // block's matrix in the batch
+    int thx   = threadIdx.x; // thread's m position
+    int thy   = threadIdx.y; // thread's n position
+    int blx   = blockIdx.x; // block's m position
+    int bly   = blockIdx.y; // block's n position
+    int batch = blockIdx.z; // block's matrix in the batch
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; blz < batch_count; blz += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
-        auto* dA = load_ptr_batch(dA_array, blz, 0, stride_a);
-        auto* dB = load_ptr_batch(dB_array, blz, 0, stride_b);
-        auto* dC = load_ptr_batch(dC_array, blz, 0, stride_c);
+        auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
+        auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);
+        auto* dC = load_ptr_batch(dC_array, batch, 0, stride_c);
 
         __shared__ T sA[DIM][DIM]; // shared memory for A
         __shared__ T sB[DIM][DIM]; // shared memory for B
@@ -185,7 +187,7 @@ rocblas_syrkx_herkx_small_kernel(rocblas_int    N,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -215,15 +217,15 @@ rocblas_syrkx_herkx_small_restrict_kernel(rocblas_int    N,
                                           rocblas_stride stride_c,
                                           rocblas_int    batch_count)
 {
-    int thx = threadIdx.x; // thread's m position
-    int thy = threadIdx.y; // thread's n position
-    int blx = blockIdx.x; // block's m position
-    int bly = blockIdx.y; // block's n position
-    int blz = blockIdx.z; // block's matrix in the batch
+    int thx   = threadIdx.x; // thread's m position
+    int thy   = threadIdx.y; // thread's n position
+    int blx   = blockIdx.x; // block's m position
+    int bly   = blockIdx.y; // block's n position
+    int batch = blockIdx.z; // block's matrix in the batch
 
-    auto* dA = load_ptr_batch(dA_array, blz, 0, stride_a);
-    auto* dB = load_ptr_batch(dB_array, blz, 0, stride_b);
-    auto* dC = load_ptr_batch(dC_array, blz, 0, stride_c);
+    auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
+    auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);
+    auto* dC = load_ptr_batch(dC_array, batch, 0, stride_c);
 
     __shared__ T sA[DIM][DIM]; // shared memory for A
     __shared__ T sB[DIM][DIM]; // shared memory for B
@@ -302,20 +304,20 @@ rocblas_syrkx_herkx_general_kernel(rocblas_int    N,
                                    rocblas_stride stride_c,
                                    rocblas_int    batch_count)
 {
-    int thx  = threadIdx.x; // thread's m position in C
-    int thy  = threadIdx.y; // thread's n position in C
-    int idt  = DIM_N * thy + thx; // thread's number
-    int blx  = blockIdx.x; // block's m position
-    int bly  = blockIdx.y; // block's n position
-    int blz  = blockIdx.z; // block's matrix in the batch
-    int thxA = idt % BLK_N; // thread's m position for loading A
-    int thyA = idt / BLK_N; // thread's n position for loading A
-    int thxB = idt % BLK_K; // thread's m position for loading B
-    int thyB = idt / BLK_K; // thread's n position for loading B
+    int thx   = threadIdx.x; // thread's m position in C
+    int thy   = threadIdx.y; // thread's n position in C
+    int idt   = DIM_N * thy + thx; // thread's number
+    int blx   = blockIdx.x; // block's m position
+    int bly   = blockIdx.y; // block's n position
+    int batch = blockIdx.z; // block's matrix in the batch
+    int thxA  = idt % BLK_N; // thread's m position for loading A
+    int thyA  = idt / BLK_N; // thread's n position for loading A
+    int thxB  = idt % BLK_K; // thread's m position for loading B
+    int thyB  = idt / BLK_K; // thread's n position for loading B
 
-    auto* dA = load_ptr_batch(dA_array, blz, 0, stride_a);
-    auto* dB = load_ptr_batch(dB_array, blz, 0, stride_b);
-    auto* dC = load_ptr_batch(dC_array, blz, 0, stride_c);
+    auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
+    auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);
+    auto* dC = load_ptr_batch(dC_array, batch, 0, stride_c);
 
     __shared__ T sA[BLK_K][BLK_N]; // shared memory for A
     __shared__ T sB[BLK_N][BLK_K]; // shared memory for B
@@ -427,20 +429,20 @@ rocblas_syrkx_herkx_restricted_kernel(rocblas_int    N,
                                       rocblas_stride stride_c,
                                       rocblas_int    batch_count)
 {
-    int thx  = threadIdx.x; // thread's m position in C
-    int thy  = threadIdx.y; // thread's n position in C
-    int idt  = DIM_N * thy + thx; // thread's number
-    int blx  = blockIdx.x; // block's m position
-    int bly  = blockIdx.y; // block's n position
-    int blz  = blockIdx.z; // block's matrix in the batch
-    int thxA = idt % BLK_N; // thread's m position for loading A
-    int thyA = idt / BLK_N; // thread's n position for loading A
-    int thxB = idt % BLK_K; // thread's m position for loading B
-    int thyB = idt / BLK_K; // thread's n position for loading B
+    int thx   = threadIdx.x; // thread's m position in C
+    int thy   = threadIdx.y; // thread's n position in C
+    int idt   = DIM_N * thy + thx; // thread's number
+    int blx   = blockIdx.x; // block's m position
+    int bly   = blockIdx.y; // block's n position
+    int batch = blockIdx.z; // block's matrix in the batch
+    int thxA  = idt % BLK_N; // thread's m position for loading A
+    int thyA  = idt / BLK_N; // thread's n position for loading A
+    int thxB  = idt % BLK_K; // thread's m position for loading B
+    int thyB  = idt / BLK_K; // thread's n position for loading B
 
-    auto* dA = load_ptr_batch(dA_array, blz, 0, stride_a);
-    auto* dB = load_ptr_batch(dB_array, blz, 0, stride_b);
-    auto* dC = load_ptr_batch(dC_array, blz, 0, stride_c);
+    auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
+    auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);
+    auto* dC = load_ptr_batch(dC_array, batch, 0, stride_c);
 
     __shared__ T sA[BLK_K][BLK_N]; // shared memory for A
     __shared__ T sB[BLK_N][BLK_K]; // shared memory for B
@@ -546,20 +548,20 @@ rocblas_syrkx_herkx_restricted_kernel(rocblas_int    N,
                                       rocblas_stride stride_c,
                                       rocblas_int    batch_count)
 {
-    int thx  = threadIdx.x; // thread's m position in C
-    int thy  = threadIdx.y; // thread's n position in C
-    int idt  = DIM_N * thy + thx; // thread's number
-    int blx  = blockIdx.x; // block's m position
-    int bly  = blockIdx.y; // block's n position
-    int blz  = blockIdx.z; // block's matrix in the batch
-    int thxA = idt % BLK_N; // thread's m position for loading A
-    int thyA = idt / BLK_N; // thread's n position for loading A
-    int thxB = idt % BLK_K; // thread's m position for loading B
-    int thyB = idt / BLK_K; // thread's n position for loading B
+    int thx   = threadIdx.x; // thread's m position in C
+    int thy   = threadIdx.y; // thread's n position in C
+    int idt   = DIM_N * thy + thx; // thread's number
+    int blx   = blockIdx.x; // block's m position
+    int bly   = blockIdx.y; // block's n position
+    int batch = blockIdx.z; // block's matrix in the batch
+    int thxA  = idt % BLK_N; // thread's m position for loading A
+    int thyA  = idt / BLK_N; // thread's n position for loading A
+    int thxB  = idt % BLK_K; // thread's m position for loading B
+    int thyB  = idt / BLK_K; // thread's n position for loading B
 
-    auto* dA = load_ptr_batch(dA_array, blz, 0, stride_a);
-    auto* dB = load_ptr_batch(dB_array, blz, 0, stride_b);
-    auto* dC = load_ptr_batch(dC_array, blz, 0, stride_c);
+    auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
+    auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);
+    auto* dC = load_ptr_batch(dC_array, batch, 0, stride_c);
 
     __shared__ T sA[BLK_K][BLK_N]; // shared memory for A
     __shared__ T sB[BLK_N][BLK_K]; // shared memory for B
@@ -1230,7 +1232,8 @@ rocblas_syr2k_her2k_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -1244,7 +1247,7 @@ rocblas_syr2k_her2k_kernel(bool           is_upper,
             is_upper, n, k, alpha, A, lda, B, ldb, C, ldc);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -1345,7 +1348,8 @@ rocblas_copy_triangular_syrk_herk_kernel(rocblas_int    n,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -1391,7 +1395,7 @@ rocblas_copy_triangular_syrk_herk_kernel(rocblas_int    n,
                 C[row + row * int64_t(ldc)] = std::real(C[row + row * int64_t(ldc)]);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/herk_syrk_device.hpp
+++ b/projects/rocblas/library/src/blas3/herk_syrk_device.hpp
@@ -73,7 +73,7 @@ rocblas_syr2k_scale_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -81,7 +81,7 @@ rocblas_syr2k_scale_kernel(bool           is_upper,
         rocblas_syr2k_scale_device<API_INT, HERK>(is_upper, n, beta, C, ldc);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -118,7 +118,7 @@ rocblas_syrkx_herkx_small_kernel(rocblas_int    N,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
@@ -187,7 +187,7 @@ rocblas_syrkx_herkx_small_kernel(rocblas_int    N,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -1233,7 +1233,7 @@ rocblas_syr2k_her2k_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -1247,7 +1247,7 @@ rocblas_syr2k_her2k_kernel(bool           is_upper,
             is_upper, n, k, alpha, A, lda, B, ldb, C, ldc);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -1349,7 +1349,7 @@ rocblas_copy_triangular_syrk_herk_kernel(rocblas_int    n,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -1395,7 +1395,7 @@ rocblas_copy_triangular_syrk_herk_kernel(rocblas_int    n,
                 C[row + row * int64_t(ldc)] = std::real(C[row + row * int64_t(ldc)]);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_dgmm_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_dgmm_kernels.cpp
@@ -47,7 +47,8 @@ rocblas_dgmm_kernel(rocblas_int    m,
     uint32_t    batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -70,7 +71,7 @@ rocblas_dgmm_kernel(rocblas_int    m,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -92,7 +93,7 @@ rocblas_dgmm_gfx942_kernel(rocblas_int    m,
                            rocblas_stride stride_C)
 {
 // gfx942 kernels
-#if defined(__gfx942__)
+#if defined(__SPIRV__) || defined(__gfx942__)
 
     rocblas_int tx = (blockIdx.x * DIM_X + threadIdx.x) * 2;
     rocblas_int ty = blockIdx.y * DIM_Y + threadIdx.y;

--- a/projects/rocblas/library/src/blas3/rocblas_dgmm_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_dgmm_kernels.cpp
@@ -48,7 +48,7 @@ rocblas_dgmm_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -71,7 +71,7 @@ rocblas_dgmm_kernel(rocblas_int    m,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_geam_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_geam_kernels.cpp
@@ -44,7 +44,7 @@ rocblas_geam_zero_matrix_device(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -56,7 +56,7 @@ rocblas_geam_zero_matrix_device(rocblas_int    m,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -93,7 +93,7 @@ rocblas_geam_device(rocblas_operation transA,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         if(tx < m && ty < n)
@@ -138,7 +138,7 @@ rocblas_geam_device(rocblas_operation transA,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -170,7 +170,7 @@ rocblas_geam_2matrix_device(rocblas_operation transA,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         if(tx < m && ty < n)
@@ -207,7 +207,7 @@ rocblas_geam_2matrix_device(rocblas_operation transA,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -236,7 +236,7 @@ rocblas_geam_1D_device(size_t         size,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         if(tx < size)
@@ -260,7 +260,7 @@ rocblas_geam_1D_device(size_t         size,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -286,7 +286,7 @@ rocblas_geam_1D_2matrix_device(size_t         size,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         if(tx < size)
@@ -307,7 +307,7 @@ rocblas_geam_1D_2matrix_device(size_t         size,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -340,7 +340,7 @@ rocblas_geam_inplace_device(rocblas_operation transB,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         if(tx < m && ty < n)
@@ -386,7 +386,7 @@ rocblas_geam_inplace_device(rocblas_operation transB,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_geam_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_geam_kernels.cpp
@@ -43,7 +43,8 @@ rocblas_geam_zero_matrix_device(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -55,7 +56,7 @@ rocblas_geam_zero_matrix_device(rocblas_int    m,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -91,7 +92,8 @@ rocblas_geam_device(rocblas_operation transA,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         if(tx < m && ty < n)
@@ -136,7 +138,7 @@ rocblas_geam_device(rocblas_operation transA,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -167,7 +169,8 @@ rocblas_geam_2matrix_device(rocblas_operation transA,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         if(tx < m && ty < n)
@@ -204,7 +207,7 @@ rocblas_geam_2matrix_device(rocblas_operation transA,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -232,7 +235,8 @@ rocblas_geam_1D_device(size_t         size,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         if(tx < size)
@@ -256,7 +260,7 @@ rocblas_geam_1D_device(size_t         size,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -281,7 +285,8 @@ rocblas_geam_1D_2matrix_device(size_t         size,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         if(tx < size)
@@ -302,7 +307,7 @@ rocblas_geam_1D_2matrix_device(size_t         size,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -334,7 +339,8 @@ rocblas_geam_inplace_device(rocblas_operation transB,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         if(tx < m && ty < n)
@@ -380,7 +386,7 @@ rocblas_geam_inplace_device(rocblas_operation transB,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_gemm_source.hpp
+++ b/projects/rocblas/library/src/blas3/rocblas_gemm_source.hpp
@@ -275,12 +275,12 @@ namespace
                                         rocblas_stride d_st_or_of,
                                         rocblas_int    batch_count)
     {
-        int     thx   = threadIdx.x; // thread's m position in C
-        int     thy   = threadIdx.y; // thread's n position in C
-        int64_t idt   = int64_t(DIM_M) * thy + thx; // thread's number
-        int     blx   = blockIdx.x; // block's m position
-        int     bly   = blockIdx.y; // block's n position
-        int     batch = blockIdx.z; // block's matrix in the batch
+        int      thx   = threadIdx.x; // thread's m position in C
+        int      thy   = threadIdx.y; // thread's n position in C
+        int64_t  idt   = int64_t(DIM_M) * thy + thx; // thread's number
+        int      blx   = blockIdx.x; // block's m position
+        int      bly   = blockIdx.y; // block's n position
+        uint32_t batch = blockIdx.z; // block's matrix in the batch
 
 #if DEVICE_GRID_YZ_16BIT
         DEVICE_GRID_SETUP
@@ -460,12 +460,12 @@ namespace
                                 rocblas_stride d_st_or_of,
                                 rocblas_int    batch_count)
     {
-        int     thx   = threadIdx.x; // thread's m position in C
-        int     thy   = threadIdx.y; // thread's n position in C
-        int64_t idt   = int64_t(DIM_M) * thy + thx; // thread's number
-        int     blx   = blockIdx.x; // block's m position
-        int     bly   = blockIdx.y; // block's n position
-        int     batch = blockIdx.z; // block's matrix in the batch
+        int      thx   = threadIdx.x; // thread's m position in C
+        int      thy   = threadIdx.y; // thread's n position in C
+        int64_t  idt   = int64_t(DIM_M) * thy + thx; // thread's number
+        int      blx   = blockIdx.x; // block's m position
+        int      bly   = blockIdx.y; // block's n position
+        uint32_t batch = blockIdx.z; // block's matrix in the batch
 
 #if DEVICE_GRID_YZ_16BIT
         DEVICE_GRID_SETUP

--- a/projects/rocblas/library/src/blas3/rocblas_gemm_source.hpp
+++ b/projects/rocblas/library/src/blas3/rocblas_gemm_source.hpp
@@ -65,7 +65,7 @@ namespace
         uint32_t batch = blockIdx.z;
 #if DEVICE_GRID_YZ_16BIT
         DEVICE_GRID_SETUP
-        do
+        for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
         {
 #endif
 
@@ -74,7 +74,7 @@ namespace
             gemm_ex_scale_device<DIM_X, DIM_Y>(m, n, beta, C, ldc, D, ldd);
 
 #if DEVICE_GRID_YZ_16BIT
-        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+        }
 #endif
     }
 
@@ -174,14 +174,14 @@ namespace
 
 #if DEVICE_GRID_YZ_16BIT
         DEVICE_GRID_SETUP
-        do
+        for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
         {
 #endif
             auto C = load_ptr_batch(dC, batch, shift_c, stride_c);
             rocblas_gemm_scale_device<DIM_X, DIM_Y>(m, n, beta, C, ldc);
 
 #if DEVICE_GRID_YZ_16BIT
-        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+        }
 #endif
     }
 
@@ -284,7 +284,7 @@ namespace
 
 #if DEVICE_GRID_YZ_16BIT
         DEVICE_GRID_SETUP
-        do
+        for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
         {
 #endif
 
@@ -420,7 +420,7 @@ namespace
             }
 
 #if DEVICE_GRID_YZ_16BIT
-        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+        }
 #endif
     }
 
@@ -469,7 +469,7 @@ namespace
 
 #if DEVICE_GRID_YZ_16BIT
         DEVICE_GRID_SETUP
-        do
+        for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
         {
 #endif
 
@@ -592,7 +592,7 @@ namespace
             }
 
 #if DEVICE_GRID_YZ_16BIT
-        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+        }
 #endif
     }
 

--- a/projects/rocblas/library/src/blas3/rocblas_gemm_source.hpp
+++ b/projects/rocblas/library/src/blas3/rocblas_gemm_source.hpp
@@ -64,7 +64,8 @@ namespace
 
         uint32_t batch = blockIdx.z;
 #if DEVICE_GRID_YZ_16BIT
-        for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+        DEVICE_GRID_SETUP
+        do
         {
 #endif
 
@@ -73,7 +74,7 @@ namespace
             gemm_ex_scale_device<DIM_X, DIM_Y>(m, n, beta, C, ldc, D, ldd);
 
 #if DEVICE_GRID_YZ_16BIT
-        }
+        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
     }
 
@@ -172,14 +173,15 @@ namespace
         uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-        for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+        DEVICE_GRID_SETUP
+        do
         {
 #endif
             auto C = load_ptr_batch(dC, batch, shift_c, stride_c);
             rocblas_gemm_scale_device<DIM_X, DIM_Y>(m, n, beta, C, ldc);
 
 #if DEVICE_GRID_YZ_16BIT
-        }
+        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
     }
 
@@ -273,22 +275,23 @@ namespace
                                         rocblas_stride d_st_or_of,
                                         rocblas_int    batch_count)
     {
-        int     thx = threadIdx.x; // thread's m position in C
-        int     thy = threadIdx.y; // thread's n position in C
-        int64_t idt = int64_t(DIM_M) * thy + thx; // thread's number
-        int     blx = blockIdx.x; // block's m position
-        int     bly = blockIdx.y; // block's n position
-        int     blz = blockIdx.z; // block's matrix in the batch
+        int     thx   = threadIdx.x; // thread's m position in C
+        int     thy   = threadIdx.y; // thread's n position in C
+        int64_t idt   = int64_t(DIM_M) * thy + thx; // thread's number
+        int     blx   = blockIdx.x; // block's m position
+        int     bly   = blockIdx.y; // block's n position
+        int     batch = blockIdx.z; // block's matrix in the batch
 
 #if DEVICE_GRID_YZ_16BIT
-        for(; blz < batch_count; blz += c_YZ_grid_launch_limit)
+        DEVICE_GRID_SETUP
+        do
         {
 #endif
 
-            auto* dA = load_ptr_batch(dA_input, blz, a_st_or_of);
-            auto* dB = load_ptr_batch(dB_input, blz, b_st_or_of);
-            auto* dC = load_ptr_batch(dC_input, blz, c_st_or_of);
-            auto* dD = load_ptr_batch(dD_input, blz, d_st_or_of);
+            auto* dA = load_ptr_batch(dA_input, batch, a_st_or_of);
+            auto* dB = load_ptr_batch(dB_input, batch, b_st_or_of);
+            auto* dC = load_ptr_batch(dC_input, batch, c_st_or_of);
+            auto* dD = load_ptr_batch(dD_input, batch, d_st_or_of);
 
             auto tmp = *dD;
             using To = decltype(tmp);
@@ -417,7 +420,7 @@ namespace
             }
 
 #if DEVICE_GRID_YZ_16BIT
-        }
+        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
     }
 
@@ -457,22 +460,23 @@ namespace
                                 rocblas_stride d_st_or_of,
                                 rocblas_int    batch_count)
     {
-        int     thx = threadIdx.x; // thread's m position in C
-        int     thy = threadIdx.y; // thread's n position in C
-        int64_t idt = int64_t(DIM_M) * thy + thx; // thread's number
-        int     blx = blockIdx.x; // block's m position
-        int     bly = blockIdx.y; // block's n position
-        int     blz = blockIdx.z; // block's matrix in the batch
+        int     thx   = threadIdx.x; // thread's m position in C
+        int     thy   = threadIdx.y; // thread's n position in C
+        int64_t idt   = int64_t(DIM_M) * thy + thx; // thread's number
+        int     blx   = blockIdx.x; // block's m position
+        int     bly   = blockIdx.y; // block's n position
+        int     batch = blockIdx.z; // block's matrix in the batch
 
 #if DEVICE_GRID_YZ_16BIT
-        for(; blz < batch_count; blz += c_YZ_grid_launch_limit)
+        DEVICE_GRID_SETUP
+        do
         {
 #endif
 
-            auto* dA = load_ptr_batch(dA_input, blz, a_st_or_of);
-            auto* dB = load_ptr_batch(dB_input, blz, b_st_or_of);
-            auto* dC = load_ptr_batch(dC_input, blz, c_st_or_of);
-            auto* dD = load_ptr_batch(dD_input, blz, d_st_or_of);
+            auto* dA = load_ptr_batch(dA_input, batch, a_st_or_of);
+            auto* dB = load_ptr_batch(dB_input, batch, b_st_or_of);
+            auto* dC = load_ptr_batch(dC_input, batch, c_st_or_of);
+            auto* dD = load_ptr_batch(dD_input, batch, d_st_or_of);
 
             auto tmp = *dD;
             using To = decltype(tmp);
@@ -588,7 +592,7 @@ namespace
             }
 
 #if DEVICE_GRID_YZ_16BIT
-        }
+        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
     }
 

--- a/projects/rocblas/library/src/blas3/rocblas_symm_hemm_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_symm_hemm_kernels.cpp
@@ -74,13 +74,14 @@ rocblas_symm_scale_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
         auto C = load_ptr_batch(CP_array, batch, shift_c, stride_c);
         rocblas_symm_scale_device<DIM_X, DIM_Y>(m, n, beta, C, ldc);
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -255,7 +256,8 @@ rocblas_symm_hemm_kernel(bool           is_upper,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -269,7 +271,7 @@ rocblas_symm_hemm_kernel(bool           is_upper,
             is_upper, m, n, alpha, A, lda, B, ldb, C, ldc);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_symm_hemm_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_symm_hemm_kernels.cpp
@@ -75,13 +75,13 @@ rocblas_symm_scale_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto C = load_ptr_batch(CP_array, batch, shift_c, stride_c);
         rocblas_symm_scale_device<DIM_X, DIM_Y>(m, n, beta, C, ldc);
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -257,7 +257,7 @@ rocblas_symm_hemm_kernel(bool           is_upper,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -271,7 +271,7 @@ rocblas_symm_hemm_kernel(bool           is_upper,
             is_upper, m, n, alpha, A, lda, B, ldb, C, ldc);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_trmm_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_trmm_kernels.cpp
@@ -90,7 +90,7 @@ rocblas_set_matrix_zero_if_alpha_zero_kernel(rocblas_int    m,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -108,7 +108,7 @@ rocblas_set_matrix_zero_if_alpha_zero_kernel(rocblas_int    m,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -209,7 +209,7 @@ rocblas_trmm_outofplace_kernel(rocblas_diagonal diag,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -363,7 +363,7 @@ rocblas_trmm_outofplace_kernel(rocblas_diagonal diag,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -498,7 +498,7 @@ rocblas_trmm_lNx_kernel(rocblas_fill     uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -556,7 +556,7 @@ rocblas_trmm_lNx_kernel(rocblas_fill     uplo,
                 C[ty * size_t(ldc) + tx] = accumulator;
         }
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -588,7 +588,7 @@ rocblas_trmm_lTx_kernel(rocblas_fill     uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -659,7 +659,7 @@ rocblas_trmm_lTx_kernel(rocblas_fill     uplo,
                 C[ty * size_t(ldc) + tx] = accumulator;
         }
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -691,7 +691,7 @@ rocblas_trmm_rNx_kernel(rocblas_fill     uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -750,7 +750,7 @@ rocblas_trmm_rNx_kernel(rocblas_fill     uplo,
                 C[ty * size_t(ldc) + tx] = accumulator;
         }
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -782,7 +782,7 @@ rocblas_trmm_rTx_kernel(rocblas_fill     uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -851,7 +851,7 @@ rocblas_trmm_rTx_kernel(rocblas_fill     uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_trmm_kernels.cpp
+++ b/projects/rocblas/library/src/blas3/rocblas_trmm_kernels.cpp
@@ -89,7 +89,8 @@ rocblas_set_matrix_zero_if_alpha_zero_kernel(rocblas_int    m,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -107,7 +108,7 @@ rocblas_set_matrix_zero_if_alpha_zero_kernel(rocblas_int    m,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -207,7 +208,8 @@ rocblas_trmm_outofplace_kernel(rocblas_diagonal diag,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -361,7 +363,7 @@ rocblas_trmm_outofplace_kernel(rocblas_diagonal diag,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -495,7 +497,8 @@ rocblas_trmm_lNx_kernel(rocblas_fill     uplo,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -553,7 +556,7 @@ rocblas_trmm_lNx_kernel(rocblas_fill     uplo,
                 C[ty * size_t(ldc) + tx] = accumulator;
         }
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -584,7 +587,8 @@ rocblas_trmm_lTx_kernel(rocblas_fill     uplo,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -655,7 +659,7 @@ rocblas_trmm_lTx_kernel(rocblas_fill     uplo,
                 C[ty * size_t(ldc) + tx] = accumulator;
         }
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -686,7 +690,8 @@ rocblas_trmm_rNx_kernel(rocblas_fill     uplo,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -745,7 +750,7 @@ rocblas_trmm_rNx_kernel(rocblas_fill     uplo,
                 C[ty * size_t(ldc) + tx] = accumulator;
         }
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -776,7 +781,8 @@ rocblas_trmm_rTx_kernel(rocblas_fill     uplo,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -845,7 +851,7 @@ rocblas_trmm_rTx_kernel(rocblas_fill     uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_trsm_kernels.hpp
+++ b/projects/rocblas/library/src/blas3/rocblas_trsm_kernels.hpp
@@ -162,7 +162,7 @@ rocblas_copy_matrix_trsm(rocblas_int    rows,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -175,7 +175,7 @@ rocblas_copy_matrix_trsm(rocblas_int    rows,
             xb[tx + size_t(ldb) * ty] = xa[tx + size_t(lda) * ty];
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -246,7 +246,7 @@ rocblas_set_matrix_trsm(int64_t        rows,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -256,7 +256,7 @@ rocblas_set_matrix_trsm(int64_t        rows,
             xa[tx + lda * ty] = T(0.0);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2019,7 +2019,7 @@ rocblas_trsm_small_right_device(rocblas_fill      uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -2271,7 +2271,7 @@ rocblas_trsm_small_right_device(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2304,7 +2304,7 @@ rocblas_trsm_small_64_right_device(rocblas_fill      uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -2407,7 +2407,7 @@ rocblas_trsm_small_64_right_device(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2449,7 +2449,7 @@ rocblas_trsm_small_left_device(rocblas_fill      uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
@@ -2630,7 +2630,7 @@ rocblas_trsm_small_left_device(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2665,7 +2665,7 @@ rocblas_trsm_small_left_device_sharedB(rocblas_fill      uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
@@ -2858,7 +2858,7 @@ rocblas_trsm_small_left_device_sharedB(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -2891,7 +2891,7 @@ rocblas_trsm_small_64_left_device(rocblas_fill      uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -2995,7 +2995,7 @@ rocblas_trsm_small_64_left_device(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -3191,7 +3191,7 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trsm_block_backward_substitution(rocblas_operat
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
@@ -3275,7 +3275,7 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trsm_block_backward_substitution(rocblas_operat
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -3313,7 +3313,7 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trsm_block_forward_substitution(rocblas_operati
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
         auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
@@ -3387,7 +3387,7 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trsm_block_forward_substitution(rocblas_operati
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_trsm_kernels.hpp
+++ b/projects/rocblas/library/src/blas3/rocblas_trsm_kernels.hpp
@@ -161,7 +161,8 @@ rocblas_copy_matrix_trsm(rocblas_int    rows,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -174,7 +175,7 @@ rocblas_copy_matrix_trsm(rocblas_int    rows,
             xb[tx + size_t(ldb) * ty] = xa[tx + size_t(lda) * ty];
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -244,7 +245,8 @@ rocblas_set_matrix_trsm(int64_t        rows,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -254,7 +256,7 @@ rocblas_set_matrix_trsm(int64_t        rows,
             xa[tx + lda * ty] = T(0.0);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2013,15 +2015,16 @@ rocblas_trsm_small_right_device(rocblas_fill      uplo,
 {
     auto alpha = load_scalar(alpha_dev_host);
 
-    uint32_t batchid = blockIdx.z;
+    uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batchid < batch_count; batchid += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
-        auto A = load_ptr_batch(Aa, batchid, offset_A, stride_A);
-        auto B = load_ptr_batch(Ba, batchid, offset_B, stride_B);
+        auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
+        auto B = load_ptr_batch(Ba, batch, offset_B, stride_B);
 
         bool      LOWER = uplo == rocblas_fill_lower;
         bool      CONJ  = transA == rocblas_operation_conjugate_transpose;
@@ -2268,7 +2271,7 @@ rocblas_trsm_small_right_device(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2297,15 +2300,16 @@ rocblas_trsm_small_64_right_device(rocblas_fill      uplo,
 {
     auto alpha = load_scalar(alpha_dev_host);
 
-    uint32_t batchid = blockIdx.z;
+    uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batchid < batch_count; batchid += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
-        auto A = load_ptr_batch(Aa, batchid, offset_A, stride_A);
-        auto B = load_ptr_batch(Ba, batchid, offset_B, stride_B);
+        auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
+        auto B = load_ptr_batch(Ba, batch, offset_B, stride_B);
 
         bool      LOWER = uplo == rocblas_fill_lower;
         bool      CONJ  = transA == rocblas_operation_conjugate_transpose;
@@ -2403,7 +2407,7 @@ rocblas_trsm_small_64_right_device(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2441,14 +2445,15 @@ rocblas_trsm_small_left_device(rocblas_fill      uplo,
     bool CONJ  = transA == rocblas_operation_conjugate_transpose;
     auto alpha = load_scalar(alpha_dev_host);
 
-    uint32_t batchid = blockIdx.z;
+    uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batchid < batch_count; batchid += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
-        auto A = load_ptr_batch(Aa, batchid, offset_A, stride_A);
-        auto B = load_ptr_batch(Ba, batchid, offset_B, stride_B);
+        auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
+        auto B = load_ptr_batch(Ba, batch, offset_B, stride_B);
 
         const int tx = threadIdx.x;
         const int bx = blockIdx.x;
@@ -2625,7 +2630,7 @@ rocblas_trsm_small_left_device(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2656,14 +2661,15 @@ rocblas_trsm_small_left_device_sharedB(rocblas_fill      uplo,
     bool CONJ  = transA == rocblas_operation_conjugate_transpose;
     auto alpha = load_scalar(alpha_dev_host);
 
-    uint32_t batchid = blockIdx.z;
+    uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batchid < batch_count; batchid += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
-        auto A = load_ptr_batch(Aa, batchid, offset_A, stride_A);
-        auto B = load_ptr_batch(Ba, batchid, offset_B, stride_B);
+        auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
+        auto B = load_ptr_batch(Ba, batch, offset_B, stride_B);
 
         const int tx = threadIdx.x;
         const int bx = blockIdx.x;
@@ -2852,7 +2858,7 @@ rocblas_trsm_small_left_device_sharedB(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -2881,15 +2887,16 @@ rocblas_trsm_small_64_left_device(rocblas_fill      uplo,
 {
     auto alpha = load_scalar(alpha_dev_host);
 
-    uint32_t batchid = blockIdx.z;
+    uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batchid < batch_count; batchid += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
-        auto A = load_ptr_batch(Aa, batchid, offset_A, stride_A);
-        auto B = load_ptr_batch(Ba, batchid, offset_B, stride_B);
+        auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
+        auto B = load_ptr_batch(Ba, batch, offset_B, stride_B);
 
         bool      LOWER = uplo == rocblas_fill_lower;
         bool      CONJ  = transA == rocblas_operation_conjugate_transpose;
@@ -2988,7 +2995,7 @@ rocblas_trsm_small_64_left_device(rocblas_fill      uplo,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -3180,14 +3187,15 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trsm_block_backward_substitution(rocblas_operat
     const bool CONJ  = transA == rocblas_operation_conjugate_transpose;
     auto       alpha = load_scalar(alpha_dev_host);
 
-    uint32_t batchid = blockIdx.z;
+    uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batchid < batch_count; batchid += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
-        auto A = load_ptr_batch(Aa, batchid, offset_A, stride_A);
-        auto B = load_ptr_batch(Ba, batchid, offset_B, stride_B);
+        auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
+        auto B = load_ptr_batch(Ba, batch, offset_B, stride_B);
 
         int64_t       lda_norm  = TRANSA ? lda : 1;
         int64_t       lda_trans = TRANSA ? 1 : lda;
@@ -3267,7 +3275,7 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trsm_block_backward_substitution(rocblas_operat
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -3301,14 +3309,15 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trsm_block_forward_substitution(rocblas_operati
     const int64_t ldb_norm  = TRANSB ? 1 : ldb;
     const int64_t ldb_trans = TRANSB ? ldb : 1;
 
-    uint32_t batchid = blockIdx.z;
+    uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batchid < batch_count; batchid += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
-        auto A = load_ptr_batch(Aa, batchid, offset_A, stride_A);
-        auto B = load_ptr_batch(Ba, batchid, offset_B, stride_B);
+        auto A = load_ptr_batch(Aa, batch, offset_A, stride_A);
+        auto B = load_ptr_batch(Ba, batch, offset_B, stride_B);
 
         const int     tx   = threadIdx.x;
         const int     ty   = threadIdx.y;
@@ -3378,7 +3387,7 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trsm_block_forward_substitution(rocblas_operati
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_trtri.hpp
+++ b/projects/rocblas/library/src/blas3/rocblas_trtri.hpp
@@ -406,7 +406,8 @@ rocblas_trtri_fill(rocblas_handle handle,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -429,7 +430,7 @@ rocblas_trtri_fill(rocblas_handle handle,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -454,7 +455,8 @@ rocblas_trtri_small_kernel(rocblas_fill     uplo,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -468,7 +470,7 @@ rocblas_trtri_small_kernel(rocblas_fill     uplo,
         rocblas_trtri_device<NB>(uplo, diag, n, individual_A, lda, individual_invA, ldinvA);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -491,7 +493,8 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trtri_remainder_kernel(rocblas_fill     uplo,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -505,7 +508,7 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trtri_remainder_kernel(rocblas_fill     uplo,
         rocblas_trtri_device<2 * NB>(uplo, diag, n, individual_A, lda, individual_invA, ldinvA);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 
@@ -605,7 +608,8 @@ rocblas_trtri_diagonal_kernel(rocblas_fill     uplo,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -624,7 +628,7 @@ rocblas_trtri_diagonal_kernel(rocblas_fill     uplo,
             uplo, diag, rem < IB ? rem : IB, individual_A, lda, individual_invA, ldinvA);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/rocblas_trtri.hpp
+++ b/projects/rocblas/library/src/blas3/rocblas_trtri.hpp
@@ -407,7 +407,7 @@ rocblas_trtri_fill(rocblas_handle handle,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -430,7 +430,7 @@ rocblas_trtri_fill(rocblas_handle handle,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -456,7 +456,7 @@ rocblas_trtri_small_kernel(rocblas_fill     uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -470,7 +470,7 @@ rocblas_trtri_small_kernel(rocblas_fill     uplo,
         rocblas_trtri_device<NB>(uplo, diag, n, individual_A, lda, individual_invA, ldinvA);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -494,7 +494,7 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trtri_remainder_kernel(rocblas_fill     uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -508,7 +508,7 @@ ROCBLAS_KERNEL_NO_BOUNDS rocblas_trtri_remainder_kernel(rocblas_fill     uplo,
         rocblas_trtri_device<2 * NB>(uplo, diag, n, individual_A, lda, individual_invA, ldinvA);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 
@@ -609,7 +609,7 @@ rocblas_trtri_diagonal_kernel(rocblas_fill     uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -628,7 +628,7 @@ rocblas_trtri_diagonal_kernel(rocblas_fill     uplo,
             uplo, diag, rem < IB ? rem : IB, individual_A, lda, individual_invA, ldinvA);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/trtri_trsm.hpp
+++ b/projects/rocblas/library/src/blas3/trtri_trsm.hpp
@@ -63,7 +63,8 @@ rocblas_trtri_trsm_kernel(rocblas_fill     uplo,
     uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
@@ -73,7 +74,7 @@ rocblas_trtri_trsm_kernel(rocblas_fill     uplo,
         rocblas_custom_trtri_device<IB>(uplo, diag, IB, a_i, lda, invA_i, NB);
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas3/trtri_trsm.hpp
+++ b/projects/rocblas/library/src/blas3/trtri_trsm.hpp
@@ -64,7 +64,7 @@ rocblas_trtri_trsm_kernel(rocblas_fill     uplo,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -74,7 +74,7 @@ rocblas_trtri_trsm_kernel(rocblas_fill     uplo,
         rocblas_custom_trtri_device<IB>(uplo, diag, IB, a_i, lda, invA_i, NB);
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas_ex/geam_ex_source.hpp
+++ b/projects/rocblas/library/src/blas_ex/geam_ex_source.hpp
@@ -479,13 +479,13 @@ namespace
                          rocblas_int               batch_count,
                          rocblas_geam_ex_operation geam_ex_op)
     {
-        int   blz   = blockIdx.z; // block's matrix in the batch
+        int   batch = blockIdx.z; // block's matrix in the batch
         auto  alpha = load_scalar(alpha_in, blockIdx.z, 1);
         auto  beta  = load_scalar(beta_in, blockIdx.z, 1);
-        auto* d_a   = alpha ? load_ptr_batch(dA_input, blz, a_st_or_of) : nullptr;
-        auto* d_b   = alpha ? load_ptr_batch(dB_input, blz, b_st_or_of) : nullptr;
-        auto* d_c   = beta ? load_ptr_batch(dC_input, blz, c_st_or_of) : nullptr;
-        auto* d_d   = load_ptr_batch(dD_input, blz, d_st_or_of);
+        auto* d_a   = alpha ? load_ptr_batch(dA_input, batch, a_st_or_of) : nullptr;
+        auto* d_b   = alpha ? load_ptr_batch(dB_input, batch, b_st_or_of) : nullptr;
+        auto* d_c   = beta ? load_ptr_batch(dC_input, batch, c_st_or_of) : nullptr;
+        auto* d_d   = load_ptr_batch(dD_input, batch, d_st_or_of);
 
         constexpr bool TRANSA = TRANSA_C != 'N';
         constexpr bool TRANSB = TRANSB_C != 'N';

--- a/projects/rocblas/library/src/blas_ex/rocblas_gemmt_kernels.hpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_gemmt_kernels.hpp
@@ -82,7 +82,7 @@ rocblas_internal_gemmt_kernel(rocblas_int    N,
 
 #if DEVICE_GRID_YZ_16BIT
     DEVICE_GRID_SETUP
-    do
+    for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
     {
 #endif
 
@@ -167,7 +167,7 @@ rocblas_internal_gemmt_kernel(rocblas_int    N,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+    }
 #endif
 }
 

--- a/projects/rocblas/library/src/blas_ex/rocblas_gemmt_kernels.hpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_gemmt_kernels.hpp
@@ -78,16 +78,17 @@ rocblas_internal_gemmt_kernel(rocblas_int    N,
     int thxB = idt % BLK_K; // thread's m position for loading B
     int thyB = idt / BLK_K; // thread's n position for loading B
 
-    uint32_t blz = blockIdx.z; // block's matrix in the batch
+    uint32_t batch = blockIdx.z; // block's matrix in the batch
 
 #if DEVICE_GRID_YZ_16BIT
-    for(; blz < batch_count; blz += c_YZ_grid_launch_limit)
+    DEVICE_GRID_SETUP
+    do
     {
 #endif
 
-        auto* dA = load_ptr_batch(dA_array, blz, stride_a);
-        auto* dB = load_ptr_batch(dB_array, blz, stride_b);
-        auto* dC = load_ptr_batch(dC_array, blz, stride_c);
+        auto* dA = load_ptr_batch(dA_array, batch, stride_a);
+        auto* dB = load_ptr_batch(dB_array, batch, stride_b);
+        auto* dC = load_ptr_batch(dC_array, batch, stride_c);
 
         __shared__ T sA[BLK_K][BLK_N]; // shared memory for A
         __shared__ T sB[BLK_N][BLK_K]; // shared memory for B
@@ -166,7 +167,7 @@ rocblas_internal_gemmt_kernel(rocblas_int    N,
         }
 
 #if DEVICE_GRID_YZ_16BIT
-    }
+    } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
 }
 

--- a/projects/rocblas/library/src/blas_ex/rocblas_syrk_herk_ex_kernels.hpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_syrk_herk_ex_kernels.hpp
@@ -50,20 +50,21 @@ rocblas_syrkx_herkx_ex_restricted_kernel(rocblas_int    N,
                                          rocblas_stride stride_C,
                                          rocblas_int    batch_count)
 {
-    int thx  = threadIdx.x; // thread's m position in C
-    int thy  = threadIdx.y; // thread's n position in C
-    int idt  = DIM_N * thy + thx; // thread's number
-    int blx  = blockIdx.x; // block's m position
-    int bly  = blockIdx.y; // block's n position
-    int blz  = blockIdx.z; // block's matrix in the batch
+    int      thx   = threadIdx.x; // thread's m position in C
+    int      thy   = threadIdx.y; // thread's n position in C
+    int      idt   = DIM_N * thy + thx; // thread's number
+    int      blx   = blockIdx.x; // block's m position
+    int      bly   = blockIdx.y; // block's n position
+    uint32_t batch = blockIdx.z; // block's matrix in the batch
+
     int thxA = idt % BLK_N; // thread's m position for loading A
     int thyA = idt / BLK_N; // thread's n position for loading A
     int thxB = idt % BLK_K; // thread's m position for loading B
     int thyB = idt / BLK_K; // thread's n position for loading B
 
-    auto* dA = load_ptr_batch(A, blz, 0, stride_A);
-    auto* dB = load_ptr_batch(B, blz, 0, stride_B);
-    auto* dC = load_ptr_batch(C, blz, 0, stride_C);
+    auto* dA = load_ptr_batch(A, batch, 0, stride_A);
+    auto* dB = load_ptr_batch(B, batch, 0, stride_B);
+    auto* dC = load_ptr_batch(C, batch, 0, stride_C);
 
     __shared__ Tex sA[BLK_K][BLK_N]; // shared memory for A
     __shared__ Tex sB[BLK_N][BLK_K]; // shared memory for B
@@ -178,20 +179,21 @@ rocblas_syrkx_herkx_ex_restricted_general_kernel(rocblas_int    N,
                                                  rocblas_stride stride_c,
                                                  rocblas_int    batch_count)
 {
-    int thx  = threadIdx.x; // thread's m position in C
-    int thy  = threadIdx.y; // thread's n position in C
-    int idt  = DIM_N * thy + thx; // thread's number
-    int blx  = blockIdx.x; // block's m position
-    int bly  = blockIdx.y; // block's n position
-    int blz  = blockIdx.z; // block's matrix in the batch
+    int      thx   = threadIdx.x; // thread's m position in C
+    int      thy   = threadIdx.y; // thread's n position in C
+    int      idt   = DIM_N * thy + thx; // thread's number
+    int      blx   = blockIdx.x; // block's m position
+    int      bly   = blockIdx.y; // block's n position
+    uint32_t batch = blockIdx.z; // block's matrix in the batch
+
     int thxA = idt % BLK_N; // thread's m position for loading A
     int thyA = idt / BLK_N; // thread's n position for loading A
     int thxB = idt % BLK_K; // thread's m position for loading B
     int thyB = idt / BLK_K; // thread's n position for loading B
 
-    auto* dA = load_ptr_batch(dA_array, blz, 0, stride_a);
-    auto* dB = load_ptr_batch(dB_array, blz, 0, stride_b);
-    auto* dC = load_ptr_batch(dC_array, blz, 0, stride_c);
+    auto* dA = load_ptr_batch(dA_array, batch, 0, stride_a);
+    auto* dB = load_ptr_batch(dB_array, batch, 0, stride_b);
+    auto* dC = load_ptr_batch(dC_array, batch, 0, stride_c);
 
     __shared__ Tex sA[BLK_K][BLK_N]; // shared memory for A
     __shared__ Tex sB[BLK_N][BLK_K]; // shared memory for B
@@ -302,20 +304,21 @@ rocblas_syrkx_herkx_ex_general_kernel(rocblas_int    N,
                                       rocblas_stride stride_C,
                                       rocblas_int    batch_count)
 {
-    int thx  = threadIdx.x; // thread's m position in C
-    int thy  = threadIdx.y; // thread's n position in C
-    int idt  = DIM_N * thy + thx; // thread's number
-    int blx  = blockIdx.x; // block's m position
-    int bly  = blockIdx.y; // block's n position
-    int blz  = blockIdx.z; // block's matrix in the batch
+    int      thx   = threadIdx.x; // thread's m position in C
+    int      thy   = threadIdx.y; // thread's n position in C
+    int      idt   = DIM_N * thy + thx; // thread's number
+    int      blx   = blockIdx.x; // block's m position
+    int      bly   = blockIdx.y; // block's n position
+    uint32_t batch = blockIdx.z; // block's matrix in the batch
+
     int thxA = idt % BLK_N; // thread's m position for loading A
     int thyA = idt / BLK_N; // thread's n position for loading A
     int thxB = idt % BLK_K; // thread's m position for loading B
     int thyB = idt / BLK_K; // thread's n position for loading B
 
-    auto* dA = load_ptr_batch(A, blz, 0, stride_A);
-    auto* dB = load_ptr_batch(B, blz, 0, stride_B);
-    auto* dC = load_ptr_batch(C, blz, 0, stride_C);
+    auto* dA = load_ptr_batch(A, batch, 0, stride_A);
+    auto* dB = load_ptr_batch(B, batch, 0, stride_B);
+    auto* dC = load_ptr_batch(C, batch, 0, stride_C);
 
     __shared__ Tex sA[BLK_K][BLK_N]; // shared memory for A
     __shared__ Tex sB[BLK_N][BLK_K]; // shared memory for B

--- a/projects/rocblas/library/src/blas_ex/rocblas_trsv_inverse.hpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_trsv_inverse.hpp
@@ -55,7 +55,8 @@ rocblas_internal_flip_vector_kernel(U* __restrict__ data,
         uint32_t batch = blockIdx.z;
 
 #if DEVICE_GRID_YZ_16BIT
-        for(; batch < batch_count; batch += c_YZ_grid_launch_limit)
+        DEVICE_GRID_SETUP
+        do
         {
 #endif
             T*          pdata = load_ptr_batch(data, batch, offset, stride);
@@ -65,7 +66,7 @@ rocblas_internal_flip_vector_kernel(U* __restrict__ data,
             pdata[end]        = pdata[start];
             pdata[start]      = temp;
 #if DEVICE_GRID_YZ_16BIT
-        }
+        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
 #endif
     }
 }

--- a/projects/rocblas/library/src/blas_ex/rocblas_trsv_inverse.hpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_trsv_inverse.hpp
@@ -56,7 +56,7 @@ rocblas_internal_flip_vector_kernel(U* __restrict__ data,
 
 #if DEVICE_GRID_YZ_16BIT
         DEVICE_GRID_SETUP
-        do
+        for(; batch < batch_count; batch += dc_YZ_grid_launch_limit)
         {
 #endif
             T*          pdata = load_ptr_batch(data, batch, offset, stride);
@@ -66,7 +66,7 @@ rocblas_internal_flip_vector_kernel(U* __restrict__ data,
             pdata[end]        = pdata[start];
             pdata[start]      = temp;
 #if DEVICE_GRID_YZ_16BIT
-        } while((batch += dc_YZ_grid_launch_limit) < batch_count);
+        }
 #endif
     }
 }

--- a/projects/rocblas/library/src/include/device_macros.hpp
+++ b/projects/rocblas/library/src/include/device_macros.hpp
@@ -38,7 +38,7 @@
 #endif
 
 #define DEVICE_GRID_SETUP                                                                    \
-    uint32_t dc_YZ_grid_launch_limit = (int)0x7fffffff;                                      \
+    uint32_t dc_YZ_grid_launch_limit = (uint32_t)0x7fffffff;                                 \
     if(__builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201")) \
         dc_YZ_grid_launch_limit = c_YZ_grid_launch_limit;
 

--- a/projects/rocblas/library/src/include/device_macros.hpp
+++ b/projects/rocblas/library/src/include/device_macros.hpp
@@ -30,11 +30,20 @@
 #undef DEVICE_GRID_YZ_16BIT
 #endif
 
-#if defined(__HIP_DEVICE_COMPILE__) && defined(__GFX12__)
+#if defined(__HIP_DEVICE_COMPILE__) && (defined(__SPIRV__) || defined(__GFX12__))
+// for SPIRV we have to assume this limitation for initial compile
 #define DEVICE_GRID_YZ_16BIT 1
 #else
 #define DEVICE_GRID_YZ_16BIT 0
 #endif
+
+#define DEVICE_GRID_SETUP                                                                    \
+    uint32_t dc_YZ_grid_launch_limit = (int)0x7fffffff;                                      \
+    if(__builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201")) \
+        dc_YZ_grid_launch_limit = c_YZ_grid_launch_limit;
+
+#define DEVICE_GRID_CONTINUE \
+    (__builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201"))
 
 #define WARP_32 32
 #define WARP_64 64


### PR DESCRIPTION
## Motivation

This pull request primarily updates the rocBLAS build and kernel code to simplify GPU target selection for testing and to clean up device kernel batch loop logic. The main changes enable the use of  "amdgcnspirv" GPU target.  Remove legacy conditional compilation blocks related to `DEVICE_GRID_YZ_16BIT`, streamlining the batch loop structure in multiple BLAS1 kernels.

**Kernel Code Cleanup:**
- Remove all `#if DEVICE_GRID_YZ_16BIT` conditional compilation and associated `#endif` blocks from BLAS1 kernels, including axpy, copy, dot, iamax/iamin, rot, rotm, and scal kernels. This results in a simpler, always-on batch loop structure, improving readability and maintainability.

**SPIR-V Backend Enablement:**
- Enable the use of the SPIR-V backend in the `rocblas_dot_kernel_gfx942_float_double` kernel by extending the conditional compilation to include `__SPIRV__` as well as `__gfx942__`.

These changes collectively make the codebase easier to maintain and ensure consistent behavior when targeting the SPIR-V backend for testing.

ROCM-8163
