### PR TITLE
[hipDNN] [ALMIOPEN-322] Fix pre-commit detection for git worktrees.

### DIFF
--- a/projects/hipdnn/cmake/CheckPreCommit.cmake
+++ b/projects/hipdnn/cmake/CheckPreCommit.cmake
@@ -16,7 +16,7 @@ if(EXISTS "${GIT_ROOT_DIR}/.git")
         file(READ "${GIT_DIR}" GIT_DIR_CONTENT)
 
         # Capture the gitdir value
-        string(REGEX MATCH "gitdir: ([^\n\r]+)" _ "${GIT_DIR_CONTENT}")
+        string(REGEX MATCH "gitdir: ([^\n\r]+/\.git)" _ "${GIT_DIR_CONTENT}")
         if(CMAKE_MATCH_1)
             set(GIT_DIR "${CMAKE_MATCH_1}")
             if(NOT IS_ABSOLUTE "${GIT_DIR}")
@@ -29,9 +29,12 @@ if(EXISTS "${GIT_ROOT_DIR}/.git")
 
     if(PRE_COMMIT_EXECUTABLE)
         if(NOT EXISTS "${GIT_DIR}/hooks/pre-commit")
-            message(WARNING "\n" "Pre-commit hooks are NOT installed\n" "Please run:\n"
-                            "  cd ${GIT_ROOT_DIR}\n" "  pre-commit install\n"
+            message(WARNING "\n"
+                            "Pre-commit hooks are NOT installed at ${GIT_DIR}/hooks/pre-commit\n"
+                            "Please run:\n" "  cd ${GIT_ROOT_DIR}\n" "  pre-commit install\n"
             )
+        else()
+            message(STATUS "Found git pre-commit hook installed at ${GIT_DIR}/hooks/pre-commit")
         endif()
     else()
         message(WARNING "\n" "pre-commit package is NOT installed\n" "Please run:"


### PR DESCRIPTION
## Motivation

The CMake check was failing to detect the pre-commit hook installed in the repository.

## Technical Details

The algorithm to search for the hook wasn't accounting for the extra content in the git repository path in the worktree. E.g. `gitdir: /workspace/rocmdev/repo/rocm-libraries/.git/worktrees/worktree1`.

## Test Plan

Run cmake build in both the worktree and the repositry and observe:
* the proper detection of the pre-commit hook.
* the proper detection of a missing pre-commit hook.

## Test Result

Repo:
```
CMake Warning at cmake/CheckPreCommit.cmake:32 (message):
  

  Pre-commit hooks are NOT installed at
  /workspace/rocmdev/repo/rocm-libraries/.git/hooks/pre-commit

  Please run:

    cd /workspace/rocmdev/repo/rocm-libraries
    pre-commit install
```

```
-- Found git pre-commit hook installed at /workspace/rocmdev/repo/rocm-libraries/.git/hooks/pre-commit
```

Worktree:
```
CMake Warning at cmake/CheckPreCommit.cmake:32 (message):
  

  Pre-commit hooks are NOT installed at
  /workspace/rocmdev/repo/rocm-libraries/.git/hooks/pre-commit

  Please run:

    cd /workspace/rocmdev/work/worktree1
    pre-commit install
```
```
-- Found git pre-commit hook installed at /workspace/rocmdev/repo/rocm-libraries/.git/hooks/pre-commit
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
