### PR TITLE
 Add WaveSeparateGlobalRead keys to mocked kernel

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -31,6 +31,8 @@ def create_base_kernel():
         "PrefetchGlobalRead": 0, "PrefetchLocalRead": 0, "DirectToLds": False,
         "GlobalReadVectorWidthA": 0, "GlobalReadVectorWidthB": 0,
         "LocalReadVectorWidth": 0,
+        "WaveSeparateGlobalReadA": 0,
+        "WaveSeparateGlobalReadB": 0,
         "MatrixInstruction": [],
         "MIWaveGroup": [],
         "LDSTrInst": False,


### PR DESCRIPTION
## Motivation

  Add WaveSeparateGlobalRead keys to mocked kernel

     Fixes inadvertent unit test failures introduced while testing was off.

## Technical Details

Unit testing was broken by PR#3075 but testing was off in the CI system so the breakage was unnoticed

## Test Plan

 TENSILELITE_CLIENT_ARGS="--build-type Debug --gpu-targets gfx950 --clean" tox -e unit -- Tensile/Tests/unit
## Test Result

pass 
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
