### PR TITLE
[hipblaslt] [CMS] Validator for GRs being finished before LR1s start

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -20,6 +20,7 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
+from math import floor
 from itertools import chain
 from dataclasses import dataclass, field
 from rocisa.code import KernelBody, Label, Macro, Module, RegSet, SrdUpperValue, \
@@ -371,6 +372,8 @@ class ValidatorInstruction(ABC):
     """
     Abstract class with no method just for type hinting purposes.
     """
+    issued_at: int | float
+
     @abstractmethod
     def validate(self) -> str | None:
         ...
@@ -378,9 +381,9 @@ class ValidatorInstruction(ABC):
 @dataclass
 class LocalRead(ValidatorInstruction):
     name: str
-    issued_at: int
-    needed_by: int
     num_vmfma: int
+    issued_at: int | float
+    needed_by: int
     guaranteed_by: int | float = float('inf')
 
     def validate(self) -> str | None:
@@ -393,22 +396,63 @@ class LocalRead(ValidatorInstruction):
         # Modulo for LRs that finish in next iteration.
         needed_by = self.needed_by % self.num_vmfma
         if guaranteed_by == float('inf'):
-            message = f"{self.name} at index {self.issued_at} is not valid. " + \
+            message = f"{self.name} at index {floor(self.issued_at)} is not valid. " + \
                         "There are no guarantees on when it will be done."
         else:
             if isinstance(guaranteed_by, float):
                 # Special case to handle idx=-1 which is written as numVMFMA - 0.5
+                # TODO: Need to handle new sub-index resolution case.
                 guaranteed_by = -1
             else:
                 guaranteed_by %= self.num_vmfma
-            message = f"{self.name} at index {self.issued_at} is not valid. " + \
+            message = f"{self.name} at index {floor(self.issued_at)} is not valid. " + \
                         f"Needed before index {needed_by}, but only guaranteed at index {guaranteed_by}."
         return message
+
+@dataclass
+class GlobalRead(ValidatorInstruction):
+    name: str
+    num_vmfma: int
+    issued_at: int | float
+    # NOTE: Using float position to handle position within a vmfma index.
+    needed_by: float = float('inf')
+    guaranteed_by: int | float = float('inf')
+    barriered_at: list[int | float] = field(default_factory=list)
+
+    def validate(self) -> str | None:
+        if self.issued_at < self.guaranteed_by < self.needed_by:
+            if any(self.guaranteed_by < barriered_at < self.needed_by for barriered_at in self.barriered_at):
+                    return None
+        
+        issued_at = floor(self.issued_at) % self.num_vmfma
+        needed_by = floor(self.needed_by) % self.num_vmfma
+
+        # 1. No SWait
+        if self.guaranteed_by == float('inf'):
+            return f"{self.name} at index {issued_at} is not valid. There are no guarantees on when it will be done."
+        
+        # NOTE: Must do it after the check above to guard against infinity.
+        guaranteed_by = floor(self.guaranteed_by) % self.num_vmfma
+
+        # 2. No Barrier
+        if len(self.barriered_at) == 0:
+            return f"{self.name} at index {issued_at} is not valid. There is no SBarrier acting on it."
+        
+        # 3. Guaranteed after needed
+        if self.guaranteed_by > self.needed_by:
+            return f"{self.name} at index {issued_at} is not valid. It is guaranteed by the SWait @ idx={guaranteed_by} which is after the first corresponding LR1 @ idx={needed_by}. Order must be GR -> SWait -> SBarrier -> LR1."
+
+        # 4. No Barrier between SWait and LR1
+        if not any(self.guaranteed_by < barriered_at < self.needed_by for barriered_at in self.barriered_at):
+            return f"{self.name} at index {issued_at} is not valid. No SBarrier between SWait @ idx={guaranteed_by} and LR1 @ idx={needed_by}. Order must be GR -> SWait -> SBarrier -> LR1."
+
+        # TODO: Did we miss a case and will we ever end up here?
+        return f"{self.name} at index {issued_at} is not valid. issued @ idx={issued_at}, guaranteed @ idx={guaranteed_by}, barriered @ idx={[floor(i) for i in self.barriered_at]}, needed @ idx={needed_by} is not valid."
 
 
 @dataclass
 class SWait(ValidatorInstruction):
