### PR TITLE
[NFC][hipblaslt] Whitespace removal in tensilelite

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/ValidParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/ValidParameters.py
@@ -509,7 +509,7 @@ validParameters = { # we need to make sure this matches develop
     "WorkGroupMapping": list(
         range(-1024, 1024 + 1)
     ),  # change a workgroup's id so that the all the workgroups on the gpu at a time are hitting L2 cache the best
-    # 0: WorkGroupMapping is predicted at runtime. 
+    # 0: WorkGroupMapping is predicted at runtime.
     # 1: No mapping
     "WorkGroupMappingXCC": [
         -1,

--- a/projects/hipblaslt/tensilelite/Tensile/Components/GSU.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/GSU.py
@@ -1598,7 +1598,7 @@ class GSUOn(GSU):
 
     def lastGsuWgBusyWaiting(self, writer, kernel, ss, tmpSgpr, lastGsuWgBusyWaitingLabel, reductionBodyLabel):
         module = Module("GSU Common lastGsuWgBusyWaiting")
-    
+
         tmpS01 = tmpSgpr.idx
 
         module.add(SLoadB32(dst=sgpr(tmpS01), base=sgpr("SrdSync",2), soffset=0, smem=SMEMModifiers(glc=True), comment="get atomic_dec value"))
@@ -1688,7 +1688,7 @@ class GSUOn(GSU):
                         module.add(codeAccVgprReadInst)
         elif kernel["LocalSplitU"] > 1:
             # read from LSU VGPRs
-            regsPerScalar = writer.states.bpeCinternal // writer.states.bpr # register per scalar            
+            regsPerScalar = writer.states.bpeCinternal // writer.states.bpr # register per scalar
             if kernel["MIArchVgpr"]:
                 tmpStartVgprValuC = writer.states.c.startVgprValu
                 writer.states.c.startVgprValu = 0
@@ -1830,7 +1830,7 @@ class GSUOn(GSU):
         sumIdxGSUSYNC = ss.elementSumIdx[len(batchElements)-1]
         addrCalc = ss.elementAddr[len(batchElements)-1]
         accvgprWriteLabel = Label(writer.labels.getNameInc("accvgpr_write"), comment="")
-        
+
         if (kernel["_GlobalAccumulation"] == 'MultipleBufferSingleKernel'):
             module.add(self.GSUSynccodegenOpt(kernel, writer, ss, batchIdx, tmpSgpr, tmpVgpr, tmpVgprDynamic, gwvw, batchElements,\
                                               endLabel, sumIdxGSUSYNC, addrCalc.addrDVgpr, reductionBodyLabel))
@@ -1952,7 +1952,7 @@ class GSUOn(GSU):
         storeOffsetSgpr = tmpSgpr.idx
         loadOffsetSgpr = tmpSgpr.idx + 1
         storeOffsetSgprRes = ContinuousRegister(storeOffsetSgpr, 1)
-        
+
         addr1 = sgpr(tmpS06, 4)
         addr0 = vgpr(vgproffset)
         bps = kernel["ProblemType"]["ComputeDataType"].numBytes() * gwvw
@@ -2476,7 +2476,7 @@ class GSUOn(GSU):
                                                 src1=vgpr(tmpVAdd+0+gwvw*i+j*2, 2), comment="buffer pk"))
 
             ss.lsuStartVgprOffset += len(batchElements) * gwvw * regsPerScalar
-            
+
             if kernel["MIArchVgpr"]:
                 writer.states.c.startVgprValu = tmpStartVgprValuC
                 module.add(RegSet("v", "vgprValuC", tmpStartVgprValuC))

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LSU.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LSU.py
@@ -356,7 +356,7 @@ class LSUOn(LSU):
                                 else:
                                 # TODO: hpa_half, int8
                                     assert(0) # unsupported data type, need to modify here and LSU write/read code
