### PR TITLE
[hipblaslt] pts: added new entires for api_overhead

### DIFF
--- a/projects/hipblaslt/clients/bench/src/client_api_overhead.cpp
+++ b/projects/hipblaslt/clients/bench/src/client_api_overhead.cpp
@@ -39,22 +39,26 @@ using HHSRunner    = Runner<hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, 
 
 size_t warmups     = 10;
 size_t hotIters    = 1000;
-size_t getAllIters = 100;
+size_t getAllIters = 100; // used for when requested_solution != 1
 int    algoIdx;
 
 double_micro total_getHeur         = double_micro::zero();
+double_micro total_getHeur100      = double_micro::zero();
 double_micro total_getHeurNeg1     = double_micro::zero();
 double_micro total_matmul          = double_micro::zero();
-double_micro total_ext_getHeur     = double_micro::zero();
+double_micro total_ext_getHeur     = double_micro::zero(); // start of ext
+double_micro total_ext_getHeur100  = double_micro::zero();
 double_micro total_ext_getHeurNeg1 = double_micro::zero();
 double_micro total_ext_getAll      = double_micro::zero();
 double_micro total_ext_getByIdx    = double_micro::zero();
 double_micro total_run             = double_micro::zero();
 
 double_micro best_getHeur         = double_micro::max();
+double_micro best_getHeur100      = double_micro::max();
 double_micro best_getHeurNeg1     = double_micro::max();
 double_micro best_matmul          = double_micro::max();
-double_micro best_ext_getHeur     = double_micro::max();
+double_micro best_ext_getHeur     = double_micro::max(); // start of ext
+double_micro best_ext_getHeur100  = double_micro::max();
 double_micro best_ext_getHeurNeg1 = double_micro::max();
 double_micro best_ext_getAll      = double_micro::max();
 double_micro best_ext_getByIdx    = double_micro::max();
@@ -127,7 +131,8 @@ void simpleGemm(hipblasLtHandle_t  handle,
                 void*              d_workspace,
                 int64_t            max_workspace_size,
                 hipStream_t        stream,
-                int                requested_solutions);
+                int                requested_solutions,
+                int&               returned_solutions);
 
 void simpleGemmExt(hipblasLtHandle_t  handle,
                    hipblasOperation_t trans_a,
@@ -145,7 +150,8 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
                    void*              d_workspace,
                    int64_t            max_workspace_size,
                    hipStream_t        stream,
-                   int                requested_solutions);
+                   int                requested_solutions,
+                   int&               returned_solutions);
 
 void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
                               hipblasOperation_t trans_a,
@@ -162,7 +168,8 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
                               void*              d_d,
                               void*              d_workspace,
                               int64_t            max_workspace_size,
-                              hipStream_t        stream);
+                              hipStream_t        stream,
+                              int&               returned_solutions);
 
 void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
                                  hipblasOperation_t trans_a,
@@ -179,12 +186,13 @@ void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
                                  void*              d_d,
                                  void*              d_workspace,
                                  int64_t            max_workspace_size,
-                                 hipStream_t        stream);
+                                 hipStream_t        stream,
+                                 int&               returned_solutions);
 
-void calcOverheadGetHeuristic(int requested_solutions = 1);
-void calcOverheadExtGetHeuristic(int requested_solutions = 1);
-void calcOverheadExtGetAllAlgos();
-void calcOverheadExtGetAlgoByIdx();
+int calcOverheadGetHeuristic(int requested_solutions = 1);
+int calcOverheadExtGetHeuristic(int requested_solutions = 1);
+int calcOverheadExtGetAllAlgos();
+int calcOverheadExtGetAlgoByIdx();
 
 int main(int argc, char** argv)
 {
@@ -194,48 +202,75 @@ int main(int argc, char** argv)
         return err;
     }
 
-    std::cout << "[overhead]:function,api_name,us/iter,best_us\n";
+    int returned_sol;
+    // new: test get heuristic with requested-solution = 100, -1
+    int requested_solutions = 1;
+
+    // ----------- Heuristic ----------- //
+    std::cout << "[overhead]:function,api_name,num_sols,us/iter,best_us\n";
     // calls hipblasLtMatmul hotIters times
