### PR TITLE
Bump TheRock refs to 20251125

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: efed3c3b10a5cce8578f58f8eb288582c26d18c4 # 2025-11-19 commit
+          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: efed3c3b10a5cce8578f58f8eb288582c26d18c4 # 2025-11-19 commit
+          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: efed3c3b10a5cce8578f58f8eb288582c26d18c4 # 2025-11-19 commit
+          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: efed3c3b10a5cce8578f58f8eb288582c26d18c4 # 2025-11-19 commit
+          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: efed3c3b10a5cce8578f58f8eb288582c26d18c4 # 2025-11-19 commit
+          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
## Motivation

Pick up commits to fix up rocWMMA testing.

## Technical Details

rocWMMA testing with TheRock was very slow due to not always using rocBLAS for validation.  We also dumped massive logs that made it difficult to work with failing tests.

## Test Plan

Expect TheRock CI rocWMMA testing to pass.

Nightly run with these changes here:
https://github.com/ROCm/rocm-libraries/actions/runs/19681881200

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
