### PR TITLE
[rocsparse][hipsparse] Update CHANGELOG and revert SpSM and SpSV deprecation

### DIFF
--- a/projects/hipsparse/CHANGELOG.md
+++ b/projects/hipsparse/CHANGELOG.md
@@ -3,11 +3,15 @@
 Documentation for hipSPARSE is available at
 [https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/](https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/).
 
-## (Unreleased) hipSPARSE 4.2.0
+## hipSPARSE 4.2.0 for ROCm 7.2.0
 
 ### Added
 
 * Added `--clients-only` option to the `install.sh` and `rmake.py` scripts to allow building only the clients while using an already installed version of hipSPARSE.
+
+### Optimized
+
+* Improved the user documentation.
 
 ### Resolved issues
 

--- a/projects/rocsparse/CHANGELOG.md
+++ b/projects/rocsparse/CHANGELOG.md
@@ -3,11 +3,26 @@
 Documentation for rocSPARSE is available at
 [https://rocm.docs.amd.com/projects/rocSPARSE/en/latest/](https://rocm.docs.amd.com/projects/rocSPARSE/en/latest/).
 
-## (Unreleased) rocSPARSE 4.2.0
+## rocSPARSE 4.2.0 for ROCm 7.2.0
 
 ### Added
 
-* Added `--clients-only` option to the `install.sh` and `rmake.py` scripts to allow building only the clients while using an already installed version of rocSPARSE.
+* Added sliced ELL format support to the `rocsparse_spmv` routine.
+* Added the `rocsparse_sptrsv` and `rocsparse_sptrsm` routines for triangular solve.
+* Added the `--clients-only` option to the `install.sh` and `rmake.py` scripts to only build the clients for a version of rocSPARSE that is already installed.
+* Added nnz split algorithm `rocsparse_spmv_alg_csr_nnzsplit` to `rocsparse_spmv`. This algorithm might be superior to the existing adaptive algorithm `rocsparse_spmv_alg_csr_adaptive` when running the computation a small number of times because it avoids paying the analysis cost of the adaptive algorithm.
+
+### Changed
+* Make rocBLAS a requirement when it's requested when building from source. Previously, rocBLAS was not used if it could not be found. To opt out of using rocblas when building from source, use the `--no-rocblas` option with the `install.sh` or `rmake.py` build scripts.
+
+### Optimized
+* Significantly improved the `rocsparse_sddmm` routine when using CSR format, especially as the number of columns in the dense `A` matrix (or rows in the dense `B` matrix) increase.
+* Improved the user documentation.
+
+### Resolved issues
+* Fix the `rmake.py` build script to properly handle `auto` and all options when selecting offload targets.
+* Fix building rocSPARSE with the install script on centOS 9.
+* Fix `std::fma` casting in host routines to properly deduce types. This could have previously caused compilation failures when building from source.
 
 ## rocSPARSE 4.1.0 for ROCm 7.1.0
 

--- a/projects/rocsparse/library/include/internal/generic/rocsparse_spsm.h
+++ b/projects/rocsparse/library/include/internal/generic/rocsparse_spsm.h
@@ -148,20 +148,18 @@ extern "C" {
 *  \par Example
 *  \snippet example_rocsparse_spsm.cpp doc example
 */
-__attribute__((deprecated("This function is deprecated and will be removed in a future release. "
-                          "Use rocsparse_sptrsm instead."))) ROCSPARSE_EXPORT rocsparse_status
-    rocsparse_spsm(rocsparse_handle            handle,
-                   rocsparse_operation         trans_A,
-                   rocsparse_operation         trans_B,
-                   const void*                 alpha,
-                   rocsparse_const_spmat_descr matA,
-                   rocsparse_const_dnmat_descr matB,
-                   const rocsparse_dnmat_descr matC,
-                   rocsparse_datatype          compute_type,
-                   rocsparse_spsm_alg          alg,
-                   rocsparse_spsm_stage        stage,
-                   size_t*                     buffer_size,
-                   void*                       temp_buffer);
+ROCSPARSE_EXPORT rocsparse_status rocsparse_spsm(rocsparse_handle            handle,
+                                                 rocsparse_operation         trans_A,
+                                                 rocsparse_operation         trans_B,
+                                                 const void*                 alpha,
+                                                 rocsparse_const_spmat_descr matA,
+                                                 rocsparse_const_dnmat_descr matB,
+                                                 const rocsparse_dnmat_descr matC,
+                                                 rocsparse_datatype          compute_type,
+                                                 rocsparse_spsm_alg          alg,
+                                                 rocsparse_spsm_stage        stage,
+                                                 size_t*                     buffer_size,
+                                                 void*                       temp_buffer);
 #ifdef __cplusplus
 }
 #endif

--- a/projects/rocsparse/library/include/internal/generic/rocsparse_spsv.h
+++ b/projects/rocsparse/library/include/internal/generic/rocsparse_spsv.h
@@ -127,19 +127,17 @@ extern "C" {
 *  \par Example
 *  \snippet example_rocsparse_spsv.cpp doc example
 */
-__attribute__((deprecated("This function is deprecated and will be removed in a future release. "
-                          "Use rocsparse_sptrsv instead."))) ROCSPARSE_EXPORT rocsparse_status
-    rocsparse_spsv(rocsparse_handle            handle,
-                   rocsparse_operation         trans,
-                   const void*                 alpha,
-                   rocsparse_const_spmat_descr mat,
-                   rocsparse_const_dnvec_descr x,
-                   const rocsparse_dnvec_descr y,
-                   rocsparse_datatype          compute_type,
-                   rocsparse_spsv_alg          alg,
-                   rocsparse_spsv_stage        stage,
-                   size_t*                     buffer_size,
-                   void*                       temp_buffer);
+ROCSPARSE_EXPORT rocsparse_status rocsparse_spsv(rocsparse_handle            handle,
+                                                 rocsparse_operation         trans,
+                                                 const void*                 alpha,
+                                                 rocsparse_const_spmat_descr mat,
+                                                 rocsparse_const_dnvec_descr x,
+                                                 const rocsparse_dnvec_descr y,
+                                                 rocsparse_datatype          compute_type,
+                                                 rocsparse_spsv_alg          alg,
+                                                 rocsparse_spsv_stage        stage,
+                                                 size_t*                     buffer_size,
+                                                 void*                       temp_buffer);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Motivation

Ensures that rocsparse and hipsparse CHANGELOG is up to date for 7.2 release and cherrypick in reverting of SpSM and SpSV deprecation

## Technical Details

SpSV and SpSM were accidently deprecated when they should not have been in develop branch. This PR updates the CHANGELOG and makes sure that the deprecation is reverted before it goes into a public release.
