### PR TITLE
Users/emezh/add missing tests

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -188,7 +188,7 @@ class TestCustomSchedule:
         ( False,   True,        True,       0)
         # fmt: on
         ])        
-    def test_schedule_256x192x64_16bit(self, transA, transB, lds_tr_inst,  tr_lds):
+    def test_schedule_256x192x64_16bit(self, transA, transB, lds_tr_inst, tr_lds):
 
         """Tests the 256x192x64 16-bit TN schedule."""
         kernel = create_base_kernel()
@@ -454,7 +454,6 @@ class TestCustomSchedule:
         ])        
     def test_schedule_208x256x64_16bit(self, transA, transB, lds_tr_inst,  tr_lds):
         """Tests the 208x256x64 16-bit schedule."""
-        NT = not transA and transB
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
         kernel["ProblemType"].update({
@@ -474,6 +473,36 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 1
         assert schedule_info.numMfma == 104
+        valid, message = schedule_info.isValid({"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize(
+        # fmt: off
+        "transA, transB, lds_tr_inst,  tr_lds", [
+        (  True,  False,       False,       1),
+        # fmt: on
+        ])        
+    def test_schedule_128x224x64_16bit(self, transA, transB, lds_tr_inst,  tr_lds):
+        """Tests the 208x256x64 16-bit schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "MacroTile0": 128, "MacroTile1": 224, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": lds_tr_inst, "TransposeLDS": tr_lds, "MIWaveTileA": 4, "MIWaveTileB": 7,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 56
         valid, message = schedule_info.isValid({"kernel" : kernel})
         assert valid, message
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -180,8 +180,16 @@ class TestCustomSchedule:
         valid, message = schedule_info.isValid({"kernel" : kernel})
         assert valid, message
 
-    @pytest.mark.parametrize("transA, transB", [(True, False), (False, False)])
-    def test_schedule_256x192x64_16bit_TN(self, transA, transB):
+    @pytest.mark.parametrize(
+        # fmt: off
+        "transA, transB, lds_tr_inst,  tr_lds", [
+        (  True,  False,       False,       1),
+        ( False,  False,        True,       1),
+        ( False,   True,        True,       0)
+        # fmt: on
+        ])        
+    def test_schedule_256x192x64_16bit(self, transA, transB, lds_tr_inst,  tr_lds):
+
         """Tests the 256x192x64 16-bit TN schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
@@ -194,7 +202,7 @@ class TestCustomSchedule:
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
             "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
-            "LDSTrInst": not transA, "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 6,
+            "LDSTrInst": lds_tr_inst, "TransposeLDS": tr_lds, "MIWaveTileA": 8, "MIWaveTileB": 6,
         })
 
         has_schedule, schedule_info = hasCustomSchedule(kernel)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Add missing CMS tests in `test_CustomSchedule.py`
These test were omitted by mistake in the PRs that added them: #3064 , #2726 
Missing tests for 256x160x64 are added in PR #3122 .

## Test Result

<!-- Briefly summarize test outcomes. -->
Tests pass with pytest.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
