### PR TITLE
[ci] fix TheRock CI Nightly to include target variance

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -188,6 +188,7 @@ if __name__ == "__main__":
     args = {}
     github_event_name = os.getenv("GITHUB_EVENT_NAME")
     platform = os.getenv("PLATFORM")
+    args["platform"] = platform
     args["is_pull_request"] = github_event_name == "pull_request"
     args["is_push"] = github_event_name == "push"
     args["is_workflow_dispatch"] = github_event_name == "workflow_dispatch"

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -66,6 +66,7 @@ def set_github_output(d: Mapping[str, str]):
     with open(step_output_file, "a") as f:
         f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
 
+
 def retry(max_attempts, delay_seconds, exceptions):
     def decorator(func):
         def newfn(*args, **kwargs):
@@ -74,14 +75,19 @@ def retry(max_attempts, delay_seconds, exceptions):
                 try:
                     return func(*args, **kwargs)
                 except exceptions as e:
-                    print(f'Exception {str(e)} thrown when attempting to run , attempt {attempt} of {max_attempts}')
+                    print(
+                        f"Exception {str(e)} thrown when attempting to run , attempt {attempt} of {max_attempts}"
+                    )
                     attempt += 1
                     if attempt < max_attempts:
                         backoff = delay_seconds * (2 ** (attempt - 1))
                         time.sleep(backoff)
             return func(*args, **kwargs)
+
         return newfn
+
     return decorator
+
 
 @retry(max_attempts=3, delay_seconds=2, exceptions=(TimeoutError))
 def get_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
@@ -137,12 +143,12 @@ def retrieve_projects(args):
     if args.get("is_push") or args.get("is_pull_request"):
         paths_set = set(modified_paths)
         contains_non_skippable_files = check_for_non_skippable_path(paths_set)
-        
+
         # If only skippable paths were modified, skip CI
         if not contains_non_skippable_files:
             logging.info("Only skippable paths were modified, skipping CI")
             return [], test_type
-    
+
     subtrees = get_changed_path_projects(modified_paths)
 
     if args.get("is_workflow_dispatch"):
@@ -155,7 +161,9 @@ def retrieve_projects(args):
     if args.get("is_push") or args.get("is_pull_request"):
         related_to_therock_ci = check_for_workflow_file_related_to_ci(modified_paths)
         if related_to_therock_ci:
-            logging.info("Enabling all projects since a related workflow file was modified")
+            logging.info(
+                "Enabling all projects since a related workflow file was modified"
+            )
             subtrees = list(subtree_to_project_map.keys())
             test_type = "smoke"
 
@@ -169,16 +177,17 @@ def retrieve_projects(args):
 
 
 def run(args):
+    platform = args.get("platform")
     project_to_run, test_type = retrieve_projects(args)
-    set_github_output({
-        "projects": json.dumps(project_to_run),
-        "test_type": test_type
-    })
+    set_github_output(
+        {f"{platform}_projects": json.dumps(project_to_run), "test_type": test_type}
+    )
 
 
 if __name__ == "__main__":
     args = {}
     github_event_name = os.getenv("GITHUB_EVENT_NAME")
+    platform = os.getenv("PLATFORM")
     args["is_pull_request"] = github_event_name == "pull_request"
     args["is_push"] = github_event_name == "push"
     args["is_workflow_dispatch"] = github_event_name == "workflow_dispatch"

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -147,7 +147,7 @@ def collect_projects_to_run(subtrees):
             project_map_data["cmake_options"] += ["-DTHEROCK_ENABLE_ALL=OFF"]
 
             cmake_flag_options = " ".join(project_map_data["cmake_options"])
-            project_to_test_options = ",".join(project_map_data["project_to_test_options"])
+            project_to_test_options = ",".join(project_map_data["project_to_test"])
             project_map_data["cmake_options"] = cmake_flag_options
             project_map_data["project_to_test"] = project_to_test_options
             project_to_run.append(project_map_data)

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -1,6 +1,8 @@
 """
 This dictionary is used to map specific file directory changes to the corresponding build flag and tests
 """
