### PR TITLE
[hipblaslt] CMS Validator : Check SCC conflicts on scalar instruction overlap

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -276,6 +276,7 @@ def apply_swaits(timeline: list[list[ValidatorInstruction]], num_vmfma: int) -> 
 def verify_scc_overlap(scheduleInfo, context: Dict = {}):
     """
     Ensure we don't overlap scalar instruction modifying scc between GR and GRInc
+    TODO: check GRinA/B dont overlap together.
     """
     kernel = context["kernel"]
     DTL = kernel["DirectToLds"]
@@ -329,7 +330,8 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
                 indexGR = getDeclarationIndex(GRName)
                 for v in m0:
                     for interval in GRIncIntervals:
-                        assert not inInterval(v,interval, indexGRInc<indexGR), f"Code path {codePath}: {GRName} M0 at index {v} can't be between {GRIncName} {interval[0]}-{interval[1]} due to SCC usage."
+                        if inInterval(v,interval, indexGR<indexGRInc):
+                            return False, f"Code path {codePath}: {GRName} M0 at index {v} can't be between {GRIncName} {interval[0]}-{interval[1]} due to SCC usage."
 
     # Validation needed only when we use m0 (ie. DTL).
     if DTL:   

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -322,7 +322,7 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
 
     # Checks value is in [interval[0],interval[1]]. 
     # if lhsGt : ]interval[0],interval[1]] else  [interval[0],interval[1][
-    def inInterval(value, interval, lhsGt):
+    def inInterval(value : int, interval : list[int], lhsGt : bool):
         if lhsGt:
             return value>interval[0] and value<=interval[1]
         else:
@@ -338,35 +338,33 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
         if DTL:
             names += ["GRA", "GRB"]
 
-        def verifyIndices(GRIncName, intervals, name, indices) -> tuple[bool, str]:
+        def verifyIndices(grIncData : GRIncData, name : str, indices : list[int]) -> tuple[bool, str]:
             dclIndex = getDeclarationIndex(name)
-            indexGRInc = getDeclarationIndex(GRIncName)
+            dclIndexGrInc = getDeclarationIndex(grIncData.name)
             for v in indices:
-                for interval in intervals:
-                    if inInterval(v,interval, dclIndex<indexGRInc):
-                        return False, f"Code path {codePath}: {name} at index {v} can't be between {GRIncName} {interval[0]}-{interval[1]} due to SCC usage."
+                for interval in grIncData.intervals:
+                    if inInterval(v,interval, dclIndex<dclIndexGrInc):
+                        return False, f"Code path {codePath}: {name} at index {v} can't be between {grIncData.name} {interval[0]}-{interval[1]} due to SCC usage."
 
         GRIncs = []
         for GRIncName in GRIncNames:
             GRInc = schedule_get(GRIncName, codePath, scheduleInfo)
             assert numElements==len(GRInc), f"Code path {codePath}: {GRIncName} expected size if {numElements}, given {len(GRInc)}."
-            GRIncIntervals = getIntervals(GRInc)
-            data = GRIncData(name = GRIncName, insts = GRInc, intervals = GRIncIntervals)
-            GRIncs.append(data)
+            GRIncs.append(GRIncData(name = GRIncName, insts = GRInc, intervals = getIntervals(GRInc)))
 
-        # First check GRInc together
-        errorMessage = verifyIndices(GRIncs[0].name,GRIncs[0].intervals,GRIncs[1].name, GRIncs[1].insts)
+        # First check GRIncA&B together
+        errorMessage = verifyIndices(GRIncs[0],GRIncs[1].name, GRIncs[1].insts)
         if errorMessage:
             return errorMessage
 
-        # Then, check GR and LW
+        # Then, check GR and LW on all GRIncs
         for grIncData in GRIncs:
             for name in names:
                 insts = schedule_get(name, codePath, scheduleInfo)
                 # In case of GRA/GRB, just take m0 updates indices 
                 if name.startswith("GR"):
                     insts = insts[0::2]
-                errorMessage = verifyIndices(grIncData.name,grIncData.intervals,name, insts)
+                errorMessage = verifyIndices(grIncData, name, insts)
                 if errorMessage:
                     return errorMessage
    

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -321,7 +321,7 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
         GRNames = ["GRA", "GRB"]
         for GRIncName in GRIncNames:
             GRInc = schedule_get(GRIncName, codePath, scheduleInfo)
