### PR TITLE
Add bfloat16 support for pooling algorithms

### DIFF
--- a/projects/miopen/driver/dm_pool.cpp
+++ b/projects/miopen/driver/dm_pool.cpp
@@ -32,6 +32,8 @@ static Driver* makeDriver(const std::string& base_arg)
         return new PoolDriver<float, double>();
     if(base_arg == "poolfp16")
         return new PoolDriver<float16, double>();
+    if(base_arg == "poolbfp16")
+        return new PoolDriver<bfloat16, double>();
     return nullptr;
 }
 

--- a/projects/miopen/driver/driver.hpp
+++ b/projects/miopen/driver/driver.hpp
@@ -383,7 +383,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
 {
     printf("Usage: ./driver *base_arg* *other_args*\n");
     printf("Supported Base Arguments: conv[fp16|int8|bfp16], CBAInfer[fp16|bfp16], "
-           "CAInfer[fp16|bfp16], pool[fp16], lrn[fp16], activ[fp16], softmax[bfp16|fp16], "
+           "CAInfer[fp16|bfp16], pool[fp16|bfp16], lrn[fp16], activ[fp16], softmax[bfp16|fp16], "
            "bnorm[fp16|bfp16], rnn[fp16], rnn_seq[fp16], gemm[fp16], ctc, dropout[fp16], tensorop, "
            "reduce[fp16|fp64], layernorm[bfp16|fp16], groupnorm[bfp16|fp16], cat[bfp16|fp16], "
            "addlayernorm[bfp16|fp16], t5layernorm[bfp16|fp16], adam[fp16], ampadam, "
@@ -417,6 +417,7 @@ inline std::string ParseBaseArg(int argc, char* argv[])
                                                         "CAInferbfp16",
                                                         "pool",
                                                         "poolfp16",
+                                                        "poolbfp16",
                                                         "lrn",
                                                         "lrnfp16",
                                                         "activ",

--- a/projects/miopen/driver/mloPoolingHost.hpp
+++ b/projects/miopen/driver/mloPoolingHost.hpp
@@ -39,6 +39,7 @@
 #include <type_traits>
 
 #include "calcerr.hpp"
+#include <miopen/bfloat16.hpp>
 
 #if 0
 template<typename _T>
@@ -394,9 +395,10 @@ bool mloPoolingForwardRunHostAndVerify(PoolingConfig poolConf,
 
     bool match = true;
     Tcheck_ MAX_VAL(3.402823466e+38);
-    Tgpu_ G_MAX_VAL = (sizeof(Tgpu_) == 4 || sizeof(Tgpu_) == 8)
-                          ? static_cast<Tgpu_>(3.402823466e+38)
-                          : static_cast<Tgpu_>(65504);
+    Tgpu_ G_MAX_VAL =
+        (sizeof(Tgpu_) == 4 || sizeof(Tgpu_) == 8 || std::is_same<Tgpu_, bfloat16>::value)
+            ? static_cast<Tgpu_>(3.402823466e+38)
+            : static_cast<Tgpu_>(65504);
 
     for(int b = 0; b < bot_dims_strides.n_batchs && match; b++)
     {

--- a/projects/miopen/driver/mloPoolingHost.hpp
+++ b/projects/miopen/driver/mloPoolingHost.hpp
@@ -36,6 +36,7 @@
 #include <cmath>
 #include <cstring>
 #include <iomanip>
+#include <limits>
 #include <type_traits>
 
 #include "calcerr.hpp"
@@ -395,8 +396,7 @@ bool mloPoolingForwardRunHostAndVerify(PoolingConfig poolConf,
 
     bool match = true;
     Tcheck_ MAX_VAL(3.402823466e+38);
-    Tgpu_ G_MAX_VAL = std::is_same<Tgpu_, float16>::value ? static_cast<Tgpu_>(65504)
-                                                          : static_cast<Tgpu_>(3.402823466e+38);
+    Tgpu_ G_MAX_VAL = std::numeric_limits<Tgpu_>::max();
 
     for(int b = 0; b < bot_dims_strides.n_batchs && match; b++)
     {
@@ -458,9 +458,7 @@ bool mloPoolingForwardRunHostAndVerify_mt(PoolingConfig poolConf,
 
     std::atomic_bool match = true;
     Tcheck_ MAX_VAL(3.402823466e+38);
-    Tgpu_ G_MAX_VAL = (sizeof(Tgpu_) == 4 || sizeof(Tgpu_) == 8)
-                          ? static_cast<Tgpu_>(3.402823466e+38)
-                          : static_cast<Tgpu_>(65504);
+    Tgpu_ G_MAX_VAL = std::numeric_limits<Tgpu_>::max();
     std::mutex stats_mutex;
     miopen::par_ford(bot_dims_strides.n_batchs, bot_dims_strides.n_outputs)([&](int b, int o) {
         fwd_pooling_compute_verify<true>(bot_dims_strides,

--- a/projects/miopen/driver/mloPoolingHost.hpp
+++ b/projects/miopen/driver/mloPoolingHost.hpp
@@ -395,10 +395,8 @@ bool mloPoolingForwardRunHostAndVerify(PoolingConfig poolConf,
 
     bool match = true;
     Tcheck_ MAX_VAL(3.402823466e+38);
-    Tgpu_ G_MAX_VAL =
-        (sizeof(Tgpu_) == 4 || sizeof(Tgpu_) == 8 || std::is_same<Tgpu_, bfloat16>::value)
-            ? static_cast<Tgpu_>(3.402823466e+38)
-            : static_cast<Tgpu_>(65504);
+    Tgpu_ G_MAX_VAL = std::is_same<Tgpu_, float16>::value ? static_cast<Tgpu_>(65504)
+                                                          : static_cast<Tgpu_>(3.402823466e+38);
 
     for(int b = 0; b < bot_dims_strides.n_batchs && match; b++)
     {

--- a/projects/miopen/driver/pool_driver.hpp
+++ b/projects/miopen/driver/pool_driver.hpp
@@ -45,6 +45,7 @@
 #include <float.h>
 #include <memory>
 #include <numeric>
+#include <type_traits>
 #include <vector>
 
 template <typename T>
@@ -66,7 +67,7 @@ public:
         miopenCreateTensorDescriptor(&dOutputTensor);
 
         miopenCreatePoolingDescriptor(&poolDesc);
-        data_type = (sizeof(Tgpu) == 4) ? miopenFloat : miopenHalf;
+        InitDataType<Tgpu>();
     }
 
     int AddCmdLineArgs() override;
@@ -462,6 +463,12 @@ float16 RanGenInput()
     return prng::gen_canonical<T>();
 #endif
 }
+
+template <>
+bfloat16 RanGenInput()
+{
+    return prng::gen_canonical<bfloat16>();
+}
 } // namespace detail
 
 template <typename Tgpu, typename Tref, typename Index>
@@ -688,10 +695,11 @@ int PoolDriver_impl<Tgpu, Tref, Index>::RunBackwardGPU()
 template <typename Tgpu, typename Tref, typename Index>
 int PoolDriver_impl<Tgpu, Tref, Index>::VerifyForward()
 {
-    const Tref tolerance =          //
-        sizeof(Tgpu) == 8   ? 1e-6  // double
-        : sizeof(Tgpu) == 4 ? 1e-5  // float
-                            : 5e-3; // half
+    const Tref tolerance =                                              //
+        sizeof(Tgpu) == 8                     ? 1e-6                    // double
+        : sizeof(Tgpu) == 4                   ? 1e-5                    // float
+        : std::is_same<Tgpu, bfloat16>::value ? static_cast<Tref>(5e-2) // bfloat16
+                                              : 5e-3;                   // half
 
     pooling_math_stats stats;
     bool match = false;
@@ -748,8 +756,11 @@ int PoolDriver_impl<Tgpu, Tref, Index>::VerifyBackward()
 {
     float ulps_tolerance = 4;
     Tref diff_tolerance  = (sizeof(Tgpu) == 4 || sizeof(Tgpu) == 8) ? static_cast<Tref>(1e-6)
+                           : std::is_same<Tgpu, bfloat16>::value    ? static_cast<Tref>(5e-2)
                                                                     : static_cast<Tref>(5e-3);
-    double rms_tolerance = (sizeof(Tgpu) == 4 || sizeof(Tgpu) == 8) ? 1e-6 : 5e-3;
+    double rms_tolerance = (sizeof(Tgpu) == 4 || sizeof(Tgpu) == 8) ? 1e-6
+                           : std::is_same<Tgpu, bfloat16>::value    ? 5e-2
+                                                                    : 5e-3;
 
     pooling_math_stats stats;
     bool match = false;

--- a/projects/miopen/src/kernels/MIOpenPooling.cpp
+++ b/projects/miopen/src/kernels/MIOpenPooling.cpp
@@ -127,10 +127,17 @@ extern "C" __global__ __launch_bounds__(block_size) void mloPoolingG(const FLOAT
             bool vis_x = run_x >= 0 && run_x < mlo_bot_width;
             bool vis   = vis_x && vis_y;
 
+#if MIOPEN_USE_BFP16
+            bot_data[j][i] = vis ? bot[bot_gbl_off]
+                             : MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX //
+                                 ? /* MAX */ FLOAT{0xFF7F}             // -max bf16
+                                 : /* AVG */ FLOAT{0};
+#else
             bot_data[j][i] = vis ? bot[bot_gbl_off]
                              : MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX //
                                  ? /* MAX */ FLOAT{-MAX_VAL}
                                  : /* AVG */ FLOAT{0};
+#endif
         }
     }
 

--- a/projects/miopen/src/kernels/MIOpenPooling.cpp
+++ b/projects/miopen/src/kernels/MIOpenPooling.cpp
@@ -58,10 +58,11 @@ constexpr auto MLO_BOT_DATA_SZ0 =
 constexpr auto MLO_BOT_DATA_SZ1 =
     (MLO_POOLING_N_VERT_OUT_PIX - 1) * MLO_POOLING_STRIDE1 + MLO_POOLING_KERNEL_SZ1;
 
-// Let's use extended-precision accumulator only in FP16 pooling and only for averaging.
+// Let's use extended-precision accumulator for FP16 averaging and always for BF16.
+// BF16 uses ushort which doesn't work correctly with signed comparisons in max pooling.
 // For all other ops and datatypes, redefine macros used for accum-float conversion
 // and accum types, so they do nothing, i.e. treate FLOAT_ACCUM as FLOAT.
-#if !(AVERAGE_OPS && MIOPEN_USE_FP16)
+#if !((AVERAGE_OPS && MIOPEN_USE_FP16) || MIOPEN_USE_BFP16)
 #define MIOPEN_USE_NATIVE_DATATYPE_ACCUM 1
 #endif
 

--- a/projects/miopen/src/kernels/MIOpenPoolingBwd.cpp
+++ b/projects/miopen/src/kernels/MIOpenPoolingBwd.cpp
@@ -258,7 +258,7 @@ extern "C" __global__ __launch_bounds__(block_size) //
                          : (y + mlo_pad1 - MLO_POOLING_KERNEL_SZ1) / MLO_POOLING_STRIDE1 + 1;
     int top_df_off = b * mlo_topdf_batch_str + o * mlo_topdf_channel_str;
 
-    FLOAT res[MLO_POOLBWD_N_VERT_OUT_PIX][MLO_POOLBWD_N_HORIZ_OUT_PIX];
+    FLOAT_ACCUM res[MLO_POOLBWD_N_VERT_OUT_PIX][MLO_POOLBWD_N_HORIZ_OUT_PIX];
     FLOAT top_df_val;
     index_t mask_val;
     // load tiles
@@ -314,7 +314,7 @@ extern "C" __global__ __launch_bounds__(block_size) //
             int lt_x = max(0, lt_x1);
 
             // find and sum up all tops that have been influenced by particular bot
-            res[k][l] = 0;
+            res[k][l] = FLOAT_ACCUM{0};
 
             for(int th = tt_y; th < tt_y + (MLO_POOLING_KERNEL_SZ1 + MLO_POOLING_STRIDE1 - 1) /
                                                MLO_POOLING_STRIDE1;
@@ -349,7 +349,7 @@ extern "C" __global__ __launch_bounds__(block_size) //
 
                     if(match)
                     {
-                        FLOAT add_val = lcl_top_df[lcl_idx];
+                        FLOAT_ACCUM add_val = CVT_FLOAT2ACCUM(lcl_top_df[lcl_idx]);
                         res[k][l] += add_val;
                     }
                 }
@@ -365,7 +365,7 @@ extern "C" __global__ __launch_bounds__(block_size) //
         {
             if((bt_y + k) < mlo_bot_height && (bt_x + l) < mlo_bot_width)
             {
-                bot_df[bot_df_off + k * mlo_botdf_str + l] = res[k][l];
+                bot_df[bot_df_off + k * mlo_botdf_str + l] = CVT_ACCUM2FLOAT(res[k][l]);
             }
         }
     }

--- a/projects/miopen/src/kernels/MIOpenPoolingForwardNaive.cpp
+++ b/projects/miopen/src/kernels/MIOpenPoolingForwardNaive.cpp
@@ -34,9 +34,10 @@
 #define AVERAGE_OPS 0
 #endif
 
-// Let's use extended-precision accumulator only in FP16 pooling and only for averaging.
+// Let's use extended-precision accumulator for FP16 averaging and always for BF16.
+// BF16 uses ushort which doesn't work correctly with signed comparisons in max pooling.
 // For all other ops and datatypes, use native accumulator, i.e. treate FLOAT_ACCUM as FLOAT.
-#if !(AVERAGE_OPS && MIOPEN_USE_FP16)
+#if !((AVERAGE_OPS && MIOPEN_USE_FP16) || MIOPEN_USE_BFP16)
 #define MIOPEN_USE_NATIVE_DATATYPE_ACCUM 1
 #endif
 
@@ -137,15 +138,16 @@ extern "C" __global__ void mloPoolingForwardNaive(const FLOAT* bot_ptr,
                                                  + static_cast<size_t>(d * bot_d_stride) //
                                                  + static_cast<size_t>(h * bot_h_stride) //
                                                  + static_cast<size_t>(w * bot_w_stride);
+                        FLOAT_ACCUM bot_val = CVT_FLOAT2ACCUM(bot_ptr[bot_index]);
                         if constexpr(AVERAGE_OPS)
                         {
-                            res += bot_ptr[bot_index];
+                            res += bot_val;
                         }
                         else // MAX
                         {
-                            if(bot_ptr[bot_index] > res)
+                            if(bot_val > res)
                             {
-                                res = bot_ptr[bot_index];
+                                res = bot_val;
                                 if(save_index)
                                 {
                                     found  = true;
@@ -207,7 +209,7 @@ extern "C" __global__ void mloPoolingForwardNaive(const FLOAT* bot_ptr,
                                      + static_cast<size_t>(j * top_h_stride) //
                                      + static_cast<size_t>(i * top_w_stride);
 
-            top_ptr[top_index] = static_cast<FLOAT>(res);
+            top_ptr[top_index] = CVT_ACCUM2FLOAT(res);
         }
     };
 

--- a/projects/miopen/src/kernels/MIOpenPoolingND.cpp
+++ b/projects/miopen/src/kernels/MIOpenPoolingND.cpp
@@ -132,10 +132,17 @@ extern "C" __global__ __launch_bounds__(MLO_POOLING_GROUP_SZ0) //
 
                     const bool vis = vis_x;
 
+#if MIOPEN_USE_BFP16
+                    bot_data[h][j][i] = vis ? bot[bot_gbl_off]
+                                        : MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX
+                                            ? /* MAX */ FLOAT{0xFF7F} // -max bf16
+                                            : /* AVG */ FLOAT{0};
+#else
                     bot_data[h][j][i] = vis ? bot[bot_gbl_off]
                                         : MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX
                                             ? /* MAX */ FLOAT{-MAX_VAL}
                                             : /* AVG */ FLOAT{0};
+#endif
                 }
             }
         }

--- a/projects/miopen/src/kernels/MIOpenPoolingND.cpp
+++ b/projects/miopen/src/kernels/MIOpenPoolingND.cpp
@@ -44,10 +44,11 @@ constexpr bool USE_MASK = false;
 #define AVERAGE_OPS 0
 #endif
 
-// Let's use extended-precision accumulator only in FP16 pooling and only for averaging.
+// Let's use extended-precision accumulator for FP16 averaging and always for BF16.
+// BF16 uses ushort which doesn't work correctly with signed comparisons in max pooling.
 // For all other ops and datatypes, redefine macros used for accum-float conversion
 // and accum types, so they do nothing, i.e. treate FLOAT_ACCUM as FLOAT.
-#if !(AVERAGE_OPS && MIOPEN_USE_FP16)
+#if !((AVERAGE_OPS && MIOPEN_USE_FP16) || MIOPEN_USE_BFP16)
 #define MIOPEN_USE_NATIVE_DATATYPE_ACCUM 1
 #endif
 
@@ -236,7 +237,7 @@ extern "C" __global__ __launch_bounds__(MLO_POOLING_GROUP_SZ0) //
                                                (top_d_id + m) * top_str_d +
                                                (top_h_id + k) * top_str_h + top_w_id + l;
 
-                        top[top_idx] = top_val;
+                        top[top_idx] = CVT_ACCUM2FLOAT(top_val);
                         if constexpr(USE_MASK)
                             mask[top_idx] = mask_idx;
                     }

--- a/projects/miopen/src/kernels/pooling_functions.h
+++ b/projects/miopen/src/kernels/pooling_functions.h
@@ -47,6 +47,14 @@ __device__ constexpr _Float16 poolingMax(_Float16 a, _Float16 b) { return __buil
 
 __device__ constexpr float poolingMax(float a, float b) { return fmaxf(a, b); }
 
+#if MIOPEN_USE_BFP16
+#include "bfloat16_dev.hpp"
+__device__ inline ushort poolingMax(ushort a, ushort b)
+{
+    return float_to_bfloat16(fmaxf(bfloat16_to_float(a), bfloat16_to_float(b)));
+}
+#endif
+
 __device__ float approxRcp(float x)
 {
     // By default, the compiler is convervative about emitting v_rcp_f32.

--- a/projects/miopen/src/pooling_api.cpp
+++ b/projects/miopen/src/pooling_api.cpp
@@ -47,11 +47,11 @@ inline void Pooling_logging_cmd(const miopenPoolingDescriptor_t poolDesc,
         switch(miopen::deref(tensorDesc).GetType())
         {
         case miopenHalf: ss << "poolfp16"; break;
+        case miopenBFloat16: ss << "poolbfp16"; break;
         case miopenFloat: ss << "pool"; break;
         case miopenInt64:
         case miopenInt32:
         case miopenInt8:
-        case miopenBFloat16:
         case miopenDouble:
         case miopenFloat8_fnuz:
         case miopenBFloat8_fnuz:

--- a/projects/miopen/src/solver/pooling/backward2d.cpp
+++ b/projects/miopen/src/solver/pooling/backward2d.cpp
@@ -178,6 +178,10 @@ bool PoolingBackward2d::IsApplicable(const ExecutionContext&,
             problem.GetPooling().GetMode() == miopenPoolingAverage ||
             problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) &&
            problem.GetXDesc().GetNumDims() == 4 &&
+           problem.GetXDesc().GetType() == problem.GetYDesc().GetType() &&
+           (problem.GetXDesc().GetType() == miopenFloat ||
+            problem.GetXDesc().GetType() == miopenHalf ||
+            problem.GetXDesc().GetType() == miopenBFloat16) &&
            problem.GetXDesc().IsPossibleLayout4D5D("NCHW", strict) &&
            problem.GetYDesc().IsPossibleLayout4D5D("NCHW", strict) &&
            sizeof_local_memory(problem) <= TargetProperties::GetMaxLocalMemorySize();

--- a/projects/miopen/src/solver/pooling/backwardNd.cpp
+++ b/projects/miopen/src/solver/pooling/backwardNd.cpp
@@ -48,7 +48,8 @@ bool PoolingBackwardNd::IsApplicable(const ExecutionContext&,
     return problem.GetDirection() == miopen::pooling::Direction::Backward          //
            && problem.GetXDesc().GetType() == problem.GetYDesc().GetType()         //
            && (problem.GetXDesc().GetType() == miopenFloat                         //
-               || problem.GetXDesc().GetType() == miopenHalf)                      //
+               || problem.GetXDesc().GetType() == miopenHalf                       //
+               || problem.GetXDesc().GetType() == miopenBFloat16)                  //
            && (problem.GetPooling().GetMode() == miopenPoolingMax                  //
                || problem.GetPooling().GetMode() == miopenPoolingAverage           //
                || problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) //

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -79,7 +79,7 @@ std::size_t sizeof_kernel_FLOAT(const miopen::pooling::ProblemDescription& probl
 std::size_t sizeof_kernel_FLOAT_ACCUM(const miopen::pooling::ProblemDescription& problem)
 {
     const auto datatype = problem.GetXDesc().GetType();
-    if(datatype == miopenHalf)
+    if(datatype == miopenHalf || datatype == miopenBFloat16)
         return get_data_size(miopenFloat); // mixed precision
     return get_data_size(datatype);
 }
@@ -142,7 +142,8 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
            problem.GetXDesc().GetNumDims() == 4 &&
            problem.GetXDesc().GetType() == problem.GetYDesc().GetType() &&
            (problem.GetXDesc().GetType() == miopenFloat ||
-            problem.GetXDesc().GetType() == miopenHalf) &&
+            problem.GetXDesc().GetType() == miopenHalf ||
+            problem.GetXDesc().GetType() == miopenBFloat16) &&
            problem.GetXDesc().IsPossibleLayout4D5D("NCHW", strict) &&
            problem.GetYDesc().IsPossibleLayout4D5D("NCHW", strict) &&
            sizeof_private_memory(problem) <=

--- a/projects/miopen/src/solver/pooling/forwardNaive.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNaive.cpp
@@ -74,7 +74,8 @@ bool PoolingForwardNaive::IsApplicable(const ExecutionContext&,
     return problem.GetDirection() == miopen::pooling::Direction::Forward           //
            && problem.GetXDesc().GetType() == problem.GetYDesc().GetType()         //
            && (problem.GetXDesc().GetType() == miopenFloat                         //
-               || problem.GetXDesc().GetType() == miopenHalf)                      //
+               || problem.GetXDesc().GetType() == miopenHalf                       //
+               || problem.GetXDesc().GetType() == miopenBFloat16)                  //
            && (problem.GetPooling().GetMode() == miopenPoolingMax                  //
                || problem.GetPooling().GetMode() == miopenPoolingAverage           //
                || problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) //

--- a/projects/miopen/src/solver/pooling/forwardNd.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNd.cpp
@@ -115,7 +115,8 @@ bool PoolingForwardNd::IsApplicable(const ExecutionContext& context,
            && problem.GetYDesc().IsPossibleLayout4D5D("NCDHW", strict)                        //
            && problem.GetXDesc().GetType() == problem.GetYDesc().GetType()                    //
            && (problem.GetXDesc().GetType() == miopenFloat                                    //
-               || problem.GetXDesc().GetType() == miopenHalf)                                 //
+               || problem.GetXDesc().GetType() == miopenHalf                                  //
+               || problem.GetXDesc().GetType() == miopenBFloat16)                             //
            && (problem.GetPooling().GetMode() == miopenPoolingMax                             //
                || problem.GetPooling().GetMode() == miopenPoolingAverage                      //
                || problem.GetPooling().GetMode() == miopenPoolingAverageInclusive)            //

--- a/projects/miopen/test/CMakeLists.txt
+++ b/projects/miopen/test/CMakeLists.txt
@@ -289,7 +289,8 @@ elseif(MIOPEN_TEST_BFLOAT16)
               test_conv_extra test_conv_for_implicit_gemm test_miopen_conv
               test_deepbench_conv test_conv_igemm_dynamic_xdlops_nhwc_wrw_bf16
               test_conv_igemm_dynamic_xdlops_nhwc_fwd_bf16
-              test_conv_igemm_dynamic_xdlops_nhwc_bwd_bf16)
+              test_conv_igemm_dynamic_xdlops_nhwc_bwd_bf16
+              test_pooling2d_bfp16 test_pooling3d_bfp16)
 endif()
 
 if(MIOPEN_NO_GPU)
@@ -310,6 +311,10 @@ endif()
 
 if (MIOPEN_TEST_GFX115X)
     list(APPEND SKIP_TESTS test_ctc)
+endif()
+
+if(NOT MIOPEN_TEST_BFLOAT16)
+    list(APPEND SKIP_TESTS test_pooling2d_bfp16 test_pooling3d_bfp16)
 endif()
 
 # The usage is non-trivial, see function add_test_command.
@@ -450,7 +455,9 @@ set(LONG_TESTS
     test_conv3d_extra
     test_conv_3d
     test_pooling2d
+    test_pooling2d_bfp16
     test_pooling3d
+    test_pooling3d_bfp16
     test_conv_ck_igemm_fwd_v6r1_dlops_nchw
     )
 

--- a/projects/miopen/test/gtest/miopendriver_common.hpp
+++ b/projects/miopen/test/gtest/miopendriver_common.hpp
@@ -47,8 +47,9 @@ static const std::string BFloat16 = "convbfp16";
 } // namespace conv
 
 namespace pool {
-static const std::string Float = "pool";
-static const std::string Half  = "poolfp16";
+static const std::string Float    = "pool";
+static const std::string Half     = "poolfp16";
+static const std::string BFloat16 = "poolbfp16";
 } // namespace pool
 
 namespace gemm {

--- a/projects/miopen/test/pooling2d_bfp16.cpp
+++ b/projects/miopen/test/pooling2d_bfp16.cpp
@@ -1,0 +1,6 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "pooling2d.hpp"
+
+int main(int argc, const char* argv[]) { test_drive<pooling2d_driver<bfloat16>>(argc, argv); }

--- a/projects/miopen/test/pooling3d.hpp
+++ b/projects/miopen/test/pooling3d.hpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2025 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include "pooling_common.hpp"
 

--- a/projects/miopen/test/pooling3d_bfp16.cpp
+++ b/projects/miopen/test/pooling3d_bfp16.cpp
@@ -1,31 +1,6 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-#include "pooling_common.hpp"
-
-template <class T>
-struct pooling3d_driver : pooling_driver<T>
-{
-    std::vector<std::vector<int>> get_3d_pooling_input_shapes()
-    {
-        return {{16, 64, 3, 4, 4},
-                {16, 32, 4, 9, 9},
-                {8, 512, 3, 14, 14},
-                {8, 512, 4, 28, 28},
-                {16, 64, 56, 56, 56},
-                {4, 3, 4, 227, 227},
-                {4, 4, 4, 161, 700}};
-    }
-
-    pooling3d_driver() : pooling_driver<T>()
-    {
-        this->add(
-            this->in_shape, "input", this->generate_data_limited(get_3d_pooling_input_shapes(), 4));
-        this->add(this->lens, "lens", this->generate_data({{2, 2, 2}, {3, 3, 3}}));
-        this->add(this->strides, "strides", this->generate_data({{2, 2, 2}, {1, 1, 1}}));
-        this->add(this->pads, "pads", this->generate_data({{0, 0, 0}, {1, 1, 1}}));
-        this->add(this->wsidx, "wsidx", this->generate_data({1}));
-    }
-};
+#include "pooling3d.hpp"
 
 int main(int argc, const char* argv[]) { test_drive<pooling3d_driver<bfloat16>>(argc, argv); }

--- a/projects/miopen/test/pooling3d_bfp16.cpp
+++ b/projects/miopen/test/pooling3d_bfp16.cpp
@@ -1,0 +1,31 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "pooling_common.hpp"
+
+template <class T>
+struct pooling3d_driver : pooling_driver<T>
+{
+    std::vector<std::vector<int>> get_3d_pooling_input_shapes()
+    {
+        return {{16, 64, 3, 4, 4},
+                {16, 32, 4, 9, 9},
+                {8, 512, 3, 14, 14},
+                {8, 512, 4, 28, 28},
+                {16, 64, 56, 56, 56},
+                {4, 3, 4, 227, 227},
+                {4, 4, 4, 161, 700}};
+    }
+
+    pooling3d_driver() : pooling_driver<T>()
+    {
+        this->add(
+            this->in_shape, "input", this->generate_data_limited(get_3d_pooling_input_shapes(), 4));
+        this->add(this->lens, "lens", this->generate_data({{2, 2, 2}, {3, 3, 3}}));
+        this->add(this->strides, "strides", this->generate_data({{2, 2, 2}, {1, 1, 1}}));
+        this->add(this->pads, "pads", this->generate_data({{0, 0, 0}, {1, 1, 1}}));
+        this->add(this->wsidx, "wsidx", this->generate_data({1}));
+    }
+};
+
+int main(int argc, const char* argv[]) { test_drive<pooling3d_driver<bfloat16>>(argc, argv); }

--- a/projects/miopen/test/pooling_common.hpp
+++ b/projects/miopen/test/pooling_common.hpp
@@ -610,8 +610,8 @@ struct pooling_driver : test_driver
                 dim_strides);
             input.desc = miopen::TensorDescriptor(miopen_type<T>{}, dim_lens, dim_strides);
         }
-        auto out   = verify(verify_forward_pooling<SptDim>{}, input, filter, indices);
-        auto dout  = out.first;
+        auto out  = verify(verify_forward_pooling<SptDim>{}, input, filter, indices);
+        auto dout = out.first;
         dout.generate(tensor_elem_gen_integer{2503});
         verify(verify_backward_pooling<SptDim>{},
                input,

--- a/projects/miopen/test/pooling_common.hpp
+++ b/projects/miopen/test/pooling_common.hpp
@@ -597,8 +597,8 @@ struct pooling_driver : test_driver
     void run_impl()
     {
         std::vector<Index> indices{};
-        auto input = tensor<T>{in_shape}.generate(
-            tensor_elem_gen_integer{miopen_type<T>{} == miopenHalf ? 5 : 17});
+        auto input = tensor<T>{in_shape}.generate(tensor_elem_gen_integer{
+            (miopen_type<T>{} == miopenHalf || miopen_type<T>{} == miopenBFloat16) ? 5 : 17});
         if(in_layout != "NCHW" && in_layout != "NCDHW")
         {
             const std::vector<std::size_t> dim_lens = input.desc.GetLengths();
@@ -610,8 +610,8 @@ struct pooling_driver : test_driver
                 dim_strides);
             input.desc = miopen::TensorDescriptor(miopen_type<T>{}, dim_lens, dim_strides);
         }
-        auto out  = verify(verify_forward_pooling<SptDim>{}, input, filter, indices);
-        auto dout = out.first;
+        auto out   = verify(verify_forward_pooling<SptDim>{}, input, filter, indices);
+        auto dout  = out.first;
         dout.generate(tensor_elem_gen_integer{2503});
         verify(verify_backward_pooling<SptDim>{},
                input,


### PR DESCRIPTION
## Motivation

Currently pooling only supports the float and float16 data types, this commit extends that to bfloat16 as well.

## Technical Details

- For maximum precision I chose 5e-2 as this roughly matches precision difference between float16 and bfloat16.

## Test Plan

Since this is an extension to the pooling algorithm, testing simplifies to extending the test cases for bfloat16 and running them.

## Test Result

CPU verification passes on all algorithm combinations.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
