### PR TITLE
Enable SK parallel reduction with LDD

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_reduction.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_reduction.yaml
@@ -219,8 +219,8 @@ BenchmarkProblems:
           - Exact: [32, 8, 1, 34576]
           - Exact: [32, 8, 1, 34832]
 
-  - # Leading dimensions
-    - # HHS NT
+  - # Large leading dimensions
+    - # S TN
       OperationType: GEMM
       DataType: s
       DestDataType: s
@@ -277,3 +277,54 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [320, 1024, 1, 29280, 138080, 138080, 29280, 29280]
+
+  - # Small leading dimensions
+    - # BBS NT
+      OperationType: GEMM
+      DataType: b
+      DestDataType: b
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # Grid
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        # - 1LDSBuffer: [1]
+        - 1LDSBuffer: [0]
+        - DepthU: [ 64 ]
+        - ExpandPointerSwap: [False]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - GlobalSplitU: [0]
+        # - LocalReadVectorWidth: [8]
+        - MatrixInstruction:
+          - [16, 16, 16, 1, 1, 8,6, 2,2]
+          # - [16, 16, 16, 1, 1, 4,4, 2,2]
+        - MIArchVgpr: [0]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ScheduleIterAlg: [3]
+        - SourceSwap: [True]
+        - StoreRemapVectorWidth: [0]
+        # - StoreVectorWidth: [4]
+        - StreamK: [3]
+        - TransposeLDS: [0]
+        # - VectorWidthA: [4]
+        # - VectorWidthB: [4]
+        - WorkGroupMapping: [1]
+        - NumLoadsCoalescedA: [2]
+        - DirectToLds: [1]
+
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [1164, 185, 1, 884736, 1216, 1216, 1216, 185]

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
@@ -279,6 +279,7 @@ namespace TensileLite
          * Calculate required workspace size.
          */
         size_t requiredWorkspaceSize(Problem const& problem, Hardware const& hardware) const;
+        size_t requiredWorkspaceSizeGsu(Problem const& problem, Hardware const& hardware, size_t gsu) const;
         size_t requiredWorkspaceSizeGroupedGemm(std::vector<Problem> const& problems,
                                                 Hardware const&             hardware) const;
         size_t requiredHostSizeGroupedGemmSingle(Problem const&  problem,

--- a/projects/hipblaslt/tensilelite/src/ContractionProblem.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionProblem.cpp
@@ -666,8 +666,7 @@ namespace TensileLite
 
         numWG.x = CeilDivide(numWG.x, sizeMapping.macroTile.x);
         numWG.y = CeilDivide(numWG.y, sizeMapping.macroTile.y);
-        if(sizeMapping.streamK == 0)
-            numWG.y *= gsu;
+        numWG.y *= gsu;
 
         size_t problemTiles = numWG.x * numWG.y;
         if(sizeMapping.persistentKernelAlongBatch || sizeMapping.streamK != 0)

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -650,7 +650,9 @@ namespace TensileLite
         size_t startStrideAB = problemType.useInitialStridesAB ? 0 : 1;
 
         // Pass wsStride if it's not in MBSK mode
-        if(gsu > 1 && sizeMapping.globalAccumulation != 3 && sizeMapping.streamK == 0)
+        bool gsuWSStride = gsu > 1 && sizeMapping.globalAccumulation != 3 && sizeMapping.streamK == 0;
+        bool skWSStride = sizeMapping.streamK > 0 && sk.reduction == ReductionType::Parallel;
+        if(gsuWSStride || skWSStride)
         {
             size_t wsStride = startStrideCD ? d.sizes()[0] : 1;
             for(size_t i = startStrideCD; i < d.dimensions(); i++)
@@ -717,7 +719,7 @@ namespace TensileLite
                 gsu = 1;
             }
 
-            auto tiles = problem.getNumTiles(sizeMapping, gsu);
+            auto tiles = problem.getNumTiles(sizeMapping, 1);
 
             // Clamp minimum iters per tile to 1 to allow stream-k index calculation to work in case K==0
             // In this case no actual iterations will be run, but workgroups will be mapped correctly for beta*C
@@ -2972,14 +2974,20 @@ namespace TensileLite
                 gsu = 1;
             }
             const bool streamKDP = Debug::Instance().useStreamKDataParrallel();