-            assert numElements==len(GRInc), f"Code path {codePath}: {GRIncName} expected size if {len(intervals)}, given {len(GRInc)}."
+            assert numElements==len(GRInc), f"Code path {codePath}: {GRIncName} expected size if {numElements}, given {len(GRInc)}."
             GRIncIntervals = getIntervals(GRInc)
             indexGRInc = getDeclarationIndex(GRIncName)
             for GRName in GRNames:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -275,27 +275,33 @@ def apply_swaits(timeline: list[list[ValidatorInstruction]], num_vmfma: int) -> 
 
 def verify_scc_overlap(scheduleInfo, context: Dict = {}):
     """
-    Ensure we don't overlap scalar instruction modifying scc between GR and GRInc
-    TODO: check GRinA/B dont overlap together.
+    Ensure we don't overlap scalar instructions modifying SCC.
+    This can happen:
+        - between GRIncA and GRIncB
+        - between GRInc and GR when DLT is activated
+        - between GRInc and LWS
+        
+    By default, GRInc instructions can be split into 3 distinct intervals where we shouldn't touch SCC
+      - s_cmp_eq_u32, s_cselect_b32,s_cselect_b32 (3)
+      - s_add_u32, s_addc_u32 (2)
+      - s_sub_u32, s_subb_u32 (2)
+      - s_cmp_eq_u32, s_cselect_b32 (2)
+    With ShadowLimit disabled (`Use64bShadowLimit`):
+      - s_cmp_eq_u32, s_cselect_b32,s_cselect_b32 (3)
+      - s_add_u32, s_addc_u32 (2)
+      - s_sub_u32  (2)
+    
+        This function checks no scalar instructions from GR and LWS are inside these intervals.
     """
     kernel = context["kernel"]
     DTL = kernel["DirectToLds"]
     ShadowLimit = kernel["Use64bShadowLimit"]
-    # GRInc intervals are defined as follow:
-    # [3,2,2,2]
-    #  - s_cmp_eq_u32, s_cselect_b32,s_cselect_b32
-    #  - s_add_u32, s_add_u32 
-    #  - s_sub_u32, s_subb_u32
-    #  - s_cmp_eq_u32, s_cselect_b32
-    # with ShadowLimit disabled:
-    # [3,2,1]
-    #  - s_cmp_eq_u32, s_cselect_b32,s_cselect_b32
-    #  - s_add_u32, s_add_u32 
-    #  - s_sub_u32 
+
     
     intervalSize = [3,2,2,2] if ShadowLimit else [3,2,1]
     numElements = sum(intervalSize)
     
+    # Gets intervals from GRInc indices based on the above `intervalSize` value
     def getIntervals(indices):
         output = []
         current_start = 0
@@ -307,6 +313,8 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
             current_start = current_end
         return output
 
+    # Checks value is in [interval[0],interval[1]]. 
+    # if lhsGt : ]interval[0],interval[1]] else  [interval[0],interval[1][
     def inInterval(value, interval, lhsGt):
         if lhsGt:
             return value>interval[0] and value<=interval[1]
@@ -316,22 +324,32 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
     def getDeclarationIndex(name):
         return list(scheduleInfo.optSchedule).index(name)
     
+    
+
     def verify(scheduleInfo: 'ScheduleInfo', codePath: int) -> tuple[bool, str]:
         GRIncNames = ["GRIncA", "GRIncB"]
-        GRNames = ["GRA", "GRB"]
+        names = ["GRA", "GRB", "LWSA", "LWSB"]
         for GRIncName in GRIncNames:
             GRInc = schedule_get(GRIncName, codePath, scheduleInfo)
             assert numElements==len(GRInc), f"Code path {codePath}: {GRIncName} expected size if {numElements}, given {len(GRInc)}."
             GRIncIntervals = getIntervals(GRInc)
             indexGRInc = getDeclarationIndex(GRIncName)
-            for GRName in GRNames:
-                GR = schedule_get(GRName, codePath, scheduleInfo)
-                m0 = GR[0::2]
-                indexGR = getDeclarationIndex(GRName)
-                for v in m0:
+
+            def verifyIndices(indices, name) -> tuple[bool, str]:
+                dclIndex = getDeclarationIndex(name)
+                for v in indices:
                     for interval in GRIncIntervals:
-                        if inInterval(v,interval, indexGR<indexGRInc):
-                            return False, f"Code path {codePath}: {GRName} M0 at index {v} can't be between {GRIncName} {interval[0]}-{interval[1]} due to SCC usage."
+                        if inInterval(v,interval, dclIndex<indexGRInc):
+                            return False, f"Code path {codePath}: {name} at index {v} can't be between {GRIncName} {interval[0]}-{interval[1]} due to SCC usage."
+
+            for name in names:
+                insts = schedule_get(name, codePath, scheduleInfo)
+                # In case of GRA/GRB, just take m0 updates indices 
+                if name.startswith("GR"):
+                    insts = insts[0::2]
+                errorMessage =  verifyIndices(insts, name)
+                if errorMessage:
+                    return errorMessage
 
     # Validation needed only when we use m0 (ie. DTL).
     if DTL:   

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -299,7 +299,7 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
       - s_add_u32, s_addc_u32 (2)
       - s_sub_u32  (2)
     