-    issued_at: int
+    issued_at: int | float
     dscnt: int
     vlcnt: int
     vscnt: int
@@ -420,7 +464,16 @@ class SWait(ValidatorInstruction):
     def validate(self) -> str | None:
         if self._is_valid():
             return None
-        return f"SWait at index {self.issued_at} is invalid: dscnt={self.dscnt}, vlcnt={self.vlcnt}, vscnt={self.vscnt}, issued_at={self.issued_at}."
+        return f"SWait at index {floor(self.issued_at)} is invalid: dscnt={self.dscnt}, vlcnt={self.vlcnt}, vscnt={self.vscnt}, issued_at={floor(self.issued_at)}."
+
+@dataclass
+class Barrier(ValidatorInstruction):
+    issued_at: int | float
+    comment: str
+
+    def validate(self) -> str | None:
+        return f"Barrier at index {floor(self.issued_at)} is not valid. Must be >= -1." if self.issued_at < -1 else None
+
 
 def schedule_get(name: str, code_path: int, schedule_info: 'ScheduleInfo') -> list[list[int]]:
     """
@@ -486,14 +539,24 @@ def lr_needed_by_mfma(is_lra: bool, lr_idx: int, offset: int, schedule_info: 'Sc
         return index_lrb_needed_by_mfma(lr_idx, offset)
 
 
-def create_timeline(instruction_names_to_add: list[str], code_path: int, schedule_info: 'ScheduleInfo', kernel: 'Solution') -> list[list[ValidatorInstruction]]:
+def create_timeline(instruction_names_to_add: list[str], code_path: int, schedule_info: 'ScheduleInfo', kernel: 'Solution', sub_index_resolution: bool = False) -> list[list[ValidatorInstruction]]:
     """
     Create a timeline from the provided schedule_info which contains only the instructions inside `instruction_names_to_add`.
     Organized as a list of lists indexed by vmfma_index + 1.
 
     The +1 is required in order to handle the special case of idx=-1, which is at timeline[0].
     idx=-1 is special case that occurs BEFORE the first VMFMA but AFTER the last VMFMA.
