### PR TITLE
[rocWMMA] Fix standalone Windows build and MinSizeRel build on Windows

### DIFF
--- a/projects/rocwmma/CMakeLists.txt
+++ b/projects/rocwmma/CMakeLists.txt
@@ -52,7 +52,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 #Set Clang C++ flags.
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O2") # clang++ crashes without -O2
-set(CMAKE_CXX_FLAGS_MINSIZEREL "-O2 -DNDEBUG") # clang++ failed to build the project with the default -Os
+set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} -O2 -DNDEBUG") # clang++ failed to build the project with the default -Os
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --driver-mode=g++ -Xclang -fallow-half-arguments-and-returns -D__HIP_HCC_COMPAT_MODE__=1 -Wno-format-nonliteral -parallel-jobs=4 -fclang-abi-compat=17")
 
 # Top level configs

--- a/projects/rocwmma/test/CMakeLists.txt
+++ b/projects/rocwmma/test/CMakeLists.txt
@@ -67,6 +67,12 @@ else()
 
   # Fetch the content using default details
   set(ROCM_DISABLE_CHECKS TRUE)
+  if(WIN32 AND BUILD_SHARED_LIBS_OLD)
+    # We build gtest as a static lib, but the test binaries are built as shared
+    # libraries.  Force gtest to link against a shared (DLL) version of the C
+    # run-time library.
+    set(gtest_force_shared_crt ON CACHE BOOL "Use shared (DLL) run-time library even when Google Test is built as static lib." FORCE)
+  endif()
   FetchContent_MakeAvailable(googletest)
   set(ROCM_DISABLE_CHECKS FALSE)
 


### PR DESCRIPTION
## Motivation

Building rocWMMA as part of TheRock on Windows worked fine, but when trying to do a standalone build we run into issues with GTest.  The MinSizeRel build was also broken on Windows.

## Technical Details

This change sets a GTest CMake variable to ensure we build the GTest _static_ library so that it _dynamically_ links against the C runtime if we are building the tests as dynamic binaries.

Also make sure we don't remove important automatically-added build flags for the MinSizeRel build on Windows.

## Test Plan

Manual testing on Windows.

## Test Result

Executables linked and ran properly.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