-        This function checks no scalar instructions from GR and LWS are inside these intervals.
+        This function checks no other scalar instructions is inside the above intervals.
     """
     kernel = context["kernel"]
     DTL = kernel["DirectToLds"]
@@ -971,7 +971,7 @@ def _get_schedule_192x256x64_16bit(kernel, useLDSTr, TLDS):
 
 def _get_schedule_256x192x64_16bit(kernel, useLDSTr, TLDS):
     kernel["MfmaInitCVgprs"] = True
-
+    numMfma = 96
     optSchedule = dict()
     syncCode = []
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
@@ -1016,6 +1016,9 @@ def _get_schedule_256x192x64_16bit(kernel, useLDSTr, TLDS):
             }
         syncCode = syncTable[1::2]
         nglshift = nllshift = 14 # vmcnt shift for ngl and nll
+        # TODO : GRA at index 10 can't be between GRIncB 9-11 due to SCC usage
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
+        opt1.disableValidation()
     elif isNT(kernel) and useLDSTr and TLDS == 0:
         kernel["SwapGlobalReadOrder"] = True
         #index and code pair
@@ -1053,6 +1056,7 @@ def _get_schedule_256x192x64_16bit(kernel, useLDSTr, TLDS):
                 'LCC' : [[95, 95]],}
         syncCode = syncTable[1::2]
         nglshift = nllshift = 14 # vmcnt shift for ngl and nll
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     elif isNN(kernel) and useLDSTr and TLDS == 1:
         kernel["SwapGlobalReadOrder"] = True
         #index and code pair
@@ -1092,11 +1096,10 @@ def _get_schedule_256x192x64_16bit(kernel, useLDSTr, TLDS):
                 }
         syncCode = syncTable[1::2]
         nglshift = nllshift = 14 # vmcnt shift for ngl and nll
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     else:
         return False, None
-
-    numMfma = 96
-    opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
+    
     return True, opt1
 
 def _get_schedule_256x256x128_8bit(kernel, useLDSTr, TLDS):
@@ -1289,7 +1292,7 @@ def _get_schedule_256x256x64_16bit(kernel, useLDSTr, TLDS):
 
 def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
     kernel["MfmaInitCVgprs"] = True
-
+    numMfma = 80
     optSchedule = dict()
     syncCode = []
 
@@ -1338,6 +1341,9 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
                     SBarrier(comment=""),
                    ]
         nglshift = nllshift = 13 # vmcnt shift for ngl and nll
+        #TODO . GRA at index 11 can't be between GRIncB 9-12 due to SCC usage
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
+        opt1.disableValidation()
     elif isNN(kernel) and useLDSTr and TLDS==1:
         kernel["SwapGlobalReadOrder"] = True
         optSchedule = {
@@ -1375,7 +1381,7 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
                     SWaitCnt(dscnt=-1, vlcnt=(13+10-13), vscnt=-1, comment="Wait for previous GRA to complete"),
                     SBarrier(comment="")]
         nglshift = nllshift = 13
-
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     elif isNT(kernel) and useLDSTr and TLDS==0:
         optSchedule = {
             'SYNC': [[-1,17,17,57,57]],
@@ -1402,17 +1408,19 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
             SBarrier(comment="")
         ]
         nglshift = nllshift = 13
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     else:
         return False, None
 
 
-    numMfma = 80
-    opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
+    
+    
     return True, opt1
 
 def _get_schedule_256x160x64_16bit(kernel, useLDSTr, TLDS):
     kernel["MfmaInitCVgprs"] = True
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
+    numMfma = 80
     if isNN(kernel) and useLDSTr and TLDS==1:
         kernel["SwapGlobalReadOrder"] = True
         optSchedule = {
@@ -1450,6 +1458,9 @@ def _get_schedule_256x160x64_16bit(kernel, useLDSTr, TLDS):
                     SWaitCnt(dscnt=-1, vlcnt=(13+10-13), vscnt=-1, comment="Wait for previous GRA to complete"),
                     SBarrier(comment="")]
         nglshift = nllshift = 13
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
+        #TODO. GRA at index 11 can't be between GRIncB 10-13 due to SCC usage.
+        opt1.disableValidation()
     elif isNT(kernel) and useLDSTr and TLDS==0:
         nglshift = nllshift = 0
         kernel["SwapGlobalReadOrder"] = True
@@ -1477,11 +1488,10 @@ def _get_schedule_256x160x64_16bit(kernel, useLDSTr, TLDS):
             SBarrier(comment="")
         ]
         nglshift = nllshift = 13
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     else:
         return False, None
 
-    numMfma = 80
-    opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     return True, opt1
 
 def _get_schedule_256x240x64_16bit(kernel, useLDSTr, TLDS):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -273,6 +273,72 @@ def apply_swaits(timeline: list[list[ValidatorInstruction]], num_vmfma: int) -> 
             local_read.guaranteed_by = min(local_read.guaranteed_by, new_guaranteed_by)
 
 
+def verify_scc_overlap(scheduleInfo, context: Dict = {}):
+    """
+    Ensure we don't overlap scalar instruction modifying scc between GR and GRInc
+    """
+    kernel = context["kernel"]
+    DTL = kernel["DirectToLds"]
+    ShadowLimit = kernel["Use64bShadowLimit"]
+    # GRInc intervals are defined as follow:
+    # [3,2,2,2]
+    #  - s_cmp_eq_u32, s_cselect_b32,s_cselect_b32
+    #  - s_add_u32, s_add_u32 
+    #  - s_sub_u32, s_subb_u32
+    #  - s_cmp_eq_u32, s_cselect_b32
+    # with ShadowLimit disabled:
+    # [3,2,1]
+    #  - s_cmp_eq_u32, s_cselect_b32,s_cselect_b32
+    #  - s_add_u32, s_add_u32 
+    #  - s_sub_u32 
+    
+    intervalSize = [3,2,2,2] if ShadowLimit else [3,2,1]
+    numElements = sum(intervalSize)
+    
+    def getIntervals(indices):
+        output = []
+        current_start = 0
+        for size in intervalSize:
+            current_end = current_start + size
+            min_val = indices[current_start]
+            max_val = indices[current_end - 1]
+            output.append([min_val, max_val])
+            current_start = current_end
+        return output
+
+    def inInterval(value, interval, lhsGt):
+        if lhsGt:
+            return value>interval[0] and value<=interval[1]
+        else:
+            return value>=interval[0] and value<interval[1]
+
+    def getDeclarationIndex(name):
+        return list(scheduleInfo.optSchedule).index(name)
+    
+    def verify(scheduleInfo: 'ScheduleInfo', codePath: int) -> tuple[bool, str]:
+        GRIncNames = ["GRIncA", "GRIncB"]
+        GRNames = ["GRA", "GRB"]
+        for GRIncName in GRIncNames:
+            GRInc = schedule_get(GRIncName, codePath, scheduleInfo)
+            assert numElements==len(GRInc), f"Code path {codePath}: {GRIncName} expected size if {len(intervals)}, given {len(GRInc)}."
+            GRIncIntervals = getIntervals(GRInc)
+            indexGRInc = getDeclarationIndex(GRIncName)
+            for GRName in GRNames:
+                GR = schedule_get(GRName, codePath, scheduleInfo)
+                m0 = GR[0::2]
+                indexGR = getDeclarationIndex(GRName)
+                for v in m0:
+                    for interval in GRIncIntervals:
+                        assert not inInterval(v,interval, indexGRInc<indexGR), f"Code path {codePath}: {GRName} M0 at index {v} can't be between {GRIncName} {interval[0]}-{interval[1]} due to SCC usage."
+
+    # Validation needed only when we use m0 (ie. DTL).
+    if DTL:   
+        for codePath in range(scheduleInfo.numCodePaths):
+            errorMessage = verify(scheduleInfo, codePath)
+            if errorMessage:
+                return False, f"Code path {codePath}: {errorMessage}"
+    return True, ""
+
 def verify_lrs_complete_before_vmfma(schedule_info: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
     """
     Ensure that the A and B data needed for VMFA at index=i is guaranteed to be in the registers before index=i.
