### PR TITLE
Improve error handling in QuickTune

### DIFF
--- a/projects/hipblaslt/utilities/QuickTune/gemm_tuning.py
+++ b/projects/hipblaslt/utilities/QuickTune/gemm_tuning.py
@@ -88,7 +88,19 @@ def main():
     if args.stablize_gpu:
         gpu_reset(args.gpu_id)
 
-    export_csv(unique_log_name, tuning_info, args)
+    success_count, total_count = export_csv(unique_log_name, tuning_info, args)
+
+    # Print summary report
+    failed_count = total_count - success_count
+    print("\n" + "="*60)
+    print("GEMM TUNING SUMMARY")
+    print("="*60)
+    print(f"Total GEMMs processed: {total_count}")
+    print(f"  - Successful: {success_count}")
+    print(f"  - Failed: {failed_count}")
+    print("="*60)
+    print(f"Results saved to: {args.output_path}/tuning_result.csv")
+    print()
 
 
 if __name__ == "__main__":

--- a/projects/hipblaslt/utilities/QuickTune/tuning_analysis.py
+++ b/projects/hipblaslt/utilities/QuickTune/tuning_analysis.py
@@ -60,6 +60,11 @@ def count_mnksol(input_file, tuning_csv, output_csv):
         if tuning_info:
             baseline_latency = float(tuning_info["baseline_latency(us)"])
             tuned_latency = float(tuning_info["tuned_latency(us)"])
+            # Treat failed latencies as 0
+            if baseline_latency < 0:
+                baseline_latency = 0.0
+            if tuned_latency < 0:
+                tuned_latency = 0.0
         else:
             baseline_latency = 0.0
             tuned_latency = 0.0

--- a/projects/hipblaslt/utilities/QuickTune/tuning_analysis.py
+++ b/projects/hipblaslt/utilities/QuickTune/tuning_analysis.py
@@ -60,14 +60,14 @@ def count_mnksol(input_file, tuning_csv, output_csv):
         if tuning_info:
             baseline_latency = float(tuning_info["baseline_latency(us)"])
             tuned_latency = float(tuning_info["tuned_latency(us)"])
-            # Treat failed latencies as 0
-            if baseline_latency < 0:
-                baseline_latency = 0.0
-            if tuned_latency < 0:
-                tuned_latency = 0.0
+            # Skip failed benchmarks - don't count in aggregation
+            if baseline_latency < 0 or tuned_latency < 0:
+                per_kernel_times[combo] = (0.0, 0.0)
+                continue
         else:
-            baseline_latency = 0.0
-            tuned_latency = 0.0
+            # Skip missing data - don't count in aggregation
+            per_kernel_times[combo] = (0.0, 0.0)
+            continue
         total_baseline = baseline_latency * cnt
         total_tuned = tuned_latency * cnt
         per_kernel_times[combo] = (total_baseline, total_tuned)

--- a/projects/hipblaslt/utilities/QuickTune/utils.py
+++ b/projects/hipblaslt/utilities/QuickTune/utils.py
@@ -8,33 +8,72 @@ import csv
 def parse_hipblaslt_output(output, line, tuning_info, mode):
     outputs = output.split('\n')
     print(output)
-    if mode == 'baseline':
-        latency = float(outputs[-5].split(',')[-1])
+
+    # Check if NO solution was found
+    if "NO solution found!" in output or "error:" in output.lower():
+        print(f"WARNING: No solution found for {mode} mode")
+        latency = -1
+        solution_idx = "NO_SOLUTION"
     else:
-        latency = float(outputs[-5].split(',')[-2])
-    solution_idx = outputs[-4].split(':')[-1]
+        try:
+            if mode == 'baseline':
+                latency = float(outputs[-5].split(',')[-1])
+            else:
+                latency = float(outputs[-5].split(',')[-2])
+            solution_idx = outputs[-4].split(':')[-1]
+        except (ValueError, IndexError) as e:
+            print(f"ERROR: Failed to parse output for {mode} mode: {e}")
+            latency = -1
+            solution_idx = "PARSE_ERROR"
+
     if mode == 'baseline':
         tuning_info[line].update({"baseline_latency(us)": latency})
         tuning_info[line].update({"baseline_solution_idx": solution_idx})
