### PR TITLE
[hipblaslt] Custom mainloop schedule (CMS) validator scaffolding 

### DIFF
--- a/projects/hipblaslt/tensilelite/README.md
+++ b/projects/hipblaslt/tensilelite/README.md
@@ -6,7 +6,7 @@ While full test suites can be run with a single `tox` command, developers may wi
 build the hipBLASLt tensilelite client executable (`tensilelite-client`) and run individual tests separately.
 This is useful for debugging specific problems or isolating issues in a specific test.
 
-### Run Full Test Suite with Tox
+### Run Test Suite with Tox
 
 The standard workflow for running the entire test suite is to use `tox`. This command will build
 `tensilelite-client` and execute all tests.
@@ -14,6 +14,12 @@ The standard workflow for running the entire test suite is to use `tox`. This co
 ```
 cd rocm-libraries/projects/hipblaslt/tensilelite
 tox -e py3 -- Tensile/Tests -m common
+```
+
+Subsequently, you can run just the Tensile unit tests via:
+
+```
+tox -e unit -- Tensile/Tests/unit
 ```
 
 ### Build client with invoke and Run a Test (Default Path)

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -20,6 +20,8 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
+# fmt: off
+
 from rocisa.code import KernelBody, Label, Macro, Module, RegSet, SrdUpperValue, \
                         StructuredModule, TextBlock, ValueEndif, ValueIf, ValueElseIf, ValueSet, SignatureBase
 from rocisa.container import vgpr, sgpr, SMEMModifiers, replaceHolder, EXEC,\
@@ -40,62 +42,78 @@ from Tensile.Utilities.Decorators.Shared import CallableGuard
 from copy import deepcopy
 from typing import Dict
 
+# fmt: on
+
+
+def validateAscendingOrder(scheduleInfo, context: Dict = {}):
+    """
+    Ensure that all sequences of optSchedule are non-decreasing.
+
+    Context and example: There will be a sequence of N 'GRIncA' instructions for
+    incrementing the memory address that the A macro tile is read from.
+    The CMS developer has the freedom to insert these N instructions into
+    'slots' of their choice. A slot is a sequence of instructions between
+    2 consecutive mfma instructions. Example: 'GRIncA' : [[0,1,1,3]] would
+    mean that the N=4 instructions to increment the pointer appear as follows:
+
+    instruction 1    : between mfma 0 and mfma 1.
+    instructions 2,3 : between mfma 1 and mfma 2.
+    instruction 4    : between mfma 3 and mfma 4.
+
+    However, there is a strict requirement that the N slots for these instructions
+    are non-decreasing. This rule is true for all groups of instructions, not
+    just the 'GRIncA' instructions (to be verified).
+    """
+
+    for k, sequences in scheduleInfo.optSchedule.items():
+        for seq in sequences:
+            # Ensure seq is non-decreasing
+            for i in range(1, len(seq)):
+                if seq[i] < seq[i - 1]:
+                    return False, (
+                        f"Non-descending-order rule violated, "
+                        f"schedule key '{k}', sequence {seq}: "
+                        f"value {seq[i]} at index {i} is less than "
+                        f"{seq[i-1]} at index {i-1}."
+                    )
+    return True, ""
+
 
 class ScheduleInfo:
     numCodePaths: int
     numMfma: int
-    isKnownValid : bool
-    def __init__(self, numCodePaths, numMfma, optSchedule, syncCode, nglshift, nllshift, mfmaReorder = [], isKnownValid = False):
+    skipValidation: bool
+
+    def __init__(
+        self,
+        numCodePaths,
+        numMfma,
+        optSchedule,
+        syncCode,
+        nglshift,
+        nllshift,
+        mfmaReorder=[],
+        skipValidation=False,
+    ):
         """
-        isKnownValid : if True, an expert should have verified that the schedule is valid (no race conditions, etc) and
-                       that no validation checks should be run.
+        skipValidation : if True, an expert should have verified that the schedule is
+            valid (no race conditions, etc). No validation checks be run during compilation.
         """
         self.numCodePaths = numCodePaths
         self.numMfma = numMfma
         self.optSchedule = optSchedule
         self.syncCode = syncCode
-        self.nglshift = nglshift # vmcnt shift for noglobalload loop
-        self.nllshift = nllshift # vmcnt shift for nolocalload loop
+        self.nglshift = nglshift  # vmcnt shift for noglobalload loop
+        self.nllshift = nllshift  # vmcnt shift for nolocalload loop
         self.mfmaReorder = mfmaReorder
-        self.isKnownValid = isKnownValid
-        self.rules = [self.ruleNonDescendingOrder] # The set of validation rules to run when this object calls `getValidationMessage`.
+        self.skipValidation = skipValidation
 
-    def ruleNonDescendingOrder(self, context: Dict = {}):
-        """
-        Ensure that all sequences of optSchedule are non-decreasing.
+        # The set of validation rules to run when this object calls `getValidationMessage`.
+        self.rules: List[Callable[[ScheduleInfo, dict], [bool, str]]] = [
+            validateAscendingOrder
+        ]
 
-        Context and example: There will be a sequence of N 'GRIncA' instructions for
-        incrementing the memory address that the A macro tile is read from.
-        The CMS developer has the freedom to insert these N instructions into
-        'slots' of their choice. A slot is a sequence of instructions between
-        2 consecutive mfma instructions. Example: 'GRIncA' : [[0,1,1,3]] would
-        mean that the N=4 instructions to increment the pointer appear as follows:
-
-        instruction 1    : between mfma 0 and mfma 1.
-        instructions 2,3 : between mfma 1 and mfma 2.
-        instruction 4    : between mfma 3 and mfma 4.
-
-        However, there is a strict requirement that the N slots for these instructions
-        are non-decreasing. This rule is true for all groups of instructions, not
-        just the 'GRIncA' instructions (to be verified).
-        """
-
-        for k, sequences in self.optSchedule.items():
-            for seq in sequences:
-                print(k)
-                print(seq)
-                # Ensure seq is non-decreasing
-                for i in range(1, len(seq)):
-                    print(seq[i])
-                    if seq[i] < seq[i - 1]:
-                        return (f"Non-descending-order rule violated, "
-                                f"schedule key '{k}', sequence {seq}: "
-                                f"value {seq[i]} at index {i} is less than "
-                                f"{seq[i-1]} at index {i-1}.")
-        return ""
-
-
-    def getValidationMessage(self, context: Dict):
+    def validate(self, context: Dict):
         """
         Returns the empty string if this schedule is considered to be
         valid for `kernel`. If the returned string is not empty, it
@@ -106,23 +124,24 @@ class ScheduleInfo:
 
         Note 2: if a non-empty string is returned, and the reason is
         considered by an expert developer to be incorrect, you can create a
-        ScheduleInfo with `isKnownValid = True`. This is a workaround
+        ScheduleInfo with `skipValidation = True`. This is a workaround
         for possible false positives.
         """
 
