### PR TITLE
[rocrand] Support backward compatibility in unit tests

### DIFF
--- a/projects/rocrand/test/linkage/test_rocrand_linkage.cpp
+++ b/projects/rocrand/test/linkage/test_rocrand_linkage.cpp
@@ -32,5 +32,5 @@
 TEST(rocrand_linkage_tests, get_version_test)
 {
     EXPECT_EQ(rocrand_get_version(NULL), ROCRAND_STATUS_OUT_OF_RANGE);
-    EXPECT_EQ(get_rocrand_version(), ROCRAND_VERSION);
+    EXPECT_GT(get_rocrand_version(), 0);
 }

--- a/projects/rocrand/test/linkage/test_rocrand_linkage.cpp
+++ b/projects/rocrand/test/linkage/test_rocrand_linkage.cpp
@@ -32,5 +32,6 @@
 TEST(rocrand_linkage_tests, get_version_test)
 {
     EXPECT_EQ(rocrand_get_version(NULL), ROCRAND_STATUS_OUT_OF_RANGE);
-    EXPECT_GT(get_rocrand_version(), 0);
+    // The library version may be newer in backward compatibility test
+    EXPECT_GE(get_rocrand_version(), ROCRAND_VERSION);
 }

--- a/projects/rocrand/test/test_rocrand_basic.cpp
+++ b/projects/rocrand/test/test_rocrand_basic.cpp
@@ -32,9 +32,9 @@ class rocrand_basic_tests : public ::testing::TestWithParam<rocrand_rng_type> { 
 TEST(rocrand_basic_tests, rocrand_get_version_test)
 {
     EXPECT_EQ(rocrand_get_version(NULL), ROCRAND_STATUS_OUT_OF_RANGE);
-    int version;
+    int version = 0;
     ROCRAND_CHECK(rocrand_get_version(&version));
-    EXPECT_EQ(version, ROCRAND_VERSION);
+    EXPECT_GT(version, 0);
 }
 
 TEST(rocrand_basic_tests, rocrand_generator_test)

--- a/projects/rocrand/test/test_rocrand_basic.cpp
+++ b/projects/rocrand/test/test_rocrand_basic.cpp
@@ -32,9 +32,10 @@ class rocrand_basic_tests : public ::testing::TestWithParam<rocrand_rng_type> { 
 TEST(rocrand_basic_tests, rocrand_get_version_test)
 {
     EXPECT_EQ(rocrand_get_version(NULL), ROCRAND_STATUS_OUT_OF_RANGE);
-    int version = 0;
+    int version;
     ROCRAND_CHECK(rocrand_get_version(&version));
-    EXPECT_GT(version, 0);
+    // The library version may be newer in backward compatibility test
+    EXPECT_GE(version, ROCRAND_VERSION);
 }
 
 TEST(rocrand_basic_tests, rocrand_generator_test)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When conducting backward compatibility tests, QA takes pre-built test binaries from older version and run on current version of ROCm. A couple of rocrand unit tests hard code the version number and compare with the number retrieved from the library. If the version from the library (.so file) is different from the hard coded version, the tests will fail. This breaks some backward compatibility tests.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
These unit tests test the implementation of the rocrand_get_version() function supported by the rocRAND API. In addition, they also verify the retrieved version from this function matches a hard coded version. This part of the test is now changed to support backward compatibility tests, where the retrieved version could be newer than the version built into the test.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Backward compatibility tests on rocrand should all pass. Normal tests of rocrand should continue passing as well.

## Test Result

<!-- Briefly summarize test outcomes. -->
All tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
