### PR TITLE
[hipblaslt] Validator for LocalRead RAW hazards

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -20,6 +20,8 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
+from itertools import chain
+from dataclasses import dataclass
 from rocisa.code import KernelBody, Label, Macro, Module, RegSet, SrdUpperValue, \
                         StructuredModule, TextBlock, ValueEndif, ValueIf, ValueElseIf, ValueSet, SignatureBase
 from rocisa.container import vgpr, sgpr, SMEMModifiers, replaceHolder, EXEC,\
@@ -36,9 +38,12 @@ from rocisa.instruction import BufferLoadB128, BufferLoadB32, BufferLoadB64, \
 from rocisa.instruction import SAddU32, SAddCU32, SCmpEQU32, SCSelectB32, SSubBU32
 from Tensile.Common import IsaVersion
 from Tensile.Utilities.Decorators.Shared import CallableGuard
+from Tensile.Common.Utilities import printWarning
+
+from abc import ABC, abstractmethod
 
 from copy import deepcopy
-from typing import Dict
+from typing import Callable, Dict
 
 class SyncSchedule:
     schedule : list[tuple[int, SWaitCnt | SBarrier]] = []
@@ -70,6 +75,235 @@ class SyncSchedule:
         return [item[0] for item in self.schedule]
     def get_code(self):
         return [item[1] for item in self.schedule]