-        if self.isKnownValid:
+        if self.skipValidation:
             # All rules bypassed, considered valid.
-            return ""
+            return True, ""
 
         for rule in self.rules:
-            result = rule(context)
-            if result:
-                return result
+            status, message = rule(self, context)
+            if status:
+                return status, message
 
         # All rules passed, considered valid.
-        return ""
+        return True, ""
 
 
+# fmt: off
 
 def removeComments(module):
     retModule = Module()
@@ -234,8 +253,8 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
 
         return InstStreams
 
-    verificationMessage = opt1.getValidationMessage({'kernel' : kernel})
-    assert not verificationMessage, f"Validation failed: {verificationMessage}"
+    status, message = opt1.validate({'kernel' : kernel})
+    assert not status, f"Validation failed: {message}"
 
     InstStreams = convOptToStream(opt1)
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -66,7 +66,7 @@ def verifyAscendingOrder(scheduleInfo, context: Dict = {}):
             for i in range(1, len(seq)):
                 if seq[i] < seq[i - 1]:
                     return False, (
-                        f"Non-descending-order rule violated, "
+                        f"Non-descending-order rule failed, "
                         f"schedule key '{k}', sequence {seq}: "
                         f"value {seq[i]} at index {i} is less than "
                         f"{seq[i-1]} at index {i-1}."
@@ -241,7 +241,7 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
         return InstStreams
 
     status, message = opt1.isValid({'kernel' : kernel})
-    assert status is True, f"Validation failed: {message}"
+    assert status is True, f"Custom mainloop schedule validation failed: {message}"
 
     InstStreams = convOptToStream(opt1)
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -77,7 +77,7 @@ def verifyAscendingOrder(scheduleInfo, context: Dict = {}):
 class ScheduleInfo:
     numCodePaths: int
     numMfma: int
-    skipValidation: bool
+    __skipValidation__: bool
 
     def __init__(
         self,
@@ -87,8 +87,7 @@ class ScheduleInfo:
         syncCode,
         nglshift,
         nllshift,
-        mfmaReorder=[],
-        skipValidation=False,
+        mfmaReorder=[]
     ):
         self.numCodePaths = numCodePaths
         self.numMfma = numMfma
@@ -97,12 +96,15 @@ class ScheduleInfo:
         self.nglshift = nglshift  # vmcnt shift for noglobalload loop
         self.nllshift = nllshift  # vmcnt shift for nolocalload loop
         self.mfmaReorder = mfmaReorder
-        self.skipValidation = skipValidation
+        self.__skipValidation__ = False
 
-        # The set of validation rules to inside `isValid`.
+        # The set of validation rules to run inside `isValid`.
         self.rules: List[Callable[[ScheduleInfo, dict], [bool, str]]] = [
             verifyAscendingOrder
         ]
+
+    def disableValidation(self):
+        self.__skipValidation__ = True
 
     def isValid(self, context: Dict):
         """
@@ -113,13 +115,19 @@ class ScheduleInfo:
         is valid. It may be a false negative.
 
         Note 2: if False is returned, this is not proof that the schedule
-        is invalid. It may be a false positive. `skipValidation` can be
-        used to avoid validation in this case.
+        is invalid. It may be a false positive.
         """
 
-        if self.skipValidation:
+
+        if self.__skipValidation__:
+            mt0 = context.get("kernel", {}).get("MacroTile0", "?")
+            mt1 = context.get("kernel", {}).get("MacroTile1", "?")
+            du  = context.get("kernel", {}).get("DepthU", "?")
+            message = f"CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = {mt0}x{mt1}x{du}"
+            print(f"WARNING: {message}")
+
             # All rules bypassed, considered valid.
-            return True, ""
+            return True, message
 
         for rule in self.rules:
             status, message = rule(self, context)
@@ -387,7 +395,7 @@ def _get_schedule_256x96x64_16bit(kernel, useLDSTr, TLDS):
 
     if isTN(kernel) and TLDS == 1:
 
-        nglshift = nllshift = 11 
+        nglshift = nllshift = 11
         syncTable = [
                     -1, SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment=""),
                     7, SWaitCnt(dscnt=8, vlcnt=-1, vscnt=-1, comment=""),
@@ -403,11 +411,11 @@ def _get_schedule_256x96x64_16bit(kernel, useLDSTr, TLDS):
 
                     42, SWaitCnt(dscnt=-1, vlcnt=11, vscnt=-1, comment="Only global reads for this iter"),
                     42, SBarrier(comment="")]
- 
+
         syncCode = syncTable[1::2]
         optSchedule = {
             'SYNC'   : [syncTable[::2]],
-            'GRIncA' : [[1,1,2,2,3,3,3,4,4]], 
+            'GRIncA' : [[1,1,2,2,3,3,3,4,4]],
             'GRIncB' : [[5,5,6,6,6,7,7,8,8]],
             'LRA0'   : [[1,2,3,4,5,6,  8,10],
                         [1,2,3,4,5,6,  9,11]],
@@ -419,8 +427,8 @@ def _get_schedule_256x96x64_16bit(kernel, useLDSTr, TLDS):
                         [17,17,19,19,21,21,23,23,25,25,27,27,29,29,31,31]],
             'LRA1'   : [[36,37,38,39,40,41,42,43]],
             'LRB1'   : [[44,45,46]],
-            'LRSA'   : [[30]], # this must come before next reads of A X0 - so the LRA1 
-            'LRSB'   : [[31]], # this must come before next reads of A X0 - so the LRB1 
+            'LRSA'   : [[30]], # this must come before next reads of A X0 - so the LRA1
+            'LRSB'   : [[31]], # this must come before next reads of A X0 - so the LRB1
             'LWSA'   : [[32]],  # swap after last gr a
             'LWSB'   : [[42]],  # swap after last gr b
             'LCC'   : [[47, 47]],
