### PR TITLE
[hipsparse] Fix testing of routines involving full sparse vectors

### DIFF
--- a/projects/hipsparse/clients/include/testing_axpby.hpp
+++ b/projects/hipsparse/clients/include/testing_axpby.hpp
@@ -117,7 +117,7 @@ hipsparseStatus_t testing_axpby(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, size);
+    hipsparseInitIndex(hx_ind.data(), nnz, idxBase, size + idxBase);
     hipsparseInit<T>(hx_val, 1, nnz);
     hipsparseInit<T>(hy, 1, size);
 

--- a/projects/hipsparse/clients/include/testing_axpyi.hpp
+++ b/projects/hipsparse/clients/include/testing_axpyi.hpp
@@ -98,7 +98,18 @@ hipsparseStatus_t testing_axpyi(const Arguments& argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hxInd.data(), nnz, 1, N);
+    hipsparseInitIndex(hxInd.data(), nnz, idx_base, N + idx_base);
+
+    std::cout << "hxInd" << std::endl;
+    for(size_t i = 0; i < hxInd.size(); i++)
+    {
+        std::cout << hxInd[i] << " ";
+    }
+    std::cout << "" << std::endl;
+
+
+
+
     hipsparseInit<T>(hxVal, 1, nnz);
     hipsparseInit<T>(hy_1, 1, N);
 

--- a/projects/hipsparse/clients/include/testing_axpyi.hpp
+++ b/projects/hipsparse/clients/include/testing_axpyi.hpp
@@ -99,17 +99,6 @@ hipsparseStatus_t testing_axpyi(const Arguments& argus)
     // Initial Data on CPU
     srand(12345ULL);
     hipsparseInitIndex(hxInd.data(), nnz, idx_base, N + idx_base);
-
-    std::cout << "hxInd" << std::endl;
-    for(size_t i = 0; i < hxInd.size(); i++)
-    {
-        std::cout << hxInd[i] << " ";
-    }
-    std::cout << "" << std::endl;
-
-
-
-
     hipsparseInit<T>(hxVal, 1, nnz);
     hipsparseInit<T>(hy_1, 1, N);
 

--- a/projects/hipsparse/clients/include/testing_dotci.hpp
+++ b/projects/hipsparse/clients/include/testing_dotci.hpp
@@ -102,7 +102,7 @@ hipsparseStatus_t testing_dotci(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, N);
+    hipsparseInitIndex(hx_ind.data(), nnz, idx_base, N + idx_base);
     hipsparseInit<T>(hx_val, 1, nnz);
     hipsparseInit<T>(hy, 1, N);
 

--- a/projects/hipsparse/clients/include/testing_doti.hpp
+++ b/projects/hipsparse/clients/include/testing_doti.hpp
@@ -102,7 +102,7 @@ hipsparseStatus_t testing_doti(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, N);
+    hipsparseInitIndex(hx_ind.data(), nnz, idx_base, N + idx_base);
     hipsparseInit<T>(hx_val, 1, nnz);
     hipsparseInit<T>(hy, 1, N);
 

--- a/projects/hipsparse/clients/include/testing_gather.hpp
+++ b/projects/hipsparse/clients/include/testing_gather.hpp
@@ -105,7 +105,7 @@ hipsparseStatus_t testing_gather(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, size);
+    hipsparseInitIndex(hx_ind.data(), nnz, idxBase, size + idxBase);
     hipsparseInit<T>(hy, 1, size);
 
     // Allocate memory on device

--- a/projects/hipsparse/clients/include/testing_gemvi.hpp
+++ b/projects/hipsparse/clients/include/testing_gemvi.hpp
@@ -184,7 +184,7 @@ hipsparseStatus_t testing_gemvi(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, n);
+    hipsparseInitIndex(hx_ind.data(), nnz, idxBase, n + idxBase);
     hipsparseInit<T>(hx_val, 1, nnz);
     hipsparseInit<T>(hy, 1, m);
     hy_gold = hy;

--- a/projects/hipsparse/clients/include/testing_gthr.hpp
+++ b/projects/hipsparse/clients/include/testing_gthr.hpp
@@ -90,7 +90,7 @@ hipsparseStatus_t testing_gthr(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, N);
+    hipsparseInitIndex(hx_ind.data(), nnz, idx_base, N + idx_base);
     hipsparseInit<T>(hy, 1, N);
 
     // allocate memory on device

--- a/projects/hipsparse/clients/include/testing_gthrz.hpp
+++ b/projects/hipsparse/clients/include/testing_gthrz.hpp
@@ -91,7 +91,7 @@ hipsparseStatus_t testing_gthrz(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, N);
+    hipsparseInitIndex(hx_ind.data(), nnz, idx_base, N + idx_base);
     hipsparseInit<T>(hy, 1, N);
 
     hy_gold = hy;