@@ -394,7 +460,8 @@ class ScheduleInfo:
         self.rules: list[Callable[[ScheduleInfo, dict], [bool, str]]] = [
             verify_correct_number_of_instructions,
             verifyAscendingOrder,
-            verify_lrs_complete_before_vmfma
+            verify_lrs_complete_before_vmfma,
+            verify_scc_overlap
         ]
 
     def disableValidation(self):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -344,12 +344,12 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
             for v in indices:
                 for interval in grIncData.intervals:
                     if inInterval(v,interval, dclIndex<dclIndexGrInc):
-                        return False, f"Code path {codePath}: {name} at index {v} can't be between {grIncData.name} {interval[0]}-{interval[1]} due to SCC usage."
+                        return False, f"{name} at index {v} can't be between {grIncData.name} {interval[0]}-{interval[1]} due to SCC usage."
 
         GRIncs = []
         for GRIncName in GRIncNames:
             GRInc = schedule_get(GRIncName, codePath, scheduleInfo)
-            assert numElements==len(GRInc), f"Code path {codePath}: {GRIncName} expected size if {numElements}, given {len(GRInc)}."
+            assert numElements==len(GRInc), f"{GRIncName} expected size if {numElements}, given {len(GRInc)}."
             GRIncs.append(GRIncData(name = GRIncName, insts = GRInc, intervals = getIntervals(GRInc)))
 
         # First check GRIncA&B together

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -272,6 +272,14 @@ def apply_swaits(timeline: list[list[ValidatorInstruction]], num_vmfma: int) -> 
                 new_guaranteed_by += 0.5
             local_read.guaranteed_by = min(local_read.guaranteed_by, new_guaranteed_by)
 