+import os
+
 subtree_to_project_map = {
     "projects/hipblas": "blas",
     "projects/hipblas-common": "blas",
@@ -28,31 +30,39 @@ subtree_to_project_map = {
 
 project_map = {
     "prim": {
-        "cmake_options": "-DTHEROCK_ENABLE_PRIM=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_PRIM=ON"],
         "project_to_test": "rocprim, rocthrust, hipcub",
     },
     "rand": {
-        "cmake_options": "-DTHEROCK_ENABLE_RAND=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_RAND=ON"],
         "project_to_test": "rocrand, hiprand",
     },
     "blas": {
-        "cmake_options": "-DTHEROCK_ENABLE_BLAS=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_BLAS=ON"],
         "project_to_test": "hipblaslt, rocblas, hipblas",
     },
     "miopen": {
-        "cmake_options": "-DTHEROCK_ENABLE_MIOPEN=ON -DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON -DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON -DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON -DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
+        "cmake_options": ["-DTHEROCK_ENABLE_MIOPEN=ON", "-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON"],
+        "additional_flags": {
+            # As composable_kernel is not enabled for Windows, we only enable these flags during Linux builds
+            "linux": ["-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON", "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON", "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel"]
+        },
         "project_to_test": "miopen, miopen_plugin",
     },
     "fft": {
-        "cmake_options": "-DTHEROCK_ENABLE_FFT=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_FFT=ON"],
         "project_to_test": "hipfft, rocfft",
     },
     "hipdnn": {  # due to MIOpen plugin project being inside the hipDNN directory, we cannot have the MIOpen plugin project as a separate project for now https://github.com/ROCm/rocm-libraries/issues/2316
-        "cmake_options": "-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON -DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON -DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON -DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
+        "cmake_options": ["-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON"],
+        "additional_flags": {
+            # As composable_kernel is not enabled for Windows, we only enable these flags during Linux builds
+            "linux": ["-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON", "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON", "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel"]
+        },        
         "project_to_test": "hipdnn, miopen_plugin",
     },
     "rocwmma": {
-        "cmake_options": "-DTHEROCK_ENABLE_ROCWMMA=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_ROCWMMA=ON"],
         "project_to_test": "rocwmma",
     },
 }
@@ -63,12 +73,12 @@ project_map = {
 # Example: SPARSE is included in BLAS, but a separate build would cause overwriting of the blas_lib.tar.xz and blas_test.tar.xz and be missing libraries and tests
 additional_options = {
     "sparse": {
-        "cmake_options": "-DTHEROCK_ENABLE_SPARSE=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_SPARSE=ON"],
         "project_to_test": "rocsparse, hipsparse",
         "project_to_add": "blas",
     },
     "solver": {
-        "cmake_options": "-DTHEROCK_ENABLE_SOLVER=ON",
+        "cmake_options": ["-DTHEROCK_ENABLE_SOLVER=ON"],
         "project_to_test": "rocsolver, hipsolver",
         "project_to_add": "blas",
     },
@@ -76,14 +86,15 @@ additional_options = {
 
 
 def collect_projects_to_run(subtrees):
+    platform = os.getenv("PLATFORM")
     projects = set()
     # collect the associated subtree to project
     for subtree in subtrees:
         if subtree in subtree_to_project_map:
             projects.add(subtree_to_project_map.get(subtree))
 
-    # Check if an optional math component was included.
     for project in list(projects):
+        # Check if an optional math component was included.
         if project in additional_options:
             project_options_to_add = additional_options[project]
 
@@ -92,10 +103,10 @@ def collect_projects_to_run(subtrees):
             if project_to_add in projects:
                 project_map[project_to_add][
                     "cmake_options"
-                ] += f" {project_options_to_add['cmake_options']}"
+                ] += project_options_to_add['cmake_options']
                 project_map[project_to_add][
                     "project_to_test"
-                ] += f", {project_options_to_add['project_to_test']}"
+                ] += project_options_to_add['project_to_test']
             # If `project_to_add` is not included, only run build and tests for the optional project
             else:
                 projects.add(project_to_add)