+
+
+class ValidatorInstruction(ABC):
+    """
+    Abstract class with no method just for type hinting purposes.
+    """
+    @abstractmethod
+    def validate(self) -> str | None:
+        ...
+
+@dataclass
+class LocalRead(ValidatorInstruction):
+    name: str
+    issued_at: int
+    needed_by: int
+    num_vmfma: int
+    guaranteed_by: int | float = float('inf')
+
+    def validate(self) -> str | None:
+        # Needs to be guaranteed BEFORE the index at which it's needed since the 
+        # SWaitCnt is issued AFTER the vmfma.
+        if self.guaranteed_by < self.needed_by:
+            return None
+        
+        guaranteed_by = self.guaranteed_by
+        # Modulo for LRs that finish in next iteration.
+        needed_by = self.needed_by % self.num_vmfma
+        if guaranteed_by == float('inf'):
+            message = f"{self.name} at index {self.issued_at} is not valid. " + \
+                        "There are no guarantees on when it will be done."
+        else:
+            if isinstance(guaranteed_by, float):
+                # Special case to handle idx=-1 which is written as numVMFMA - 0.5
+                guaranteed_by = -1
+            else:
+                guaranteed_by %= self.num_vmfma
+            message = f"{self.name} at index {self.issued_at} is not valid. " + \
+                        f"Needed before index {needed_by}, but only guaranteed at index {guaranteed_by}."
+        return message
+     
+
+@dataclass
+class SWait(ValidatorInstruction):
+    issued_at: int
+    dscnt: int
+    vlcnt: int
+    vscnt: int
+    comment: str
+
+    def _is_valid(self) -> bool:
+        return self.dscnt >= -1 and self.vlcnt >= -1 and self.vscnt >= -1 and self.issued_at >= -1
+
+    def validate(self) -> str | None:
+        if self._is_valid():
+            return None
+        return f"SWait at index {self.issued_at} is invalid: dscnt={self.dscnt}, vlcnt={self.vlcnt}, vscnt={self.vscnt}, issued_at={self.issued_at}."
+
+def schedule_get(name: str, code_path: int, schedule_info: 'ScheduleInfo') -> list[list[int]]:
+    """
+    Helper function to get the schedule for a given instruction name and code path.
+    When multiple code paths are provided, return the schedule for the given code path.
+    If only one code path is implemented, return that schedule.
+
+    Args:
+        name: The name of the instruction to get the schedule for (e.g. "LRA0", "LRB0", "SYNC")
+        code_path: The code path to get the schedule for (0-indexed)
+        schedule_info: The schedule information (ScheduleInfo object)
+
+    Returns:
+        The schedule for the given instruction name and code path.
+    """
+    assert code_path >= 0, f"Code path {code_path} is not valid. Must be >= 0."
+    schedules = schedule_info.optSchedule[name]
+    return schedules[0] if len(schedules) == 1 else schedules[code_path]
+
+
+def lr_needed_by_mfma(is_lra: bool, lr_idx: int, offset: int, schedule_info: 'ScheduleInfo', kernel: 'Solution') -> int:
+    """
+    Helper fucntion to calculate the index of the MFMA at which the given LRA/LRB will be needed by.
+
+    Args:
+        is_lra: Whether the given LRA/LRB is an LRA (True) or LRB (False).
+        lr_idx: The index of the LRA/LRB in the list of LRAs/LRBs for the given code path.
+        offset: The offset from the halfway point of the main loop.
+        schedule_info: The schedule information (ScheduleInfo object)
+        kernel: The kernel (Solution object)
+
+    Returns:
+        The index of the MFMA at which the given LRA/LRB will be needed by.
+    """
+    assert len(schedule_info.mfmaReorder) == 0, "Not implemented for mfmaReorder"
+
+    n_tiles_a = kernel['MIWaveTileA']
+    n_tiles_b = kernel['MIWaveTileB']
+    # NOTE: This calculation will produce incorrect results if the user provided the wrong number of LRs.
+    n_lr_a = len(schedule_get("LRA0", 0, schedule_info))
+    n_lr_b = len(schedule_get("LRB0", 0, schedule_info))
+
+    # How many MFMA worth of data is loaded by each LRA/LRB
+    n_tiles_per_lra = n_tiles_a / n_lr_a
+    n_tiles_per_lrb = n_tiles_b / n_lr_b
+
+    # NOTE: This is based on the current bahaviour where we iterate through A faster than B.
+    def index_lra_needed_by_mfma(lra_idx: int, offset: int) -> int:
+        """
+        Calculate the index of the MFMA at which the given LRA will be needed by.
+        """
+        return int(lra_idx * n_tiles_per_lra) + offset
+    
+    def index_lrb_needed_by_mfma(lrb_idx: int, offset: int) -> int:
+        """
+        Calculate the index of the MFMA at which the given LRB will be needed by.
+        """
+        return n_tiles_a * int(lrb_idx * n_tiles_per_lrb) + offset
+    
+    if is_lra:
+        return index_lra_needed_by_mfma(lr_idx, offset)
+    else:
+        return index_lrb_needed_by_mfma(lr_idx, offset)
+
+
+def create_timeline(instruction_names_to_add: list[str], code_path: int, schedule_info: 'ScheduleInfo', kernel: 'Solution') -> list[list[ValidatorInstruction]]:
+    """
+    Create a timeline from the provided schedule_info which contains only the instructions inside `instruction_names_to_add`.
+    Organized as a list of lists indexed by vmfma_index + 1.
+    
+    The +1 is required in order to handle the special case of idx=-1, which is at timeline[0].
+    idx=-1 is special case that occurs BEFORE the first VMFMA but AFTER the last VMFMA.
+    """
+    # NOTE: numMfma + 1 to account for special idx=-1.
+    #       idx=-1 is special case that occurs BEFORE the first VMFMA but AFTER the last VMFMA.
+    #       Instructions at idx=-1 happen after all instructions at idx=numVMFMA-1 and BEFORE all instructions (including the VMFMA) at idx=0.
+    timeline = [[] for _ in range(schedule_info.numMfma+1)]
+
+    num_vmfma = schedule_info.numMfma
+    halfway_point = num_vmfma // 2
+    
+    # NOTE: Relative ordering of instructions must be preserved.
+    #       Order dictates the order in which instructions are scheduled if they are scheduled at the same vmfmaindex.
+    for name in schedule_info.optSchedule.keys():
+        if name not in instruction_names_to_add:
+            continue
+
+        if name == "SYNC":
+            for idx_sync, (idx_vmfma, sync) in enumerate(zip(schedule_get(name, code_path, schedule_info), schedule_info.syncCode)):
+                assert idx_vmfma >= -1, f"Code path {code_path}: SWaitCnt at index {idx_sync} is not valid. Must be >= -1."
+                if not isinstance(sync, SWaitCnt):
+                    continue 
+                
+                swait = SWait(issued_at=idx_vmfma, dscnt=sync.dscnt, vlcnt=sync.vlcnt, vscnt=sync.vscnt, comment=sync.comment)
+                timeline[idx_vmfma+1].append(swait)
+        elif name.startswith("LRA") or name.startswith("LRB"):
+            offset = halfway_point if "0" in name else num_vmfma
+            is_lra = name.startswith("LRA")
+            for idx_LR, idx_vmfma in enumerate(schedule_get(name, code_path, schedule_info)):
+                assert idx_vmfma >= -1, f"Code path {code_path}: LocalRead {name} at index {idx_LR} is not valid. Must be >= -1."
+
+                needed_by = lr_needed_by_mfma(is_lra, idx_LR, offset, schedule_info, kernel)
+                local_read = LocalRead(name=name, issued_at=idx_vmfma, needed_by=needed_by, num_vmfma=num_vmfma)
+                timeline[idx_vmfma+1].append(local_read)
+        else:
+            raise NotImplementedError(f"Instruction {name} not implemented")
+    
+    return timeline
+
+def apply_swaits(timeline: list[list[ValidatorInstruction]], num_vmfma: int) -> None:
+    """
+    Apply the effect of SWaitCnts to the timeline by updating the guaranteed_by field of LocalReads.
+    Timeline is modified in place.
+    """
+    num_instructions = len(timeline)
+    # Mapping between linear index and swait at that index
+    swaits: dict[int, SWait] = {i: swait for i, swait in enumerate(timeline) if isinstance(swait, SWait)}
+
+    for i_swait, swait in swaits.items():
+        num_left_in_flight = swait.dscnt
+        if num_left_in_flight == -1:
+            continue # -1 is special value to indicate doing nothing.
+        
+        for i_lr in chain(range(i_swait-1, -1, -1), range(num_instructions-1, i_swait, -1)):
+            local_read = timeline[i_lr]
+            if not isinstance(local_read, LocalRead):
+                continue  # Only LRs are supported at the moment.
+            if num_left_in_flight > 0:
+                num_left_in_flight -= 1
+                continue
+
+            new_guaranteed_by = swait.issued_at
+            if i_lr > i_swait:
+                # LRs which finish during the next iteration.
+                new_guaranteed_by += num_vmfma
+            if swait.issued_at == -1:
+                # Need a number between (numVMFMA-1) and numVMFMA, resort to floats.
+                new_guaranteed_by += 0.5
+            local_read.guaranteed_by = min(local_read.guaranteed_by, new_guaranteed_by)
+
+
+def verify_lrs_complete_before_vmfma(schedule_info: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
+    """
+    Ensure that the A and B data needed for VMFA at index=i is guaranteed to be in the registers before index=i.
+    """    
+    def verify(schedule_info: 'ScheduleInfo', code_path: int) -> tuple[bool, str]:
+        if len(schedule_info.mfmaReorder) != 0:
+            printWarning("Do not currently support mfmaReorder in CMS validation.")
+            return None
+        
+        relevant_names = ["LRA0", "LRB0", "LRA1", "LRB1", "SYNC"]
+        for name in schedule_info.optSchedule.keys():
+            if name.startswith("LRA") or name.startswith("LRB"):
+                if name not in relevant_names:
+                    printWarning(f"LocalRead {name} not implemented in CMS validation.")
+                    return None
+
+        timeline = create_timeline(relevant_names, code_path, schedule_info, context["kernel"])
+        timeline = [instruction for instructions in timeline for instruction in instructions]
+
+        apply_swaits(timeline, schedule_info.numMfma)
+
+        for instruction in timeline:
+            error_message = instruction.validate()
+            if error_message:
+                return error_message
+        return None
+    
+    for code_path in range(schedule_info.numCodePaths):
+        error_message = verify(schedule_info, code_path)
+        if error_message:
+            return False, f"Code path {code_path}: {error_message}"
+    return True, ""
 
 
 def verifyAscendingOrder(scheduleInfo, context: Dict = {}):
@@ -130,8 +364,9 @@ class ScheduleInfo:
         self.__skipValidation__ = False
 
         # The set of validation rules to run inside `isValid`.
-        self.rules: List[Callable[[ScheduleInfo, dict], [bool, str]]] = [
-            verifyAscendingOrder
+        self.rules: list[Callable[[ScheduleInfo, dict], [bool, str]]] = [
+            verifyAscendingOrder,
+            verify_lrs_complete_before_vmfma
         ]
 
     def disableValidation(self):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -850,6 +850,7 @@ def _get_schedule_192x256x64_16bit(kernel, useLDSTr, TLDS):
 
     numMfma = 96
     opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
+    opt1.disableValidation()  # TODO: Remove after schedule is fixed
     return True, opt1
 
 def _get_schedule_256x192x64_16bit(kernel, useLDSTr, TLDS):
@@ -1539,6 +1540,7 @@ def _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS):
 
     numMfma = 104
     opt1 = ScheduleInfo(1, numMfma, optSchedule, syncCode, nglshift, nllshift)
+    opt1.disableValidation()  # TODO: Fix and re-enable
     return True, opt1
 
 def _get_schedule_224x256x64_16bit(kernel, userLDSTr, TLDS):
@@ -1770,6 +1772,7 @@ def _get_schedule_320x192x64_16bit(kernel, useLDSTr, TLDS):
 
     numMfma = 120
     opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
+    opt1.disableValidation()  # TODO: Remove after landing fix
     return True, opt1
 
 def _get_schedule_240x256x64_16bit(kernel, useLDSTr, TLDS):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -515,7 +515,18 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
         return InstStreams
 
     status, message = opt1.isValid({'kernel' : kernel})
-    assert status is True, f"Custom mainloop schedule validation failed: {message}"
+    # create the case str (TN, NT, TT, or NN)
+    if isTN(kernel):
+        case_str = "TN"
+    elif isNT(kernel):
+        case_str = "NT"
+    elif isTT(kernel):
+        case_str = "TT"
+    elif isNN(kernel):
+        case_str = "NN"
+    else:
+        case_str = "Unknown"
+    assert status is True, f"Custom mainloop schedule validation failed for kernel {kernel['MacroTile0']}x{kernel['MacroTile1']}x{kernel['DepthU']} {case_str}: {message}"
 
     InstStreams = convOptToStream(opt1)
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -98,6 +98,32 @@ class TestCustomSchedule:
             assert 'PackB0' in schedule_info.optSchedule
             assert kernel["UsePLRPack"]
     
+    @pytest.mark.parametrize("force_unroll_sub_iter", [True, False])
+    def test_schedule_256x256x128_8bit_TN(self, force_unroll_sub_iter: bool):
+        """Tests the 256x256x128 8-bit TNschedule."""
+
+        kernel = create_base_kernel()
+        dtype_8bit = _mock_dtype(is_8bit=True, num_bytes=1)
+        kernel["ProblemType"].update({
+            "DataType": dtype_8bit, "DataTypeA": dtype_8bit, "DataTypeB": dtype_8bit,
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 256, "DepthU": 128,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 16, "GlobalReadVectorWidthB": 16, "LocalReadVectorWidth": 16,
+            "MatrixInstruction": [16,16,128,1], "MIWaveGroup": [2,2], "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 8, "ForceUnrollSubIter": force_unroll_sub_iter,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 1
+        assert schedule_info.numMfma == 64
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+    
     def test_schedule_256x96x64_16bit_TN(self):
         """Tests the 256x96x64 16-bit TN schedule."""
         kernel = create_base_kernel()

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_VerifyLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_VerifyLRsCompleteBeforeVMFMA.py
@@ -1,0 +1,369 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+################################################################################
+import unittest
+from rocisa.instruction import SWaitCnt
+
+from Tensile.Components.CustomSchedule import verify_lrs_complete_before_vmfma
+from test_CustomSchedule import create_base_kernel, ScheduleInfo
+
+class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
+    def setUp(self):
+        self.kernel = create_base_kernel()
+        self.num_vmfma = 2 * self.kernel["MIWaveTileA"] * self.kernel["MIWaveTileB"]
+
+    def test_simple_LR0(self):
+        """
+        Verify the simple case where both LRA0 and LRB0 are issued and finished before the halfway point of the main loop.
+        """
+        assert self.num_vmfma == 8
+        
+        optSchedule = {
+            "SYNC": [[3]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[0, 0]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        optSchedule["LRA0"] = [[1, 6]]
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (LRA0 issued after halfway point), but passed."
+        assert message == "Code path 0: LRA0 at index 6 is not valid. Needed before index 5, but only guaranteed at index 3."
+
+        optSchedule["LRA0"] = [[1, 2]]
+        optSchedule["LRB0"] = [[3, 6]]
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (LRB0 issued after halfway point), but passed."
+        assert message == "Code path 0: LRB0 at index 3 is not valid. Needed before index 4, but only guaranteed at index 3."
+
+    def test_simple_LR0_w_LR1(self):
+        """
+        Handle case where we start reading LRA1 before halfway point.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[3, 7]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[0, 0]],
+            "LRA1": [[2]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation 1/2 but did not. {message}"
+
+        # Changing barrier from 0 to 1 for LRA1 should still pass
+        syncCode[0].dscnt = 1
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation 2/2 but did not. {message}"
+
+    def test_complex_LR0(self):
+        """
+        2nd LRB0 is not needed until iteration 6 & 7, can have SWaitCnt for it after the halfway point.
+        """
+        assert self.num_vmfma == 8
+        
+        optSchedule = {
+            "SYNC": [[3, 5]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[0, 2]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment=""),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_simple_LR1(self):
+        """
+        Case where LR1 is finished before the end of the current iteration.
+        """
+        assert self.num_vmfma == 8
+        
+        optSchedule = {
+            "SYNC": [[1, 7]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[0, 0]],
+            "LRA1": [[4, 4]],
+            "LRB1": [[4, 4]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_pre_loop_SWaitCnt(self):
+        """
+        Case where LR1 is finished before start of next iteration.
+        """
+        assert self.num_vmfma == 8
+        
+        optSchedule = {
+            "SYNC": [[-1, 3]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[0, 0]],
+            "LRA1": [[5, 5]],
+            "LRB1": [[6, 6]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_pre_loop_LR(self):
+        """
+        Case where an LR is issued before the start of the loop (idx=-1).
+        """
+        assert self.num_vmfma == 8
+        
+        optSchedule = {
+            "SYNC": [[3]],
+            "LRA0": [[-1, -1]],
+            "LRB0": [[-1, -1]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="")
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_simple_LR1_never_guaranteed(self):
+        """
+        Case where LR1 is finished before the end of loop.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[1]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[0, 0]],
+            "LRA1": [[4, 4]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (LRA1 never guaranteed), but passed. {message}"
+        assert message == "Code path 0: LRA1 at index 4 is not valid. Needed before index 0, but only guaranteed at index 1."
+
+    def test_complex_LR1(self):
+        """
+        Case where LR1 finishes during the beginning of next iteration.
+        """
+        assert self.num_vmfma == 8
+        
+        optSchedule = {
+            "SYNC": [[1, 3, 7]],
+            "LRA0": [[2, 2]],
+            "LRB0": [[2, 2]],
+            "LRA1": [[4, 4]],
+            "LRB1": [[4, 4]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="2/2 LRB1"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="All of LRA0 and LRB0"),
+            SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="2/2 LRA1 and 1/2 LRB1"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        # Failing case: LRA1 finishes too late
+        optSchedule["LRA1"] = [[4, 5]]
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (LRA1 finishes too late), but passed. {message}"
+        assert message == "Code path 0: LRA1 at index 5 is not valid. Needed before index 1, but only guaranteed at index 1."
+
+    def test_more_LRs(self):
+        """
+        Case where each LR reads less than 1 WaveTile worth of data.
+        Even though there are only 2 tiles of A and 2 of B there are 4 LRAs and 4 LRBs, each loading 1/2 a tile of A and B respectively.
+        """
+        assert self.num_vmfma == 8
+        
+        optSchedule = {
+            "SYNC": [[0, 1, 3, 4, 5, 7]],
+            "LRA0": [[0, 0, 3, 3]],
+            "LRB0": [[1, 1, 2, 4]],
+            "LRA1": [[5, 5, 7, 7]],
+            "LRB1": [[6, 6, 7, 7]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="4/4 LRA1 and 2/4 LRB1"),
+            SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="4/4 LRB1"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="2/4 LRA0 and 3/4 LRB0"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="4/4 LRA0 and 3/4 LRB0"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="4/4 LRB0"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="2/4 LRA1 and 2/4 LRB1"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_more_LRs_failure(self):
+        """
+        Case where each LR reads less than 1 WaveTile worth of data, but barriers set up wrong.
+        Even though there are only 2 tiles of A and 2 of B there are 4 LRAs and 4 LRBs, each loading 1/2 a tile of A and B respectively.
+        """
+        assert self.num_vmfma == 8
+        
+        optSchedule = {
+            "SYNC": [[3, 4]],
+            "LRA0": [[1, 1, 1, 1]],
+            "LRB0": [[0, 0, 0, 0]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=4, vlcnt=-1, vscnt=-1, comment="Incorrectly wait for only LRB0"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for all loads"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        
+        # Failure case 1: Don't wait for any LRA0
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (incorrectly wait for only LRB0), but passed. {message}"
+        assert message == "Code path 0: LRA0 at index 1 is not valid. Needed before index 4, but only guaranteed at index 4."
+
+        # Failure case 2: Wait for only 1/4 LRA0 (need at least 2/4 LRA0) to do VMFMA 4.
+        syncCode[0].dscnt = 3
+        syncCode[0].comment = "Wait for LRB0 and 1/4 LRA0"
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (incorrectly wait for only 1/4 LRA0), but passed. {message}"
+        assert message == "Code path 0: LRA0 at index 1 is not valid. Needed before index 4, but only guaranteed at index 4."
+
+        # Passing case: Correctly SWaitCnt for 2/4 LRA0 (i.e. 1/2 As) in time for VMFMA 4.
+        syncCode[0].dscnt = 2
+        syncCode[0].comment = "Wait for LRB0 and 2/4 LRA0"
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        # Failing case: Disable SWaitCnt at 4 should leave last A unguaranteed.
+        syncCode[1].dscnt = -1
+        syncCode[1].comment = "Do nothing"
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (SwaitCnt at 4 does nothing, last 2 LRA0s never guaranteed to finish), but passed. {message}"
+        assert message == "Code path 0: LRA0 at index 1 is not valid. There are no guarantees on when it will be done."
+    
+    def test_less_LRs(self):
+        """
+        Case where each LR reads more than 1 WaveTile worth of data.
+        Even though there are 4 tiles of A and 4 of B there are only 2 LRAs and 2 LRBs, each loading 2 tiles of A and B respectively.
+        """
+        self.kernel = create_base_kernel()
+        self.kernel["MIWaveTileA"] = 4
+        self.kernel["MIWaveTileB"] = 4
+        self.num_vmfma = 2 * self.kernel["MIWaveTileA"] * self.kernel["MIWaveTileB"]
+        assert self.num_vmfma == 32
+        
+        optSchedule = {
+            "SYNC": [[7, 15, 31]],
+            "LRA0": [[12, 13]],
+            "LRB0": [[13, 14]],
+            "LRA1": [[16, 17]],
+            "LRB1": [[18, 19]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="2/2 LRB1"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LRA0 and LRB0"),
+            SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="LRA1 and 1/2 LRB1"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        # Failure case
+        optSchedule["SYNC"][0][0] = 8
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (LRB0 not finished before being needed), but passed. {message}"
+        assert message == "Code path 0: LRB1 at index 19 is not valid. Needed before index 8, but only guaranteed at index 8."
+
+    def test_handling_instruction_order(self):
+        """
+        The order in which instructions are added to optSchedule dictate the order in which instructions are added at each index.
+        Ensure that the code correctly handles this ordering, specifically the relative order of LRs and the relative order of SWaitCnts.
+        """
+        assert self.num_vmfma == 8
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LR0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LR1s"),
+        ]
+
+        # 1. SwaitCnt before all LRs
+        optSchedule = {
+            "SYNC": [[3, 7]],
+            "LRA0": [[3]],
+            "LRB0": [[3]],
+            "LRA1": [[7]],
+            "LRB1": [[7]],
+        }
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (LRA0 not finished before being needed), but passed. {message}"
+        assert message == "Code path 0: LRA0 at index 3 is not valid. Needed before index 4, but only guaranteed at index 7."
+
+        # 2. SwaitCnt after LR0s but before LR1s
+        # LR0s will now pass, but LR1s will fail
+        optSchedule = {
+            "LRA0": [[3]],
+            "LRB0": [[3]],
+            "SYNC": [[3, 7]],
+            "LRA1": [[7]],
+            "LRB1": [[7]],
+        }
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (LRA1 not finished before being needed), but passed. {message}"
+        assert message == "Code path 0: LRA1 at index 7 is not valid. Needed before index 0, but only guaranteed at index 3."
+
+        # 3. SwaitCnt after all LRs
+        optSchedule = {
+            "LRA0": [[3]],
+            "LRB0": [[3]],
+            "LRA1": [[7]],
+            "LRB1": [[7]],
+            "SYNC": [[3, 7]],
+        }
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_lrs_complete_before_vmfma(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"


### PR DESCRIPTION
## Motivation

Ensuring that local reads are finished (using an SWaitCnt) is tricky and can easily lead to overlooked edge cases, especially when using more than one codepath.

## Technical Details

Add another pass to the validator to verify that all issued LRs have an SWaitCnt to guaranteed they are finished before the index at which they are used.
1. Places each LR and SWait into a a timeline at the vmfma index at which its issued. Order for multiple instructions at the same index is dictate by the order of keys in optSchedule (same behaviour as in kernel generation).
2. For the each LR, calculate the FIRST vmfma index at which it's needed.
3. Linearize the schedule.
4. Iterate over all Swaits.
5. From the index at which it's issued, traverse **backwards** through the timeline from that SWaitCnt to the start of the loop and then backwards from the end of the loop to the SWaitCnt. While doing so, mark all encountered LRs (ignoring the first `dscnt` LRs encountered) as being guaranteed to finish by this SWaitCnt at the latest.
6. Iterate through all LRs and ensure that the vmfma they are guaranteed to be finished by is less than the index at which they are required.

Handles
- LR0 
- LR1
- Local reads that are wider or narrower than needed per each vmfma. I.e. in several transpose cases we may have 8 MIWaveTiles in A, but require 16 ds_reads (or the opposite case where we need only 4 ds_reads).

Does not handle
- LR2 or LR3

## Test Plan

1. Added several tests on toy schedules to verify functionality.
2. Running existing pytests.
3. Run existing CMS tests which will exercise the validator on all currently implemented custom schedules.

## Test Result

1. Done, passing.
2. Done, several examples have RAW issues, the following were fixed before landing.
   1. #3002
   2. #3003
   3. #3005
   7. #3016
   8. #3017
   9. #3021
3. Pass, or have been disabled for known issues that will be filed.

The following are being fixed forward:
- #3091
- #3092
- #3093

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
