### PR TITLE
[hipblaslt] Fix for 256x96x64 TN CMS

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -428,11 +428,13 @@ def _get_schedule_256x96x64_16bit(kernel, useLDSTr, TLDS):
 
         nglshift = nllshift = 11
         syncTable = [
-                    -1, SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment=""),
-                    7, SWaitCnt(dscnt=8, vlcnt=-1, vscnt=-1, comment=""),
+                    -1, SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="Finish all LRA1 and 1/3 LRB1"),
+                    7, SWaitCnt(dscnt=6, vlcnt=-1, vscnt=-1, comment="Finish 2/3 LRB1"),
 
-                    15, SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="All LRA0 done"),
+                    15, SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="All LRB1 and LRA0 done"),
                     15, SBarrier(comment=""),
+
+                    23, SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="1/3 LRB0 done"),
 
                     29, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="All LRB0 done"),
                     29, SBarrier(comment=""),

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -429,7 +429,7 @@ def _get_schedule_256x96x64_16bit(kernel, useLDSTr, TLDS):
         nglshift = nllshift = 11
         syncTable = [
                     -1, SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="Finish all LRA1 and 1/3 LRB1"),
-                    7, SWaitCnt(dscnt=6, vlcnt=-1, vscnt=-1, comment="Finish 2/3 LRB1"),
+                    7, SWaitCnt(dscnt=7, vlcnt=-1, vscnt=-1, comment="Finish 2/3 LRB1"),
 
                     15, SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="All LRB1 and LRA0 done"),
                     15, SBarrier(comment=""),


### PR DESCRIPTION
## Motivation

An SwaitCnt is missing at 23 to ensure that at least the first few LRB0s are loaded before they are needed.

## Technical Details

1. Fix comments.
2. Add SWaitCnt at 23 to ensure 1/3 of LRB0 is done before before accessing it.
3. Change barrier at 7 from dscnt=8 to dscnt=7 to ensure 2nd LRB1 is loaded.

## Test Plan

Run existing tests

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