+@dataclass
+class GRIncData:
+    """
+    Data structure representing GRInc-related information.
+    """
+    name: list[int]
+    intervals: list[tuple[int, int]]
+    insts: list[int]
 
 def verify_scc_overlap(scheduleInfo, context: Dict = {}):
     """
@@ -296,9 +304,8 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
     kernel = context["kernel"]
     DTL = kernel["DirectToLds"]
     ShadowLimit = kernel["Use64bShadowLimit"]
-
     
-    intervalSize = [3,2,2,2] if ShadowLimit else [3,2,1]
+    intervalSize = [3,2,2,2] if ShadowLimit else [3,2,1] # Values explained above
     numElements = sum(intervalSize)
     
     # Gets intervals from GRInc indices based on the above `intervalSize` value
@@ -323,37 +330,47 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
 
     def getDeclarationIndex(name):
         return list(scheduleInfo.optSchedule).index(name)
-    
-    
 
     def verify(scheduleInfo: 'ScheduleInfo', codePath: int) -> tuple[bool, str]:
         GRIncNames = ["GRIncA", "GRIncB"]
-        names = ["GRA", "GRB", "LWSA", "LWSB"]
+        names = ["LWSA", "LWSB"]
+        # We only care about GRA/B when DTL is activated (m0 usage)
+        if DTL:
+            names += ["GRA", "GRB"]
+
+        def verifyIndices(GRIncName, intervals, name, indices) -> tuple[bool, str]:
+            dclIndex = getDeclarationIndex(name)
+            indexGRInc = getDeclarationIndex(GRIncName)
+            for v in indices:
+                for interval in intervals:
+                    if inInterval(v,interval, dclIndex<indexGRInc):
+                        return False, f"Code path {codePath}: {name} at index {v} can't be between {GRIncName} {interval[0]}-{interval[1]} due to SCC usage."
+
+        GRIncs = []
         for GRIncName in GRIncNames:
             GRInc = schedule_get(GRIncName, codePath, scheduleInfo)
             assert numElements==len(GRInc), f"Code path {codePath}: {GRIncName} expected size if {numElements}, given {len(GRInc)}."
             GRIncIntervals = getIntervals(GRInc)
-            indexGRInc = getDeclarationIndex(GRIncName)
+            data = GRIncData(name = GRIncName, insts = GRInc, intervals = GRIncIntervals)
+            GRIncs.append(data)
 
-            def verifyIndices(indices, name) -> tuple[bool, str]:
-                dclIndex = getDeclarationIndex(name)
-                for v in indices:
-                    for interval in GRIncIntervals:
-                        if inInterval(v,interval, dclIndex<indexGRInc):
-                            return False, f"Code path {codePath}: {name} at index {v} can't be between {GRIncName} {interval[0]}-{interval[1]} due to SCC usage."
+        # First check GRInc together
+        errorMessage = verifyIndices(GRIncs[0].name,GRIncs[0].intervals,GRIncs[1].name, GRIncs[1].insts)
+        if errorMessage:
+            return errorMessage
 
+        # Then, check GR and LW
+        for grIncData in GRIncs:
             for name in names:
                 insts = schedule_get(name, codePath, scheduleInfo)
                 # In case of GRA/GRB, just take m0 updates indices 
                 if name.startswith("GR"):
                     insts = insts[0::2]
-                errorMessage =  verifyIndices(insts, name)
+                errorMessage = verifyIndices(grIncData.name,grIncData.intervals,name, insts)
                 if errorMessage:
                     return errorMessage
-
-    # Validation needed only when we use m0 (ie. DTL).
-    if DTL:   
-        for codePath in range(scheduleInfo.numCodePaths):
+   
+    for codePath in range(scheduleInfo.numCodePaths):
             errorMessage = verify(scheduleInfo, codePath)
             if errorMessage:
                 return False, f"Code path {codePath}: {errorMessage}"

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -33,6 +33,7 @@ def create_base_kernel():
         "LocalReadVectorWidth": 0,
         "WaveSeparateGlobalReadA": 0,
         "WaveSeparateGlobalReadB": 0,
+        "Use64bShadowLimit" : 1,
         "MatrixInstruction": [],
         "MIWaveGroup": [],
         "LDSTrInst": False,

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
@@ -33,12 +33,13 @@ class TestVerifySCCOverlap(unittest.TestCase):
         self.kernel = create_base_kernel()
         self.kernel["MIWaveTileA"] = 4
         self.kernel["MIWaveTileB"] = 4
-        self.kernel["Use64bShadowLimit"] = 1
+        
         self.kernel["DirectToLds"] = 1
         self.num_vmfma = 2 * self.kernel["MIWaveTileA"] * self.kernel["MIWaveTileB"]
 
     
     def test_simple(self):
+        self.kernel["Use64bShadowLimit"] = 1
         assert self.num_vmfma == 32
         optSchedule = {
             "SYNC": [0],
@@ -67,12 +68,19 @@ class TestVerifySCCOverlap(unittest.TestCase):
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
     def test_simple_declaration_order(self):
+        self.kernel["Use64bShadowLimit"] = 1
         assert self.num_vmfma == 32
         optSchedule = {
             "SYNC": [0],
             "GRA": [[16, 17]],
-            "GRIncA": [[0, 0, 1, 2, 3, 4, 5, 6, 7]],
-            "GRIncB": [[8, 8, 9, 10, 11, 12, 13, 14, 15]],
+            "GRIncA": [[0, 0, 1,
+                        2, 3,
+                        4, 5,
+                        6, 7]],
+            "GRIncB": [[8, 8, 9,
+                        10, 11,
+                        12, 13,
+                        14, 15]],
             "GRB": [[18, 19]]
         }
         syncCode = [
@@ -107,11 +115,18 @@ class TestVerifySCCOverlap(unittest.TestCase):
 
 
     def test_simple_interval(self):
+        self.kernel["Use64bShadowLimit"] = 1
         assert self.num_vmfma == 32
         optSchedule = {
             "SYNC": [0],
-            "GRIncA": [[0, 0, 1, 2, 3, 4, 5, 6, 7]],
-            "GRIncB": [[8, 8, 9, 10, 11, 12, 13, 14, 15]],
+            "GRIncA": [[0, 0, 1,
+                        2, 3,
+                        4, 5,
+                        6, 7]],
+            "GRIncB": [[8, 8, 9,
+                        10, 11,
+                        12, 13,
+                        14, 15]],
             "GRA": [[16, 17]],
             "GRB": [[18, 19]]
         }
@@ -140,15 +155,44 @@ class TestVerifySCCOverlap(unittest.TestCase):
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
 
-    # def test_simple_noshadow(self):
-    #     assert self.num_vmfma == 32
-    #     optSchedule = {
-    #         "SYNC": [0],
-    #         "GRIncA": [[0, 0, 1, 2, 3, 4, 5, 6, 7]],
-    #         "GRIncB": [[8, 8, 9, 10, 11, 12, 13, 14, 15]],
-    #         "GRA": [[16, 17]],
-    #         "GRB": [[18, 19]]
-    #     }
-    #     syncCode = [
-    #         SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
-    #     ]
+    def test_simple_noshadow(self):
+        self.kernel["Use64bShadowLimit"] = 0
+        assert self.num_vmfma == 32
+        optSchedule = {
+            "SYNC": [0],
+            "GRIncA": [[0, 0, 1,
+                        2, 3,
+                        4]],
+            "GRA": [[16, 17]],
+            "GRIncB": [[6, 7, 8,
+                        9, 10,
+                        10]],
+            "GRB": [[18, 19]]
+        }
+        syncCode = [
+            SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        # GRA inside GRInc interval
+        optSchedule["GRA"] = [[0, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+        # GRA just after GRInc interval
+        optSchedule["GRA"] = [[1, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        # GRB after GRIncB-10 
+        optSchedule["GRB"] = [[10, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        # GRA before GRIncB-10 -> middle of interval
+        optSchedule["GRA"] = [[10, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
@@ -1,0 +1,136 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+################################################################################
+import unittest
+from rocisa.instruction import SWaitCnt
+
+from Tensile.Components.CustomSchedule import verify_scc_overlap
+from test_CustomSchedule import create_base_kernel, ScheduleInfo
+
+class TestVerifySCCOverlap(unittest.TestCase):
+    def setUp(self):
+        self.kernel = create_base_kernel()
+        self.kernel["MIWaveTileA"] = 4
+        self.kernel["MIWaveTileB"] = 4
+        self.kernel["Use64bShadowLimit"] = 1
+        self.kernel["DirectToLds"] = 1
+        self.num_vmfma = 2 * self.kernel["MIWaveTileA"] * self.kernel["MIWaveTileB"]
+
+    
+    def test_simple(self):
+        assert self.num_vmfma == 32
+        optSchedule = {
+            "SYNC": [0],
+            "GRIncA": [[0, 0, 1, 1, 2, 2, 3, 3, 4]],
+            "GRIncB": [[5, 5, 6, 6, 7, 7, 8, 8, 9]],
+            "GRA": [[10, 11]],
+            "GRB": [[12, 13]]
+        }
+        syncCode = [
+            SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        # GRA in GRIncA
+        optSchedule["GRA"] = [[2, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+        # GRB in GRIncB
+        optSchedule["GRA"] = [[10, 11]]
+        optSchedule["GRB"] = [[6, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+    def test_simple_declaration_order(self):
+        assert self.num_vmfma == 32
+        optSchedule = {
+            "SYNC": [0],
+            "GRA": [[16, 17]],
+            "GRIncA": [[0, 0, 1, 2, 3, 4, 5, 6, 7]],
+            "GRIncB": [[8, 8, 9, 10, 11, 12, 13, 14, 15]],
+            "GRB": [[18, 19]]
+        }
+        syncCode = [
+            SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        # GRA just before GRIncA
+        optSchedule["GRA"] = [[0, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert  status, f"Schedule should have passed validation but did not. {message}"
+
+        # GRB just before GRIncB
+        optSchedule["GRB"] = [[8, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+        # GRA just after GRIncA
+        optSchedule["GRB"] = [[12, 13]]
+        optSchedule["GRA"] = [[1, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+        # GRB just after GRIncA
+        optSchedule["GRA"] = [[10, 11]]
+        optSchedule["GRB"] = [[1, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+
+    def test_simple_interval(self):
+        assert self.num_vmfma == 32
+        optSchedule = {
+            "SYNC": [0],
+            "GRIncA": [[0, 0, 1, 2, 3, 4, 5, 6, 7]],
+            "GRIncB": [[8, 8, 9, 10, 11, 12, 13, 14, 15]],
+            "GRA": [[16, 17]],
+            "GRB": [[18, 19]]
+        }
+        syncCode = [
+            SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        optSchedule["GRA"] = [[0, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert  not status, f"Schedule should have failed validation but did not. {message}"
+
+        optSchedule["GRA"] = [[2, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+        optSchedule["GRA"] = [[3, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert  status, f"Schedule should have passed validation but did not. {message}"

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
@@ -46,7 +46,9 @@ class TestVerifySCCOverlap(unittest.TestCase):
             "GRIncA": [[0, 0, 1, 1, 2, 2, 3, 3, 4]],
             "GRIncB": [[5, 5, 6, 6, 7, 7, 8, 8, 9]],
             "GRA": [[10, 11]],
-            "GRB": [[12, 13]]
+            "GRB": [[12, 13]],
+            'LWSA': [[31]],
+            'LWSB': [[31]]
         }
         syncCode = [
             SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
@@ -81,7 +83,9 @@ class TestVerifySCCOverlap(unittest.TestCase):
                         10, 11,
                         12, 13,
                         14, 15]],
-            "GRB": [[18, 19]]
+            "GRB": [[18, 19]],
+            'LWSA': [[31]],
+            'LWSB': [[31]]
         }
         syncCode = [
             SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
@@ -128,7 +132,9 @@ class TestVerifySCCOverlap(unittest.TestCase):
                         12, 13,
                         14, 15]],
             "GRA": [[16, 17]],
-            "GRB": [[18, 19]]
+            "GRB": [[18, 19]],
+            'LWSA': [[31]],
+            'LWSB': [[31]]
         }
         syncCode = [
             SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
@@ -167,7 +173,9 @@ class TestVerifySCCOverlap(unittest.TestCase):
             "GRIncB": [[6, 7, 8,
                         9, 10,
                         10]],
-            "GRB": [[18, 19]]
+            "GRB": [[18, 19]],
+            'LWSA': [[31]],
+            'LWSB': [[31]]
         }
         syncCode = [
             SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
@@ -194,5 +202,45 @@ class TestVerifySCCOverlap(unittest.TestCase):
 
         # GRA before GRIncB-10 -> middle of interval
         optSchedule["GRA"] = [[10, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+    def test_lws(self):
+        self.kernel["Use64bShadowLimit"] = 0
+        assert self.num_vmfma == 32
+        optSchedule = {
+            "SYNC": [0],
+            'LWSA': [[31]],
+            "GRIncA": [[0, 0, 1,
+                        2, 3,
+                        4]],
+            "GRA": [[16, 17]],
+            "GRIncB": [[6, 7, 8,
+                        9, 10,
+                        10]],
+            "GRB": [[18, 19]],
+            'LWSB': [[31]]
+        }
+        syncCode = [
+            SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        optSchedule["LWSA"] = [[0]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        optSchedule["LWSA"] = [[1]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+        optSchedule["LWSA"] = [[2]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        optSchedule["LWSB"] = [[9]]
         status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
         assert not status, f"Schedule should have failed validation but did not. {message}"

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
@@ -134,3 +134,21 @@ class TestVerifySCCOverlap(unittest.TestCase):
         optSchedule["GRA"] = [[3, 11]]
         status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
         assert  status, f"Schedule should have passed validation but did not. {message}"
+
+        optSchedule["GRB"] = [[6, 11]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+
+    # def test_simple_noshadow(self):
+    #     assert self.num_vmfma == 32
+    #     optSchedule = {
+    #         "SYNC": [0],
+    #         "GRIncA": [[0, 0, 1, 2, 3, 4, 5, 6, 7]],
+    #         "GRIncB": [[8, 8, 9, 10, 11, 12, 13, 14, 15]],
+    #         "GRA": [[16, 17]],
+    #         "GRB": [[18, 19]]
+    #     }
+    #     syncCode = [
+    #         SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
+    #     ]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
@@ -38,7 +38,7 @@ class TestVerifySCCOverlap(unittest.TestCase):
         self.num_vmfma = 2 * self.kernel["MIWaveTileA"] * self.kernel["MIWaveTileB"]
 
     
-    def test_simple(self):
+    def test_gr_simple(self):
         self.kernel["Use64bShadowLimit"] = 1
         assert self.num_vmfma == 32
         optSchedule = {
@@ -69,7 +69,7 @@ class TestVerifySCCOverlap(unittest.TestCase):
         status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
-    def test_simple_declaration_order(self):
+    def test_gr_declaration_order(self):
         self.kernel["Use64bShadowLimit"] = 1
         assert self.num_vmfma == 32
         optSchedule = {
@@ -118,7 +118,7 @@ class TestVerifySCCOverlap(unittest.TestCase):
         assert status, f"Schedule should have passed validation but did not. {message}"
 
 
-    def test_simple_interval(self):
+    def test_gr_interval(self):
         self.kernel["Use64bShadowLimit"] = 1
         assert self.num_vmfma == 32
         optSchedule = {
@@ -161,7 +161,7 @@ class TestVerifySCCOverlap(unittest.TestCase):
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
 
-    def test_simple_noshadow(self):
+    def test_gr_noshadow(self):
         self.kernel["Use64bShadowLimit"] = 0
         assert self.num_vmfma == 32
         optSchedule = {
@@ -244,3 +244,44 @@ class TestVerifySCCOverlap(unittest.TestCase):
         optSchedule["LWSB"] = [[9]]
         status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
         assert not status, f"Schedule should have failed validation but did not. {message}"
+
+        
+    def test_gr_inc_together(self):
+        self.kernel["Use64bShadowLimit"] = 0
+        assert self.num_vmfma == 32
+        optSchedule = {
+            "SYNC": [0],
+            'LWSA': [[31]],
+            "GRIncA": [[0, 0, 1,
+                        3, 4,
+                        4]],
+            "GRA": [[16, 17]],
+            "GRIncB": [[6, 7, 8,
+                        9, 10,
+                        10]],
+            "GRB": [[18, 19]],
+            'LWSB': [[31]]
+        }
+        syncCode = [
+            SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+        optSchedule["GRIncB"] = [[0, 0, 1,
+                                  9, 10,
+                                  10]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but did not. {message}"
+
+        optSchedule["GRIncB"] = [[1, 1, 2,
+                            9, 10,
+                            10]]
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+
+
+    


### PR DESCRIPTION
## Description

Adds CMS validator to check scalar instructions overlap using SCC. This can happen in the following cases:
 - interleaving of GRIncA and GRIncB
 - interleaving of GRIncA/B and GRA/B when DTL is activated
 - interleaving GRIncA/B and LWSA/B

This PR disables CMS validation for (to be fixed in separate PR):
 - 256x192x64 TN : https://github.com/ROCm/rocm-libraries/pull/3104 . Fixed but Validation still disabled due to https://github.com/ROCm/rocm-libraries/issues/3091
 - 160x256x64 TN : https://github.com/ROCm/rocm-libraries/pull/3127
 - 256x160x64 NN : https://github.com/ROCm/rocm-libraries/pull/3122
 
