### PR TITLE
[hipblaslt][CMS] Add CMS for BBS 160x256x64 TN DTL

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Alik_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -307559,6 +307559,250 @@
     reorderGRInstForDTVB: false
     tailLoopOptA: false
     tailLoopOptB: false
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: true
+    ActivationFused: true
+    AssertAIGreaterThanEqual: -1
+    AssertAILessThanEqual: -1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BaseName: Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT1_Ox6qLZKC3dmEzM2z7HLjTQN6j_daniX_iE0uOwhghI=
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    CUOccupancy: -1
+    ClusterLocalRead: 1
+    CodeObjectVersion: '4'
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DebugStreamK: 0
+    DepthU: 64
+    DirectToLds: true
+    DirectToLdsA: true
+    DirectToLdsB: true
+    DirectToVgprA: false
+    DirectToVgprB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: true
+    ExpandPointerSwap: 0
+    ExpertSchedulingMode: 0
+    ForceDisableShadowInit: false
+    ForceUnrollSubIter: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 8
+    GlobalReadVectorWidthB: 8
+    GlobalSplitU: 0
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [9, 5, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 2, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: false, UseSFC: false, UseUniversalArgs: true}
+    Kernel: true
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT160x256x64_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA8_GRVWB8_GSU0_GSUAMB_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA16_LPB16_LPM0_LRVW8_LWPMn1_MIAV0_MIWT5_8_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SPO0_SRVW0_SSO0_SVW1_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA1_VWB8_WSGRA0_WSGRB0_WS64_WG32_8_1
+    LDSTrInst: false
+    LSCA: 64
+    LSCB: 64
+    LSPA: 32
+    LSPB: 32
+    LVCA: 8
+    LVCB: 8
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 1024
+    LdsBlockSizePerPadB: 1024
+    LdsBlockSizePerPadMetadata: 0
+    LdsBytesNoAmax: 120448
+    LdsInitCVgprs: false
+    LdsNumBytes: 120448
+    LdsNumElementsAlignedA: 21120
+    LdsNumElementsAlignedB: 33792
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 65536
+    LdsOffsetB: 21120
+    LdsOffsetB_Blk: 86656
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 21120
+    LdsOffsetMetadata_Blk: 86656
+    LdsPadA: 16
+    LdsPadB: 16
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 8
+    LocalSplitU: 1
+    LocalSplitUReuseLDS: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: true
+    LocalWriteUseSgprB: true
+    LoopIters: 2
+    LoopUnroll: 64
+    MFMA_BF16_1K: false
+    MIArchVgpr: false
+    MIBlock: [16, 16, 32, 1, 1, 1]
+    MIInputPerThread: 8
+    MIInputPerThreadA: 8
+    MIInputPerThreadB: 8
+    MIInputPerThreadMetadata: 8
+    MIOutputVectorWidth: 4
+    MIRegPerOut: 1
+    MIWaveGroup: [2, 2]
+    MIWaveTile: [5, 8]
+    MIWaveTileA: 5
+    MIWaveTileB: 8
+    MIWaveTileMetadata: 0
+    MacroTile0: 160
+    MacroTile1: 256
+    MacroTileA: 160
+    MacroTileB: 256
+    MagicDivAlg: 2
+    MathClocksUnrolledLoop: 0
+    MatrixInstB: 1
+    MatrixInstBM: 1
+    MatrixInstBN: 1
+    MatrixInstK: 32
+    MatrixInstM: 16
+    MatrixInstN: 16
+    MatrixInstruction: [16, 16, 32, 1]
+    MaxLDS: 163840
+    MaxOccupancy: 40
+    MbskPrefetchMethod: 0
+    MfmaInitCVgprs: true
+    NoLdsWriteCode: true
+    NoReject: false
+    NoTailLoop: false
+    NonDTLTailLoopA: true
+    NonDTLTailLoopB: true
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 4
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NonTemporalWS: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 160
+    NumGlobalWriteVectorsPerThread: 160
+    NumLoadsA: 5
+    NumLoadsB: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 5
+    NumLoadsPerpendicularB: 8
+    NumThreads: 256
+    NumTotalPackedLoadsA: 5
+    NumTotalPackedLoadsB: 8
+    NumWaveSplitK: 1
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 2
+    PrefetchLocalRead: 1
+    PreloadKernArgs: true
+    SFCWGM:
+    - [1, 1]
+    - [1, 1]
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 3
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1314
+    SolutionNameMin: Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT160x256x64_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA8_GRVWB8_GSU0_GSUAMB_GSUC0_GSUWGMRR0_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA16_LPB16_LPM0_LRVW8_LWPMn1_MIAV0_MIWT5_8_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SU0_SUM0_SUS128_SPO0_SRVW0_SSO0_SVW1_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA1_VWB8_WSGRA0_WSGRB0_WS64_WG32_8_1_WGM8_WGMXCC1_WGMXCCGn1
+    SourceSwap: 1
+    SpaceFillingAlgo: []
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 128
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSwapAddr: false
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    StreamK: 3
+    StreamKAtomic: 0
+    StreamKFixupTreeReduction: 0
+    StreamKXCCMapping: 0
+    SubGroup0: 8
+    SubGroup1: 32
+    SubGroupA: 8
+    SubGroupB: 32
+    SuppressNoLoadLoop: false
+    SwapGlobalReadOrder: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 20
+    ThreadTile1: 8
+    ThreadTileA: 20
+    ThreadTileB: 8
+    TransposeLDS: 1
+    TransposeLDSMetadata: true
+    ULSGRODoubleG2L: 0
+    UnrollLoopSwapGlobalReadOrder: 0
+    UnrollMajorLDSA: true
+    UnrollMajorLDSB: true
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseCustomMainLoopSchedule: true
+    UseDirect32XEmulation: false
+    UseDot2F32XEmulation: false
+    UseDotInstruction: false
+    UseF32XEmulation: false
+    UseGeneralizedNLCOneA: true
+    UseGeneralizedNLCOneB: true
+    UseGeneralizedNLCOneMetadata: false
+    UseInstOffsetForGRO: 0
+    UsePLRPack: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 8
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WaveSplitK: false
+    WavefrontSize: 64
+    WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingXCC: 1
+    WorkGroupMappingXCCGroup: -1
+    WorkGroupReduction: false
+    WorkspaceCheck: [4, 0, 0]
+    _DepthU: 64
+    _DepthUA: 64
+    _DepthUB: 64
+    _DepthUMetadata: 64
+    _GlobalAccumulation: PartialsBuffer
+    _UseSgprForGRO: 0
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 4
+    _staggerStrideShift: 0
+    enableGLTrA: false
+    enableGLTrB: false
+    enableLDSTrA: false
+    enableLDSTrB: false
+    numSubTiles: 1
+    reorderGRInstForDTVA: false
+    reorderGRInstForDTVB: false
+    tailLoopOptA: false
+    tailLoopOptB: false
 - [2, 3, 0, 1]
 - - - [16, 368640, 1, 224]
     - [0, 0.0]
