### PR TITLE
Pruning of PerfHelper struct

### DIFF
--- a/projects/miopen/CMakeLists.txt
+++ b/projects/miopen/CMakeLists.txt
@@ -71,7 +71,7 @@ if(NOT WIN32)
     set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "")
 endif()
 
-project ( MIOpen C CXX )
+project(MIOpen CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -80,8 +80,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(CTest)
 
 find_package(Threads REQUIRED)
-find_package(ROCM 0.7.3 REQUIRED PATHS /opt/rocm)
 
+find_package(ROCmCMakeBuildTools)
 include(ROCMInstallTargets)
 include(ROCMPackageConfigHelpers)
 include(ROCMSetupVersion)
@@ -103,6 +103,8 @@ set(MIOPEN_ENABLE_SQLITE_KERN_CACHE On CACHE BOOL "")
 
 # By default build shared libraries
 option(BUILD_SHARED_LIBS "Create shared libraries" ON)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 if(MIOPEN_ENABLE_SQLITE)
     # MIOpen now depends on SQLite as well
@@ -137,7 +139,6 @@ endif()
 
 rocm_setup_version(VERSION 3.5.1)
 
-list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 include(TargetFlags)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -494,15 +495,8 @@ if(MIOPEN_USE_HIPRTC)
 endif()
 
 option(Boost_USE_STATIC_LIBS "Use boost static libraries" ON)
-set(BOOST_COMPONENTS filesystem)
-if(MIOPEN_BUILD_DRIVER)
-    # boost core is a header only component that can't be found by find_package
-    # list(APPEND BOOST_COMPONENTS core)
-endif()
-
-# The FindBoost module has been removed since CMake 3.30. Use the Boost 1.83 configuration file instead.
 add_definitions(-DBOOST_ALL_NO_LIB=1)
-find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS} CONFIG)
+find_package(Boost REQUIRED COMPONENTS filesystem CONFIG)
 
 find_path(HALF_INCLUDE_DIR half/half.hpp)
 message(STATUS "HALF_INCLUDE_DIR: ${HALF_INCLUDE_DIR}")

