### PR TITLE
Re-enable gfx12-generic target

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -164,8 +164,7 @@
             || __builtin_amdgcn_processor_is("gfx9-generic")
     #define IS_RDNA4()                                                                       \
         __builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201") \
-            || __builtin_amdgcn_processor_is("gfx1250")                                      \
-            || __builtin_amdgcn_processor_is("gfx12-generic")
+            || __builtin_amdgcn_processor_is("gfx12-generic")  // TODO: Re-enable gfx1250 when supported by compiler
     #define IS_RDNA3()                                                                       \
         __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \
             || __builtin_amdgcn_processor_is("gfx1102")                                      \

--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -164,9 +164,8 @@
             || __builtin_amdgcn_processor_is("gfx9-generic")
     #define IS_RDNA4()                                                                       \
         __builtin_amdgcn_processor_is("gfx1200") || __builtin_amdgcn_processor_is("gfx1201") \
-        // TODO: enable when these structures are supported
-            /*|| __builtin_amdgcn_processor_is("gfx1250")                                      \
-            || __builtin_amdgcn_processor_is("gfx12-generic")*/
+            || __builtin_amdgcn_processor_is("gfx1250")                                      \
+            || __builtin_amdgcn_processor_is("gfx12-generic")
     #define IS_RDNA3()                                                                       \
         __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \
             || __builtin_amdgcn_processor_is("gfx1102")                                      \


### PR DESCRIPTION
## Motivation

Re-enable gfx12-generic support as it seems like it is now supported by __builtin_amdgcn_processor_is.  However it looks like gfx1250 is still unsupported.  I will file a ticket.

## Technical Details

Previously this target were not supported by the compiler version used in CI.  I think they are enabled now, but this PR will check it.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
