### PR TITLE
rocfft: only apply mapped solutions to contiguous transforms

### DIFF
--- a/projects/rocfft/CHANGELOG.md
+++ b/projects/rocfft/CHANGELOG.md
@@ -19,6 +19,7 @@ Documentation for rocFFT is available at
 * Fixed issue that sometimes blocked complex-to-complex FFT plan creation when using noncontiguous strides in multiple dimensions.
 * Fixed issue that sometimes blocked complex-to-real FFT plan creation when using noncontiguous strides with small lengths on the two fastest dimensions.
 * Fixed potential launch failure of data generation kernels in test and benchmark programs.
+* Fixed incorrect results on some strided real-complex FFTs on gfx90a.
 
 ## rocFFT 1.0.35 for ROCM 7.1.0
 

--- a/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
+++ b/projects/rocfft/clients/tests/accuracy_test_adhoc.cpp
@@ -493,6 +493,7 @@ const auto adhoc_nondefault_layout_real_tokens = {
     "real_forward_len_9_8_double_ip_batch_6908_istride_14_1_R_ostride_7_1_HI_idist_924_odist_462_ioffset_0_0_ooffset_0_0",
     "real_forward_len_486_double_op_batch_7014_istride_7014_R_ostride_7014_HI_idist_1_odist_1_ioffset_0_0_ooffset_0_0",
     "real_forward_len_486_double_op_batch_910_istride_910_R_ostride_910_HI_idist_1_odist_1_ioffset_0_0_ooffset_0_0",
+    "real_forward_len_26_52_double_op_batch_3899_istride_240_4_R_ostride_224_7_HI_idist_15600_odist_8960_ioffset_0_0_ooffset_0_0",
     // clang-format on
 };
 

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -1761,7 +1761,7 @@ static std::unique_ptr<ExecPlan> BuildSingleDevicePlan(NodeMetaData&         roo
                                              ? execPlan.rootPlan->length
                                              : execPlan.rootPlan->outputLength;
             const bool  evenLengthReal = (transformType == rocfft_transform_type_real_forward
-                                         || transformType == rocfft_transform_type_real_forward)
+                                         || transformType == rocfft_transform_type_real_inverse)
                                         && realLength.front() % 2 == 0;
             const bool stride1 = execPlan.rootPlan->inStride.front() == 1
                                  && execPlan.rootPlan->outStride.front() == 1;

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -1757,9 +1757,12 @@ static std::unique_ptr<ExecPlan> BuildSingleDevicePlan(NodeMetaData&         roo
             // the fastest dimension.  So only apply a solution if
             // we're not doing even-length real, or if fastest dim
             // stride is 1.
-            const bool evenLengthReal = (transformType == rocfft_transform_type_real_forward
+            const auto& realLength     = transformType == rocfft_transform_type_real_forward
+                                             ? execPlan.rootPlan->length
+                                             : execPlan.rootPlan->outputLength;
+            const bool  evenLengthReal = (transformType == rocfft_transform_type_real_forward
                                          || transformType == rocfft_transform_type_real_forward)
-                                        && execPlan.rootPlan->length[0] % 2 == 0;
+                                        && realLength.front() % 2 == 0;
             const bool stride1 = execPlan.rootPlan->inStride.front() == 1
                                  && execPlan.rootPlan->outStride.front() == 1;
             if(evenLengthReal && !stride1)

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -1747,21 +1747,34 @@ static std::unique_ptr<ExecPlan> BuildSingleDevicePlan(NodeMetaData&         roo
         execPlan.deviceProp = rootPlanData.deviceProp;
         execPlan.rootPlan   = NodeFactory::CreateExplicitNode(rootPlanData, nullptr);
 
-        // TODO: some solutions require the problems to be unit_stride, otherwise the
-        //   scheme-tree may not be applicable. In this case, we can't apply the solutions.
-        //   Currently, it happens on Real3DEven with REAL_2D_SINGLE kernels. This needs to
-        //   be detected.
-
         // If we are doing tuning initialzing now, we shouldn't apply any solution,
         // since we are trying enumerating solutions now
         if(TuningBenchmarker::GetSingleton().IsInitializingTuning() == false)
         {
-            execPlan.rootScheme = ApplySolution(execPlan);
-            if(execPlan.rootScheme)
+            // Solutions are tuned on the common case of contiguous
+            // transforms.  They are not necessarily correct for
+            // non-default strides.
+            if(rocfft_plan_t::is_contiguous(
+                   execPlan.rootPlan->length, execPlan.rootPlan->inStride, execPlan.rootPlan->iDist)
+               && rocfft_plan_t::is_contiguous(execPlan.rootPlan->outputLength,
+                                               execPlan.rootPlan->outStride,
+                                               execPlan.rootPlan->oDist))
             {
-                execPlan.rootPlan = nullptr;
-                execPlan.rootPlan = NodeFactory::CreateExplicitNode(
-                    rootPlanData, nullptr, execPlan.rootScheme->curScheme);
+                execPlan.rootScheme = ApplySolution(execPlan);
+                if(execPlan.rootScheme)
+                {
+                    execPlan.rootPlan = nullptr;
+                    execPlan.rootPlan = NodeFactory::CreateExplicitNode(
+                        rootPlanData, nullptr, execPlan.rootScheme->curScheme);
+                }
+            }
+            else
+            {
+                if(LOG_TRACE_ENABLED())
+                {
+                    (*LogSingleton::GetInstance().GetTraceOS())
+                        << "transform is not contiguous, not applying solution map" << std::endl;
+                }
             }
         }
 

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -1751,14 +1751,28 @@ static std::unique_ptr<ExecPlan> BuildSingleDevicePlan(NodeMetaData&         roo
         // since we are trying enumerating solutions now
         if(TuningBenchmarker::GetSingleton().IsInitializingTuning() == false)
         {
-            // Solutions are tuned on the common case of contiguous
-            // transforms.  They are not necessarily correct for
-            // non-default strides.
-            if(rocfft_plan_t::is_contiguous(
-                   execPlan.rootPlan->length, execPlan.rootPlan->inStride, execPlan.rootPlan->iDist)
-               && rocfft_plan_t::is_contiguous(execPlan.rootPlan->outputLength,
-                                               execPlan.rootPlan->outStride,
-                                               execPlan.rootPlan->oDist))
+            // Solutions do not consider strides.  Even-length real
+            // transforms need special consideration, since the
+            // even-length optimization is only valid for stride-1 on
+            // the fastest dimension.  So only apply a solution if
+            // we're not doing even-length real, or if fastest dim
+            // stride is 1.
+            const bool evenLengthReal = (transformType == rocfft_transform_type_real_forward
+                                         || transformType == rocfft_transform_type_real_forward)
+                                        && execPlan.rootPlan->length[0] % 2 == 0;
+            const bool stride1 = execPlan.rootPlan->inStride.front() == 1
+                                 && execPlan.rootPlan->outStride.front() == 1;
+            if(evenLengthReal && !stride1)
+            {
+                if(LOG_TRACE_ENABLED())
+                {
+                    (*LogSingleton::GetInstance().GetTraceOS())
+                        << "transform is even-length real but not stride-1, not applying solution "
+                           "map"
+                        << std::endl;
+                }
+            }
+            else
             {
                 execPlan.rootScheme = ApplySolution(execPlan);
                 if(execPlan.rootScheme)
@@ -1766,14 +1780,6 @@ static std::unique_ptr<ExecPlan> BuildSingleDevicePlan(NodeMetaData&         roo
                     execPlan.rootPlan = nullptr;
                     execPlan.rootPlan = NodeFactory::CreateExplicitNode(
                         rootPlanData, nullptr, execPlan.rootScheme->curScheme);
-                }
-            }
-            else
-            {
-                if(LOG_TRACE_ENABLED())
-                {
-                    (*LogSingleton::GetInstance().GetTraceOS())
-                        << "transform is not contiguous, not applying solution map" << std::endl;
                 }
             }
         }


### PR DESCRIPTION
## Motivation

Fix potential incorrect results on strided transforms, where stored solutions are incorrectly applied.

## Technical Details

rocFFT's solution map contains tuned solutions that were computed on contiguous transforms.  It is not always appropriate to apply these solutions to strided FFTs (most notably for even-length real-complex transforms).

So fix the planner to only apply solutions to contiguous transforms.

## Test Plan

Added a test case to cover this case.

## Test Result

The test case passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
