### PR TITLE
Apply pre-commit exclusion filter to `shared/` folder

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,7 +24,7 @@ jobs:
           # Filter changed files to opted-in projects
           FILTERED_FILES=""
           for project in "${OPTED_IN_PROJECTS[@]}"; do
-            PROJECT_FILES=$(echo "$CHANGED_FILES" | grep "^projects/$project/" || true)
+            PROJECT_FILES=$(echo "$CHANGED_FILES" | grep -e "^projects/$project/" -e "^shared/$project/" || true)
             if [ -n "$PROJECT_FILES" ]; then
               FILTERED_FILES="$FILTERED_FILES $PROJECT_FILES"
 
@@ -33,8 +33,8 @@ jobs:
             fi
           done
 
-          # Add any files outside the projects folder
-          NON_PROJECT_FILES=$(echo "$CHANGED_FILES" | grep -v "^projects/" || true)
+          # Add any files outside the projects and shared folders
+          NON_PROJECT_FILES=$(echo "$CHANGED_FILES" | grep -v -e "^projects/" -e "^shared/" || true)
           if [ -n "$NON_PROJECT_FILES" ]; then
             FILTERED_FILES="$FILTERED_FILES $NON_PROJECT_FILES"
           fi


### PR DESCRIPTION
## Motivation

We are observing pre-commit CI failures on changes within the `shared/` folder this. An example is the [[rocRoller] Nested convert propagation](https://github.com/ROCm/rocm-libraries/actions/runs/19709972299/job/56467624581?pr=2362) PR. The failure occurs because there is no project exclusion filter applied to changes within this folder.

## Technical Details

Replicates the filtering used for the `projects/` folder for the `shared/` folder.

## Test Plan

Make 2 test branches:
1. [Pre-commit exclusion cherry picked onto rocroller changes](https://github.com/ROCm/rocm-libraries/pull/2935)--to observe CI pass on the original PR.
2. [Branch with problematic changes to opted out projects within `shared/` and `projects/` folder](https://github.com/ROCm/rocm-libraries/pull/2934)--to observe CI pass given various files that should be ignored.

## Test Result

CI green on both PRs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
