### PR TITLE
[hipDNN] [ALMIOPEN-509] Remove workaround and reduce test sizes

### DIFF
--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackwardActivation.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/IntegrationGpuBatchnormBackwardActivation.cpp
@@ -15,9 +15,6 @@
 #include "../tests/common/BatchnormCommon.hpp"
 #include "IntegrationGraphVerificationHarness.hpp"
 
-// Skipping slow running tests on Windows to prevent inconsistent timeout issues
-#define WORKAROUND_ALMIOPEN_509 1
-
 using namespace hipdnn_frontend;
 using namespace hipdnn_sdk::utilities;
 using namespace hipdnn_sdk::test_utilities;
@@ -69,10 +66,6 @@ protected:
 
     void runGraphTest([[maybe_unused]] DataType tolerance, const TensorLayout& layout) override
     {
-#if WORKAROUND_ALMIOPEN_509
-        SKIP_IF_WINDOWS();
-#endif
-
         namespace fe = hipdnn_frontend;
 
         const auto& [bnTestCase, activTestCase] = this->GetParam();

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/BatchnormCommon.hpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/common/BatchnormCommon.hpp
@@ -71,8 +71,8 @@ inline std::vector<BatchnormTestCase> getBnFwdInferenceFullTestCases()
     unsigned seed = hipdnn_sdk::test_utilities::getGlobalTestSeed();
 
     return {
-        {{64, 64, 112, 112}, seed},
-        {{64, 512, 14, 14}, seed},
+        {{1, 16, 112, 112}, seed},
+        {{5, 256, 14, 14}, seed},
     };
 }
 
@@ -105,8 +105,8 @@ inline std::vector<BatchnormTestCase> getBnBwdFullTestCases()
     unsigned seed = hipdnn_sdk::test_utilities::getGlobalTestSeed();
 
     return {
-        {{64, 64, 112, 112}, seed},
-        {{64, 512, 14, 14}, seed},
+        {{1, 16, 112, 112}, seed},
+        {{5, 256, 14, 14}, seed},
     };
 }
 


### PR DESCRIPTION
## Motivation

We were seeing Windows randomly timing out due to large runtime variance (5 - 10+ minute runs).
A workaround to disable the slowest running tests was put in last week.
After reviewing the tests, this set was also taking a majority of the runtime for Linux as well.

This change reduces the large test sizes to improve overall runtime, and ensure they aren't taking > 1/2 of all test time for MIOpen plugin tests.