+        # Set status if baseline failed
+        if latency == -1:
+            tuning_info[line].update({"status": "BASELINE_FAILED"})
     elif mode == 'tuning':
         tuning_info[line].update({"tuned_latency(us)": latency})
         tuning_info[line].update({"tuned_solution_idx": solution_idx})
-        ratio = tuning_info[line]['baseline_latency(us)'] / latency * 100
-        ratio = round(ratio, 2)
-        tuning_info[line].update({"baseline/tuned": f"{ratio}%"})
+        baseline_latency = tuning_info[line].get('baseline_latency(us)', -1)
+        if baseline_latency > 0 and latency > 0:
+            ratio = baseline_latency / latency * 100
+            ratio = round(ratio, 2)
+            tuning_info[line].update({"baseline/tuned": f"{ratio}%"})
+            tuning_info[line].update({"status": "SUCCESS"})
+        else:
+            tuning_info[line].update({"baseline/tuned": "N/A"})
+            # Set status based on what failed
+            if baseline_latency == -1 and latency == -1:
+                tuning_info[line].update({"status": "BOTH_FAILED"})
+            elif latency == -1:
+                tuning_info[line].update({"status": "TUNING_FAILED"})
+            # If only baseline failed, status is already "BASELINE_FAILED" from baseline mode
 
 def export_csv(input_file, tuning_info, args):
-    fieldnames = ['m', 'n', 'k', 'lda', 'ldb', 'ldc', 'ldd', 'a_type', 'b_type', 'c_type', 'd_type', 'count', 'baseline_latency(us)', 'baseline_solution_idx', 'tuned_latency(us)', 'tuned_solution_idx', 'baseline/tuned']
+    fieldnames = ['m', 'n', 'k', 'lda', 'ldb', 'ldc', 'ldd', 'a_type', 'b_type', 'c_type', 'd_type', 'count', 'baseline_latency(us)', 'baseline_solution_idx', 'tuned_latency(us)', 'tuned_solution_idx', 'baseline/tuned', 'status']
     tuning_info_list = []
+
+    success_count = 0
+    total_count = 0
 
     with open(input_file, 'r') as f:
         for line in f:
-            tuning_info_list.append(tuning_info[line])
+            info = tuning_info[line]
+            status = info.get('status', 'UNKNOWN')
+
+            total_count += 1
+            if status == 'SUCCESS':
+                success_count += 1
+
+            tuning_info_list.append(info)
 
     with open(args.output_path + '/tuning_result.csv', 'w') as file:
         writer = csv.DictWriter(file, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(tuning_info_list)
+
+    return success_count, total_count
 
 def dynamic_iters(input_cmd, cold_iters, iters, tuning_info):
     if cold_iters == -1 or iters == -1:

--- a/projects/hipblaslt/utilities/QuickTune/utils.py
+++ b/projects/hipblaslt/utilities/QuickTune/utils.py
@@ -10,7 +10,7 @@ def parse_hipblaslt_output(output, line, tuning_info, mode):
     print(output)
 
     # Check if NO solution was found
-    if "NO solution found!" in output or "error:" in output.lower():
+    if "NO solution found!" in output:
         print(f"WARNING: No solution found for {mode} mode")
         latency = -1
         solution_idx = "NO_SOLUTION"


### PR DESCRIPTION
- Implemented error handling for latency parsing in `parse_hipblaslt_output`
- Modified the CSV export to include a status field for each tuning entry.
- Updated the `export_csv` function to return success and total counts.
- Added a summary report after exporting tuning results, displaying total, successful, and failed GEMMs.

## Motivation

Currently gemm_tuning.py doesn't include error handling in case hipblaslt-bench run fails. When running gemm_tuning.py I observed errors ("error: NO solution found!") for some hipblaslt-bench commands which caused the script to fail. I think it would be better for the script to emit error message and continue with the next hipblaslt-bench command instead of failing ungracefully. This PR introduces that change.

## Technical Details

- Implemented error handling for latency parsing in `parse_hipblaslt_output`.
- Modified the CSV export to include a status field for each tuning entry.
- Updated the `export_csv` function to return success and total counts.
- Added a summary report after exporting tuning results, displaying total, successful, and failed GEMMs.

## Test Plan

No automated tests. Does this script have tests in repo? I tested the script on the case I have, and it worked even if some of the hipblaslt-bench commands errored.

## Test Result

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
