### PR TITLE
[hipblaslt] Skip tf32 CMS validation with warning

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1069,6 +1069,13 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
     is invalid. It may be a false positive.
     """
 
+    # Cases where validation is not currently possible.
+    if context.get("kernel", {}).get("UseF32XEmulation", False):
+        message = "CMS validation is currently disabled for F32X emulation"
+        printWarning(f"{message}")
+        return True, message
+
+    # Case where there was an explicit request to skip validation.
     if scheduleInfo.__skipValidation__:
         mt0 = context.get("kernel", {}).get("MacroTile0", "?")
         mt1 = context.get("kernel", {}).get("MacroTile1", "?")
@@ -1078,7 +1085,7 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
         transA = "T" if transA else "N"
         transB = "T" if transB else "N"
         message = f"CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = {mt0}x{mt1}x{du} {transA}{transB}"
-        print(f"WARNING: {message}")
+        printWarning(f"{message}")
 
         # All rules bypassed, considered valid.
         return True, message

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -211,7 +211,7 @@ class TestCustomSchedule:
         ( False,  False,        True,       1),
         ( False,   True,        True,       0)
         # fmt: on
-        ])        
+        ])
     def test_schedule_256x192x64_16bit(self, transA, transB, lds_tr_inst, tr_lds):
 
         """Tests the 256x192x64 16-bit TN schedule."""
@@ -456,7 +456,7 @@ class TestCustomSchedule:
         ( False,   True,       False,       0),
         ( False,  False,        True,       1)
         # fmt: on
-        ])  
+        ])
     def test_schedule_240x256x64_16bit(self, transA, transB, lds_tr_inst,  tr_lds):
         """Tests the 240x256x64 16-bit schedule."""
         NT = not transA and transB
@@ -490,7 +490,7 @@ class TestCustomSchedule:
         ( False,  False,        True,       1),
         ( False,   True,        True,       0)
         # fmt: on
-        ])        
+        ])
     def test_schedule_208x256x64_16bit(self, transA, transB, lds_tr_inst,  tr_lds):
         """Tests the 208x256x64 16-bit schedule."""
         kernel = create_base_kernel()
@@ -520,7 +520,7 @@ class TestCustomSchedule:
         "transA, transB, lds_tr_inst,  tr_lds", [
         (  True,  False,       False,       1),
         # fmt: on
-        ])        
+        ])
     def test_schedule_128x224x64_16bit(self, transA, transB, lds_tr_inst,  tr_lds):
         """Tests the 208x256x64 16-bit schedule."""
         kernel = create_base_kernel()
@@ -569,3 +569,18 @@ class TestCustomScheduleValidation:
             ScheduleInfo(None, None, invalid_schedule, None, None, None, None), {}
         )
         assert status == False
+
+    def test_f32_emulation_disabled(self):
+        kernel = create_base_kernel()
+        # Create what should be an invalid schedule:
+        invalid_schedule = {"P": [[3, 2, 1]]}
+        scheduleInfo = ScheduleInfo(
+            None, None, invalid_schedule, None, None, None, None
+        )
+        # Verify that this invalid schedule passes when this specific flag is true.
+        # Currently a warning message is printed.
+        status, message = isValid(scheduleInfo, {"kernel": {"UseF32XEmulation": True}})
+        assert status == True
+        assert message == "CMS validation is currently disabled for F32X emulation"
+
+


### PR DESCRIPTION
## Motivation

The CMS validation rules are currently handcrafted for a very specific GEMM structure on bf16. They are not applicable to tf32 CMS schedules. Until they have been generalized to apply to tf32, they should be disabled for tf32. 