### PR TITLE
[hipblaslt] pts - added api_overhead to PR's perf-ci workload

### DIFF
--- a/projects/hipblaslt/clients/bench/src/client_api_overhead.cpp
+++ b/projects/hipblaslt/clients/bench/src/client_api_overhead.cpp
@@ -28,6 +28,7 @@
 #include <hip/hip_runtime.h>
 #include <hipblaslt/hipblaslt-ext.hpp>
 #include <hipblaslt/hipblaslt.h>
+#include <hipblaslt_arguments.hpp>
 #include <iostream>
 
 #include "helper.h"
@@ -36,23 +37,28 @@ using clock_point  = std::chrono::time_point<std::chrono::steady_clock>;
 using double_micro = std::chrono::duration<double, std::micro>;
 using HHSRunner    = Runner<hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, float>;
 
-size_t warmups  = 10;
-size_t hotIters = 1000;
+size_t warmups     = 10;
+size_t hotIters    = 1000;
+size_t getAllIters = 100;
 int    algoIdx;
 
-double_micro total_getHeur      = double_micro::zero();
-double_micro total_matmul       = double_micro::zero();
-double_micro total_ext_getHeur  = double_micro::zero();
-double_micro total_ext_getAll   = double_micro::zero();
-double_micro total_ext_getByIdx = double_micro::zero();
-double_micro total_run          = double_micro::zero();
+double_micro total_getHeur         = double_micro::zero();
+double_micro total_getHeurNeg1     = double_micro::zero();
+double_micro total_matmul          = double_micro::zero();
+double_micro total_ext_getHeur     = double_micro::zero();
+double_micro total_ext_getHeurNeg1 = double_micro::zero();
+double_micro total_ext_getAll      = double_micro::zero();
+double_micro total_ext_getByIdx    = double_micro::zero();
+double_micro total_run             = double_micro::zero();
 
-double_micro best_getHeur      = double_micro::max();
-double_micro best_matmul       = double_micro::max();
-double_micro best_ext_getHeur  = double_micro::max();
-double_micro best_ext_getAll   = double_micro::max();
-double_micro best_ext_getByIdx = double_micro::max();
-double_micro best_run          = double_micro::max();
+double_micro best_getHeur         = double_micro::max();
+double_micro best_getHeurNeg1     = double_micro::max();
+double_micro best_matmul          = double_micro::max();
+double_micro best_ext_getHeur     = double_micro::max();
+double_micro best_ext_getHeurNeg1 = double_micro::max();
+double_micro best_ext_getAll      = double_micro::max();
+double_micro best_ext_getByIdx    = double_micro::max();
+double_micro best_run             = double_micro::max();
 
 void printUsage(char* programName)
 {
@@ -60,10 +66,11 @@ void printUsage(char* programName)
               << "options:\n"
               << "\t-h, --help\t\t\tShow this help message\n"
               << "\t-i, --iters\t\t\tHot iterations, default is 1000.\n"
-              << "\t-j, --cold_iters\t\t\tWarmup iterations, default is 10.\n";
+              << "\t-j, --cold_iters\t\t\tWarmup iterations, default is 10.\n"
+              << "\t-k, --get_all_iters\t\t\tHot iterations for getAll, default is 100.\n";
 }
 
-int parseArgs(int argc, char** argv, size_t& cold, size_t& hot)
+int parseArgs(int argc, char** argv, size_t& cold, size_t& hot, size_t& getAllIters)
 {
     if(argc <= 1)
     {
@@ -87,6 +94,10 @@ int parseArgs(int argc, char** argv, size_t& cold, size_t& hot)
             else if(arg == "-j" || arg == "--cold_iters")
             {
                 cold = std::stoul(argv[++i]);
+            }
+            else if(arg == "-k" || arg == "--get_all_iters")
+            {
+                getAllIters = std::stoul(argv[++i]);
             }
         }
         else
@@ -115,7 +126,8 @@ void simpleGemm(hipblasLtHandle_t  handle,
                 void*              d_d,
                 void*              d_workspace,
                 int64_t            max_workspace_size,
-                hipStream_t        stream);
+                hipStream_t        stream,
+                int                requested_solutions);
 
 void simpleGemmExt(hipblasLtHandle_t  handle,
                    hipblasOperation_t trans_a,
@@ -132,7 +144,8 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
                    void*              d_d,
                    void*              d_workspace,
                    int64_t            max_workspace_size,
-                   hipStream_t        stream);
+                   hipStream_t        stream,
+                   int                requested_solutions);
 
 void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
                               hipblasOperation_t trans_a,
