### PR TITLE
Fix global read validator by considering LR[AB]1

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -46,94 +46,52 @@ from copy import deepcopy
 from collections import Counter, defaultdict
 from typing import Callable, Dict, List, Tuple
 
-def getMostRecents(
-    vmfmaIndices: List[int],
+def get_most_recent_local_reads(
+    vmfmas: List[int],
     counts: List[int],
-    localReadA0: List[int],
-    localReadB0: List[int],
-    localReadA1: List[int],
-    localReadB1: List[int],
-    positions: Dict[str, int],
+    history: List[Tuple[int, List[str]]],
 ) -> List[Dict[str, int]]:
     """
-    For each waitcnt instruction located at `vmfmaIndices[i]`, compute how many
-    of the most recent `counts[i]` local reads belong to operand A and operand B.
-
-    This is computed by walking backwards through historical local read positions.
+    For each waitcnt instruction located at `vmfmas[i]`, compute how many
+    of the most recent `counts[i]` local reads come from each of the 4 local read
+    types (LRA0, LRA1, LRB0, LRB1). This is computed by walking backwards through
+    historical local read positions.
 
     Args:
-        vmfmaIndices:
+        vmfmas:
             List of vmfma instruction indices where s_waitcnt appears.
         counts:
             Number of outstanding operations each waitcnt must account for.
-        localReadA:
-            vmfma indices where local reads for operand A occur.
-        localReadB:
-            vmfma indices where local reads for operand B occur.
+        history:
+            A list containing all local read events for every vmfma index where
+            at least one local read occured.
 
     Returns:
-        A list of dicts of the form:
-            [{"A": int, "B": int}, ...]
+        A list of dicts, of the form:
+            [{"LRA0": int, "LRB0": int, "LRA1": int, "LRB1": int}, ...]
+
         where each entry corresponds to the number of most-recent local reads
-        attributed to A and B for that waitcnt.
+        attributed to different local read types for that waitcnt.
     """
 
     assert len(counts) == len(
-        vmfmaIndices
-    ), "Counts and vmfmaIndices must match in length."
+        vmfmas
+    ), "Counts and vmfmas must match in length."
 
-    def countMostRecent(
-        vmfma_index: int,
-        count: int,
-        history: List[Tuple[int, List[str]]],
-    ) -> Dict[str, int]:
-        """
-        Walk backward through local-read history and count how many of the
-        most recent `count` operations were for A vs B.
-        """
-
+    results: List[Dict[str, int]] = []
+    for count, vmfma in zip(counts, vmfmas):
         idx = 0
-        while idx + 1 < len(history) and history[idx + 1][0] <= vmfma_index:
+        while idx + 1 < len(history) and history[idx + 1][0] <= vmfma:
             idx += 1
-
-        result = {"A": 0, "B": 0}
+        result = {"LRA0": 0, "LRB0": 0, "LRA1": 0, "LRB1": 0}
         remaining = count
-
         while idx >= 0 and remaining > 0:
             for operand in history[idx][1][::-1]:
-                if operand == "LRA0":
-                    result["A"] += 1
-                if operand == "LRB0":
-                    result["B"] += 1
+                result[operand] += 1
                 remaining -= 1
                 if remaining == 0:
                     break
-
             idx -= 1
-
-        return result
-
-    X = [
-        ("LRA0", localReadA0),
-        ("LRB0", localReadB0),
-        ("LRA1", localReadA1),
-        ("LRB1", localReadB1),
-    ]
-    X.sort(key=lambda x: positions[x[0]])
-
-    history = {}
-    for symbol, values in X:
-        for v in values:  # iterate over each int inside the list
-            if v not in history:
-                history[v] = []
-            history[v].append(symbol)
-
-    # Convert dict → sorted list of tuples (v, ["A","B",...])
-    history = sorted(history.items(), key=lambda t: t[0])
-
-    results: List[Dict[str, int]] = []
-    for wait_count, slot in zip(counts, vmfmaIndices):
-        result = countMostRecent(slot, wait_count, history)
         results.append(result)
 
     return results