-    calcOverheadGetHeuristic();
-    std::cout << "api_overhead,hipblasLtMatmulAlgoGetHeuristic,"
-              << std::to_string(total_getHeur.count() / hotIters) << ","
+    returned_sol = calcOverheadGetHeuristic();
+    std::cout << "api_overhead,hipblasLtMatmulAlgoGetHeuristic," << std::to_string(returned_sol)
+              << "," << std::to_string(total_getHeur.count() / hotIters) << ","
               << std::to_string(best_getHeur.count()) << std::endl;
 
     // calls ext::run hotIters times
-    calcOverheadExtGetHeuristic();
-    std::cout << "api_overhead,hipblaslt_ext::algoGetHeuristic,"
-              << std::to_string(total_ext_getHeur.count() / hotIters) << ","
+    returned_sol = calcOverheadExtGetHeuristic();
+    std::cout << "api_overhead,hipblaslt_ext::algoGetHeuristic," << std::to_string(returned_sol)
+              << "," << std::to_string(total_ext_getHeur.count() / hotIters) << ","
               << std::to_string(best_ext_getHeur.count()) << std::endl;
 
+    // ----------- GetAll ----------- //
     // won't calls ext::run, and note that the hot iter is getAllIters
-    calcOverheadExtGetAllAlgos();
-    std::cout << "api_overhead,hipblaslt_ext::getAllAlgos,"
+    returned_sol = calcOverheadExtGetAllAlgos();
+    std::cout << "api_overhead,hipblaslt_ext::getAllAlgos," << std::to_string(returned_sol) << ","
               << std::to_string(total_ext_getAll.count() / getAllIters) << ","
               << std::to_string(best_ext_getAll.count()) << std::endl;
 
+    // ----------- GetByIdx ----------- //
     // calls ext::run hotIters times
-    calcOverheadExtGetAlgoByIdx();
-    std::cout << "api_overhead,hipblaslt_ext::getAlgosFromIndex,"
-              << std::to_string(total_ext_getByIdx.count() / hotIters) << ","
+    returned_sol = calcOverheadExtGetAlgoByIdx();
+    std::cout << "api_overhead,hipblaslt_ext::getAlgosFromIndex," << std::to_string(returned_sol)
+              << "," << std::to_string(total_ext_getByIdx.count() / hotIters) << ","
               << std::to_string(best_ext_getByIdx.count()) << std::endl;
 
-    // new: get heuristic with requested-solution = -1
-    int requested_solutions = -1;
+    // ----------- GetHeuristic(100) ----------- //
+    requested_solutions = 100;
     // won't calls hipblasLtMatmul if requested_solutions != 1, and note that the hot iter is getAllIters
-    calcOverheadGetHeuristic(requested_solutions);
+    returned_sol = calcOverheadGetHeuristic(requested_solutions);
+    std::cout << "api_overhead,hipblasLtMatmulAlgoGetHeuristic[100],"
+              << std::to_string(returned_sol) << ","
+              << std::to_string(total_getHeur100.count() / getAllIters) << ","
+              << std::to_string(best_getHeur100.count()) << std::endl;
+    // won't calls ext::run if requested_solutions != 1, and note that the hot iter is getAllIters
+    returned_sol = calcOverheadExtGetHeuristic(requested_solutions);
+    std::cout << "api_overhead,hipblaslt_ext::algoGetHeuristic[100],"
+              << std::to_string(returned_sol) << ","
+              << std::to_string(total_ext_getHeur100.count() / getAllIters) << ","
+              << std::to_string(best_ext_getHeur100.count()) << std::endl;
+
+    // ----------- GetHeuristic(-1) ----------- //
+    requested_solutions = -1;
+    // won't calls hipblasLtMatmul if requested_solutions != 1, and note that the hot iter is getAllIters
+    returned_sol = calcOverheadGetHeuristic(requested_solutions);
     std::cout << "api_overhead,hipblasLtMatmulAlgoGetHeuristic[Neg1],"
+              << std::to_string(returned_sol) << ","
               << std::to_string(total_getHeurNeg1.count() / getAllIters) << ","
               << std::to_string(best_getHeurNeg1.count()) << std::endl;
     // won't calls ext::run if requested_solutions != 1, and note that the hot iter is getAllIters
-    calcOverheadExtGetHeuristic(requested_solutions);
+    returned_sol = calcOverheadExtGetHeuristic(requested_solutions);
     std::cout << "api_overhead,hipblaslt_ext::algoGetHeuristic[Neg1],"
