### PR TITLE
[rocblas] optimize sbmv, cherry-pick to 7.2

### DIFF
--- a/projects/rocblas/library/src/blas2/rocblas_sbmv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_sbmv_kernels.cpp
@@ -38,46 +38,62 @@ inline __device__ T rocblas_sbmv_kernel_helper(rocblas_int ty,
                                                const T* __restrict__ x,
                                                int64_t incx)
 {
-    T           res_A = 0.0;
-    rocblas_int col;
+    T res_A = 0.0;
 
-    // Since the column is consistent, we iterate up diagonally in banded format
-    // ty defines the column of banded matrix
-    for(col = ty; col < n; col += DIM_Y)
+    if(ind >= n)
+        return res_A;
+
+    // key_point serves two purposes:
+    // 1. Marks the column-wise turning point (ty = key_point) in the banded matrix.
+    // 2. Marks the row-wise turning point (ty = key_point) in the banded matrix.
+    rocblas_int key_point = min(k, ind);
+
+    rocblas_int ind_row  = UPPER ? max(k - ind, 0) : min(k, ind);
+    rocblas_int ind_col  = UPPER ? ind : max(ind - k, 0);
+    rocblas_int ind_xcol = ind < k ? 0 : ind - k;
+
+    rocblas_int invaliad_right = max((n - (k + 1) - ind), 0);
+    rocblas_int invaliad_left  = max(ind - k, 0);
+    rocblas_int valiad_num     = n - (invaliad_right + invaliad_left);
+
+    for(rocblas_int xcol = ind_xcol + ty; ty < valiad_num; ty += DIM_Y, xcol += DIM_Y)
     {
-        // We have to convert ind to banded matrix row
-        rocblas_int row = UPPER ? ind + (k - col) : ind - col;
-
-        if(ind < n)
-        {
-            if((ind <= col && UPPER) || (ind >= col && !UPPER))
-            {
-                // in upper/lower triangular part
-                if(row <= k && row >= 0)
-                {
-                    res_A += A[row + col * size_t(lda)] * x[col * incx];
-                }
-            }
-            else
-            {
-                // in the opposite triangle, get value at transposed position
-                rocblas_int trans_row = col;
-                rocblas_int trans_col = ind;
-                trans_row             = UPPER ? trans_row + (k - trans_col) : trans_row - trans_col;
-                if(trans_row <= k && trans_row >= 0)
-                {
-                    res_A += A[trans_row + trans_col * size_t(lda)] * x[col * incx];
-                }
-            }
-        }
+        rocblas_int row = ty < key_point ? (UPPER ? ind_row + ty : ind_row - ty)
+                                         : (UPPER ? k - (ty - key_point) : ty - key_point);
+        rocblas_int col = ty < key_point
+                              ? (UPPER ? ind_col : ind_col + ty)
+                              : (UPPER ? ind_col + (ty - key_point) : ind_col + key_point);
+        res_A += A[col * size_t(lda) + row] * x[xcol * int64_t(incx)];
     }
+
     return res_A;
 }
 
 /**
-  *  Computes y := alpha*A*x + beta*y where A is a symmetric matrix.
+  *  Computes y := alpha*A*x + beta*y where A is a symmetric banded matrix.
   *  If uplo == upper, the strictly lower part of A is not referenced,
   *  if uplo == lower, the strictly upper part of A is not referenced.
+  * 
+  *  Ex: (n = 6; k = 2)
+  * 
+  *  uplo == upper:
+  * 
+  *  a11 a12 a13  .   .   .              .   .  a13 a24 a35 a46
+  *  a12 a22 a23 a24  .   .              .  a12 a23 a34 a45 a56
+  *  a13 a23 a33 a34 a35  .     upper   a11 a22 a33 a44 a55 a66  <- main diag
+  *   .  a24 a34 a44 a45 a46    ---->    .   .   .   .   .   .
+  *   .   .  a35 a45 a55 a56             .   .   .   .   .   .
+  *   .   .   .  a46 a56 a66             .   .   .   .   .   .
+  * 
+  *  uplo == lower:
+  * 
+  *  a11 a12 a13  .   .   .             a11 a22 a33 a44 a55 a66  <- main diag
+  *  a12 a22 a23 a24  .   .             a12 a23 a34 a45 a56  .
+  *  a13 a23 a33 a34 a35  .     lower   a13 a24 a35 a46  .   .
+  *   .  a24 a34 a44 a45 a46    ---->    .   .   .   .   .   .
+  *   .   .  a35 a45 a55 a56             .   .   .   .   .   .
+  *   .   .   .  a46 a56 a66             .   .   .   .   .   .
+  * 
   */
 template <bool UPPER, rocblas_int DIM_X, rocblas_int DIM_Y, typename T>
 inline __device__ void rocblas_sbmv_kernel_calc(rocblas_int n,


### PR DESCRIPTION
  The A*x loop only iterates through valid data,
  which helps reduce divergence.


