### PR TITLE
Guard against missing directories in Tensile Toolchain.py

### DIFF
--- a/shared/tensile/Tensile/Utilities/Toolchain.py
+++ b/shared/tensile/Tensile/Utilities/Toolchain.py
@@ -48,10 +48,14 @@ def _windowsLatestRocmBin(path: Union[Path, str]) -> Path:
     Returns:
         The path to the ROCm bin directory for the latest ROCm version.
         Typically of the form ``C:/Program Files/AMD/ROCm/X.Y/bin``.
+        May return ``None`` if no ``X.Y`` subdirectories exist, perhaps due to
+        a partial uninstall.
     """
     path = Path(path)
     pattern = re.compile(r"^\d+\.\d+$")
-    versions = filter(lambda d: d.is_dir() and pattern.match(d.name), path.iterdir())
+    versions = list(filter(lambda d: d.is_dir() and pattern.match(d.name), path.iterdir()))
+    if len(versions) == 0:
+        return None
     latest = max(versions, key=lambda d: tuple(map(int, d.name.split("."))))
     return latest / "bin"
 
@@ -65,7 +69,9 @@ def _windowsSearchPaths() -> List[Path]:
         searchPaths.extend(hipPaths)
 
     if Path(defaultPath).exists():
-        searchPaths.append(_windowsLatestRocmBin(defaultPath))
+        latestRocmBin = _windowsLatestRocmBin(defaultPath)
+        if latestRocmBin:
+            searchPaths.append(defaultPath)
 
     if os.environ.get("PATH"):
         envPath = [Path(p) for p in os.environ["PATH"].split(os.pathsep)]


### PR DESCRIPTION
Building rocBLAS with a `C:\Program Files\AMD\ROCm` directory that has no `X.Y` directories (e.g. `C:\Program Files\AMD\ROCm\7.2`) produces errors:

```
[rocBLAS] [0/622] Generating libraries with TensileCreateLibrary
[rocBLAS] Traceback (most recent call last):
[rocBLAS]   File "C:\develop\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\bin\TensileCreateLibrary", line 43, in <module>
[rocBLAS]     TensileCreateLibrary()
[rocBLAS]   File "C:\develop\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\TensileCreateLibrary.py", line 1357, in TensileCreateLibrary
[rocBLAS]     args = parseArguments()
[rocBLAS]            ^^^^^^^^^^^^^^^^
[rocBLAS]   File "C:\develop\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\TensileCreateLib\ParseArguments.py", line 331, in parseArguments
[rocBLAS]     ) = validateToolchain(
[rocBLAS]         ^^^^^^^^^^^^^^^^^^
[rocBLAS]   File "C:\develop\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\Utilities\Toolchain.py", line 258, in validateToolchain
[rocBLAS]     searchPaths = _windowsSearchPaths() if os.name == "nt" else _posixSearchPaths()
[rocBLAS]                   ^^^^^^^^^^^^^^^^^^^^^
[rocBLAS]   File "C:\develop\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\Utilities\Toolchain.py", line 68, in _windowsSearchPaths
[rocBLAS]     searchPaths.append(_windowsLatestRocmBin(defaultPath))
[rocBLAS]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rocBLAS]   File "C:\develop\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\Utilities\Toolchain.py", line 55, in _windowsLatestRocmBin
[rocBLAS]     latest = max(versions, key=lambda d: tuple(map(int, d.name.split("."))))
[rocBLAS]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rocBLAS] ValueError: max() iterable argument is empty
```

Similar issue but for hipBLASLt happened and it is solved and merged in [Guard against missing directories in Tensile Validators.py. #2110](https://github.com/ROCm/hipBLASLt/pull/2110). 
The same changes are added in this case but in `Toolchain.py` file which is causing error during rocBLAS build.