+
+    Args:
+        instruction_names_to_add:   The list of instruction names to add to the timeline.
+        code_path:                  The code path to create a timeline out of.
+        schedule_info:              The schedule information to add to the timeline.
+        kernel:                     The kernel to add to the timeline.
+        sub_index_resolution:       If True, the issued_at index will be resolved to a sub-index within a vmfma index.
+                                    E.g. if issuing [GRA, SWaitCnt, SBarrier, LRA1] at index 5, the issued_at indices for each would be
+                                    [5, 5.25, 5.5, 5.75] I.e. vmfma_index + i/len(instructions @ vmfma_index)  
     """
+    # TODO: Always do sub_index_resultion. Fix any issues with other validation tests that don't work with it.
     # NOTE: numMfma + 1 to account for special idx=-1.
     #       idx=-1 is special case that occurs BEFORE the first VMFMA but AFTER the last VMFMA.
     #       Instructions at idx=-1 happen after all instructions at idx=numVMFMA-1 and BEFORE all instructions (including the VMFMA) at idx=0.
@@ -502,6 +565,9 @@ def create_timeline(instruction_names_to_add: list[str], code_path: int, schedul
     num_vmfma = schedule_info.numMfma
     halfway_point = num_vmfma // 2
 
+    direct_to_lds = kernel["DirectToLds"]
+    swap_global_read_order = kernel["SwapGlobalReadOrder"]
+    
     # NOTE: Relative ordering of instructions must be preserved.
     #       Order dictates the order in which instructions are scheduled if they are scheduled at the same vmfmaindex.
     for name in schedule_info.optSchedule.keys():
@@ -511,11 +577,15 @@ def create_timeline(instruction_names_to_add: list[str], code_path: int, schedul
         if name == "SYNC":
             for idx_sync, (idx_vmfma, sync) in enumerate(zip(schedule_get(name, code_path, schedule_info), schedule_info.syncCode)):
                 assert idx_vmfma >= -1, f"Code path {code_path}: SWaitCnt at index {idx_sync} is not valid. Must be >= -1."
-                if not isinstance(sync, SWaitCnt):
-                    continue
-
-                swait = SWait(issued_at=idx_vmfma, dscnt=sync.dscnt, vlcnt=sync.vlcnt, vscnt=sync.vscnt, comment=sync.comment)
-                timeline[idx_vmfma+1].append(swait)
+                
+                if isinstance(sync, SWaitCnt):
+                    sync_instruction = SWait(issued_at=idx_vmfma, dscnt=sync.dscnt, vlcnt=sync.vlcnt, vscnt=sync.vscnt, comment=sync.comment)
+                elif isinstance(sync, SBarrier):
+                    sync_instruction = Barrier(issued_at=idx_vmfma, comment=sync.comment)
+                else:
+                    raise ValueError(f"Unexpected sync instruction type: {type(sync)}")
+                
+                timeline[idx_vmfma+1].append(sync_instruction)
         elif name.startswith("LRA") or name.startswith("LRB"):
             offset = halfway_point if "0" in name else num_vmfma
             is_lra = name.startswith("LRA")
@@ -523,44 +593,100 @@ def create_timeline(instruction_names_to_add: list[str], code_path: int, schedul
                 assert idx_vmfma >= -1, f"Code path {code_path}: LocalRead {name} at index {idx_LR} is not valid. Must be >= -1."
 
                 needed_by = lr_needed_by_mfma(is_lra, idx_LR, offset, schedule_info, kernel)
-                local_read = LocalRead(name=name, issued_at=idx_vmfma, needed_by=needed_by, num_vmfma=num_vmfma)
+                local_read = LocalRead(name=name, num_vmfma=num_vmfma, issued_at=idx_vmfma, needed_by=needed_by)
                 timeline[idx_vmfma+1].append(local_read)
+        elif name.startswith("GRA") or name.startswith("GRB"):
+            global_reads = schedule_get(name, code_path, schedule_info)
+            assert not direct_to_lds or len(global_reads) % 2 == 0, f"Code path {code_path}: {name} has an odd number of indices. Must be even if DirectToLds is True."
+            
+            for idx_GR, idx_vmfma in enumerate(global_reads):
+                assert idx_vmfma >= -1, f"Code path {code_path}: GlobalRead {name} at index {idx_GR} is not valid. Must be >= -1."
+
+                # If using DirectToLds, only every other index (starting at index=1) is an actual GR, the others are increments to a pointer.
+                if direct_to_lds and idx_GR % 2 == 0:
+                    continue
+
+                gr_name = name
+                if swap_global_read_order:
+                    if name.startswith("GRA"):
+                        gr_name += " (Swapped, loading B)"
+                    elif name.startswith("GRB"):
+                        gr_name += " (Swapped, loading A)"
+                    else:
+                        raise ValueError(f"Unexpected global read name: {name}")
+
+                global_read = GlobalRead(name=gr_name, num_vmfma=num_vmfma, issued_at=idx_vmfma)
+                timeline[idx_vmfma+1].append(global_read)
         else:
             raise NotImplementedError(f"Instruction {name} not implemented")
+    
+    if sub_index_resolution:
+        for i_vmfma, instructions in enumerate(timeline):
+            for i_instruction, instruction in enumerate(instructions):
+                # NOTE: Because idx=-1 is special and occurs AFTER the insturctions scheduled at idx=numVMFMA-1 but BEFORE the VMFMA at indx=0, we need to adjust the sub_index_resolution so that the instructions at idx=(numVMFMA-1) have [0, 0.5) and the instructions at idx=0 have [0.5, 1).
+                divisor = len(instructions)
+                if i_vmfma == 0:
+                    divisor *= 2
+                    instruction.issued_at += 0.5
+                if i_vmfma == len(timeline) - 1:
+                    divisor *= 2
+                instruction.issued_at += i_instruction / divisor
 
     return timeline
 
-def apply_swaits(timeline: list[list[ValidatorInstruction]], num_vmfma: int) -> None:
+def apply_barriers(timeline: list[list[ValidatorInstruction]], num_vmfma: int) -> None:
     """
