### PR TITLE
Fix conversion from rocisa DataType to origami data_type_t

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
@@ -29,7 +29,7 @@
 #include <set>
 #include <vector>
 
-#include <origami/utils.hpp>
+#include <Tensile/UtilsOrigami.hpp>
 
 namespace TensileLite
 {
@@ -170,7 +170,7 @@ namespace TensileLite
                 analytical_hardware.print();
             }
             int defaultWGM = std::ceil(std::sqrt(analytical_hardware.N_CU / analytical_hardware.NUM_XCD));
-            origami::data_type_t miDataType = static_cast<origami::data_type_t>(problem.computeInputType());
+            origami::data_type_t miDataType = datatypeToAnalyticalDatatype(problem.computeInputType());
             if(problem.f32XdlMathOp() == rocisa::DataType::XFloat32) // Check F32 compute type
                 miDataType = origami::data_type_t::XFloat32;
             auto selected_tiles = origami::select_best_macro_tile_size(

--- a/projects/hipblaslt/tensilelite/include/Tensile/UtilsOrigami.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/UtilsOrigami.hpp
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <origami/utils.hpp>
+#include <rocisa/include/enum.hpp>
+
+namespace TensileLite
+{
+ 
+    inline origami::data_type_t datatypeToAnalyticalDatatype(rocisa::DataType type)
+    {
+        switch(type)
+        {
+            case rocisa::DataType::Float:
+                return origami::data_type_t::Float;
+            case rocisa::DataType::Double:
+                return origami::data_type_t::Double;
+            case rocisa::DataType::ComplexFloat:
+                return origami::data_type_t::ComplexFloat;
+            case rocisa::DataType::ComplexDouble:
+                return origami::data_type_t::ComplexDouble;
+            case rocisa::DataType::Half:
+                return origami::data_type_t::Half;
+            case rocisa::DataType::Int8x4:
+                return origami::data_type_t::Int8x4;
+            case rocisa::DataType::Int32:
+                return origami::data_type_t::Int32;
+            case rocisa::DataType::BFloat16:
+                return origami::data_type_t::BFloat16;
+            case rocisa::DataType::Int8:
+                return origami::data_type_t::Int8;
+            case rocisa::DataType::Int64:
+                return origami::data_type_t::Int64;
+            case rocisa::DataType::XFloat32:
+                return origami::data_type_t::XFloat32;
+            case rocisa::DataType::Float8_fnuz:
+                return origami::data_type_t::Float8_fnuz;
+            case rocisa::DataType::BFloat8_fnuz:
+                return origami::data_type_t::BFloat8_fnuz;
+            case rocisa::DataType::Float8BFloat8_fnuz:
+                return origami::data_type_t::Float8BFloat8_fnuz;
+            case rocisa::DataType::BFloat8Float8_fnuz:
+                return origami::data_type_t::BFloat8Float8_fnuz;
+            case rocisa::DataType::Float8:
+                return origami::data_type_t::Float8;
+            case rocisa::DataType::BFloat8:
+                return origami::data_type_t::BFloat8;
+            case rocisa::DataType::Float8BFloat8:
+                return origami::data_type_t::Float8BFloat8;
+            case rocisa::DataType::BFloat8Float8:
+                return origami::data_type_t::BFloat8Float8;
+
+            default:
+                return origami::data_type_t::None;
+        }
+    }
+} // namespace TensileLite
+  

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -35,7 +35,7 @@
 #include <Tensile/hip/HipHardware.hpp>
 
 #include <origami/streamk.hpp>
-#include <origami/utils.hpp>
+#include <Tensile/UtilsOrigami.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -3121,50 +3121,6 @@ namespace TensileLite
             return tiles * sizeMapping.synchronizerSizePerWG * sizeof(int);
         }
         return 0;
-    }
-
-    origami::data_type_t datatypeToAnalyticalDatatype(rocisa::DataType type)
-    {
-        switch(type)
-        {
-            case rocisa::DataType::Float:
-                return origami::data_type_t::Float;
-            case rocisa::DataType::Double:
-                return origami::data_type_t::Double;
-            case rocisa::DataType::Half:
-                return origami::data_type_t::Half;
-            case rocisa::DataType::Int8x4:
-                return origami::data_type_t::Int8x4;
-            case rocisa::DataType::Int32:
-                return origami::data_type_t::Int32;
-            case rocisa::DataType::BFloat16:
-                return origami::data_type_t::BFloat16;
-            case rocisa::DataType::Int8:
-                return origami::data_type_t::Int8;
-            case rocisa::DataType::Int64:
-                return origami::data_type_t::Int64;
-            case rocisa::DataType::XFloat32:
-                return origami::data_type_t::XFloat32;
-            case rocisa::DataType::Float8_fnuz:
-                return origami::data_type_t::Float8_fnuz;
-            case rocisa::DataType::BFloat8_fnuz:
-                return origami::data_type_t::BFloat8_fnuz;
-            case rocisa::DataType::Float8BFloat8_fnuz:
-                return origami::data_type_t::Float8BFloat8_fnuz;
-            case rocisa::DataType::BFloat8Float8_fnuz:
-                return origami::data_type_t::BFloat8Float8_fnuz;
-            case rocisa::DataType::Float8:
-                return origami::data_type_t::Float8;
-            case rocisa::DataType::BFloat8:
-                return origami::data_type_t::BFloat8;
-            case rocisa::DataType::Float8BFloat8:
-                return origami::data_type_t::Float8BFloat8;
-            case rocisa::DataType::BFloat8Float8:
-                return origami::data_type_t::BFloat8Float8;
-
-            default:
-                return origami::data_type_t::None;
-        }
     }
 
     ReductionType ContractionSolution::getSKReduction(Problem const& problem, Hardware const& hardware) const


### PR DESCRIPTION
## Motivation

Fix a bug converting rocisa DataType to origami data_type_t.

## Technical Details

A static_cast is not sufficient, since the types don't map 1:1. Move the conversion function to a utility file and use for all instances where a conversion is needed. This fixes a bug where Origami would use the wrong latency values for selection of some types.

## Test Plan

Origami was printing warning messages of invalid data types. Verified this patch fixes the issue.