--- a/projects/miopen/test/gtest/bn_activ_infer.cpp
+++ b/projects/miopen/test/gtest/bn_activ_infer.cpp
@@ -56,7 +56,7 @@ void BatchNormInferenceGPU(const miopen::Handle& handle,
                            ConstData_t estimatedMean,
                            ConstData_t estimatedVariance,
                            double epsilon,
-                           PerfHelper<float>& perf_helper,
+                           PerfHelper& perf_helper,
                            bool use_hip = true)
 {
     int n, c, h, w;

--- a/projects/miopen/test/gtest/bn_fwd_infer.cpp
+++ b/projects/miopen/test/gtest/bn_fwd_infer.cpp
@@ -55,7 +55,7 @@ void BatchNormInferenceGPU(const miopen::Handle& handle,
                            ConstData_t estimatedMean,
                            ConstData_t estimatedVariance,
                            double epsilon,
-                           PerfHelper<float>& perf_helper,
+                           PerfHelper& perf_helper,
                            bool use_hip = true)
 {
     int n, c, h, w;

--- a/projects/miopen/test/gtest/bn_infer_tester.hpp
+++ b/projects/miopen/test/gtest/bn_infer_tester.hpp
@@ -171,12 +171,12 @@ struct BatchNormInferTester
     miopen::Allocator::ManageDataPtr estVariance_dev; // GPU estimated variance data
     miopenActivationMode_t activ_mode;                // Activation mode
     miopenTensorLayout_t tensor_layout;               // Tensor layout
-    const float activ_alpha = static_cast<float>(0.5f);
-    const float activ_beta  = static_cast<float>(0.5f);
-    const float activ_gamma = static_cast<float>(0.5f);
+    const float activ_alpha = 0.5f;
+    const float activ_beta  = 0.5f;
+    const float activ_gamma = 0.5f;
     double epsilon          = 1.0e-5;
     bool perf_enable        = false;
-    PerfHelper<float> perf_helper;
+    PerfHelper perf_helper;
 };
 
 template <typename T>

--- a/projects/miopen/test/gtest/bn_test_data.hpp
+++ b/projects/miopen/test/gtest/bn_test_data.hpp
@@ -264,9 +264,9 @@ struct BNInferTestData : public BNTestData<XDataType, YDataType, AccDataType, TC
     miopen::Allocator::ManageDataPtr shift_dev;
     miopen::Allocator::ManageDataPtr estMean_dev;
     miopen::Allocator::ManageDataPtr estVariance_dev;
-    double epsilon = 1.0e-5;
-    float alpha    = static_cast<float>(1.0f);
-    float beta     = static_cast<float>(0);
+    double epsilon{1.0e-5};
+    float alpha{1.0f};
+    float beta{0.0f};
     double activ_alpha;
     double activ_beta;
     miopenActivationMode_t activ_mode;
@@ -359,8 +359,8 @@ struct BNBwdTestData : public BNTestData<XDataType, DyDataType, AccDataType, TCo
     miopen::Allocator::ManageDataPtr dBias_ref_dev;
     double epsilon = std::numeric_limits<float>::epsilon();
 
-    float alphaDataDiff = static_cast<float>(1), betaDataDiff = static_cast<float>(0);
-    float alphaParamDiff = static_cast<float>(1), betaParamDiff = static_cast<float>(0);
+    float alphaDataDiff{1.0f}, betaDataDiff{0.0f};
+    float alphaParamDiff{1.0f}, betaParamDiff{0.0f};
 
     double activ_alpha;
     double activ_beta;
@@ -474,8 +474,8 @@ struct BNFwdTrainTestData : public BNTestData<XDataType, YDataType, AccDataType,
     miopen::Allocator::ManageDataPtr runVariance_dev;
     double epsilon       = 1.0e-5;
     double averageFactor = 0.1;
-    float alpha          = static_cast<float>(1.0f);
-    float beta           = static_cast<float>(0);
+    float alpha          = 1.0f;
+    float beta           = 0.0f;
     double activ_alpha;
     double activ_beta;
     miopenActivationMode_t activ_mode;

--- a/projects/miopen/test/gtest/perf_helper.hpp
+++ b/projects/miopen/test/gtest/perf_helper.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,46 +29,32 @@
 #define NUM_PERF_RUNS 5
 #define NUM_WARMUP_RUNS 3
 
-template <typename T>
 struct PerfHelper
 {
-    std::vector<std::tuple<std::string, T, T, double, double, double>> kernelTestStats;
+    std::vector<std::tuple<std::string, double, double, double, double, double>> kernelTestStats;
 
-    // hold the min, max, mean, median, and standard deviation
-    std::tuple<T, T, double, double, double> gpuStats;
-
-    // number of warmup runs
-    int numWarmupRuns = NUM_WARMUP_RUNS;
-
-    // number of performance runs
-    int numPerfRuns = NUM_PERF_RUNS;
-
-    // Setters for number of runs
-    void setWarmupRuns(int n) { numWarmupRuns = n; }
-    void setPerfRuns(int n) { numPerfRuns = n; }
-
-    static T perf_min(const std::vector<T>& data)
+    static double perf_min(const std::vector<double>& data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
         return *std::min_element(data.begin(), data.end());
     }
 
-    static T perf_max(const std::vector<T>& data)
+    static double perf_max(const std::vector<double>& data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
         return *std::max_element(data.begin(), data.end());
     }
 
-    static double perf_mean(const std::vector<T>& data)
+    static double perf_mean(const std::vector<double>& data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
         return std::accumulate(data.begin(), data.end(), 0.0) / data.size();
     }
 
-    static double perf_median(std::vector<T> data)
+    static double perf_median(std::vector<double> data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
@@ -84,26 +70,29 @@ struct PerfHelper
         }
     }
 
-    static double perf_standardDeviation(const std::vector<T>& data)
+    static double perf_standardDeviation(const std::vector<double>& data)
     {
         if(data.empty())
             throw std::invalid_argument("Empty vector");
         double data_mean = perf_mean(data);
         double sq_sum    = std::inner_product(
-            data.begin(), data.end(), data.begin(), 0.0, std::plus<>(), [data_mean](T a, T b) {
-                return (a - data_mean) * (b - data_mean);
-            });
+            data.begin(),
+            data.end(),
+            data.begin(),
+            0.0,
+            std::plus<>(),
+            [data_mean](double a, double b) { return (a - data_mean) * (b - data_mean); });
         return std::sqrt(sq_sum / data.size());
     }
 
-    static std::tuple<T, T, double, double, double> calcStats(const std::vector<T>& data)
+    static auto calcStats(const std::vector<double>& data)
     {
-        T min_val         = perf_min(data);
-        T max_val         = perf_max(data);
+        double min_val    = perf_min(data);
+        double max_val    = perf_max(data);
         double mean_val   = perf_mean(data);
         double median_val = perf_median(data); // Note: This modifies the data(sorts it)
         double sd_val     = perf_standardDeviation(data);
-        return {min_val, max_val, mean_val, median_val, sd_val};
+        return std::make_tuple(min_val, max_val, mean_val, median_val, sd_val);
     }
 
     void writeStatsToCSV(const std::string& filename, std::string test_info)