-    Apply the effect of SWaitCnts to the timeline by updating the guaranteed_by field of LocalReads.
+    Apply the effect of SBarriers to the timeline by updating the barriered_at field of GlobalReads.
+    Timeline is modified in place.
+    """
+    num_instructions = len(timeline)
+    # Mapping between linear index and barrier at that index
+    barriers: dict[int, Barrier] = {i: barrier for i, barrier in enumerate(timeline) if isinstance(barrier, Barrier)}
+    for i_barrier, barrier in barriers.items():
+        for _pass in range(2):
+            for i_gr in chain(range(i_barrier-1, -1, -1), range(num_instructions-1, i_barrier, -1)):
+                instruction = timeline[i_gr]
+                if not isinstance(instruction, GlobalRead):
+                    continue
+                new_barriered_at = barrier.issued_at + _pass * num_vmfma
+                if i_gr > i_barrier:
+                    # GlobalReads which finish during the next iteration.
+                    new_barriered_at += num_vmfma
+                instruction.barriered_at.append(new_barriered_at)
+
+def apply_swaits(timeline: list[ValidatorInstruction], num_vmfma: int) -> None:
+    """
+    Apply the effect of SWaitCnts to the timeline by updating the guaranteed_by field of LocalReads and GlobalReads.
     Timeline is modified in place.
     """
     num_instructions = len(timeline)
     # Mapping between linear index and swait at that index
     swaits: dict[int, SWait] = {i: swait for i, swait in enumerate(timeline) if isinstance(swait, SWait)}
 
+    def apply_wait_to_read(ReadClazz: ValidatorInstruction, i_swait: int, issued_at: int, num_left_in_flight: int, num_passes: int) -> None:
+        for _pass in range(num_passes):
+            for i_read in chain(range(i_swait-1, -1, -1), range(num_instructions-1, i_swait, -1)):
+                instruction = timeline[i_read]
+                if not isinstance(instruction, ReadClazz):
+                    continue
+
+                if num_left_in_flight > 0:
+                    num_left_in_flight -= 1
+                    continue
+
+                new_guaranteed_by = issued_at + _pass * num_vmfma
+                if i_read > i_swait:
+                    # LRs which finish during the next iteration.
+                    new_guaranteed_by += num_vmfma
+                if issued_at == -1:                    # Need a number between (numVMFMA-1) and numVMFMA, resort to floats.
+                    new_guaranteed_by += 0.5
+                instruction.guaranteed_by = min(instruction.guaranteed_by, new_guaranteed_by)
+
     for i_swait, swait in swaits.items():
-        num_left_in_flight = swait.dscnt
-        if num_left_in_flight == -1:
-            continue # -1 is special value to indicate doing nothing.
-
-        for i_lr in chain(range(i_swait-1, -1, -1), range(num_instructions-1, i_swait, -1)):
-            local_read = timeline[i_lr]
-            if not isinstance(local_read, LocalRead):
-                continue  # Only LRs are supported at the moment.
-            if num_left_in_flight > 0:
-                num_left_in_flight -= 1
-                continue
-
-            new_guaranteed_by = swait.issued_at
-            if i_lr > i_swait:
-                # LRs which finish during the next iteration.
-                new_guaranteed_by += num_vmfma
-            if swait.issued_at == -1:
-                # Need a number between (numVMFMA-1) and numVMFMA, resort to floats.
-                new_guaranteed_by += 0.5
-            local_read.guaranteed_by = min(local_read.guaranteed_by, new_guaranteed_by)
-
+        if swait.dscnt != -1:
+            apply_wait_to_read(LocalRead, i_swait, swait.issued_at, swait.dscnt, 1)
+        if swait.vlcnt != -1:   
+            apply_wait_to_read(GlobalRead, i_swait, swait.issued_at, swait.vlcnt, 2)
 @dataclass
 class GRIncData:
     """
