### PR TITLE
[hipblaslt] Disable CMS for UnrollLoopSwapGlobalReadOrder

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -2803,6 +2803,9 @@ def hasCustomSchedule(kernel):
         return False, None
     if not kernel["ISA"] == IsaVersion(9,5,0):
         return False, None
+    # Currently ULSGRO not checked for in CMS, disabled for now
+    if kernel["UnrollLoopSwapGlobalReadOrder"]:
+        return False, None
 
     is16bit = kernel["ProblemType"]["DataType"].isHalf() or kernel["ProblemType"]["DataType"].isBFloat16()
     is8bit = kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat()

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1495,9 +1495,7 @@ class Solution(collections.abc.Mapping):
 
     # Check if CMS is available for this solution
     hasCMS,_ = hasCustomSchedule(state)
-    # List of state params which does not support CMS
-    disableCMS = state["UnrollLoopSwapGlobalReadOrder"]
-    state["UseCustomMainLoopSchedule"] = hasCMS and not disableCMS
+    state["UseCustomMainLoopSchedule"] = hasCMS
 
     # 0: Normal mode. Hardware applies all of the normal data dependency checks
     # 1: Full expert mode (not suppoeted yet). Disable hardware checks against: VA_VDST, VA_SDST, VA_SSRC, VA_VCC, VM_VSRC and SA_SDST.

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1495,7 +1495,9 @@ class Solution(collections.abc.Mapping):
 
     # Check if CMS is available for this solution
     hasCMS,_ = hasCustomSchedule(state)
-    state["UseCustomMainLoopSchedule"] = hasCMS
+    # List of state params which does not support CMS
+    disableCMS = state["UnrollLoopSwapGlobalReadOrder"]
+    state["UseCustomMainLoopSchedule"] = hasCMS and not disableCMS
 
     # 0: Normal mode. Hardware applies all of the normal data dependency checks
     # 1: Full expert mode (not suppoeted yet). Disable hardware checks against: VA_VDST, VA_SDST, VA_SSRC, VA_VCC, VM_VSRC and SA_SDST.

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -19,6 +19,7 @@ def create_base_kernel():
     kernel = {
         "UseCustomMainLoopSchedule": True,
         "EnableMatrixInstruction": True,
+        "UnrollLoopSwapGlobalReadOrder": False,
         "ISA": IsaVersion(9,5,0),
         "ProblemType": {
             "DataType": _mock_dtype(),


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Current CMS logic does not check for `UnrollLoopSwapGlobalReadOrder` (ULSGRO), for now we disable CMS when ULSGRO is enabled. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