@@ -1096,11 +1104,11 @@ def _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS):
         ]
 
         nglshift = nllshift = 34
-        
+
     elif isNN(kernel) and useLDSTr and TLDS==1:
         kernel["SwapGlobalReadOrder"] = True
         nglshift = nllshift = 0
-        
+
         optSchedule = {
             # last index of producer <SYNC> first index of consumer
             # SYNC[0] = -1 to align all waves at the start of the loop
@@ -1113,7 +1121,7 @@ def _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS):
             # LRB0 scheduled after the A fence, overlapping with GRA/GRB
             'LRB0': [[24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 35]],
 
-            # Address increments for GR 
+            # Address increments for GR
             'GRIncA': [[0, 0, 0, 1, 1, 1, 2, 2, 2]],
             'GRIncB': [[3, 3, 3, 4, 4, 4, 5, 5, 5]],
 
@@ -1131,7 +1139,7 @@ def _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS):
                     64, 64, 66, 66, 67, 67, 69, 69,
                     71, 71, 73, 73, 74, 74, 76, 76,
                     78, 78, 79, 79]],
-            
+
             # from epilogue in the default schedule
             # these are not updated in the updated schedule
             'LRSA': [[50]],
@@ -1142,19 +1150,19 @@ def _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS):
             'LRB1': [[83, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99]], # 13
             'LCC':  [[100, 100]],
         }
-        
+
         syncCode = [
             SWaitCnt(dscnt=12, vlcnt=-1, vscnt=-1, comment="wait for prior iteration LR/LW"),
             SWaitCnt(dscnt=11, vlcnt=-1, vscnt=-1, comment="ensure all previous LRA1/LRB1 done before early MFMA use"),
             SWaitCnt(dscnt=10, vlcnt=-1, vscnt=-1, comment="ensure all previous LRA1/LRB1 done before early MFMA use"),
 
-            
+
             # A fence: all LRA0 are done before DTL writes from the first GR stream startign at 23 (swapped)
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="wait for LRA0 to complete before first DTL writes"),
             # barrier after LRA0, before first global DTL phase at 23
             SBarrier(comment="barrier after LRA0 , before GR at 23"),
 
-            # B fence : all LRB0 are done before second DTL stream 
+            # B fence : all LRB0 are done before second DTL stream
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="wait for LRB0 to complete before second DTL writes"),
             # barrier after LRB0 before second global stream at 36
             SBarrier(comment="barrier after LRB0, before GR at 36"),
@@ -1164,7 +1172,7 @@ def _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS):
             # final barrier : all waves; make next-tile LDS visible to LRA1/LRB1
             SBarrier(comment="final barrier before LRA1/LRB1 (at 83)"),
         ]
-        
+
         nglshift = nllshift = 34
     else:
         return False, None
@@ -1356,7 +1364,7 @@ def _get_schedule_240x256x64_16bit(kernel, useLDSTr, TLDS):
             SBarrier(comment=""),
             SWaitCnt(dscnt=-1, vlcnt=38, vscnt=-1, comment="wait for previous set of GRB"),
             SBarrier(comment="")
-        ]   
+        ]
         numMfma = 120
         nglshift = nllshift = len(optSchedule["GRA"][0])/2 + len(optSchedule["GRB"][0])/2
     else:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -38,11 +38,18 @@ from Tensile.Common import IsaVersion
 from Tensile.Utilities.Decorators.Shared import CallableGuard
 
 from copy import deepcopy
+from typing import Dict
+
 
 class ScheduleInfo:
     numCodePaths: int
     numMfma: int
-    def __init__(self, numCodePaths, numMfma, optSchedule, syncCode, nglshift, nllshift, mfmaReorder = []):
+    isKnownValid : bool
+    def __init__(self, numCodePaths, numMfma, optSchedule, syncCode, nglshift, nllshift, mfmaReorder = [], isKnownValid = False):
+        """
+        isKnownValid : if True, an expert should have verified that the schedule is valid (no race conditions, etc) and
+                       that no validation checks should be run.
+        """
         self.numCodePaths = numCodePaths
         self.numMfma = numMfma
         self.optSchedule = optSchedule
@@ -50,6 +57,71 @@ class ScheduleInfo:
         self.nglshift = nglshift # vmcnt shift for noglobalload loop
         self.nllshift = nllshift # vmcnt shift for nolocalload loop
         self.mfmaReorder = mfmaReorder
+        self.isKnownValid = isKnownValid
+        self.rules = [self.ruleNonDescendingOrder] # The set of validation rules to run when this object calls `getValidationMessage`.
+
+    def ruleNonDescendingOrder(self, context: Dict = {}):
+        """
+        Ensure that all sequences of optSchedule are non-decreasing.
+
+        Context and example: There will be a sequence of N 'GRIncA' instructions for
+        incrementing the memory address that the A macro tile is read from.
+        The CMS developer has the freedom to insert these N instructions into
+        'slots' of their choice. A slot is a sequence of instructions between
+        2 consecutive mfma instructions. Example: 'GRIncA' : [[0,1,1,3]] would
+        mean that the N=4 instructions to increment the pointer appear as follows:
+
+        instruction 1    : between mfma 0 and mfma 1.
+        instructions 2,3 : between mfma 1 and mfma 2.
+        instruction 4    : between mfma 3 and mfma 4.
+
+        However, there is a strict requirement that the N slots for these instructions
+        are non-decreasing. This rule is true for all groups of instructions, not
+        just the 'GRIncA' instructions (to be verified).
+        """
+
+        for k, sequences in self.optSchedule.items():
+            for seq in sequences:
+                print(k)
+                print(seq)
+                # Ensure seq is non-decreasing
+                for i in range(1, len(seq)):
+                    print(seq[i])
+                    if seq[i] < seq[i - 1]:
+                        return (f"Non-descending-order rule violated, "
+                                f"schedule key '{k}', sequence {seq}: "
+                                f"value {seq[i]} at index {i} is less than "
+                                f"{seq[i-1]} at index {i-1}.")
+        return ""
+
+
+    def getValidationMessage(self, context: Dict):
+        """
+        Returns the empty string if this schedule is considered to be
+        valid for `kernel`. If the returned string is not empty, it
+        contains the reason that this schedule is considered invalid.
+
+        Note 1: An empty string is not proof that this schedule is valid.
+        i.e: it may be a false negative.
+
+        Note 2: if a non-empty string is returned, and the reason is
+        considered by an expert developer to be incorrect, you can create a
+        ScheduleInfo with `isKnownValid = True`. This is a workaround
+        for possible false positives.
+        """
+
+        if self.isKnownValid:
+            # All rules bypassed, considered valid.
+            return ""
+
+        for rule in self.rules:
+            result = rule(context)
+            if result:
+                return result
+
+        # All rules passed, considered valid.
+        return ""
+
 
 
 def removeComments(module):
