### PR TITLE
[rocsparse] Fix SpMV sliced ELL rounding errors.

### DIFF
--- a/projects/rocsparse/clients/benchmarks/rocsparse_arguments_config.cpp
+++ b/projects/rocsparse/clients/benchmarks/rocsparse_arguments_config.cpp
@@ -130,6 +130,8 @@ rocsparse_arguments_config::rocsparse_arguments_config()
         this->boostval                    = static_cast<double>(0);
         this->boostvali                   = static_cast<double>(0);
         this->tolm                        = static_cast<double>(0);
+        this->rand_gen_min                = static_cast<double>(0);
+        this->rand_gen_max                = static_cast<double>(1);
         this->graph_test                  = false;
         this->skip_reproducibility        = false;
         this->sparsity_pattern_statistics = false;

--- a/projects/rocsparse/clients/common/rocsparse_init.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_init.cpp
@@ -1821,18 +1821,18 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_coo_tridiagonal<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,    \
                                                                std::vector<ITYPE> & col_ind,    \
                                                                std::vector<TTYPE> & val,        \
-                                                               ITYPE                M,          \
-                                                               ITYPE                N,          \
-                                                               int64_t&             nnz,        \
+                                                               ITYPE M,                         \
+                                                               ITYPE N,                         \
+                                                               int64_t & nnz,                   \
                                                                rocsparse_index_base base,       \
                                                                ITYPE                l,          \
                                                                ITYPE                u);                        \
     template void rocsparse_init_coo_pentadiagonal<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,  \
                                                                  std::vector<ITYPE> & col_ind,  \
                                                                  std::vector<TTYPE> & val,      \
-                                                                 ITYPE                M,        \
-                                                                 ITYPE                N,        \
-                                                                 int64_t&             nnz,      \
+                                                                 ITYPE M,                       \
+                                                                 ITYPE N,                       \
+                                                                 int64_t & nnz,                 \
                                                                  rocsparse_index_base base,     \
                                                                  ITYPE                ll,       \
                                                                  ITYPE                l,        \
@@ -1841,19 +1841,19 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_coo_laplace2d<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,      \
                                                              std::vector<ITYPE> & col_ind,      \
                                                              std::vector<TTYPE> & val,          \
-                                                             int32_t              dim_x,        \
-                                                             int32_t              dim_y,        \
-                                                             ITYPE&               M,            \
-                                                             ITYPE&               N,            \
-                                                             int64_t&             nnz,          \
+                                                             int32_t dim_x,                     \
+                                                             int32_t dim_y,                     \
+                                                             ITYPE & M,                         \
+                                                             ITYPE & N,                         \
+                                                             int64_t & nnz,                     \
                                                              rocsparse_index_base base);        \
     template void rocsparse_init_ell_laplace2d<ITYPE, TTYPE>(std::vector<ITYPE> & col_ind,      \
                                                              std::vector<TTYPE> & val,          \
-                                                             int32_t              dim_x,        \
-                                                             int32_t              dim_y,        \
-                                                             ITYPE&               M,            \
-                                                             ITYPE&               N,            \
-                                                             ITYPE&               width,        \
+                                                             int32_t dim_x,                     \
+                                                             int32_t dim_y,                     \
+                                                             ITYPE & M,                         \
+                                                             ITYPE & N,                         \
+                                                             ITYPE & width,                     \
                                                              rocsparse_index_base base);        \
     template void rocsparse_init_coo_matrix<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,         \
                                                           std::vector<ITYPE> & col_ind,         \
@@ -1867,12 +1867,12 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_coo_laplace3d<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,      \
                                                              std::vector<ITYPE> & col_ind,      \
                                                              std::vector<TTYPE> & val,          \
