### PR TITLE
[hipDNN] [ALMIOPEN-509] Skip slow running tests on Windows to workaround inconsistent machine timeouts

### DIFF
--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackwardActivation.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackwardActivation.cpp
@@ -15,6 +15,9 @@
 #include "../tests/common/BatchnormCommon.hpp"
 #include "IntegrationGraphVerificationHarness.hpp"
 
+// Skipping slow running tests on Windows to prevent inconsistent timeout issues
+#define WORKAROUND_ALMIOPEN_509 1
+
 using namespace hipdnn_frontend;
 using namespace hipdnn_sdk::utilities;
 using namespace hipdnn_sdk::test_utilities;
@@ -66,6 +69,10 @@ protected:
 
     void runGraphTest([[maybe_unused]] DataType tolerance, const TensorLayout& layout) override
     {
+#if WORKAROUND_ALMIOPEN_509
+        SKIP_IF_WINDOWS();
+#endif
+
         namespace fe = hipdnn_frontend;
 
         const auto& [bnTestCase, activTestCase] = this->GetParam();


### PR DESCRIPTION
## Motivation

The Windows tests are seeming to randomly fail due to timeouts and it’s inconsistent.

Failing 10 minute timeout:

[[hipDNN] Add clang tidy github action · ROCm/rocm-libraries@64967d3](https://github.com/ROCm/rocm-libraries/actions/runs/19770723884/job/56658605466?pr=2858)

Passing in 5 minutes:

[[hipDNN] Add clang tidy github action · ROCm/rocm-libraries@64967d3](https://github.com/ROCm/rocm-libraries/actions/runs/19770723884/job/56665511846?pr=2858)

Same code re-ran in both attempts. 
The inconsistencies seem to be machine related, but a significant amount of the test time is spent in this specific suite.
Disabling these tests on Windows for now while we sort out other mitigation strategies.

Likely will follow-up next week with a combination of:
- Reducing the runtime of these tests to generally improve overall runtime
- Increasing the timeout to allow for more room for machine variance
- Investigation into why we are seeing this variance

## Technical Details

Temporarily disabling these slower running batchnorm tests on Windows as a temporary workaround.