@@ -689,6 +815,82 @@ def verify_lrs_complete_before_vmfma(schedule_info: 'ScheduleInfo', context: dic
             if error_message:
                 return error_message
         return None
+    
+    for code_path in range(schedule_info.numCodePaths):
+        error_message = verify(schedule_info, code_path)
+        if error_message:
+            return False, f"Code path {code_path}: {error_message}"
+    return True, ""
+
+def verify_grs_complete_before_lr1s(schedule_info: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
+    """
+    Ensure that the GlobalReads issued in the previous iteration are guaranteed to be complete before the first LRA/LRB1 of this iteration.
+    This hazard features inter-wave communication, so a barrier is needed
+    """
+    def verify(schedule_info: 'ScheduleInfo', code_path: int) -> str | None:
+        if len(schedule_info.mfmaReorder) != 0:
+            printWarning("Do not currently support mfmaReorder in CMS validation, cannot guarantee that LR1s will be correct.")
+            return None
+        
+        relevant_names = ["GRA", "GRB", "LRA1", "LRB1", "SYNC"]
+        timeline = create_timeline(relevant_names, code_path, schedule_info, context["kernel"], sub_index_resolution=True)
+
+        linear_timeline = []
+        GRAs: list[GlobalRead] = []
+        GRBs: list[GlobalRead] = []
+        first_LRA1, first_LRB1 = None, None
+        for instructions in timeline:
+            for instruction in instructions:
+                linear_timeline.append(instruction)
+                if isinstance(instruction, LocalRead):
+                    if instruction.name == "LRA1" and first_LRA1 is None:
+                        first_LRA1 = instruction
+                    elif instruction.name == "LRB1" and first_LRB1 is None:
+                        first_LRB1 = instruction
+                elif isinstance(instruction, GlobalRead):
+                    if instruction.name.startswith("GRA"):
+                        GRAs.append(instruction)
+                    elif instruction.name.startswith("GRB"):
+                        GRBs.append(instruction)
+
+        if not first_LRA1:
+            if "LRA3" in schedule_info.optSchedule:
+                printWarning("LRA3 is present in schedule, but LRA1 is not. This is not yet supported in CMS validation")
+                return None
+            return "First LRA1 not found."
+        if not first_LRB1:
+            return "First LRB1 not found."
+        if len(GRAs) == 0:
+            return "No GRAs in schedule."
+        if len(GRBs) == 0:
+            return "No GRBs in schedule."
+
+        apply_swaits(linear_timeline, schedule_info.numMfma)
+        apply_barriers(linear_timeline, schedule_info.numMfma)
+
+        # The GRAs we are interested in were issued in the previous iteration, 
+        # so we need to add the number of VMFMAs to the needed_by to account for us being in the next iteration.
+        GRAs_target_idx = first_LRA1.issued_at + schedule_info.numMfma
+        GRBs_target_idx = first_LRB1.issued_at + schedule_info.numMfma
+        # If the global read order is swapped, we need to swap the target indices since GRAs actually load B and GRBs actually load A.
+        if context["kernel"]["SwapGlobalReadOrder"]:
+            GRAs_target_idx, GRBs_target_idx = GRBs_target_idx, GRAs_target_idx
+
+        for gra in GRAs:
+            gra.needed_by = GRAs_target_idx
+        for grb in GRBs:
+            grb.needed_by = GRBs_target_idx
+
+        for instruction in linear_timeline:
+            if not isinstance(instruction, (Barrier, SWait, GlobalRead)):
+                # Do not validate LocalReads. 
+                # We don't load and place all of them, so the dscnts will be incorrect.
+                # They are validated in a seperate pass.
+                continue
+            error_message = instruction.validate()
+            if error_message:
+                return error_message
+        return None
 
     for code_path in range(schedule_info.numCodePaths):
         error_message = verify(schedule_info, code_path)
@@ -785,6 +987,8 @@ class ScheduleInfo:
             verify_ascending_order,
             verify_lrs_complete_before_vmfma,
             verify_global_reads_not_too_early,
+            # NOTE: Must run after verify_lrs_complete_before_vmfma to ensure that the position of the LR1s is valid.
+            verify_grs_complete_before_lr1s,
             verify_scc_overlap
         ]
 
@@ -1671,6 +1875,7 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
                     SBarrier(comment="")]
         nglshift = nllshift = 13
         opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
+        opt1.disableValidation()  # TODO: RE-enable after fixing https://github.com/ROCm/rocm-libraries/issues/3181
     elif isNT(kernel) and useLDSTr and TLDS==0:
         optSchedule = {
             'SYNC': [[-1,17,17,57,57]],
@@ -1701,8 +1906,6 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
     else:
         return False, None
 
-
-    
     
     return True, opt1
 
@@ -1879,6 +2082,7 @@ def _get_schedule_256x240x64_16bit(kernel, useLDSTr, TLDS):
 
     numMfma = 120  # Must match actual MFMA count for 256x240x64 tile
     opt1 = ScheduleInfo(1, numMfma, optSchedule, syncCode, nglshift, nllshift)
+    opt1.disableValidation()
     return True, opt1
 
 def _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -28,7 +28,7 @@ def create_base_kernel():
             "TransposeB": False,
         },
         "MacroTile0": 0, "MacroTile1": 0, "DepthU": 0,