@@ -168,43 +181,62 @@ void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
                                  int64_t            max_workspace_size,
                                  hipStream_t        stream);
 
-void calcOverheadGetHeuristic();
-void calcOverheadExtGetHeuristic();
+void calcOverheadGetHeuristic(int requested_solutions = 1);
+void calcOverheadExtGetHeuristic(int requested_solutions = 1);
 void calcOverheadExtGetAllAlgos();
 void calcOverheadExtGetAlgoByIdx();
 
 int main(int argc, char** argv)
 {
-    if(auto err = parseArgs(argc, argv, warmups, hotIters))
+    if(auto err = parseArgs(argc, argv, warmups, hotIters, getAllIters))
     {
         printUsage(argv[0]);
         return err;
     }
 
     std::cout << "[overhead]:function,api_name,us/iter,best_us\n";
+    // calls hipblasLtMatmul hotIters times
     calcOverheadGetHeuristic();
     std::cout << "api_overhead,hipblasLtMatmulAlgoGetHeuristic,"
               << std::to_string(total_getHeur.count() / hotIters) << ","
               << std::to_string(best_getHeur.count()) << std::endl;
-    std::cout << "api_overhead,hipblasLtMatmul," << std::to_string(total_matmul.count() / hotIters)
-              << "," << std::to_string(best_matmul.count()) << std::endl;
 
-    calcOverheadExtGetHeuristic(); // calls ext::run hotIters times
+    // calls ext::run hotIters times
+    calcOverheadExtGetHeuristic();
     std::cout << "api_overhead,hipblaslt_ext::algoGetHeuristic,"
               << std::to_string(total_ext_getHeur.count() / hotIters) << ","
               << std::to_string(best_ext_getHeur.count()) << std::endl;
 
-    calcOverheadExtGetAllAlgos(); // calls ext::run hotIters times
+    // won't calls ext::run, and note that the hot iter is getAllIters
+    calcOverheadExtGetAllAlgos();
     std::cout << "api_overhead,hipblaslt_ext::getAllAlgos,"
-              << std::to_string(total_ext_getAll.count() / hotIters) << ","
+              << std::to_string(total_ext_getAll.count() / getAllIters) << ","
               << std::to_string(best_ext_getAll.count()) << std::endl;
 
-    calcOverheadExtGetAlgoByIdx(); // calls ext::run hotIters times
+    // calls ext::run hotIters times
+    calcOverheadExtGetAlgoByIdx();
     std::cout << "api_overhead,hipblaslt_ext::getAlgosFromIndex,"
               << std::to_string(total_ext_getByIdx.count() / hotIters) << ","
               << std::to_string(best_ext_getByIdx.count()) << std::endl;
+
+    // new: get heuristic with requested-solution = -1
+    int requested_solutions = -1;
+    // won't calls hipblasLtMatmul if requested_solutions != 1, and note that the hot iter is getAllIters
+    calcOverheadGetHeuristic(requested_solutions);
+    std::cout << "api_overhead,hipblasLtMatmulAlgoGetHeuristic[Neg1],"
+              << std::to_string(total_getHeurNeg1.count() / getAllIters) << ","
+              << std::to_string(best_getHeurNeg1.count()) << std::endl;
+    // won't calls ext::run if requested_solutions != 1, and note that the hot iter is getAllIters
+    calcOverheadExtGetHeuristic(requested_solutions);
+    std::cout << "api_overhead,hipblaslt_ext::algoGetHeuristic[Neg1],"
+              << std::to_string(total_ext_getHeurNeg1.count() / getAllIters) << ","
+              << std::to_string(best_ext_getHeurNeg1.count()) << std::endl;
+
+    // put matmul exec time in the end
+    std::cout << "api_overhead,hipblasLtMatmul," << std::to_string(total_matmul.count() / hotIters)
+              << "," << std::to_string(best_matmul.count()) << std::endl;
     std::cout << "api_overhead,hipblaslt_ext::run,"
-              << std::to_string(total_run.count() / (hotIters * 3)) << ","
+              << std::to_string(total_run.count() / (hotIters * 2)) << ","
               << std::to_string(best_run.count()) << std::endl;
 
     return 0;
@@ -213,10 +245,13 @@ int main(int argc, char** argv)
 /////////////////////////////////////////
 // hipBLASLt GetHeuristic & MatMul
 /////////////////////////////////////////
-void calcOverheadGetHeuristic()
+void calcOverheadGetHeuristic(int requested_solutions)
 {
+    requested_solutions
+        = requested_solutions < 0 ? HIPBLASLT_MAX_REQUESTED_SOLUTION_NUM : requested_solutions;
+
     HHSRunner runner(1024, 512, 1024, 1, 1.f, 1.f, 32 * 1024 * 1024);
-    runner.run([&runner] {
+    runner.run([&] {
         simpleGemm(runner.handle,
                    HIPBLAS_OP_N,
                    HIPBLAS_OP_N,
@@ -232,7 +267,8 @@ void calcOverheadGetHeuristic()
                    runner.d_d,
                    runner.d_workspace,
                    runner.max_workspace_size,
-                   runner.stream);
+                   runner.stream,
+                   requested_solutions);
     });
 }
 
@@ -251,7 +287,8 @@ void simpleGemm(hipblasLtHandle_t  handle,
                 void*              d_d,
                 void*              d_workspace,
                 int64_t            max_workspace_size,
-                hipStream_t        stream)
+                hipStream_t        stream,
+                int                requested_solutions)
 {
     hipblasLtMatrixLayout_t matA, matB, matC, matD;
     CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matA, HIP_R_16F, m, k, m));
