### PR TITLE
[rocroller] Enable Prefetching with StreamK

### DIFF
--- a/shared/rocroller/lib/source/KernelGraph/Transformations/AddComputeIndex.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Transformations/AddComputeIndex.cpp
@@ -255,38 +255,10 @@ namespace rocRoller::KernelGraph
         // Next, consider Unroll coordinates.
         auto unrolls = filterCoordinates<Unroll>(required, graph);
 
-        // StreamK creates a coordinate structure where Unroll coordinates are
-        // only connected via Identify edges (not CoordinateTransformEdges).
-        // findRequiredCoordinates doesn't traverse Identify edges, so these
-        // Unrolls aren't in the `required` set.
-        //
-        // Solution: Find Unrolls via the MAPPER by tracing up the control graph
-        // from the operation to find SetCoordinate nodes, which are mapped to Unrolls.
-        {
-            int current = op;
-            while(true)
-            {
-                auto parent = only(graph.control.getInputNodeIndices<Body>(current));
-                if(!parent)
-                    break;
-
-                auto maybeSetCoord = graph.control.get<SetCoordinate>(*parent);
-                if(maybeSetCoord)
-                {
-                    auto unrollCoord = graph.mapper.get<Unroll>(*parent);
-                    if(unrollCoord > 0)
-                    {
-                        unrolls.insert(unrollCoord);
-                    }
-                }
-                current = *parent;
-            }
-        }
-
         for(auto unroll : unrolls)
         {
-            // The Unroll is connected to a coordinate via an Identify edge.
-            // Follow the Identify chain and find a neighbour that's in the path.
+            // In StreamK, Unroll coordinates are connected via Identify edges.
+            // followIdentify resolves these chains (or returns the original if none).
             auto unrollTarget = followIdentify(unroll, graph);
 
             // Find a neighbour of unrollTarget that's actually in the path

--- a/shared/rocroller/lib/source/KernelGraph/Transformations/AddComputeIndex.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Transformations/AddComputeIndex.cpp
@@ -254,24 +254,54 @@ namespace rocRoller::KernelGraph
 
         // Next, consider Unroll coordinates.
         auto unrolls = filterCoordinates<Unroll>(required, graph);
+
+        // StreamK creates a coordinate structure where Unroll coordinates are
+        // only connected via Identify edges (not CoordinateTransformEdges).
+        // findRequiredCoordinates doesn't traverse Identify edges, so these
+        // Unrolls aren't in the `required` set.
+        //
+        // Solution: Find Unrolls via the MAPPER by tracing up the control graph
+        // from the operation to find SetCoordinate nodes, which are mapped to Unrolls.
+        {
+            int current = op;
+            while(true)
+            {
+                auto parent = only(graph.control.getInputNodeIndices<Body>(current));
+                if(!parent)
+                    break;
+
+                auto maybeSetCoord = graph.control.get<SetCoordinate>(*parent);
+                if(maybeSetCoord)
+                {
+                    auto unrollCoord = graph.mapper.get<Unroll>(*parent);
+                    if(unrollCoord > 0)
+                    {
+                        unrolls.insert(unrollCoord);
+                    }
+                }
+                current = *parent;
+            }
+        }
+
         for(auto unroll : unrolls)
         {
-            std::vector<int> neighbourNodes;
-            if(direction == Graph::Direction::Upstream)
-                neighbourNodes = graph.coordinates.childNodes(unroll).to<std::vector>();
-            else
-                neighbourNodes = graph.coordinates.parentNodes(unroll).to<std::vector>();
+            // The Unroll is connected to a coordinate via an Identify edge.
+            // Follow the Identify chain and find a neighbour that's in the path.
+            auto unrollTarget = followIdentify(unroll, graph);
 
-            for(auto neighbourNode : neighbourNodes)
+            // Find a neighbour of unrollTarget that's actually in the path
+            auto coord = getNeighbourNodeInPath(unrollTarget, direction, path, graph);
+            if(coord != -1 && !isForLoop.contains(coord))
             {
-                if(path.contains(neighbourNode) && !isForLoop.contains(neighbourNode))
+                auto it = std::find(codegen.cbegin(), codegen.cend(), coord);
+                if(it == codegen.cend())
                 {
-                    auto it = std::find(codegen.cbegin(), codegen.cend(), neighbourNode);
-                    if(it == codegen.cend())
+                    // Check if this coordinate is already in ordered
+                    if(std::find(ordered.begin(), ordered.end(), coord) == ordered.end())
                     {
-                        ordered.push_back(neighbourNode);
-                        isUnroll.insert(neighbourNode);
+                        ordered.push_back(coord);
                     }
+                    isUnroll.insert(coord);
                 }
             }
         }

--- a/shared/rocroller/lib/source/KernelGraph/Transformations/AddPrefetch.cpp
+++ b/shared/rocroller/lib/source/KernelGraph/Transformations/AddPrefetch.cpp
@@ -197,6 +197,25 @@ namespace rocRoller
                         if(fl->loopName != rocRoller::KLOOP)
                             continue;
 
+                        // Prefetching requires LDS for double-buffering. Check if there are
+                        // any StoreLDSTile operations in the loop body. Without LDS stores,
+                        // prefetching doesn't make sense (e.g., BufferToVGPR load path).
+                        auto isBodyPredicate = kgraph.control.isElemType<Body>();
+                        auto isStoreLDSTile  = kgraph.control.isElemType<StoreLDSTile>();
+                        auto bodyEdges
+                            = filter(isBodyPredicate,
+                                     kgraph.control.getNeighbours<GD::Downstream>(*maybeForLoop))
+                                  .to<std::vector>();
+                        auto storeLDSTileNodes
+                            = kgraph.control.findNodes(bodyEdges, isStoreLDSTile, GD::Downstream);
+                        if(storeLDSTileNodes.empty())
+                        {
+                            Log::debug("KernelGraph::AddPrefetch(): ForLoop {} has no LDS stores, "
+                                       "skipping prefetch",
+                                       *maybeForLoop);
+                            continue;
+                        }
+
                         auto forLoopCoord     = getForLoopCoords(*maybeForLoop, kgraph).first;
                         auto maybeUnrollCoord = findUnrollNeighbour(kgraph, forLoopCoord);
                         if(forLoopCoordinates.contains(forLoopCoord)

--- a/shared/rocroller/scripts/lib/rrperf/rrsuites.py
+++ b/shared/rocroller/scripts/lib/rrperf/rrsuites.py
@@ -535,6 +535,9 @@ def tensile_sgemm_guidepost():
 
 
 def streamk_sweep():
+    # Prefetch configurations: (prefetch, prefetchInFlight, prefetchLDSFactor)
+    prefetchConfigs = [(False, 0, 0)] + [(True, 2, 2)]
+
     for twoTile, twoTileDPFirst in [(True, False), (False, True), (False, False)]:
         for base in [HGEMM_7680x8448x8448]:
             # Currently these run out of LDS everywhere except gfx950.
@@ -542,12 +545,31 @@ def streamk_sweep():
             for mac_m in [64, 128]:
                 for mac_n in [64, 128, 256]:
                     for mac_k in [16, 32, 64]:
-                        if (twoTile or twoTileDPFirst) and mac_m * mac_n * mac_k >= (
-                            64 * 256 * 64
-                        ):
-                            # currently these run out of VGPRs.
-                            pass
-                        else:
+                        for (
+                            prefetch,
+                            prefetchInFlight,
+                            prefetchLDSFactor,
+                        ) in prefetchConfigs:
+                            # Runs out of VGPRs
+                            if (
+                                twoTile or twoTileDPFirst
+                            ) and mac_m * mac_n * mac_k >= (64 * 256 * 64):
+                                continue
+
+                            # Runs out of VGPRs: TwoTile/TwoTileDPFirst + prefetch
+                            if (twoTile or twoTileDPFirst) and prefetch:
+                                continue
+
+                            # Runs out of VGPRs: Standard + large tiles + prefetchLDSFactor=2
+                            if (
+                                (not twoTile and not twoTileDPFirst)
+                                and prefetch
+                                and mac_n == 256
+                                and mac_k == 64
+                                and prefetchLDSFactor == 2
+                            ):
+                                continue
+
                             yield mkGEMM(
                                 base,
                                 mac_m=mac_m,
@@ -556,9 +578,9 @@ def streamk_sweep():
                                 workgroup_size_x=128,
                                 workgroup_size_y=2,
                                 visualize=False,
-                                prefetch=False,  # TODO: Fix k loop unrolling with stream k
-                                # prefetchInFlight=2,
-                                # prefetchLDSFactor=2,
+                                prefetch=prefetch,
+                                prefetchInFlight=prefetchInFlight,
+                                prefetchLDSFactor=prefetchLDSFactor,
                                 streamK=True,
                                 streamKTwoTile=twoTile,
                                 streamKTwoTileDPFirst=twoTileDPFirst,
@@ -575,6 +597,10 @@ def streamk():
         workgroup_size_x=128,
         workgroup_size_y=2,
         prefetch=False,
+        # TODO: Consider enabling, some run out of VGPRs
+        # prefetch=True,
+        # prefetchInFlight=2,
+        # prefetchLDSFactor=2,
         streamK=True,
     )
 
@@ -628,7 +654,7 @@ def smallMN_largeK_fp32():
         workgroup_size_x=128,
         workgroup_size_y=2,
         visualize=False,
-        prefetch=False,  # TODO: Fix k loop unrolling with stream k
+        prefetch=False,
         # prefetchInFlight=2,
         # prefetchLDSFactor=2,
         streamK=False,

--- a/shared/rocroller/test/unit/GEMMStreamKTest.cpp
+++ b/shared/rocroller/test/unit/GEMMStreamKTest.cpp
@@ -52,14 +52,18 @@ namespace GEMMTests
     {
     };
 
-    // Params are: A & B type, UnrollK, LoadPath A, LoadPath B, LDS D, StreamK two-tile, beta is zero
+    // PrefetchConfig: (prefetchInFlight, prefetchLDSFactor)
+    using PrefetchConfig = std::tuple<int, int>;
+
+    // Params: typeAB, unrollK, loadPathA, loadPathB, storeLDSD, mode, betaZero, prefetchConfig
     class StreamKTestGPU : public BaseGEMMContextFixture<std::tuple<rocRoller::DataType,
                                                                     int,
                                                                     SolutionParams::LoadPath,
                                                                     SolutionParams::LoadPath,
                                                                     bool,
                                                                     rocRoller::StreamKMode,
-                                                                    bool>>
+                                                                    bool,
+                                                                    PrefetchConfig>>
     {
     };
 
@@ -67,7 +71,7 @@ namespace GEMMTests
     {
         if(m_context->targetArchitecture().target().isCDNA1GPU())
         {
-            GTEST_SKIP() << "Skipping GPU_BasicGEMMStreamK test";
+            GTEST_SKIP() << "Skipping GPU_BasicGEMMFP16 test: CDNA1 not supported";
         }
 
         GEMMProblem gemm;
@@ -109,7 +113,8 @@ namespace GEMMTests
     {
         if(m_context->targetArchitecture().target().isCDNA1GPU())
         {
-            GTEST_SKIP() << "Skipping GPU_BasicGEMMStreamKWorkgroupMapping test";
+            GTEST_SKIP()
+                << "Skipping GPU_BasicGEMMStreamKWorkgroupMapping test: CDNA1 not supported";
         }
 
         GEMMProblem gemm;
@@ -138,20 +143,12 @@ namespace GEMMTests
     {
         if(m_context->targetArchitecture().target().isCDNA1GPU())
         {
-            GTEST_SKIP() << "Skipping GPU_BasicGEMMStreamK test";
+            GTEST_SKIP() << "Skipping GPU_BasicGEMM test: CDNA1 not supported";
         }
 
-        auto [typeAB, unrollK, loadPathA, loadPathB, storeLDSD, mode, betaZero]
+        auto [typeAB, unrollK, loadPathA, loadPathB, storeLDSD, mode, betaZero, prefetchConfig]
             = std::get<1>(GetParam());
-
-        if((typeAB == DataType::Float)
-           && (loadPathA == SolutionParams::LoadPath::BufferToLDSViaVGPR)
-           && (loadPathB == SolutionParams::LoadPath::BufferToLDSViaVGPR) && (storeLDSD)
-           && (mode != StreamKMode::Standard))
-        {
-            // We run out of LDS in this case
-            GTEST_SKIP() << "Skipping GPU_BasicGEMMStreamK test";
-        }
+        auto [prefetchInFlight, prefetchLDSFactor] = prefetchConfig;
 
         GEMMProblem gemm;
 
@@ -183,6 +180,14 @@ namespace GEMMTests
 
         if(betaZero)
             gemm.beta = 0;
+
+        // Enable prefetch if prefetchInFlight > 0
+        if(prefetchInFlight > 0)
+        {
+            gemm.prefetch          = true;
+            gemm.prefetchInFlight  = prefetchInFlight;
+            gemm.prefetchLDSFactor = prefetchLDSFactor;
+        }
 
         switch(typeAB)
         {
@@ -224,23 +229,81 @@ namespace GEMMTests
                 ::testing::Values(true, false) /* storeLDSD */
                 )));
 
+    using StreamKParamGenerator = ::testing::internal::ParamGenerator<StreamKTestGPU::ParamType>;
+    static auto FilterValidStreamKParams(StreamKParamGenerator&& inputParamGenerator)
+    {
+        using LP = SolutionParams::LoadPath;
+        using DT = rocRoller::DataType;
+        using SM = rocRoller::StreamKMode;
+
+        std::vector<StreamKTestGPU::ParamType> filtered;
+        for(auto const& inputParam : inputParamGenerator)
+        {
+            auto const& params = std::get<1>(inputParam);
+
+            auto const& typeAB                                = std::get<0>(params);
+            auto const& unrollK                               = std::get<1>(params);
+            auto const& loadPathA                             = std::get<2>(params);
+            auto const& loadPathB                             = std::get<3>(params);
+            auto const& storeLDSD                             = std::get<4>(params);
+            auto const& mode                                  = std::get<5>(params);
+            auto const& [prefetchInFlight, prefetchLDSFactor] = std::get<7>(params);
+
+            // Prefetch requires LDS
+            if((prefetchInFlight > 0) and (loadPathA == LP::BufferToVGPR)
+               and (loadPathB == LP::BufferToVGPR))
+            {
+                continue;
+            }
+
+            // Prefetch requires unrollK > 1
+            if(prefetchInFlight > 0 and unrollK < 2)
+            {
+                continue;
+            }
+
+            // Runs out of LDS
+            if((typeAB == DT::Float) and (loadPathA == LP::BufferToLDSViaVGPR)
+               and (loadPathB == LP::BufferToLDSViaVGPR) and (storeLDSD) and (mode != SM::Standard))
+            {
+                continue;
+            }
+
+            // Runs out of VGPRs: Float + both LDS paths + non-Standard StreamK + prefetch
+            if((typeAB == DT::Float) and (loadPathA == LP::BufferToLDSViaVGPR)
+               and (loadPathB == LP::BufferToLDSViaVGPR) and (mode != SM::Standard)
+               and (prefetchInFlight > 0))
+            {
+                continue;
+            }
+
+            filtered.push_back(inputParam);
+        }
+
+        return ::testing::ValuesIn(filtered);
+    }
+
     INSTANTIATE_TEST_SUITE_P(
         GEMMTest,
         StreamKTestGPU,
-        ::testing::Combine(
+        FilterValidStreamKParams(::testing::Combine(
             currentGPUISA(),
-            ::testing::Combine(
-                ::testing::Values(rocRoller::DataType::Float,
-                                  rocRoller::DataType::Half), // typeAB
-                ::testing::Values(1, 2), // UnrollK
-                ::testing::Values(SolutionParams::LoadPath::BufferToVGPR,
-                                  SolutionParams::LoadPath::BufferToLDSViaVGPR), // LoadPath A
-                ::testing::Values(SolutionParams::LoadPath::BufferToVGPR,
-                                  SolutionParams::LoadPath::BufferToLDSViaVGPR), // LoadPath B
-                ::testing::Values(true, false), // storeLDSD
-                ::testing::Values(rocRoller::StreamKMode::Standard,
-                                  rocRoller::StreamKMode::TwoTile,
-                                  rocRoller::StreamKMode::TwoTileDPFirst), // StreamKMode
-                ::testing::Values(true, false)))); // betaZero
+            ::testing::Combine(::testing::Values(rocRoller::DataType::Float,
+                                                 rocRoller::DataType::Half),
+                               ::testing::Values(1, 2), // unrollK
+                               ::testing::Values(SolutionParams::LoadPath::BufferToVGPR,
+                                                 SolutionParams::LoadPath::BufferToLDSViaVGPR),
+                               ::testing::Values(SolutionParams::LoadPath::BufferToVGPR,
+                                                 SolutionParams::LoadPath::BufferToLDSViaVGPR),
+                               ::testing::Values(true, false), // storeLDSD
+                               ::testing::Values(rocRoller::StreamKMode::Standard,
+                                                 rocRoller::StreamKMode::TwoTile,
+                                                 rocRoller::StreamKMode::TwoTileDPFirst),
+                               ::testing::Values(true, false), // betaZero
+                               ::testing::Values(PrefetchConfig{0, 0},
+                                                 PrefetchConfig{1, 0},
+                                                 PrefetchConfig{1, 2},
+                                                 PrefetchConfig{2, 0},
+                                                 PrefetchConfig{2, 2})))));
 
 } // namespace GEMMTests


### PR DESCRIPTION
## Motivation

GEMMs with StreamK + prefetch enabled and prefetchInFlight > 1 fail with high RNorms. The culprit is the second+ prefetched tile's loads are generated with an incorrect offset value (i.e. no offset), and load the wrong data.

This patch ensures that the correct offset value is computed.

## Technical Details

- Fixed Unroll coordinate handling for StreamK in `AddComputeIndex.cpp`. StreamK connects Unroll coordinates via Identify edges rather than CoordinateTransformEdges. The fix uses followIdentify() to resolve these chains before finding neighbors in the path, ensuring correct offset computation for prefetched loads.

- Added early-exit safeguard in findPrefetch() to skip loops without StoreLDSTile operations. This prevents attempting prefetch setup for BufferToVGPR load paths where LDS isn't used.

## Test Plan

- Expand the StreamK GEMM Test fixture to include prefetching options
- Adds prefetching options to the rrsuites StreamK sweep

## Test Result

- All StreamK + Prefetch GEMMs pass
- A few configurations in GEMMTest and the rrsuite need to be filtered out to avoid register pressure issues

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
