### PR TITLE
[hipDNN] Fix hardcoded clang version for ASAN

### DIFF
--- a/projects/hipdnn/cmake/Sanitizers.cmake
+++ b/projects/hipdnn/cmake/Sanitizers.cmake
@@ -4,44 +4,34 @@
 # Enable Address Sanitizer and set linker flags for security
 message(STATUS "Building with Sanitizers: ${BUILD_ADDRESS_SANITIZER}")
 
-if (BUILD_ADDRESS_SANITIZER)
+if(BUILD_ADDRESS_SANITIZER)
 
-    # Address Sanitizer requires specific GPU targets which
-    # support XNACK.
-    set(GPU_TARGETS 
-        gfx908:xnack+    # MI100 (Arcturus)
-        gfx90a:xnack+    # MI200 series (MI210, MI250, MI250X)
-        gfx942:xnack+    # MI300X (GPU)
+    # Address Sanitizer requires specific GPU targets which support XNACK.
+    set(GPU_TARGETS
+        gfx908:xnack+ # MI100 (Arcturus)
+        gfx90a:xnack+ # MI200 series (MI210, MI250, MI250X)
+        gfx942:xnack+ # MI300X (GPU)
     )
 
-    link_directories(${ROCM_LLVM_LIB_DIR}/clang/20/lib/linux)
+    string(REGEX MATCH "^[0-9]+" CLANG_MAJOR_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+    link_directories(${ROCM_LLVM_LIB_DIR}/clang/${CLANG_MAJOR_VERSION}/lib/linux)
 
     # Define sanitizer flags as variables for reuse
-    set(SANITIZER_COMPILE_FLAGS 
-        -fsanitize=address
-        -fno-omit-frame-pointer
-    )
-    
-    set(SANITIZER_LINK_FLAGS 
-        -fsanitize=address
-        -fno-omit-frame-pointer
-        -shared-libasan
-    )
+    set(SANITIZER_COMPILE_FLAGS -fsanitize=address -fno-omit-frame-pointer)
+
+    set(SANITIZER_LINK_FLAGS -fsanitize=address -fno-omit-frame-pointer -shared-libasan)
 
     # Apply sanitizer flags globally (can be overridden per target)
     add_compile_options(${SANITIZER_COMPILE_FLAGS})
     add_link_options(${SANITIZER_LINK_FLAGS})
-    
+
     # Add compile definition for conditional compilation
     add_compile_definitions(ADDRESS_SANITIZER)
 
-    # Set environment variables for Address Sanitizer
-    # XNACK is required for Address Sanitizer on AMD GPUs
-    # ASAN_SYMBOLIZER_PATH is set to the LLVM symbolizer to make the output
-    # from leak detection more readable.
-    set(TEST_ENVIRONMENT 
-        "ASAN_SYMBOLIZER_PATH=${CMAKE_SYMBOLIZER}" 
-        "HSA_XNACK=1"
-        #"ASAN_OPTIONS=halt_on_error=1:abort_on_error=1"
+    # Set environment variables for Address Sanitizer XNACK is required for Address Sanitizer on AMD
+    # GPUs ASAN_SYMBOLIZER_PATH is set to the LLVM symbolizer to make the output from leak detection
+    # more readable.
+    set(TEST_ENVIRONMENT "ASAN_SYMBOLIZER_PATH=${CMAKE_SYMBOLIZER}" "HSA_XNACK=1"
+                         # "ASAN_OPTIONS=halt_on_error=1:abort_on_error=1"
     )
 endif()

--- a/projects/hipdnn/cmake/Sanitizers.cmake
+++ b/projects/hipdnn/cmake/Sanitizers.cmake
@@ -13,8 +13,12 @@ if(BUILD_ADDRESS_SANITIZER)
         gfx942:xnack+ # MI300X (GPU)
     )
 
-    string(REGEX MATCH "^[0-9]+" CLANG_MAJOR_VERSION ${CMAKE_CXX_COMPILER_VERSION})
-    link_directories(${ROCM_LLVM_LIB_DIR}/clang/${CLANG_MAJOR_VERSION}/lib/linux)
+    # Query the compiler for the resource directory to locate sanitizer libraries reliably
+    execute_process(
+        COMMAND ${CMAKE_CXX_COMPILER} -print-resource-dir OUTPUT_VARIABLE CLANG_RESOURCE_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    link_directories(${CLANG_RESOURCE_DIR}/lib/linux)
 
     # Define sanitizer flags as variables for reuse
     set(SANITIZER_COMPILE_FLAGS -fsanitize=address -fno-omit-frame-pointer)


### PR DESCRIPTION
## Motivation

ASAN build was assuming clang was version 20 which caused it to use the wrong directory path when linking for updated LLVM.
Changed to instead find the clang version from the compiler resource path. 

## Testing

Ran ASAN build & tests locally.
Verified it's now working with compiler resource path detection.