### PR TITLE
rocfft: pass GPU_TARGETS to rocm_check_target_ids

### DIFF
--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -162,11 +162,12 @@ endif()
 
 if(AMDGPU_TARGETS AND NOT GPU_TARGETS)
   message( DEPRECATION "AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS." )
+  set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for")
+else()
+  # Don't force, users should be able to override GPU_TARGETS at the command line if desired
+  set(GPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "GPU architectures to build for")
 endif()
-set(AMDGPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "Target default GPUs if AMDGPU_TARGETS is not defined. (Deprecated, prefer GPU_TARGETS)")
-rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${AMDGPU_TARGETS}")
-# Don't force, users should be able to override GPU_TARGETS at the command line if desired
-set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for")
+rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${GPU_TARGETS}")
   
 # HIP is required - library and clients use HIP to access the device
 find_package( hip REQUIRED CONFIG PATHS /opt/rocm/lib/cmake/hip/ )

--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -167,7 +167,7 @@ else()
   # Don't force, users should be able to override GPU_TARGETS at the command line if desired
   set(GPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "GPU architectures to build for")
 endif()
-rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${GPU_TARGETS}")
+rocm_check_target_ids(GPU_TARGETS TARGETS "${GPU_TARGETS}")
   
 # HIP is required - library and clients use HIP to access the device
 find_package( hip REQUIRED CONFIG PATHS /opt/rocm/lib/cmake/hip/ )

--- a/projects/rocfft/scripts/perf/perflib/build.py
+++ b/projects/rocfft/scripts/perf/perflib/build.py
@@ -70,7 +70,7 @@ def build_rocfft(
     defs = [
         '-DCMAKE_CXX_COMPILER=amdclang++', '-DCMAKE_C_COMPILER=amdclang',
         '-DBUILD_CLIENTS_BENCH=ON', '-DROCFFT_CALLBACKS_ENABLED=OFF',
-        '-DSINGLELIB=ON', '-DAMDGPU_TARGETS=' + local_amdgpu_target()
+        '-DSINGLELIB=ON', '-DGPU_TARGETS=' + local_amdgpu_target()
     ]
     if dest:
         defs += [f'-DCMAKE_INSTALL_PREFIX={dest}']


### PR DESCRIPTION
## Motivation

Allow rocm-cmake to check targets specified by the GPU_TARGETS CMake variable.

## Technical Details

Check currently happens on AMDGPU_TARGETS, but that is deprecated.

## Test Plan

Manually ran builds using both GPU_TARGETS and AMDGPU_TARGETS.

## Test Result

Builds are successful.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