@@ -118,6 +190,7 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
     numCodePath = opt1.numCodePaths
     assert opt1.numMfma == len(mfmaCode)
 
+
     for _, indexList in opt1.optSchedule.items():
         assert len(indexList) <= opt1.numCodePaths
 
@@ -160,6 +233,9 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
             addToStream(key, stream, idMap[key])
 
         return InstStreams
+
+    verificationMessage = opt1.getValidationMessage({'kernel' : kernel})
+    assert not verificationMessage, f"Validation failed: {verificationMessage}"
 
     InstStreams = convOptToStream(opt1)
 
@@ -402,7 +478,7 @@ def _get_schedule_192x256x64_16bit(kernel, useLDSTr, TLDS):
         nglshift = nllshift = 14 # vmcnt shift for ngl and nll
     elif isNT(kernel) and not useLDSTr and TLDS == 0:
         kernel["UsePLRPack"] = True
-        
+
         optSchedule = {
             'SYNC'  : [[25, 25, 46, 46, 55, 55]],
             'GRIncA': [[0, 0, 0, 1, 1, 1, 2, 2, 2]],
@@ -429,7 +505,7 @@ def _get_schedule_192x256x64_16bit(kernel, useLDSTr, TLDS):
             'PackA0': [[47, 47, 47, 47, 47, 47, 48, 48, 48, 48, 48, 48, 48, 48, 49, 49, 49, 49, 49, 49, 49, 49, 50, 50]],
             'LCC'   : [[95, 95]],
         }
-        
+
         syncCode = [SWaitCnt(dscnt=15, vlcnt=-1, vscnt=-1, comment="Wait for LRA0 to complete") ,
                     SBarrier(comment="") ,
                     SWaitCnt(dscnt=8, vlcnt=-1, vscnt=-1, comment="Wait for LRB0 to complete") ,
@@ -753,7 +829,7 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
             'LRB0'   : [[0,1,2,3,4,5,6,7]],
             # Buffer loads.
             'GRB'    : [[51,51, 55,55, 59,61, 76,77, 78,78]],
-            'GRA'    : [[11,12, 16,16, 20,20, 24,24, 28, 28, 32,32, 36, 36, 40, 40]], 
+            'GRA'    : [[11,12, 16,16, 20,20, 24,24, 28, 28, 32,32, 36, 36, 40, 40]],
             # Prefetch next iteration.
             'LRA1'   : [[62,63,64,65,66,67,68,69,70,71]],
             'LRB1'   : [[41,42,43,44,45,46,47,49]],
@@ -828,7 +904,7 @@ def _get_schedule_256x160x64_16bit(kernel, useLDSTr, TLDS):
             'LRB0'   : [[0,0,1,2,3]],
             # Buffer loads.
             'GRB'    : [[30,30, 33,33, 36,36, 52,52, 56,56, 60,61, 76,77, 78,78]],
-            'GRA'    : [[11,12, 16,16, 20,20, 23,25, 26, 28]], 
+            'GRA'    : [[11,12, 16,16, 20,20, 23,25, 26, 28]],
             # Prefetch next iteration.
             'LRA1'   : [[62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77]],
             'LRB1'   : [[41,42,43,44,45]],
@@ -1379,7 +1455,7 @@ def hasCustomSchedule(kernel):
     elif is256x240x64DTL and is16bit and not isMixed and ([GRVWA, GRVWB, LRVW] == [8,2,8]) and MI == [16,16,32,1] and MIWG == [4,1]:
         return _get_schedule_256x240x64_16bit(kernel, useLDSTr, TLDS)
     elif is256x208x64DTL and is16bit and not isMixed and ([GRVWA, GRVWB, LRVW] == [8, 2, 8]) and MI == [16, 16, 32, 1] and MIWG == [4, 1]:
-        return _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS) 
+        return _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS)
     elif is224x256x64DTL and is16bit and not isMixed and ([GRVWA, GRVWB, LRVW] == [8, 8, 8]) and MI == [16, 16, 32, 1] and MIWG == [2, 2]:
         return _get_schedule_224x256x64_16bit(kernel, useLDSTr, TLDS)
     elif is256x224x64DTL and is16bit and not isMixed and ([GRVWA, GRVWB, LRVW] == [8, 8, 8]) and MI == [16, 16, 32, 1] and MIWG == [2, 2]:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -545,8 +545,8 @@ def _get_schedule_256x192x64_16bit(kernel, useLDSTr, TLDS):
                      55, SWaitCnt(dscnt=6, vlcnt=-1, vscnt=-1, comment="wait for LRB0-1"),
                      63, SWaitCnt(dscnt=6, vlcnt=-1, vscnt=-1, comment="wait for LRB0-2"),
                      70, SWaitCnt(dscnt=-1, vlcnt=12, vscnt=-1, comment="for LRB1"),
-                     71, SWaitCnt(dscnt=11, vlcnt=-1, vscnt=-1, comment="wait for LRB0-3"),
                      70, SBarrier(comment="for LRB1"),
