### PR TITLE
Fix v_dot4 op_sel modifiers (#2110)

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/MAC_I8X4.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/MAC_I8X4.py
@@ -51,7 +51,7 @@ class MAC_I8X4_Plain(MAC):
                     cStr         = "v[vgprValuC+{a}+{b}*{ThreadTile0}]".format_map(vars)
                     aStr         = "v[vgprValuA_X{m}_I{iui}+{a}]".format_map(vars)
                     bStr         = "v[vgprValuB_X{m}_I{iui}+{b}]".format_map(vars)
-                    module.addInst("v_dot4_i32_i8", cStr, aStr, bStr, cStr, "op_sel:[0,0]", "op_sel_hi:[1,1]", "valuC[%u]" % cidx)
+                    module.addInst("v_dot4_i32_i8", cStr, aStr, bStr, cStr, "valuC[%u]" % cidx)
                     module.add(priority(writer, 1, "Raise priority while processing macs"))
 
         module.add(priority(writer, 0, "Reset priority after macs"))

--- a/shared/tensile/Tensile/Code.py
+++ b/shared/tensile/Tensile/Code.py
@@ -632,7 +632,7 @@ class  MacInst (Inst):
             cStr = "v[%s+%u+%u*%u]" % ("vgprValuC", self.aIdx, self.bIdx, self.kernel["ThreadTile0"])
             aStr = "v[%s+%u]"       % ("vgprValuA_X%u_I%u"%(self.PLR,iui), self.aIdx)
             bStr = "v[%s+%u]"       % ("vgprValuB_X%u_I%u"%(self.PLR,iui), self.bIdx)
-            kStr += "v_dot4_i32_i8  %s, %s, %s, %s op_sel:[0,0] op_sel_hi:[1,1] //valuC[%u]%s" % (cStr, aStr, bStr, cStr, cidx, self.endLine)
+            kStr += "v_dot4_i32_i8  %s, %s, %s, %s //valuC[%u]%s" % (cStr, aStr, bStr, cStr, cidx, self.endLine)
       # single precision
       elif self.kernel["ProblemType"]["DataType"].isSingle():
         for iui in range(0, self.innerUnroll):

--- a/shared/tensile/Tensile/Components/MAC_I8X4.py
+++ b/shared/tensile/Tensile/Components/MAC_I8X4.py
@@ -49,7 +49,7 @@ class MAC_I8X4_Plain(MAC):
                     vars["cStr"] = "v[vgprValuC+{a}+{b}*{ThreadTile0}]".format_map(vars)
                     vars["aStr"] = "v[vgprValuA_X{m}_I{iui}+{a}]".format_map(vars)
                     vars["bStr"] = "v[vgprValuB_X{m}_I{iui}+{b}]".format_map(vars)
-                    kStr += "v_dot4_i32_i8 {cStr}, {aStr}, {bStr}, {cStr} op_sel:[0,0] op_sel_hi:[1,1] //valuC[{cidx}]{endLine}".format_map(vars)
+                    kStr += "v_dot4_i32_i8 {cStr}, {aStr}, {bStr}, {cStr} //valuC[{cidx}]{endLine}".format_map(vars)
                     kStr += priority(writer, 1, "Raise priority while processing macs")
 
         kStr += priority(writer, 0, "Reset priority after macs")


### PR DESCRIPTION
## Motivation

op_sel modifiers are not supported on v_dot4 and v_dot8 instructions.

## Technical Details

Tensile codegen using op_sel for v_dot4 is blocking an llvm patch to remove the modifiers. They are not supported, and not covered in the ISA documentation.

## Test Plan

Run regular CI test suite, which includes 4xi8 kernels with the affected instructions.

## Test Result

Related tests passed when ran locally.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
