### PR TITLE
[MIOpen] Implement tuning support for 2d pooling solvers

### DIFF
--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -312,6 +312,7 @@ set( MIOpen_Source
     solver/pooling/forwardNd.cpp
     solver/pooling/backward2d.cpp
     solver/pooling/backwardNd.cpp
+    solver/pooling/performanceConfig2d.cpp
     solver/prelu/backward_prelu_multi_weights.cpp
     solver/prelu/backward_prelu_single_weight.cpp
     solver/prelu/utils.cpp

--- a/projects/miopen/src/include/miopen/pooling/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/pooling/problem_description.hpp
@@ -50,7 +50,8 @@ struct ProblemDescriptionTag
 {
 };
 
-struct ProblemDescription : ProblemDescriptionTag
+struct ProblemDescription : ProblemDescriptionBase,
+                            ProblemDescriptionTag
 #if MIOPEN_ENABLE_SQLITE
     ,
                             SQLiteSerializable<ProblemDescription>
@@ -109,7 +110,7 @@ struct ProblemDescription : ProblemDescriptionTag
         return save_index;
     }
 
-    NetworkConfig MakeNetworkConfig() const;
+    NetworkConfig MakeNetworkConfig() const override;
 
     template <class Self>
     static void Visit(Self&& self, std::function<void(int64_t, std::string)> f)

--- a/projects/miopen/src/include/miopen/pooling/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/pooling/problem_description.hpp
@@ -117,35 +117,24 @@ struct ProblemDescription : ProblemDescriptionTag
         // The column names match the driver command line argument names
         f(static_cast<uint64_t>(self.direction), "direction");
         f(static_cast<uint64_t>(self.pooling.GetPaddingMode()), "pad_mode");