+                     71, SWaitCnt(dscnt=11, vlcnt=-1, vscnt=-1, comment="wait for LRB0-3"),
                      79, SWaitCnt(dscnt=13, vlcnt=-1, vscnt=-1, comment="wait for LRB0 remaining"),]
         optSchedule = {
                 'SYNC'  : [syncTable[::2]],

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -20,8 +20,6 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-# fmt: off
-
 from rocisa.code import KernelBody, Label, Macro, Module, RegSet, SrdUpperValue, \
                         StructuredModule, TextBlock, ValueEndif, ValueIf, ValueElseIf, ValueSet, SignatureBase
 from rocisa.container import vgpr, sgpr, SMEMModifiers, replaceHolder, EXEC,\
@@ -42,15 +40,13 @@ from Tensile.Utilities.Decorators.Shared import CallableGuard
 from copy import deepcopy
 from typing import Dict
 
-# fmt: on
 
-
-def validateAscendingOrder(scheduleInfo, context: Dict = {}):
+def verifyAscendingOrder(scheduleInfo, context: Dict = {}):
     """
-    Ensure that all sequences of optSchedule are non-decreasing.
+    Ensure that all sequences of scheduleInfo.optSchedule are non-decreasing.
 
-    Context and example: There will be a sequence of N 'GRIncA' instructions for
-    incrementing the memory address that the A macro tile is read from.
+    Context and example: There will be a sequence of N 'GRIncA' instructions
+    for incrementing the memory address that the A macro tile is read from.
     The CMS developer has the freedom to insert these N instructions into
     'slots' of their choice. A slot is a sequence of instructions between
     2 consecutive mfma instructions. Example: 'GRIncA' : [[0,1,1,3]] would
@@ -60,14 +56,13 @@ def validateAscendingOrder(scheduleInfo, context: Dict = {}):
     instructions 2,3 : between mfma 1 and mfma 2.
     instruction 4    : between mfma 3 and mfma 4.
 
-    However, there is a strict requirement that the N slots for these instructions
-    are non-decreasing. This rule is true for all groups of instructions, not
-    just the 'GRIncA' instructions (to be verified).
+    However, there is a correctness requirement that the N slots for these
+    instructions are non-decreasing. This rule is true for all groups of instructions,
+    not just the 'GRIncA' instructions.
     """
 
     for k, sequences in scheduleInfo.optSchedule.items():
         for seq in sequences:
-            # Ensure seq is non-decreasing
             for i in range(1, len(seq)):
                 if seq[i] < seq[i - 1]:
                     return False, (
@@ -95,10 +90,6 @@ class ScheduleInfo:
         mfmaReorder=[],
         skipValidation=False,
     ):
-        """
-        skipValidation : if True, an expert should have verified that the schedule is
-            valid (no race conditions, etc). No validation checks be run during compilation.
-        """
         self.numCodePaths = numCodePaths
         self.numMfma = numMfma
         self.optSchedule = optSchedule
@@ -108,24 +99,22 @@ class ScheduleInfo:
         self.mfmaReorder = mfmaReorder
         self.skipValidation = skipValidation
 
-        # The set of validation rules to run when this object calls `getValidationMessage`.
+        # The set of validation rules to inside `isValid`.
         self.rules: List[Callable[[ScheduleInfo, dict], [bool, str]]] = [
-            validateAscendingOrder
+            verifyAscendingOrder
         ]
 
-    def validate(self, context: Dict):
+    def isValid(self, context: Dict):
         """
-        Returns the empty string if this schedule is considered to be
-        valid for `kernel`. If the returned string is not empty, it
-        contains the reason that this schedule is considered invalid.
+        Return True if all the validation rules pass, False otherwise.
+        If validation fails, a string containing the reason is returned.
 
-        Note 1: An empty string is not proof that this schedule is valid.
-        i.e: it may be a false negative.
+        Note 1: If True is returned, this is not proof that this schedule
+        is valid. It may be a false negative.
 
-        Note 2: if a non-empty string is returned, and the reason is
-        considered by an expert developer to be incorrect, you can create a
-        ScheduleInfo with `skipValidation = True`. This is a workaround
-        for possible false positives.
+        Note 2: if False is returned, this is not proof that the schedule
+        is invalid. It may be a false positive. `skipValidation` can be
+        used to avoid validation in this case.
         """
 
         if self.skipValidation:
@@ -134,14 +123,12 @@ class ScheduleInfo:
 
         for rule in self.rules:
             status, message = rule(self, context)
-            if status:
-                return status, message
+            if status is False:
+                return False, message
 
         # All rules passed, considered valid.
         return True, ""
 
-
-# fmt: off
 
 def removeComments(module):
     retModule = Module()
@@ -253,13 +240,12 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
 
         return InstStreams
 
-    status, message = opt1.validate({'kernel' : kernel})
-    assert not status, f"Validation failed: {message}"
+    status, message = opt1.isValid({'kernel' : kernel})
+    assert status is True, f"Validation failed: {message}"
 
     InstStreams = convOptToStream(opt1)
 
     macro = Macro("MAINLOOP", ["ID", "useGR=1", "usePLR=1", "useGRInc=1", "useLoop=1"])
-    #macro.add(SBarrier(comment="debug"))
 
     lastIter = numLoopIter - 1
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/Common/test_Architectures.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/Common/test_Architectures.py
@@ -201,6 +201,7 @@ def test_filterLogicFilesByPredicates_no_match(mock_logic_file):
         result = filterLogicFilesByPredicates(logicFiles, predicateMap)
         assert len(result) == 0
 
+@pytest.mark.xfail
 def test_filterLogicFilesByPredicates_match_emulation_ids(mock_logic_file):
     logicFiles = ["file1.yaml"]
     predicateMap = {

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -1,0 +1,180 @@
+import pytest
+from unittest.mock import MagicMock
+
+from Tensile.Components.CustomSchedule import hasCustomSchedule, ScheduleInfo
+from Tensile.Common import IsaVersion
+
+# Helper to create a mock data type
+def _mock_dtype(is_16bit=False, is_8bit=False, num_bytes=4):
+    mock = MagicMock()
+    mock.isHalf.return_value = is_16bit
+    mock.isBFloat16.return_value = False # Assuming isHalf is enough for is16bit
+    mock.isInt8.return_value = is_8bit
+    mock.is8bitFloat.return_value = False # Assuming isInt8 is enough for is8bit
+    mock.numBytes.return_value = num_bytes
+    return mock
+
+# Base kernel configuration factory
+def create_base_kernel():
+    kernel = {
+        "UseCustomMainLoopSchedule": True,
+        "EnableMatrixInstruction": True,
+        "ISA": IsaVersion(9,5,0),
+        "ProblemType": {
+            "DataType": _mock_dtype(),
+            "DataTypeA": _mock_dtype(),
+            "DataTypeB": _mock_dtype(),
+            "TransposeA": False,
+            "TransposeB": False,
+        },
+        "MacroTile0": 0, "MacroTile1": 0, "DepthU": 0,
+        "PrefetchGlobalRead": 0, "PrefetchLocalRead": 0, "DirectToLds": False,
+        "GlobalReadVectorWidthA": 0, "GlobalReadVectorWidthB": 0,
+        "LocalReadVectorWidth": 0,
+        "MatrixInstruction": [],
+        "MIWaveGroup": [],
+        "LDSTrInst": False,
+        "TransposeLDS": 0,
+        "ForceUnrollSubIter": False,
+        "SwapGlobalReadOrder": False, # For asserting it gets set
+        "UsePLRPack": False, # For asserting it gets set
+    }
+    return kernel
+
+class TestCustomSchedule:
+    def test_no_custom_schedule(self):
+        """Test that a kernel that doesn't match any condition returns False."""
+        kernel = create_base_kernel()
+        # An empty kernel should not have a custom schedule
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert not has_schedule
+        assert schedule_info is None
+
+    def test_schedule_256x256x64_16bit_TN(self):
+        """Tests the 256x256x64 16-bit TN schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 256, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2], "TransposeLDS": 1
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 128
+        assert 'PackA0' not in schedule_info.optSchedule
+        assert not kernel["UsePLRPack"]
+
+    def test_schedule_256x256x64_16bit_NT(self):
+        """Tests the 256x256x64 16-bit NT schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": False, "TransposeB": True
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 256, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": False, "TransposeLDS": 0
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 128
+        assert 'PackA0' in schedule_info.optSchedule
+        assert kernel["UsePLRPack"]
+
+    @pytest.mark.parametrize("transA, transB", [(False, False), (True, True)])
+    def test_schedule_256x256x64_16bit_NN_TT(self, transA, transB):
+        """Tests the 256x256x64 16-bit NN and TT schedules."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 256, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": False, "TransposeLDS": 1
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 128
+        assert kernel["UsePLRPack"]
+        if transA and transB: # isTT
+            assert kernel["SwapGlobalReadOrder"]
+            assert 'PackB0' in schedule_info.optSchedule
+            assert 'PackA0' not in schedule_info.optSchedule
+        else: # isNN
+            assert not kernel["SwapGlobalReadOrder"]
+            assert 'PackA0' in schedule_info.optSchedule
+            assert 'PackB0' not in schedule_info.optSchedule
+
+    def test_schedule_256x256x128_8bit_TN(self):
+        """Tests the 256x256x128 8-bit TN schedule."""
+        kernel = create_base_kernel()
+        dtype_8bit = _mock_dtype(is_8bit=True, num_bytes=1)
+        kernel["ProblemType"].update({
+            "DataType": dtype_8bit, "DataTypeA": dtype_8bit, "DataTypeB": dtype_8bit,
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 256, "DepthU": 128,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 16, "GlobalReadVectorWidthB": 16, "LocalReadVectorWidth": 16,
+            "MatrixInstruction": [16,16,128,1], "MIWaveGroup": [2,2], "TransposeLDS": 1
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 1
+        assert schedule_info.numMfma == 64
+        assert len(schedule_info.mfmaReorder) > 0
+
+    def test_schedule_192x256x64_16bit_NN(self):
+        """Tests the 192x256x64 16-bit NN schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": False, "TransposeB": False
+        })
+        kernel.update({
+            "MacroTile0": 192, "MacroTile1": 256, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": True, "TransposeLDS": 1
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 96
+        assert kernel["SwapGlobalReadOrder"]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -50,6 +50,40 @@ class TestCustomSchedule:
         assert not has_schedule
         assert schedule_info is None
 
+    def test_schedule_validation_non_descending_order(self):
+        """
+        Test of the rule that instructions in each instruction category appear in non-descending order
+        """
+
+        sched = ScheduleInfo(None, None,  {'P' : [[3, 2, 1]]}, None, None, None, None, None)
+        output = sched.ruleNonDescendingOrder()
+
+        expected = "Non-descending-order rule violated, schedule key 'P', sequence [3, 2, 1]: value 2 at index 1 is less than 3 at index 0."
+        print(output in expected)
+        print(expected in output)
+        assert output == expected
+
+        sched = ScheduleInfo(None, None,  {'P' : [[1, 1, 2]]}, None, None, None, None, None)
+        output = sched.ruleNonDescendingOrder()
+        assert not output
+
+    def test_schedule_validation_is_known_valid(self):
+        """
+        Test of the flag that expect custom mainloop schedule (CMS) developers can use to override the
+        validation checks.
+        """
+        kernel = create_base_kernel()
+        invalid_schedule = {'P' : [[3, 2, 1]]}
+
+        # No verification message means that the schedule info is considered valid.
+        sched = ScheduleInfo(None, None, invalid_schedule, None, None, None, None, isKnownValid = True)
+        assert not sched.getValidationMessage({})
+
+        # A non-empty verification message means that the schedule info is considered invalid.
+        sched = ScheduleInfo(None, None,  invalid_schedule, None, None, None, None, isKnownValid = False)
+        assert sched.getValidationMessage({})
+
+
     def test_schedule_256x256x64_16bit_TN(self):
         """Tests the 256x256x64 16-bit TN schedule."""
         kernel = create_base_kernel()
@@ -172,9 +206,9 @@ class TestCustomSchedule:
         })
 
         has_schedule, schedule_info = hasCustomSchedule(kernel)