@@ -106,13 +117,23 @@ def collect_projects_to_run(subtrees):
                     "project_to_test"
                 ]
 
+
     # retrieve the subtrees to checkout, cmake options to build, and projects to test
     project_to_run = []
     for project in projects:
         if project in project_map:
             project_map_data = project_map.get(project)
+
+            # Check if platform-based additional flags are needed
+            if "additional_flags" in project_map_data and platform in project_map_data["additional_flags"]:
+                project_map_data["cmake_options"] += project_map_data["additional_flags"][platform]
+                del project_map_data["additional_flags"][platform]
+
             # To save time, only build what is needed
-            project_map_data["cmake_options"] += " -DTHEROCK_ENABLE_ALL=OFF"
+            project_map_data["cmake_options"] += ["-DTHEROCK_ENABLE_ALL=OFF"]
+
+            cmake_flag_options = " ".join(project_map_data["cmake_options"])
+            project_map_data["cmake_options"] = cmake_flag_options
             project_to_run.append(project_map_data)
 
     return project_to_run

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -42,23 +42,34 @@ project_map = {
         "project_to_test": "hipblaslt, rocblas, hipblas",
     },
     "miopen": {
-        "cmake_options": ["-DTHEROCK_ENABLE_MIOPEN=ON", "-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON"],
+        "cmake_options": [
+            "-DTHEROCK_ENABLE_MIOPEN=ON",
+            "-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON",
+        ],
         "additional_flags": {
             # As composable_kernel is not enabled for Windows, we only enable these flags during Linux builds
-            "linux": ["-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON", "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON", "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel"]
+            "linux": [
+                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
+                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
+                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
+            ]
         },
         "project_to_test": "miopen, miopen_plugin",
     },
     "fft": {
-        "cmake_options": ["-DTHEROCK_ENABLE_FFT=ON"],
+        "cmake_options": ["-DTHEROCK_ENABLE_FFT=ON", "-DTHEROCK_ENABLE_RAND=ON"],
         "project_to_test": "hipfft, rocfft",
     },
     "hipdnn": {  # due to MIOpen plugin project being inside the hipDNN directory, we cannot have the MIOpen plugin project as a separate project for now https://github.com/ROCm/rocm-libraries/issues/2316
         "cmake_options": ["-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON"],
         "additional_flags": {
             # As composable_kernel is not enabled for Windows, we only enable these flags during Linux builds
-            "linux": ["-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON", "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON", "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel"]
-        },        
+            "linux": [
+                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
+                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
+                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
+            ]
+        },
         "project_to_test": "hipdnn, miopen_plugin",
     },
     "rocwmma": {
@@ -101,12 +112,12 @@ def collect_projects_to_run(subtrees):
             project_to_add = project_options_to_add["project_to_add"]
             # If `project_to_add` is in included, add options to the existing `project_map` entry
             if project_to_add in projects:
-                project_map[project_to_add][
+                project_map[project_to_add]["cmake_options"] += project_options_to_add[
                     "cmake_options"
-                ] += project_options_to_add['cmake_options']
+                ]
                 project_map[project_to_add][
                     "project_to_test"
-                ] += project_options_to_add['project_to_test']
+                ] += project_options_to_add["project_to_test"]
             # If `project_to_add` is not included, only run build and tests for the optional project
             else:
                 projects.add(project_to_add)
@@ -117,7 +128,6 @@ def collect_projects_to_run(subtrees):
                     "project_to_test"
                 ]
 
-
     # retrieve the subtrees to checkout, cmake options to build, and projects to test
     project_to_run = []
     for project in projects:
