### PR TITLE
Remove requirements-external.txt installs from workflows and Dockerfiles

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -94,10 +94,6 @@ jobs:
           # rm ./TheRock/patches/amd-mainline/rocm-libraries/*.patch
           git -c user.name="therockbot" -c "user.email=therockbot@amd.com" am --whitespace=nowarn ./TheRock/patches/amd-mainline/rocm-libraries/*.patch
 
-      - name: Install external python deps
-        run: |
-          pip install -r TheRock/requirements-external.txt
-
       - name: Configure Projects
         env:
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -105,10 +105,6 @@ jobs:
           git config --global core.longpaths true
           python ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-libraries --no-include-ml-frameworks
 
-      - name: Install external python deps
-        run: |
-          pip install -r TheRock/requirements-external.txt
-
       - name: Configure Projects
         env:
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -146,9 +146,6 @@ RUN git config --global url."https://github.com/".insteadOf git@github.com: && \
     git config --global credential.helper "!f() { echo username=anonymous; echo password=; }; f" && \
     python ./build_tools/fetch_sources.py
 
-# Do this after fetch_sources.py or you wont have the repos pulled this file references.
-RUN pip install -r requirements-external.txt
-
 RUN mkdir build
 WORKDIR /TheRock/build
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- Since `requirements-external.txt` was removed from TheRock, we need to remove the calls to it from the `rocm-libraries` side as well

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Removed references to `requirements-external.txt` in workflows and Dockerfiles

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure no workflows are broken after this change

## Test Result

<!-- Briefly summarize test outcomes. -->
- 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
