### PR TITLE
[hipRAND] Enable gfx1152 and gfx1153

### DIFF
--- a/projects/hiprand/CMakeLists.txt
+++ b/projects/hiprand/CMakeLists.txt
@@ -106,7 +106,7 @@ if (NOT BUILD_WITH_LIB STREQUAL "CUDA")
 
   if(GPU_TARGETS STREQUAL "all")
     rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-      TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
+      TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201"
     )
     set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)
   endif()


### PR DESCRIPTION
## Motivation

Enable gfx1152 and gfx1153.

## Technical Details

Enable by default archs gfx1152 and gfx1153 since the pass the tests.

## Test Plan

ctest --test-dir /tmp/rogarcia/rocm/bin/hipRAND --output-on-failure --parallel 1 --timeout 120

## Test Result

All test passed.

gfx1152 log:
```
$ ctest --test-dir /tmp/rogarcia/rocm/bin/hipRAND --output-on-failure --parallel 1 --timeout 120
Test project /tmp/rogarcia/rocm/bin/hipRAND
    Start 1: test_hiprand_api
1/4 Test #1: test_hiprand_api .................   Passed   16.15 sec
    Start 2: test_hiprand_cpp_wrapper
2/4 Test #2: test_hiprand_cpp_wrapper .........   Passed   26.00 sec
    Start 3: test_hiprand_kernel
3/4 Test #3: test_hiprand_kernel ..............   Passed    0.15 sec
    Start 4: test_hiprand_linkage
4/4 Test #4: test_hiprand_linkage .............   Passed    0.02 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  42.32 sec
```

gfx1153 log:
```
$ ctest --test-dir /tmp/rogarcia/rocm/bin/hipRAND --output-on-failure --parallel 1 --timeout 120
Test project /tmp/rogarcia/rocm/bin/hipRAND
    Start 1: test_hiprand_api
1/4 Test #1: test_hiprand_api .................   Passed   33.06 sec
    Start 2: test_hiprand_cpp_wrapper
2/4 Test #2: test_hiprand_cpp_wrapper .........   Passed   53.39 sec
    Start 3: test_hiprand_kernel
3/4 Test #3: test_hiprand_kernel ..............   Passed    0.21 sec
    Start 4: test_hiprand_linkage
4/4 Test #4: test_hiprand_linkage .............   Passed    0.02 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  86.67 sec
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
