### PR TITLE
Update rocm_ci_caller.yml to trigger legacy rocm-ci psdb for rel-7.2

### DIFF
--- a/.azuredevops/rocm_ci_caller.yml
+++ b/.azuredevops/rocm_ci_caller.yml
@@ -3,7 +3,7 @@ pr:
   branches:
     include:
       - develop
-      - release-staging/rocm-rel-*
+      - release/rocm-rel-7.2
   paths:
     include:
       - projects/*


### PR DESCRIPTION
## Motivation
CQE staging has been stopped, which used to be the gate before rocm-libraries PR used to get merged. Enabling rocm-ci Legacy PSDB for 7.2 to make sure the builds will be kosher. This is an interim solution meanwhile the effort moves to theROCK CI