### PR TITLE
[hipblaslt] Re-enable CMS validation for 256x192x64TN

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -1553,9 +1553,7 @@ def _get_schedule_256x192x64_16bit(kernel, useLDSTr, TLDS):
             }
         syncCode = syncTable[1::2]
         nglshift = nllshift = 14 # vmcnt shift for ngl and nll
-        # TODO : GRA at index 10 can't be between GRIncB 9-11 due to SCC usage
         opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
-        opt1.disableValidation()
     elif isNT(kernel) and useLDSTr and TLDS == 0:
         kernel["SwapGlobalReadOrder"] = True
         #index and code pair


### PR DESCRIPTION
## Description

Re-enable CMS validator on 256x192x64TN since https://github.com/ROCm/rocm-libraries/pull/3104 has been merged