-
         assert has_schedule
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 96
         assert kernel["SwapGlobalReadOrder"]
+

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 
-from Tensile.Components.CustomSchedule import hasCustomSchedule, ScheduleInfo, validateAscendingOrder
+from Tensile.Components.CustomSchedule import hasCustomSchedule, ScheduleInfo, verifyAscendingOrder
 from Tensile.Common import IsaVersion
 
 # Helper to create a mock data type
@@ -49,39 +49,6 @@ class TestCustomSchedule:
         has_schedule, schedule_info = hasCustomSchedule(kernel)
         assert not has_schedule
         assert schedule_info is None
-
-    def test_schedule_validation_non_descending_order(self):
-        """
-        Test of the rule that instructions in each instruction category appear in non-descending order
-        """
-
-        sched = ScheduleInfo(None, None,  {'P' : [[3, 2, 1]]}, None, None, None, None, None)
-        status, message = validateAscendingOrder(sched)
-
-        expected = "Non-descending-order rule violated, schedule key 'P', sequence [3, 2, 1]: value 2 at index 1 is less than 3 at index 0."
-        assert status == False
-        assert message == expected
-
-        sched = ScheduleInfo(None, None,  {'P' : [[1, 1, 2]]}, None, None, None, None, None)
-        status, message = validateAscendingOrder(sched)
-        assert status == True
-
-    def test_schedule_validation_is_known_valid(self):
-        """
-        Test of the flag that expect custom mainloop schedule (CMS) developers can use to override the
-        validation checks.
-        """
-        kernel = create_base_kernel()
-        invalid_schedule = {'P' : [[3, 2, 1]]}
-
-        # No verification message means that the schedule info is considered valid.
-        sched = ScheduleInfo(None, None, invalid_schedule, None, None, None, None, skipValidation = True)
-        status, message = sched.validate({})
-        assert status == True
-
-        # A non-empty verification message means that the schedule info is considered invalid.
-        satus, message = ScheduleInfo(None, None,  invalid_schedule, None, None, None, None, skipValidation = False).validate({})
-        assert status == False
 
 
     def test_schedule_256x256x64_16bit_TN(self):