@@ -310210,6 +310454,8 @@
     - [1312, 0.0]
   - - [4096, 1536, 1, 8192]
     - [1313, 0.0]
+  - - [2560, 4096, 1, 8192]
+    - [1314, 0.0]
 - null
 - null
 - DeviceEfficiency

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -687,9 +687,57 @@ def _get_schedule_256x256x64_16bit(kernel, useLDSTr, TLDS):
 
 def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
     kernel["MfmaInitCVgprs"] = True
-    if isNN(kernel) and useLDSTr and TLDS==1:
+
+    optSchedule = dict()
+    syncCode = []
+
+    nglshift = nllshift = 0 # vmcnt shift for ngl and nll
+    if isTN(kernel) and TLDS==1:
+        optSchedule = {
+
+            ## sync index: LRB0, LRA0, GRB, GRA
+            'SYNC'   : [[-1, 10,10, 38,39,43, 70,70]],
+            'GRIncA' : [[0,1,2,3,4,5,6,7,8]],
+            'GRIncB' : [[9,11,12,13,14,15,16,17,18]],
+
+            'LRA0'   : [[0,2,3,4,5]],  ## -2 is place holder
+
+            'LRB0'   : [[12,15,18,21,24,26,28,30],   ## After LRB0, we can mix LRA0 and GRB
+                        [13,16,19,22,25,27,29,31]],
+            ## GRA should start after LRA0 is done.
+            'GRA'    : [[11,11, 14,14, 17,17, 20,20, 23,23],
+                        [12,12, 15,15, 18,18, 21,21, 24,24]],
+
+            ## GRB should start after LRB0 is done
+            'GRB'    : [[40,40, 43,43, 46,46, 49,49, 59,59, 62,62, 65,65, 67,68],  # m0 inc is part of GRA/GRB
+                        [41,41, 44,44, 47,47, 57,57, 60,60, 63,63, 66,66, 68,69]],
+            'LRA1'   : [[44, 47, 53, 58, 63],
+                        [45, 48, 54, 59, 64]],
+
+            #After GRB is done.
+            'LRB1'   : [[70,71,72,73,75,76,77,78]],
+
+            'LRSA'   : [[33]], # after LRA0 and before LRA1
+            'LRSB'   : [[33]], # after LRB0 and before LRB2
+            'LWSA'   : [[74]], # For A
+            'LWSB'   : [[76]],
+
+            'LCC'    : [[79, 79]],
+        }
+        # note: syncCode needs to be
+        syncCode = [SWaitCnt(dscnt=13, vlcnt=-1, vscnt=-1, comment="Wait for prior LRA0/LRB0 before starting main loop"),
+                    SWaitCnt(dscnt=13, vlcnt=-1, vscnt=-1, comment="Wait for LRA0 to complete"),
+                    SBarrier(comment="for GRA start"),
+                    SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0 to complete"),
+                    SBarrier(comment="for GRB / LRA1 start"),
+                    SWaitCnt(dscnt=-1, vlcnt=13, vscnt=-1, comment="Wait for GRA to complete"),
+                    #SBarrier(comment=""),
+                    SWaitCnt(dscnt=-1, vlcnt=13, vscnt=-1, comment="Wait for GRB to complete"),
+                    SBarrier(comment=""),
+                   ]
+        nglshift = nllshift = 13 # vmcnt shift for ngl and nll
+    elif isNN(kernel) and useLDSTr and TLDS==1:
         kernel["SwapGlobalReadOrder"] = True