@@ -125,9 +135,13 @@ def collect_projects_to_run(subtrees):
             project_map_data = project_map.get(project)
 
             # Check if platform-based additional flags are needed
-            if "additional_flags" in project_map_data and platform in project_map_data["additional_flags"]:
-                project_map_data["cmake_options"] += project_map_data["additional_flags"][platform]
-                del project_map_data["additional_flags"][platform]
+            if (
+                "additional_flags" in project_map_data
+                and platform in project_map_data["additional_flags"]
+            ):
+                project_map_data["cmake_options"] += project_map_data[
+                    "additional_flags"
+                ][platform]
 
             # To save time, only build what is needed
             project_map_data["cmake_options"] += ["-DTHEROCK_ENABLE_ALL=OFF"]

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -31,15 +31,15 @@ subtree_to_project_map = {
 project_map = {
     "prim": {
         "cmake_options": ["-DTHEROCK_ENABLE_PRIM=ON"],
-        "project_to_test": "rocprim, rocthrust, hipcub",
+        "project_to_test": ["rocprim", "rocthrust", "hipcub"],
     },
     "rand": {
         "cmake_options": ["-DTHEROCK_ENABLE_RAND=ON"],
-        "project_to_test": "rocrand, hiprand",
+        "project_to_test": ["rocrand", "hiprand"],
     },
     "blas": {
         "cmake_options": ["-DTHEROCK_ENABLE_BLAS=ON"],
-        "project_to_test": "hipblaslt, rocblas, hipblas",
+        "project_to_test": ["hipblaslt", "rocblas", "hipblas"],
     },
     "miopen": {
         "cmake_options": [
@@ -54,11 +54,11 @@ project_map = {
                 "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
             ]
         },
-        "project_to_test": "miopen, miopen_plugin",
+        "project_to_test": ["miopen", "miopen_plugin"],
     },
     "fft": {
         "cmake_options": ["-DTHEROCK_ENABLE_FFT=ON", "-DTHEROCK_ENABLE_RAND=ON"],
-        "project_to_test": "hipfft, rocfft",
+        "project_to_test": ["hipfft", "rocfft"],
     },
     "hipdnn": {  # due to MIOpen plugin project being inside the hipDNN directory, we cannot have the MIOpen plugin project as a separate project for now https://github.com/ROCm/rocm-libraries/issues/2316
         "cmake_options": ["-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON"],
@@ -70,11 +70,11 @@ project_map = {
                 "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
             ]
         },
-        "project_to_test": "hipdnn, miopen_plugin",
+        "project_to_test": ["hipdnn", "miopen_plugin"],
     },
     "rocwmma": {
         "cmake_options": ["-DTHEROCK_ENABLE_ROCWMMA=ON"],
-        "project_to_test": "rocwmma",
+        "project_to_test": ["rocwmma"],
     },
 }
 
