### PR TITLE
updating workflow trigger for release branch and using head of rock rel 7.10

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: "release/therock-7.10" # 2025-11-24 pointing to release/therock-7.10 head commit
+          ref: "e238c0269a9e54b275ef34ffb43c6c52a0cddc83" # 2025-11-26 commit on release/therock-7.10 branch
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: "release/therock-7.10" # 2025-11-24 pointing to release/therock-7.10 head commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: "release/therock-7.10" # 2025-11-24 pointing to release/therock-7.10 head commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: "release/therock-7.10" # 2025-11-24 pointing to release/therock-7.10 head commit
+          ref: "e238c0269a9e54b275ef34ffb43c6c52a0cddc83" # 2025-11-26 commit on release/therock-7.10 branch
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - release/therock-*
   pull_request:
     types:
       - opened

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -3,7 +3,8 @@ name: TheRock CI
 on:
   push:
     branches:
-      - release/therock-7.10
+      - develop
+      - release/therock-*
   pull_request:
     types:
       - opened

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -3,7 +3,7 @@ name: TheRock CI
 on:
   push:
     branches:
-      - develop
+      - release/therock-7.10
   pull_request:
     types:
       - opened

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: e238c0269a9e54b275ef34ffb43c6c52a0cddc83 # 2025-11-26 commit on release/therock-7.10 branch
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: e238c0269a9e54b275ef34ffb43c6c52a0cddc83 # 2025-11-26 commit on release/therock-7.10 branch
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: e238c0269a9e54b275ef34ffb43c6c52a0cddc83 # 2025-11-26 commit on release/therock-7.10 branch
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION

## Motivation
PSDB or per PR build and test workflow needs to be triggered, as this is the blocking gate

## Technical Details
Needed for 7.10 release branch cherrypick validation

## Test Plan
Test gate will be same as what it is there for develop branch