-                                                             int32_t              dim_x,        \
-                                                             int32_t              dim_y,        \
-                                                             int32_t              dim_z,        \
-                                                             ITYPE&               M,            \
-                                                             ITYPE&               N,            \
-                                                             int64_t&             nnz,          \
+                                                             int32_t dim_x,                     \
+                                                             int32_t dim_y,                     \
+                                                             int32_t dim_z,                     \
+                                                             ITYPE & M,                         \
+                                                             ITYPE & N,                         \
+                                                             int64_t & nnz,                     \
                                                              rocsparse_index_base base);        \
     template void rocsparse_init_coo_mtx<ITYPE, TTYPE>(const char*          filename,           \
                                                        std::vector<ITYPE>&  coo_row_ind,        \
@@ -1917,9 +1917,9 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_coo_random<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,         \
                                                           std::vector<ITYPE> & col_ind,         \
                                                           std::vector<TTYPE> & val,             \
-                                                          ITYPE                      M,         \
-                                                          ITYPE                      N,         \
-                                                          int64_t&                   nnz,       \
+                                                          ITYPE M,                              \
+                                                          ITYPE N,                              \
+                                                          int64_t & nnz,                        \
                                                           rocsparse_index_base       base,      \
                                                           rocsparse_matrix_init_kind init_kind, \
                                                           bool                       full_rank, \
@@ -1951,21 +1951,21 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_csr_laplace2d<ITYPE, JTYPE, TTYPE>(std::vector<ITYPE> & row_ptr,    \
                                                                     std::vector<JTYPE> & col_ind,    \
                                                                     std::vector<TTYPE> & val,        \
-                                                                    int32_t              dim_x,      \
-                                                                    int32_t              dim_y,      \
-                                                                    JTYPE&               M,          \
-                                                                    JTYPE&               N,          \
-                                                                    ITYPE&               nnz,        \
+                                                                    int32_t dim_x,                   \
+                                                                    int32_t dim_y,                   \
+                                                                    JTYPE & M,                       \
+                                                                    JTYPE & N,                       \
+                                                                    ITYPE & nnz,                     \
                                                                     rocsparse_index_base base);      \
     template void rocsparse_init_csr_laplace3d<ITYPE, JTYPE, TTYPE>(std::vector<ITYPE> & row_ptr,    \
                                                                     std::vector<JTYPE> & col_ind,    \
                                                                     std::vector<TTYPE> & val,        \
-                                                                    int32_t              dim_x,      \
-                                                                    int32_t              dim_y,      \
-                                                                    int32_t              dim_z,      \
-                                                                    JTYPE&               M,          \
-                                                                    JTYPE&               N,          \
-                                                                    ITYPE&               nnz,        \
+                                                                    int32_t dim_x,                   \
+                                                                    int32_t dim_y,                   \
+                                                                    int32_t dim_z,                   \
+                                                                    JTYPE & M,                       \
+                                                                    JTYPE & N,                       \
+                                                                    ITYPE & nnz,                     \
                                                                     rocsparse_index_base base);      \
     template void rocsparse_init_csr_mtx<ITYPE, JTYPE, TTYPE>(const char*          filename,         \
                                                               std::vector<ITYPE>&  csr_row_ptr,      \
@@ -2048,11 +2048,11 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
         std::vector<ITYPE> & row_ptr,                                                                \
         std::vector<JTYPE> & col_ind,                                                                \
         std::vector<TTYPE> & val,                                                                    \
-        int32_t              dim_x,                                                                  \
-        int32_t              dim_y,                                                                  \
-        JTYPE&               Mb,                                                                     \
-        JTYPE&               Nb,                                                                     \
-        ITYPE&               nnzb,                                                                   \
+        int32_t dim_x,                                                                               \
+        int32_t dim_y,                                                                               \
+        JTYPE & Mb,                                                                                  \
+        JTYPE & Nb,                                                                                  \
+        ITYPE & nnzb,                                                                                \
         JTYPE                row_block_dim,                                                          \
         JTYPE                col_block_dim,                                                          \
         rocsparse_index_base base);                                                                  \
@@ -2060,12 +2060,12 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
         std::vector<ITYPE> & row_ptr,                                                                \
         std::vector<JTYPE> & col_ind,                                                                \
         std::vector<TTYPE> & val,                                                                    \
-        int32_t              dim_x,                                                                  \
-        int32_t              dim_y,                                                                  \
-        int32_t              dim_z,                                                                  \
-        JTYPE&               Mb,                                                                     \
-        JTYPE&               Nb,                                                                     \
-        ITYPE&               nnzb,                                                                   \
+        int32_t dim_x,                                                                               \
+        int32_t dim_y,                                                                               \
+        int32_t dim_z,                                                                               \
+        JTYPE & Mb,                                                                                  \
+        JTYPE & Nb,                                                                                  \
+        ITYPE & nnzb,                                                                                \
         JTYPE                row_block_dim,                                                          \
         JTYPE                col_block_dim,                                                          \
         rocsparse_index_base base);                                                                  \

--- a/projects/rocsparse/clients/common/rocsparse_init.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_init.cpp
@@ -55,6 +55,14 @@ void rocsparse_init_exact(
 }
 
 template <typename T>
+void rocsparse_init_1d_array(T* A, size_t size, bool use_exact, T a, T b)
+{
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
+
+    rocsparse_init(A, size, 1, 1, use_exact, 0, 1, a, b);
+}
+
+template <typename T>
 void rocsparse_init(T*     A,
                     size_t M,
                     size_t N,
@@ -169,6 +177,14 @@ void rocsparse_init_exact(std::vector<T>& A,
     ROCSPARSE_CLIENTS_ROUTINE_TRACE;
 
     rocsparse_init_exact(A.data(), M, N, lda, stride, batch_count, a, b);
+}
+
+template <typename T>
+void rocsparse_init_1d_array(std::vector<T>& A, size_t size, bool use_exact, T a, T b)
+{
+    ROCSPARSE_CLIENTS_ROUTINE_TRACE;
+
+    rocsparse_init(A.data(), size, 1, 1, use_exact, 0, 1, a, b);
 }
 
 template <typename T>
@@ -1744,6 +1760,11 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
                                              size_t batch_count,                                   \
                                              int    a = 1,                                         \
                                              int    b = 10);                                          \
+    template void rocsparse_init_1d_array<TYPE>(std::vector<TYPE> & A,                             \
+                                                size_t size,                                       \
+                                                bool   use_exact,                                  \
+                                                TYPE   a = static_cast<TYPE>(0),                   \
+                                                TYPE   b = static_cast<TYPE>(1));                    \
     template void rocsparse_init<TYPE>(std::vector<TYPE> & A,                                      \
                                        size_t M,                                                   \
                                        size_t N,                                                   \
@@ -1780,6 +1801,11 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
                                            size_t batch_count);
 
 #define INSTANTIATE(TYPE)                                                         \
