### PR TITLE
[rocSOLVER] gebrd workspace fixes

### DIFF
--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ void rocsolver_orglq_unglq_getMemorySize(const rocblas_int m,
         // size of workspace is maximum of what is needed by larft and larfb.
         // size of Abyx_tmptr is maximum of what is needed by orgl2/ungl2 and larfb.
         rocsolver_larft_getMemorySize<BATCHED, T>(n, jb, batch_count, &unused, size_work, &unused);
-        rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_left, m - jb, n, jb, batch_count,
+        rocsolver_larfb_getMemorySize<BATCHED, T>(rocblas_side_right, m - jb, n, jb, batch_count,
                                                   &temp, &unused);
 
         *size_Abyx_tmptr = *size_Abyx_tmptr >= temp ? *size_Abyx_tmptr : temp;

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     November 2017
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,12 +73,11 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
     else
     {
         size_t s1, s2, w1, w2, unused;
-        rocblas_int k = GEBRD_GEBD2_SWITCHSIZE;
-        rocblas_int d = std::min(m / k, n / k);
+        rocblas_int k = GEBRD_BLOCKSIZE;
+        rocblas_int diff = std::min(m, n) - GEBRD_GEBD2_SWITCHSIZE;
 
         // sizes are maximum of what is required by GEBD2 and LABRD
-        rocsolver_gebd2_getMemorySize<BATCHED, T>(m - d * k, n - d * k, batch_count, &unused, &w1,
-                                                  &s1);
+        rocsolver_gebd2_getMemorySize<BATCHED, T>(m - diff, n - diff, batch_count, &unused, &w1, &s1);
         rocsolver_labrd_getMemorySize<BATCHED, T>(m, n, k, batch_count, size_scalars, &w2, &s2);
         *size_work_workArr = std::max(w1, w2);
         *size_Abyx_norms = std::max(s1, s2);

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,8 +65,8 @@ rocblas_status rocsolver_gebrd_batched_impl(rocblas_handle handle,
 
     // batched execution
     rocblas_stride strideA = 0;
-    rocblas_stride strideX = m * GEBRD_GEBD2_SWITCHSIZE;
-    rocblas_stride strideY = n * GEBRD_GEBD2_SWITCHSIZE;
+    rocblas_stride strideX = m * GEBRD_BLOCKSIZE;
+    rocblas_stride strideY = n * GEBRD_BLOCKSIZE;
 
     // memory workspace sizes:
     // size for constants in rocblas calls

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,8 +65,8 @@ rocblas_status rocsolver_gebrd_strided_batched_impl(rocblas_handle handle,
     rocblas_int shiftY = 0;
 
     // strided_batched execution
-    rocblas_stride strideX = m * GEBRD_GEBD2_SWITCHSIZE;
-    rocblas_stride strideY = n * GEBRD_GEBD2_SWITCHSIZE;
+    rocblas_stride strideX = m * GEBRD_BLOCKSIZE;
+    rocblas_stride strideY = n * GEBRD_BLOCKSIZE;
 
     // memory workspace sizes:
     // size for constants in rocblas calls

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     April 2012
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -418,8 +418,8 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
     const rocblas_int shiftV = 0;
     const rocblas_int ldx = thinSVD ? k : m;
     const rocblas_int ldy = thinSVD ? k : n;
-    const rocblas_stride strideX = ldx * GEBRD_GEBD2_SWITCHSIZE;
-    const rocblas_stride strideY = ldy * GEBRD_GEBD2_SWITCHSIZE;
+    const rocblas_stride strideX = ldx * GEBRD_BLOCKSIZE;
+    const rocblas_stride strideY = ldy * GEBRD_BLOCKSIZE;
     T* bufferT = tempArrayT;
     rocblas_int ldt = k;
     rocblas_stride strideT = k * k;

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvdx.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvdx.hpp
@@ -376,8 +376,8 @@ rocblas_status rocsolver_gesvdx_template(rocblas_handle handle,
     const rocblas_stride strideD = k;
     const rocblas_stride strideE = k;
     const rocblas_stride strideT = k * k;
-    const rocblas_stride strideX = ldx * GEBRD_GEBD2_SWITCHSIZE;
-    const rocblas_stride strideY = ldy * GEBRD_GEBD2_SWITCHSIZE;
+    const rocblas_stride strideX = ldx * GEBRD_BLOCKSIZE;
+    const rocblas_stride strideY = ldy * GEBRD_BLOCKSIZE;
     const rocblas_stride strideZ = 2 * k * nsv_max;
     T* UV;
     rocblas_stride strideUV;

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvdx_notransv.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvdx_notransv.hpp
@@ -376,8 +376,8 @@ rocblas_status rocsolver_gesvdx_notransv_template(rocblas_handle handle,
     const rocblas_stride strideD = k;
     const rocblas_stride strideE = k;
     const rocblas_stride strideT = k * k;
-    const rocblas_stride strideX = ldx * GEBRD_GEBD2_SWITCHSIZE;
-    const rocblas_stride strideY = ldy * GEBRD_GEBD2_SWITCHSIZE;
+    const rocblas_stride strideX = ldx * GEBRD_BLOCKSIZE;
+    const rocblas_stride strideY = ldy * GEBRD_BLOCKSIZE;
     const rocblas_stride strideZ = 2 * k * nsv_max;
     T* UV;
     rocblas_stride strideUV;


### PR DESCRIPTION
While working on the workspace management I noticed that gebrd was calling `rocsolver_gebd2_getMemorySize` with incorrect values. This would cause gebrd to fail intermittently on sizes that are a multiple of 32. With these changes, it will now allocate slightly more than enough space.