### PR TITLE
Cherry-pick PR 2670 into 7.2

### DIFF
--- a/projects/rocthrust/thrust/system/hip/detail/adjacent_difference.h
+++ b/projects/rocthrust/thrust/system/hip/detail/adjacent_difference.h
@@ -197,11 +197,13 @@ adjacent_difference(execution_policy<Derived>& policy, InputIt first, InputIt la
     {
       result = __adjacent_difference::adjacent_difference(policy, first, last, result, binary_op);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static void
     seq(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt& result, BinaryOp binary_op)
     {
       result = thrust::adjacent_difference(cvt_to_seq(derived_cast(policy)), first, last, result, binary_op);
     }
+# endif
   };
 #  if __THRUST_HAS_HIPRT__
   workaround::par(policy, first, last, result, binary_op);

--- a/projects/rocthrust/thrust/system/hip/detail/binary_search.h
+++ b/projects/rocthrust/thrust/system/hip/detail/binary_search.h
@@ -269,7 +269,7 @@ OutputIt THRUST_HIP_FUNCTION lower_bound(
     {
       return __binary_search::lower_bound(policy, first, last, values_first, values_last, result, compare_op);
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIt
     seq(execution_policy<Derived>& policy,
         HaystackIt first,
@@ -282,6 +282,7 @@ OutputIt THRUST_HIP_FUNCTION lower_bound(
       return thrust::lower_bound(
         cvt_to_seq(derived_cast(policy)), first, last, values_first, values_last, result, compare_op);
     }
+#  endif
   };
 
 #  if __THRUST_HAS_HIPRT__
@@ -327,7 +328,7 @@ OutputIt THRUST_HIP_FUNCTION upper_bound(
     {
       return __binary_search::upper_bound(policy, first, last, values_first, values_last, result, compare_op);
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIt
     seq(execution_policy<Derived>& policy,
         HaystackIt first,
@@ -340,6 +341,7 @@ OutputIt THRUST_HIP_FUNCTION upper_bound(
       return thrust::upper_bound(
         cvt_to_seq(derived_cast(policy)), first, last, values_first, values_last, result, compare_op);
     }
+# endif
   };
 
 #  if __THRUST_HAS_HIPRT__
@@ -385,7 +387,7 @@ OutputIt THRUST_HIP_FUNCTION binary_search(
     {
       return __binary_search::binary_search(policy, first, last, values_first, values_last, result, compare_op);
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIt
     seq(execution_policy<Derived>& policy,
         HaystackIt first,
@@ -398,6 +400,7 @@ OutputIt THRUST_HIP_FUNCTION binary_search(
       return thrust::binary_search(
         cvt_to_seq(derived_cast(policy)), first, last, values_first, values_last, result, compare_op);
     }
+#  endif
   };
 
 #  if __THRUST_HAS_HIPRT__
@@ -469,7 +472,7 @@ lower_bound(execution_policy<Derived>& policy, HaystackIt first, HaystackIt last
 
       return first + h_result;
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static HaystackIt
     seq(execution_policy<Derived>& policy, HaystackIt first, HaystackIt last, const T& value, CompareOp compare_op)
     {
@@ -477,6 +480,7 @@ lower_bound(execution_policy<Derived>& policy, HaystackIt first, HaystackIt last
       thrust::lower_bound(cvt_to_seq(derived_cast(policy)), first, last, &value, &value + 1, &result, compare_op);
       return first + result;
     }
+# endif
   };
 
 #  if __THRUST_HAS_HIPRT__
@@ -530,7 +534,7 @@ upper_bound(execution_policy<Derived>& policy, HaystackIt first, HaystackIt last
 
       return first + h_result;
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static HaystackIt
     seq(execution_policy<Derived>& policy, HaystackIt first, HaystackIt last, const T& value, CompareOp compare_op)
     {
@@ -538,6 +542,7 @@ upper_bound(execution_policy<Derived>& policy, HaystackIt first, HaystackIt last
       thrust::upper_bound(cvt_to_seq(derived_cast(policy)), first, last, &value, &value + 1, &result, compare_op);
       return first + result;
     }
+# endif
   };
 
 #  if __THRUST_HAS_HIPRT__
@@ -590,7 +595,7 @@ THRUST_HIP_FUNCTION bool binary_search(
 
       return h_result != 0;
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static bool
     seq(execution_policy<Derived>& policy, HaystackIt first, HaystackIt last, const T& value, CompareOp compare_op)
     {
@@ -598,6 +603,7 @@ THRUST_HIP_FUNCTION bool binary_search(
       thrust::binary_search(cvt_to_seq(derived_cast(policy)), first, last, &value, &value + 1, &result, compare_op);
       return result;
     }
+#  endif
   };
 
 #  if __THRUST_HAS_HIPRT__

--- a/projects/rocthrust/thrust/system/hip/detail/copy.h
+++ b/projects/rocthrust/thrust/system/hip/detail/copy.h
@@ -100,13 +100,14 @@ copy(execution_policy<System>& system, InputIterator first, InputIterator last, 
     {
       return result = __copy::device_to_device(system, first, last, result);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIterator
     seq(execution_policy<System>& system, InputIterator first, InputIterator last, OutputIterator result)
     {
       return result = thrust::copy(cvt_to_seq(derived_cast(system)), first, last, result);
     }
+#  endif
   };
-
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(system, first, last, result);
 #  else
@@ -127,11 +128,13 @@ copy_n(execution_policy<System>& system, InputIterator first, Size n, OutputIter
     {
       return result = __copy::device_to_device(system, first, thrust::next(first, n), result);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIterator
     seq(execution_policy<System>& system, InputIterator first, Size n, OutputIterator result)
     {
       return result = thrust::copy_n(cvt_to_seq(derived_cast(system)), first, n, result);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(system, first, n, result);

--- a/projects/rocthrust/thrust/system/hip/detail/copy_if.h
+++ b/projects/rocthrust/thrust/system/hip/detail/copy_if.h
@@ -280,11 +280,13 @@ OutputIterator THRUST_HOST_DEVICE copy_if(
     {
       return __copy_if::copy_if(policy, first, last, result, pred);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIterator seq(
       execution_policy<Derived>& policy, InputIterator first, InputIterator last, OutputIterator result, Predicate pred)
     {
       return thrust::copy_if(cvt_to_seq(derived_cast(policy)), first, last, result, pred);
     }
+#  endif
   };
 
 #  if __THRUST_HAS_HIPRT__
@@ -317,6 +319,7 @@ OutputIterator THRUST_HOST_DEVICE copy_if(
     {
       return __copy_if::copy_if(policy, first, last, stencil, result, pred);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIterator
     seq(execution_policy<Derived>& policy,
         InputIterator first,
@@ -327,6 +330,7 @@ OutputIterator THRUST_HOST_DEVICE copy_if(
     {
       return thrust::copy_if(cvt_to_seq(derived_cast(policy)), first, last, stencil, result, pred);
     }
+#  endif
   };
 
 #  if __THRUST_HAS_HIPRT__

--- a/projects/rocthrust/thrust/system/hip/detail/merge.h
+++ b/projects/rocthrust/thrust/system/hip/detail/merge.h
@@ -234,6 +234,7 @@ merge(execution_policy<Derived>& policy,
     {
       return __merge::merge(policy, keys1_begin, keys1_end, keys2_begin, keys2_end, result_begin, compare_op);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static ResultIt
     seq(execution_policy<Derived>& policy,
         KeysIt1 keys1_begin,
@@ -246,6 +247,7 @@ merge(execution_policy<Derived>& policy,
       return thrust::merge(
         cvt_to_seq(derived_cast(policy)), keys1_begin, keys1_end, keys2_begin, keys2_end, result_begin, compare_op);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, keys1_begin, keys1_end, keys2_begin, keys2_end, result_begin, compare_op);
@@ -302,6 +304,7 @@ pair<KeysOutputIt, ItemsOutputIt> THRUST_HOST_DEVICE merge_by_key(
         items_out_begin,
         compare_op);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static pair<KeysOutputIt, ItemsOutputIt> seq(
       execution_policy<Derived>& policy,
       KeysIt1 keys1_begin,
@@ -326,6 +329,7 @@ pair<KeysOutputIt, ItemsOutputIt> THRUST_HOST_DEVICE merge_by_key(
         items_out_begin,
         compare_op);
     }
+#  endif
   };
 
 #  if __THRUST_HAS_HIPRT__

--- a/projects/rocthrust/thrust/system/hip/detail/parallel_for.h
+++ b/projects/rocthrust/thrust/system/hip/detail/parallel_for.h
@@ -154,8 +154,7 @@ void THRUST_HOST_DEVICE parallel_for(execution_policy<Derived>& policy, F f, Siz
       status = hip_rocprim::synchronize_optional(policy);
       hip_rocprim::throw_on_error(status, "parallel_for: failed to synchronize");
     }
-
-    // CDP sequential impl:
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static void seq(execution_policy<Derived>& policy, F f, Size count)
     {
       (void) policy;
@@ -164,6 +163,7 @@ void THRUST_HOST_DEVICE parallel_for(execution_policy<Derived>& policy, F f, Siz
         f(idx);
       }
     }
+#  endif
   };
   // clang-format on
 

--- a/projects/rocthrust/thrust/system/hip/detail/partition.h
+++ b/projects/rocthrust/thrust/system/hip/detail/partition.h
@@ -422,6 +422,7 @@ pair<SelectedOutIt, RejectedOutIt> THRUST_HOST_DEVICE partition_copy(
       return detail::partition_copy(policy, first, last, stencil, selected_result, rejected_result, predicate);
     }
 
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static pair<SelectedOutIt, RejectedOutIt>
     seq(execution_policy<Derived>& policy,
         InputIt first,
@@ -434,6 +435,7 @@ pair<SelectedOutIt, RejectedOutIt> THRUST_HOST_DEVICE partition_copy(
       return thrust::partition_copy(
         cvt_to_seq(derived_cast(policy)), first, last, stencil, selected_result, rejected_result, predicate);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, stencil, selected_result, rejected_result, predicate);
@@ -466,6 +468,7 @@ pair<SelectedOutIt, RejectedOutIt> THRUST_HOST_DEVICE partition_copy(
       return detail::partition_copy(policy, first, last, selected_result, rejected_result, predicate);
     }
 
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static pair<SelectedOutIt, RejectedOutIt>
     seq(execution_policy<Derived>& policy,
         InputIt first,
@@ -477,6 +480,7 @@ pair<SelectedOutIt, RejectedOutIt> THRUST_HOST_DEVICE partition_copy(
       return thrust::partition_copy(
         cvt_to_seq(derived_cast(policy)), first, last, selected_result, rejected_result, predicate);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, selected_result, rejected_result, predicate);
@@ -510,6 +514,7 @@ pair<SelectedOutIt, RejectedOutIt> THRUST_HOST_DEVICE stable_partition_copy(
     {
       return detail::partition_copy(policy, first, last, stencil, selected_result, rejected_result, predicate);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static pair<SelectedOutIt, RejectedOutIt>
     seq(execution_policy<Derived>& policy,
         InputIt first,
@@ -522,6 +527,7 @@ pair<SelectedOutIt, RejectedOutIt> THRUST_HOST_DEVICE stable_partition_copy(
       return thrust::stable_partition_copy(
         cvt_to_seq(derived_cast(policy)), first, last, stencil, selected_result, rejected_result, predicate);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, stencil, selected_result, rejected_result, predicate);
@@ -554,6 +560,7 @@ pair<SelectedOutIt, RejectedOutIt> THRUST_HOST_DEVICE stable_partition_copy(
       return detail::partition_copy(policy, first, last, selected_result, rejected_result, predicate);
     }
 
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static pair<SelectedOutIt, RejectedOutIt>
     seq(execution_policy<Derived>& policy,
         InputIt first,
@@ -565,6 +572,7 @@ pair<SelectedOutIt, RejectedOutIt> THRUST_HOST_DEVICE stable_partition_copy(
       return thrust::stable_partition_copy(
         cvt_to_seq(derived_cast(policy)), first, last, selected_result, rejected_result, predicate);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, selected_result, rejected_result, predicate);
@@ -588,11 +596,13 @@ partition(execution_policy<Derived>& policy, Iterator first, Iterator last, Sten
     {
       return last = detail::inplace_partition(policy, first, last, stencil, predicate);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static Iterator
     seq(execution_policy<Derived>& policy, Iterator first, Iterator last, StencilIt stencil, Predicate predicate)
     {
       return last = thrust::partition(cvt_to_seq(derived_cast(policy)), first, last, stencil, predicate);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, stencil, predicate);
@@ -614,11 +624,13 @@ partition(execution_policy<Derived>& policy, Iterator first, Iterator last, Pred
     {
       return last = detail::inplace_partition(policy, first, last, predicate);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static Iterator
     seq(execution_policy<Derived>& policy, Iterator first, Iterator last, Predicate predicate)
     {
       return last = thrust::partition(cvt_to_seq(derived_cast(policy)), first, last, predicate);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, predicate);
@@ -645,12 +657,13 @@ Iterator THRUST_HOST_DEVICE stable_partition(
       hip_rocprim::reverse(policy, ret, last);
       return ret;
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static Iterator
     seq(execution_policy<Derived>& policy, Iterator first, Iterator last, StencilIt stencil, Predicate predicate)
     {
       return thrust::stable_partition(cvt_to_seq(derived_cast(policy)), first, last, stencil, predicate);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, stencil, predicate);
@@ -677,12 +690,13 @@ stable_partition(execution_policy<Derived>& policy, Iterator first, Iterator las
       hip_rocprim::reverse(policy, ret, last);
       return ret;
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static Iterator
     seq(execution_policy<Derived>& policy, Iterator first, Iterator last, Predicate predicate)
     {
       return thrust::stable_partition(cvt_to_seq(derived_cast(policy)), first, last, predicate);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, predicate);

--- a/projects/rocthrust/thrust/system/hip/detail/reduce.h
+++ b/projects/rocthrust/thrust/system/hip/detail/reduce.h
@@ -150,13 +150,14 @@ reduce_n(execution_policy<Derived>& policy, InputIt first, Size num_items, T ini
     {
       return init = __reduce::reduce(policy, first, num_items, init, binary_op);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static T
     seq(execution_policy<Derived>& policy, InputIt first, Size num_items, T init, BinaryOp binary_op)
     {
       return init = thrust::reduce(cvt_to_seq(derived_cast(policy)), first, first + num_items, init, binary_op);
     }
+#  endif
   };
-
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, num_items, init, binary_op);
 #  else

--- a/projects/rocthrust/thrust/system/hip/detail/reduce_by_key.h
+++ b/projects/rocthrust/thrust/system/hip/detail/reduce_by_key.h
@@ -287,6 +287,8 @@ pair<KeyOutputIt, ValOutputIt> THRUST_HOST_DEVICE reduce_by_key(
       return __reduce_by_key::reduce_by_key(
         policy, keys_first, keys_last, values_first, keys_output, values_output, binary_pred, binary_op);
     }
+
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static pair<KeyOutputIt, ValOutputIt>
     seq(execution_policy<Derived>& policy,
         KeyInputIt keys_first,
@@ -307,6 +309,7 @@ pair<KeyOutputIt, ValOutputIt> THRUST_HOST_DEVICE reduce_by_key(
         binary_pred,
         binary_op);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(

--- a/projects/rocthrust/thrust/system/hip/detail/scan.h
+++ b/projects/rocthrust/thrust/system/hip/detail/scan.h
@@ -292,12 +292,14 @@ THRUST_HOST_DEVICE OutputIt inclusive_scan_n(
     {
       return result = __scan::inclusive_scan(policy, first, result, num_items, init, scan_op);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIt
     seq(execution_policy<Derived>& policy, InputIt first, Size num_items, OutputIt result, T init, ScanOp scan_op)
     {
       return result = thrust::inclusive_scan(
                cvt_to_seq(derived_cast(policy)), first, first + num_items, result, init, scan_op);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, num_items, result, init, scan_op);
@@ -318,12 +320,14 @@ THRUST_HOST_DEVICE OutputIt inclusive_scan_n(
     {
       return result = __scan::inclusive_scan(policy, first, result, num_items, scan_op);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIt
     seq(execution_policy<Derived>& policy, InputIt first, Size num_items, OutputIt result, ScanOp scan_op)
     {
       return result =
                thrust::inclusive_scan(cvt_to_seq(derived_cast(policy)), first, first + num_items, result, scan_op);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, num_items, result, scan_op);
@@ -380,15 +384,15 @@ THRUST_HOST_DEVICE OutputIt exclusive_scan_n(
     {
       return result = __scan::exclusive_scan(policy, first, result, num_items, init, scan_op);
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIt
     seq(execution_policy<Derived>& policy, InputIt first, Size num_items, OutputIt result, T init, ScanOp scan_op)
     {
       return result = thrust::exclusive_scan(
                cvt_to_seq(derived_cast(policy)), first, first + num_items, result, init, scan_op);
     }
+#  endif
   };
-
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, num_items, result, init, scan_op);
 #  else

--- a/projects/rocthrust/thrust/system/hip/detail/scan_by_key.h
+++ b/projects/rocthrust/thrust/system/hip/detail/scan_by_key.h
@@ -377,7 +377,7 @@ ValOutputIt THRUST_HOST_DEVICE inclusive_scan_by_key(
       return thrust::hip_rocprim::__scan_by_key::inclusive_scan_by_key(
         policy, key_first, key_last, value_first, value_result, binary_pred, scan_op);
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static ValOutputIt
     seq(execution_policy<Derived>& policy,
         KeyInputIt key_first,
@@ -390,8 +390,8 @@ ValOutputIt THRUST_HOST_DEVICE inclusive_scan_by_key(
       return thrust::inclusive_scan_by_key(
         cvt_to_seq(derived_cast(policy)), key_first, key_last, value_first, value_result, binary_pred, scan_op);
     }
+#  endif
   };
-
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, key_first, key_last, value_first, value_result, binary_pred, scan_op);
 #  else
@@ -456,7 +456,7 @@ ValOutputIt THRUST_HOST_DEVICE exclusive_scan_by_key(
       return thrust::hip_rocprim::__scan_by_key::exclusive_scan_by_key(
         policy, key_first, key_last, value_first, value_result, init, binary_pred, scan_op);
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static ValOutputIt
     seq(execution_policy<Derived>& policy,
         KeyInputIt key_first,
@@ -470,6 +470,7 @@ ValOutputIt THRUST_HOST_DEVICE exclusive_scan_by_key(
       return thrust::exclusive_scan_by_key(
         cvt_to_seq(derived_cast(policy)), key_first, key_last, value_first, value_result, init, binary_pred, scan_op);
     }
+#  endif
   };
 
 #  if __THRUST_HAS_HIPRT__

--- a/projects/rocthrust/thrust/system/hip/detail/sort.h
+++ b/projects/rocthrust/thrust/system/hip/detail/sort.h
@@ -380,10 +380,12 @@ void THRUST_HOST_DEVICE stable_sort(execution_policy<Derived>& policy, ItemsIt f
       __smart_sort::smart_sort<thrust::detail::false_type, thrust::detail::false_type>(
         policy, first, last, null_, compare_op);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static void seq(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, CompareOp compare_op)
     {
       thrust::stable_sort(cvt_to_seq(derived_cast(policy)), first, last, compare_op);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   workaround::par(policy, first, last, compare_op);
@@ -413,12 +415,13 @@ void THRUST_HOST_DEVICE stable_sort_by_key(
       __smart_sort::smart_sort<thrust::detail::true_type, thrust::detail::false_type>(
         policy, keys_first, keys_last, values, compare_op);
     }
-
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static void
     seq(execution_policy<Derived>& policy, KeysIt keys_first, KeysIt keys_last, ValuesIt values, CompareOp compare_op)
     {
       thrust::stable_sort_by_key(cvt_to_seq(derived_cast(policy)), keys_first, keys_last, values, compare_op);
     }
+#  endif
   };
 
 #  if __THRUST_HAS_HIPRT__

--- a/projects/rocthrust/thrust/system/hip/detail/unique.h
+++ b/projects/rocthrust/thrust/system/hip/detail/unique.h
@@ -172,11 +172,13 @@ unique_copy(execution_policy<Derived>& policy, InputIt first, InputIt last, Outp
     {
       return result = __unique::unique(policy, first, last, result, binary_pred);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static OutputIt
     seq(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result, BinaryPred binary_pred)
     {
       return result = thrust::unique_copy(cvt_to_seq(derived_cast(policy)), first, last, result, binary_pred);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, result, binary_pred);
@@ -205,11 +207,13 @@ unique(execution_policy<Derived>& policy, ForwardIt first, ForwardIt last, Binar
     {
       return hip_rocprim::unique_copy(policy, first, last, first, binary_pred);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static ForwardIt
     seq(execution_policy<Derived>& policy, ForwardIt first, ForwardIt last, BinaryPred binary_pred)
     {
       return thrust::unique(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, first, last, binary_pred);

--- a/projects/rocthrust/thrust/system/hip/detail/unique_by_key.h
+++ b/projects/rocthrust/thrust/system/hip/detail/unique_by_key.h
@@ -198,6 +198,7 @@ pair<KeyOutputIt, ValOutputIt> THRUST_HOST_DEVICE unique_by_key_copy(
     {
       return detail::unique_by_key(policy, keys_first, keys_last, values_first, keys_result, values_result, binary_pred);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static pair<KeyOutputIt, ValOutputIt>
     seq(execution_policy<Derived>& policy,
         KeyInputIt keys_first,
@@ -210,6 +211,7 @@ pair<KeyOutputIt, ValOutputIt> THRUST_HOST_DEVICE unique_by_key_copy(
       return thrust::unique_by_key_copy(
         cvt_to_seq(derived_cast(policy)), keys_first, keys_last, values_first, keys_result, values_result, binary_pred);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, keys_first, keys_last, values_first, keys_result, values_result, binary_pred);
@@ -253,6 +255,7 @@ pair<KeyInputIt, ValInputIt> THRUST_HOST_DEVICE unique_by_key(
       return hip_rocprim::unique_by_key_copy(
         policy, keys_first, keys_last, values_first, keys_first, values_first, binary_pred);
     }
+#  if !__THRUST_HAS_HIPRT__
     THRUST_DEVICE static pair<KeyInputIt, ValInputIt>
     seq(execution_policy<Derived>& policy,
         KeyInputIt keys_first,
@@ -262,6 +265,7 @@ pair<KeyInputIt, ValInputIt> THRUST_HOST_DEVICE unique_by_key(
     {
       return thrust::unique_by_key(cvt_to_seq(derived_cast(policy)), keys_first, keys_last, values_first, binary_pred);
     }
+#  endif
   };
 #  if __THRUST_HAS_HIPRT__
   return workaround::par(policy, keys_first, keys_last, values_first, binary_pred);


### PR DESCRIPTION
Do not merge until PM approval given.  This PR cherry-picks #2760.

## Motivation

In certain cases, compiling with `-std=gnu++17` would cause compile errors.

## Technical Details

This change disables defining the sequential implementation whenever we have the HIP runtime. The sequential implementation is not required in that case, since if the HIP runtime is available we always want to run the parallel implementation (i.e. we're on host!). When compile for device, both parallel and sequential need to be defined. The sequential one is required due to it the implementation being requested. The parallel one is required because the device compiler needs to know what kernels are launched from host. We therefore define it, but never call it in our device compilation.

## Test Plan

Compiling the following program with `hipcc -std=gnu++17 main.cpp` must work after installing rocThrust.

```cpp
// main.cpp
int main() {
    using K = __int128;
    using V = int;
    const int N = 4;
    thrust::device_vector<K> keys(N);
    thrust::device_vector<V> vals(N);
 
    K hkeys[N];
    for (int i = 0; i < N; ++i) hkeys[i] = (K)i * 100;
 
    thrust::copy(hkeys, hkeys + N, keys.begin());
    thrust::sort_by_key(keys.begin(), keys.end(), vals.begin()); // ---- Fails here ----
    return 0; 
}
```

## Test Result

Test plan succeeded.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
