### PR TITLE
Fix docs-only labeller

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -116,7 +116,7 @@ documentation:
 
 "ci:docs-only":
 - changed-files:
-  - all-globs-to-all-files:
+  - any-glob-to-all-files:
     - docs/**/*
     - '**/docs/**/*'
     - '**/*.md'


### PR DESCRIPTION
## Motivation

I made a silly mistake in https://github.com/ROCm/rocm-libraries/pull/2770

It is impossible for all the listed globs to match.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