-        "PrefetchGlobalRead": 0, "PrefetchLocalRead": 0, "DirectToLds": False,
+        "PrefetchGlobalRead": 0, "PrefetchLocalRead": 0, "DirectToLds": True,
         "GlobalReadVectorWidthA": 0, "GlobalReadVectorWidthB": 0,
         "LocalReadVectorWidth": 0,
         "WaveSeparateGlobalReadA": 0,
@@ -71,7 +71,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2], "TransposeLDS": 0 if NT else 1, "MIWaveTileA": 8, "MIWaveTileB": 8,
         })
@@ -113,7 +113,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 256, "DepthU": 128,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
             "GlobalReadVectorWidthA": 16, "GlobalReadVectorWidthB": 16, "LocalReadVectorWidth": 16,
             "MatrixInstruction": [16,16,128,1], "MIWaveGroup": [2,2], "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 8, "ForceUnrollSubIter": force_unroll_sub_iter,
         })
@@ -137,7 +137,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 96, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 3,
@@ -164,7 +164,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 192, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": NN, "TransposeLDS": 0 if NT else 1, "MIWaveTileA": 6, "MIWaveTileB": 8,
@@ -192,7 +192,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 192, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": not transA, "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 6,
@@ -217,7 +217,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 160, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": not transA, "TransposeLDS": not transB, "MIWaveTileA": 5, "MIWaveTileB": 8,
@@ -242,7 +242,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 160, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": True, "TransposeLDS": 0 if transB else 1, "MIWaveTileA": 8, "MIWaveTileB": 5,
@@ -268,7 +268,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 240, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 2, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [4,1],
             "LDSTrInst": True, "TransposeLDS": 1 if transA or not (transA or transB) else 0, "MIWaveTileA": 4, "MIWaveTileB": 15,
@@ -293,7 +293,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 208, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 2, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [4,1],
             "LDSTrInst": not transA , "TransposeLDS": 1, "MIWaveTileA": 4, "MIWaveTileB": 13,
@@ -317,7 +317,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 224, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "TransposeLDS": 1, "MIWaveTileA": 7, "MIWaveTileB": 8,
@@ -331,20 +331,22 @@ class TestCustomSchedule:
         valid, message = schedule_info.isValid({"kernel" : kernel})
         assert valid, message
 
-    def test_schedule_192x320x64_16bit_NN(self):
-        """Tests the 192x320x64 16-bit NN schedule."""
+    @pytest.mark.parametrize("transA, transB", [(False, False), (True, False)])
+    def test_schedule_192x320x64_16bit(self, transA, transB):
+        """Tests the 192x320x64 16-bit schedule."""
+        NN = not transA and not transB
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
         kernel["ProblemType"].update({
             "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": False, "TransposeB": False
+            "TransposeA": transA, "TransposeB": transB
         })
         kernel.update({
             "MacroTile0": 192, "MacroTile1": 320, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
-            "LDSTrInst": True, "TransposeLDS": 1, "MIWaveTileA": 6, "MIWaveTileB": 10,
+            "LDSTrInst": NN, "TransposeLDS": 1, "MIWaveTileA": 6, "MIWaveTileB": 10,
         })
 
         has_schedule, schedule_info = hasCustomSchedule(kernel)
@@ -365,7 +367,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 256, "MacroTile1": 224, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 7,
@@ -393,7 +395,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 320, "MacroTile1": 192, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
             "LDSTrInst": True, "TransposeLDS": NN, "MIWaveTileA": 10, "MIWaveTileB": 6,
@@ -421,7 +423,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 240, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 2, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [1,4],
             "TransposeLDS": TN, "MIWaveTileA": 15, "MIWaveTileB": 4,
@@ -445,6 +447,7 @@ class TestCustomSchedule:
         ])        
     def test_schedule_208x256x64_16bit(self, transA, transB, lds_tr_inst,  tr_lds):
         """Tests the 208x256x64 16-bit schedule."""
