### PR TITLE
rocfft: tolerate comma as GPU_TARGETS separator

### DIFF
--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -169,7 +169,7 @@ else()
 endif()
 # tolerate comma as a value separator since the compiler does the
 # same
-string(REPLACE "," ";" GPU_TARGETS ${GPU_TARGETS})
+string(REPLACE "," ";" GPU_TARGETS "${GPU_TARGETS}")
 rocm_check_target_ids(GPU_TARGETS TARGETS "${GPU_TARGETS}")
   
 # HIP is required - library and clients use HIP to access the device

--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -167,6 +167,9 @@ else()
   # Don't force, users should be able to override GPU_TARGETS at the command line if desired
   set(GPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "GPU architectures to build for")
 endif()
+# tolerate comma as a value separator since the compiler does the
+# same
+string(REPLACE "," ";" GPU_TARGETS ${GPU_TARGETS})
 rocm_check_target_ids(GPU_TARGETS TARGETS "${GPU_TARGETS}")
   
 # HIP is required - library and clients use HIP to access the device


### PR DESCRIPTION
## Motivation

Fix mishandling of comma-separated GPU_TARGETS CMake variable.

## Technical Details

Multi-valued CMake variables are semicolon-separated.  But the compiler tolerates a comma-separated offload arch list and treats it like each arch was specified separately anyway.

So allow GPU_TARGETS to be comma-separated.  With this change, our build steps that depend on knowing the exact list of architectures (AOT compilation, solution map construction) will gracefully handle the separate values.

## Test Plan

Manual builds with comma- and semicolon-separated architectures.

## Test Result

Builds run fine.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