@@ -212,3 +179,45 @@ class TestCustomSchedule:
         assert schedule_info.numMfma == 96
         assert kernel["SwapGlobalReadOrder"]
 
+
+class TestCustomScheduleValidation:
+    def test_schedule_validation_non_descending_order(self):
+        """
+        Test of the rule that instructions in each category
+        appear in non-descending order
+        """
+
+        sched = ScheduleInfo(
+            None, None, {"P": [[3, 2, 1]]}, None, None, None, None, None
+        )
+        status, message = verifyAscendingOrder(sched)
+
+        expected = "Non-descending-order rule violated, schedule key 'P', sequence [3, 2, 1]: value 2 at index 1 is less than 3 at index 0."
+        assert status == False
+        assert message == expected
+
+        sched = ScheduleInfo(
+            None, None, {"P": [[1, 1, 2]]}, None, None, None, None, None
+        )
+        status, message = verifyAscendingOrder(sched)
+        assert status == True
+
+    def test_schedule_validation_disable(self):
+        """
+        Test of the flag that custom mainloop schedule (CMS) developers can use to override the
+        validation checks.
+        """
+        kernel = create_base_kernel()
+        invalid_schedule = {"P": [[3, 2, 1]]}
+
+        # No verification message means that the schedule info is considered valid.
+        status, message = ScheduleInfo(
+            None, None, invalid_schedule, None, None, None, None, skipValidation=True
+        ).isValid({})
+        assert status == True
+
+        # A non-empty verification message means that the schedule info is considered invalid.
+        status, message = ScheduleInfo(
+            None, None, invalid_schedule, None, None, None, None, skipValidation=False
+        ).isValid({})
+        assert status == False

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 
-from Tensile.Components.CustomSchedule import hasCustomSchedule, ScheduleInfo
+from Tensile.Components.CustomSchedule import hasCustomSchedule, ScheduleInfo, validateAscendingOrder
 from Tensile.Common import IsaVersion
 
 # Helper to create a mock data type
@@ -56,16 +56,15 @@ class TestCustomSchedule:
         """
 
         sched = ScheduleInfo(None, None,  {'P' : [[3, 2, 1]]}, None, None, None, None, None)
-        output = sched.ruleNonDescendingOrder()
+        status, message = validateAscendingOrder(sched)
 
         expected = "Non-descending-order rule violated, schedule key 'P', sequence [3, 2, 1]: value 2 at index 1 is less than 3 at index 0."
-        print(output in expected)
-        print(expected in output)
-        assert output == expected
+        assert status == False
+        assert message == expected
 
         sched = ScheduleInfo(None, None,  {'P' : [[1, 1, 2]]}, None, None, None, None, None)
-        output = sched.ruleNonDescendingOrder()
-        assert not output
+        status, message = validateAscendingOrder(sched)
+        assert status == True
 
     def test_schedule_validation_is_known_valid(self):
         """
@@ -76,12 +75,13 @@ class TestCustomSchedule:
         invalid_schedule = {'P' : [[3, 2, 1]]}
 
         # No verification message means that the schedule info is considered valid.
-        sched = ScheduleInfo(None, None, invalid_schedule, None, None, None, None, isKnownValid = True)
-        assert not sched.getValidationMessage({})
+        sched = ScheduleInfo(None, None, invalid_schedule, None, None, None, None, skipValidation = True)
+        status, message = sched.validate({})
+        assert status == True
 
         # A non-empty verification message means that the schedule info is considered invalid.