-                    
+
                     if kernel["GlobalSplitUAlgorithm"] == "MultipleBufferSingleKernel":
                         if not kernel["MIArchVgpr"]:
                             # write to accvgpr

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -834,7 +834,7 @@ class LocalReadMFMA(LocalRead):
                             if (kernel["LdsBlockSizePerPad%s"%tc] != 0) and (kernel["LdsPad%s"%tc] != 0):
                                 offset_val = offset_val + (offset_val // kernel["LdsBlockSizePerPad%s"%tc]) * kernel["LdsPad%s"%tc] * tP["bpeDS"]
                             offset_val = offset_val + tP["localReadSwapByteOffset"]
-                            # TODO: Add NLC>1 offset calcs here? 
+                            # TODO: Add NLC>1 offset calcs here?
                             if (kernel["DirectToLds%s" % tc] and  \
                                 kernel["GlobalReadVectorWidth%c"%tc] * tP["bpeDS"] > 4) and not kernel["UseGeneralizedNLCOne%s"%tc]:
                               # another address conversion for DirectToLds + NumLoadsCoalesced > 1

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LraTileAssignment.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LraTileAssignment.py
@@ -243,7 +243,7 @@ class LraTileAssignmentMFMA(LraTileAssignment):
            reMap0 = writer.vgprPool.checkOut(1)
            reMap1 = writer.vgprPool.checkOut(1)
            perpStrideInv = permBlock // perpStride
-           
+
            module.addComment0("Computing strided(%u) perp indicies"%perpStrideInv)
            module.add(VAndB32(dst=vgpr(reMap0), src0=(permBlock // perpStrideInv - 1), src1=vgpr(vgprReg), comment="r0 = I %% (%u // %u)"%(permBlock, perpStrideInv)))
            module.add(VLShiftLeftB32(dst=vgpr(reMap0), shiftHex=log2(perpStrideInv), src=vgpr(reMap0), comment="r0 = %u * r0"%(perpStrideInv)))

--- a/projects/hipblaslt/tensilelite/Tensile/Components/SIA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/SIA.py
@@ -257,7 +257,7 @@ def getLocalWriteMFMAEnd(writer, kernel, tensorParametersA, tensorParametersB):
     # final index definition
     writer.states.numMfmaForNextLoopLR = min(writer.states.numMfmaForNextLoopLR,numMfmaPerIter-1)
     writer.states.syncPlrMfmaIndex = numMfmaPerIter*(kernel["LoopIters"]-writer.states.numItersPLR+1) - writer.states.numMfmaForNextLoopLR - 1 if writer.states.numItersPLR else 0
-    
+
     if kernel["ForceUnrollSubIter"]:
         if ( kernel["ProblemType"]["DataType"].isComplex()):
             writer.states.syncPlrMfmaIndex = writer.states.syncPlrMfmaIndex *4   # Complex

--- a/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/WorkGroupMappingAlgos.py
@@ -116,7 +116,7 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
             tmpSgpr = SgprWGMXCC
             group   = SgprQ
             # offset  = SgprR
-            
+
             tmpVgpr     = writer.vgprPool.checkOutAligned(4,2)
             tmpVgprRes  = ContinuousRegister(tmpVgpr, 4)
 
@@ -129,7 +129,7 @@ def wgmXCC(writer, kernel, tmpSgprNumWorkGroups):
             module.add(scalarUInt24DivideAndRemainder(qReg=SgprX, rReg=SgprG, dReg="WorkGroup0", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
             module.add(SWaitCnt(kmcnt=0, comment="wait for args to load"))
             module.addComment0("divmod(WG, WGMXCC)")
-            module.add(scalarUInt24DivideAndRemainder(qReg=SgprQ, rReg=SgprR, dReg="skGrid", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))            
+            module.add(scalarUInt24DivideAndRemainder(qReg=SgprQ, rReg=SgprR, dReg="skGrid", divReg=SgprWGMXCC, tmpVgprRes=tmpVgprRes, wavewidth=kernel["WavefrontSize"], doRemainder=True))
             writer.vgprPool.checkIn(tmpVgpr)
             # Check if current group requires a remainder WG or not
             module.add(SCmpLtU32(src0=sgpr(SgprG), src1=sgpr(SgprR)))

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionSolution.hpp
@@ -566,8 +566,8 @@ namespace TensileLite
         uint32_t magicNumber(int magicDivAlg, uint32_t x, uint32_t* magicShift) const;
         uint32_t smallMagicNumber(uint32_t x) const;
 
-        std::pair<int32_t, uint32_t> calculateAutoWGM(Problem const&  problem, 
-                                                      Hardware const* hardware, 
+        std::pair<int32_t, uint32_t> calculateAutoWGM(Problem const&  problem,
+                                                      Hardware const* hardware,
                                                       uint32_t        skgrid) const;
         uint32_t calculateAutoGSU(Problem const& problem, Hardware const* hardware) const;
     };

--- a/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
@@ -184,7 +184,7 @@ namespace TensileLite
                 if(row.first.value->type() == "ExperimentalStreamK" && !streamK)
                     continue;
 
-                if(predictionLib && ((row.first.value->type() == "EqualityMatching") 
+                if(predictionLib && ((row.first.value->type() == "EqualityMatching")
                                      || (row.first.value->type() == "RangeMatching")))
                     continue;
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
@@ -94,7 +94,7 @@ namespace TensileLite
                                 solution->sizeMapping.workGroupMapping,     // WGM
                                 solution->sizeMapping.nonTemporalA,         // Cache flag: A
                                 solution->sizeMapping.nonTemporalB          // Cache flag: B
-                            ); 
+                            );
 
                             lib.tile_list.emplace_back(solution_tuple);
                             lib.tile_map.insert(std::make_pair(solution_tuple, index));

--- a/projects/hipblaslt/tensilelite/tests/RangeLibrary_test.cpp
+++ b/projects/hipblaslt/tensilelite/tests/RangeLibrary_test.cpp
@@ -108,7 +108,7 @@ TEST_P(RangeLibraryTest, SpecificSizes)
     // transposeA: true, transposeB false, datatype BFloat16,
     // M in [128, 768], N in [1024, 1408], batch_count in [-1, -1], K in [49024, 49280]
 
-    std::vector<std::tuple<size_t, size_t, size_t, size_t, bool>> MNKB = 
+    std::vector<std::tuple<size_t, size_t, size_t, size_t, bool>> MNKB =
         {{128, 1024, 1,  49024, true},
          {768, 1024, 1,  49024, true},
          {128, 1408, 1,  49024, true},
@@ -119,7 +119,7 @@ TEST_P(RangeLibraryTest, SpecificSizes)
          {128, 1409, 1,  49024, false},
          {128, 1024, 1,  16,    false},
          {128, 1024, 1,  49285, false}};
-         
+
 
     for(auto [M, N, B, K, in_range] : MNKB)
     {


### PR DESCRIPTION
## Questions

I'm new to rocm-libraries and have 2 questions which I'd love answers to, and might put this PR in context. 
1) How is hipblaslt (and rocm-libraries more generally) linted? 
2) Is hipblaslt/tensilelite/Tensile a copy-paste from a few years ago of shared/Tensile? 

## Motivation

Get code in a canonical form

## Technical Details
I ran 

```
git ls-files -- . | xargs pre-commit run end-of-file-fixer  --files
git ls-files -- . | xargs pre-commit run trailing-whitespace --files
```

from within tensilelite directory. Ultimately I would like to run 

```
git ls-files -- . | xargs pre-commit run --files
```

to also run the 'black' python linter, clang-format c++ linter, and the raft of others. Even better, I would like to run 

```
pre-commit run  --all-files
```

to run ALL linters on ALL files in rocm-libraries but I guess that's a long way off. 