@@ -85,12 +85,12 @@ project_map = {
 additional_options = {
     "sparse": {
         "cmake_options": ["-DTHEROCK_ENABLE_SPARSE=ON"],
-        "project_to_test": "rocsparse, hipsparse",
+        "project_to_test": ["rocsparse", "hipsparse"],
         "project_to_add": "blas",
     },
     "solver": {
         "cmake_options": ["-DTHEROCK_ENABLE_SOLVER=ON"],
-        "project_to_test": "rocsolver, hipsolver",
+        "project_to_test": ["rocsolver", "hipsolver"],
         "project_to_add": "blas",
     },
 }
@@ -147,7 +147,9 @@ def collect_projects_to_run(subtrees):
             project_map_data["cmake_options"] += ["-DTHEROCK_ENABLE_ALL=OFF"]
 
             cmake_flag_options = " ".join(project_map_data["cmake_options"])
+            project_to_test_options = ",".join(project_map_data["project_to_test_options"])
             project_map_data["cmake_options"] = cmake_flag_options
+            project_map_data["project_to_test"] = project_to_test_options
             project_to_run.append(project_map_data)
 
     return project_to_run

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -94,10 +94,6 @@ jobs:
           # rm ./TheRock/patches/amd-mainline/rocm-libraries/*.patch
           git -c user.name="therockbot" -c "user.email=therockbot@amd.com" am --whitespace=nowarn ./TheRock/patches/amd-mainline/rocm-libraries/*.patch
 
-      - name: Install external python deps
-        run: |
-          pip install -r TheRock/requirements-external.txt
-
       - name: Configure Projects
         env:
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
+          ref: 00d29d2dfe81ddbdc1908a0b992d928d498b2826 # 2025-12-05 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
+          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
+          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
+          ref: 00d29d2dfe81ddbdc1908a0b992d928d498b2826 # 2025-12-05 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
+          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -19,6 +19,8 @@ jobs:
     outputs:
       projects: ${{ steps.projects.outputs.projects }}
       test_type: ${{ steps.projects.outputs.test_type }}
+      linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
+      windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -26,6 +28,13 @@ jobs:
           sparse-checkout: .github
           sparse-checkout-cone-mode: true
           fetch-depth: 2
+
+      - name: Checkout TheRock repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/TheRock"
+          path: TheRock
+          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -44,8 +53,24 @@ jobs:
         run: |
           python .github/scripts/therock_configure_ci.py
 
+      - name: Fetch Linux targets for build and test
+        env:
+          THEROCK_PACKAGE_PLATFORM: "linux"
+          # TODO(geomin12): Allow dynamic values of AMDGPU_FAMILIES, with opt-in options
+          AMDGPU_FAMILIES: "gfx94X, gfx950"
+        id: configure_linux
+        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
+
+      - name: Fetch Windows targets for build and test
+        env:
+          THEROCK_PACKAGE_PLATFORM: "windows"
+          # TODO(geomin12): Allow dynamic values of AMDGPU_FAMILIES, with opt-in options
+          AMDGPU_FAMILIES: "gfx1151"
+        id: configure_windows
+        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
+
   therock-ci-linux:
-    name: Linux (${{ matrix.projects.project_to_test }})
+    name: Linux (${{ matrix.projects.project_to_test }}) | ${{ matrix.target_bundle.amdgpu_family }})
     permissions:
       contents: read
       id-token: write
@@ -55,15 +80,18 @@ jobs:
       fail-fast: false
       matrix:
         projects: ${{ fromJSON(needs.setup.outputs.projects) }}
+        target_bundle: ${{ fromJSON(needs.setup.outputs.linux_package_targets) }}
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       project_to_test: ${{ matrix.projects.project_to_test }}
       test_type: ${{ needs.setup.outputs.test_type }}
+      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
+      test_runs_on: ${{ matrix.target_bundle.test_machine }}
 
   therock-ci-windows:
-    name: Windows (${{ matrix.projects.project_to_test }})
+    name: Windows (${{ matrix.projects.project_to_test }}) | ${{ matrix.target_bundle.amdgpu_family }})
     permissions:
       contents: read
       id-token: write
@@ -73,12 +101,15 @@ jobs:
       fail-fast: false
       matrix:
         projects: ${{ fromJSON(needs.setup.outputs.projects) }}
+        target_bundle: ${{ fromJSON(needs.setup.outputs.windows_package_targets) }}
     uses: ./.github/workflows/therock-ci-windows.yml
     secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       project_to_test: ${{ matrix.projects.project_to_test }}
       test_type: ${{ needs.setup.outputs.test_type }}
+      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
+      test_runs_on: ${{ matrix.target_bundle.test_machine }}
 
   therock_ci_nightly_summary:
     name: TheRock CI Nightly Summary

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -105,10 +105,6 @@ jobs:
           git config --global core.longpaths true
           python ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-libraries --no-include-ml-frameworks
 
-      - name: Install external python deps
-        run: |
-          pip install -r TheRock/requirements-external.txt
-
       - name: Configure Projects
         env:
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
+          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
+          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
+          ref: 00d29d2dfe81ddbdc1908a0b992d928d498b2826 # 2025-12-05 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -33,7 +33,8 @@ jobs:
     name: "Setup"
     runs-on: ubuntu-24.04
     outputs:
-      projects: ${{ steps.projects.outputs.projects }}
+      linux_projects: ${{ steps.projects.outputs.linux_projects }}
+      windows_projects: ${{ steps.projects.outputs.windows_projects }}
       test_type: ${{ steps.projects.outputs.test_type }}
       linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
       windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
@@ -62,10 +63,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install pydantic requests
 
-      - name: Determine projects to run
-        id: projects
+      - name: Determine Linux projects to run
+        id: linux_projects
         env:
           PROJECTS: ${{ inputs.projects }}
+          PLATFORM: "linux"
+        run: |
+          python .github/scripts/therock_configure_ci.py
+
+      - name: Determine Windows projects to run
+        id: windows_projects
+        env:
+          PROJECTS: ${{ inputs.projects }}
+          PLATFORM: "windows"
         run: |
           python .github/scripts/therock_configure_ci.py
 
@@ -95,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        projects: ${{ fromJSON(needs.setup.outputs.projects) }}
+        projects: ${{ fromJSON(needs.setup.outputs.linux_projects) }}
         target_bundle: ${{ fromJSON(needs.setup.outputs.linux_package_targets) }}
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
@@ -116,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        projects: ${{ fromJSON(needs.setup.outputs.projects) }}
+        projects: ${{ fromJSON(needs.setup.outputs.windows_projects) }}
         target_bundle: ${{ fromJSON(needs.setup.outputs.windows_package_targets) }}
     uses: ./.github/workflows/therock-ci-windows.yml
     secrets: inherit

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -33,8 +33,8 @@ jobs:
     name: "Setup"
     runs-on: ubuntu-24.04
     outputs:
-      linux_projects: ${{ steps.projects.outputs.linux_projects }}
-      windows_projects: ${{ steps.projects.outputs.windows_projects }}
+      linux_projects: ${{ steps.linux_projects.outputs.linux_projects }}
+      windows_projects: ${{ steps.windows_projects.outputs.windows_projects }}
       test_type: ${{ steps.projects.outputs.test_type }}
       linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
       windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
+          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: f3f77a3161922df3eee006b888b439d75b2b4668 # 2025-10-29 commit
+          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -101,7 +101,7 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.projects != '[]' }}
+    if: ${{ needs.setup.outputs.linux_projects != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -122,7 +122,7 @@ jobs:
       contents: read
       id-token: write
     needs: setup
-    if: ${{ needs.setup.outputs.projects != '[]' }}
+    if: ${{ needs.setup.outputs.windows_projects != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
+          ref: 00d29d2dfe81ddbdc1908a0b992d928d498b2826 # 2025-12-05 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
+          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
+          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
+          ref: 00d29d2dfe81ddbdc1908a0b992d928d498b2826 # 2025-12-05 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
+          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
+          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
+          ref: 00d29d2dfe81ddbdc1908a0b992d928d498b2826 # 2025-12-05 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 4bdb0bc40badaffb56b9c495353f69a7e8ce9e12 # 2025-12-04 commit
+          ref: 00d29d2dfe81ddbdc1908a0b992d928d498b2826 # 2025-12-05 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
+          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: a1f6b57cc31890c05ab0094212ae0b269765db8e # 2025-11-25 commit
+          ref: 51e83dbcd0f3c7723badfc3a7d4fde7008e99e21 # 2025-12-02 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
Added target variance to TheRock CI, but not TheRock CI nightly.

This PR fixes CI nightly and includes hash bumps

Works here with a workflow_dispatch: https://github.com/ROCm/rocm-libraries/actions/runs/19903659152