--- a/projects/hipsparse/clients/include/testing_rot.hpp
+++ b/projects/hipsparse/clients/include/testing_rot.hpp
@@ -119,7 +119,7 @@ hipsparseStatus_t testing_rot(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, size);
+    hipsparseInitIndex(hx_ind.data(), nnz, idxBase, size + idxBase);
     hipsparseInit<T>(hx_val_1, 1, nnz);
     hipsparseInit<T>(hy_1, 1, size);
 

--- a/projects/hipsparse/clients/include/testing_roti.hpp
+++ b/projects/hipsparse/clients/include/testing_roti.hpp
@@ -109,7 +109,7 @@ hipsparseStatus_t testing_roti(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, N);
+    hipsparseInitIndex(hx_ind.data(), nnz, idx_base, N + idx_base);
     hipsparseInit<T>(hx_val_1, 1, nnz);
     hipsparseInit<T>(hy_1, 1, N);
 

--- a/projects/hipsparse/clients/include/testing_scatter.hpp
+++ b/projects/hipsparse/clients/include/testing_scatter.hpp
@@ -106,7 +106,7 @@ hipsparseStatus_t testing_scatter(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, size);
+    hipsparseInitIndex(hx_ind.data(), nnz, idxBase, size + idxBase);
     hipsparseInit<T>(hx_val, 1, nnz);
     hipsparseInit<T>(hy, 1, size);
 

--- a/projects/hipsparse/clients/include/testing_sctr.hpp
+++ b/projects/hipsparse/clients/include/testing_sctr.hpp
@@ -94,7 +94,7 @@ hipsparseStatus_t testing_sctr(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, N);
+    hipsparseInitIndex(hx_ind.data(), nnz, idx_base, N + idx_base);
     hipsparseInit<T>(hx_val, 1, nnz);
     hipsparseInit<T>(hy, 1, N);
 

--- a/projects/hipsparse/clients/include/testing_spvv.hpp
+++ b/projects/hipsparse/clients/include/testing_spvv.hpp
@@ -143,7 +143,7 @@ hipsparseStatus_t testing_spvv(Arguments argus)
 
     // Initial Data on CPU
     srand(12345ULL);
-    hipsparseInitIndex(hx_ind.data(), nnz, 1, size);
+    hipsparseInitIndex(hx_ind.data(), nnz, idxBase, size + idxBase);
     hipsparseInit<T>(hx_val, 1, nnz);
     hipsparseInit<T>(hy, 1, size);
 

--- a/projects/hipsparse/clients/tests/test_axpby.yaml
+++ b/projects/hipsparse/clients/tests/test_axpby.yaml
@@ -33,12 +33,38 @@ Tests:
   precision: *single_double_precisions_complex_real
 
 - name: axpby
+  category: quick
+  function: axpby
+  indextype: *i32
+  precision: *single_double_precisions
+  N: [5000]
+  nnz: [0, 500, 2500]
+  alpha: [1.0]
+  alphai: [0.0]
+  beta: [1.0]
+  betai: [0.0]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: axpby
   category: pre_checkin
   function: axpby
   indextype: *i32_i64
   precision: *single_double_precisions_complex_real
   N: [22031]
   nnz: [0, 5, 1000, 10000]
+  alpha: [1.0]
+  alphai: [0.0]
+  beta: [1.0]
+  betai: [0.0]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: axpby
+  category: nightly
+  function: axpby
+  indextype: *i32_i64
+  precision: *single_double_precisions_complex_real
+  N: [100000, 500000]
+  nnz: [0, 10000, 50000, 100000]
   alpha: [1.0]
   alphai: [0.0]
   beta: [1.0]

--- a/projects/hipsparse/clients/tests/test_axpyi.yaml
+++ b/projects/hipsparse/clients/tests/test_axpyi.yaml
@@ -32,11 +32,31 @@ Tests:
   precision: *single_double_precisions_complex_real
 
 - name: axpyi
+  category: quick
+  function: axpyi
+  precision: *single_double_precisions
+  N: [5000]
+  nnz: [0, 500, 2500, 5000]
+  alpha: [0.3]
+  alphai: [1.7]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: axpyi
   category: pre_checkin
   function: axpyi
   precision: *single_double_precisions_complex_real
-  N: [15332, 22031, 31958]
-  nnz: [0, 1543, 7111, 10000]
+  N: [15332, 22031]
+  nnz: [0, 1543, 7111, 10000, 15332]
   alpha: [0.3]
   alphai: [-0.2, 1.7]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: axpyi
