### PR TITLE
[Hipblas][CMS] 96x256x64 TN

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -565,6 +565,91 @@ class RegisterSchedule:
         # Return original function unchanged (so it can still be called directly)
         return func
 
+@RegisterSchedule(
+    tile_config=TileConfig(96, 256, 64, 2, 1, True, 0, 0),
+    dtype_predicate=is16bit,
+    vector_widths=[8, 8, 8],
+    matrix_inst=[16, 16, 32, 1],
+    mfma_wave_group=[2, 2]
+)
+def _get_schedule_96x256x64_16bit(kernel, useLDSTr, TLDS):
+    numMfma = 48
+    nglshift = nllshift = 11
+    numCodePaths = 2
+    kernel["MfmaInitCVgprs"] = True
+
+    if isTN(kernel) and TLDS==1:
+        kernel["SwapGlobalReadOrder"] = True
+
+        syncTable = [
+            7, SWaitCnt(dscnt=8, vlcnt=-1, vscnt=-1, comment="Finish all LRA1s and LRB1s"),
+
+            9, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="All LRB0 done"),
+            9, SBarrier(comment=""),
+
+            23, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="All LRA0 done"),
+
+            35, SWaitCnt(dscnt=-1, vlcnt=11, vscnt=-1, comment="Wait for prev GRBs"),
+            35, SBarrier(comment=""),
+
+            43, SWaitCnt(dscnt=-1, vlcnt=11, vscnt=-1, comment="Wait for prev GRA"),
+            43, SBarrier(comment=""),
+
+            47, SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="Finish all LRB1 and 1/3 LRA1"),
+        ]
+
+        syncCode = syncTable[1::2]
+        optSchedule = {
+            'GRIncA' : [[0,0,0,    2,2,2, 3, 4,4],
+                        [-1,-1,-1, 1,1,1, 3, 3,3]],
+            'GRIncB' : [[4, 5,5,5, 6,6,6, 7,7],
+                        [4, 5,5,5, 6,6,6, 7,7]],
+
+            'LRB0'   : [[-1,-1,-1, 1,1,1, 3,3],
+                        [0,0,0,    2,2,2, 4,4]],
+            'LRSB'   : [[8], [9]],
+            
+            'SYNC'   : [syncTable[::2]],
+
+            # Actually loads GRB
+            'GRA'    : [[8,9,  11,11, 13,13, 15,15,  20,20, 22,22, 24,24, 26,26],
+                        [8,10, 12,12, 14,14, 16,16,  21,21, 23,23, 25,25, 27,27]],
+            'LWSB'   : [[32]],
+
+            'LRA0'   : [[17, 17, 17],
+                        [15, 15, 15]],
+            'LRSA'   : [[19]],
+            
+            # Actually loads GRA
+            'GRB'    : [[36,36, 38,38, 40,40],
+                        [37,37, 39,39, 41,41]],
+            'LWSA'   : [[45]],
+            
+            'LRB1'   : [[35,35, 37,37, 39,39, 41,41],
+                        [36,36, 38,38, 40,40, 42,42]],
+            'LRA1'   : [[43,44,46],
+                        [43,45,46]],
+            
+            'LCC'   : [[47, 47]],
+        }
+
+        # Reorder to basically create the 256x96 case
+        mfmaReorder = [
+             0,  3,  6,  9, 12, 15, 18, 21,
+             1,  4,  7, 10, 13, 16, 19, 22,
+             2,  5,  8, 11, 14, 17, 20, 23,
+              # Second half
+             24, 27, 30, 33, 36, 39, 42, 45,
+             25, 28, 31, 34, 37, 40, 43, 46,
+             26, 29, 32, 35, 38, 41, 44, 47
+        ]
+
+        opt1 = ScheduleInfo(numCodePaths, numMfma, optSchedule, syncCode, nglshift, nllshift, mfmaReorder=mfmaReorder)
+    else:
+        return False, None
+    
+    return True, opt1
+
 
 @RegisterSchedule(
     tile_config=TileConfig(256, 96, 64, 2, 1, True, 0, 0),

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
@@ -960,6 +960,42 @@ BenchmarkProblems:
           - Range: [[192], [256], [1], [1, 17, 64]]
           - Range: [[192], [256], [1], [32, 64, 256]]
         - BiasTypeArgs: ['b']
+    - # BenchmarkProblemSizeGroup - 96x256x64 TN
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16,16,32,1, 1, 3,8, 2,2]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - LDSTrInst: [1]
+        - StreamK: [3]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+        - MaxLDS: [163840]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [1536, 4096, 1, 8192]
+          - Range: [[96], [256], [1], [64, 64, 256]]
+          - Range: [[96], [256], [1], [32, 64, 256]]
+          - Range: [[96], [256], [1], [1, 1, 64]]
+        - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -177,6 +177,30 @@ class TestCustomScheduleBF16:
         valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
+    def test_schedule_96x256x64_16bit_TN(self):
+        """Tests the 96x256x64 16-bit TN schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "MacroTile0": 96, "MacroTile1": 256, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "TransposeLDS": 1, "MIWaveTileA": 3, "MIWaveTileB": 8,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 48
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
+        assert valid, message
+
     @pytest.mark.parametrize("transA, transB", [(False, False), (False, True), (True, False)])
     def test_schedule_192x256x64_16bit(self, transA, transB):
         """Tests the 192x256x64 16-bit NN schedule."""


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Problem Size: (M, N, K) = (1536, 4096, 8192)

Tensile: 2.2% speedup over non-CMS of same shape.
main-loop efficiency: **-8.2%** (61.8% -> 53.6%)
hipblaslt-bench with K=8192: 5% faster than baseline (96x256x64 Non-CMS)
hipblaslt-bench with K=4096: 11.3% faster than baseline (96x256x64 Non-CMS)

## Test Plan

Run existing tests.
Added new tests for this schedule

## Test Result

Tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

AIGECORE-93