+    template void rocsparse_init_1d_array<TYPE>(TYPE * A,                         \
+                                                size_t size,                      \
+                                                bool   use_exact,                 \
+                                                TYPE   a = static_cast<TYPE>(0),  \
+                                                TYPE   b = static_cast<TYPE>(1));   \
     template void rocsparse_init<TYPE>(TYPE * A,                                  \
                                        size_t M,                                  \
                                        size_t N,                                  \
@@ -1795,18 +1821,18 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_coo_tridiagonal<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,    \
                                                                std::vector<ITYPE> & col_ind,    \
                                                                std::vector<TTYPE> & val,        \
-                                                               ITYPE M,                         \
-                                                               ITYPE N,                         \
-                                                               int64_t & nnz,                   \
+                                                               ITYPE                M,          \
+                                                               ITYPE                N,          \
+                                                               int64_t&             nnz,        \
                                                                rocsparse_index_base base,       \
                                                                ITYPE                l,          \
                                                                ITYPE                u);                        \
     template void rocsparse_init_coo_pentadiagonal<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,  \
                                                                  std::vector<ITYPE> & col_ind,  \
                                                                  std::vector<TTYPE> & val,      \
-                                                                 ITYPE M,                       \
-                                                                 ITYPE N,                       \
-                                                                 int64_t & nnz,                 \
+                                                                 ITYPE                M,        \
+                                                                 ITYPE                N,        \
+                                                                 int64_t&             nnz,      \
                                                                  rocsparse_index_base base,     \
                                                                  ITYPE                ll,       \
                                                                  ITYPE                l,        \
@@ -1815,19 +1841,19 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_coo_laplace2d<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,      \
                                                              std::vector<ITYPE> & col_ind,      \
                                                              std::vector<TTYPE> & val,          \
-                                                             int32_t dim_x,                     \
-                                                             int32_t dim_y,                     \
-                                                             ITYPE & M,                         \
-                                                             ITYPE & N,                         \
-                                                             int64_t & nnz,                     \
+                                                             int32_t              dim_x,        \
+                                                             int32_t              dim_y,        \
+                                                             ITYPE&               M,            \
+                                                             ITYPE&               N,            \
+                                                             int64_t&             nnz,          \
                                                              rocsparse_index_base base);        \
     template void rocsparse_init_ell_laplace2d<ITYPE, TTYPE>(std::vector<ITYPE> & col_ind,      \
                                                              std::vector<TTYPE> & val,          \
-                                                             int32_t dim_x,                     \
-                                                             int32_t dim_y,                     \
-                                                             ITYPE & M,                         \
-                                                             ITYPE & N,                         \
-                                                             ITYPE & width,                     \
+                                                             int32_t              dim_x,        \
+                                                             int32_t              dim_y,        \
+                                                             ITYPE&               M,            \
+                                                             ITYPE&               N,            \
+                                                             ITYPE&               width,        \
                                                              rocsparse_index_base base);        \
     template void rocsparse_init_coo_matrix<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,         \
                                                           std::vector<ITYPE> & col_ind,         \
@@ -1841,12 +1867,12 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_coo_laplace3d<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,      \
                                                              std::vector<ITYPE> & col_ind,      \
                                                              std::vector<TTYPE> & val,          \