+  category: nightly
+  function: axpyi
+  precision: *single_double_precisions_complex_real
+  N: [100000, 500000]
+  nnz: [0, 10000, 50000, 100000]
+  alpha: [0.3]
+  alphai: [1.7]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]

--- a/projects/hipsparse/clients/tests/test_dotci.yaml
+++ b/projects/hipsparse/clients/tests/test_dotci.yaml
@@ -32,9 +32,25 @@ Tests:
   precision: *single_double_precisions_complex
 
 - name: dotci
+  category: quick
+  function: dotci
+  precision: *single_only_precisions_complex
+  N: [5000]
+  nnz: [0, 500, 2500, 5000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: dotci
   category: pre_checkin
   function: dotci
   precision: *single_double_precisions_complex
-  N: [15332, 22031, 31958]
-  nnz: [0, 1543, 7111, 10000]
+  N: [15332, 22031]
+  nnz: [0, 1543, 7111, 10000, 15332]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: dotci
+  category: nightly
+  function: dotci
+  precision: *single_double_precisions_complex
+  N: [100000, 500000]
+  nnz: [0, 10000, 50000, 100000]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]

--- a/projects/hipsparse/clients/tests/test_doti.yaml
+++ b/projects/hipsparse/clients/tests/test_doti.yaml
@@ -32,9 +32,25 @@ Tests:
   precision: *single_double_precisions_complex_real
 
 - name: doti
+  category: quick
+  function: doti
+  precision: *single_double_precisions
+  N: [5000]
+  nnz: [0, 500, 2500, 5000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: doti
   category: pre_checkin
   function: doti
   precision: *single_double_precisions_complex_real
-  N: [15332, 22031, 31958]
-  nnz: [0, 1543, 7111, 10000]
+  N: [15332, 22031]
+  nnz: [0, 1543, 7111, 10000, 15332]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: doti
+  category: nightly
+  function: doti
+  precision: *single_double_precisions_complex_real
+  N: [100000, 500000]
+  nnz: [0, 10000, 50000, 100000]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]

--- a/projects/hipsparse/clients/tests/test_gather.yaml
+++ b/projects/hipsparse/clients/tests/test_gather.yaml
@@ -33,10 +33,28 @@ Tests:
   precision: *single_double_precisions_complex_real
 
 - name: gather
