### PR TITLE
Temporarily revert BoundCtrl change in warp_move_dpp for GFX10, GFX11, GFX12 and SPIR-V

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -49,12 +49,14 @@ public:
     {
         output = input;
 
-        // Temporary fix: issue with dpp bound_ctrl on Windows
-        #ifndef _WIN32
-        bool constexpr bndCtrl = true;
-        #else
+// Temporary fix: issue with dpp bound_ctrl on Windows, GFX10, GFX11, GFX12 and SPIR-V
+// RDNA encounters compile issues in hipCUB and rocThrust.
+#if defined(_WIN32) || defined(__GFX10__) || defined(__GFX11__) || defined(__GFX12__) \
+    || defined(__SPIRV__)
         bool constexpr bndCtrl = false;
-        #endif
+#else
+        bool constexpr bndCtrl = true;
+#endif
 
         if(VirtualWaveSize > 1)
         {


### PR DESCRIPTION
## Motivation

Due to the changes of https://github.com/ROCm/rocm-libraries/commit/2ffd0eda48aa2d2ebadb4294122f0e2c274873fc, hipCUB and rocThrust have compilation errors with gfx10, gfx11, gfx12 and SPIR-V (see one of the failures below). To fix it, BoundCtrl is temporarily reverted to false for them.

```
[585/728] Building CXX object testing/CMakeFiles/test_thrust_inner_product.dir/inner_product.cu.o
FAILED: testing/CMakeFiles/test_thrust_inner_product.dir/inner_product.cu.o 
phc_sccache_cxx /opt/rocm/llvm/bin/clang++ -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__=1 -I/builds/amd/libraries/rocm-libraries/artifacts/rocthrust/build/thrust/include -I/pipeline/amd/libraries/rocm-libraries/projects/rocthrust/thrust/.. -isystem /pipeline/amd/libraries/rocm-libraries/projects/rocthrust/testing -isystem /opt/rocm-7.1.0/include -isystem /opt/rocm/include -Wall -Wextra -Werror  -D_GLIBCXX_ASSERTIONS=ON -D ROCPRIM_ENABLE_ASSERTS=ON --offload-compress -O3 -DNDEBUG -std=c++17 -Wall -Wextra -x hip --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx1030 --offload-arch=gfx90a --offload-arch=gfx1100 --offload-arch=gfx942 --offload-arch=gfx1201 -DGTEST_HAS_PTHREAD=1 -MD -MT testing/CMakeFiles/test_thrust_inner_product.dir/inner_product.cu.o -MF testing/CMakeFiles/test_thrust_inner_product.dir/inner_product.cu.o.d -o testing/CMakeFiles/test_thrust_inner_product.dir/inner_product.cu.o -c /pipeline/amd/libraries/rocm-libraries/projects/rocthrust/testing/inner_product.cu
error: Illegal instruction detected: Operand has incorrect register class.
renamable $vgpr3, renamable $sgpr2 = V_ADD_CO_U32_e64_dpp undef $vgpr3(tied-def 0), killed $sgpr2, $sgpr2, 0, 177, 15, 15, 1, implicit $exec
error: Illegal instruction detected: Operand has incorrect register class.
renamable $vgpr3, renamable $sgpr0 = V_ADD_CO_U32_e64_dpp undef $vgpr3(tied-def 0), killed $sgpr0, $sgpr0, 0, 177, 15, 15, 1, implicit $exec
error: Illegal instruction detected: Operand has incorrect register class.
renamable $vgpr3, renamable $sgpr0 = V_ADD_CO_U32_e64_dpp undef $vgpr3(tied-def 0), killed $sgpr0, $sgpr0, 0, 177, 15, 15, 1, implicit $exec
error: Illegal instruction detected: Operand has incorrect register class.
renamable $vgpr3, renamable $sgpr0 = V_ADD_CO_U32_e64_dpp undef $vgpr3(tied-def 0), killed $sgpr0, $sgpr0, 0, 177, 15, 15, 1, implicit $exec
error: Illegal instruction detected: Operand has incorrect register class.
renamable $vgpr3, renamable $sgpr0 = V_ADD_CO_U32_e64_dpp undef $vgpr3(tied-def 0), killed $sgpr0, $sgpr0, 0, 177, 15, 15, 1, implicit $exec
error: Illegal instruction detected: Operand has incorrect register class.
renamable $vgpr3, renamable $sgpr0 = V_ADD_CO_U32_e64_dpp undef $vgpr3(tied-def 0), killed $sgpr0, $sgpr0, 0, 177, 15, 15, 1, implicit $exec
error: Illegal instruction detected: Operand has incorrect register class.
renamable $vgpr3, renamable $sgpr0 = V_ADD_CO_U32_e64_dpp undef $vgpr3(tied-def 0), killed $sgpr0, $sgpr0, 0, 177, 15, 15, 1, implicit $exec
error: Illegal instruction detected: Operand has incorrect register class.
renamable $vgpr3, renamable $sgpr0 = V_ADD_CO_U32_e64_dpp undef $vgpr3(tied-def 0), killed $sgpr0, $sgpr0, 0, 177, 15, 15, 1, implicit $exec
8 errors generated when compiling for gfx1201.
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
