### PR TITLE
[hipblaslt] [CMS] Fix tests in test_CustomSchedule.py

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -40,6 +40,8 @@ def create_base_kernel():
         "UsePLRPack": False, # For asserting it gets set
         "MIWaveTileA": 2,
         "MIWaveTileB": 2,
+        "WaveSeparateGlobalReadA": 0,
+        "WaveSeparateGlobalReadB": 0,
     }
     return kernel
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -28,7 +28,7 @@ def create_base_kernel():
             "TransposeB": False,
         },
         "MacroTile0": 0, "MacroTile1": 0, "DepthU": 0,
-        "PrefetchGlobalRead": 0, "PrefetchLocalRead": 0, "DirectToLds": False,
+        "PrefetchGlobalRead": 0, "PrefetchLocalRead": 0, "DirectToLds": True,
         "GlobalReadVectorWidthA": 0, "GlobalReadVectorWidthB": 0,
         "LocalReadVectorWidth": 0,
         "MatrixInstruction": [],
@@ -70,7 +70,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2], "TransposeLDS": 0 if NT else 1, "MIWaveTileA": 8, "MIWaveTileB": 8,
         })
@@ -112,7 +112,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 256, "DepthU": 128,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
             "GlobalReadVectorWidthA": 16, "GlobalReadVectorWidthB": 16, "LocalReadVectorWidth": 16,
             "MatrixInstruction": [16,16,128,1], "MIWaveGroup": [2,2], "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 8, "ForceUnrollSubIter": force_unroll_sub_iter,
         })
@@ -136,7 +136,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 96, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 3,
@@ -163,7 +163,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 192, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": NN, "TransposeLDS": 0 if NT else 1, "MIWaveTileA": 6, "MIWaveTileB": 8,
@@ -191,7 +191,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 192, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": not transA, "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 6,
@@ -216,7 +216,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 160, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": not transA, "TransposeLDS": not transB, "MIWaveTileA": 5, "MIWaveTileB": 8,
@@ -241,7 +241,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 160, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": True, "TransposeLDS": 0 if transB else 1, "MIWaveTileA": 8, "MIWaveTileB": 5,
@@ -267,7 +267,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 240, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 2, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [4,1],
             "LDSTrInst": True, "TransposeLDS": 1 if transA or not (transA or transB) else 0, "MIWaveTileA": 4, "MIWaveTileB": 15,
@@ -292,7 +292,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 208, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 2, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [4,1],
             "LDSTrInst": not transA , "TransposeLDS": 1, "MIWaveTileA": 4, "MIWaveTileB": 13,
@@ -316,7 +316,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 224, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "TransposeLDS": 1, "MIWaveTileA": 7, "MIWaveTileB": 8,
@@ -340,7 +340,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 192, "MacroTile1": 320, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": True, "TransposeLDS": 1, "MIWaveTileA": 6, "MIWaveTileB": 10,
@@ -364,7 +364,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 224, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 7,
@@ -392,7 +392,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 320, "MacroTile1": 192, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": True, "TransposeLDS": NN, "MIWaveTileA": 10, "MIWaveTileB": 6,
@@ -420,7 +420,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 240, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 2, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [1,4],
             "TransposeLDS": TN, "MIWaveTileA": 15, "MIWaveTileB": 4,
@@ -445,7 +445,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 208, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 2, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [1,4],
             "LDSTrInst": not transA, "TransposeLDS": 1, "MIWaveTileA": 13, "MIWaveTileB": 4,


### PR DESCRIPTION
## Motivation

Originally broken by #3075 since the tests did not add values for `WaveSeparateGlobalReadA` and `WaveSeparateGlobalReadB`.

## Technical Details

Add defaults.

## Test Plan

The unit tests have now been enabled as part of CI to prevent future regressions.

## Test Result

Passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