@@ -317,9 +354,8 @@ void simpleGemm(hipblasLtHandle_t  handle,
     //
     for(size_t iter = 0; iter < warmups; ++iter)
     {
-        const int                        request_solutions = 1;
-        hipblasLtMatmulHeuristicResult_t heuristicResult[request_solutions];
-        int                              returnedAlgoCount = 0;
+        std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResult(requested_solutions);
+        int                                           returnedAlgoCount = 0;
         CHECK_HIPBLASLT_ERROR(hipblasLtMatmulAlgoGetHeuristic(handle,
                                                               matmul,
                                                               matA,
@@ -327,8 +363,8 @@ void simpleGemm(hipblasLtHandle_t  handle,
                                                               matC,
                                                               matD,
                                                               pref,
-                                                              request_solutions,
-                                                              heuristicResult,
+                                                              requested_solutions,
+                                                              heuristicResult.data(),
                                                               &returnedAlgoCount));
 
         if(returnedAlgoCount == 0)
@@ -339,38 +375,41 @@ void simpleGemm(hipblasLtHandle_t  handle,
         }
 
         uint64_t workspace_size = 0;
-        for(int i = 0; i < returnedAlgoCount; i++)
-            workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
+        if(requested_solutions == 1)
+        {
+            for(int i = 0; i < returnedAlgoCount; i++)
+                workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
 
-        CHECK_HIPBLASLT_ERROR(hipblasLtMatmul(handle,
-                                              matmul,
-                                              &alpha,
-                                              d_a,
-                                              matA,
-                                              d_b,
-                                              matB,
-                                              &beta,
-                                              d_c,
-                                              matC,
-                                              d_d,
-                                              matD,
-                                              &heuristicResult[0].algo,
-                                              d_workspace,
-                                              workspace_size,
-                                              stream));
+            CHECK_HIPBLASLT_ERROR(hipblasLtMatmul(handle,
+                                                  matmul,
+                                                  &alpha,
+                                                  d_a,
+                                                  matA,
+                                                  d_b,
+                                                  matB,
+                                                  &beta,
+                                                  d_c,
+                                                  matC,
+                                                  d_d,
+                                                  matD,
+                                                  &heuristicResult[0].algo,
+                                                  d_workspace,
+                                                  workspace_size,
+                                                  stream));
+        }
     }
 
     clock_point start_getHeur, end_getHeur;
     clock_point start_matmul, end_matmul;
+    size_t      iters = (requested_solutions == 1) ? hotIters : getAllIters;
 
     //
     // hot-iters
     //
-    for(size_t iter = 0; iter < hotIters; ++iter)
+    for(size_t iter = 0; iter < iters; ++iter)
     {
-        const int                        request_solutions = 1;
-        hipblasLtMatmulHeuristicResult_t heuristicResult[request_solutions];
-        int                              returnedAlgoCount = 0;
+        std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResult(requested_solutions);
+        int                                           returnedAlgoCount = 0;
 
         start_getHeur = std::chrono::steady_clock::now();
         CHECK_HIPBLASLT_ERROR(hipblasLtMatmulAlgoGetHeuristic(handle,
@@ -380,13 +419,21 @@ void simpleGemm(hipblasLtHandle_t  handle,
                                                               matC,
                                                               matD,
                                                               pref,
-                                                              request_solutions,
-                                                              heuristicResult,
+                                                              requested_solutions,
+                                                              heuristicResult.data(),
                                                               &returnedAlgoCount));
         end_getHeur           = std::chrono::steady_clock::now();
         double_micro duration = end_getHeur - start_getHeur;
-        best_getHeur          = std::min(best_getHeur, duration);
-        total_getHeur += duration;
+        if(requested_solutions == 1)
+        {
+            best_getHeur = std::min(best_getHeur, duration);
+            total_getHeur += duration;
+        }
+        else
+        {
+            best_getHeurNeg1 = std::min(best_getHeurNeg1, duration);
+            total_getHeurNeg1 += duration;
+        }
 
         if(returnedAlgoCount == 0)
         {
@@ -396,30 +443,33 @@ void simpleGemm(hipblasLtHandle_t  handle,
         }
 
         uint64_t workspace_size = 0;
-        for(int i = 0; i < returnedAlgoCount; i++)
-            workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
+        if(requested_solutions == 1)
+        {
+            for(int i = 0; i < returnedAlgoCount; i++)
+                workspace_size = max(workspace_size, heuristicResult[i].workspaceSize);
 
-        start_matmul = std::chrono::steady_clock::now();
-        CHECK_HIPBLASLT_ERROR(hipblasLtMatmul(handle,
-                                              matmul,
-                                              &alpha,
-                                              d_a,
-                                              matA,
-                                              d_b,
-                                              matB,
-                                              &beta,
-                                              d_c,
-                                              matC,
-                                              d_d,
-                                              matD,
-                                              &heuristicResult[0].algo,
-                                              d_workspace,
-                                              workspace_size,
-                                              stream));
-        end_matmul  = std::chrono::steady_clock::now();
-        duration    = end_matmul - start_matmul;
-        best_matmul = std::min(best_matmul, duration);
-        total_matmul += duration;
+            start_matmul = std::chrono::steady_clock::now();
+            CHECK_HIPBLASLT_ERROR(hipblasLtMatmul(handle,
+                                                  matmul,
+                                                  &alpha,
+                                                  d_a,
+                                                  matA,
+                                                  d_b,
+                                                  matB,
+                                                  &beta,
+                                                  d_c,
+                                                  matC,
+                                                  d_d,
+                                                  matD,
+                                                  &heuristicResult[0].algo,
+                                                  d_workspace,
+                                                  workspace_size,
+                                                  stream));
+            end_matmul  = std::chrono::steady_clock::now();
+            duration    = end_matmul - start_matmul;
+            best_matmul = std::min(best_matmul, duration);
+            total_matmul += duration;
+        }
     }
 
     freeResource();
@@ -430,10 +480,13 @@ void simpleGemm(hipblasLtHandle_t  handle,
 /////////////////////////////////////////
 // hipBLASLt_ext - algoGetHeuristic & run
 /////////////////////////////////////////
-void calcOverheadExtGetHeuristic()
+void calcOverheadExtGetHeuristic(int requested_solutions)
 {
+    requested_solutions
+        = requested_solutions < 0 ? HIPBLASLT_MAX_REQUESTED_SOLUTION_NUM : requested_solutions;
+
     HHSRunner runner(1024, 512, 1024, 1, 1.f, 1.f, 32 * 1024 * 1024);
-    runner.run([&runner] {
+    runner.run([&] {
         simpleGemmExt(runner.handle,
                       HIPBLAS_OP_N,
                       HIPBLAS_OP_N,
@@ -449,7 +502,8 @@ void calcOverheadExtGetHeuristic()
                       runner.d_d,
                       runner.d_workspace,
                       runner.max_workspace_size,
-                      runner.stream);
+                      runner.stream,
+                      requested_solutions);
     });
 }
 
@@ -468,7 +522,8 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
                    void*              d_d,
                    void*              d_workspace,
                    int64_t            max_workspace_size,
-                   hipStream_t        stream)
+                   hipStream_t        stream,
+                   int                requested_solutions)
 {
     hipblaslt_ext::GemmPreference gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
@@ -491,9 +546,9 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
     //
     for(size_t iter = 0; iter < warmups; ++iter)
     {
-        const int                                     request_solutions = 1;
         std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResult;
-        CHECK_HIPBLASLT_ERROR(gemm.algoGetHeuristic(request_solutions, gemmPref, heuristicResult));
+        CHECK_HIPBLASLT_ERROR(
+            gemm.algoGetHeuristic(requested_solutions, gemmPref, heuristicResult));
 
         if(heuristicResult.empty())
         {
@@ -501,29 +556,42 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
             return;
         }
 
-        // Make sure to initialize every time when algo changes
-        gemm.setMaxWorkspaceBytes(max_workspace_size);
-        CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
-        CHECK_HIPBLASLT_ERROR(gemm.run(stream));
+        if(requested_solutions == 1)
+        {
+            // Make sure to initialize every time when algo changes
+            gemm.setMaxWorkspaceBytes(max_workspace_size);
+            CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
+            CHECK_HIPBLASLT_ERROR(gemm.run(stream));
+        }
     }
 
     clock_point start_ext_getHeur, end_ext_getHeur;
     clock_point start_ext_run, end_ext_run;
+    size_t      iters = (requested_solutions == 1) ? hotIters : getAllIters;
 
     //
     // hot-iters
     //
-    for(size_t iter = 0; iter < hotIters; ++iter)
+    for(size_t iter = 0; iter < iters; ++iter)
     {
-        const int                                     request_solutions = 1;
         std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResult;
 
         start_ext_getHeur = std::chrono::steady_clock::now();
-        CHECK_HIPBLASLT_ERROR(gemm.algoGetHeuristic(request_solutions, gemmPref, heuristicResult));
+        CHECK_HIPBLASLT_ERROR(
+            gemm.algoGetHeuristic(requested_solutions, gemmPref, heuristicResult));
         end_ext_getHeur       = std::chrono::steady_clock::now();
         double_micro duration = end_ext_getHeur - start_ext_getHeur;
-        best_ext_getHeur      = std::min(best_ext_getHeur, duration);
-        total_ext_getHeur += duration;
+
+        if(requested_solutions == 1)
+        {
+            best_ext_getHeur = std::min(best_ext_getHeur, duration);
+            total_ext_getHeur += duration;
+        }
+        else
+        {
+            best_ext_getHeurNeg1 = std::min(best_ext_getHeurNeg1, duration);
+            total_ext_getHeurNeg1 += duration;
+        }
 
         if(heuristicResult.empty())
         {
@@ -531,19 +599,22 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
             return;
         }
 
-        // save the algoIdx for testing getByIdx
-        algoIdx = hipblaslt_ext::getIndexFromAlgo(heuristicResult[0].algo);
+        if(requested_solutions == 1)
+        {
+            // save the algoIdx for testing getByIdx
+            algoIdx = hipblaslt_ext::getIndexFromAlgo(heuristicResult[0].algo);
 
-        // Make sure to initialize every time when algo changes
-        gemm.setMaxWorkspaceBytes(max_workspace_size);
-        CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
+            // Make sure to initialize every time when algo changes
+            gemm.setMaxWorkspaceBytes(max_workspace_size);
+            CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
 
-        start_ext_run = std::chrono::steady_clock::now();
-        CHECK_HIPBLASLT_ERROR(gemm.run(stream));
-        end_ext_run = std::chrono::steady_clock::now();
-        duration    = end_ext_run - start_ext_run;
-        best_run    = std::min(best_run, duration);
-        total_run += duration;
+            start_ext_run = std::chrono::steady_clock::now();
+            CHECK_HIPBLASLT_ERROR(gemm.run(stream));
+            end_ext_run = std::chrono::steady_clock::now();
+            duration    = end_ext_run - start_ext_run;
+            best_run    = std::min(best_run, duration);
+            total_run += duration;
+        }
     }
 
     return;
@@ -645,11 +716,6 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
             std::cerr << "[GetAllAlgosExt]:No valid solution found!" << std::endl;
             return;
         }
-
-        // Make sure to initialize every time when algo changes
-        gemm.setMaxWorkspaceBytes(workspace_size);
-        CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[validIdx[0]].algo, d_workspace));
-        CHECK_HIPBLASLT_ERROR(gemm.run(stream));
     }
 
     clock_point start_ext_getAll, end_ext_getAll;
@@ -658,7 +724,7 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
     //
     // hot-iters
     //
-    for(size_t iter = 0; iter < hotIters; ++iter)
+    for(size_t iter = 0; iter < getAllIters; ++iter)
     {
         std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResult;
         start_ext_getAll = std::chrono::steady_clock::now();
@@ -676,39 +742,6 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
         double_micro duration = end_ext_getAll - start_ext_getAll;
         best_ext_getAll       = std::min(best_ext_getAll, duration);
         total_ext_getAll += duration;
-
-        uint64_t            workspace_size = 0;
-        std::vector<size_t> validIdx;
-        for(size_t i = 0; i < heuristicResult.size(); i++)
-        {
-            size_t workspaceSizeInBytes = 0;
-            if(gemm.isAlgoSupported(heuristicResult[i].algo, workspaceSizeInBytes)
-               == HIPBLAS_STATUS_SUCCESS)
-            {
-                if(workspaceSizeInBytes <= max_workspace_size)
-                {
-                    workspace_size = max(workspace_size, workspaceSizeInBytes);
-                    validIdx.push_back(i);
-                }
-            }
-        }
-
-        if(validIdx.empty())
-        {
-            std::cerr << "[GetAllAlgosExt]:No valid solution found!" << std::endl;
-            return;
-        }
-
-        // Make sure to initialize every time when algo changes
-        gemm.setMaxWorkspaceBytes(workspace_size);
-        CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[validIdx[0]].algo, d_workspace));
-
-        start_ext_run = std::chrono::steady_clock::now();
-        CHECK_HIPBLASLT_ERROR(gemm.run(stream));
-        end_ext_run = std::chrono::steady_clock::now();
-        duration    = end_ext_run - start_ext_run;
-        best_run    = std::min(best_run, duration);
-        total_run += duration;
     }
 
     return;

