### PR TITLE
[hipDNN] [ALMIOPEN-515] Created empty plugin sdk

### DIFF
--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -174,6 +174,7 @@ if(HIP_DNN_BUILD_FRONTEND)
 endif()
 
 add_subdirectory(test_sdk)
+add_subdirectory(plugin_sdk)
 
 add_subdirectory(tests)
 

--- a/projects/hipdnn/plugin_sdk/CMakeLists.txt
+++ b/projects/hipdnn/plugin_sdk/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+include(CMakePackageConfigHelpers)
+
+set(HIP_DNN_PLUGIN_SDK_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+add_library(hipdnn_plugin_sdk INTERFACE)
+
+target_link_libraries(hipdnn_plugin_sdk INTERFACE hipdnn_sdk)
+
+set(HIP_DNN_PLUGIN_SDK_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/hipdnn/plugin_sdk")
+
+target_include_directories(
+    hipdnn_plugin_sdk INTERFACE $<BUILD_INTERFACE:${HIP_DNN_PLUGIN_SDK_INCLUDE_DIR}>
+                                $<INSTALL_INTERFACE:${HIP_DNN_PLUGIN_SDK_INSTALL_INCLUDE_DIR}>
+)
+
+# Generate the config file from template
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/hipdnn_plugin_sdkConfig.cmake.in"
+    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_plugin_sdk/hipdnn_plugin_sdkConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_plugin_sdk
+)
+
+export(
+    TARGETS hipdnn_plugin_sdk
+    FILE "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_plugin_sdk/hipdnn_plugin_sdkTargets.cmake"
+)
+
+install(TARGETS hipdnn_plugin_sdk EXPORT hipdnn_plugin_sdk_targets COMPONENT Development)
+
+install(
+    DIRECTORY ${HIP_DNN_PLUGIN_SDK_INCLUDE_DIR}/
+    DESTINATION ${HIP_DNN_PLUGIN_SDK_INSTALL_INCLUDE_DIR}
+    COMPONENT Development
+    FILES_MATCHING
+    PATTERN "*.hpp"
+)
+
+install(EXPORT hipdnn_plugin_sdk_targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_plugin_sdk
+        FILE hipdnn_plugin_sdkTargets.cmake COMPONENT Development
+)
+
+install(
+    FILES
+        "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_plugin_sdk/hipdnn_plugin_sdkConfig.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_plugin_sdk
+    COMPONENT Development
+)
+
+add_subdirectory(tests)

--- a/projects/hipdnn/plugin_sdk/cmake/hipdnn_plugin_sdkConfig.cmake.in
+++ b/projects/hipdnn/plugin_sdk/cmake/hipdnn_plugin_sdkConfig.cmake.in
@@ -1,0 +1,11 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(hipdnn_sdk CONFIG REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/hipdnn_plugin_sdkTargets.cmake")
+
+check_required_components(hipdnn_plugin_sdk)

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/PluginSdk.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/PluginSdk.hpp
@@ -1,0 +1,12 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+namespace hipdnn::plugin_sdk
+{
+inline void hello()
+{
+    // Placeholder function
+}
+}

--- a/projects/hipdnn/plugin_sdk/tests/CMakeLists.txt
+++ b/projects/hipdnn/plugin_sdk/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+include(GoogleTest)
+
+if(HIP_DNN_SKIP_TESTS)
+    message(STATUS "Skipping Plugin SDK tests")
+    return()
+endif()
+
+add_compile_definitions(__HIP_PLATFORM_AMD__)
+find_package(hip REQUIRED)
+find_package(Threads REQUIRED)
+enable_language(HIP)
+
+add_executable(hipdnn_plugin_sdk_tests main.cpp TestExample.cpp)
+target_compile_definitions(hipdnn_plugin_sdk_tests PRIVATE COMPONENT_NAME="hipdnn_plugin_sdk_tests")
+
+target_compile_options(hipdnn_plugin_sdk_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+target_link_libraries(
+    hipdnn_plugin_sdk_tests GTest::gtest GTest::gmock Threads::Threads hipdnn_plugin_sdk hip::host
+)
+
+clang_tidy_check(hipdnn_plugin_sdk_tests)
+add_unit_test_target(hipdnn_plugin_sdk_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/projects/hipdnn/plugin_sdk/tests/TestExample.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/TestExample.cpp
@@ -1,0 +1,11 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <hipdnn_plugin_sdk/PluginSdk.hpp>
+
+TEST(PluginSdk, Example)
+{
+    hipdnn::plugin_sdk::hello();
+    EXPECT_TRUE(true);
+}

--- a/projects/hipdnn/plugin_sdk/tests/main.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/main.cpp
@@ -1,0 +1,16 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <hipdnn_sdk/logging/Logger.hpp>
+#include <hipdnn_sdk/test_utilities/LoggingUtils.hpp>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    hipdnn::logging::initializeCallbackLogging(COMPONENT_NAME,
+                                               hipdnn_sdk::test_utilities::testLoggingCallback);
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Motivation
Create a blank plugin_sdk to begin the process of integrating into TheRock in a non-damaging fashion

## Technical Details
- Add basic plugin_sdk with test header
- Add basic plugin_sdk test with test executable

## Test Plan
- Run all unit tests
- Run all integration tests

## Test Result
- [x] All tests pass

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