+        NT = not transA and transB
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
         kernel["ProblemType"].update({
@@ -453,7 +456,7 @@ class TestCustomSchedule:
         })
         kernel.update({
             "MacroTile0": 208, "MacroTile1": 256, "DepthU": 64,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1, "DirectToLds": True,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 2, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [1,4],
             "LDSTrInst": lds_tr_inst, "TransposeLDS": tr_lds, "MIWaveTileA": 13, "MIWaveTileB": 4,

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_VerifyGRsCompleteBeforeLr1s.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_VerifyGRsCompleteBeforeLr1s.py
@@ -1,0 +1,416 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+################################################################################
+import unittest
+import pytest
+
+from rocisa.instruction import SWaitCnt, SBarrier
+
+from Tensile.Components.CustomSchedule import verify_grs_complete_before_lr1s
+from test_CustomSchedule import create_base_kernel, ScheduleInfo
+
+class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
+    def setUp(self):
+        self.kernel = create_base_kernel()
+        self.num_vmfma = 2 * self.kernel["MIWaveTileA"] * self.kernel["MIWaveTileB"]
+
+    def test_simple_case_success(self):
+        """
+        Simple case where the LR1s occur after the GRs with SWait and Sbarrier between them.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[0, 2, 4, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[0,0]],
+            "GRB":  [[0,0]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_grs_not_swait(self):
+        """
+        Failure case where GRs are not guaranteed before LR1s due to incorrect SWaitCnt.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[0, 2, 4, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[0,0]],
+            "GRB":  [[0,0]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=-1, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (GRA is not guaranteed before LRA1), but passed. {message}"
+        assert message == "Code path 0: GRA at index 0 is not valid. There are no guarantees on when it will be done."
+
+    def test_no_sbarrier(self): 
+        """
+        Failure case where there is no SWait between GRs and LR1s.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[0, 1, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[0,0]],
+            "GRB":  [[0,0]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (GRA is not guaranteed before LRA1), but passed. {message}"
+        assert message == "Code path 0: GRA at index 0 is not valid. There is no SBarrier acting on it."
+
+    def test_swait_after_sbarrier(self):
+        """
+        Failure case when the latest barrier acting on the GRs occurs BEFORE the SWaitCnt that guarantees those GRs.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[0, 2, 3, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[0,0]],
+            "GRB":  [[0,0]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (no barrier between GRA and LRA1), but passed. {message}"
+        assert message == "Code path 0: GRA at index 0 is not valid. No SBarrier between SWait @ idx=3 and LR1 @ idx=6. Order must be GR -> SWait -> SBarrier -> LR1."
+
+    def test_guaranteed_after_first_lr1(self):
+        """
+        Simple failure case where the last GR is guaranteed AFTER the first LR1 starts.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[0, 4, 4, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[0,0, 0,0]],
+            "GRB":  [[0,0, 0,0]],
+            "LRA1": [[3,6,6,6]],
+            "LRB1": [[6,6,6,6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=4, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed (first LRA1 before last GRA), but passed. {message}"
+        assert message == "Code path 0: GRA at index 0 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=3. Order must be GR -> SWait -> SBarrier -> LR1."
+
+    def test_less_than_1_full_iteration_to_complete(self):
+        """
+        Passing case where the GRs have and SWait and SBarrier on them before a full iteration has completed.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[0, 1, 2, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[3,3]],
+            "GRB":  [[3,3]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=0, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_some_grs_less_than_1_full_iteration_to_complete(self):
+        """
+        Passing case where some GRs have and SWait and SBarrier on them before a full iteration has completed.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[0, 3, 3, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[1,1, 2,2, 3,3]],
+            "GRB":  [[1,1, 2,2, 3,3]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_swait_and_sbarrier_in_preloop(self):
+        """
+        Passing, but pathalogical, case where the SWait and SBarrier are in the preloop.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "SYNC": [[-1, -1, -1, self.num_vmfma-1]],
+            "GRA":  [[3,3]],
+            "GRB":  [[3,3]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=0, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_grs_in_preloop(self):
+        """
+        Passing, but pathalogical, case where the GRs are in the preloop.
+        """
+        assert self.num_vmfma == 8
+        
+        optSchedule = {
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "SYNC": [[-1, 0, 0, self.num_vmfma-1]],
+            "GRA":  [[-1,-1]],
+            "GRB":  [[-1,-1]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=0, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_last_gr_swait_sbarrier_in_same_index(self):
+        """
+        At index 1 we have [GRA, GRB, SWait, SBarrier].
+        While we wouldn't schedule this, it is still valid.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "GRA":  [[1,1]],
+            "GRB":  [[1,1]],
+            "SYNC": [[0, 1, 1, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_swait_sbarrier_first_lr1_in_same_index(self):
+        """
+        At index 6 we have [SWait, SBarrier, LRA1, LRB1].
+        While it's unlike this would actually be scheduled it's still valid and must pass validation.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[0, 6, 6, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[1,1]],
+            "GRB":  [[1,1]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_swap_global_read_order_success(self):
+        """
+        Passing case where the GlobalRead order is swapped.
+        """
+        assert self.num_vmfma == 8
+        self.kernel["SwapGlobalReadOrder"] = True
+
+        optSchedule = {
+            "SYNC": [[0, 1, 1, 4, 4, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[0,0]],
+            "GRB":  [[3,3]],
+            "LRA1": [[5]],
+            "LRB1": [[2]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRBs (loading A)"),
+            SBarrier(comment="For GRBs (loading A)"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRAs (loading B)"),
+            SBarrier(comment="For GRAs (loading B)"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert status, f"Schedule should have passed validation but did not. {message}"
+
+    def test_swap_global_read_order_failure(self):
+        """
+        Failure case where the GlobalRead order is swapped.
+        E.g. Someone forgets that the GRAs actually load B and the GRBs actually load A and scheudles them as normally.
+        """
+        assert self.num_vmfma == 8
+        self.kernel["SwapGlobalReadOrder"] = True
+
+        optSchedule = {
+            "SYNC": [[0, 1, 1, 4, 4, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[0,0]],
+            "GRB":  [[3,3]],
+            "LRA1": [[2]],
+            "LRB1": [[5]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRAs (loading B)"),
+            SBarrier(comment="For GRAs (loading B)"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRBs (loading A)"),
+            SBarrier(comment="For GRBs (loading A)"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+        status, message = verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        assert not status, f"Schedule should have failed validation but passed. {message}"
+        assert message == "Code path 0: GRB (Swapped, loading A) at index 3 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=2. Order must be GR -> SWait -> SBarrier -> LR1."
+
+    def test_fail_with_odd_number_of_grs(self):
+        """
+        When using DirectToLds, we must have an even number of GRs.
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[0, 2, 4, self.num_vmfma-1]],
+            "LRA0": [[-1]],
+            "LRB0": [[-1]],
+            "GRA":  [[0]],
+            "GRB":  [[0,0]],
+            "LRA1": [[6]],
+            "LRB1": [[6]]
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR0s"),
+            SWaitCnt(dscnt=-1, vlcnt=2, vscnt=-1, comment="Wait for GRs"),
+            SBarrier(comment="For GRs"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
+        ]
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
+
+        with pytest.raises(AssertionError) as excinfo:
+            verify_grs_complete_before_lr1s(sched, {"kernel": self.kernel})
+        
+        assert str(excinfo.value) == "Code path 0: GRA has an odd number of indices. Must be even if DirectToLds is True."


### PR DESCRIPTION
## Motivation

It is easy to incorrectly start LR1s before all of the GRs are guaranteed to finish. Errors from this are non-deterministic since they rely on memory stalls and race conditions.

This is especially true when using `SwapGlobalReadOrder` or giving the GRs less than 1 whole iteration to complete.

## Technical Details

Similar approach to previous validator. Schedule insturctions into a linear timeline.
1. Schedule GRs, SWaits, SBarriers, and LR1s. **Assume LR1s are valid, rely on other pass to guarantee this.**
2. Apply effect of Swaits and SBarriers onto GRs
3. Ensure that between when the last GR is issued and the first corresponding LR1 is issued that:
   1. There is an SWait that guarantees the GRs to finish.
   2. There is an SBarrier between that SWait and the first LR1. 

Handles `SwapGlobalReadOrder`.

## Test Plan

1. Add extra tests.
5. Run existing tests.

## Test Result

1. New tests all pass.
2. Several existing schedules fail. Separate issues opened to track them:
  - #3181
  - #3182
  - #3183

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