@@ -182,15 +140,29 @@ def verify_global_reads_not_too_early_single_code_path(
             indicesOfWaitsInSyncCode.append(syncCodeIndex)
         syncCodeIndex += 1
 
-    preceding = getMostRecents(
+
+    # Construct, for every index where a local read occured, the sequence of
+    # local reads that occured, in chronological order.
+    localReads = [
+        ("LRA0", localReadA0),
+        ("LRB0", localReadB0),
+        ("LRA1", localReadA1),
+        ("LRB1", localReadB1),
+    ]
+    localReads.sort(key=lambda x: positions[x[0]])
+
+    history = {}
+    for symbol, values in localReads:
+        for v in values:
+            if v not in history:
+                history[v] = []
+            history[v].append(symbol)
+    history = sorted(history.items(), key=lambda t: t[0])
+
+    preceding = get_most_recent_local_reads(
         vmfmaIndices,
         counts,
-        localReadA0,
-        localReadB0,
-        localReadA1,
-        localReadB1,
-        positions,
-    )
+        history)
     for l, g, operand in [
         (localReadA0, globalReadA, "A"),
         (localReadB0, globalReadB, "B"),
@@ -214,10 +186,12 @@ def verify_global_reads_not_too_early_single_code_path(
         waveCompleteIndex = None
         # From the start of the schedule which waitcnt is the current one?
         waitIndex = 0
-        for syncIndex, p in zip(vmfmaIndices, preceding):
+        for syncIndex, precede in zip(vmfmaIndices, preceding):
             if closedLowerBound <= syncIndex and syncIndex < openUpperBound:
-                outstandings.append(p[operand])
-                if waveCompleteIndex is None and p[operand] == 0:
+                print(precede)
+                count = precede[LRX]
+                outstandings.append(count)
+                if waveCompleteIndex is None and count == 0:
                     waveCompleteIndex = syncIndex
                     break
             waitIndex += 1
@@ -453,7 +427,7 @@ class GlobalRead(ValidatorInstruction):
         if self.issued_at < self.guaranteed_by < self.needed_by:
             if any(self.guaranteed_by < barriered_at < self.needed_by for barriered_at in self.barriered_at):
                     return None
-        
+
         issued_at = floor(self.issued_at) % self.num_vmfma
         needed_by = floor(self.needed_by) % self.num_vmfma
 
@@ -462,14 +436,14 @@ class GlobalRead(ValidatorInstruction):
         # 1. No SWait
         if self.guaranteed_by == float('inf'):
             return f"{name} at index {issued_at} is not valid. There are no guarantees on when it will be done."
-        
+
         # NOTE: Must do it after the check above to guard against infinity.
         guaranteed_by = floor(self.guaranteed_by) % self.num_vmfma
 
         # 2. No Barrier
         if len(self.barriered_at) == 0:
             return f"{name} at index {issued_at} is not valid. There is no SBarrier acting on it."
-        
+
         # 3. Guaranteed after needed
         if self.guaranteed_by > self.needed_by:
             return f"{name} at index {issued_at} is not valid. It is guaranteed by the SWait @ idx={guaranteed_by} which is after the first corresponding LR1 @ idx={needed_by}. Order must be GR -> SWait -> SBarrier -> LR1."
@@ -485,7 +459,7 @@ class GlobalRead(ValidatorInstruction):
         name = self.name
         if not self.swap_global_read_order:
             return name
-        
+
         if name.startswith("GRA"):
             return name + " (Swapped, loading B)"
         elif name.startswith("GRB"):
@@ -531,19 +505,19 @@ class Timeline:
 
     def __iter__(self):
         return iter(self._timeline)
-    
+
     def __len__(self):
         return len(self._timeline)
 
     def __getitem__(self, index: int) -> ValidatorInstruction:
         return self._timeline[index]
-    
+
     def insert(self, vmfma_index: int, instruction: ValidatorInstruction) -> None:
         """
         Add an instruction to the timeline at a given VMFMA index.
         """
         self._instructions_at_index[vmfma_index+1].append(instruction)
-        
+
         # If we've already linearized the timeline, we need to do so again now that we've added a new instruction.
         if self._timeline:
             self.linearize_timeline()
@@ -553,7 +527,7 @@ class Timeline:
         Return the instructions scheduled with a given name (e.g. "GRA").
         """
         return self._instructions_for_name[name]
-    
+
     def get_instructions_at_index(self, index: int) -> list[ValidatorInstruction]:
         """
         Return the instructions scheduled at a given VMFMA index.
@@ -659,7 +633,7 @@ def create_timeline(instruction_names_to_add: list[str], code_path: int, schedul
         instruction_names_to_add:   The list of instruction names to add to the timeline.
         code_path:                  The code path to create a timeline out of.
         schedule_info:              The schedule information to add to the timeline.
-        kernel:                     The kernel to add to the timeline. 
+        kernel:                     The kernel to add to the timeline.
     """
     num_vmfma = schedule_info.numMfma
     halfway_point = num_vmfma // 2
@@ -668,7 +642,7 @@ def create_timeline(instruction_names_to_add: list[str], code_path: int, schedul
     swap_global_read_order = kernel["SwapGlobalReadOrder"]
 
     timeline = Timeline(num_vmfma)
-    
+
     # NOTE: Relative ordering of instructions must be preserved.
     #       Order dictates the order in which instructions are scheduled if they are scheduled at the same vmfmaindex.
     for name in schedule_info.optSchedule.keys():
@@ -678,14 +652,14 @@ def create_timeline(instruction_names_to_add: list[str], code_path: int, schedul
         if name == "SYNC":
             for idx_sync, (idx_vmfma, sync) in enumerate(zip(schedule_get(name, code_path, schedule_info), schedule_info.syncCode)):
                 assert idx_vmfma >= -1, f"Code path {code_path}: SWaitCnt at index {idx_sync} is not valid. Must be >= -1."
-                
+
                 if isinstance(sync, SWaitCnt):
                     sync_instruction = SWait(issued_at=idx_vmfma, dscnt=sync.dscnt, vlcnt=sync.vlcnt, vscnt=sync.vscnt, comment=sync.comment)
                 elif isinstance(sync, SBarrier):
                     sync_instruction = Barrier(issued_at=idx_vmfma, comment=sync.comment)
                 else:
                     raise ValueError(f"Unexpected sync instruction type: {type(sync)}")
-                
+
                 timeline.insert(idx_vmfma, sync_instruction)
         elif name.startswith("LRA") or name.startswith("LRB"):
             offset = halfway_point if "0" in name else num_vmfma
@@ -699,7 +673,7 @@ def create_timeline(instruction_names_to_add: list[str], code_path: int, schedul
         elif name.startswith("GRA") or name.startswith("GRB"):
             global_reads = schedule_get(name, code_path, schedule_info)
             assert not direct_to_lds or len(global_reads) % 2 == 0, f"Code path {code_path}: {name} has an odd number of indices. Must be even if DirectToLds is True."
-            
+
             for idx_GR, idx_vmfma in enumerate(global_reads):
                 assert idx_vmfma >= -1, f"Code path {code_path}: GlobalRead {name} at index {idx_GR} is not valid. Must be >= -1."
 
@@ -711,10 +685,10 @@ def create_timeline(instruction_names_to_add: list[str], code_path: int, schedul
                 timeline.insert(idx_vmfma, global_read)
         else:
             raise NotImplementedError(f"Instruction {name} not implemented")
-    
+
     # Resolve issued_at index to a sub-index resolution
     # E.g. if issuing [GRA, SWaitCnt, SBarrier, LRA1] at index 5, the issued_at indices for each would be [5, 5.25, 5.5, 5.75].
-    # I.e. vmfma_index + i/len(instructions @ vmfma_index) 
+    # I.e. vmfma_index + i/len(instructions @ vmfma_index)
     # NOTE: Because idx=-1 is special and occurs AFTER the insturctions scheduled at idx=numVMFMA-1 but BEFORE the VMFMA at indx=0, we need to adjust the index so that the instructions at idx=(numVMFMA-1) have [0, 0.5) and the instructions at idx=0 have [0.5, 1).
     for i_vmfma in range(-1, num_vmfma):
         instructions = timeline.get_instructions_at_index(i_vmfma)
@@ -776,7 +750,7 @@ def apply_swaits(timeline: Timeline, num_vmfma: int) -> None:
     for i_swait, swait in timeline.get_instructions_for_name("SWaitCnt"):
         if swait.dscnt != -1:
             apply_wait_to_read(LocalRead, i_swait, swait.issued_at, swait.dscnt, 1)
-        if swait.vlcnt != -1:   
+        if swait.vlcnt != -1:
             apply_wait_to_read(GlobalRead, i_swait, swait.issued_at, swait.vlcnt, 2)
 @dataclass
 class GRIncData:
@@ -794,7 +768,7 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
         - between GRIncA and GRIncB
         - between GRInc and GR when DLT is activated
         - between GRInc and LWS
-        
+
     By default, GRInc instructions can be split into 3 distinct intervals where we shouldn't touch SCC
       - s_cmp_eq_u32, s_cselect_b32,s_cselect_b32 (3)
       - s_add_u32, s_addc_u32 (2)
@@ -804,16 +778,16 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
       - s_cmp_eq_u32, s_cselect_b32,s_cselect_b32 (3)
       - s_add_u32, s_addc_u32 (2)
       - s_sub_u32  (2)
-    
+
         This function checks no other scalar instructions is inside the above intervals.
     """
     kernel = context["kernel"]
     DTL = kernel["DirectToLds"]
     ShadowLimit = kernel["Use64bShadowLimit"]
-    
+
     intervalSize = [3,2,2,2] if ShadowLimit else [3,2,1] # Values explained above
     numElements = sum(intervalSize)
-    
+
     # Gets intervals from GRInc indices based on the above `intervalSize` value
     def getIntervals(indices):
         output = []
@@ -826,7 +800,7 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
             current_start = current_end
         return output
 
-    # Checks value is in [interval[0],interval[1]]. 
+    # Checks value is in [interval[0],interval[1]].
     # if lhsGt : ]interval[0],interval[1]] else  [interval[0],interval[1][
     def inInterval(value : int, interval : list[int], lhsGt : bool):
         if lhsGt:
@@ -867,13 +841,13 @@ def verify_scc_overlap(scheduleInfo, context: Dict = {}):
         for grIncData in GRIncs:
             for name in names:
                 insts = schedule_get(name, codePath, scheduleInfo)
-                # In case of GRA/GRB, just take m0 updates indices 
+                # In case of GRA/GRB, just take m0 updates indices
                 if name.startswith("GR"):
                     insts = insts[0::2]
                 errorMessage = verifyIndices(grIncData, name, insts)
                 if errorMessage:
                     return errorMessage
-   
+
     for codePath in range(scheduleInfo.numCodePaths):
             errorMessage = verify(scheduleInfo, codePath)
             if errorMessage:
@@ -900,7 +874,7 @@ def verify_lrs_complete_before_vmfma(schedule_info: 'ScheduleInfo', context: dic
 
         apply_swaits(timeline, schedule_info.numMfma)
         return timeline.validate()
-    
+
     for code_path in range(schedule_info.numCodePaths):
         error_message = verify(schedule_info, code_path)
         if error_message:
@@ -916,7 +890,7 @@ def verify_grs_complete_before_lr1s(schedule_info: 'ScheduleInfo', context: dict
         if len(schedule_info.mfmaReorder) != 0:
             printWarning("Do not currently support mfmaReorder in CMS validation, cannot guarantee that LR1s will be correct.")
             return None
-        
+
         available_keys = schedule_info.optSchedule.keys()
         if "LRA1" not in available_keys and "LRA3" in available_keys:
             printWarning("LRA3 is present in schedule, but LRA1 is not. This is not yet supported in CMS validation")
@@ -933,7 +907,7 @@ def verify_grs_complete_before_lr1s(schedule_info: 'ScheduleInfo', context: dict
 
         _, first_LRA1 = timeline.get_instructions_for_name("LRA1")[0]
         _, first_LRB1 = timeline.get_instructions_for_name("LRB1")[0]
-        # The GRAs we are interested in were issued in the previous iteration, 
+        # The GRAs we are interested in were issued in the previous iteration,
         # so we need to add the number of VMFMAs to the needed_by to account for us being in the next iteration.
         GRAs_target_idx = first_LRA1.issued_at + schedule_info.numMfma
         GRBs_target_idx = first_LRB1.issued_at + schedule_info.numMfma
@@ -1668,7 +1642,7 @@ def _get_schedule_256x192x64_16bit(kernel, useLDSTr, TLDS):
         opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     else:
         return False, None
-    
+
     return True, opt1
 
 def _get_schedule_256x256x128_8bit(kernel, useLDSTr, TLDS):
@@ -1982,7 +1956,7 @@ def _get_schedule_160x256x64_16bit(kernel, useLDSTr, TLDS):
     else:
         return False, None
 
-    
+
     return True, opt1
 
 def _get_schedule_256x160x64_16bit(kernel, useLDSTr, TLDS):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -49,9 +49,11 @@ from typing import Callable, Dict, List, Tuple
 def getMostRecents(
     vmfmaIndices: List[int],
     counts: List[int],
-    localReadA: List[int],
-    localReadB: List[int],
-    aBeforeB: bool,
+    localReadA0: List[int],
+    localReadB0: List[int],
+    localReadA1: List[int],
+    localReadB1: List[int],
+    positions: Dict[str, int],
 ) -> List[Dict[str, int]]:
     """
     For each waitcnt instruction located at `vmfmaIndices[i]`, compute how many
@@ -68,8 +70,6 @@ def getMostRecents(
             vmfma indices where local reads for operand A occur.
         localReadB:
             vmfma indices where local reads for operand B occur.
-        aBeforeB:
-            True if local reads for A happen before B within a vmfma index.
 
     Returns:
         A list of dicts of the form:
@@ -85,13 +85,13 @@ def getMostRecents(
     def countMostRecent(
         vmfma_index: int,
         count: int,
-        history: List[Tuple[int, Dict[str, int]]],
-        aBeforeB: bool,
+        history: List[Tuple[int, List[str]]],
     ) -> Dict[str, int]:
         """
         Walk backward through local-read history and count how many of the
         most recent `count` operations were for A vs B.
         """
+
         idx = 0
         while idx + 1 < len(history) and history[idx + 1][0] <= vmfma_index:
             idx += 1
@@ -100,41 +100,52 @@ def getMostRecents(
         remaining = count
 
         while idx >= 0 and remaining > 0:
-            order = ["B", "A"] if aBeforeB else ["A", "B"]
-            for operand in order:
-                delta = min(history[idx][1][operand], remaining)
-                result[operand] += delta
-                remaining -= delta
+            for operand in history[idx][1][::-1]:
+                if operand == "LRA0":
+                    result["A"] += 1
+                if operand == "LRB0":
+                    result["B"] += 1
+                remaining -= 1
+                if remaining == 0:
+                    break
 
             idx -= 1
 
         return result
 
-    # Build combined event map: vmfma_index -> {"A": n, "B": n}
-    event_map: Dict[int, Dict[str, int]] = {}
+    X = [
+        ("LRA0", localReadA0),
+        ("LRB0", localReadB0),
+        ("LRA1", localReadA1),
+        ("LRB1", localReadB1),
+    ]
+    X.sort(key=lambda x: positions[x[0]])
 
-    for idx in localReadA:
-        event_map.setdefault(idx, {"A": 0, "B": 0})["A"] += 1
+    history = {}
+    for symbol, values in X:
+        for v in values:  # iterate over each int inside the list
+            if v not in history:
+                history[v] = []
+            history[v].append(symbol)
 
-    for idx in localReadB:
-        event_map.setdefault(idx, {"A": 0, "B": 0})["B"] += 1
-
-    # Historical timeline sorted by vmfma index
-    history = sorted(event_map.items())
+    # Convert dict → sorted list of tuples (v, ["A","B",...])
+    history = sorted(history.items(), key=lambda t: t[0])
 
     results: List[Dict[str, int]] = []
     for wait_count, slot in zip(counts, vmfmaIndices):
-        result = countMostRecent(slot, wait_count, history, aBeforeB)
+        result = countMostRecent(slot, wait_count, history)
         results.append(result)
 
     return results
 
 
-def verify_global_reads_not_too_earlySingleCodePath(
+def verify_global_reads_not_too_early_single_code_path(
     globalReadA: List[int],
     globalReadB: List[int],
-    localReadA: List[int],
-    localReadB: List[int],
+    localReadA0: List[int],
+    localReadB0: List[int],
+    localReadA1: List[int],
+    localReadB1: List[int],
     syncIndices: List[int],
     syncCodes: List,
     context: Dict,
@@ -171,11 +182,18 @@ def verify_global_reads_not_too_earlySingleCodePath(
             indicesOfWaitsInSyncCode.append(syncCodeIndex)
         syncCodeIndex += 1
 
-    aBeforeB = positions["LRA0"] < positions["LRB0"]
-    preceding = getMostRecents(vmfmaIndices, counts, localReadA, localReadB, aBeforeB)
+    preceding = getMostRecents(
+        vmfmaIndices,
+        counts,
+        localReadA0,
+        localReadB0,
+        localReadA1,
+        localReadB1,
+        positions,
+    )
     for l, g, operand in [
-        (localReadA, globalReadA, "A"),
-        (localReadB, globalReadB, "B"),
+        (localReadA0, globalReadA, "A"),
+        (localReadB0, globalReadB, "B"),
     ]:
         if len(l) == 0 or len(g) == 0:
             continue
@@ -272,14 +290,22 @@ def verify_global_reads_not_too_early(scheduleInfo, context: Dict):
     """
 
     # Get the relative order of the relevant operations within a vmfma index.
-    positions = {"SYNC": -1, "LRA0": -1, "LRB0": -1, "GRA": -1, "GRB": -1}
+    positions = {
+        "SYNC": -1,
+        "LRA0": -1,
+        "LRB0": -1,
+        "GRA": -1,
+        "GRB": -1,
+        "LRA1": -1,
+        "LRB1": -1,
+    }
     index = 0
     for n in scheduleInfo.optSchedule.keys():
         positions[n] = index
         index += 1
 
     def get(name, codePath):
-        l = scheduleInfo.optSchedule[name]
+        l = scheduleInfo.optSchedule.get(name, [[]])
         if len(l) == 1:
             return l[0]
         return l[codePath]
@@ -305,16 +331,20 @@ def verify_global_reads_not_too_early(scheduleInfo, context: Dict):
         if bDirect:
             globalReadB = globalReadB[1::2]
 
-        localReadA = get("LRA0", codePath)
-        localReadB = get("LRB0", codePath)
+        localReadA0 = get("LRA0", codePath)
+        localReadB0 = get("LRB0", codePath)
+        localReadA1 = get("LRA1", codePath)
+        localReadB1 = get("LRB1", codePath)
         syncIndices = get("SYNC", codePath)
         syncCodes = scheduleInfo.syncCode
 
-        status, message = verify_global_reads_not_too_earlySingleCodePath(
+        status, message = verify_global_reads_not_too_early_single_code_path(
             globalReadA,
             globalReadB,
-            localReadA,
-            localReadB,
+            localReadA0,
+            localReadB0,
+            localReadA1,
+            localReadB1,
             syncIndices,
             syncCodes,
             context,

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomScheduleGlobalReadValidation.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomScheduleGlobalReadValidation.py
@@ -30,6 +30,7 @@ from Tensile.Components.CustomSchedule import (
 
 from rocisa.instruction import SBarrier, SWaitCnt
 
+
 def getSyncsAndCodes(waitcnts: dict, barriers: list):
     """
     Utility for unit tests.
@@ -57,6 +58,7 @@ def getSyncsAndCodes(waitcnts: dict, barriers: list):
 
     return syncs, codes
 
+
 def scheduleFromSequence(seq: list):
     """
     Utility for unit tests. Constructs a schedule from a sequence description.
@@ -76,6 +78,8 @@ def scheduleFromSequence(seq: list):
         "grb": [],
         "lra0": [],
         "lrb0": [],
+        "lra1": [],
+        "lrb1": [],
         "waitcnt": {},
         "barrier": [],
     }
@@ -96,19 +100,30 @@ def scheduleFromSequence(seq: list):
         "SYNC": syncs,
         "GRA": [counts["gra"]],
         "LRA0": [counts["lra0"]],
+        "LRA1": [counts["lra1"]],
         "GRB": [counts["grb"]],
         "LRB0": [counts["lrb0"]],
+        "LRB1": [counts["lrb1"]],
     }
     numCodePaths = 1
     return ScheduleInfo(numCodePaths, None, optSchedule, syncCode, None, None, None)
 
 
 class TestCustomScheduleGlobalReadValidation:
-    def test_get_most_recent(self):
+
+    def test_get_most_recent_basic(self):
         """
         Test of utility function used to determine how many of the most recent ds_read
         operations are for A, and how many are for B.
         """
+
+        def getMostRecentsSansLR1(indices, counts, A, B, aBeforeB):
+            """
+            Assume that LRA0 appears before LRB0 within mfma index slots, and
+            don't include LRA1 or LRB1 in the analysis.
+            """
+            positions = {"LRA1": -1, "LRB1": -1, "LRA0": 1 - aBeforeB, "LRB0": aBeforeB}
+            return getMostRecents(indices, counts, A, B, [], [], positions)
 
         A = [0, 1, 4, 6, 8, 9]
         B = [2, 6, 7]
@@ -125,7 +140,7 @@ class TestCustomScheduleGlobalReadValidation:
         counts = [2]
         aBeforeB = True
         bBeforeA = not aBeforeB
-        result = getMostRecents(indices, counts, A, B, aBeforeB)
+        result = getMostRecentsSansLR1(indices, counts, A, B, aBeforeB)
         expected0 = [{"A": 2, "B": 0}]
         assert result == expected0
 
@@ -137,14 +152,14 @@ class TestCustomScheduleGlobalReadValidation:
         # index               ^
         indices = [6]
         counts = [4]
-        result = getMostRecents(indices, counts, A, B, aBeforeB)
+        result = getMostRecentsSansLR1(indices, counts, A, B, aBeforeB)
         expected1 = [{"A": 2, "B": 2}]
         assert result == expected1
 
         # Multiple indices and counts are handled independently
         indices = [1, 6]
         counts = [2, 4]
-        result = getMostRecents(indices, counts, A, B, aBeforeB)
+        result = getMostRecentsSansLR1(indices, counts, A, B, aBeforeB)
         assert result == [expected0[0], expected1[0]]
 
         A = [1, 1, 1]
@@ -164,12 +179,38 @@ class TestCustomScheduleGlobalReadValidation:
         # and so as we're going in reverse chronological order, we take B).
         #
         # index=5, count=0: A:0 B:0
-        result = getMostRecents(indices, counts, A, B, aBeforeB)
+        result = getMostRecentsSansLR1(indices, counts, A, B, aBeforeB)
         assert result == [{"A": 3, "B": 3}, {"A": 0, "B": 2}, {"A": 0, "B": 0}]
 
         # Changed so that B is before A.
-        result = getMostRecents(indices, counts, A, B, bBeforeA)
+        result = getMostRecentsSansLR1(indices, counts, A, B, bBeforeA)
         assert result == [{"A": 3, "B": 3}, {"A": 1, "B": 1}, {"A": 0, "B": 0}]
+
+    def test_get_most_recent(self):
+        """
+        Testing that LRA1 and LRB1 are correctly handled.
+        """
+
+        indices = [10, 10, 10, 10]
+        counts = [1, 2, 3, 4]
+        LRA0 = [7]
+        LRA1 = [7]
+        LRB0 = [7]
+        LRB1 = [7]
+
+        positions = {"LRA0": 0, "LRA1": 1, "LRB0": 2, "LRB1": 3}
+        foo = getMostRecents(indices, counts, LRA0, LRB0, LRA1, LRB1, positions)
+        assert foo[0] == {"A": 0, "B": 0}
+        assert foo[1] == {"A": 0, "B": 1}
+        assert foo[2] == {"A": 0, "B": 1}
+        assert foo[3] == {"A": 1, "B": 1}
+
+        positions = {"LRA0": 3, "LRA1": 2, "LRB0": 1, "LRB1": 0}
+        foo = getMostRecents(indices, counts, LRA0, LRB0, LRA1, LRB1, positions)
+        assert foo[0] == {"A": 1, "B": 0}
+        assert foo[1] == {"A": 1, "B": 0}
+        assert foo[2] == {"A": 1, "B": 1}
+        assert foo[3] == {"A": 1, "B": 1}
 
     def test_basic(self):
         schedule = scheduleFromSequence(
@@ -235,7 +276,7 @@ class TestCustomScheduleGlobalReadValidation:
 
     def test_negative_lda_before_ldb_so_grb_unsafe(self):
         """
-        scheduleFromSequence is implemented with LRA0 after LDB0.
+        scheduleFromSequence is implemented with LRA0 after LRB0.
         """
         schedule = scheduleFromSequence(
             [
@@ -257,6 +298,27 @@ class TestCustomScheduleGlobalReadValidation:
             "1 waitcnt operation(s) in [1, 3) provide upper bounds on the number of outstanding LRB0 operations: [1] <-- none of these is 0."
         )
         assert status is False
+
+    def test_interleave_gr_and_lrs(self):
+        """
+        This is like the preceding test, but now the waitcnt 1 is for an unrelated ds_load
+        """
+        schedule = scheduleFromSequence(
+            [
+                ("lrb0", 0),
+                ("lra0", 0),
+                ("lrb1", 0),
+                ("waitcnt", 1, 1),
+                ("barrier", 1),
+                ("grb", 2),
+                ("waitcnt", 0, 9),
+                ("barrier", 9),
+                ("gra", 10),
+            ]
+        )
+        status, message = verify_global_reads_not_too_early(schedule, {})
+        assert message == ""
+        assert status is True
 
     def test_different_simd_codes(self):
         """
@@ -802,3 +864,90 @@ class TestCustomScheduleGlobalReadValidation:
             "Expected a barrier in the range [5, 10)."
         )
         assert status is False
+
+    def test_on_the_edge(self):
+        schedule = ScheduleInfo(
+            1,  # 1 code path.
+            None,
+            {
+                "LRA0": [[0, 1, 2, 3]],
+                "LRB0": [[2, 3, 4, 5, 6, 7]],
+                "SYNC": [[4, 4, 8, 8]],
+                "GRA": [[4]],
+                "GRB": [[10]],
+            },
+            [
+                SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment=""),
+                SBarrier(),
+                SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+                SBarrier(),
+            ],
+            None,
+            None,
+            None,
+        )
+        status, message = verify_global_reads_not_too_early(schedule, {})
+        assert message == ""
+        assert status is True
+
+    def test_on_the_edge_tipped_by_a(self):
+        schedule = ScheduleInfo(
+            1,  # 1 code path.
+            None,
+            {
+                "LRA0": [[0, 1, 2, 3]],
+                "LRB0": [[2, 3, 4, 5, 6, 7]],
+                "SYNC": [[4, 4, 8, 8]],
+                "GRA": [[4]],
+                "GRB": [[10]],
+            },
+            [
+                SWaitCnt(dscnt=3, vlcnt=-1, vscnt=-1, comment=""),
+                SBarrier(),
+                SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+                SBarrier(),
+            ],
+            None,
+            None,
+            None,
+        )
+        status, message = verify_global_reads_not_too_early(schedule, {})
+        assert message == (
+            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
+            "Last local read for A issued at vmfma_index:3. First global read for A issued at vmfma_index:4. "
+            "1 waitcnt operation(s) in [3, 5) provide upper bounds on the number of outstanding LRA0 operations: [1] <-- none of these is 0."
+        )
+        assert status is False
+
+    def test_on_the_edge_tipped_by_a_saved_by_lr1(self):
+        schedule = ScheduleInfo(
+            1,  # 1 code path.
+            None,
+            {
+                "LRA0": [[0, 1, 2, 3]],
+                "LRA1": [[3, 4]],
+                "LRB0": [[2, 3, 4, 5, 6, 7]],
+                "SYNC": [[4, 4, 8, 8]],
+                "GRA": [[4]],
+                "GRB": [[10]],
+            },
+            [
+                SWaitCnt(dscnt=4, vlcnt=-1, vscnt=-1, comment=""),
+                SBarrier(),
+                SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+                SBarrier(),
+            ],
+            None,
+            None,
+            None,
+        )
+        status, message = verify_global_reads_not_too_early(schedule, {})
+        assert message == ""
+        assert status is True
+
+    def test_regression_3188(self):
+        """
+        Test that bug in https://github.com/ROCm/rocm-libraries/issues/3188 is fixed
+        TODO(newling)
+        """
+        pass

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomScheduleGlobalReadValidation.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomScheduleGlobalReadValidation.py
@@ -25,7 +25,7 @@ import pytest
 from Tensile.Components.CustomSchedule import (
     ScheduleInfo,
     verify_global_reads_not_too_early,
-    getMostRecents,
+    get_most_recent_local_reads,
 )
 
 from rocisa.instruction import SBarrier, SWaitCnt
@@ -117,13 +117,34 @@ class TestCustomScheduleGlobalReadValidation:
         operations are for A, and how many are for B.
         """
 
-        def getMostRecentsSansLR1(indices, counts, A, B, aBeforeB):
+        def get_most_recent_local_reads_without_lr1(indices, counts, A, B, aBeforeB):
             """
             Assume that LRA0 appears before LRB0 within mfma index slots, and
             don't include LRA1 or LRB1 in the analysis.
             """
             positions = {"LRA1": -1, "LRB1": -1, "LRA0": 1 - aBeforeB, "LRB0": aBeforeB}
-            return getMostRecents(indices, counts, A, B, [], [], positions)
+
+            localReads = [
+                ("LRA0", A),
+                ("LRB0", B),
+                ("LRA1", []),
+                ("LRB1", []),
+            ]
+            localReads.sort(key=lambda x: positions[x[0]])
+
+            history = {}
+            for symbol, values in localReads:
+                for v in values:
+                    if v not in history:
+                        history[v] = []
+                    history[v].append(symbol)
+            history = sorted(history.items(), key=lambda t: t[0])
+
+            mr = get_most_recent_local_reads(indices, counts, history)
+            filtered = []
+            for l in mr:
+                filtered.append({"A": l["LRA0"], "B": l["LRB0"]})
+            return filtered
 
         A = [0, 1, 4, 6, 8, 9]
         B = [2, 6, 7]
@@ -140,7 +161,9 @@ class TestCustomScheduleGlobalReadValidation:
         counts = [2]
         aBeforeB = True
         bBeforeA = not aBeforeB
-        result = getMostRecentsSansLR1(indices, counts, A, B, aBeforeB)
+        result = get_most_recent_local_reads_without_lr1(
+            indices, counts, A, B, aBeforeB
+        )
         expected0 = [{"A": 2, "B": 0}]
         assert result == expected0
 
@@ -152,14 +175,18 @@ class TestCustomScheduleGlobalReadValidation:
         # index               ^
         indices = [6]
         counts = [4]
-        result = getMostRecentsSansLR1(indices, counts, A, B, aBeforeB)
+        result = get_most_recent_local_reads_without_lr1(
+            indices, counts, A, B, aBeforeB
+        )
         expected1 = [{"A": 2, "B": 2}]
         assert result == expected1
 
         # Multiple indices and counts are handled independently
         indices = [1, 6]
         counts = [2, 4]
-        result = getMostRecentsSansLR1(indices, counts, A, B, aBeforeB)
+        result = get_most_recent_local_reads_without_lr1(
+            indices, counts, A, B, aBeforeB
+        )
         assert result == [expected0[0], expected1[0]]
 
         A = [1, 1, 1]
@@ -179,38 +206,42 @@ class TestCustomScheduleGlobalReadValidation:
         # and so as we're going in reverse chronological order, we take B).
         #
         # index=5, count=0: A:0 B:0
-        result = getMostRecentsSansLR1(indices, counts, A, B, aBeforeB)
+        result = get_most_recent_local_reads_without_lr1(
+            indices, counts, A, B, aBeforeB
+        )
         assert result == [{"A": 3, "B": 3}, {"A": 0, "B": 2}, {"A": 0, "B": 0}]
 
         # Changed so that B is before A.
-        result = getMostRecentsSansLR1(indices, counts, A, B, bBeforeA)
+        result = get_most_recent_local_reads_without_lr1(
+            indices, counts, A, B, bBeforeA
+        )
         assert result == [{"A": 3, "B": 3}, {"A": 1, "B": 1}, {"A": 0, "B": 0}]
 
     def test_get_most_recent(self):
         """
-        Testing that LRA1 and LRB1 are correctly handled.
+        Testing that within vmfma index ordering is correctly handled.
         """
 
         indices = [10, 10, 10, 10]
         counts = [1, 2, 3, 4]
-        LRA0 = [7]
-        LRA1 = [7]
-        LRB0 = [7]
-        LRB1 = [7]
 
-        positions = {"LRA0": 0, "LRA1": 1, "LRB0": 2, "LRB1": 3}
-        foo = getMostRecents(indices, counts, LRA0, LRB0, LRA1, LRB1, positions)
-        assert foo[0] == {"A": 0, "B": 0}
-        assert foo[1] == {"A": 0, "B": 1}
-        assert foo[2] == {"A": 0, "B": 1}
-        assert foo[3] == {"A": 1, "B": 1}
+        history = [[7, ["LRA0", "LRA1", "LRB0", "LRB1"]]]
+        foo = get_most_recent_local_reads(indices, counts, history)
+        # counts = 1
+        assert foo[0] == {"LRA0": 0, "LRB0": 0, "LRA1": 0, "LRB1": 1}
+        # counts = 2
+        assert foo[1] == {"LRA0": 0, "LRB0": 1, "LRA1": 0, "LRB1": 1}
+        # counts = 3
+        assert foo[2] == {"LRA0": 0, "LRB0": 1, "LRA1": 1, "LRB1": 1}
+        # counts = 4
+        assert foo[3] == {"LRA0": 1, "LRB0": 1, "LRA1": 1, "LRB1": 1}
 
-        positions = {"LRA0": 3, "LRA1": 2, "LRB0": 1, "LRB1": 0}
-        foo = getMostRecents(indices, counts, LRA0, LRB0, LRA1, LRB1, positions)
-        assert foo[0] == {"A": 1, "B": 0}
-        assert foo[1] == {"A": 1, "B": 0}
-        assert foo[2] == {"A": 1, "B": 1}
-        assert foo[3] == {"A": 1, "B": 1}
+        history = [[7, ["LRB1", "LRB0", "LRA1", "LRA0"]]]
+        foo = get_most_recent_local_reads(indices, counts, history)
+        assert foo[0] == {"LRA0": 1, "LRB0": 0, "LRA1": 0, "LRB1": 0}
+        assert foo[1] == {"LRA0": 1, "LRB0": 0, "LRA1": 1, "LRB1": 0}
+        assert foo[2] == {"LRA0": 1, "LRB0": 1, "LRA1": 1, "LRB1": 0}
+        assert foo[3] == {"LRA0": 1, "LRB0": 1, "LRA1": 1, "LRB1": 1}
 
     def test_basic(self):
         schedule = scheduleFromSequence(
@@ -945,9 +976,33 @@ class TestCustomScheduleGlobalReadValidation:
         assert message == ""
         assert status is True
 
-    def test_regression_3188(self):
-        """
-        Test that bug in https://github.com/ROCm/rocm-libraries/issues/3188 is fixed
-        TODO(newling)
-        """
-        pass
+    def test_lr1_in_the_middle(self):
+        schedule = ScheduleInfo(
+            1,  # 1 code path.
+            None,
+            {
+                "LRA0": [2 * [3]],
+                "LRA1": [3 * [3]],
+                "LRB0": [[]],
+                "LRB1": [4 * [3]],
+                "SYNC": [[3, 3]],
+                "GRA": [[4]],
+                "GRB": [[]],
+            },
+            [
+                # 3 LRA1 and 4 LRB1 can be outstanding.
+                SWaitCnt(dscnt=3 + 4 + 1, vlcnt=-1, vscnt=-1, comment=""),
+                SBarrier(),
+            ],
+            None,
+            None,
+            None,
+        )
+        status, message = verify_global_reads_not_too_early(schedule, {})
+        assert message == (
+            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
+            "Last local read for A issued at vmfma_index:3. "
+            "First global read for A issued at vmfma_index:4. "
+            "1 waitcnt operation(s) in [3, 5) provide upper bounds on the number of outstanding LRA0 operations: [1] <-- none of these is 0."
+        )
+        assert status is False


### PR DESCRIPTION
## Motivation

See https://github.com/ROCm/rocm-libraries/pull/3149 and https://github.com/ROCm/rocm-libraries/issues/3188: previously the validator did not consider the possibility that LRA1 and LRB1 appear before GRA or GRB. This is remedied here. 

## Technical Details


## Test Plan


## Test Result


## Submission Checklist

