### PR TITLE
[rocRAND] Enable gfx1152 and gfx1153

### DIFF
--- a/projects/rocrand/CMakeLists.txt
+++ b/projects/rocrand/CMakeLists.txt
@@ -128,7 +128,7 @@ if(GPU_TARGETS STREQUAL "all")
     )
   else()
     rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-      TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx1151"
+      TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx1151;gfx1152;gfx1153"
     )
   endif()
 


### PR DESCRIPTION
## Motivation

Enable gfx1152 and gfx1153.

## Test Plan

`ctest --test-dir build/bin/rocRAND/ --parallel 2`

## Test Result

All passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