-        f(self.pooling.GetStrides().size() > 2 ? static_cast<uint64_t>(self.pooling.GetStrides()[0])
-                                               : 0,
-          "pool_stride_d");
-        f(self.pooling.GetStrides().size() > 2
-              ? static_cast<uint64_t>(self.pooling.GetStrides()[1])
-              : static_cast<uint64_t>(self.pooling.GetStrides()[0]),
+        f(self.pooling.GetStrides().size() > 2 ? self.pooling.GetStrides()[0] : 0, "pool_stride_d");
+        f(self.pooling.GetStrides().size() > 2 ? self.pooling.GetStrides()[1]
+                                               : self.pooling.GetStrides()[0],
           "pool_stride_h");
-        f(self.pooling.GetStrides().size() > 2
-              ? static_cast<uint64_t>(self.pooling.GetStrides()[2])
-              : static_cast<uint64_t>(self.pooling.GetStrides()[1]),
+        f(self.pooling.GetStrides().size() > 2 ? self.pooling.GetStrides()[2]
+                                               : self.pooling.GetStrides()[1],
           "pool_stride_w");
-        f(self.pooling.GetPads().size() > 2 ? static_cast<uint64_t>(self.pooling.GetPads()[0]) : 0,
-          "pad_d");
-        f(self.pooling.GetPads().size() > 2 ? static_cast<uint64_t>(self.pooling.GetPads()[1])
-                                            : static_cast<uint64_t>(self.pooling.GetPads()[0]),
+        f(self.pooling.GetPads().size() > 2 ? self.pooling.GetPads()[0] : 0, "pad_d");
+        f(self.pooling.GetPads().size() > 2 ? self.pooling.GetPads()[1] : self.pooling.GetPads()[0],
           "pad_h");
-        f(self.pooling.GetPads().size() > 2 ? static_cast<uint64_t>(self.pooling.GetPads()[2])
-                                            : static_cast<uint64_t>(self.pooling.GetPads()[1]),
+        f(self.pooling.GetPads().size() > 2 ? self.pooling.GetPads()[2] : self.pooling.GetPads()[1],
           "pad_w");
-        f(self.pooling.GetLengths().size() > 2 ? static_cast<uint64_t>(self.pooling.GetLengths()[0])
-                                               : 0,
-          "win_d");
-        f(self.pooling.GetLengths().size() > 2
-              ? static_cast<uint64_t>(self.pooling.GetLengths()[1])
-              : static_cast<uint64_t>(self.pooling.GetLengths()[0]),
+        f(self.pooling.GetLengths().size() > 2 ? self.pooling.GetLengths()[0] : 0, "win_d");
+        f(self.pooling.GetLengths().size() > 2 ? self.pooling.GetLengths()[1]
+                                               : self.pooling.GetLengths()[0],
           "win_h");
-        f(self.pooling.GetLengths().size() > 2
-              ? static_cast<uint64_t>(self.pooling.GetLengths()[2])
-              : static_cast<uint64_t>(self.pooling.GetLengths()[1]),
+        f(self.pooling.GetLengths().size() > 2 ? self.pooling.GetLengths()[2]
+                                               : self.pooling.GetLengths()[1],
           "win_w");
     }
 

--- a/projects/miopen/src/include/miopen/pooling/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/pooling/problem_description.hpp
@@ -29,6 +29,7 @@
 #include <miopen/problem_description_base.hpp>
 #include <miopen/tensor.hpp>
 #include <miopen/pooling.hpp>
+#include <miopen/mlo_internal.hpp>
 
 #include <cassert>
 #include <string>
@@ -45,7 +46,15 @@ enum class Direction
     Backward,
 };
 
-struct ProblemDescription
+struct ProblemDescriptionTag
+{
+};
+
+struct ProblemDescription : ProblemDescriptionTag
+#if MIOPEN_ENABLE_SQLITE
+    ,
+                            SQLiteSerializable<ProblemDescription>
+#endif
 {
     // Forward
     ProblemDescription(const PoolingDescriptor& pooling_,
@@ -102,6 +111,73 @@ struct ProblemDescription
 
     NetworkConfig MakeNetworkConfig() const;
 
+#if MIOPEN_ENABLE_SQLITE
+    template <class Self>
+    static void Visit(Self&& self, std::function<void(int64_t, std::string)> f)
+    {
+        // The column names match the driver command line argument names
+        f(static_cast<uint64_t>(self.direction), "direction");
+        f(static_cast<uint64_t>(self.pooling.GetPaddingMode()), "pad_mode");
+        f(self.pooling.GetStrides().size() > 2 ? static_cast<uint64_t>(self.pooling.GetStrides()[0])
+                                               : 0,
+          "pool_stride_d");
+        f(self.pooling.GetStrides().size() > 2
+              ? static_cast<uint64_t>(self.pooling.GetStrides()[1])
+              : static_cast<uint64_t>(self.pooling.GetStrides()[0]),
+          "pool_stride_h");
+        f(self.pooling.GetStrides().size() > 2
+              ? static_cast<uint64_t>(self.pooling.GetStrides()[2])
+              : static_cast<uint64_t>(self.pooling.GetStrides()[1]),
+          "pool_stride_w");
+        f(self.pooling.GetPads().size() > 2 ? static_cast<uint64_t>(self.pooling.GetPads()[0]) : 0,
+          "pad_d");
+        f(self.pooling.GetPads().size() > 2 ? static_cast<uint64_t>(self.pooling.GetPads()[1])
+                                            : static_cast<uint64_t>(self.pooling.GetPads()[0]),
+          "pad_h");
+        f(self.pooling.GetPads().size() > 2 ? static_cast<uint64_t>(self.pooling.GetPads()[2])
+                                            : static_cast<uint64_t>(self.pooling.GetPads()[1]),
+          "pad_w");
+        f(self.pooling.GetLengths().size() > 2 ? static_cast<uint64_t>(self.pooling.GetLengths()[0])
+                                               : 0,
+          "win_d");
+        f(self.pooling.GetLengths().size() > 2
+              ? static_cast<uint64_t>(self.pooling.GetLengths()[1])
+              : static_cast<uint64_t>(self.pooling.GetLengths()[0]),
+          "win_h");
+        f(self.pooling.GetLengths().size() > 2
+              ? static_cast<uint64_t>(self.pooling.GetLengths()[2])
+              : static_cast<uint64_t>(self.pooling.GetLengths()[1]),
+          "win_w");
+    }
+
+    template <class Self>
+    static void Visit(Self&& self, std::function<void(std::string, std::string)> f)
+    {
+        f(self.GetInShape(), "in_shape");
+        f(self.GetOutShape(), "out_shape");
+        f(self.xDesc.GetLayout_str(), "layout");
+        f(self.GetDirectionStr(), "direction");
+        f(GetDataTypeName(self.xDesc.GetType()), "data_type");
+        f(self.GetModeStr(), "mode");
+    }
+
+    template <class Self, class Visitor>
+    static void VisitAll(Self&& self, const Visitor& f)
+    {
+        Visit(std::forward<Self>(self), [&](int64_t value, std::string name) { f(value, name); });
+        Visit(std::forward<Self>(self),
+              [&](std::string value, std::string name) { f(value, name); });
+    }
+
+    void Serialize(std::ostream& stream) const { stream << MakeNetworkConfig().ToString(); }
+
+    // This declaration marks pooling as a primitive with tuning enabled.
+    // Any tunable solver would be able pick it and fetch a db instance in ExecutePrimitive.
+    // It has to be discoverable via ADL from problem description.
+    friend auto GetDb(const ExecutionContext& context, const ProblemDescriptionTag&)
+        -> PerformanceDb;
+#endif
+
 private:
     Direction direction;
     PoolingDescriptor pooling;
@@ -110,6 +186,61 @@ private:
     TensorDescriptor dxDesc;
     TensorDescriptor dyDesc;
     bool save_index = false;
+    std::size_t GetInBatchSize() const { return xDesc.GetLengths()[0]; }
+    std::size_t GetInChannel() const { return xDesc.GetLengths()[1]; }
+    std::size_t GetInDepth() const { return xDesc.GetNumDims() > 4 ? xDesc.GetLengths()[2] : 0; }
+    std::size_t GetInHeight() const { return xDesc.GetLengths()[xDesc.GetNumDims() - 2]; }
+    std::size_t GetInWidth() const { return xDesc.GetLengths()[xDesc.GetNumDims() - 1]; }
+    std::size_t GetOutBatchSize() const { return yDesc.GetLengths()[0]; }
+    std::size_t GetOutChannel() const { return yDesc.GetLengths()[1]; }
+    std::size_t GetOutDepth() const { return yDesc.GetNumDims() > 4 ? yDesc.GetLengths()[2] : 0; }
+    std::size_t GetOutHeight() const { return yDesc.GetLengths()[yDesc.GetNumDims() - 2]; }
+    std::size_t GetOutWidth() const { return yDesc.GetLengths()[yDesc.GetNumDims() - 1]; }
+    std::string GetInShape() const
+    {
+        std::string shape = "(" + std::to_string(GetInBatchSize());
+        shape += "," + std::to_string(GetInChannel());
+        if(GetInDepth() != 0)
+            shape += "," + std::to_string(GetInDepth());
+        shape += "," + std::to_string(GetInHeight());
+        shape += "," + std::to_string(GetInWidth());
+        shape += ")";
+        return shape;
+    }
+    std::string GetOutShape() const
+    {
+        std::string shape = "(" + std::to_string(GetOutBatchSize());
+        shape += "," + std::to_string(GetOutChannel());
+        if(GetOutDepth() != 0)
+            shape += "," + std::to_string(GetOutDepth());
+        shape += "," + std::to_string(GetOutHeight());
+        shape += "," + std::to_string(GetOutWidth());
+        shape += ")";
+        return shape;
+    }
+    std::string GetDirectionStr() const
+    {
+        std::string s;
+
+        switch(direction)
+        {
+        case Direction::Forward: return "Fwd";
+        case Direction::Backward: return "Bwd";
+        default: MIOPEN_THROW(miopenStatusInvalidValue, "Wrong pooling direction provided");
+        }
+
+        return s;
+    }
+    std::string GetModeStr() const
+    {
+        switch(pooling.GetMode())
+        {
+        case miopenPoolingMax: return "max";
+        case miopenPoolingAverage: return "avg";
+        case miopenPoolingAverageInclusive: return "avg_in";
+        default: MIOPEN_THROW(miopenStatusInvalidValue, "Wrong pooling mode provided");
+        }
+    }
 };
 
 } // namespace pooling

--- a/projects/miopen/src/include/miopen/pooling/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/pooling/problem_description.hpp
@@ -111,7 +111,6 @@ struct ProblemDescription : ProblemDescriptionTag
 
     NetworkConfig MakeNetworkConfig() const;
 
-#if MIOPEN_ENABLE_SQLITE
     template <class Self>
     static void Visit(Self&& self, std::function<void(int64_t, std::string)> f)
     {
@@ -176,7 +175,6 @@ struct ProblemDescription : ProblemDescriptionTag
     // It has to be discoverable via ADL from problem description.
     friend auto GetDb(const ExecutionContext& context, const ProblemDescriptionTag&)
         -> PerformanceDb;
-#endif
 
 private:
     Direction direction;
@@ -198,24 +196,22 @@ private:
     std::size_t GetOutWidth() const { return yDesc.GetLengths()[yDesc.GetNumDims() - 1]; }
     std::string GetInShape() const
     {
-        std::string shape = "(" + std::to_string(GetInBatchSize());
-        shape += "," + std::to_string(GetInChannel());
+        std::string shape = std::to_string(GetInBatchSize());
+        shape += "x" + std::to_string(GetInChannel());
         if(GetInDepth() != 0)
-            shape += "," + std::to_string(GetInDepth());
-        shape += "," + std::to_string(GetInHeight());
-        shape += "," + std::to_string(GetInWidth());
-        shape += ")";
+            shape += "x" + std::to_string(GetInDepth());
+        shape += "x" + std::to_string(GetInHeight());
+        shape += "x" + std::to_string(GetInWidth());
         return shape;
     }
     std::string GetOutShape() const
     {
-        std::string shape = "(" + std::to_string(GetOutBatchSize());
-        shape += "," + std::to_string(GetOutChannel());
+        std::string shape = std::to_string(GetOutBatchSize());
+        shape += "x" + std::to_string(GetOutChannel());
         if(GetOutDepth() != 0)
-            shape += "," + std::to_string(GetOutDepth());
-        shape += "," + std::to_string(GetOutHeight());
-        shape += "," + std::to_string(GetOutWidth());
-        shape += ")";
+            shape += "x" + std::to_string(GetOutDepth());
+        shape += "x" + std::to_string(GetOutHeight());
+        shape += "x" + std::to_string(GetOutWidth());
         return shape;
     }
     std::string GetDirectionStr() const

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -64,12 +64,12 @@ struct PerformanceConfigPooling2d : PerfConfigBase<PerformanceConfigPooling2d<Op
     int out_pix_tile1;
     int local_size0;
     int local_size1;
-    static constexpr int min_out_pix_tile0 = (OpType == OperationType::Forward) ? 1 : 1;
+    static constexpr int min_out_pix_tile0 = 1;
     static constexpr int max_out_pix_tile0 = (OpType == OperationType::Forward) ? 1 : 4;
-    static constexpr int min_out_pix_tile1 = (OpType == OperationType::Forward) ? 1 : 1;
+    static constexpr int min_out_pix_tile1 = 1;
     static constexpr int max_out_pix_tile1 = (OpType == OperationType::Forward) ? 16 : 8;
     static constexpr int min_local_size0   = (OpType == OperationType::Forward) ? 8 : 4;
-    static constexpr int max_local_size0   = (OpType == OperationType::Forward) ? 32 : 32;
+    static constexpr int max_local_size0   = 32;
     static constexpr int min_local_size1   = (OpType == OperationType::Forward) ? 8 : 4;
     static constexpr int max_local_size1   = (OpType == OperationType::Forward) ? 128 : 16;
 

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -53,12 +53,12 @@ struct PerformanceConfigPoolingForward2d : PerfConfigBase<PerformanceConfigPooli
     int out_pix_tile1;
     int local_size0;
     int local_size1;
+    static constexpr int min_out_pix_tile1 = 1;
+    static constexpr int max_out_pix_tile1 = 16;
     static constexpr int min_local_size0   = 8;
     static constexpr int max_local_size0   = 32;
     static constexpr int min_local_size1   = 8;
     static constexpr int max_local_size1   = 128;
-    static constexpr int min_out_pix_tile1 = 1;
-    static constexpr int max_out_pix_tile1 = 16;
 
     PerformanceConfigPoolingForward2d(int out_pix_tile1_, int local_size0_, int local_size1_)
         : out_pix_tile1(out_pix_tile1_), local_size0(local_size0_), local_size1(local_size1_)
@@ -103,6 +103,7 @@ struct PoolingForward2d final : PoolingTunableSolver<PerformanceConfigPoolingFor
     GetSolutionImpl(const ExecutionContext& context,
                     const miopen::pooling::ProblemDescription& problem,
                     const std::optional<PerformanceConfigPoolingForward2d>& config) const;
+    // This method is added to maintain compatibility with TransposedPoolingFwd2d solver
     ConvSolution GetSolution(const ExecutionContext& context,
                              const miopen::pooling::ProblemDescription& problem) const
     {
@@ -209,16 +210,97 @@ struct TransposedPoolingFwdNd final : PoolingFwdNCHWTransposingSolver<PoolingFor
     }
 };
 
-struct PoolingBackward2d final : PoolingSolver
+struct PerformanceConfigPoolingBackward2d : PerfConfigBase<PerformanceConfigPoolingBackward2d>
+{
+    int out_pix_tile0;
+    int out_pix_tile1;
+    int local_size0;
+    int local_size1;
+    static constexpr int min_out_pix_tile0 = 1;
+    static constexpr int max_out_pix_tile0 = 4;
+    static constexpr int min_out_pix_tile1 = 1;
+    static constexpr int max_out_pix_tile1 = 8;
+    static constexpr int min_local_size0   = 4;
+    static constexpr int max_local_size0   = 32;
+    static constexpr int min_local_size1   = 4;
+    static constexpr int max_local_size1   = 16;
+
+    PerformanceConfigPoolingBackward2d(int out_pix_tile0_,
+                                       int out_pix_tile1_,
+                                       int local_size0_,
+                                       int local_size1_)
+        : out_pix_tile0(out_pix_tile0_),
+          out_pix_tile1(out_pix_tile1_),
+          local_size0(local_size0_),
+          local_size1(local_size1_)
+    {
+    }
+    PerformanceConfigPoolingBackward2d()
+        : PerformanceConfigPoolingBackward2d(
+              static_cast<int>(1), static_cast<int>(1), static_cast<int>(4), static_cast<int>(4))
+    {
+    }
+    PerformanceConfigPoolingBackward2d(bool)
+        : PerformanceConfigPoolingBackward2d(
+              static_cast<int>(1), static_cast<int>(1), static_cast<int>(4), static_cast<int>(4))
+    {
+    }
+
+    void HeuristicInit(const miopen::pooling::ProblemDescription&);
+    bool SetNextValue(const miopen::pooling::ProblemDescription&);
+    bool IsValidValue() const;
+    bool IsValid(const ExecutionContext&, const miopen::pooling::ProblemDescription&) const;
+    bool operator==(const PerformanceConfigPoolingBackward2d& other) const;
+
+    template <class Self, class F>
+    static void Visit(Self&& self, F f)
+    {
+        f(self.out_pix_tile0, "out_pix_tile0");
+        f(self.out_pix_tile1, "out_pix_tile1");
+        f(self.local_size0, "local_size0");
+        f(self.local_size1, "local_size1");
+    }
+
+private:
+    void Init(const miopen::pooling::ProblemDescription&);
+};
+
+struct PoolingBackward2d final : PoolingTunableSolver<PerformanceConfigPoolingBackward2d>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingBackward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
+    ConvSolution
+    GetSolutionImpl(const ExecutionContext& context,
+                    const miopen::pooling::ProblemDescription& problem,
+                    const std::optional<PerformanceConfigPoolingBackward2d>& config) const;
+    // This method is added to maintain compatibility with TransposedPoolingBwd2d solver
     ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const override;
+                             const miopen::pooling::ProblemDescription& problem) const
+    {
+        return GetSolutionImpl(context, problem, std::nullopt);
+    }
+    ConvSolution GetSolution(const ExecutionContext& context,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PerformanceConfigPoolingBackward2d& config) const override
+    {
+        return GetSolutionImpl(context, problem, config);
+    }
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
+    PerformanceConfigPoolingBackward2d
+    GetDefaultPerformanceConfig(const ExecutionContext&,
+                                const miopen::pooling::ProblemDescription&) const override;
+    bool IsValidPerformanceConfig(const ExecutionContext&,
+                                  const miopen::pooling::ProblemDescription&,
+                                  const PerformanceConfigPoolingBackward2d&) const override;
+    PerformanceConfigPoolingBackward2d Search(const ExecutionContext& context,
+                                             const miopen::pooling::ProblemDescription& problem,
+                                             const AnyInvokeParams& invoke_context) const override
+    {
+        return GenericSearch(*this, context, problem, invoke_context);
+    }
 };
 
 struct PoolingBackwardNd final : PoolingSolver

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -53,7 +53,6 @@ struct PerformanceConfigPoolingForward2d : PerfConfigBase<PerformanceConfigPooli
     int out_pix_tile1;
     int local_size0;
     int local_size1;
-    bool initialized                       = false;
     static constexpr int min_local_size0   = 8;
     static constexpr int max_local_size0   = 32;
     static constexpr int min_local_size1   = 8;

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -31,6 +31,9 @@
 #include <miopen/pooling/invoke_params.hpp>
 #include <miopen/pooling/problem_description.hpp>
 #include <miopen/utility/transposing_solver.hpp>
+#include <miopen/performance_config.hpp>
+#include <miopen/execution_context.hpp>
+#include <miopen/generic_search.hpp>
 
 #include <utility>
 
@@ -41,17 +44,91 @@ namespace solver {
 namespace pooling {
 
 using PoolingSolver = NonTunableSolverBase<ExecutionContext, miopen::pooling::ProblemDescription>;
+template <class PerformanceConfig>
+using PoolingTunableSolver =
+    SolverBaseTunable<ExecutionContext, miopen::pooling::ProblemDescription, PerformanceConfig>;
 
-struct PoolingForward2d final : PoolingSolver
+struct PerformanceConfigPoolingForward2d : PerfConfigBase<PerformanceConfigPoolingForward2d>
+{
+    int out_pix_tile1;
+    int local_size0;
+    int local_size1;
+    bool initialized                       = false;
+    static constexpr int min_local_size0   = 8;
+    static constexpr int max_local_size0   = 32;
+    static constexpr int min_local_size1   = 8;
+    static constexpr int max_local_size1   = 128;
+    static constexpr int min_out_pix_tile1 = 1;
+    static constexpr int max_out_pix_tile1 = 16;
+
+    PerformanceConfigPoolingForward2d(int out_pix_tile1_, int local_size0_, int local_size1_)
+        : out_pix_tile1(out_pix_tile1_), local_size0(local_size0_), local_size1(local_size1_)
+    {
+    }
+    PerformanceConfigPoolingForward2d()
+        : PerformanceConfigPoolingForward2d(
+              static_cast<int>(1), static_cast<int>(8), static_cast<int>(8))
+    {
+    }
+    PerformanceConfigPoolingForward2d(bool)
+        : PerformanceConfigPoolingForward2d(
+              static_cast<int>(1), static_cast<int>(8), static_cast<int>(8))
+    {
+    }
+
+    void HeuristicInit(const miopen::pooling::ProblemDescription&);
+    bool SetNextValue(const miopen::pooling::ProblemDescription&);
+    bool IsValidValue() const;
+    bool IsValid(const ExecutionContext&, const miopen::pooling::ProblemDescription&) const;
+    bool operator==(const PerformanceConfigPoolingForward2d& other) const;
+
+    template <class Self, class F>
+    static void Visit(Self&& self, F f)
+    {
+        f(self.out_pix_tile1, "out_pix_tile1");
+        f(self.local_size0, "local_size0");
+        f(self.local_size1, "local_size1");
+    }
+
+private:
+    void Init(const miopen::pooling::ProblemDescription&);
+};
+
+struct PoolingForward2d final : PoolingTunableSolver<PerformanceConfigPoolingForward2d>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
+    ConvSolution
+    GetSolutionImpl(const ExecutionContext& context,
+                    const miopen::pooling::ProblemDescription& problem,
+                    const std::optional<PerformanceConfigPoolingForward2d>& config) const;
     ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const override;
+                             const miopen::pooling::ProblemDescription& problem) const
+    {
+        return GetSolutionImpl(context, problem, std::nullopt);
+    }
+    ConvSolution GetSolution(const ExecutionContext& context,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PerformanceConfigPoolingForward2d& config) const override
+    {
+        return GetSolutionImpl(context, problem, config);
+    }
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
+    PerformanceConfigPoolingForward2d
+    GetDefaultPerformanceConfig(const ExecutionContext&,
+                                const miopen::pooling::ProblemDescription&) const override;
+    bool IsValidPerformanceConfig(const ExecutionContext&,
+                                  const miopen::pooling::ProblemDescription&,
+                                  const PerformanceConfigPoolingForward2d&) const override;
+    PerformanceConfigPoolingForward2d Search(const ExecutionContext& context,
+                                             const miopen::pooling::ProblemDescription& problem,
+                                             const AnyInvokeParams& invoke_context) const override
+    {
+        return GenericSearch(*this, context, problem, invoke_context);
+    }
 };
 
 struct PoolingForwardNd final : PoolingSolver

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -43,35 +43,54 @@ namespace solver {
 
 namespace pooling {
 
+enum class OperationType
+{
+    Forward,
+    Backward
+};
+
 using PoolingSolver = NonTunableSolverBase<ExecutionContext, miopen::pooling::ProblemDescription>;
 template <class PerformanceConfig>
 using PoolingTunableSolver =
     SolverBaseTunable<ExecutionContext, miopen::pooling::ProblemDescription, PerformanceConfig>;
 
-struct PerformanceConfigPoolingForward2d : PerfConfigBase<PerformanceConfigPoolingForward2d>
+template <OperationType OpType>
+struct PerformanceConfigPooling2d : PerfConfigBase<PerformanceConfigPooling2d<OpType>>
 {
+    static_assert(OpType == OperationType::Forward || OpType == OperationType::Backward,
+                  "OperationType must be either Forward or Backward");
+
+    int out_pix_tile0;
     int out_pix_tile1;
     int local_size0;
     int local_size1;
-    static constexpr int min_out_pix_tile1 = 1;
-    static constexpr int max_out_pix_tile1 = 16;
-    static constexpr int min_local_size0   = 8;
-    static constexpr int max_local_size0   = 32;
-    static constexpr int min_local_size1   = 8;
-    static constexpr int max_local_size1   = 128;
+    static constexpr int min_out_pix_tile0 = (OpType == OperationType::Forward) ? 1 : 1;
+    static constexpr int max_out_pix_tile0 = (OpType == OperationType::Forward) ? 1 : 4;
+    static constexpr int min_out_pix_tile1 = (OpType == OperationType::Forward) ? 1 : 1;
+    static constexpr int max_out_pix_tile1 = (OpType == OperationType::Forward) ? 16 : 8;
+    static constexpr int min_local_size0   = (OpType == OperationType::Forward) ? 8 : 4;
+    static constexpr int max_local_size0   = (OpType == OperationType::Forward) ? 32 : 32;
+    static constexpr int min_local_size1   = (OpType == OperationType::Forward) ? 8 : 4;
+    static constexpr int max_local_size1   = (OpType == OperationType::Forward) ? 128 : 16;
 
-    PerformanceConfigPoolingForward2d(int out_pix_tile1_, int local_size0_, int local_size1_)
-        : out_pix_tile1(out_pix_tile1_), local_size0(local_size0_), local_size1(local_size1_)
+    PerformanceConfigPooling2d(int out_pix_tile0_,
+                               int out_pix_tile1_,
+                               int local_size0_,
+                               int local_size1_)
+        : out_pix_tile0(out_pix_tile0_),
+          out_pix_tile1(out_pix_tile1_),
+          local_size0(local_size0_),
+          local_size1(local_size1_)
     {
     }
-    PerformanceConfigPoolingForward2d()
-        : PerformanceConfigPoolingForward2d(
-              static_cast<int>(1), static_cast<int>(8), static_cast<int>(8))
+    PerformanceConfigPooling2d()
+        : PerformanceConfigPooling2d(
+              min_out_pix_tile0, min_out_pix_tile1, min_local_size0, min_local_size1)
     {
     }
-    PerformanceConfigPoolingForward2d(bool)
-        : PerformanceConfigPoolingForward2d(
-              static_cast<int>(1), static_cast<int>(8), static_cast<int>(8))
+    PerformanceConfigPooling2d(bool)
+        : PerformanceConfigPooling2d(
+              min_out_pix_tile0, min_out_pix_tile1, min_local_size0, min_local_size1)
     {
     }
 
@@ -79,11 +98,12 @@ struct PerformanceConfigPoolingForward2d : PerfConfigBase<PerformanceConfigPooli
     bool SetNextValue(const miopen::pooling::ProblemDescription&);
     bool IsValidValue() const;
     bool IsValid(const ExecutionContext&, const miopen::pooling::ProblemDescription&) const;
-    bool operator==(const PerformanceConfigPoolingForward2d& other) const;
+    bool operator==(const PerformanceConfigPooling2d& other) const;
 
     template <class Self, class F>
     static void Visit(Self&& self, F f)
     {
+        f(self.out_pix_tile0, "out_pix_tile0");
         f(self.out_pix_tile1, "out_pix_tile1");
         f(self.local_size0, "local_size0");
         f(self.local_size1, "local_size1");
@@ -93,39 +113,46 @@ private:
     void Init(const miopen::pooling::ProblemDescription&);
 };
 
-struct PoolingForward2d final : PoolingTunableSolver<PerformanceConfigPoolingForward2d>
+extern template struct PerformanceConfigPooling2d<OperationType::Forward>;
+extern template struct PerformanceConfigPooling2d<OperationType::Backward>;
+
+struct PoolingForward2d final
+    : PoolingTunableSolver<PerformanceConfigPooling2d<OperationType::Forward>>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
-    ConvSolution
-    GetSolutionImpl(const ExecutionContext& context,
-                    const miopen::pooling::ProblemDescription& problem,
-                    const std::optional<PerformanceConfigPoolingForward2d>& config) const;
+    ConvSolution GetSolutionImpl(
+        const ExecutionContext& context,
+        const miopen::pooling::ProblemDescription& problem,
+        const std::optional<PerformanceConfigPooling2d<OperationType::Forward>>& config) const;
     // This method is added to maintain compatibility with TransposedPoolingFwd2d solver
     ConvSolution GetSolution(const ExecutionContext& context,
                              const miopen::pooling::ProblemDescription& problem) const
     {
         return GetSolutionImpl(context, problem, std::nullopt);
     }
-    ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem,
-                             const PerformanceConfigPoolingForward2d& config) const override
+    ConvSolution
+    GetSolution(const ExecutionContext& context,
+                const miopen::pooling::ProblemDescription& problem,
+                const PerformanceConfigPooling2d<OperationType::Forward>& config) const override
     {
         return GetSolutionImpl(context, problem, config);
     }
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
-    PerformanceConfigPoolingForward2d
+    PerformanceConfigPooling2d<OperationType::Forward>
     GetDefaultPerformanceConfig(const ExecutionContext&,
                                 const miopen::pooling::ProblemDescription&) const override;
-    bool IsValidPerformanceConfig(const ExecutionContext&,
-                                  const miopen::pooling::ProblemDescription&,
-                                  const PerformanceConfigPoolingForward2d&) const override;
-    PerformanceConfigPoolingForward2d Search(const ExecutionContext& context,
-                                             const miopen::pooling::ProblemDescription& problem,
-                                             const AnyInvokeParams& invoke_context) const override
+    bool IsValidPerformanceConfig(
+        const ExecutionContext&,
+        const miopen::pooling::ProblemDescription&,
+        const PerformanceConfigPooling2d<OperationType::Forward>&) const override;
+    PerformanceConfigPooling2d<OperationType::Forward>
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
     {
         return GenericSearch(*this, context, problem, invoke_context);
     }
@@ -210,94 +237,43 @@ struct TransposedPoolingFwdNd final : PoolingFwdNCHWTransposingSolver<PoolingFor
     }
 };
 
-struct PerformanceConfigPoolingBackward2d : PerfConfigBase<PerformanceConfigPoolingBackward2d>
-{
-    int out_pix_tile0;
-    int out_pix_tile1;
-    int local_size0;
-    int local_size1;
-    static constexpr int min_out_pix_tile0 = 1;
-    static constexpr int max_out_pix_tile0 = 4;
-    static constexpr int min_out_pix_tile1 = 1;
-    static constexpr int max_out_pix_tile1 = 8;
-    static constexpr int min_local_size0   = 4;
-    static constexpr int max_local_size0   = 32;
-    static constexpr int min_local_size1   = 4;
-    static constexpr int max_local_size1   = 16;
-
-    PerformanceConfigPoolingBackward2d(int out_pix_tile0_,
-                                       int out_pix_tile1_,
-                                       int local_size0_,
-                                       int local_size1_)
-        : out_pix_tile0(out_pix_tile0_),
-          out_pix_tile1(out_pix_tile1_),
-          local_size0(local_size0_),
-          local_size1(local_size1_)
-    {
-    }
-    PerformanceConfigPoolingBackward2d()
-        : PerformanceConfigPoolingBackward2d(
-              static_cast<int>(1), static_cast<int>(1), static_cast<int>(4), static_cast<int>(4))
-    {
-    }
-    PerformanceConfigPoolingBackward2d(bool)
-        : PerformanceConfigPoolingBackward2d(
-              static_cast<int>(1), static_cast<int>(1), static_cast<int>(4), static_cast<int>(4))
-    {
-    }
-
-    void HeuristicInit(const miopen::pooling::ProblemDescription&);
-    bool SetNextValue(const miopen::pooling::ProblemDescription&);
-    bool IsValidValue() const;
-    bool IsValid(const ExecutionContext&, const miopen::pooling::ProblemDescription&) const;
-    bool operator==(const PerformanceConfigPoolingBackward2d& other) const;
-
-    template <class Self, class F>
-    static void Visit(Self&& self, F f)
-    {
-        f(self.out_pix_tile0, "out_pix_tile0");
-        f(self.out_pix_tile1, "out_pix_tile1");
-        f(self.local_size0, "local_size0");
-        f(self.local_size1, "local_size1");
-    }
-
-private:
-    void Init(const miopen::pooling::ProblemDescription&);
-};
-
-struct PoolingBackward2d final : PoolingTunableSolver<PerformanceConfigPoolingBackward2d>
+struct PoolingBackward2d final
+    : PoolingTunableSolver<PerformanceConfigPooling2d<OperationType::Backward>>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingBackward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
-    ConvSolution
-    GetSolutionImpl(const ExecutionContext& context,
-                    const miopen::pooling::ProblemDescription& problem,
-                    const std::optional<PerformanceConfigPoolingBackward2d>& config) const;
+    ConvSolution GetSolutionImpl(
+        const ExecutionContext& context,
+        const miopen::pooling::ProblemDescription& problem,
+        const std::optional<PerformanceConfigPooling2d<OperationType::Backward>>& config) const;
     // This method is added to maintain compatibility with TransposedPoolingBwd2d solver
     ConvSolution GetSolution(const ExecutionContext& context,
                              const miopen::pooling::ProblemDescription& problem) const
     {
         return GetSolutionImpl(context, problem, std::nullopt);
     }
-    ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem,
-                             const PerformanceConfigPoolingBackward2d& config) const override
+    ConvSolution
+    GetSolution(const ExecutionContext& context,
+                const miopen::pooling::ProblemDescription& problem,
+                const PerformanceConfigPooling2d<OperationType::Backward>& config) const override
     {
         return GetSolutionImpl(context, problem, config);
     }
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
-    PerformanceConfigPoolingBackward2d
+    PerformanceConfigPooling2d<OperationType::Backward>
     GetDefaultPerformanceConfig(const ExecutionContext&,
                                 const miopen::pooling::ProblemDescription&) const override;
-    bool IsValidPerformanceConfig(const ExecutionContext&,
-                                  const miopen::pooling::ProblemDescription&,
-                                  const PerformanceConfigPoolingBackward2d&) const override;
-    PerformanceConfigPoolingBackward2d Search(const ExecutionContext& context,
-                                             const miopen::pooling::ProblemDescription& problem,
-                                             const AnyInvokeParams& invoke_context) const override
+    bool IsValidPerformanceConfig(
+        const ExecutionContext&,
+        const miopen::pooling::ProblemDescription&,
+        const PerformanceConfigPooling2d<OperationType::Backward>&) const override;
+    PerformanceConfigPooling2d<OperationType::Backward>
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
     {
         return GenericSearch(*this, context, problem, invoke_context);
     }

--- a/projects/miopen/src/pooling.cpp
+++ b/projects/miopen/src/pooling.cpp
@@ -36,11 +36,23 @@
 #include <miopen/subbuffers.hpp>
 #include <miopen/tensor.hpp>
 #include <miopen/tensor_layout.hpp>
+#include "miopen/pooling/problem_description.hpp"
 
 #include <cassert>
 #include <cmath>
 
 namespace miopen {
+
+namespace pooling {
+
+miopen::PerformanceDb GetDb(const miopen::ExecutionContext& context,
+                            const miopen::pooling::ProblemDescriptionTag&)
+{
+    return {
+        DbKinds::PerfDb, context.GetPerfDbPath("pooling"), context.GetUserPerfDbPath("pooling")};
+}
+
+} // namespace pooling
 
 template <class T, class U>
 T iciel_div(T x, U y)

--- a/projects/miopen/src/solver/pooling/backward2d.cpp
+++ b/projects/miopen/src/solver/pooling/backward2d.cpp
@@ -32,6 +32,7 @@
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/mlo_internal.hpp>
 #include <miopen/target_properties.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
 
 namespace miopen {
 
@@ -56,7 +57,8 @@ struct kernel_params
     std::size_t grp_tile0;
     std::size_t grp_tile1;
 
-    kernel_params(const miopen::pooling::ProblemDescription& problem)
+    kernel_params(const miopen::pooling::ProblemDescription& problem,
+                  const std::optional<PerformanceConfigPoolingBackward2d>& config = std::nullopt)
     {
         const auto& pd = problem.GetPooling();
 
@@ -68,34 +70,44 @@ struct kernel_params
         std::tie(batch_sz, n_inputs, in_height, in_width) =
             miopen::tien<4>(problem.GetXDesc().GetLengths(), 1);
 
-        out_pix_tile0 = 1;
-        out_pix_tile1 = 1;
-        if(pd.GetMode() == miopenPoolingMax)
+        if(config)
         {
-            out_pix_tile0 = in_width > 8 && in_width <= 24 ? 4 : 1;
-            out_pix_tile1 = in_width <= 24 ? 1 : (in_width > 64 && in_width <= 96 ? 4 : 8);
+            out_pix_tile0 = config->out_pix_tile0;
+            out_pix_tile1 = config->out_pix_tile1;
+            grp_tile0     = config->local_size0;
+            grp_tile1     = config->local_size1;
         }
-
-        grp_tile0 = 8;
-        grp_tile1 = 8;
-        if(pd.GetMode() == miopenPoolingMax)
+        else
         {
-            grp_tile0 = in_width <= 8     ? 8  //
-                        : in_width <= 16  ? 4  //
-                        : in_width <= 24  ? 8  //
-                        : in_width <= 32  ? 32 //
-                        : in_width <= 64  ? 8  //
-                        : in_width <= 96  ? 16 //
-                        : in_width <= 128 ? 16
-                                          : 32;
-            grp_tile1 = in_width <= 8     ? 8  //
-                        : in_width <= 16  ? 16 //
-                        : in_width <= 24  ? 8  //
-                        : in_width <= 32  ? 4  //
-                        : in_width <= 64  ? 8  //
-                        : in_width <= 96  ? 4  //
-                        : in_width <= 128 ? 16
-                                          : 4;
+            out_pix_tile0 = 1;
+            out_pix_tile1 = 1;
+            if(pd.GetMode() == miopenPoolingMax)
+            {
+                out_pix_tile0 = in_width > 8 && in_width <= 24 ? 4 : 1;
+                out_pix_tile1 = in_width <= 24 ? 1 : (in_width > 64 && in_width <= 96 ? 4 : 8);
+            }
+
+            grp_tile0 = 8;
+            grp_tile1 = 8;
+            if(pd.GetMode() == miopenPoolingMax)
+            {
+                grp_tile0 = in_width <= 8     ? 8  //
+                            : in_width <= 16  ? 4  //
+                            : in_width <= 24  ? 8  //
+                            : in_width <= 32  ? 32 //
+                            : in_width <= 64  ? 8  //
+                            : in_width <= 96  ? 16 //
+                            : in_width <= 128 ? 16
+                                              : 32;
+                grp_tile1 = in_width <= 8     ? 8  //
+                            : in_width <= 16  ? 16 //
+                            : in_width <= 24  ? 8  //
+                            : in_width <= 32  ? 4  //
+                            : in_width <= 64  ? 8  //
+                            : in_width <= 96  ? 4  //
+                            : in_width <= 128 ? 16
+                                              : 4;
+            }
         }
     }
 };
@@ -126,12 +138,13 @@ std::size_t sizeof_local_memory(const miopen::pooling::ProblemDescription& probl
     // aliases to ease programming
     const auto& MLO_POOLING_KERNEL_SZ0      = kp.kernel_size_w;
     const auto& MLO_POOLING_KERNEL_SZ1      = kp.kernel_size_h;
-    const auto& MLO_POOLBWD_N_HORIZ_OUT_PIX = kp.out_pix_tile0;
-    const auto& MLO_POOLBWD_N_VERT_OUT_PIX  = kp.out_pix_tile1;
     const auto& MLO_POOLING_STRIDE0         = kp.kernel_stride_w;
     const auto& MLO_POOLING_STRIDE1         = kp.kernel_stride_h;
-    const auto& MLO_POOLBWD_GROUP_SZ0       = kp.grp_tile0;
-    const auto& MLO_POOLBWD_GROUP_SZ1       = kp.grp_tile1;
+    // safer estimates of memory with max values of tunable parameters
+    const auto& MLO_POOLBWD_N_HORIZ_OUT_PIX = PerformanceConfigPoolingBackward2d::max_out_pix_tile0;
+    const auto& MLO_POOLBWD_N_VERT_OUT_PIX  = PerformanceConfigPoolingBackward2d::max_out_pix_tile1;
+    const auto& MLO_POOLBWD_GROUP_SZ0       = PerformanceConfigPoolingBackward2d::max_local_size0;
+    const auto& MLO_POOLBWD_GROUP_SZ1       = PerformanceConfigPoolingBackward2d::max_local_size1;
 
     const auto MLO_POOLBWD_LCL_DATA_WIDTH =
         (static_cast<std::size_t>(MLO_POOLBWD_GROUP_SZ0) * MLO_POOLBWD_N_HORIZ_OUT_PIX +
@@ -183,13 +196,14 @@ bool PoolingBackward2d::IsApplicable(const ExecutionContext&,
            sizeof_local_memory(problem) <= TargetProperties::GetMaxLocalMemorySize();
 }
 
-ConvSolution
-PoolingBackward2d::GetSolution(const ExecutionContext&,
-                               const miopen::pooling::ProblemDescription& problem) const
+ConvSolution PoolingBackward2d::GetSolutionImpl(
+    const ExecutionContext&,
+    const miopen::pooling::ProblemDescription& problem,
+    const std::optional<PerformanceConfigPoolingBackward2d>& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
-    const kernel_params kp(problem);
+    const kernel_params kp(problem, config);
 
     {
         auto kernel = KernelInfo{};
@@ -301,6 +315,121 @@ PoolingBackward2d::GetWorkspaceSize(const ExecutionContext&,
     if(problem.GetPooling().GetMode() != miopenPoolingMax)
         return 0;
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
+}
+
+void PerformanceConfigPoolingBackward2d::Init(const miopen::pooling::ProblemDescription&)
+{
+    // initialize with minimum values
+    out_pix_tile0 = min_out_pix_tile0;
+    out_pix_tile1 = min_out_pix_tile1;
+    local_size0   = min_local_size0;
+    local_size1   = min_local_size1;
+}
+
+void PerformanceConfigPoolingBackward2d::HeuristicInit(
+    const miopen::pooling::ProblemDescription& problem)
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat: Init(problem); break;
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+#endif
+}
+
+bool PerformanceConfigPoolingBackward2d::SetNextValue(
+    const miopen::pooling::ProblemDescription& problem)
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+    return false;
+#else
+    do
+    {
+        if(!NextTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
+            break;
+        if(!NextTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+            break;
+        if(!NextTwoPower<min_local_size0, max_local_size0>(local_size0))
+            break;
+        if(!NextTwoPower<min_local_size1, max_local_size1>(local_size1))
+            break;
+        return false;
+    } while(false);
+    return true;
+#endif
+}
+
+bool PerformanceConfigPoolingBackward2d::IsValidValue() const
+{
+    if(!IsTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
+        return false;
+    if(!IsTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+        return false;
+    if(!IsTwoPower<min_local_size0, max_local_size0>(local_size0))
+        return false;
+    if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
+        return false;
+    return true;
+}
+
+bool PerformanceConfigPoolingBackward2d::IsValid(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+    return false;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat:
+        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+    return false;
+#endif
+}
+
+bool PerformanceConfigPoolingBackward2d::operator==(
+    const PerformanceConfigPoolingBackward2d& other) const
+{
+    return out_pix_tile0 == other.out_pix_tile0 && out_pix_tile1 == other.out_pix_tile1 &&
+           local_size0 == other.local_size0 && local_size1 == other.local_size1;
+}
+
+bool PoolingBackward2d::IsValidPerformanceConfig(
+    const ExecutionContext& context,
+    const miopen::pooling::ProblemDescription& problem,
+    const PerformanceConfigPoolingBackward2d& config) const
+{
+    return config.IsValid(context, problem);
+}
+
+PerformanceConfigPoolingBackward2d PoolingBackward2d::GetDefaultPerformanceConfig(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+    PerformanceConfigPoolingBackward2d config;
+    config.HeuristicInit(problem);
+    return config;
 }
 
 } // namespace pooling

--- a/projects/miopen/src/solver/pooling/backward2d.cpp
+++ b/projects/miopen/src/solver/pooling/backward2d.cpp
@@ -58,7 +58,8 @@ struct kernel_params
     std::size_t grp_tile1;
 
     kernel_params(const miopen::pooling::ProblemDescription& problem,
-                  const std::optional<PerformanceConfigPoolingBackward2d>& config = std::nullopt)
+                  const std::optional<PerformanceConfigPooling2d<OperationType::Backward>>& config =
+                      std::nullopt)
     {
         const auto& pd = problem.GetPooling();
 
@@ -136,15 +137,25 @@ std::size_t sizeof_local_memory(const miopen::pooling::ProblemDescription& probl
     const kernel_params kp(problem);
 
     // aliases to ease programming
-    const auto& MLO_POOLING_KERNEL_SZ0      = kp.kernel_size_w;
-    const auto& MLO_POOLING_KERNEL_SZ1      = kp.kernel_size_h;
-    const auto& MLO_POOLING_STRIDE0         = kp.kernel_stride_w;
-    const auto& MLO_POOLING_STRIDE1         = kp.kernel_stride_h;
+    const auto& MLO_POOLING_KERNEL_SZ0 = kp.kernel_size_w;
+    const auto& MLO_POOLING_KERNEL_SZ1 = kp.kernel_size_h;
+    const auto& MLO_POOLING_STRIDE0    = kp.kernel_stride_w;
+    const auto& MLO_POOLING_STRIDE1    = kp.kernel_stride_h;
     // safer estimates of memory with max values of tunable parameters
-    const auto& MLO_POOLBWD_N_HORIZ_OUT_PIX = PerformanceConfigPoolingBackward2d::max_out_pix_tile0;
-    const auto& MLO_POOLBWD_N_VERT_OUT_PIX  = PerformanceConfigPoolingBackward2d::max_out_pix_tile1;
-    const auto& MLO_POOLBWD_GROUP_SZ0       = PerformanceConfigPoolingBackward2d::max_local_size0;
-    const auto& MLO_POOLBWD_GROUP_SZ1       = PerformanceConfigPoolingBackward2d::max_local_size1;
+    assert(kp.out_pix_tile0 <=
+           PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile0);
+    const auto& MLO_POOLBWD_N_HORIZ_OUT_PIX =
+        PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile0;
+    assert(kp.out_pix_tile1 <=
+           PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile1);
+    const auto& MLO_POOLBWD_N_VERT_OUT_PIX =
+        PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile1;
+    assert(kp.grp_tile0 <= PerformanceConfigPooling2d<OperationType::Backward>::max_local_size0);
+    const auto& MLO_POOLBWD_GROUP_SZ0 =
+        PerformanceConfigPooling2d<OperationType::Backward>::max_local_size0;
+    assert(kp.grp_tile1 <= PerformanceConfigPooling2d<OperationType::Backward>::max_local_size1);
+    const auto& MLO_POOLBWD_GROUP_SZ1 =
+        PerformanceConfigPooling2d<OperationType::Backward>::max_local_size1;
 
     const auto MLO_POOLBWD_LCL_DATA_WIDTH =
         (static_cast<std::size_t>(MLO_POOLBWD_GROUP_SZ0) * MLO_POOLBWD_N_HORIZ_OUT_PIX +
@@ -199,7 +210,7 @@ bool PoolingBackward2d::IsApplicable(const ExecutionContext&,
 ConvSolution PoolingBackward2d::GetSolutionImpl(
     const ExecutionContext&,
     const miopen::pooling::ProblemDescription& problem,
-    const std::optional<PerformanceConfigPoolingBackward2d>& config) const
+    const std::optional<PerformanceConfigPooling2d<OperationType::Backward>>& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -317,117 +328,18 @@ PoolingBackward2d::GetWorkspaceSize(const ExecutionContext&,
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
 }
 
-void PerformanceConfigPoolingBackward2d::Init(const miopen::pooling::ProblemDescription&)
-{
-    // initialize with minimum values
-    out_pix_tile0 = min_out_pix_tile0;
-    out_pix_tile1 = min_out_pix_tile1;
-    local_size0   = min_local_size0;
-    local_size1   = min_local_size1;
-}
-
-void PerformanceConfigPoolingBackward2d::HeuristicInit(
-    const miopen::pooling::ProblemDescription& problem)
-{
-#if !MIOPEN_BACKEND_HIP
-    std::ignore = problem;
-#else
-    switch(problem.GetXDesc().GetType())
-    {
-    case miopenHalf:
-    case miopenFloat: Init(problem); break;
-    case miopenBFloat16:
-    case miopenDouble:
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenInt32:
-    case miopenInt64:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-#endif
-}
-
-bool PerformanceConfigPoolingBackward2d::SetNextValue(
-    const miopen::pooling::ProblemDescription& problem)
-{
-#if !MIOPEN_BACKEND_HIP
-    std::ignore = problem;
-    return false;
-#else
-    do
-    {
-        if(!NextTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
-            break;
-        if(!NextTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
-            break;
-        if(!NextTwoPower<min_local_size0, max_local_size0>(local_size0))
-            break;
-        if(!NextTwoPower<min_local_size1, max_local_size1>(local_size1))
-            break;
-        return false;
-    } while(false);
-    return true;
-#endif
-}
-
-bool PerformanceConfigPoolingBackward2d::IsValidValue() const
-{
-    if(!IsTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
-        return false;
-    if(!IsTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
-        return false;
-    if(!IsTwoPower<min_local_size0, max_local_size0>(local_size0))
-        return false;
-    if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
-        return false;
-    return true;
-}
-
-bool PerformanceConfigPoolingBackward2d::IsValid(
-    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
-{
-#if !MIOPEN_BACKEND_HIP
-    std::ignore = problem;
-    return false;
-#else
-    switch(problem.GetXDesc().GetType())
-    {
-    case miopenHalf:
-    case miopenFloat:
-        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
-    case miopenBFloat16:
-    case miopenDouble:
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenInt32:
-    case miopenInt64:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-    return false;
-#endif
-}
-
-bool PerformanceConfigPoolingBackward2d::operator==(
-    const PerformanceConfigPoolingBackward2d& other) const
-{
-    return out_pix_tile0 == other.out_pix_tile0 && out_pix_tile1 == other.out_pix_tile1 &&
-           local_size0 == other.local_size0 && local_size1 == other.local_size1;
-}
-
 bool PoolingBackward2d::IsValidPerformanceConfig(
     const ExecutionContext& context,
     const miopen::pooling::ProblemDescription& problem,
-    const PerformanceConfigPoolingBackward2d& config) const
+    const PerformanceConfigPooling2d<OperationType::Backward>& config) const
 {
     return config.IsValid(context, problem);
 }
 
-PerformanceConfigPoolingBackward2d PoolingBackward2d::GetDefaultPerformanceConfig(
+PerformanceConfigPooling2d<OperationType::Backward> PoolingBackward2d::GetDefaultPerformanceConfig(
     const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
 {
-    PerformanceConfigPoolingBackward2d config;
+    PerformanceConfigPooling2d<OperationType::Backward> config;
     config.HeuristicInit(problem);
     return config;
 }

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -343,6 +343,7 @@ bool PerformanceConfigPoolingForward2d::IsValidValue() const
         return false;
     if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
         return false;
+    // this constraint is enforced to avoid grp_tile1 becoming zero in GetSolutionImpl
     if(local_size1 / out_pix_tile1 < 1)
         return false;
     return true;

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -312,7 +312,6 @@ void PerformanceConfigPoolingForward2d::HeuristicInit(
     default: MIOPEN_THROW("Unsupported datatype");
     }
 #endif
-    initialized = true;
 }
 
 bool PerformanceConfigPoolingForward2d::SetNextValue(
@@ -322,11 +321,6 @@ bool PerformanceConfigPoolingForward2d::SetNextValue(
     std::ignore = problem;
     return false;
 #else
-    if(!initialized)
-    {
-        HeuristicInit(problem);
-        return true;
-    }
     do
     {
         if(!NextTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -53,7 +53,8 @@ struct kernel_params
     int out_pix_tile1;
 
     kernel_params(const miopen::pooling::ProblemDescription& p,
-                  const std::optional<PerformanceConfigPoolingForward2d>& config = std::nullopt)
+                  const std::optional<PerformanceConfigPooling2d<OperationType::Forward>>& config =
+                      std::nullopt)
     {
         const auto& pd  = p.GetPooling();
         const auto& yd  = p.GetYDesc();
@@ -75,7 +76,6 @@ struct kernel_params
                                                : 8;
             if(out_height > 16 && out_height % 32 > 16)
                 out_pix_tile1 = std::min(16, std::max(1, prePow2(out_pix_tile1 * kernel_stride_h)));
-            assert(out_pix_tile1 <= PerformanceConfigPoolingForward2d::max_out_pix_tile1);
         }
     }
 };
@@ -123,7 +123,10 @@ std::size_t sizeof_private_memory(const miopen::pooling::ProblemDescription& pro
     const auto& MLO_POOLING_STRIDE0         = kp.kernel_stride_w;
     const auto& MLO_POOLING_N_HORIZ_OUT_PIX = kp.out_pix_tile0;
     // safer estimate of memory with max_out_pix_tile1
-    const auto& MLO_POOLING_N_VERT_OUT_PIX = PerformanceConfigPoolingForward2d::max_out_pix_tile1;
+    assert(kp.out_pix_tile1 <=
+           PerformanceConfigPooling2d<OperationType::Forward>::max_out_pix_tile1);
+    const auto& MLO_POOLING_N_VERT_OUT_PIX =
+        PerformanceConfigPooling2d<OperationType::Forward>::max_out_pix_tile1;
 
     const auto MLO_BOT_DATA_SZ0 =
         (static_cast<std::size_t>(MLO_POOLING_N_HORIZ_OUT_PIX) - 1) * MLO_POOLING_STRIDE0 +
@@ -163,7 +166,7 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
 ConvSolution PoolingForward2d::GetSolutionImpl(
     const ExecutionContext&,
     const miopen::pooling::ProblemDescription& problem,
-    const std::optional<PerformanceConfigPoolingForward2d>& config) const
+    const std::optional<PerformanceConfigPooling2d<OperationType::Forward>>& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -284,115 +287,18 @@ PoolingForward2d::GetWorkspaceSize(const ExecutionContext&,
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
 }
 
-void PerformanceConfigPoolingForward2d::Init(const miopen::pooling::ProblemDescription&)
-{
-    // initialize with minimum values
-    out_pix_tile1 = min_out_pix_tile1;
-    local_size0   = min_local_size0;
-    local_size1   = min_local_size1;
-}
-
-void PerformanceConfigPoolingForward2d::HeuristicInit(
-    const miopen::pooling::ProblemDescription& problem)
-{
-#if !MIOPEN_BACKEND_HIP
-    std::ignore = problem;
-#else
-    switch(problem.GetXDesc().GetType())
-    {
-    case miopenHalf:
-    case miopenFloat: Init(problem); break;
-    case miopenBFloat16:
-    case miopenDouble:
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenInt32:
-    case miopenInt64:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-#endif
-}
-
-bool PerformanceConfigPoolingForward2d::SetNextValue(
-    const miopen::pooling::ProblemDescription& problem)
-{
-#if !MIOPEN_BACKEND_HIP
-    std::ignore = problem;
-    return false;
-#else
-    do
-    {
-        if(!NextTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
-            break;
-        if(!NextTwoPower<min_local_size0, max_local_size0>(local_size0))
-            break;
-        if(!NextTwoPower<min_local_size1, max_local_size1>(local_size1))
-            break;
-        return false;
-    } while(false);
-    return true;
-#endif
-}
-
-bool PerformanceConfigPoolingForward2d::IsValidValue() const
-{
-    if(!IsTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
-        return false;
-    if(!IsTwoPower<min_local_size0, max_local_size0>(local_size0))
-        return false;
-    if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
-        return false;
-    // this constraint is enforced to avoid grp_tile1 becoming zero in GetSolutionImpl
-    if(local_size1 / out_pix_tile1 < 1)
-        return false;
-    return true;
-}
-
-bool PerformanceConfigPoolingForward2d::IsValid(
-    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
-{
-#if !MIOPEN_BACKEND_HIP
-    std::ignore = problem;
-    return false;
-#else
-    switch(problem.GetXDesc().GetType())
-    {
-    case miopenHalf:
-    case miopenFloat:
-        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
-    case miopenBFloat16:
-    case miopenDouble:
-    case miopenFloat8_fnuz:
-    case miopenBFloat8_fnuz:
-    case miopenInt8:
-    case miopenInt32:
-    case miopenInt64:
-    default: MIOPEN_THROW("Unsupported datatype");
-    }
-    return false;
-#endif
-}
-
-bool PerformanceConfigPoolingForward2d::operator==(
-    const PerformanceConfigPoolingForward2d& other) const
-{
-    return out_pix_tile1 == other.out_pix_tile1 && local_size0 == other.local_size0 &&
-           local_size1 == other.local_size1;
-}
-
 bool PoolingForward2d::IsValidPerformanceConfig(
     const ExecutionContext& context,
     const miopen::pooling::ProblemDescription& problem,
-    const PerformanceConfigPoolingForward2d& config) const
+    const PerformanceConfigPooling2d<OperationType::Forward>& config) const
 {
     return config.IsValid(context, problem);
 }
 
-PerformanceConfigPoolingForward2d PoolingForward2d::GetDefaultPerformanceConfig(
+PerformanceConfigPooling2d<OperationType::Forward> PoolingForward2d::GetDefaultPerformanceConfig(
     const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
 {
-    PerformanceConfigPoolingForward2d config;
+    PerformanceConfigPooling2d<OperationType::Forward> config;
     config.HeuristicInit(problem);
     return config;
 }

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -31,6 +31,7 @@
 #include <miopen/pooling.hpp>
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/mlo_internal.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
 
 namespace miopen {
 
@@ -51,7 +52,8 @@ struct kernel_params
     int out_pix_tile0;
     int out_pix_tile1;
 
-    kernel_params(const miopen::pooling::ProblemDescription& p)
+    kernel_params(const miopen::pooling::ProblemDescription& p,
+                  const std::optional<PerformanceConfigPoolingForward2d>& config = std::nullopt)
     {
         const auto& pd  = p.GetPooling();
         const auto& yd  = p.GetYDesc();
@@ -62,11 +64,19 @@ struct kernel_params
         out_height      = yd.GetLengths()[2];
         out_width       = yd.GetLengths()[3];
         out_pix_tile0   = 1;
-        out_pix_tile1   = out_height <= 8    ? 1 //
-                          : out_height <= 32 ? 4 //
-                                             : 8;
-        if(out_height > 16 && out_height % 32 > 16)
-            out_pix_tile1 = std::min(16, std::max(1, prePow2(out_pix_tile1 * kernel_stride_h)));
+        if(config)
+        {
+            out_pix_tile1 = config->out_pix_tile1;
+        }
+        else
+        {
+            out_pix_tile1 = out_height <= 8    ? 1 //
+                            : out_height <= 32 ? 4 //
+                                               : 8;
+            if(out_height > 16 && out_height % 32 > 16)
+                out_pix_tile1 = std::min(16, std::max(1, prePow2(out_pix_tile1 * kernel_stride_h)));
+            assert(out_pix_tile1 <= PerformanceConfigPoolingForward2d::max_out_pix_tile1);
+        }
     }
 };
 
@@ -112,7 +122,8 @@ std::size_t sizeof_private_memory(const miopen::pooling::ProblemDescription& pro
     const auto& MLO_POOLING_KERNEL_SZ0      = kp.kernel_size_w;
     const auto& MLO_POOLING_STRIDE0         = kp.kernel_stride_w;
     const auto& MLO_POOLING_N_HORIZ_OUT_PIX = kp.out_pix_tile0;
-    const auto& MLO_POOLING_N_VERT_OUT_PIX  = kp.out_pix_tile1;
+    // safer estimate of memory with max_out_pix_tile1
+    const auto& MLO_POOLING_N_VERT_OUT_PIX = PerformanceConfigPoolingForward2d::max_out_pix_tile1;
 
     const auto MLO_BOT_DATA_SZ0 =
         (static_cast<std::size_t>(MLO_POOLING_N_HORIZ_OUT_PIX) - 1) * MLO_POOLING_STRIDE0 +
@@ -149,8 +160,10 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
                TargetProperties::GetMaxWaveScratchSize() / context.GetStream().GetWavefrontWidth();
 }
 
-ConvSolution PoolingForward2d::GetSolution(const ExecutionContext&,
-                                           const miopen::pooling::ProblemDescription& problem) const
+ConvSolution PoolingForward2d::GetSolutionImpl(
+    const ExecutionContext&,
+    const miopen::pooling::ProblemDescription& problem,
+    const std::optional<PerformanceConfigPoolingForward2d>& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -160,7 +173,7 @@ ConvSolution PoolingForward2d::GetSolution(const ExecutionContext&,
         kernel.kernel_file = "MIOpenPooling.cpp";
         kernel.kernel_name = "mloPoolingG";
 
-        const kernel_params kp(problem);
+        const kernel_params kp(problem, config);
 
         int batch_sz, n_outputs;
         std::tie(batch_sz, n_outputs, std::ignore, std::ignore) =
@@ -169,12 +182,21 @@ ConvSolution PoolingForward2d::GetSolution(const ExecutionContext&,
         const auto& pool_d   = problem.GetPooling();
         const auto wsp_index = pool_d.GetWorkspaceIndexMode();
 
-        int grp_tile0 = kp.out_width <= 8 ? 8 : (kp.out_width % 32 <= 16 ? 16 : 32);
-        int grp_tile1 = kp.out_height <= 8    ? 8
+        int grp_tile0, grp_tile1;
+        if(config)
+        {
+            grp_tile0 = config->local_size0;
+            grp_tile1 = config->local_size1;
+        }
+        else
+        {
+            grp_tile0 = kp.out_width <= 8 ? 8 : (kp.out_width % 32 <= 16 ? 16 : 32);
+            grp_tile1 = kp.out_height <= 8    ? 8
                         : kp.out_height < 16  ? 16
                         : kp.out_height <= 32 ? 32
                         : kp.out_height <= 64 ? 64
                                               : 128;
+        }
         grp_tile1 /= kp.out_pix_tile1;
         while(grp_tile0 * grp_tile1 > 256 && grp_tile0 > 1)
             grp_tile0 >>= 1;
@@ -260,6 +282,124 @@ PoolingForward2d::GetWorkspaceSize(const ExecutionContext&,
     if(problem.GetPooling().GetMode() != miopenPoolingMax)
         return 0;
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
+}
+
+void PerformanceConfigPoolingForward2d::Init(const miopen::pooling::ProblemDescription&)
+{
+    // initialize with minimum values
+    out_pix_tile1 = min_out_pix_tile1;
+    local_size0   = min_local_size0;
+    local_size1   = min_local_size1;
+}
+
+void PerformanceConfigPoolingForward2d::HeuristicInit(
+    const miopen::pooling::ProblemDescription& problem)
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat: Init(problem); break;
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+#endif
+    initialized = true;
+}
+
+bool PerformanceConfigPoolingForward2d::SetNextValue(
+    const miopen::pooling::ProblemDescription& problem)
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+    return false;
+#else
+    if(!initialized)
+    {
+        HeuristicInit(problem);
+        return true;
+    }
+    do
+    {
+        if(!NextTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+            break;
+        if(!NextTwoPower<min_local_size0, max_local_size0>(local_size0))
+            break;
+        if(!NextTwoPower<min_local_size1, max_local_size1>(local_size1))
+            break;
+        return false;
+    } while(false);
+    return true;
+#endif
+}
+
+bool PerformanceConfigPoolingForward2d::IsValidValue() const
+{
+    if(!IsTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+        return false;
+    if(!IsTwoPower<min_local_size0, max_local_size0>(local_size0))
+        return false;
+    if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
+        return false;
+    if(local_size1 / out_pix_tile1 < 1)
+        return false;
+    return true;
+}
+
+bool PerformanceConfigPoolingForward2d::IsValid(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+    return false;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat:
+        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+    return false;
+#endif
+}
+
+bool PerformanceConfigPoolingForward2d::operator==(
+    const PerformanceConfigPoolingForward2d& other) const
+{
+    return out_pix_tile1 == other.out_pix_tile1 && local_size0 == other.local_size0 &&
+           local_size1 == other.local_size1;
+}
+
+bool PoolingForward2d::IsValidPerformanceConfig(
+    const ExecutionContext& context,
+    const miopen::pooling::ProblemDescription& problem,
+    const PerformanceConfigPoolingForward2d& config) const
+{
+    return config.IsValid(context, problem);
+}
+
+PerformanceConfigPoolingForward2d PoolingForward2d::GetDefaultPerformanceConfig(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+    PerformanceConfigPoolingForward2d config;
+    config.HeuristicInit(problem);
+    return config;
 }
 
 } // namespace pooling

--- a/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
+++ b/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
@@ -1,0 +1,142 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <miopen/pooling/solvers.hpp>
+#include <miopen/mlo_internal.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
+
+namespace miopen {
+
+namespace solver {
+
+namespace pooling {
+
+template <OperationType OpType>
+void PerformanceConfigPooling2d<OpType>::Init(const miopen::pooling::ProblemDescription&)
+{
+    // initialize with minimum values
+    out_pix_tile0 = min_out_pix_tile0;
+    out_pix_tile1 = min_out_pix_tile1;
+    local_size0   = min_local_size0;
+    local_size1   = min_local_size1;
+}
+
+template <OperationType OpType>
+void PerformanceConfigPooling2d<OpType>::HeuristicInit(
+    const miopen::pooling::ProblemDescription& problem)
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat: Init(problem); break;
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+#endif
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPooling2d<OpType>::SetNextValue(
+    const miopen::pooling::ProblemDescription& problem)
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+    return false;
+#else
+    do
+    {
+        if constexpr(OpType == OperationType::Backward)
+        {
+            // tune out_pix_tile0 only for the backward solver
+            if(!NextTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
+                break;
+        }
+        if(!NextTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+            break;
+        if(!NextTwoPower<min_local_size0, max_local_size0>(local_size0))
+            break;
+        if(!NextTwoPower<min_local_size1, max_local_size1>(local_size1))
+            break;
+        return false;
+    } while(false);
+    return true;
+#endif
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPooling2d<OpType>::IsValidValue() const
+{
+    if constexpr(OpType == OperationType::Backward)
+    {
+        // check out_pix_tile0 only for the backward solver
+        if(!IsTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
+            return false;
+    }
+    if(!IsTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+        return false;
+    if(!IsTwoPower<min_local_size0, max_local_size0>(local_size0))
+        return false;
+    if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
+        return false;
+    if constexpr(OpType == OperationType::Forward)
+    {
+        // this constraint is enforced to avoid grp_tile1 becoming zero in GetSolutionImpl in the
+        // PoolingForward2d solver
+        if(local_size1 / out_pix_tile1 < 1)
+            return false;
+    }
+    return true;
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPooling2d<OpType>::IsValid(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+    return false;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat:
+        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+    return false;
+#endif
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPooling2d<OpType>::operator==(
+    const PerformanceConfigPooling2d<OpType>& other) const
+{
+    return out_pix_tile0 == other.out_pix_tile0 && out_pix_tile1 == other.out_pix_tile1 &&
+           local_size0 == other.local_size0 && local_size1 == other.local_size1;
+}
+
+// explicit template instantiations
+template struct PerformanceConfigPooling2d<OperationType::Forward>;
+template struct PerformanceConfigPooling2d<OperationType::Backward>;
+
+} // namespace pooling
+
+} // namespace solver
+
+} // namespace miopen

--- a/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
+++ b/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
@@ -46,10 +46,9 @@ void PerformanceConfigPooling2d<OpType>::HeuristicInit(
 
 template <OperationType OpType>
 bool PerformanceConfigPooling2d<OpType>::SetNextValue(
-    const miopen::pooling::ProblemDescription& problem)
+    const miopen::pooling::ProblemDescription&)
 {
 #if !MIOPEN_BACKEND_HIP
-    std::ignore = problem;
     return false;
 #else
     do


### PR DESCRIPTION
## Motivation

This PR introduces tuning support for **2D pooling solvers** in MIOpen. It is the first step in a larger effort to enable tuning across all pooling solver variants (2D, ND, naive, and transposed). The work in this PR targets the _tuning-support-for-pooling_ feature branch, which will be tested and merged once tuning support for all solver types is implemented.

## Technical Details

- Adds a new `PerformanceConfigPooling2d` class template parameterized by the pooling operation type (Forward/Backward) to manage the relevant tuning parameters and operations for 2d solvers.
- Makes the `PoolingForward2d` and `PoolingBackward2d` solvers tunable by adding the necessary methods.
- Integrates the new performance config with `PoolingForward2d` and `PoolingBackward2d` solvers.
- Implements some other general modifications to enable tuning in the pooling solvers.

## Test Plan

- Run tests for 2D pooling forward and backward solvers through the `MIOpenDriver` to confirm correctness.
- Validate the tuning infrastructure works correctly through the output from the `MIOpenDriver` with `MIOPEN_LOG_LEVEL=6` and `MIOPEN_FIND_ENFORCE=4`.
- Compare the performance results before and after implementing tuning to determine whether tuning provides any improvement.

## Test Result

- All tests pass with the updated 2D pooling solvers.
- The tuning process runs successfully without errors and generates valid parameters.
- The tunable solvers are observed to perform better than the untunable solvers with static parameters.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
