### PR TITLE
[hipblaslt] Fix missing rejection of unsupported LRVW for DS read

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1628,9 +1628,9 @@ class Solution(collections.abc.Mapping):
           else:
             optPadA //= 2
             readRegsA //= 2
-        if (not isaInfoMap[isa].asmCaps['HasWMMA']) and (readRegsA > 4 or readRegsB > 4):
+
+        if (not isaInfoMap[isa].asmCaps['HasWMMA_V1']) and (readRegsA > 4 or readRegsB > 4):
           reject(state, "LocalReadVectorWidth results in attemping to read LDS larger than b128, reject")
-          return ldsPadA, ldsPadB, ldsPadM
         if state["EnableMatrixInstruction"]:
           # for readRegs = 1 or 4, we need to double pad for MI16x16xNx1 to avoid bank conflict.
           if state["MatrixInstB"] == 1 and state["MatrixInstM"] == 16:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan_gfx11.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan_gfx11.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx950, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx950, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1200, skip-gfx1201] # not supported by arch
 
 GlobalParameters:
   MinimumRequiredVersion: 5.0.0


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
To fit ds_load_b128, for bpe = 16, max LRVW is 8.
Current tensilelite can generate a kernel with the tuning yaml’s input data type set to FP16 and LRVW = 16 when running on Navi3/4. However, the kernel produces incorrect results on Navi4.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
If a larger LRVW (larger than MIInputPerThread & LRVW * bpe > 128, ex: 16 in this case) is chosen and not rejected during the tuning process, the codegen assumes that 256 bits will be loaded in one step. However, the kernel assembly actually issues only a single ds_load_b128 instruction. This leads to unpredictable kernel behavior. Even if we manually append additional ds_load_b128 instruction, the result remains incorrect because LRVW affects not only the number of read elements but also PLR, local read offset calculations, and other factors.

This commit narrows the allowed check to whether the platform supports WMMA_V1 instructions, causing this case to be rejected.
The reason WMMA_V1 can pass is that its MIInputPerThread is 16.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->
gfx1201
1. gtest
<img width="950" height="145" alt="Screenshot 2025-11-24 092151" src="https://github.com/user-attachments/assets/b0a4b05d-10f3-40b5-8835-1395560dcc03" />
2. tox test
<img width="1877" height="114" alt="image" src="https://github.com/user-attachments/assets/dac31681-b885-4f0a-a61e-a92a5d7640b5" />

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