--- a/projects/hipblaslt/clients/scripts/performance/suites.py
+++ b/projects/hipblaslt/clients/scripts/performance/suites.py
@@ -56,8 +56,8 @@ lengths = {
 def api_overhead():
     """API overhead"""
 
-    # iteraion 10000 takes too long time for "getAll", 1000 is enough
-    problemlist = [Problem(args={"--cold_iters" : "10" , "--iters" : "1000"})]
+    # set different value for hot iteration of getHeuristic and getAll
+    problemlist = [Problem(args={"--cold_iters" : "10" , "--iters" : "1000" , "--get_all_iters" : "100"})]
     yield ProblemSet(benchType="api_overhead", name="benchset_1", problems=problemlist)
 
 def amax_example():
@@ -97,6 +97,13 @@ def matmul_set_2():
 
     problemlist = [Problem(args={"--log_function_name" : "" , "--yaml" : "matmul_probset2_bench.yaml"})]
     yield ProblemSet(benchType="matmul", name="benchset_2", problems=problemlist)
+
+def ci_perf_job():
+    """run basic job for PR-CI"""
+
+    # general suites for all arches
+    yield from api_overhead()
+    yield from matmul_set_1()
 
 def all():
     """all routine benchmarks"""


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Each PR now runs perf-ci with a modified "generic matmul problem set". I'd like to put "api_overhead" into the perf-ci workload.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
From the script in Jenkins, we know that the full test (**--suite all**) will be run only when it is merged into develop branch. And for each PR, CI runs a perf-job with "**--suite matmul_set_1**", but with the modified file with lots of generic tests. 

I'd like to make a new suite "**ci_perf_job**" for PR's perf-job, which includes "**matmul_set_1**" and "**api_overhead**" since the api_overhead has becoming a important concern for solution-selection. 

Also, I added two new cases: "getHeuristic & requested-solution = -1" (for both c/cpp api) to the api_overhead sample. Since we believe we can optimize this special case. A follow-up PR will be submitted after this is merged.

After this PR is merged, 
The script in Jenkins: https://github.com/ROCm/rocJenkins/blob/pong/src/com/amd/project/hipblaslt/performanceRunner.groovy#L97
should be re-written from "**--suite matmul_set_1**" to "**--suite ci_perf_job**" to cover the api_overhead. 

hipblaslt team will confirm this change with rocPTS team.

#### Others

- [x] Use different hot-iteration values for getHeuristic and getAll, since getAll takes too long.
- [x] Reduce the times of calling matmul and ext::run to make the test faster. We won't call them in all getAll samples.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
