### PR TITLE
[hipFFT] Enable gfx1152 & gfx1153

### DIFF
--- a/projects/hipfft/CMakeLists.txt
+++ b/projects/hipfft/CMakeLists.txt
@@ -89,6 +89,8 @@ set(DEFAULT_GPUS
   gfx1101
   gfx1102
   gfx1151
+  gfx1152
+  gfx1153
   gfx1200
   gfx1201)
 


### PR DESCRIPTION
## Motivation

Enable gfx1152 and gfx1153.

## Test Plan

Used a fixed seed to make sure I test the same on gfx1152 than in gfx1153. Let me know if I should try with a bigger `test_prob` value.

$ hipfft-test --test_prob 0.02 --seed 1234567890

## Test Result

My board has little memory (8 GiB) and since FFTW_MULTITHREAD is enabled some test got skipped because host memory usage limit was exceeded.

gfx1152
```
[==========] 1456 tests from 40 test suites ran. (472572 ms total)
[  PASSED  ] 1445 tests.
[  SKIPPED ] 11 tests, listed below:
[  SKIPPED ] pow2_1D/accuracy_test.vs_fftw/complex_forward_len_134217728_double_op_batch_4_istride_1_CI_ostride_1_CI_idist_134217728_odist_134217728_ioffset_0_0_ooffset_0_0
[  SKIPPED ] pow2_1D/accuracy_test.vs_fftw/complex_forward_len_134217728_double_op_batch_2_istride_1_CI_ostride_1_CI_idist_134217728_odist_134217728_ioffset_0_0_ooffset_0_0
[  SKIPPED ] pow2_1D/accuracy_test.vs_fftw/real_forward_len_536870912_double_op_batch_1_istride_1_R_ostride_1_HI_idist_536870912_odist_268435457_ioffset_0_0_ooffset_0_0
[  SKIPPED ] pow2_2D/accuracy_test.vs_fftw/complex_forward_len_8192_8192_double_op_batch_2_istride_8192_1_CI_ostride_8192_1_CI_idist_67108864_odist_67108864_ioffset_0_0_ooffset_0_0
[  SKIPPED ] pow2_2D/accuracy_test.vs_fftw/complex_forward_len_8192_8192_double_ip_batch_1_istride_8192_1_CI_ostride_8192_1_CI_idist_67108864_odist_67108864_ioffset_0_0_ooffset_0_0
[  SKIPPED ] various_2D/accuracy_test.vs_fftw/complex_forward_len_8192_8192_double_op_batch_2_istride_8192_1_CI_ostride_8192_1_CI_idist_67108864_odist_67108864_ioffset_0_0_ooffset_0_0_autoallocation_off
[  SKIPPED ] various_2D/accuracy_test.vs_fftw/complex_forward_len_8192_8192_double_ip_batch_1_istride_8192_1_CI_ostride_8192_1_CI_idist_67108864_odist_67108864_ioffset_0_0_ooffset_0_0_autoallocation_off
[  SKIPPED ] hipfftw_test/hipfftw_functional_validation_sp.accuracy_vs_fftw/complex_inverse_len_394_431_379_single_op_batch_1_istride_163349_379_1_CI_ostride_163349_379_1_CI_idist_64359506_odist_64359506_ioffset_0_0_ooffset_0_0_flags_64_creation_input_mem_type_pageable_host_creation_output_mem_type_pageable_host_execution_input_mem_type_device_execution_output_mem_type_pinned_host
[  SKIPPED ] hipfftw_test/hipfftw_functional_validation_dp.accuracy_vs_fftw/complex_forward_len_6143_double_op_batch_7189_istride_1_CI_ostride_1_CI_idist_6143_odist_6143_ioffset_0_0_ooffset_0_0_flags_64_creation_input_mem_type_managed_creation_output_mem_type_pageable_host_execution_input_mem_type_pinned_host_execution_output_mem_type_pinned_host
[  SKIPPED ] hipfftw_test/hipfftw_functional_validation_dp.accuracy_vs_fftw/complex_inverse_len_466_double_op_batch_6850_istride_8_CI_ostride_8_CI_idist_5064_odist_3736_ioffset_0_0_ooffset_0_0_flags_64_creation_input_mem_type_managed_creation_output_mem_type_pinned_host_execution_input_mem_type_pinned_host_execution_output_mem_type_device
[  SKIPPED ] hipfftw_test/hipfftw_functional_validation_dp.accuracy_vs_fftw/real_inverse_len_22_1_23_double_op_batch_7930_istride_95160_95160_7930_HI_ostride_182390_182390_7930_R_idist_1_odist_1_ioffset_0_0_ooffset_0_0_flags_64_creation_input_mem_type_device_creation_output_mem_type_device

  YOU HAVE 1606 DISABLED TESTS

half precision max l-inf epsilon: 0.00082158
half precision max l2 epsilon:     0.00591627
single precision max l-inf epsilon: 1.43133e-07
single precision max l2 epsilon:     2.1346e-06
double precision max l-inf epsilon: 4.17951e-16
double precision max l2 epsilon:     5.27972e-15
Used random_seed = 1234567890
```

gfx1153
```
[==========] 1454 tests from 40 test suites ran. (525642 ms total)
[  PASSED  ] 1449 tests.
[  SKIPPED ] 5 tests, listed below:
[  SKIPPED ] pow2_1D/accuracy_test.vs_fftw/complex_forward_len_134217728_double_op_batch_4_istride_1_CI_ostride_1_CI_idist_134217728_odist_134217728_ioffset_0_0_ooffset_0_0
[  SKIPPED ] pow2_1D/accuracy_test.vs_fftw/complex_forward_len_134217728_double_op_batch_2_istride_1_CI_ostride_1_CI_idist_134217728_odist_134217728_ioffset_0_0_ooffset_0_0
[  SKIPPED ] pow2_1D/accuracy_test.vs_fftw/real_forward_len_536870912_double_op_batch_1_istride_1_R_ostride_1_HI_idist_536870912_odist_268435457_ioffset_0_0_ooffset_0_0
[  SKIPPED ] pow2_2D/accuracy_test.vs_fftw/complex_forward_len_8192_8192_double_op_batch_2_istride_8192_1_CI_ostride_8192_1_CI_idist_67108864_odist_67108864_ioffset_0_0_ooffset_0_0
[  SKIPPED ] various_2D/accuracy_test.vs_fftw/complex_forward_len_8192_8192_double_op_batch_2_istride_8192_1_CI_ostride_8192_1_CI_idist_67108864_odist_67108864_ioffset_0_0_ooffset_0_0_autoallocation_off

  YOU HAVE 1606 DISABLED TESTS

half precision max l-inf epsilon: 0.00082158
half precision max l2 epsilon:     0.00591627
single precision max l-inf epsilon: 1.43133e-07
single precision max l2 epsilon:     2.64272e-06
double precision max l-inf epsilon: 4.17951e-16
double precision max l2 epsilon:     7.79305e-15
Used random_seed = 1234567890
```


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
