### PR TITLE
Xfail icache_flush YAML test on ROCm 7.1

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/test_config.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/test_config.py
@@ -205,11 +205,6 @@ def findConfigs(rootDir=None):
     params = []
     for (dirpath, dirnames, filenames) in os.walk(rootDir):
         for filename in filenames:
-            # Conditionally skip icache_flush.yaml on rocm 7.1 due to ROCm bug.
-            if filename == "icache_flush.yaml" and rocm_version and rocm_version.startswith("7.1"):
-                print(f"INFO: Skipping '{filename}' on ROCm {rocm_version}.")
-                continue
-
             # Skip build client script
             if filename == "build_client.yaml":
                 continue
@@ -218,6 +213,12 @@ def findConfigs(rootDir=None):
                 filepath = os.path.join(rootDir, dirpath, filename)
                 if not "test_data" in filepath:
                     marks = configMarks(filepath, rootDir, availableArchs)
+
+                    # Conditionally xfail icache_flush.yaml on rocm 7.1 due to ROCm bug.
+                    if filename == "icache_flush.yaml" and rocm_version and rocm_version.startswith("7.1"):
+                        reason = "Test is expected to fail on ROCm 7.1 due to a known bug."
+                        marks.append(pytest.mark.xfail(reason=reason, strict=True))
+
                     relpath = os.path.relpath(filepath, printRoot)
                     params.append(pytest.param(filepath, marks=marks, id=relpath))
     return params


### PR DESCRIPTION
Instead of skipping the test, xfail it if we detect the platform is ROCm 7.1

This fixes the problem in #3203 where we just skipped the test in that case.

## Motivation

Preference was to xfail the test instead of skip

## Technical Details

Detect ROCm 7.1 and then xfail

## Test Plan

TENSILELITE_CLIENT_ARGS="--build-type Debug --gpu-targets gfx950 --clean" tox -e py3 -- Tensile/Tests -m common

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