+              << std::to_string(returned_sol) << ","
               << std::to_string(total_ext_getHeurNeg1.count() / getAllIters) << ","
               << std::to_string(best_ext_getHeurNeg1.count()) << std::endl;
 
+    // ----------- matmul ----------- //
     // put matmul exec time in the end
-    std::cout << "api_overhead,hipblasLtMatmul," << std::to_string(total_matmul.count() / hotIters)
-              << "," << std::to_string(best_matmul.count()) << std::endl;
-    std::cout << "api_overhead,hipblaslt_ext::run,"
+    returned_sol = 0;
+    std::cout << "api_overhead,hipblasLtMatmul," << std::to_string(returned_sol) << ","
+              << std::to_string(total_matmul.count() / hotIters) << ","
+              << std::to_string(best_matmul.count()) << std::endl;
+    std::cout << "api_overhead,hipblaslt_ext::run," << std::to_string(returned_sol) << ","
               << std::to_string(total_run.count() / (hotIters * 2)) << ","
               << std::to_string(best_run.count()) << std::endl;
 
@@ -245,12 +280,13 @@ int main(int argc, char** argv)
 /////////////////////////////////////////
 // hipBLASLt GetHeuristic & MatMul
 /////////////////////////////////////////
-void calcOverheadGetHeuristic(int requested_solutions)
+int calcOverheadGetHeuristic(int requested_solutions)
 {
     requested_solutions
         = requested_solutions < 0 ? HIPBLASLT_MAX_REQUESTED_SOLUTION_NUM : requested_solutions;
 
     HHSRunner runner(1024, 512, 1024, 1, 1.f, 1.f, 32 * 1024 * 1024);
+    int       returned_sols = 0;
     runner.run([&] {
         simpleGemm(runner.handle,
                    HIPBLAS_OP_N,
@@ -268,8 +304,11 @@ void calcOverheadGetHeuristic(int requested_solutions)
                    runner.d_workspace,
                    runner.max_workspace_size,
                    runner.stream,
-                   requested_solutions);
+                   requested_solutions,
+                   returned_sols);
     });
+
+    return returned_sols;
 }
 
 void simpleGemm(hipblasLtHandle_t  handle,
@@ -288,7 +327,8 @@ void simpleGemm(hipblasLtHandle_t  handle,
                 void*              d_workspace,
                 int64_t            max_workspace_size,
                 hipStream_t        stream,
-                int                requested_solutions)
+                int                requested_solutions,
+                int&               returned_solutions)
 {
     hipblasLtMatrixLayout_t matA, matB, matC, matD;
     CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matA, HIP_R_16F, m, k, m));
@@ -367,6 +407,7 @@ void simpleGemm(hipblasLtHandle_t  handle,
                                                               heuristicResult.data(),
                                                               &returnedAlgoCount));
 