-        nglshift = nllshift = 0 # vmcnt shift for ngl and nll
         optSchedule = {
             'SYNC'   : [[-1,
             12, 12, # Wait for B
@@ -727,7 +775,6 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
         nglshift = nllshift = 13
 
     elif isNT(kernel) and useLDSTr and TLDS==0:
-        nglshift = nllshift = 0 # vmcnt shift for ngl and nll
         optSchedule = {
             'SYNC': [[-1,17,17,57,57]],
             'GRA': [[16,17,20,20,24,24,28,28,31,31]],

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -695,18 +695,17 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
     if isTN(kernel) and TLDS==1:
         optSchedule = {
 
-            ## sync index: LRB0, LRA0, GRB, GRA
-            'SYNC'   : [[-1, 10,10, 38,39,43, 70,70]],
+            'SYNC'   : [[-1, 4, 13,13, 38,39, 42,43, 70,70]],
             'GRIncA' : [[0,1,2,3,4,5,6,7,8]],
             'GRIncB' : [[9,11,12,13,14,15,16,17,18]],
 
             'LRA0'   : [[0,2,3,4,5]],  ## -2 is place holder
 
-            'LRB0'   : [[12,15,18,21,24,26,28,30],   ## After LRB0, we can mix LRA0 and GRB
-                        [13,16,19,22,25,27,29,31]],
+            'LRB0'   : [[13,15,18,21,24,26,28,30],   ## After LRB0, we can mix LRA0 and GRB
+                        [14,16,19,22,25,27,29,31]],
             ## GRA should start after LRA0 is done.
-            'GRA'    : [[11,11, 14,14, 17,17, 20,20, 23,23],
-                        [12,12, 15,15, 18,18, 21,21, 24,24]],
+            'GRA'    : [[11,14, 17,17, 20,20, 23,23, 26,27],
+                        [12,15, 18,18, 21,21, 24,24, 27,28]],
 
             ## GRB should start after LRB0 is done
             'GRB'    : [[40,40, 43,43, 46,46, 49,49, 59,59, 62,62, 65,65, 67,68],  # m0 inc is part of GRA/GRB
@@ -725,14 +724,15 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
             'LCC'    : [[79, 79]],
         }
         # note: syncCode needs to be
-        syncCode = [SWaitCnt(dscnt=13, vlcnt=-1, vscnt=-1, comment="Wait for prior LRA0/LRB0 before starting main loop"),
-                    SWaitCnt(dscnt=13, vlcnt=-1, vscnt=-1, comment="Wait for LRA0 to complete"),
-                    SBarrier(comment="for GRA start"),
-                    SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0 to complete"),
-                    SBarrier(comment="for GRB / LRA1 start"),
-                    SWaitCnt(dscnt=-1, vlcnt=13, vscnt=-1, comment="Wait for GRA to complete"),
-                    #SBarrier(comment=""),
-                    SWaitCnt(dscnt=-1, vlcnt=13, vscnt=-1, comment="Wait for GRB to complete"),
+        syncCode = [SWaitCnt(dscnt=7, vlcnt=-1, vscnt=-1, comment="Wait for necessary prior LRA1/LRB1 before starting main loop"),
+                    SWaitCnt(dscnt=3, vlcnt=-1, vscnt=-1, comment="Wait for prior LRA1/LRB1 for the remaining main loop"),
+                    SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0 to complete to start GRA"),
+                    SBarrier(comment=""),
+                    SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0 to complete to start GRB"),
+                    SBarrier(comment=""),
+                    SWaitCnt(dscnt=-1, vlcnt=(13 + 1), vscnt=-1, comment="Wait for GRA to complete to start LRA1"),
+                    SBarrier(comment=""),
+                    SWaitCnt(dscnt=-1, vlcnt=13, vscnt=-1, comment="Wait for GRB to complete to start LRB1"),
                     SBarrier(comment=""),
                    ]
         nglshift = nllshift = 13 # vmcnt shift for ngl and nll

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
@@ -809,6 +809,43 @@ BenchmarkProblems:
           - Range: [[8192], [3072], [1], [64, 64, 256]]
           - Exact: [4096,  1536,  1,  8192]  # Compute bound
         - BiasTypeArgs: ['b']
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+           - [16, 16, 32, 1, 1, 5, 8, 2, 2]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - StreamK: [3]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - StaggerU: [0]
+        - WorkGroupMapping: [0]
+        - WorkGroupMappingXCC: [-1]
+        - 1LDSBuffer: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [0, 1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[160], [256], [1], [64, 64, 256]]
+          - Range: [[160], [256], [1], [1, 1, 64]]
+          - Range: [[160], [256], [1], [32, 64, 256]]
+          - Range: [[5120], [8192], [1], [64, 64, 256]]
+          - Exact: [2560, 4096, 1, 8192]
+        - BiasTypeArgs: ['b']
 
 
   ########################################


### PR DESCRIPTION
## Motivation

Add CMS for BBS 160x256x64 TN tile, which improve performance with the tile by CMS.

## Technical Details

Applied CMS optimization for 160x256x64 TN tile, and the new kernel improves the performance as below:
* ~~**main loop efficiency**: improved from 86% efficiency to 96% efficiency.~~
* ~~**tensilelite yaml**: **~5.1%** speedup compared to non-CMS version.~~
* ~~**hipblaslt-bench**: **~4.2%** speedup compared to hipblaslt without adding the CMS kernel for 160x256x64 TN.~~

Updated CMS optimization performance result:
* **main loop efficiency**: improved from 86% efficiency to **94.8%** efficiency.
* **tensilelite yaml**: **~4.7%** speedup compared to non-CMS version.
* **hipblaslt-bench**: **~4.3%** speedup compared to hipblaslt without adding the CMS kernel for 160x256x64 TN.

## Test Result
* Tested through Tensilelite yaml file and all tests PASSED:
```
        - ProblemSizes:
          - Exact: [2560, 4096, 1, 8192]  # [160x16, 256x16, 1, 64x128]
          - Range: [[160], [256], [1], [64, 64, 256]]    # - Range: [[MT0], [MT1], [1], [DU, DU, 4*DU]]
          - Range: [[160], [256], [1], [1,1,64]]         # - Range: [[MT0], [MT1], [1], [1,1,DU]]
          - Range: [[160], [256], [1], [32, 64, 256]]    # - Range: [[MT0], [MT1], [1], [DU/2, DU, 4*DU]]
          - Range: [[5120], [8192], [1], [64, 64, 256]]  # - Range: [[32*MT0], [32*MT1], [1], [DU, DU, 4*DU]]
```
* `hipblaslt-test` with `--gtest_filter="*_TN_*" and all tests PASSED.
```
[----------] Global test environment tear-down
[==========] 5714 tests from 2 test suites ran. (1053435 ms total)
[  PASSED  ] 5714 tests.
hipBLASLt version: 100200
hipBLASLt git version: 1eb7acfc2d-dirty
command line: ./build/release/clients/hipblaslt-test --gtest_filter=*_TN_*
```
With the updated CMS optimization:
```
[----------] Global test environment tear-down
[==========] 5714 tests from 2 test suites ran. (1070277 ms total)
[  PASSED  ] 5714 tests.
hipBLASLt version: 100200
hipBLASLt git version: f5de00f2cf
command line: ./build/release/clients/hipblaslt-test --gtest_filter=*_TN_*
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
