### PR TITLE
Skip icache_flush.yaml on ROCm 7.1

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/test_config.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/test_config.py
@@ -49,6 +49,20 @@ def locateExe( defaultPath, exeName ): # /opt/rocm/bin, hip-clang
     return exePath
   return None
 
+def get_rocm_version_or_none():
+    """Gets the ROCm version from the version file."""
+    try:
+        rocmpath = os.environ.get("ROCM_PATH", "/opt/rocm")
+        version_file_path = os.path.join(rocmpath, ".info/version")
+
+        with open(version_file_path, 'r') as f:
+            # Read the first line and strip whitespace
+            version_string = f.readline().strip()
+            return version_string
+    except (FileNotFoundError, IOError):
+        return None
+
+
 def walkDict(root, path=""):
     """
     Recursively walks a structure which may consist of dictionaries, lists,
@@ -186,9 +200,16 @@ def findConfigs(rootDir=None):
     globaParamArchsStr = ';'.join(availableArchs)
     os.environ["PyTestBuildArchNames"] = globaParamArchsStr
 
+    rocm_version = get_rocm_version_or_none()
+
     params = []
     for (dirpath, dirnames, filenames) in os.walk(rootDir):
         for filename in filenames:
+            # Conditionally skip icache_flush.yaml on rocm 7.1 due to ROCm bug.
+            if filename == "icache_flush.yaml" and rocm_version and rocm_version.startswith("7.1"):
+                print(f"INFO: Skipping '{filename}' on ROCm {rocm_version}.")
+                continue
+
             # Skip build client script
             if filename == "build_client.yaml":
                 continue


### PR DESCRIPTION
Due to a bug in ROCm 7.1, Tensile can crash on certain architectures when input contains icache flush. Skip the test when ROCm 7.1 is detected for now.

## Motivation

Jenkins CI uses a ROCm 7.1 image and the existing icache flush test crashes on gfx942

## Technical Details

Disable the test if we positively identify ROCm 7.1, otherwise run the test.

## Test Plan

math-ci: preliminary(hipblaslt) test suite

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
