### PR TITLE
[rocWMMA] Suppress printing of extra information in CTest test suites

### DIFF
--- a/projects/rocwmma/test/CMakeLists.txt
+++ b/projects/rocwmma/test/CMakeLists.txt
@@ -157,13 +157,13 @@ function(add_rocwmma_test TEST_TARGET TEST_SOURCE)
           set(EXE_NAME "${TEST_TARGET}")
       endif()
   endif()
-  file(APPEND "${INSTALL_TEST_FILE}" "add_test(${TEST_TARGET} \"../${EXE_NAME}\")\n")
+  file(APPEND "${INSTALL_TEST_FILE}" "add_test(${TEST_TARGET} \"../${EXE_NAME}\" --omit 5)\n")
   file(APPEND "${INSTALL_TEST_FILE}" "set_tests_properties(${TEST_TARGET} PROPERTIES SKIP_REGULAR_EXPRESSION \"no ROCm-capable device;unsupported host device\")\n")
 
-  file(APPEND "${INSTALL_SMOKE_TEST_FILE}" "add_test(\"${TEST_TARGET} smoke\" \"../../${EXE_NAME}\" --emulation smoke)\n")
+  file(APPEND "${INSTALL_SMOKE_TEST_FILE}" "add_test(\"${TEST_TARGET} smoke\" \"../../${EXE_NAME}\" --emulation smoke --omit 5)\n")
   file(APPEND "${INSTALL_SMOKE_TEST_FILE}" "set_tests_properties(\"${TEST_TARGET} smoke\" PROPERTIES SKIP_REGULAR_EXPRESSION \"no ROCm-capable device;unsupported host device\")\n")
 
-  file(APPEND "${INSTALL_REGRESSION_TEST_FILE}" "add_test(\"${TEST_TARGET} regression\" \"../../${EXE_NAME}\" --emulation regression)\n")
+  file(APPEND "${INSTALL_REGRESSION_TEST_FILE}" "add_test(\"${TEST_TARGET} regression\" \"../../${EXE_NAME}\" --emulation regression --omit 5)\n")
   file(APPEND "${INSTALL_REGRESSION_TEST_FILE}" "set_tests_properties(\"${TEST_TARGET} regression\" PROPERTIES SKIP_REGULAR_EXPRESSION \"no ROCm-capable device;unsupported host device\")\n")
 endfunction()
 


### PR DESCRIPTION
## Motivation

The massive logs generated from tests make it difficult to determine what is going on when CI fails, and may potentially cause slowdowns when multiple tests are running and writing their logs to disk (rocWMMA has millions of tests).

## Technical Details

Setting  `--omit 5` will suppress extra output for skipped and passed tests.

## Test Plan

Ran with ctest, and checked that output is reduced for passing and skipped tests.

## Test Result

Reduces the number of lines in test output for passed tests by ~1/3.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
