### PR TITLE
[hipblaslt] Fix 256x256x64 TN CMS

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -754,7 +754,7 @@ def _get_schedule_256x256x64_16bit(kernel, useLDSTr, TLDS):
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
     if isTN(kernel) and TLDS == 1:
         optSchedule = {
-            'SYNC'   : [[19,20, 50,51, 67,68, 104, 105]],
+            'SYNC'   : [[19,20, 50,51, 67,68, 104, 105, 127]],
             'GRIncA' : [[0,1,2,3,4,5,6,7,8]],
             'GRIncB' : [[9,10,11,12,13,14,15,16,17]],
             'LRA0'   : [[0,2,4,6,8,10,12,14],
@@ -781,8 +781,9 @@ def _get_schedule_256x256x64_16bit(kernel, useLDSTr, TLDS):
                     SBarrier(comment=""),
                     SWaitCnt(dscnt=-1, vlcnt=(2 + 8 + 8), vscnt=-1, comment="Wait for previous GRA to completely"),
                     SBarrier(comment=""),
-                    SWaitCnt(dscnt=-1, vlcnt=15, vscnt=-1, comment="Wait for previous GRA to completely"),
-                    SBarrier(comment="")]
+                    SWaitCnt(dscnt=-1, vlcnt=15, vscnt=-1, comment="Wait for previous GRB to completely"),
+                    SBarrier(comment=""),
+                    SWaitCnt(dscnt=5, vlcnt=-1, vscnt=-1, comment="Wait for LRA1 and 3/8 LRB1 to complete")]
         nglshift = nllshift = 16
     elif isNT(kernel) and not useLDSTr and TLDS == 0:
         kernel["UsePLRPack"] = True


### PR DESCRIPTION
## Motivation

LRA1s and LRB1s missing an SWaitCnt to ensure they're loaded (even partially) before the start of next iteration.

## Technical Details

Add SWaitCnt at 127 to ensure all LRAs and enough LRBs are loaded to make it to the SWaitCnt at 19.

## Test Plan

Existing tests.

## Test Result

Passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