-        sched = ScheduleInfo(None, None,  invalid_schedule, None, None, None, None, isKnownValid = False)
-        assert sched.getValidationMessage({})
+        satus, message = ScheduleInfo(None, None,  invalid_schedule, None, None, None, None, skipValidation = False).validate({})
+        assert status == False
 
 
     def test_schedule_256x256x64_16bit_TN(self):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -193,7 +193,7 @@ class TestCustomScheduleValidation:
         """
 
         sched = ScheduleInfo(
-            None, None, {"P": [[3, 2, 1]]}, None, None, None, None, None
+            None, None, {"P": [[3, 2, 1]]}, None, None, None, None
         )
         status, message = verifyAscendingOrder(sched)
 
@@ -202,7 +202,7 @@ class TestCustomScheduleValidation:
         assert message == expected
 
         sched = ScheduleInfo(
-            None, None, {"P": [[1, 1, 2]]}, None, None, None, None, None
+            None, None, {"P": [[1, 1, 2]]}, None, None, None, None
         )
         status, message = verifyAscendingOrder(sched)
         assert status == True
@@ -216,19 +216,18 @@ class TestCustomScheduleValidation:
         invalid_schedule = {"P": [[3, 2, 1]]}
 
         # No verification message means that the schedule info is considered valid.
-        status, message = ScheduleInfo(
-            None, None, invalid_schedule, None, None, None, None, skipValidation=True
-        ).isValid({})
+        scheduleInfo = ScheduleInfo(
+            None, None, invalid_schedule, None, None, None, None
+        )
+        scheduleInfo.disableValidation()
+        status, message = scheduleInfo.isValid({"kernel" : {"DepthU": 42}})
         assert status == True
+        assert message == "CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = ?x?x42"
 
         # A non-empty verification message means that the schedule info is considered invalid.
         status, message = ScheduleInfo(
-            None, None, invalid_schedule, None, None, None, None, skipValidation=False
+            None, None, invalid_schedule, None, None, None, None
         ).isValid({})
         assert status == False
-
-
-
-
 
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -72,6 +72,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 128
+        assert schedule_info.isValid({"kernel" : kernel})[0]
         assert 'PackA0' not in schedule_info.optSchedule
         assert not kernel["UsePLRPack"]
 
@@ -99,6 +100,7 @@ class TestCustomSchedule:
         assert schedule_info.numMfma == 128
         assert 'PackA0' in schedule_info.optSchedule
         assert kernel["UsePLRPack"]
+        assert schedule_info.isValid({"kernel" : kernel})[0]
 
     @pytest.mark.parametrize("transA, transB", [(False, False), (True, True)])
     def test_schedule_256x256x64_16bit_NN_TT(self, transA, transB):
@@ -124,6 +126,7 @@ class TestCustomSchedule:
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 128
         assert kernel["UsePLRPack"]
+        assert schedule_info.isValid({"kernel" : kernel})[0]
         if transA and transB: # isTT
             assert kernel["SwapGlobalReadOrder"]
             assert 'PackB0' in schedule_info.optSchedule
@@ -155,6 +158,7 @@ class TestCustomSchedule:
         assert schedule_info.numCodePaths == 1
         assert schedule_info.numMfma == 64
         assert len(schedule_info.mfmaReorder) > 0
+        assert schedule_info.isValid({"kernel" : kernel})[0]
 
     def test_schedule_192x256x64_16bit_NN(self):
         """Tests the 192x256x64 16-bit NN schedule."""
@@ -178,6 +182,7 @@ class TestCustomSchedule:
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 96
         assert kernel["SwapGlobalReadOrder"]
+        assert schedule_info.isValid({"kernel" : kernel})[0]
 
 
 class TestCustomScheduleValidation:
@@ -192,7 +197,7 @@ class TestCustomScheduleValidation:
         )
         status, message = verifyAscendingOrder(sched)
 
-        expected = "Non-descending-order rule violated, schedule key 'P', sequence [3, 2, 1]: value 2 at index 1 is less than 3 at index 0."
+        expected = "Non-descending-order rule failed, schedule key 'P', sequence [3, 2, 1]: value 2 at index 1 is less than 3 at index 0."
         assert status == False
         assert message == expected
 
@@ -221,3 +226,9 @@ class TestCustomScheduleValidation:
             None, None, invalid_schedule, None, None, None, None, skipValidation=False
         ).isValid({})
         assert status == False
+
+
+
+
+
+

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_MatrixInstructionConversion.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_MatrixInstructionConversion.py
@@ -98,7 +98,6 @@ WorkGroup: [16, 16, 1]
     assert outputConf["MIInputPerThreadB"] == 5
     assert outputConf["MIInputPerThreadMetadata"] == 5
     assert outputConf["ThreadTile"] == [1, 1]
-    assert outputConf["Sparse"] == 0
     assert outputConf["WorkGroup"] == [128, 3, 1]
     assert outputConf["WavefrontSize"] == 48
     assert outputConf["ISA"] == isa
@@ -201,7 +200,6 @@ custom.config:
     assert outputConf["MIInputPerThreadB"] == 5
     assert outputConf["MIInputPerThreadMetadata"] == 5
     assert outputConf["ThreadTile"] == [1, 1]
-    assert outputConf["Sparse"] == 0
     assert outputConf["WorkGroup"] == [1280, 2, 6]  # Why do we change the workgroup here?
     assert outputConf["WavefrontSize"] == 48
     assert outputConf["ISA"] == isa

--- a/projects/hipblaslt/tensilelite/tox.ini
+++ b/projects/hipblaslt/tensilelite/tox.ini
@@ -20,17 +20,26 @@ deps =
     invoke
 setenv =
     TENSILE_CLIENT_STATIC = {env:TENSILE_CLIENT_STATIC:}
-    PYTHONPATH = {envdir}/build_tmp/tensilelite/rocisa/lib
+    PYTHONPATH = {toxinidir}/build_tmp/tensilelite/rocisa/lib
     TENSILELITE_CLIENT_ARGS = {env:TENSILELITE_CLIENT_ARGS:}
 commands =
     pip install --upgrade pip
     pip install pytest-cov
-    invoke build-client --build-dir {envdir}/build_tmp {env:TENSILELITE_CLIENT_ARGS}
-    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 4 --prebuilt-client={envdir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
+    invoke build-client --build-dir {toxinidir}/build_tmp {env:TENSILELITE_CLIENT_ARGS}
+    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 4 --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
 allowlist_externals =
     mkdir
     sh
     cmake
+
+[testenv:unit]
+description = "Runs Python unit tests quickly, skipping the client build. Assumes a build has run before."
+basepython = python3
+# This environment inherits 'deps' and 'setenv' from [testenv]
+commands =
+    pytest -v --basetemp={envtmpdir} {posargs}
+
+
 [testenv:lint]
 basepython = python3
 deps =


### PR DESCRIPTION
(top commit is the validator, others set up testing)

## Motivation

This introduces scaffolding for adding rules to validate the correct of CMS (custom main loop schedules) in Tensile, that developers handcraft. The motivation is to automatically detect scheduling issues is bespoke instruction schedules. Rules will include the obvious ones like getting the order of instructions to increment the global pointer for A (GRIncA) correct, and more subtle ones like ensuring that there are no RAW and WAR race conditions as data moves (HBM -> LDS -> registers). These will be added later. 

Note: A non-goal here is to create something to completely replace careful human verification of CMS schedules

## Design 

This PR adds basic functionality to ScheduleInfo class. Only 1 rule is added, more can be added by developers in parallel. See the internal doc for suggested rules. 

By default, all custom schedules are validated before codegen. It is possible to override the validation, if a CMS writer knows their schedule is valid and the rules are flagging a false positive. 

## Test Plan

Initial unit tests added. Note: only the top commit(s) here are specific to validator, they are on top of other commits from @talumbau setting up test infra. 