+        returned_solutions = returnedAlgoCount;
         if(returnedAlgoCount == 0)
         {
             std::cerr << "No valid solution found!" << std::endl;
@@ -429,12 +470,18 @@ void simpleGemm(hipblasLtHandle_t  handle,
             best_getHeur = std::min(best_getHeur, duration);
             total_getHeur += duration;
         }
-        else
+        else if(requested_solutions == HIPBLASLT_MAX_REQUESTED_SOLUTION_NUM)
         {
             best_getHeurNeg1 = std::min(best_getHeurNeg1, duration);
             total_getHeurNeg1 += duration;
         }
+        else
+        {
+            best_getHeur100 = std::min(best_getHeur100, duration);
+            total_getHeur100 += duration;
+        }
 
+        returned_solutions = returnedAlgoCount;
         if(returnedAlgoCount == 0)
         {
             std::cerr << "No valid solution found!" << std::endl;
@@ -480,12 +527,13 @@ void simpleGemm(hipblasLtHandle_t  handle,
 /////////////////////////////////////////
 // hipBLASLt_ext - algoGetHeuristic & run
 /////////////////////////////////////////
-void calcOverheadExtGetHeuristic(int requested_solutions)
+int calcOverheadExtGetHeuristic(int requested_solutions)
 {
     requested_solutions
         = requested_solutions < 0 ? HIPBLASLT_MAX_REQUESTED_SOLUTION_NUM : requested_solutions;
 
     HHSRunner runner(1024, 512, 1024, 1, 1.f, 1.f, 32 * 1024 * 1024);
+    int       returned_sols = 0;
     runner.run([&] {
         simpleGemmExt(runner.handle,
                       HIPBLAS_OP_N,
@@ -503,8 +551,11 @@ void calcOverheadExtGetHeuristic(int requested_solutions)
                       runner.d_workspace,
                       runner.max_workspace_size,
                       runner.stream,
-                      requested_solutions);
+                      requested_solutions,
+                      returned_sols);
     });
+
+    return returned_sols;
 }
 
 void simpleGemmExt(hipblasLtHandle_t  handle,
@@ -523,7 +574,8 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
                    void*              d_workspace,
                    int64_t            max_workspace_size,
                    hipStream_t        stream,
-                   int                requested_solutions)
+                   int                requested_solutions,
+                   int&               returned_solutions)
 {
     hipblaslt_ext::GemmPreference gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
@@ -550,6 +602,7 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
         CHECK_HIPBLASLT_ERROR(
             gemm.algoGetHeuristic(requested_solutions, gemmPref, heuristicResult));
 
+        returned_solutions = heuristicResult.size();
         if(heuristicResult.empty())
         {
             std::cerr << "[GemmExt]:No valid solution found!" << std::endl;
@@ -587,12 +640,18 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
             best_ext_getHeur = std::min(best_ext_getHeur, duration);
             total_ext_getHeur += duration;
         }
-        else
+        else if(requested_solutions == HIPBLASLT_MAX_REQUESTED_SOLUTION_NUM)
         {
             best_ext_getHeurNeg1 = std::min(best_ext_getHeurNeg1, duration);
             total_ext_getHeurNeg1 += duration;
         }
+        else
+        {
+            best_ext_getHeur100 = std::min(best_ext_getHeur100, duration);
+            total_ext_getHeur100 += duration;
+        }
 
+        returned_solutions = heuristicResult.size();
         if(heuristicResult.empty())
         {
             std::cerr << "[GemmExt]:No valid solution found!" << std::endl;
@@ -623,10 +682,11 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
 /////////////////////////////////////////
 // hipBLASLt_ext - getAllAlgos & run
 /////////////////////////////////////////
-void calcOverheadExtGetAllAlgos()
+int calcOverheadExtGetAllAlgos()
 {
     HHSRunner runner(1024, 512, 1024, 1, 1.f, 1.f, 32 * 1024 * 1024);
-    runner.run([&runner] {
+    int       returned_sols = 0;
+    runner.run([&runner, &returned_sols] {
         simpleGemmGetAllAlgosExt(runner.handle,
                                  HIPBLAS_OP_N,
                                  HIPBLAS_OP_N,
@@ -642,8 +702,11 @@ void calcOverheadExtGetAllAlgos()
                                  runner.d_d,
                                  runner.d_workspace,
                                  runner.max_workspace_size,
-                                 runner.stream);
+                                 runner.stream,
+                                 returned_sols);
     });
+
+    return returned_sols;
 }
 
 void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
@@ -661,7 +724,8 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
                               void*              d_d,
                               void*              d_workspace,
                               int64_t            max_workspace_size,
-                              hipStream_t        stream)
+                              hipStream_t        stream,
+                              int&               returned_solutions)
 {
     hipblaslt_ext::GemmPreference gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
@@ -711,6 +775,7 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
             }
         }
 
+        returned_solutions = validIdx.size();
         if(validIdx.empty())
         {
             std::cerr << "[GetAllAlgosExt]:No valid solution found!" << std::endl;
@@ -742,6 +807,29 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
         double_micro duration = end_ext_getAll - start_ext_getAll;
         best_ext_getAll       = std::min(best_ext_getAll, duration);
         total_ext_getAll += duration;
+
+        uint64_t            workspace_size = 0;
+        std::vector<size_t> validIdx;
+        for(size_t i = 0; i < heuristicResult.size(); i++)
+        {
+            size_t workspaceSizeInBytes = 0;
+            if(gemm.isAlgoSupported(heuristicResult[i].algo, workspaceSizeInBytes)
+               == HIPBLAS_STATUS_SUCCESS)
+            {
+                if(workspaceSizeInBytes <= max_workspace_size)
+                {
+                    workspace_size = max(workspace_size, workspaceSizeInBytes);
+                    validIdx.push_back(i);
+                }
+            }
+        }
+
+        returned_solutions = validIdx.size();
+        if(validIdx.empty())
+        {
+            std::cerr << "[GetAllAlgosExt]:No valid solution found!" << std::endl;
+            return;
+        }
     }
 
     return;
@@ -750,10 +838,11 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
 /////////////////////////////////////////
 // hipBLASLt_ext - getAlgosFromIndex & run
 /////////////////////////////////////////
-void calcOverheadExtGetAlgoByIdx()
+int calcOverheadExtGetAlgoByIdx()
 {
     HHSRunner runner(1024, 512, 1024, 1, 1.f, 1.f, 32 * 1024 * 1024);
-    runner.run([&runner] {
+    int       returned_sols = 0;
+    runner.run([&runner, &returned_sols] {
         simpleGemmGetAlgoByIndexExt(runner.handle,
                                     HIPBLAS_OP_N,
                                     HIPBLAS_OP_N,
@@ -769,8 +858,11 @@ void calcOverheadExtGetAlgoByIdx()
                                     runner.d_d,
                                     runner.d_workspace,
                                     runner.max_workspace_size,
-                                    runner.stream);
+                                    runner.stream,
+                                    returned_sols);
     });
+
+    return returned_sols;
 }
 
 void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
@@ -788,7 +880,8 @@ void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
                                  void*              d_d,
                                  void*              d_workspace,
                                  int64_t            max_workspace_size,
-                                 hipStream_t        stream)
+                                 hipStream_t        stream,
+                                 int&               returned_solutions)
 {
     hipblaslt_ext::GemmPreference gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
@@ -840,6 +933,7 @@ void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
             }
         }
 
