### PR TITLE
[miopen] Report docker build status to git

### DIFF
--- a/projects/miopen/Dockerfile
+++ b/projects/miopen/Dockerfile
@@ -162,7 +162,7 @@ RUN echo Building for GPU Archs: ${GPU_ARCHS} && \
     mkdir build && cd build && \
     num_threads=64 && \
     echo Building CK with ${num_threads} threads && \
-    CXX=/opt/rocm/bin/amdclang++ cmake -G Ninja \
+    CXX=/opt/rocm/bin/amdclang++ cmake \
     -D CMAKE_PREFIX_PATH=/opt/rocm \
     -D CMAKE_CXX_COMPILER_LAUNCHER="${COMPILER_LAUNCHER}" \
     -D CMAKE_C_COMPILER_LAUNCHER="${COMPILER_LAUNCHER}" \

--- a/projects/miopen/Dockerfile
+++ b/projects/miopen/Dockerfile
@@ -162,7 +162,7 @@ RUN echo Building for GPU Archs: ${GPU_ARCHS} && \
     mkdir build && cd build && \
     num_threads=64 && \
     echo Building CK with ${num_threads} threads && \
-    CXX=/opt/rocm/bin/amdclang++ cmake \
+    CXX=/opt/rocm/bin/amdclang++ cmake -G Ninja \
     -D CMAKE_PREFIX_PATH=/opt/rocm \
     -D CMAKE_CXX_COMPILER_LAUNCHER="${COMPILER_LAUNCHER}" \
     -D CMAKE_C_COMPILER_LAUNCHER="${COMPILER_LAUNCHER}" \

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -226,7 +226,7 @@ pipeline {
             steps{
                 script {
                     withWorkingDir {
-                        utils.getDockerImage()
+                        utils.getDockerImageWithStatus()
                     }
                 }
             }

--- a/projects/miopen/vars/utils.groovy
+++ b/projects/miopen/vars/utils.groovy
@@ -319,6 +319,30 @@ def getDockerImage(Map conf=[:])
     return [dockerImage, image]
 }
 
+// New wrapper function to add gitStatusWrapper around getDockerImage
+def getDockerImageWithStatus(Map conf=[:]) {
+    def variant = env.STAGE_NAME ?: "unknown"  // Fallback if STAGE_NAME is not set
+    def credentialsID = env.monorepo_status_wrapper_creds
+    if (env.REPO_NAME == "MIOpen") {
+        credentialsID = env.miopen_git_creds
+    }
+    
+    gitStatusWrapper(credentialsId: "${credentialsID}", gitHubContext: "${variant}", account: 'ROCm', repo: "${env.REPO_NAME}") {
+        try {
+            return getDockerImage(conf) 
+        }
+        catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e){
+                echo "The job was cancelled or aborted"
+                throw e
+        }
+        catch (Exception ex) {
+            // Log the error and re-throw to ensure status is updated to "failure"
+            echo "Error in getDockerImageWithStatus: ${ex.message}"
+            throw ex
+        }
+    }
+}
+
 def buildHipClangJob(Map conf=[:]){
         show_node_info()
         /*

--- a/projects/miopen/vars/utils.groovy
+++ b/projects/miopen/vars/utils.groovy
@@ -321,13 +321,13 @@ def getDockerImage(Map conf=[:])
 
 // New wrapper function to add gitStatusWrapper around getDockerImage
 def getDockerImageWithStatus(Map conf=[:]) {
-    def variant = env.STAGE_NAME ?: "unknown"  // Fallback if STAGE_NAME is not set
+    def stageName = env.STAGE_NAME ?: "Docker Image"  
     def credentialsID = env.monorepo_status_wrapper_creds
     if (env.REPO_NAME == "MIOpen") {
         credentialsID = env.miopen_git_creds
     }
     
-    gitStatusWrapper(credentialsId: "${credentialsID}", gitHubContext: "${variant}", account: 'ROCm', repo: "${env.REPO_NAME}") {
+    gitStatusWrapper(credentialsId: "${credentialsID}", gitHubContext: "${stageName}", account: 'ROCm', repo: "${env.REPO_NAME}") {
         try {
             return getDockerImage(conf) 
         }
@@ -336,7 +336,6 @@ def getDockerImageWithStatus(Map conf=[:]) {
                 throw e
         }
         catch (Exception ex) {
-            // Log the error and re-throw to ensure status is updated to "failure"
             echo "Error in getDockerImageWithStatus: ${ex.message}"
             throw ex
         }


### PR DESCRIPTION
## Motivation
The Docker build stage in the CI pipeline was failing silently because it lacked a Git reporting wrapper. As a result, Git was unaware of these failures, and some PRs were merged despite breaking the MIOpen CI. This PR addresses that issue by ensuring Docker build failures are properly reported to Git.

## Technical Details

- Introduced a new method: `getDockerImageWithStatus`.
- This method wraps the existing `getDockerImage` call with the Git reporting wrapper.
- The reason for creating a separate method instead of modifying getDockerImage directly:
   - `getDockerImage` is sometimes called within an existing Git reporting wrapper in other stages.
   - Modifying it directly would lead to nested wrappers, which is undesirable.
- Updated the Docker build stage to use `getDockerImageWithStatus` for proper status reporting.

## Test Plan

- Verify that the Docker build stage now reports failures to Git.
  - Successful builds are reported correctly.
  - Failed builds trigger the appropriate Git status update.

## Test Results

- Docker build failure correctly reported to Git.
- No nested Git reporting wrappers observed.
- CI pipeline behaves as expected with updated reporting.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
