### PR TITLE
Implement some APIs for parity with cuTENSOR 2.0

### DIFF
--- a/projects/hiptensor/library/src/hiptensor.cpp
+++ b/projects/hiptensor/library/src/hiptensor.cpp
@@ -297,6 +297,24 @@ hiptensorStatus_t
     case HIPTENSOR_OPERATION_DESCRIPTOR_TAG:
         std::memcpy(&desc->mTag, buf, sizeInBytes);
         break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE:
+        std::memcpy(&desc->mScalarType, buf, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_FLOPS:
+        std::memcpy(&desc->mFlops, buf, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_MOVED_BYTES:
+        std::memcpy(&desc->mMovedBytes, buf, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_PADDING_LEFT:
+        std::memcpy(&desc->mPaddingLeft, buf, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_PADDING_RIGHT:
+        std::memcpy(&desc->mPaddingRighT, buf, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_PADDING_VALUE:
+        std::memcpy(desc->mPaddingValue, buf, sizeInBytes);
+        break;
     default:
         retStatus = HIPTENSOR_STATUS_NOT_SUPPORTED;
         break;
@@ -312,7 +330,37 @@ hiptensorStatus_t
                                              void*                                   buf,
                                              size_t                                  sizeInBytes)
 {
-    return HIPTENSOR_STATUS_SUCCESS;
+    hiptensorStatus_t retStatus = HIPTENSOR_STATUS_SUCCESS;
+
+    switch(attr)
+    {
+    case HIPTENSOR_OPERATION_DESCRIPTOR_TAG:
+        std::memcpy(buf, &desc->mTag, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE:
+        std::memcpy(buf, &desc->mScalarType, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_FLOPS:
+        std::memcpy(buf, &desc->mFlops, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_MOVED_BYTES:
+        std::memcpy(buf, &desc->mMovedBytes, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_PADDING_LEFT:
+        std::memcpy(buf, &desc->mPaddingLeft, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_PADDING_RIGHT:
+        std::memcpy(buf, &desc->mPaddingRighT, sizeInBytes);
+        break;
+    case HIPTENSOR_OPERATION_DESCRIPTOR_PADDING_VALUE:
+        std::memcpy(buf, desc->mPaddingValue, sizeInBytes);
+        break;
+    default:
+        retStatus = HIPTENSOR_STATUS_NOT_SUPPORTED;
+        break;
+    }
+
+    return retStatus;
 }
 
 hiptensorStatus_t hiptensorCreatePermutation(const hiptensorHandle_t            handle,
@@ -559,7 +607,18 @@ hiptensorStatus_t hiptensorPlanGetAttribute(const hiptensorHandle_t  handle,
                                             void*                    buf,
                                             size_t                   sizeInBytes)
 {
-    return HIPTENSOR_STATUS_SUCCESS;
+    hiptensorStatus_t retStatus = HIPTENSOR_STATUS_SUCCESS;
+    switch(attr)
+    {
+    case HIPTENSOR_PLAN_REQUIRED_WORKSPACE:
+        std::memcpy(buf, &plan->mRequiredWorkspace, sizeInBytes);
+        break;
+    default:
+        retStatus = HIPTENSOR_STATUS_NOT_SUPPORTED;
+        break;
+    }
+
+    return retStatus;
 }
 
 hiptensorStatus_t contractionGetWorkspaceSize(const hiptensorHandle_t              handle,

--- a/projects/hiptensor/library/src/include/data_types_impl.hpp
+++ b/projects/hiptensor/library/src/include/data_types_impl.hpp
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "data_types.hpp"
+#include <iostream>
 
 namespace hiptensor
 {

--- a/projects/hiptensor/samples/01_contraction/simple_bilinear_contraction.hpp
+++ b/projects/hiptensor/samples/01_contraction/simple_bilinear_contraction.hpp
@@ -217,14 +217,14 @@ int bilinearContractionSample(void* alpha, void* beta)
                                                      modeC.data(),
                                                      typeCompute));
 
-#if 0 // TODO
     hiptensorDataType_t scalarType;
     CHECK_HIPTENSOR_ERROR(hiptensorOperationDescriptorGetAttribute(handle,
                 desc,
                 HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE,
                 (void*)&scalarType,
                 sizeof(scalarType)));
-#endif
+    assert(scalarType == *hiptensor::convertToHipTensorDataType(typeCompute));
+
     /***************************
      * Set the algorithm to use
      ***************************/

--- a/projects/hiptensor/samples/01_contraction/simple_contraction_plan_cache.cpp
+++ b/projects/hiptensor/samples/01_contraction/simple_contraction_plan_cache.cpp
@@ -263,14 +263,14 @@ int main(int argc, char* argv[])
                                                      modeC.data(),
                                                      typeCompute));
 
-#if 0 // TODO
     hiptensorDataType_t scalarType;
     CHECK_HIPTENSOR_ERROR(hiptensorOperationDescriptorGetAttribute(handle,
                 desc,
                 HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE,
                 (void*)&scalarType,
                 sizeof(scalarType)));
-#endif
+    assert(scalarType == HIPTENSOR_R_32F);
+
     /**************************
    * Set the algorithm to use
    ***************************/

--- a/projects/hiptensor/samples/01_contraction/simple_scale_contraction.hpp
+++ b/projects/hiptensor/samples/01_contraction/simple_scale_contraction.hpp
@@ -214,14 +214,14 @@ int scaleContractionSample(void* alpha)
                                                      modeD.data(),
                                                      typeCompute));
 
-#if 0 // TODO
     hiptensorDataType_t scalarType;
     CHECK_HIPTENSOR_ERROR(hiptensorOperationDescriptorGetAttribute(handle,
                 desc,
                 HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE,
                 (void*)&scalarType,
                 sizeof(scalarType)));
-#endif
+    assert(scalarType == *hiptensor::convertToHipTensorDataType(typeCompute));
+
     /**************************
    * Set the algorithm to use
    ***************************/

--- a/projects/hiptensor/samples/02_elementwise/elementwise_binary.cpp
+++ b/projects/hiptensor/samples/02_elementwise/elementwise_binary.cpp
@@ -178,13 +178,15 @@ int main()
      * Optional (but recommended): ensure that the scalar type is correct.
      *****************************/
 
-    // hiptensorDataType_t scalarType;
-    // CHECK_HIPTENSOR_ERROR(hiptensorOperationDescriptorGetAttribute(handle, desc,
-    // HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE,
-    // (void*)&scalarType,
-    // sizeof(scalarType)));
-    //
-    // assert(scalarType == CUTENSOR_R_32F);
+    hiptensorDataType_t scalarType;
+    CHECK_HIPTENSOR_ERROR(
+        hiptensorOperationDescriptorGetAttribute(handle,
+                                                 desc,
+                                                 HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE,
+                                                 (void*)&scalarType,
+                                                 sizeof(scalarType)));
+
+    assert(scalarType == HIPTENSOR_R_32F);
 
     /***************************
      * Set the algorithm to use

--- a/projects/hiptensor/samples/02_elementwise/elementwise_permute.cpp
+++ b/projects/hiptensor/samples/02_elementwise/elementwise_permute.cpp
@@ -148,13 +148,15 @@ int main()
      * Optional (but recommended): ensure that the scalar type is correct.
      *****************************/
 
-    // hiptensorDataType_t scalarType;
-    // CHECK_HIPTENSOR_ERROR(hiptensorOperationDescriptorGetAttribute(handle, desc,
-    // HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE,
-    // (void*)&scalarType,
-    // sizeof(scalarType)));
-    //
-    // assert(scalarType == HIPTENSOR_R_32F);
+    hiptensorDataType_t scalarType;
+    CHECK_HIPTENSOR_ERROR(
+        hiptensorOperationDescriptorGetAttribute(handle,
+                                                 desc,
+                                                 HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE,
+                                                 (void*)&scalarType,
+                                                 sizeof(scalarType)));
+
+    assert(scalarType == HIPTENSOR_R_32F);
 
     /**************************
     * Set the algorithm to use

--- a/projects/hiptensor/test/01_contraction/contraction_test.cpp
+++ b/projects/hiptensor/test/01_contraction/contraction_test.cpp
@@ -494,14 +494,14 @@ namespace hiptensor
                 d_ms_ns,
                 cd_ms_ns_modes.data(),
                 computeType));
-#if 0 // TODO
+
             hiptensorDataType_t scalarType;
             CHECK_HIPTENSOR_ERROR(hiptensorOperationDescriptorGetAttribute(handle,
                         desc,
                         HIPTENSOR_OPERATION_DESCRIPTOR_SCALAR_TYPE,
                         (void*)&scalarType,
                         sizeof(scalarType)));
-#endif
+            assert(scalarType == *hiptensor::convertToHipTensorDataType(computeType));
 
             /**************************
             * Set the algorithm to use


### PR DESCRIPTION
## Motivation

After upgrading to hiptensor 2.0, some new functions have not been implemented or used. Implemented some functions in this PR.

## Technical Details

Implemented following functions and updated related samples and tests:
   (1) hiptensorOperationDescriptorSetAttribute
   (2) hiptensorOperationDescriptorGetAttribute
   (3) hiptensorPlanGetAttribute

## Test Plan

1. build both release and debug versions.
2. run normal tests.

## Test Result

all tests passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
