### PR TITLE
[miopen][bugfix] Skip CK specific gtest when MIOpen is not built with CK

### DIFF
--- a/projects/miopen/test/gtest/unit_implicitgemm_ck_util.cpp
+++ b/projects/miopen/test/gtest/unit_implicitgemm_ck_util.cpp
@@ -145,7 +145,14 @@ struct CPU_UnitTestImplicitGemmCKUtil_NONE : CKArgParsingTest<StubbedCKArgs, Stu
 {
 };
 
-TEST_P(CPU_UnitTestImplicitGemmCKUtil_NONE, TestParsing) { this->TestParsing(); };
+TEST_P(CPU_UnitTestImplicitGemmCKUtil_NONE, TestParsing)
+{
+#if MIOPEN_USE_COMPOSABLEKERNEL
+    this->TestParsing();
+#else
+    GTEST_SKIP();
+#endif
+};
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          CPU_UnitTestImplicitGemmCKUtil_NONE,


### PR DESCRIPTION
## Motivation
A specific CK-related gtest was still being run when MIOpen was compiled without CK, specifically when `-DMIOPEN_USE_COMPOSABLEKERNEL=OFF`. We caught this based on failures we were seeing on theRock where MIOpen was not being built with CK is for all architectures yet.

## Technical Details
Change: Disabled a specific gtest when MIOpen is not compiled with COMPOSABLE KERNEL.
Implementation: Added a check to skip this gtest when MIOPEN_USE_COMPOSABLEKERNEL is not set.

## Test Plan

Local Testing:
Built MIOpen with CK and verified that the test is executed.
Built MIOpen without CK and verified that the test is skipped.

## Test Result

The gtest is only executed when MIOpen is built with CK and is skipped otherwise.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
