### PR TITLE
Additional gtests to be disabled

### DIFF
--- a/projects/miopen/test/gtest/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
+++ b/projects/miopen/test/gtest/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
@@ -76,10 +76,12 @@ using TestCase = decltype(GetTestCases())::value_type;
 class GPU_Conv2d_conv_ck_igemm_fwd_v6r1_dlops_nchw_FP32
     : public FloatTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 class GPU_Conv2d_conv_ck_igemm_fwd_v6r1_dlops_nchw_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 bool IsTestSupportedForDevice()

--- a/projects/miopen/test/gtest/conv_igemm_dynamic_dlops.cpp
+++ b/projects/miopen/test/gtest/conv_igemm_dynamic_dlops.cpp
@@ -155,6 +155,7 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dDefaultIGemmDynamicDLops_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dDefaultIGemmDynamicDLops_FP16, HalfTest_conv_igemm_dynamic_dlops)

--- a/projects/miopen/test/gtest/conv_igemm_mlir_bwd_wrw.cpp
+++ b/projects/miopen/test/gtest/conv_igemm_mlir_bwd_wrw.cpp
@@ -82,9 +82,11 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dIGemmBwdWrwMLIRTest_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 class GPU_Conv2dIGemmBwdWrwMLIRTest_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dIGemmBwdWrwMLIRTest_FP32, FloatTest_conv_igemm_mlir_bwd_wrw)

--- a/projects/miopen/test/gtest/conv_igemm_mlir_fwd.cpp
+++ b/projects/miopen/test/gtest/conv_igemm_mlir_fwd.cpp
@@ -69,12 +69,15 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dMLIRTestIGemmFwd_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 class GPU_Conv2dMLIRTestIGemmFwd_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 class GPU_Conv2dMLIRTestIGemmFwd_I8 : public Int8TestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dMLIRTestIGemmFwd_FP32, FloatTest_conv_igemm_mlir_fwd)

--- a/projects/miopen/test/gtest/conv_igemm_mlir_xdlops_bwd_wrw.cpp
+++ b/projects/miopen/test/gtest/conv_igemm_mlir_xdlops_bwd_wrw.cpp
@@ -67,8 +67,7 @@ auto GetTestCases()
     std::pair{wrw, flags_wrw + " --input 128 2048 7  7  --weights 512  2048 1 1 --pads_strides_dilations 0 0 1 1 1 1" + layout},
     std::pair{wrw, flags_wrw + " --input 128 64   56 56 --weights 64   64   1 1 --pads_strides_dilations 0 0 1 1 1 1" + layout},
     std::pair{wrw, flags_wrw + " --input 256 1024 14 14 --weights 1024 32   1 1 --pads_strides_dilations 0 0 1 1 1 1" + groupCount_32},
-    std::pair{wrw, flags_wrw + " --input 64 1024 14 14 --weights 1024 1024  1 1 --pads_strides_dilations 0 0 1 1 1 1"}
-        // clang-format on
+    std::pair{wrw, flags_wrw + " --input 64 1024 14 14 --weights 1024 1024  1 1 --pads_strides_dilations 0 0 1 1 1 1"} // clang-format on
     };
 }
 
@@ -85,6 +84,7 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dMLIRTestIGemmXDlopsBwdWrw_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dMLIRTestIGemmXDlopsBwdWrw_FP32, FloatTest_conv_igemm_mlir_xdlops_bwd_wrw)

--- a/projects/miopen/test/gtest/conv_igemm_mlir_xdlops_fwd.cpp
+++ b/projects/miopen/test/gtest/conv_igemm_mlir_xdlops_fwd.cpp
@@ -70,10 +70,12 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dMLIRTestIGemmXDLopsFwd_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 class GPU_Conv2dMLIRTestIGemmXDLopsFwd_I8 : public Int8TestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dMLIRTestIGemmXDLopsFwd_FP32, FloatTest_conv_igemm_mlir_xdlops_fwd)

--- a/projects/miopen/test/gtest/deepbench_conv.cpp
+++ b/projects/miopen/test/gtest/deepbench_conv.cpp
@@ -82,6 +82,7 @@ using TestCase = decltype(GetTestCases())::value_type;
 
 class GPU_Conv2d_DeepBench_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 bool IsTestSupportedForDevice()

--- a/projects/miopen/test/gtest/regression_float_mi100.cpp
+++ b/projects/miopen/test/gtest/regression_float_mi100.cpp
@@ -58,6 +58,7 @@ using TestCase = decltype(GetTestCases())::value_type;
 
 class GPU_Conv2d_regression_mi100_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 bool IsTestSupportedForDevice()

--- a/projects/miopen/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC.cpp
+++ b/projects/miopen/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC.cpp
@@ -66,6 +66,7 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dTuningDynamicFwdDlops_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dTuningDynamicFwdDlops_FP16,

--- a/projects/miopen/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_bf16.cpp
+++ b/projects/miopen/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_bf16.cpp
@@ -70,6 +70,7 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dTuning_BFP16 : public Bf16TestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dTuning_BFP16, Bf16Test_smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_bf16)

--- a/projects/miopen/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_fp32_fp16.cpp
+++ b/projects/miopen/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_fp32_fp16.cpp
@@ -70,10 +70,12 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dTuningDynamicXdlops_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 class GPU_Conv2dTuningDynamicXdlops_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dTuningDynamicXdlops_FP32,

--- a/projects/miopen/test/gtest/smoke_solver_ConvCkIgemmFwdV6r1DlopsNchw.cpp
+++ b/projects/miopen/test/gtest/smoke_solver_ConvCkIgemmFwdV6r1DlopsNchw.cpp
@@ -68,6 +68,7 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dTuningV6R1_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dTuningV6R1_FP16, HalfTest_smoke_solver_ConvCkIgemmFwdV6r1DlopsNchw)

--- a/projects/miopen/test/gtest/smoke_solver_convasmbwdwrw.cpp
+++ b/projects/miopen/test/gtest/smoke_solver_convasmbwdwrw.cpp
@@ -84,18 +84,22 @@ bool IsTestSupportedForDevice()
 
 class GPU_Conv2dSingleAsmBwdWrw_FP32 : public FloatTestCase<std::vector<RegrTestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 class GPU_Conv2dTuningAsmBwdWrw_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 class GPU_Conv2dTuningAsmBwdWrw_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 class GPU_Conv2dTuningAsmBwdWrw_BFP16 : public Bf16TestCase<std::vector<TestCase>>
 {
+    MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE();
 };
 
 TEST_P(GPU_Conv2dTuningAsmBwdWrw_FP32, FloatTest_smoke_solver_convasmbwdwrw)


### PR DESCRIPTION
## Motivation

This PR is continuation of this PR https://github.com/ROCm/MIOpen/pull/3765 , it disables additional gtests that are using `test_drive<>` through `invoke_with_params<>`

## Technical Details

Tests are disabled using already existing `MIOPEN_DECLARE_GTEST_USES_TEST_DRIVE()` macro

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
