### PR TITLE
[rocBLAS] Users/torrezuk/swdev 568158 syrk ex tolerance fix (#2851)

### DIFF
--- a/projects/rocblas/clients/common/cblas_interface.cpp
+++ b/projects/rocblas/clients/common/cblas_interface.cpp
@@ -2242,26 +2242,52 @@ void ref_syrk_ex(rocblas_fill      uplo,
                  U*                C,
                  int64_t           ldc)
 {
-    float alpha_float = alpha;
-    float beta_float  = beta;
+    if constexpr(!std::is_same_v<Tc, double>)
+    {
+        float alpha_float = alpha;
+        float beta_float  = beta;
 
-    host_vector<float> A_float, C_float;
+        host_vector<float> A_float, C_float;
 
-    cast_to_buffer(transA, n, k, lda, A, A_float);
-    cast_to_buffer(rocblas_operation_none, n, n, ldc, C, C_float);
+        cast_to_buffer(transA, n, k, lda, A, A_float);
+        cast_to_buffer(rocblas_operation_none, n, n, ldc, C, C_float);
 
-    ref_syrk(uplo,
-             transA,
-             n,
-             k,
-             alpha_float,
-             (const float*)A_float.data(),
-             lda,
-             beta_float,
-             C_float.data(),
-             ldc);
+        ref_syrk(uplo,
+                 transA,
+                 n,
+                 k,
+                 alpha_float,
+                 (const float*)A_float.data(),
+                 lda,
+                 beta_float,
+                 C_float.data(),
+                 ldc);
 
-    cast_from_buffer(n, n, ldc, C_float, C);
+        cast_from_buffer(n, n, ldc, C_float, C);
+    }
+    else
+    {
+        double alpha_double = alpha;
+        double beta_double  = beta;
+
+        host_vector<double> A_double, C_double;
+
+        cast_to_buffer(transA, n, k, lda, A, A_double);
+        cast_to_buffer(rocblas_operation_none, n, n, ldc, C, C_double);
+
+        ref_syrk(uplo,
+                 transA,
+                 n,
+                 k,
+                 alpha_double,
+                 (const double*)A_double.data(),
+                 lda,
+                 beta_double,
+                 C_double.data(),
+                 ldc);
+
+        cast_from_buffer(n, n, ldc, C_double, C);
+    }
 }
 
 #define INSTANTIATE_SYRK_EX_TEMPLATE(T_, U_, Tc_)                    \

--- a/projects/rocblas/clients/include/blas_ex/testing_syrk_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_syrk_ex.hpp
@@ -372,8 +372,8 @@ void testing_syrk_ex(const Arguments& arg)
                     // reference is computed on floats
                     double tol = rocblas_handle(handle)->getArchMajor() == 11
                                      ? sum_error_tolerance_for_gfx11<Tex, Ti, To>
-                                     : sum_error_tolerance<Ti>;
-                    tol *= K * 4;
+                                     : 4 * sum_error_tolerance<Ti>;
+                    tol = tol * K + 2 * sum_error_tolerance<To>; // add To conversion rounding error
                     near_check_general<To, To_hpa>(N, N, ldc, hC_gold, hC, tol);
                 }
                 else

--- a/projects/rocblas/clients/include/near.hpp
+++ b/projects/rocblas/clients/include/near.hpp
@@ -86,6 +86,12 @@ template <>
 inline constexpr double
     sum_error_tolerance_for_gfx11<rocblas_half, rocblas_half, rocblas_half> = 1 / 100.0;
 
+template <> // syrk_ex use
+inline constexpr double sum_error_tolerance_for_gfx11<double, float, float> = get_epsilon<float>();
+
+template <> // syrk_ex use
+inline constexpr double sum_error_tolerance_for_gfx11<double, float, double> = get_epsilon<float>();
+
 template <>
 inline constexpr double sum_error_tolerance_for_gfx11<rocblas_float_complex,
                                                       rocblas_float_complex,


### PR DESCRIPTION
* fix syrk_ex tolerance due to reference conversions and add double precision reference function
* add gfx11 tolerance template using f32 for f64 compute

(cherry picked from commit d471513e9aa6f90500237dc4eb097421ed9f30c6)