+  category: quick
+  function: gather
+  indextype: *i32
+  precision: *single_double_precisions
+  N: [5000]
+  nnz: [0, 10, 500, 2500, 5000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: gather
   category: pre_checkin
   function: gather
   indextype: *i32_i64
   precision: *single_double_precisions_complex_real
   N: [12000, 15332, 22031]
-  nnz: [0, 5, 10, 500, 1000, 7111, 10000]
+  nnz: [0, 5, 10, 500, 1000, 7111, 10000, 12000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: gather
+  category: nightly
+  function: gather
+  indextype: *i32_i64
+  precision: *single_double_precisions_complex_real
+  N: [100000, 500000]
+  nnz: [0, 1000, 10000, 50000, 100000]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]

--- a/projects/hipsparse/clients/tests/test_gthr.yaml
+++ b/projects/hipsparse/clients/tests/test_gthr.yaml
@@ -32,9 +32,25 @@ Tests:
   precision: *single_double_precisions_complex_real
 
 - name: gthr
+  category: quick
+  function: gthr
+  precision: *single_double_precisions
+  N: [5000]
+  nnz: [0, 10, 500, 2500, 5000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: gthr
   category: pre_checkin
   function: gthr
   precision: *single_double_precisions_complex_real
   N: [12000, 15332, 22031]
-  nnz: [0, 5, 10, 500, 1000, 7111, 10000]
+  nnz: [0, 5, 10, 500, 1000, 7111, 10000, 12000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: gthr
+  category: nightly
+  function: gthr
+  precision: *single_double_precisions_complex_real
+  N: [100000, 500000]
+  nnz: [0, 1000, 10000, 50000, 100000]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]

--- a/projects/hipsparse/clients/tests/test_gthrz.yaml
+++ b/projects/hipsparse/clients/tests/test_gthrz.yaml
@@ -32,9 +32,25 @@ Tests:
   precision: *single_double_precisions_complex_real
 
 - name: gthrz
+  category: quick
+  function: gthrz
+  precision: *single_double_precisions
+  N: [5000]
+  nnz: [0, 10, 500, 2500, 5000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: gthrz
   category: pre_checkin
   function: gthrz
   precision: *single_double_precisions_complex_real
   N: [12000, 15332, 22031]
-  nnz: [0, 5, 10, 500, 1000, 7111, 10000]
+  nnz: [0, 5, 10, 500, 1000, 7111, 10000, 12000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: gthrz
+  category: nightly
+  function: gthrz
+  precision: *single_double_precisions_complex_real
+  N: [100000, 500000]
+  nnz: [0, 1000, 10000, 50000, 100000]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]

--- a/projects/hipsparse/clients/tests/test_rot.yaml
+++ b/projects/hipsparse/clients/tests/test_rot.yaml
@@ -33,12 +33,34 @@ Tests:
   precision: *single_double_precisions_complex_real
 
 - name: rot
+  category: quick
+  function: rot
+  indextype: *i32
+  precision: *single_double_precisions
+  N: [5000]
+  nnz: [0, 2500, 5000]
+  c: [1.0]
+  s: [0.0]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: rot
   category: pre_checkin
   function: rot
   indextype: *i32_i64
   precision: *single_double_precisions_complex_real
-  N: [12000, 15332, 22031]
-  nnz: [0, 5, 10, 500, 1000, 7111, 10000]
-  c: [-2.0, 0.0, 1.0]
-  s: [-3.0, 0.0, 4.0]
+  N: [15332]
+  nnz: [0, 1000, 10000, 15332]
+  c: [0.0, 1.0]
+  s: [0.0, 4.0]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: rot
+  category: nightly
+  function: rot
+  indextype: *i32_i64
+  precision: *single_double_precisions
+  N: [100000]
+  nnz: [0, 10000, 50000, 100000]
+  c: [0.0, 1.0]
+  s: [0.0, 4.0]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]

--- a/projects/hipsparse/clients/tests/test_roti.yaml
+++ b/projects/hipsparse/clients/tests/test_roti.yaml
@@ -31,11 +31,31 @@ Tests:
   precision: *single_double_precisions
 
 - name: roti
+  category: quick
+  function: roti
+  precision: *single_only_precisions
+  N: [5000]
+  nnz: [0, 10, 500, 2500, 5000]
+  c: [0.0, 1.0]
+  s: [0.0, 4.0]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: roti
   category: pre_checkin
   function: roti
   precision: *single_double_precisions
   N: [12000, 15332, 22031]
-  nnz: [0, 5, 10, 500, 1000, 7111, 10000]
+  nnz: [0, 5, 10, 500, 1000, 7111, 10000, 12000]
+  c: [-2.0, 0.0, 1.0]
+  s: [-3.0, 0.0, 4.0]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: roti
+  category: nightly
+  function: roti
+  precision: *single_double_precisions
+  N: [100000, 500000]
+  nnz: [0, 1000, 10000, 50000, 100000]
   c: [-2.0, 0.0, 1.0]
   s: [-3.0, 0.0, 4.0]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]

--- a/projects/hipsparse/clients/tests/test_scatter.yaml
+++ b/projects/hipsparse/clients/tests/test_scatter.yaml
@@ -33,10 +33,28 @@ Tests:
   precision: *single_double_precisions_complex_real
 
 - name: scatter
+  category: quick
+  function: scatter
+  indextype: *i32
+  precision: *single_double_precisions
+  N: [5000]
+  nnz: [0, 10, 500, 2500, 5000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO]
+
+- name: scatter
   category: pre_checkin
   function: scatter
   indextype: *i32_i64
   precision: *single_double_precisions_complex_real
   N: [12000, 15332, 22031]
-  nnz: [0, 5, 10, 500, 1000, 7111, 10000]
+  nnz: [0, 5, 10, 500, 1000, 7111, 10000, 12000]
+  baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]
+
+- name: scatter
+  category: nightly
+  function: scatter
+  indextype: *i32_i64
+  precision: *single_double_precisions_complex_real
+  N: [100000, 500000]
+  nnz: [0, 1000, 10000, 50000, 100000]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]

--- a/projects/hipsparse/clients/tests/test_sctr.yaml
+++ b/projects/hipsparse/clients/tests/test_sctr.yaml
@@ -36,5 +36,5 @@ Tests:
   function: sctr
   precision: *single_double_precisions_complex_real
   N: [12000, 15332, 22031]
-  nnz: [0, 5, 10, 500, 1000, 7111, 10000]
+  nnz: [0, 5, 10, 500, 1000, 7111, 10000, 12000]
   baseA: [HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE]


### PR DESCRIPTION
## Motivation

Fix testing of routines involving full sparse vectors

## Technical Details

A number of our routines use sparse vectors. We were not testing the case where these sparse vectors were full, i.e. dense. This PR adds testing of full sparse vectors in these routines

## Test Plan

Ensure all tests pass