-                                                             int32_t dim_x,                     \
-                                                             int32_t dim_y,                     \
-                                                             int32_t dim_z,                     \
-                                                             ITYPE & M,                         \
-                                                             ITYPE & N,                         \
-                                                             int64_t & nnz,                     \
+                                                             int32_t              dim_x,        \
+                                                             int32_t              dim_y,        \
+                                                             int32_t              dim_z,        \
+                                                             ITYPE&               M,            \
+                                                             ITYPE&               N,            \
+                                                             int64_t&             nnz,          \
                                                              rocsparse_index_base base);        \
     template void rocsparse_init_coo_mtx<ITYPE, TTYPE>(const char*          filename,           \
                                                        std::vector<ITYPE>&  coo_row_ind,        \
@@ -1891,9 +1917,9 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_coo_random<ITYPE, TTYPE>(std::vector<ITYPE> & row_ind,         \
                                                           std::vector<ITYPE> & col_ind,         \
                                                           std::vector<TTYPE> & val,             \
-                                                          ITYPE M,                              \
-                                                          ITYPE N,                              \
-                                                          int64_t & nnz,                        \
+                                                          ITYPE                      M,         \
+                                                          ITYPE                      N,         \
+                                                          int64_t&                   nnz,       \
                                                           rocsparse_index_base       base,      \
                                                           rocsparse_matrix_init_kind init_kind, \
                                                           bool                       full_rank, \
@@ -1925,21 +1951,21 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
     template void rocsparse_init_csr_laplace2d<ITYPE, JTYPE, TTYPE>(std::vector<ITYPE> & row_ptr,    \
                                                                     std::vector<JTYPE> & col_ind,    \
                                                                     std::vector<TTYPE> & val,        \
-                                                                    int32_t dim_x,                   \
-                                                                    int32_t dim_y,                   \
-                                                                    JTYPE & M,                       \
-                                                                    JTYPE & N,                       \
-                                                                    ITYPE & nnz,                     \
+                                                                    int32_t              dim_x,      \
+                                                                    int32_t              dim_y,      \
+                                                                    JTYPE&               M,          \
+                                                                    JTYPE&               N,          \
+                                                                    ITYPE&               nnz,        \
                                                                     rocsparse_index_base base);      \
     template void rocsparse_init_csr_laplace3d<ITYPE, JTYPE, TTYPE>(std::vector<ITYPE> & row_ptr,    \
                                                                     std::vector<JTYPE> & col_ind,    \
                                                                     std::vector<TTYPE> & val,        \
-                                                                    int32_t dim_x,                   \
-                                                                    int32_t dim_y,                   \
-                                                                    int32_t dim_z,                   \
-                                                                    JTYPE & M,                       \
-                                                                    JTYPE & N,                       \
-                                                                    ITYPE & nnz,                     \
+                                                                    int32_t              dim_x,      \
+                                                                    int32_t              dim_y,      \
+                                                                    int32_t              dim_z,      \
+                                                                    JTYPE&               M,          \
+                                                                    JTYPE&               N,          \
+                                                                    ITYPE&               nnz,        \
                                                                     rocsparse_index_base base);      \
     template void rocsparse_init_csr_mtx<ITYPE, JTYPE, TTYPE>(const char*          filename,         \
                                                               std::vector<ITYPE>&  csr_row_ptr,      \
@@ -2022,11 +2048,11 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
         std::vector<ITYPE> & row_ptr,                                                                \
         std::vector<JTYPE> & col_ind,                                                                \
         std::vector<TTYPE> & val,                                                                    \
-        int32_t dim_x,                                                                               \
-        int32_t dim_y,                                                                               \
-        JTYPE & Mb,                                                                                  \
-        JTYPE & Nb,                                                                                  \
-        ITYPE & nnzb,                                                                                \
+        int32_t              dim_x,                                                                  \
+        int32_t              dim_y,                                                                  \
+        JTYPE&               Mb,                                                                     \
+        JTYPE&               Nb,                                                                     \
+        ITYPE&               nnzb,                                                                   \
         JTYPE                row_block_dim,                                                          \
         JTYPE                col_block_dim,                                                          \
         rocsparse_index_base base);                                                                  \
@@ -2034,12 +2060,12 @@ void rocsparse_init_gebsr_pentadiagonal(std::vector<I>&      row_ptr,
         std::vector<ITYPE> & row_ptr,                                                                \
         std::vector<JTYPE> & col_ind,                                                                \
         std::vector<TTYPE> & val,                                                                    \
-        int32_t dim_x,                                                                               \
-        int32_t dim_y,                                                                               \
-        int32_t dim_z,                                                                               \
-        JTYPE & Mb,                                                                                  \
-        JTYPE & Nb,                                                                                  \
-        ITYPE & nnzb,                                                                                \
+        int32_t              dim_x,                                                                  \
+        int32_t              dim_y,                                                                  \
+        int32_t              dim_z,                                                                  \
+        JTYPE&               Mb,                                                                     \
+        JTYPE&               Nb,                                                                     \
+        ITYPE&               nnzb,                                                                   \
         JTYPE                row_block_dim,                                                          \
         JTYPE                col_block_dim,                                                          \
         rocsparse_index_base base);                                                                  \

--- a/projects/rocsparse/clients/include/rocsparse_arguments.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_arguments.hpp
@@ -151,6 +151,8 @@ struct Arguments
     double boostvali;
 
     double tolm;
+    double rand_gen_min;
+    double rand_gen_max;
 
     bool graph_test;
     bool skip_reproducibility;
@@ -298,6 +300,8 @@ struct Arguments
         ROCSPARSE_FORMAT_CHECK(boostval);
         ROCSPARSE_FORMAT_CHECK(boostvali);
         ROCSPARSE_FORMAT_CHECK(tolm);
+        ROCSPARSE_FORMAT_CHECK(rand_gen_min);
+        ROCSPARSE_FORMAT_CHECK(rand_gen_max);
         ROCSPARSE_FORMAT_CHECK(graph_test);
         ROCSPARSE_FORMAT_CHECK(skip_reproducibility);
         ROCSPARSE_FORMAT_CHECK(sparsity_pattern_statistics);
@@ -517,6 +521,8 @@ private:
         print("boost_val", arg.boostval);
         print("boost_vali", arg.boostvali);
         print("tolm", arg.tolm);
+        print("rand_gen_min", arg.rand_gen_min);
+        print("rand_gen_max", arg.rand_gen_max);
         print("graph_test", arg.graph_test);
         print("skip_reproducibility", arg.skip_reproducibility);
         print("sparsity_pattern_statistics", arg.sparsity_pattern_statistics);

--- a/projects/rocsparse/clients/include/rocsparse_common.yaml
+++ b/projects/rocsparse/clients/include/rocsparse_common.yaml
@@ -595,6 +595,8 @@ Arguments:
   - boostval: c_double
   - boostvali: c_double
   - tolm: c_double
+  - rand_gen_min: c_double
+  - rand_gen_max: c_double
   - graph_test: c_bool
   - skip_reproducibility: c_bool
   - sparsity_pattern_statistics: c_bool
@@ -746,6 +748,8 @@ Defaults:
   boostval: 1.0
   boostvali: 0.0
   tolm: 1.0
+  rand_gen_min: 0.0
+  rand_gen_max: 1.0
   graph_test: false
   skip_reproducibility: false
   sparsity_pattern_statistics: false

--- a/projects/rocsparse/clients/include/rocsparse_init.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_init.hpp
@@ -40,6 +40,10 @@
 // If use_exact is false (default value), the values will be random floating point values
 // If use_exact is true, the values will be integers in the range [a, b]
 template <typename T>
+void rocsparse_init_1d_array(
+    T* A, size_t size, bool use_exact = false, T a = static_cast<T>(0), T b = static_cast<T>(1));
+
+template <typename T>
 void rocsparse_init(T*     A,
                     size_t M,
                     size_t N,
@@ -75,6 +79,13 @@ void rocsparse_init_exact(T*     A,
 // Initialize vector with random values
 // If use_exact is false (default value), the values will be random floating point values
 // If use_exact is true, the values will be integers in the range [a, b]
+template <typename T>
+void rocsparse_init_1d_array(std::vector<T>& A,
+                             size_t          size,
+                             bool            use_exact = false,
+                             T               a         = static_cast<T>(0),
+                             T               b         = static_cast<T>(1));
+
 template <typename T>
 void rocsparse_init(std::vector<T>& A,
                     size_t          M,

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_coo.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_coo.cpp
@@ -191,6 +191,10 @@ void testing_spmm_batched_coo(const Arguments& arg)
                             nnz_A,
                             base);
 
+    // Redfine values
+    rocsparse_init_1d_array<A>(
+        hcoo_val_temp, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+
     // Some matrix properties
     I A_m = (trans_A == rocsparse_operation_none) ? M : K;
     I A_n = (trans_A == rocsparse_operation_none) ? K : M;
@@ -230,14 +234,7 @@ void testing_spmm_batched_coo(const Arguments& arg)
         {
             hcoo_row_ind[nnz_A * i + j] = hcoo_row_ind_temp[j];
             hcoo_col_ind[nnz_A * i + j] = hcoo_col_ind_temp[j];
-            if(arg.convert_to_int)
-            {
-                hcoo_val[nnz_A * i + j] = convertToInt<A>(hcoo_val_temp[j]);
-            }
-            else
-            {
-                hcoo_val[nnz_A * i + j] = hcoo_val_temp[j];
-            }
+            hcoo_val[nnz_A * i + j] = hcoo_val_temp[j];
         }
     }
 
@@ -246,16 +243,8 @@ void testing_spmm_batched_coo(const Arguments& arg)
     host_vector<C> hC_1(batch_count_C * nnz_C);
 
     // Initialize data on CPU
-    rocsparse_init<B>(hB, batch_count_B * nnz_B, 1, 1, arg.convert_to_int);
-    rocsparse_init<C>(hC_1, batch_count_C * nnz_C, 1, 1, arg.convert_to_int);
-
-    if(arg.convert_to_int)
-    {
-        for(I i = 0; i < batch_count_B * nnz_B; i++)
-        {
-            hB[i] = convertToInt<B>(hB[i]);
-        }
-    }
+    rocsparse_init_1d_array<B>(hB, batch_count_B * nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<C>(hC_1, batch_count_C * nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     host_vector<C> hC_2(hC_1);
     host_vector<C> hC_gold(hC_1);

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_coo.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_coo.cpp
@@ -191,7 +191,7 @@ void testing_spmm_batched_coo(const Arguments& arg)
                             nnz_A,
                             base);
 
-    // Redfine values
+    // Redefine values
     rocsparse_init_1d_array<A>(
         hcoo_val_temp, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
@@ -234,7 +234,7 @@ void testing_spmm_batched_coo(const Arguments& arg)
         {
             hcoo_row_ind[nnz_A * i + j] = hcoo_row_ind_temp[j];
             hcoo_col_ind[nnz_A * i + j] = hcoo_col_ind_temp[j];
-            hcoo_val[nnz_A * i + j] = hcoo_val_temp[j];
+            hcoo_val[nnz_A * i + j]     = hcoo_val_temp[j];
         }
     }
 
@@ -243,8 +243,10 @@ void testing_spmm_batched_coo(const Arguments& arg)
     host_vector<C> hC_1(batch_count_C * nnz_C);
 
     // Initialize data on CPU
-    rocsparse_init_1d_array<B>(hB, batch_count_B * nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
-    rocsparse_init_1d_array<C>(hC_1, batch_count_C * nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<B>(
+        hB, batch_count_B * nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<C>(
+        hC_1, batch_count_C * nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     host_vector<C> hC_2(hC_1);
     host_vector<C> hC_gold(hC_1);

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_csc.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_csc.cpp
@@ -204,7 +204,7 @@ void testing_spmm_batched_csc(const Arguments& arg)
                             nnz_A,
                             base);
 
-    // Redfine values
+    // Redefine values
     rocsparse_init_1d_array<A>(
         hcsc_val_temp, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
@@ -252,7 +252,7 @@ void testing_spmm_batched_csc(const Arguments& arg)
         for(size_t j = 0; j < nnz_A; j++)
         {
             hcsc_row_ind[nnz_A * i + j] = hcsc_row_ind_temp[j];
-            hcsc_val[nnz_A * i + j] = hcsc_val_temp[j];
+            hcsc_val[nnz_A * i + j]     = hcsc_val_temp[j];
         }
     }
 
@@ -263,8 +263,10 @@ void testing_spmm_batched_csc(const Arguments& arg)
     host_vector<C> hC_gold(batch_count_C * nnz_C);
 
     // Initialize data on CPU
-    rocsparse_init_1d_array<B>(hB, batch_count_B * nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
-    rocsparse_init_1d_array<C>(hC_1, batch_count_C * nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<B>(
+        hB, batch_count_B * nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<C>(
+        hC_1, batch_count_C * nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_csc.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_csc.cpp
@@ -204,6 +204,10 @@ void testing_spmm_batched_csc(const Arguments& arg)
                             nnz_A,
                             base);
 
+    // Redfine values
+    rocsparse_init_1d_array<A>(
+        hcsc_val_temp, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+
     // Some matrix properties
     J A_m = (trans_A == rocsparse_operation_none) ? M : K;
     J A_n = (trans_A == rocsparse_operation_none) ? K : M;
@@ -248,14 +252,7 @@ void testing_spmm_batched_csc(const Arguments& arg)
         for(size_t j = 0; j < nnz_A; j++)
         {
             hcsc_row_ind[nnz_A * i + j] = hcsc_row_ind_temp[j];
-            if(arg.convert_to_int)
-            {
-                hcsc_val[nnz_A * i + j] = convertToInt<A>(hcsc_val_temp[j]);
-            }
-            else
-            {
-                hcsc_val[nnz_A * i + j] = hcsc_val_temp[j];
-            }
+            hcsc_val[nnz_A * i + j] = hcsc_val_temp[j];
         }
     }
 
@@ -266,16 +263,8 @@ void testing_spmm_batched_csc(const Arguments& arg)
     host_vector<C> hC_gold(batch_count_C * nnz_C);
 
     // Initialize data on CPU
-    rocsparse_init<B>(hB, batch_count_B * nnz_B, 1, 1, arg.convert_to_int);
-    rocsparse_init<C>(hC_1, batch_count_C * nnz_C, 1, 1, arg.convert_to_int);
-
-    if(arg.convert_to_int)
-    {
-        for(J i = 0; i < batch_count_B * nnz_B; i++)
-        {
-            hB[i] = convertToInt<B>(hB[i]);
-        }
-    }
+    rocsparse_init_1d_array<B>(hB, batch_count_B * nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<C>(hC_1, batch_count_C * nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_csr.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_csr.cpp
@@ -203,7 +203,7 @@ void testing_spmm_batched_csr(const Arguments& arg)
                             nnz_A,
                             base);
 
-    // Redfine values
+    // Redefine values
     rocsparse_init_1d_array<A>(
         hcsr_val_temp, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
@@ -251,7 +251,7 @@ void testing_spmm_batched_csr(const Arguments& arg)
         for(size_t j = 0; j < nnz_A; j++)
         {
             hcsr_col_ind[nnz_A * i + j] = hcsr_col_ind_temp[j];
-            hcsr_val[nnz_A * i + j] = hcsr_val_temp[j];
+            hcsr_val[nnz_A * i + j]     = hcsr_val_temp[j];
         }
     }
 
@@ -262,8 +262,10 @@ void testing_spmm_batched_csr(const Arguments& arg)
     host_vector<C> hC_gold(batch_count_C * nnz_C);
 
     // Initialize data on CPU
-    rocsparse_init_1d_array<B>(hB, batch_count_B * nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
-    rocsparse_init_1d_array<C>(hC_1, batch_count_C * nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<B>(
+        hB, batch_count_B * nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<C>(
+        hC_1, batch_count_C * nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/projects/rocsparse/clients/testings/testing_spmm_batched_csr.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_batched_csr.cpp
@@ -203,6 +203,10 @@ void testing_spmm_batched_csr(const Arguments& arg)
                             nnz_A,
                             base);
 
+    // Redfine values
+    rocsparse_init_1d_array<A>(
+        hcsr_val_temp, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+
     // Some matrix properties
     J A_m = (trans_A == rocsparse_operation_none) ? M : K;
     J A_n = (trans_A == rocsparse_operation_none) ? K : M;
@@ -247,14 +251,7 @@ void testing_spmm_batched_csr(const Arguments& arg)
         for(size_t j = 0; j < nnz_A; j++)
         {
             hcsr_col_ind[nnz_A * i + j] = hcsr_col_ind_temp[j];
-            if(arg.convert_to_int)
-            {
-                hcsr_val[nnz_A * i + j] = convertToInt<A>(hcsr_val_temp[j]);
-            }
-            else
-            {
-                hcsr_val[nnz_A * i + j] = hcsr_val_temp[j];
-            }
+            hcsr_val[nnz_A * i + j] = hcsr_val_temp[j];
         }
     }
 
@@ -265,16 +262,8 @@ void testing_spmm_batched_csr(const Arguments& arg)
     host_vector<C> hC_gold(batch_count_C * nnz_C);
 
     // Initialize data on CPU
-    rocsparse_init<B>(hB, batch_count_B * nnz_B, 1, 1, arg.convert_to_int);
-    rocsparse_init<C>(hC_1, batch_count_C * nnz_C, 1, 1, arg.convert_to_int);
-
-    if(arg.convert_to_int)
-    {
-        for(J i = 0; i < batch_count_B * nnz_B; i++)
-        {
-            hB[i] = convertToInt<B>(hB[i]);
-        }
-    }
+    rocsparse_init_1d_array<B>(hB, batch_count_B * nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<C>(hC_1, batch_count_C * nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/projects/rocsparse/clients/testings/testing_spmm_coo.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_coo.cpp
@@ -23,8 +23,6 @@
 
 #include "testing.hpp"
 
-#include <algorithm>
-
 template <typename I, typename A, typename B, typename C, typename T>
 void testing_spmm_coo_bad_arg(const Arguments& arg)
 {
@@ -146,7 +144,7 @@ void testing_spmm_coo(const Arguments& arg)
                             nnz_A,
                             base);
 
-    // Redfine values
+    // Redefine values
     rocsparse_init_1d_array<A>(
         hcoo_val, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 

--- a/projects/rocsparse/clients/testings/testing_spmm_coo.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_coo.cpp
@@ -146,6 +146,10 @@ void testing_spmm_coo(const Arguments& arg)
                             nnz_A,
                             base);
 
+    // Redfine values
+    rocsparse_init_1d_array<A>(
+        hcoo_val, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+
     // Some matrix properties
     I A_m = (trans_A == rocsparse_operation_none) ? M : K;
     I A_n = (trans_A == rocsparse_operation_none) ? K : M;
@@ -181,8 +185,8 @@ void testing_spmm_coo(const Arguments& arg)
     host_vector<C> hC_gold(nnz_C, 0);
 
     // Initialize data on CPU
-    rocsparse_init<B>(hB, nnz_B, 1, 1, arg.convert_to_int);
-    rocsparse_init<C>(hC_1, nnz_C, 1, 1, arg.convert_to_int);
+    rocsparse_init_1d_array<B>(hB, nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<C>(hC_1, nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/projects/rocsparse/clients/testings/testing_spmm_csc.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_csc.cpp
@@ -158,6 +158,10 @@ void testing_spmm_csc(const Arguments& arg)
                             nnz_A,
                             base);
 
+    // Redfine values
+    rocsparse_init_1d_array<A>(
+        hcsc_val, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+
     // Some matrix properties
     J A_m = (trans_A == rocsparse_operation_none) ? M : K;
     J A_n = (trans_A == rocsparse_operation_none) ? K : M;
@@ -189,8 +193,8 @@ void testing_spmm_csc(const Arguments& arg)
     host_vector<C> hC_gold(nnz_C);
 
     // Initialize data on CPU
-    rocsparse_init<B>(hB, nnz_B, 1, 1, arg.convert_to_int);
-    rocsparse_init<C>(hC_1, nnz_C, 1, 1, arg.convert_to_int);
+    rocsparse_init_1d_array<B>(hB, nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<C>(hC_1, nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/projects/rocsparse/clients/testings/testing_spmm_csc.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_csc.cpp
@@ -158,7 +158,7 @@ void testing_spmm_csc(const Arguments& arg)
                             nnz_A,
                             base);
 
-    // Redfine values
+    // Redefine values
     rocsparse_init_1d_array<A>(
         hcsc_val, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 

--- a/projects/rocsparse/clients/testings/testing_spmm_csr.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_csr.cpp
@@ -147,9 +147,8 @@ void testing_spmm_csr(const Arguments& arg)
                             (trans_A == rocsparse_operation_none) ? K : M,
                             nnz_A,
                             base);
-            
-    
-    // Redfine values
+
+    // Redefine values
     rocsparse_init_1d_array<A>(
         hcsr_val, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 

--- a/projects/rocsparse/clients/testings/testing_spmm_csr.cpp
+++ b/projects/rocsparse/clients/testings/testing_spmm_csr.cpp
@@ -147,6 +147,11 @@ void testing_spmm_csr(const Arguments& arg)
                             (trans_A == rocsparse_operation_none) ? K : M,
                             nnz_A,
                             base);
+            
+    
+    // Redfine values
+    rocsparse_init_1d_array<A>(
+        hcsr_val, nnz_A, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     // Some matrix properties
     J A_m = (trans_A == rocsparse_operation_none) ? M : K;
@@ -179,8 +184,8 @@ void testing_spmm_csr(const Arguments& arg)
     host_vector<C> hC_gold(nnz_C);
 
     // Initialize data on CPU
-    rocsparse_init<B>(hB, nnz_B, 1, 1, arg.convert_to_int);
-    rocsparse_init<C>(hC_1, nnz_C, 1, 1, arg.convert_to_int);
+    rocsparse_init_1d_array<B>(hB, nnz_B, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
+    rocsparse_init_1d_array<C>(hC_1, nnz_C, arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     hC_2    = hC_1;
     hC_gold = hC_1;

--- a/projects/rocsparse/clients/testings/testing_v2_spmv_sell.cpp
+++ b/projects/rocsparse/clients/testings/testing_v2_spmv_sell.cpp
@@ -127,6 +127,9 @@ void testing_v2_spmv_sell(const Arguments& arg)
 
     matrix_factory.init_sell(hA, M, N, sell_slice_size, base);
 
+    // Scale matrix values
+    rocsparse_init<A>(hA.val, hA.nnz, 1, 1, arg.convert_to_int);
+
     // Allocate host memory for vectors
     host_vector<X> hx((trans == rocsparse_operation_none) ? N : M);
     host_vector<Y> hy((trans == rocsparse_operation_none) ? M : N);

--- a/projects/rocsparse/clients/testings/testing_v2_spmv_sell.cpp
+++ b/projects/rocsparse/clients/testings/testing_v2_spmv_sell.cpp
@@ -24,8 +24,6 @@
 #include "testing.hpp"
 #include "testing_v2_spmv.hpp"
 
-#include <algorithm>
-
 template <typename I, typename J, typename A, typename X, typename Y, typename T>
 void testing_v2_spmv_sell_bad_arg(const Arguments& arg)
 {

--- a/projects/rocsparse/clients/testings/testing_v2_spmv_sell.cpp
+++ b/projects/rocsparse/clients/testings/testing_v2_spmv_sell.cpp
@@ -24,6 +24,8 @@
 #include "testing.hpp"
 #include "testing_v2_spmv.hpp"
 
+#include <algorithm>
+
 template <typename I, typename J, typename A, typename X, typename Y, typename T>
 void testing_v2_spmv_sell_bad_arg(const Arguments& arg)
 {
@@ -127,16 +129,25 @@ void testing_v2_spmv_sell(const Arguments& arg)
 
     matrix_factory.init_sell(hA, M, N, sell_slice_size, base);
 
-    // Scale matrix values
-    rocsparse_init<A>(hA.val, hA.nnz, 1, 1, arg.convert_to_int);
+    // Redefine matrix values
+    rocsparse_init_1d_array<A>(
+        hA.val, hA.val.size(), arg.convert_to_int, arg.rand_gen_min, arg.rand_gen_max);
 
     // Allocate host memory for vectors
     host_vector<X> hx((trans == rocsparse_operation_none) ? N : M);
     host_vector<Y> hy((trans == rocsparse_operation_none) ? M : N);
 
     // Initialize data on CPU
-    rocsparse_init<X>(hx, (trans == rocsparse_operation_none) ? N : M, 1, 1, arg.convert_to_int);
-    rocsparse_init<Y>(hy, (trans == rocsparse_operation_none) ? M : N, 1, 1, arg.convert_to_int);
+    rocsparse_init_1d_array<X>(hx,
+                               (trans == rocsparse_operation_none) ? N : M,
+                               arg.convert_to_int,
+                               arg.rand_gen_min,
+                               arg.rand_gen_max);
+    rocsparse_init_1d_array<Y>(hy,
+                               (trans == rocsparse_operation_none) ? M : N,
+                               arg.convert_to_int,
+                               arg.rand_gen_min,
+                               arg.rand_gen_max);
 
     host_vector<Y> hy_gold(hy);
 

--- a/projects/rocsparse/clients/tests/test_spmm_batched_coo.yaml
+++ b/projects/rocsparse/clients/tests/test_spmm_batched_coo.yaml
@@ -479,5 +479,7 @@ Tests:
   spmm_alg: [rocsparse_spmm_alg_coo_atomic]
   orderB: [rocsparse_order_row, rocsparse_order_column]
   orderC: [rocsparse_order_row, rocsparse_order_column]
+  rand_gen_min: -100.0
+  rand_gen_max: 100.0
   convert_to_int: true
   filename: [mac_econ_fwd500]

--- a/projects/rocsparse/clients/tests/test_spmm_batched_csc.yaml
+++ b/projects/rocsparse/clients/tests/test_spmm_batched_csc.yaml
@@ -457,6 +457,8 @@ Tests:
   spmm_alg: [rocsparse_spmm_alg_csr]
   orderB: [rocsparse_order_column]
   orderC: [rocsparse_order_row, rocsparse_order_column]
+  rand_gen_min: -100.0
+  rand_gen_max: 100.0
   convert_to_int: true
   filename: [mac_econ_fwd500,
              scircuit]

--- a/projects/rocsparse/clients/tests/test_spmm_coo.yaml
+++ b/projects/rocsparse/clients/tests/test_spmm_coo.yaml
@@ -37,6 +37,7 @@ Definitions:
   - &alpha_beta_range_nightly
     - { alpha:  -0.5, beta:  0.5,  alphai:  1.0, betai: -0.5 }
     - { alpha:  -1.0, beta: -0.5,  alphai:  0.0, betai:  0.0 }
+    - { alpha:  1.0, beta:  0.0,  alphai:  0.0, betai: 0.0 }
 
   - &alpha_beta_range_stress
     - { alpha:   1.0, beta:  0.0, alphai:  0.0, betai:  0.0 }
@@ -685,4 +686,6 @@ Tests:
   orderB: [rocsparse_order_row, rocsparse_order_column]
   orderC: [rocsparse_order_row, rocsparse_order_column]
   filename: [bmwcra_1]
+  rand_gen_min: -100.0
+  rand_gen_max: 100.0
   convert_to_int: true

--- a/projects/rocsparse/clients/tests/test_spmm_csc.yaml
+++ b/projects/rocsparse/clients/tests/test_spmm_csc.yaml
@@ -733,6 +733,8 @@ Tests:
   orderB: [rocsparse_order_row, rocsparse_order_column]
   orderC: [rocsparse_order_row, rocsparse_order_column]
   filename: [bmwcra_1]
+  rand_gen_min: -100.0
+  rand_gen_max: 100.0
   convert_to_int: true
 
 - name: spmm_csc_file

--- a/projects/rocsparse/clients/tests/test_v2_spmv_sell.yaml
+++ b/projects/rocsparse/clients/tests/test_v2_spmv_sell.yaml
@@ -149,6 +149,9 @@ Tests:
   transA: [rocsparse_operation_none, rocsparse_operation_transpose]
   baseA: [rocsparse_index_base_one]
   matrix: [rocsparse_matrix_file_rocalution]
+  rand_gen_min: 0.0
+  rand_gen_max: 100.0
+  convert_to_int: true
   filename: [mac_econ_fwd500,
              bmwcra_1,
              scircuit,

--- a/projects/rocsparse/library/src/level2/sellmv_device.h
+++ b/projects/rocsparse/library/src/level2/sellmv_device.h
@@ -81,14 +81,16 @@ namespace rocsparse
         __syncthreads();
 
         for(int32_t level = 4; level > 0; level /= 2)
+        {
             if(tidy < level && tidy + level < THREADS_PER_ROW)
             {
                 if(tidy < level && tidy + level < THREADS_PER_ROW)
                 {
                     shared[idx] = shared[idx] + shared[idx + sell_slice_size * level];
                 }
-                __syncthreads();
             }
+            __syncthreads();
+        }
 
         if(row < m && tidy == 0)
         {


### PR DESCRIPTION
## Motivation

Redefine sparse matrix values to be between -1 and 1 for spmv sliced ell when not converting to int and when converting to int allow using a range that can be specified in the yaml files using `rand_gen_min` and `rand_gen_max`

## Technical Details

Seeing rounding errors because input sparse matrix data covers a very large floating point range of numbers and differences between the host and device solution math, arch differences, and atomic add usage can result in failures from inadequate tolerance when comparing the host and device solution. Solution is to use sparse matrix values constrained either to a tighter window around 0 or to convert to int as integers can be exactly represented in float up to 2^24.

## Test Plan

Ensure all tests pass
