### PR TITLE
Bump pre-commit black version to 25.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 25.12.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
## Motivation

Bump to latest stable black version ([25.12.0](https://black.readthedocs.io/en/stable/)), to avoid bugs we observed where black failed to parse `except subprocess.TimeoutExpired:` lines.

See an example failure in this [GitHub Action](https://github.com/ROCm/rocm-libraries/actions/runs/19976917249/job/57295180557?pr=3186).
 
## Technical Details

Bumps black version from 22.10.0 to 25.12.0 in the `.pre-commit-config.yaml`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
