### PR TITLE
[hipblast][CMS] Add pytests for validator

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -38,6 +38,8 @@ def create_base_kernel():
         "ForceUnrollSubIter": False,
         "SwapGlobalReadOrder": False, # For asserting it gets set
         "UsePLRPack": False, # For asserting it gets set
+        "MIWaveTileA": 2,
+        "MIWaveTileB": 2,
     }
     return kernel
 
@@ -50,61 +52,14 @@ class TestCustomSchedule:
         assert not has_schedule
         assert schedule_info is None
 
+    @pytest.mark.parametrize("transA, transB", [(True, False), (False, True), (False, False), (True, True)])
+    def test_schedule_256x256x64_16bit(self, transA, transB):
+        """Tests the 256x256x64 16-bit schedule."""
+        TN = transA and not transB
+        NT = not transA and transB
+        NN = not transA and not transB
+        TT = transA and transB
 
-    def test_schedule_256x256x64_16bit_TN(self):
-        """Tests the 256x256x64 16-bit TN schedule."""
-        kernel = create_base_kernel()
-        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": True, "TransposeB": False
-        })
-        kernel.update({
-            "MacroTile0": 256, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
-            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
-            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2], "TransposeLDS": 1
-        })
-
-        has_schedule, schedule_info = hasCustomSchedule(kernel)
-
-        assert has_schedule
-        assert isinstance(schedule_info, ScheduleInfo)
-        assert schedule_info.numCodePaths == 2
-        assert schedule_info.numMfma == 128
-        assert schedule_info.isValid({"kernel" : kernel})[0]
-        assert 'PackA0' not in schedule_info.optSchedule
-        assert not kernel["UsePLRPack"]
-
-    def test_schedule_256x256x64_16bit_NT(self):
-        """Tests the 256x256x64 16-bit NT schedule."""
-        kernel = create_base_kernel()
-        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": False, "TransposeB": True
-        })
-        kernel.update({
-            "MacroTile0": 256, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
-            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
-            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
-            "LDSTrInst": False, "TransposeLDS": 0
-        })
-
-        has_schedule, schedule_info = hasCustomSchedule(kernel)
-
-        assert has_schedule
-        assert isinstance(schedule_info, ScheduleInfo)
-        assert schedule_info.numCodePaths == 2
-        assert schedule_info.numMfma == 128
-        assert 'PackA0' in schedule_info.optSchedule
-        assert kernel["UsePLRPack"]
-        assert schedule_info.isValid({"kernel" : kernel})[0]
-
-    @pytest.mark.parametrize("transA, transB", [(False, False), (True, True)])
-    def test_schedule_256x256x64_16bit_NN_TT(self, transA, transB):
-        """Tests the 256x256x64 16-bit NN and TT schedules."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
         kernel["ProblemType"].update({
@@ -115,8 +70,7 @@ class TestCustomSchedule:
             "MacroTile0": 256, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
-            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
-            "LDSTrInst": False, "TransposeLDS": 1
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2], "TransposeLDS": 0 if NT else 1, "MIWaveTileA": 8, "MIWaveTileB": 8,
         })
 
         has_schedule, schedule_info = hasCustomSchedule(kernel)
@@ -125,55 +79,94 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 128
-        assert kernel["UsePLRPack"]
-        assert schedule_info.isValid({"kernel" : kernel})[0]
-        if transA and transB: # isTT
-            assert kernel["SwapGlobalReadOrder"]
-            assert 'PackB0' in schedule_info.optSchedule
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+        if TN:
             assert 'PackA0' not in schedule_info.optSchedule
-        else: # isNN
+            assert not kernel["UsePLRPack"]
+        elif NT:
+            assert 'PackA0' in schedule_info.optSchedule
+            assert kernel["UsePLRPack"]
+        elif NN:
             assert not kernel["SwapGlobalReadOrder"]
             assert 'PackA0' in schedule_info.optSchedule
             assert 'PackB0' not in schedule_info.optSchedule
-
-    def test_schedule_256x256x128_8bit_TN(self):
-        """Tests the 256x256x128 8-bit TN schedule."""
-        kernel = create_base_kernel()
-        dtype_8bit = _mock_dtype(is_8bit=True, num_bytes=1)
-        kernel["ProblemType"].update({
-            "DataType": dtype_8bit, "DataTypeA": dtype_8bit, "DataTypeB": dtype_8bit,
-            "TransposeA": True, "TransposeB": False
-        })
-        kernel.update({
-            "MacroTile0": 256, "MacroTile1": 256, "DepthU": 128,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0, "DirectToLds": True,
-            "GlobalReadVectorWidthA": 16, "GlobalReadVectorWidthB": 16, "LocalReadVectorWidth": 16,
-            "MatrixInstruction": [16,16,128,1], "MIWaveGroup": [2,2], "TransposeLDS": 1
-        })
-
-        has_schedule, schedule_info = hasCustomSchedule(kernel)
-
-        assert has_schedule
-        assert isinstance(schedule_info, ScheduleInfo)
-        assert schedule_info.numCodePaths == 1
-        assert schedule_info.numMfma == 64
-        assert len(schedule_info.mfmaReorder) > 0
-        assert schedule_info.isValid({"kernel" : kernel})[0]
-
-    def test_schedule_192x256x64_16bit_NN(self):
-        """Tests the 192x256x64 16-bit NN schedule."""
+            assert kernel["UsePLRPack"]
+        elif TT:
+            assert kernel["SwapGlobalReadOrder"]
+            assert 'PackA0' not in schedule_info.optSchedule
+            assert 'PackB0' in schedule_info.optSchedule
+            assert kernel["UsePLRPack"]
+    
+    def test_schedule_256x96x64_16bit_TN(self):
+        """Tests the 256x96x64 16-bit TN schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
         kernel["ProblemType"].update({
             "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": False, "TransposeB": False
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 96, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 3,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 48
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize("transA, transB", [(False, False), (False, True), (True, False)])
+    def test_schedule_192x256x64_16bit(self, transA, transB):
+        """Tests the 192x256x64 16-bit NN schedule."""
+        NN = not transA and not transB
+        NT = not transA and transB
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
         })
         kernel.update({
             "MacroTile0": 192, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
-            "LDSTrInst": True, "TransposeLDS": 1
+            "LDSTrInst": NN, "TransposeLDS": 0 if NT else 1, "MIWaveTileA": 6, "MIWaveTileB": 8,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        schedule_info.disableValidation()  # TODO: disable once fix has been added
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 96
+        if NN:
+            assert kernel["SwapGlobalReadOrder"]
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize("transA, transB", [(True, False), (False, False)])
+    def test_schedule_256x192x64_16bit_TN(self, transA, transB):
+        """Tests the 256x192x64 16-bit TN schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 192, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": not transA, "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 6,
         })
 
         has_schedule, schedule_info = hasCustomSchedule(kernel)
@@ -181,8 +174,262 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 96
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize("transA, transB", [(True, False), (False, False), (False, True)])
+    def test_schedule_160x256x64_16bit(self, transA, transB):
+        """Tests the 160x256x64 16-bit schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 160, "MacroTile1": 256, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": not transA, "TransposeLDS": not transB, "MIWaveTileA": 5, "MIWaveTileB": 8,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 80
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize("transA, transB", [(False, False), (False, True)])
+    def test_schedule_256x160x64_16bit(self, transA, transB):
+        """Tests the 256x160x64 16-bit schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 160, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": True, "TransposeLDS": 0 if transB else 1, "MIWaveTileA": 8, "MIWaveTileB": 5,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 80
         assert kernel["SwapGlobalReadOrder"]
-        assert schedule_info.isValid({"kernel" : kernel})[0]
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize("transA, transB", [(True, False), (False, True), (False, False)])
+    def test_schedule_256x240x64_16bit(self, transA, transB):
+        """Tests the 256x240x64 16-bit schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 240, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 2, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [4,1],
+            "LDSTrInst": True, "TransposeLDS": 1 if transA or not (transA or transB) else 0, "MIWaveTileA": 4, "MIWaveTileB": 15,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 1
+        assert schedule_info.numMfma == 120
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize("transA, transB", [(True, False), (False, False)])
+    def test_schedule_256x208x64_16bit(self, transA, transB):
+        """Tests the 256x208x64 16-bit schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 208, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 2, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [4,1],
+            "LDSTrInst": not transA , "TransposeLDS": 1, "MIWaveTileA": 4, "MIWaveTileB": 13,
+        })  
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 1
+        assert schedule_info.numMfma == 104
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    def test_schedule_224x256x64_16bit_TN(self):
+        """Tests the 224x256x64 16-bit TN schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "MacroTile0": 224, "MacroTile1": 256, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "TransposeLDS": 1, "MIWaveTileA": 7, "MIWaveTileB": 8,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 112
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    def test_schedule_192x320x64_16bit_NN(self):
+        """Tests the 192x320x64 16-bit NN schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": False, "TransposeB": False
+        })
+        kernel.update({
+            "MacroTile0": 192, "MacroTile1": 320, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": True, "TransposeLDS": 1, "MIWaveTileA": 6, "MIWaveTileB": 10,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 1
+        assert schedule_info.numMfma == 120
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    def test_schedule_256x224x64_16bit_TN(self):
+        """Tests the 256x224x64 16-bit TN schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "MacroTile0": 256, "MacroTile1": 224, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 7,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 112
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize("transA, transB", [(False, False), (False, True)])
+    def test_schedule_320x192x64_16bit(self, transA, transB):
+        """Tests the 320x192x64 16-bit schedule."""
+        NN = not transA and not transB
+        NT = not transA and transB
+
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 320, "MacroTile1": 192, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": True, "TransposeLDS": NN, "MIWaveTileA": 10, "MIWaveTileB": 6,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 120
+        assert kernel["SwapGlobalReadOrder"]
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize("transA, transB", [(True, False), (False, True)])
+    def test_schedule_240x256x64_16bit(self, transA, transB):
+        """Tests the 240x256x64 16-bit schedule."""
+        NT = not transA and transB
+        TN = transA and not transB
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 240, "MacroTile1": 256, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 2, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [1,4],
+            "TransposeLDS": TN, "MIWaveTileA": 15, "MIWaveTileB": 4,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == (2 if TN else 1)
+        assert schedule_info.numMfma == 120
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize("transA, transB", [(True, False), (False, False)])
+    def test_schedule_208x256x64_16bit(self, transA, transB):
+        """Tests the 208x256x64 16-bit schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 208, "MacroTile1": 256, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "GlobalReadVectorWidthA": 2, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [1,4],
+            "LDSTrInst": not transA, "TransposeLDS": 1, "MIWaveTileA": 13, "MIWaveTileB": 4,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 1
+        assert schedule_info.numMfma == 104
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
 
 
 class TestCustomScheduleValidation:
@@ -229,5 +476,3 @@ class TestCustomScheduleValidation:
             None, None, invalid_schedule, None, None, None, None
         ).isValid({})
         assert status == False
-
-


### PR DESCRIPTION
## Motivation

To validate the schedules already included they must be generated. The current best way of doing that is by running the tox test using `custom_mainloop_scheudling.yaml`, but this take >10 minutes and exits early on the first test.

## Technical Details

Introduce a pytest for each existing schedule which creates and runs the existing validation passes on each currently implemented schedule.

## Test Plan

This is adding more tests. Running existing tests will cover the same code as these tests, but will take longer. The yaml tests are taken as the source of truth.

## Test Result

Passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
