### PR TITLE
[rocsparse] Add more information about rocsparse testing to documentation

### DIFF
--- a/projects/rocsparse/docs/install/Linux_Install_Guide.rst
+++ b/projects/rocsparse/docs/install/Linux_Install_Guide.rst
@@ -242,7 +242,7 @@ For more comprehensive testing, you can run the entire unit test suite using the
       # Execute rocSPARSE example
       ./rocsparse-test
 
-or for more focused testing, you can run a specific test by running the following command:
+For more focused testing, you can run a specific test by running the following command:
 
 .. code-block:: shell
 

--- a/projects/rocsparse/docs/install/Linux_Install_Guide.rst
+++ b/projects/rocsparse/docs/install/Linux_Install_Guide.rst
@@ -231,3 +231,29 @@ after successfully compiling the library with the clients.
 
       # Execute rocSPARSE example
       ./example_csrmv 1000
+
+For more comprehensive testing, you can run the entire unit test suite using the command:
+
+.. code-block:: shell
+
+      # Navigate to clients binary directory
+      cd build/release/clients/staging
+
+      # Execute rocSPARSE example
+      ./rocsparse-test
+
+or for more focused testing, you can run a specific test by running the following command:
+
+.. code-block:: shell
+
+      # Navigate to clients binary directory
+      cd build/release/clients/staging
+
+      # Execute rocSPARSE example
+      ./rocsparse-test --gtest_filter=TestName
+
+.. warning::
+
+   The unit test suite is a comprehensive test of the rocSPARSE library and will take multiple hours to complete. Consider running 
+   more focused tests for quicker feedback.
+

--- a/projects/rocsparse/docs/install/Linux_Install_Guide.rst
+++ b/projects/rocsparse/docs/install/Linux_Install_Guide.rst
@@ -254,6 +254,6 @@ For more focused testing, you can run a specific test by running the following c
 
 .. warning::
 
-   The unit test suite is a comprehensive test of the rocSPARSE library and will take multiple hours to complete. Consider running 
+   The unit test suite is a comprehensive test of the rocSPARSE library and takes multiple hours to finish. Consider running 
    more focused tests for quicker feedback.
 


### PR DESCRIPTION
## Motivation

Adds more information about testing in rocsparse, specifically regarding how to run the entire rocsparse test suite and how to use googletest filters for more specific testing. Also adds warning that running the entire test suite will take multiple hours.