-            auto       tiles     = problem.getNumTiles(sizeMapping, gsu);
+            auto       tiles     = problem.getNumTiles(sizeMapping, 1);
             if(tiles > 0) // Grouped GEMM reports 0 tiles
             {
                 ReductionType reductionStrat = getSKReduction(problem, hardware);
                 size_t skGrid = getSKGrid(problem, hardware, tiles, reductionStrat);
                 // Get space required for partial tiles=
-                // TODO Revise parallel reduction WS to account for LDD
-                if(skGrid > 0 && (reductionStrat == ReductionType::Parallel || (tiles % skGrid != 0 && !streamKDP)))
+                if(reductionStrat == ReductionType::Parallel)
+                {
+                    size_t splitk = skGrid / tiles;
+                    size_t idealWorkspace = requiredWorkspaceSizeGsu(problem, hardware, splitk);
+                    if(idealWorkspace <= problem.workspaceSize())
+                        size += idealWorkspace;
+                }
+                else if(skGrid > 0 && (tiles % skGrid != 0 && !streamKDP))
                 {
                     // Check ideal amount of workspace for optimal performance
                     size_t idealWorkspace = partialTileSize(skGrid);
@@ -2994,41 +3002,50 @@ namespace TensileLite
         {
             // TODO: Pass GSU from problem and change value[2] to gsu if gsu != default value
             size_t gsu = problem.getParams().gsu() > 0 ? problem.getParams().gsu() : calculateAutoGSU(problem, &hardware);
-            size_t gsuMultiplier = gsu > 1 ? gsu : 0;
-            size_t batch         = problem.d().sizes()[2];
-            size_t tiles         = problem.getNumTiles(sizeMapping, gsu) * batch;
-            size_t tileSize      = sizeMapping.macroTile.x * sizeMapping.macroTile.y
-                              * sizeMapping.workspaceSizePerElemC;
-            size_t bufSize = gsu > 1 ? tiles * tileSize : 0;
-            size += bufSize;
+            size += requiredWorkspaceSizeGsu(problem, hardware, gsu);
+        }
 
-            if(problemType.useGradient && problemType.useBias
-               && problem.getParams().biasEnum() != rocisa::DataType::None)
-            {
-                if(problem.biasSrc() == ContractionProblemGemm::TENSOR::A)
-                {
-                    size += problem.freeSizeA(0) * sizeMapping.workspaceSizePerElemBias
-                            * gsuMultiplier;
-                }
-                else if(problem.biasSrc() == ContractionProblemGemm::TENSOR::B)
-                {
-                    size += problem.freeSizeB(0) * sizeMapping.workspaceSizePerElemBias
-                            * gsuMultiplier;
-                }
-                else if(problem.biasSrc() == ContractionProblemGemm::TENSOR::D
-                        && (gsuMultiplier == 0))
-                {
-                    size += problem.d().totalLogicalElements() * problem.computeTypeElementSize()
-                            * gsu;
-                }
-            }
+        return size;
+    }
 
-            // workspace for amaxD
-            if(problemType.outputAmaxD)
+    size_t ContractionSolution::requiredWorkspaceSizeGsu(Problem const& problem, Hardware const& hardware, size_t gsu) const
+    {
+        size_t size = 0;
+
+        size_t gsuMultiplier = gsu > 1 ? gsu : 0;
+        size_t batch         = problem.d().sizes()[2];
+        size_t tiles         = problem.getNumTiles(sizeMapping, gsu) * batch;
+        size_t tileSize      = sizeMapping.macroTile.x * sizeMapping.macroTile.y
+                          * sizeMapping.workspaceSizePerElemC;
+        size_t bufSize = gsu > 1 ? tiles * tileSize : 0;
+        size += bufSize;
+
+        if(problemType.useGradient && problemType.useBias
+           && problem.getParams().biasEnum() != rocisa::DataType::None)
+        {
+            if(problem.biasSrc() == ContractionProblemGemm::TENSOR::A)
             {
-                auto numWGS = getNumWorkGroups(problem, sizeMapping);
-                size += problem.amaxd().elementBytes() * numWGS;
+                size += problem.freeSizeA(0) * sizeMapping.workspaceSizePerElemBias
+                        * gsuMultiplier;
             }
+            else if(problem.biasSrc() == ContractionProblemGemm::TENSOR::B)
+            {
+                size += problem.freeSizeB(0) * sizeMapping.workspaceSizePerElemBias
+                        * gsuMultiplier;
+            }
+            else if(problem.biasSrc() == ContractionProblemGemm::TENSOR::D
+                    && (gsuMultiplier == 0))
+            {
+                size += problem.d().totalLogicalElements() * problem.computeTypeElementSize()
+                        * gsu;
+            }
+        }
+
+        // workspace for amaxD
+        if(problemType.outputAmaxD)
+        {
+            auto numWGS = getNumWorkGroups(problem, sizeMapping);
+            size += problem.amaxd().elementBytes() * numWGS;
         }
 
         return size;
@@ -3145,11 +3162,6 @@ namespace TensileLite
         if(!sizeMapping.customKernelName.empty())
         {
             // Custom kernel currently only supports single-kernel reduction
-            reductionStrat = ReductionType::Tree;
-        }
-        else if (problem.d().totalAllocatedElements() > problem.d().totalLogicalElements())
-        {
-            // If LDD > M, fall back to tree reduction
             reductionStrat = ReductionType::Tree;
         }
         else if(pAMDGPU->skDynamicGrid > 0)


### PR DESCRIPTION
Fix WS calculation for parallel reduction with LDD.
Fix stride W/D argument for SK kernel with parallel reduction.

## Motivation

This PR enables SK parallel reduction if LDD > M. Parallel reduction was previously limited to problems with no leading dimension.

## Technical Details

To fix this case, the required WS estimate was fixed to account for parallel reduction data layout, and the stride D/W argument was fixed to match GW layout with LDD.

## Test Plan

A new test case was added for small LDD, and existing test case with large LDD still passes.

## Test Result

Tests pass locally, waiting for CI results.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