+        returned_solutions = heuristicResult.size();
         if(heuristicResult.empty())
         {
             std::cerr << "[GetAlgoByIndexExt]:No valid solution found!" << std::endl;
@@ -895,6 +989,7 @@ void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
             }
         }
 
+        returned_solutions = heuristicResult.size();
         if(heuristicResult.empty())
         {
             std::cerr << "[GetAlgoByIndexExt]:No valid solution found!" << std::endl;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR is adding a few new tracking entries api_overhead in hipblaslt. And this is also a preparation PR for https://github.com/ROCm/rocm-libraries/pull/2757 which I would like to verify that PR can really reduce the overhead.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Added:
- [x] Added a "num_sols" field to check if the follow-up PR can still return correct solutions
- [x] GetHeuristic with requested_solution = 100
- [x] GetHeuristic with requested_solution = -1

After the first two GetHeuristic (get only one solution, both in c/cpp API), "CachingLibrary" will contain only one solution. 
In this case, I'd like to know if we bench the same problem but request 100 solutions again, what is the behavior ?

When I'm tracing the code, I found that the GetHeuristic( get 100 ) only return one solution from cache, and the rest of 99 solutions are from "getAll" (even if 100 solutions can be returned from findTopSolutions without getAll)
This situation is similar as when setting requested_solution = -1, getAll is always called. 

The result shows:

> ### [overhead]:function,api_name,num_sols,us/iter,best_us
> api_overhead,hipblasLtMatmulAlgoGetHeuristic,1,15.111134,14.859000
> api_overhead,hipblaslt_ext::algoGetHeuristic,1,7.788060,7.558000
> api_overhead,hipblaslt_ext::getAllAlgos,1505,**144378.582950**,141457.371000
> api_overhead,hipblasLtMatmulAlgoGetHeuristic[100],100,**144179.146080**,142785.777000
> api_overhead,hipblaslt_ext::algoGetHeuristic[100],100,**143197.977740**,141912.436000
> api_overhead,hipblasLtMatmulAlgoGetHeuristic[Neg1],1505,**161085.538430**,159418.012000
> api_overhead,hipblaslt_ext::algoGetHeuristic[Neg1],1505,**150868.661910**,149525.587000

getHeuristic with requested solution > 1 (no need to be -1, only 100), the spent time is almost the same as getAll, which I think there is still some way to polish it. (**NOTE: only when the previous request saving a smaller number of solutions in caches**)

My plan is to refine the find-solution process in the PR https://github.com/ROCm/rocm-libraries/pull/2757, and then I can see if I can still get the same "num_sols" but much lower u-seconds. 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Need to notify rocPTS team that the "api_overhead" has new entries to be added in the notification email.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