@@ -122,40 +111,14 @@ struct PerfHelper
         // If the file was just created (i.e., its size is 0), write the header.
         if(miopen::fs::file_size(filename) == 0)
         {
-            if(kernelTestStats.size() == 1)
-            {
-                file << "KernelAndTestInfo,min_exec_time (ms),max_exec_time (ms),mean_exec_time "
-                        "(ms),median_exec_time (ms),SD_exec_time (ms)\n";
-            }
-            else
-            {
-                file << "KernelAndTestInfo,min_exec_time_ratio,max_exec_time_ratio,mean_exec_time_"
-                        "ratio,median_exec_time_ratio,SD_reference (ms),SD_actual (ms)\n";
-            }
+            file << "KernelAndTestInfo,min_exec_time_ratio,max_exec_time_ratio,mean_exec_time_"
+                    "ratio,median_exec_time_ratio,SD_ocl,SD_hip\n";
         }
 
-        // if the number of entries in the kernelTestStats vector is not 1 and not even, throw an
-        // exception
-        if((kernelTestStats.size() != 1) && (kernelTestStats.size() % 2 != 0))
+        // if the number of entries in the kernelTestStats vector is odd, throw an exception
+        if(kernelTestStats.size() % 2 != 0)
         {
-            throw std::runtime_error(
-                "The number of entries in the kernelTestStats vector is not 1 and not even");
-        }
-
-        // if the number of entries in the kernelTestStats vector is 1
-        if(kernelTestStats.size() == 1)
-        {
-            auto& element = kernelTestStats[0];
-            // write the perf data to the file
-            file << std::get<0>(element) + test_info << "," // KernelAndTestInfo
-                 << std::get<1>(element) << ","             // min_exec_time
-                 << std::get<2>(element) << ","             // max_exec_time
-                 << std::get<3>(element) << ","             // mean_exec_time
-                 << std::get<4>(element) << ","             // median_exec_time
-                 << std::get<5>(element)                    // SD_exec_time
-                 << "\n";
-            file.close();
-            return;
+            throw std::runtime_error("The number of entries in the kernelTestStats vector is odd");
         }
 
         // Calculate the half size of the kernelTestStats vector
@@ -190,41 +153,30 @@ struct PerfHelper
     void perfTest(const miopen::Handle& handle,
                   const std::string& kernel_name,
                   const std::string& network_config,
-                  bool append,
                   Args&&... args)
     {
+        miopen::AutoEnableProfiling autoProfiling(handle);
+
         // Get kernels matching the kernel_name and network_config from the cache
-        auto kernels = handle.GetKernelsImpl(kernel_name, network_config);
+        auto&& kernels = handle.GetKernels(kernel_name, network_config);
         // Ensure we have at least one kernel
         assert(!kernels.empty());
-        // Vector to hold the execution times
-        std::vector<T> elapsedTime_ms;
 
-        if(handle.IsProfilingEnabled())
-        { // If profiling was enabled elsewhere, reset the kernel time
-            handle.ResetKernelTime();
-        }
-        else
-        {
-            handle.EnableProfiling(true); // Enable profiling
-            handle.ResetKernelTime();     // for good measure?
-        }
+        // Vector to hold the execution times
+        std::vector<double> elapsedTime_ms;
         // Optionally ignore the first few runs to allow for warm-up
-        for(size_t i = 0; i < numWarmupRuns + numPerfRuns; i++)
+        for(size_t i = 0; i < NUM_PERF_RUNS + NUM_WARMUP_RUNS; i++)
         {
             // Execute the kernel
-            handle.Run(kernels.front())(std::forward<Args>(args)...);
+            kernels.front()(std::forward<Args>(args)...);
             // Append the elapsed time to the vector
-            if(i >= numWarmupRuns)
-            {
+            if(i >= NUM_WARMUP_RUNS)
                 elapsedTime_ms.push_back(handle.GetKernelTime());
-            }
             handle.ResetKernelTime();
         }
 
-        handle.EnableProfiling(false); // Disable profiling
-
-        gpuStats = calcStats(elapsedTime_ms);
+        // Calculate the min, max, mean, median, and standard deviation
+        auto gpuStats = calcStats(elapsedTime_ms);
         kernelTestStats.push_back({kernel_name,
                                    std::get<0>(gpuStats),
                                    std::get<1>(gpuStats),

--- a/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
@@ -565,7 +565,7 @@ protected:
     TensorsConfig tensorsConfig;
     float alpha0, alpha1, beta;
 
-    PerfHelper<T> ph;
+    PerfHelper ph;
 };
 
 struct GPU_Op4dTensorGenericTest_FP32 : Op4DTensorGenericTest<float>


### PR DESCRIPTION
## Motivation
struct PerfHelper (/gtest/perf_helper.hpp) declared without a type template due to a problem with the conversion of the GetKernelTime() function's return result for a type different from 'float'.