### PR TITLE
[release/7.10] Pin CI workflows to the latest TheRock commit

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: "release/therock-7.10" # 2025-11-24 pointing to release/therock-7.10 head commit
+          ref: "e238c0269a9e54b275ef34ffb43c6c52a0cddc83" # 2025-11-26 commit on release/therock-7.10 branch
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: "release/therock-7.10" # 2025-11-24 pointing to release/therock-7.10 head commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -53,10 +53,6 @@ jobs:
         run: |
           pip install -r TheRock/requirements.txt
 
-      - name: Install external python deps
-        run: |
-          pip install -r TheRock/requirements-external.txt
-
       # safe.directory must be set before Runner health status
       - name: Adjust git config
         run: |
@@ -93,6 +89,10 @@ jobs:
           # Remove patches here if they cannot be applied cleanly, and they have not been deleted from TheRock repo
           # rm ./TheRock/patches/amd-mainline/rocm-libraries/*.patch
           git -c user.name="therockbot" -c "user.email=therockbot@amd.com" am --whitespace=nowarn ./TheRock/patches/amd-mainline/rocm-libraries/*.patch
+
+      - name: Install external python deps
+        run: |
+          pip install -r TheRock/requirements-external.txt
 
       - name: Configure Projects
         env:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -53,6 +53,10 @@ jobs:
         run: |
           pip install -r TheRock/requirements.txt
 
+      - name: Install external python deps
+        run: |
+          pip install -r TheRock/requirements-external.txt
+
       # safe.directory must be set before Runner health status
       - name: Adjust git config
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: "release/therock-7.10" # 2025-11-24 pointing to release/therock-7.10 head commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: "release/therock-7.10" # 2025-11-24 pointing to release/therock-7.10 head commit
+          ref: "e238c0269a9e54b275ef34ffb43c6c52a0cddc83" # 2025-11-26 commit on release/therock-7.10 branch
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -66,6 +66,10 @@ jobs:
         run: |
           pip install -r TheRock/requirements.txt
 
+      - name: Install external python deps
+        run: |
+          pip install -r TheRock/requirements-external.txt
+
       - name: Patch rocm-libraries
         run: |
           # Remove patches here if they cannot be applied cleanly, and they have not been deleted from TheRock repo

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -66,10 +66,6 @@ jobs:
         run: |
           pip install -r TheRock/requirements.txt
 
-      - name: Install external python deps
-        run: |
-          pip install -r TheRock/requirements-external.txt
-
       - name: Patch rocm-libraries
         run: |
           # Remove patches here if they cannot be applied cleanly, and they have not been deleted from TheRock repo
@@ -108,6 +104,10 @@ jobs:
         run: |
           git config --global core.longpaths true
           python ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-libraries --no-include-ml-frameworks
+
+      - name: Install external python deps
+        run: |
+          pip install -r TheRock/requirements-external.txt
 
       - name: Configure Projects
         env:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - release/therock-*
   pull_request:
     types:
       - opened

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -3,7 +3,8 @@ name: TheRock CI
 on:
   push:
     branches:
-      - release/therock-7.10
+      - develop
+      - release/therock-*
   pull_request:
     types:
       - opened

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -3,7 +3,7 @@ name: TheRock CI
 on:
   push:
     branches:
-      - develop
+      - release/therock-7.10
   pull_request:
     types:
       - opened

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: e238c0269a9e54b275ef34ffb43c6c52a0cddc83 # 2025-11-26 commit on release/therock-7.10 branch
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: e238c0269a9e54b275ef34ffb43c6c52a0cddc83 # 2025-11-26 commit on release/therock-7.10 branch
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: d24cccc1820fa5469b88c0f14e36a14349d38cac # 2025-11-12 commit
+          ref: e238c0269a9e54b275ef34ffb43c6c52a0cddc83 # 2025-11-26 commit on release/therock-7.10 branch
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
Pins the commit hash to the latest `theRock/release/therock-7.10` and adds installation of missing python dependencies.

This should fix and replace PR #2893 