### PR TITLE
Remove instances of gfx000 as a rocm_agent_enumerator output

### DIFF
--- a/projects/hiprand/rmake.py
+++ b/projects/hiprand/rmake.py
@@ -39,7 +39,7 @@ def parse_args():
     parser.add_argument(      '--cmake-darg', required=False, dest='cmake_dargs', action='append', default=[],
                         help='List of additional cmake defines for builds (e.g. CMAKE_CXX_COMPILER_LAUNCHER=ccache)')
     parser.add_argument('-a', '--architecture', dest='gpu_architecture', required=False, default=default_gpus, #:sramecc+:xnack-" ) #gfx1030" ) #gfx906" ) # gfx1030" )
-                        help='Set GPU architectures, e.g. all, gfx000, gfx803, gfx906:xnack-;gfx1030;gfx1100 (optional, default: all)')
+                        help='Set GPU architectures, e.g. all, gfx803, gfx906:xnack-;gfx1030;gfx1100 (optional, default: all)')
     parser.add_argument('-v', '--verbose', required=False, default=False, action='store_true',
                         help='Verbose build (default: False)')
     parser.add_argument('--rocrand-path', dest='rocrand_path', type=str, default="C:/hipSDK", help="Set specific path to custom build rocRAND (optional)")

--- a/projects/hipsparselt/install.sh
+++ b/projects/hipsparselt/install.sh
@@ -35,7 +35,7 @@ function display_help()
 #  echo "    [--prefix] Specify an alternate CMAKE_INSTALL_PREFIX for cmake"
   echo "    [-i|--install] install after build"
   echo "    [-d|--dependencies] install build dependencies"
-  echo "    [-a|--architecture] Set AMD GPU architecture target(s), e.g., all, gfx000, gfx900, gfx906:xnack-;gfx908:xnack-"
+  echo "    [-a|--architecture] Set AMD GPU architecture target(s), e.g., all, gfx900, gfx906:xnack-;gfx908:xnack-"
   echo "    [-c|--clients] build library clients too (combines with -i & -d)"
   echo "    [--cpu_ref_lib <lib>] specify library to use for CPU reference code in testing (blis or lapack)"
   echo "    [-r]--relocatable] create a package to support relocatable ROCm"

--- a/projects/rocblas/scripts/performance/blas/getspecs.py
+++ b/projects/rocblas/scripts/performance/blas/getspecs.py
@@ -77,8 +77,7 @@ def getgfx(devicenum, cuda):
         success, cout = _subprocess_helper(cmd)
         if not success:
             return "N/A"
-        # Add 1 to devicenum since rocm-agent-enum always prints gfx000 first
-        return cout.splitlines()[devicenum+1]
+        return cout.splitlines()[devicenum]
 
 # Get the hostname
 def gethostname():

--- a/projects/rocprim/rmake.py
+++ b/projects/rocprim/rmake.py
@@ -41,7 +41,7 @@ def parse_args():
     parser.add_argument(      '--cmake-darg', required=False, dest='cmake_dargs', action='append', default=[],
                         help='List of additional cmake defines for builds (e.g. CMAKE_CXX_COMPILER_LAUNCHER=ccache)')
     parser.add_argument('-a', '--architecture', dest='gpu_architecture', required=False, default=default_gpus, #:sramecc+:xnack-" ) #gfx1030" ) #gfx906" ) # gfx1030" )
-                        help='Set GPU architectures, e.g. all, gfx000, gfx906:xnack-;gfx1030;gfx1100 (optional, default: all)')
+                        help='Set GPU architectures, e.g. all, gfx803, gfx906:xnack-;gfx1030;gfx1100 (optional, default: all)')
     parser.add_argument('-v', '--verbose', required=False, default=False, action='store_true',
                         help='Verbose build (default: False)')
     parser.add_argument('--no-offload-compress', required=False, default=False, action='store_true', help='Do not apply offload compression (deafult: False)')

--- a/projects/rocrand/rmake.py
+++ b/projects/rocrand/rmake.py
@@ -42,7 +42,7 @@ def parse_args():
     parser.add_argument(      '--cmake-darg', required=False, dest='cmake_dargs', action='append', default=[],
                         help='List of additional cmake defines for builds (e.g. CMAKE_CXX_COMPILER_LAUNCHER=ccache)')
     parser.add_argument('-a', '--architecture', dest='gpu_architecture', required=False, default=default_gpus, #:sramecc+:xnack-" ) #gfx1030" ) #gfx906" ) # gfx1030" )
-                        help='Set GPU architectures, e.g. all, gfx000, gfx803, gfx906:xnack-;gfx1030;gfx1100 (optional, default: all)')
+                        help='Set GPU architectures, e.g. all, gfx803, gfx906:xnack-;gfx1030;gfx1100 (optional, default: all)')
     parser.add_argument('-v', '--verbose', required=False, default=False, action='store_true',
                         help='Verbose build (default: False)')
     return parser.parse_args()

--- a/projects/rocsparse/install.sh
+++ b/projects/rocsparse/install.sh
@@ -36,7 +36,7 @@ function display_help()
 #  echo "    [--prefix] Specify an alternate CMAKE_INSTALL_PREFIX for cmake"
   echo "    [-i|--install] install after build"
   echo "    [-d|--dependencies] install build dependencies"
-  echo "    [-a|--architecture] Set GPU architecture target(s), e.g., all, gfx000, gfx900, gfx906:xnack-;gfx908:xnack-"
+  echo "    [-a|--architecture] Set GPU architecture target(s), e.g., all, gfx900, gfx906:xnack-;gfx908:xnack-"
   echo "    [-c|--clients] build library clients too (combines with -i & -d)"
   echo "    [-o|--clients-only] build clients only"
   echo "    [-r]--relocatable] create a package to support relocatable ROCm"

--- a/projects/rocthrust/rmake.py
+++ b/projects/rocthrust/rmake.py
@@ -39,7 +39,7 @@ def parse_args():
     parser.add_argument(      '--cmake-darg', required=False, dest='cmake_dargs', action='append', default=[],
                         help='List of additional cmake defines for builds (e.g. CMAKE_CXX_COMPILER_LAUNCHER=ccache)')
     parser.add_argument('-a', '--architecture', dest='gpu_architecture', required=False, default=default_gpus, #:sramecc+:xnack-" ) #gfx1030" ) #gfx906" ) # gfx1030" )
-                        help='Set GPU architectures, e.g. all, gfx000, gfx803, gfx906:xnack-;gfx1030 (optional, default: all)')
+                        help='Set GPU architectures, e.g. all, gfx803, gfx906:xnack-;gfx1030 (optional, default: all)')
     parser.add_argument('-v', '--verbose', required=False, default=False, action='store_true',
                         help='Verbose build (default: False)')
     parser.add_argument('--no-offload-compress', required=False, default=False, action='store_true', help='Do not apply offload compression (defult: False)')                        


### PR DESCRIPTION
## Motivation

`rocm_agent_enumerator` stopped outputting an initial `gfx000` in its output in ROCm 6. To remove possible technical debt, it makes sense to remove mention or use of `gfx000` from documentation, test infrastructure, and scripts.

## Technical Details

Deprecation commit: [ROCm/rocm-systems `9f6d7cd`](https://github.com/ROCm/rocm-systems/commit/9f6d7cdf6b3fe5ffef7417a35b4af206d35cd9fd)