### PR TITLE
[hipblaslt] [CMS] Add transpose case to CMS validation bypass logging

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -1053,7 +1053,11 @@ class ScheduleInfo:
             mt0 = context.get("kernel", {}).get("MacroTile0", "?")
             mt1 = context.get("kernel", {}).get("MacroTile1", "?")
             du = context.get("kernel", {}).get("DepthU", "?")
-            message = f"CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = {mt0}x{mt1}x{du}"
+            transA = context.get("kernel", {}).get("TransA")
+            transB = context.get("kernel", {}).get("TransB")
+            transA = "T" if transA else "N"
+            transB = "T" if transB else "N"
+            message = f"CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = {mt0}x{mt1}x{du} {transA}{transB}"
             print(f"WARNING: {message}")
 
             # All rules bypassed, considered valid.

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -507,7 +507,7 @@ class TestCustomScheduleValidation:
         scheduleInfo.disableValidation()
         status, message = scheduleInfo.isValid({"kernel" : {"DepthU": 42}})
         assert status == True
-        assert message == "CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = ?x?x42"
+        assert message == "CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = ?x?x42 NN"
 
         # A non-empty verification message means that the schedule info is considered invalid.
         status, message = ScheduleInfo(


### PR DESCRIPTION
## Motivation

Currently logging message only outputs MT0xMT1xDU which is ambiguous about which kernel has validation disabled.

## Technical Details

Add transposeA and transposeB to logging message.

## Test Plan

Run existing case, no functional differences made.

## Test Result

Passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
