### PR TITLE
[hipDNN] [ALMIOPEN-446] Fix convolution checks not accounting for dropped values, and invalid input

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Error.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Error.hpp
@@ -119,4 +119,16 @@ typedef Error error_t; // NOLINT(readability-identifier-naming)
     {                                                    \
         return {error_status, message};                  \
     }
+
+#define HIPDNN_RETURN_IF_GE(x, y, error_status, message) \
+    if(x >= y)                                           \
+    {                                                    \
+        return {error_status, message};                  \
+    }
+
+#define HIPDNN_RETURN_IF_LE(x, y, error_status, message) \
+    if(x <= y)                                           \
+    {                                                    \
+        return {error_status, message};                  \
+    }
 }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/ConvolutionDgradNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/ConvolutionDgradNode.hpp
@@ -202,6 +202,37 @@ public:
                                 0,
                                 ErrorCode::INVALID_VALUE,
                                 "ConvolutionDgradNode: Post-padding must be non-negative");
+
+            if(!dxDims.empty())
+            {
+                auto outputSize = dyDims[i + 2];
+                auto kernelSize = wDims[i + 2];
+                auto inputSize = dxDims[i + 2];
+
+                auto dilatedKernelSize = (dilationVal * (kernelSize - 1)) + 1;
+                auto numerator = inputSize + prePad + postPad - dilatedKernelSize;
+
+                HIPDNN_RETURN_IF_LT(numerator,
+                                    0,
+                                    ErrorCode::INVALID_VALUE,
+                                    "ConvolutionDgradNode: Input spatial dimension at index "
+                                        + std::to_string(i) + " (" + std::to_string(inputSize)
+                                        + ") is too small for the kernel size ("
+                                        + std::to_string(kernelSize) + ") and dilation ("
+                                        + std::to_string(dilationVal) + ")");
+
+                int64_t expectedOutputSize = (numerator / strideVal) + 1;
+
+                HIPDNN_RETURN_IF_NE(
+                    outputSize,
+                    expectedOutputSize,
+                    ErrorCode::INVALID_VALUE,
+                    "ConvolutionDgradNode: dy tensor spatial dimension at index "
+                        + std::to_string(i) + " (" + std::to_string(outputSize)
+                        + ") does not match expected dimension ("
+                        + std::to_string(expectedOutputSize)
+                        + ") given dx dimensions, kernel size, padding, stride, and dilation");
+            }
         }
 
         return {};
@@ -294,6 +325,14 @@ public:
                 auto dilatedKernelSize = (dilationVal * (kernelSize - 1)) + 1;
 
                 dxDims[i] = strideVal * (dySize - 1) + dilatedKernelSize - prePad - postPad;
+
+                HIPDNN_RETURN_IF_LE(
+                    dxDims[i],
+                    0,
+                    ErrorCode::INVALID_VALUE,
+                    "ConvolutionDgradNode: Inferred input spatial dimension at index "
+                        + std::to_string(i) + " (" + std::to_string(dxDims[i])
+                        + ") is non-positive. Check padding, stride, and dilation parameters.");
             }
 
             dx->set_dim(dxDims);

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/ConvolutionFpropNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/ConvolutionFpropNode.hpp
@@ -207,6 +207,37 @@ public:
                                 0,
                                 ErrorCode::INVALID_VALUE,
                                 "ConvolutionFpropNode: Post-padding must be non-negative");
+
+            if(!yDims.empty())
+            {
+                auto inputSize = xDims[i + 2];
+                auto kernelSize = wDims[i + 2];
+                auto outputSize = yDims[i + 2];
+
+                auto dilatedKernelSize = (dilationVal * (kernelSize - 1)) + 1;
+                auto numerator = inputSize + prePad + postPad - dilatedKernelSize;
+
+                HIPDNN_RETURN_IF_LT(numerator,
+                                    0,
+                                    ErrorCode::INVALID_VALUE,
+                                    "ConvolutionFpropNode: Input spatial dimension at index "
+                                        + std::to_string(i) + " (" + std::to_string(inputSize)
+                                        + ") is too small for the kernel size ("
+                                        + std::to_string(kernelSize) + ") and dilation ("
+                                        + std::to_string(dilationVal) + ")");
+
+                int64_t expectedOutputSize = (numerator / strideVal) + 1;
+
+                HIPDNN_RETURN_IF_NE(
+                    outputSize,
+                    expectedOutputSize,
+                    ErrorCode::INVALID_VALUE,
+                    "ConvolutionFpropNode: Output tensor spatial dimension at index "
+                        + std::to_string(i) + " (" + std::to_string(outputSize)
+                        + ") does not match expected dimension ("
+                        + std::to_string(expectedOutputSize)
+                        + ") given input dimensions, kernel size, padding, stride, and dilation");
+            }
         }
 
         return {};

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/ConvolutionWgradNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/ConvolutionWgradNode.hpp
@@ -146,8 +146,18 @@ public:
                 int64_t kernelDim = dwDims[spatialIdx];
 
                 int64_t kernelSize = (dilation[i] * (kernelDim - 1)) + 1;
-                int64_t expectedDyDim
-                    = ((xDim + prePadding[i] + postPadding[i] - kernelSize) / stride[i]) + 1;
+                auto numerator = xDim + prePadding[i] + postPadding[i] - kernelSize;
+
+                HIPDNN_RETURN_IF_LT(numerator,
+                                    0,
+                                    ErrorCode::INVALID_VALUE,
+                                    "ConvolutionWgradNode: Input spatial dimension at index "
+                                        + std::to_string(i) + " (" + std::to_string(xDim)
+                                        + ") is too small for the kernel size ("
+                                        + std::to_string(kernelDim) + ") and dilation ("
+                                        + std::to_string(dilation[i]) + ")");
+
+                int64_t expectedDyDim = (numerator / stride[i]) + 1;
 
                 // Verifying dy implicitly verifies dw and x
                 HIPDNN_RETURN_IF_NE(
@@ -316,13 +326,20 @@ public:
                     ErrorCode::INVALID_VALUE,
                     "ConvolutionWgradNode: Invalid spatial dimensions for kernel size inference");
 
-                HIPDNN_RETURN_IF_NE(numerator % dilationVal,
-                                    0,
+                // Calculate the remainder of pixels that are "dropped" at the end of the convolution
+                // We want to find the smallest remainder r such that (numerator - r) is divisible by dilation
+                // and r < stride.
+                // r = numerator % dilation satisfies the divisibility.
+                // We check if it satisfies the stride constraint.
+                auto remainder = numerator % dilationVal;
+
+                HIPDNN_RETURN_IF_GE(remainder,
+                                    strideVal,
                                     ErrorCode::INVALID_VALUE,
                                     "ConvolutionWgradNode: Spatial dimensions incompatible with "
-                                    "dilation parameter");
+                                    "dilation and stride parameters for kernel size inference");
 
-                dwDims[i] = (numerator / dilationVal) + 1;
+                dwDims[i] = ((numerator - remainder) / dilationVal) + 1;
             }
 
             dw->set_dim(dwDims);

--- a/projects/hipdnn/frontend/tests/TestConvolutionDgradNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestConvolutionDgradNode.cpp
@@ -1275,3 +1275,98 @@ TEST(TestConvolutionDgradNode, InferGroupedConvDepthwiseSeparable)
     EXPECT_EQ(inferredStrides[2], 112); // H stride
     EXPECT_EQ(inferredStrides[3], 1); // W stride
 }
+
+TEST(TestConvolutionDgradNode, PreValidateNodeInvalidSpatialDimensions)
+{
+    ConvDgradAttributes convAttributes;
+
+    auto dyTensor = std::make_shared<TensorAttributes>();
+    dyTensor->set_dim({1, 64, 32, 32});
+    dyTensor->set_stride({65536, 1024, 32, 1});
+    convAttributes.set_dy(dyTensor);
+
+    auto wTensor = std::make_shared<TensorAttributes>();
+    wTensor->set_dim({64, 3, 3, 3});
+    wTensor->set_stride({27, 9, 3, 1});
+    convAttributes.set_w(wTensor);
+
+    auto dxTensor = std::make_shared<TensorAttributes>();
+    dxTensor->set_dim({1, 3, 30, 30}); // Incorrect dx size (should be 32x32)
+    dxTensor->set_stride({2700, 900, 30, 1});
+    convAttributes.set_dx(dxTensor);
+
+    convAttributes.set_pre_padding({1, 1});
+    convAttributes.set_post_padding({1, 1});
+    convAttributes.set_stride({1, 1});
+    convAttributes.set_dilation({1, 1});
+
+    GraphAttributes graphAttributes;
+    ConvolutionDgradNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
+}
+
+TEST(TestConvolutionDgradNode, PreValidateNodeWithDroppedPixels)
+{
+    ConvDgradAttributes convAttributes;
+
+    // Index (0, 1, 2) & (2, 3, 4) are the two 3x3 kernels applied with stride 2 on 6x6 dx
+    // 5th is dropped / unused due to stride
+    auto dyTensor = std::make_shared<TensorAttributes>();
+    dyTensor->set_dim({1, 64, 2, 2}); // Output 2x2
+    dyTensor->set_stride({256, 4, 2, 1});
+    convAttributes.set_dy(dyTensor);
+
+    auto wTensor = std::make_shared<TensorAttributes>();
+    wTensor->set_dim({64, 3, 3, 3}); // Kernel 3x3
+    wTensor->set_stride({27, 9, 3, 1});
+    convAttributes.set_w(wTensor);
+
+    auto dxTensor = std::make_shared<TensorAttributes>();
+    dxTensor->set_dim({1, 3, 6, 6}); // Input 6x6
+    dxTensor->set_stride({108, 36, 6, 1});
+    convAttributes.set_dx(dxTensor);
+
+    convAttributes.set_pre_padding({0, 0});
+    convAttributes.set_post_padding({0, 0});
+    convAttributes.set_stride({2, 2});
+    convAttributes.set_dilation({1, 1});
+
+    GraphAttributes graphAttributes;
+    ConvolutionDgradNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, error_code_t::OK) << error.err_msg;
+}
+
+TEST(TestConvolutionDgradNode, PreValidateNodeInputTooSmall)
+{
+    ConvDgradAttributes convAttributes;
+
+    auto dyTensor = std::make_shared<TensorAttributes>();
+    dyTensor->set_dim({1, 64, 1, 1});
+    dyTensor->set_stride({64, 1, 1, 1});
+    convAttributes.set_dy(dyTensor);
+
+    auto wTensor = std::make_shared<TensorAttributes>();
+    wTensor->set_dim({64, 3, 3, 3}); // Kernel 3x3
+    wTensor->set_stride({27, 9, 3, 1});
+    convAttributes.set_w(wTensor);
+
+    auto dxTensor = std::make_shared<TensorAttributes>();
+    dxTensor->set_dim({1, 3, 2, 2}); // Input smaller than kernel
+    dxTensor->set_stride({12, 4, 2, 1});
+    convAttributes.set_dx(dxTensor);
+
+    convAttributes.set_pre_padding({0, 0});
+    convAttributes.set_post_padding({0, 0});
+    convAttributes.set_stride({1, 1});
+    convAttributes.set_dilation({1, 1});
+
+    GraphAttributes graphAttributes;
+    ConvolutionDgradNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
+}

--- a/projects/hipdnn/frontend/tests/TestConvolutionDgradNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestConvolutionDgradNode.cpp
@@ -1311,8 +1311,8 @@ TEST(TestConvolutionDgradNode, PreValidateNodeWithDroppedPixels)
 {
     ConvDgradAttributes convAttributes;
 
-    // Index (0, 1, 2) & (2, 3, 4) are the two 3x3 kernels applied with stride 2 on 6x6 dx
-    // 5th is dropped / unused due to stride
+    // For each spatial dim Index (0, 1, 2) & (2, 3, 4) are the two 3x3 kernels
+    // applied with stride 2 on 6x6 dx 5th is dropped / unused due to stride
     auto dyTensor = std::make_shared<TensorAttributes>();
     dyTensor->set_dim({1, 64, 2, 2}); // Output 2x2
     dyTensor->set_stride({256, 4, 2, 1});

--- a/projects/hipdnn/frontend/tests/TestConvolutionNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestConvolutionNode.cpp
@@ -2439,8 +2439,8 @@ TEST(TestConvolutionNode, PreValidateNodeWithDroppedPixels)
 {
     ConvFpropAttributes convAttributes;
 
-    // Index (0, 1, 2) & (2, 3, 4) are the two 3x3 kernels applied with stride 2 on 6x6 input
-    // 5th is dropped / unused due to stride
+    // For each spatial dim Index (0, 1, 2) & (2, 3, 4) are the two 3x3 kernels
+    // applied with stride 2 on 6x6 dx 5th is dropped / unused due to stride
     auto xTensor = std::make_shared<TensorAttributes>();
     xTensor->set_dim({1, 3, 6, 6});
     xTensor->set_stride({108, 36, 6, 1});

--- a/projects/hipdnn/frontend/tests/TestConvolutionNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestConvolutionNode.cpp
@@ -2403,3 +2403,98 @@ TEST(TestConvolutionNode, PreValidateGroupedConvInvalidOutputChannels)
     auto error = node.pre_validate_node();
     EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
 }
+
+TEST(TestConvolutionNode, PreValidateNodeInvalidOutputDimensions)
+{
+    ConvFpropAttributes convAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({1, 3, 32, 32});
+    xTensor->set_stride({3072, 1024, 32, 1});
+    convAttributes.set_x(xTensor);
+
+    auto wTensor = std::make_shared<TensorAttributes>();
+    wTensor->set_dim({64, 3, 3, 3});
+    wTensor->set_stride({27, 9, 3, 1});
+    convAttributes.set_w(wTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_dim({1, 64, 30, 30}); // Incorrect output size (should be 32x32)
+    yTensor->set_stride({57600, 900, 30, 1});
+    convAttributes.set_y(yTensor);
+
+    convAttributes.set_pre_padding({1, 1});
+    convAttributes.set_post_padding({1, 1});
+    convAttributes.set_stride({1, 1});
+    convAttributes.set_dilation({1, 1});
+
+    GraphAttributes graphAttributes;
+    ConvolutionFpropNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
+}
+
+TEST(TestConvolutionNode, PreValidateNodeWithDroppedPixels)
+{
+    ConvFpropAttributes convAttributes;
+
+    // Index (0, 1, 2) & (2, 3, 4) are the two 3x3 kernels applied with stride 2 on 6x6 input
+    // 5th is dropped / unused due to stride
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({1, 3, 6, 6});
+    xTensor->set_stride({108, 36, 6, 1});
+    convAttributes.set_x(xTensor);
+
+    auto wTensor = std::make_shared<TensorAttributes>();
+    wTensor->set_dim({64, 3, 3, 3});
+    wTensor->set_stride({27, 9, 3, 1});
+    convAttributes.set_w(wTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_dim({1, 64, 2, 2});
+    yTensor->set_stride({256, 4, 2, 1});
+    convAttributes.set_y(yTensor);
+
+    convAttributes.set_pre_padding({0, 0});
+    convAttributes.set_post_padding({0, 0});
+    convAttributes.set_stride({2, 2});
+    convAttributes.set_dilation({1, 1});
+
+    GraphAttributes graphAttributes;
+    ConvolutionFpropNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, error_code_t::OK) << error.err_msg;
+}
+
+TEST(TestConvolutionNode, PreValidateNodeInputTooSmall)
+{
+    ConvFpropAttributes convAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({1, 3, 2, 2}); // Input smaller than kernel
+    xTensor->set_stride({12, 4, 2, 1});
+    convAttributes.set_x(xTensor);
+
+    auto wTensor = std::make_shared<TensorAttributes>();
+    wTensor->set_dim({64, 3, 3, 3}); // 3x3 kernel
+    wTensor->set_stride({27, 9, 3, 1});
+    convAttributes.set_w(wTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_dim({1, 64, 1, 1}); // Even if output is 1x1, it's invalid
+    yTensor->set_stride({64, 1, 1, 1});
+    convAttributes.set_y(yTensor);
+
+    convAttributes.set_pre_padding({0, 0});
+    convAttributes.set_post_padding({0, 0});
+    convAttributes.set_stride({1, 1});
+    convAttributes.set_dilation({1, 1});
+
+    GraphAttributes graphAttributes;
+    ConvolutionFpropNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
+}

--- a/projects/hipdnn/frontend/tests/TestConvolutionWgradNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestConvolutionWgradNode.cpp
@@ -1870,8 +1870,8 @@ TEST(TestConvolutionWgradNode, PreValidateNodeWithDroppedPixels)
 {
     ConvWgradAttributes convAttributes;
 
-    // Index (0, 1, 2) & (2, 3, 4) are the two 3x3 kernels applied with stride 2 on 6x6 input
-    // 5th is dropped / unused due to stride
+    // For each spatial dim Index (0, 1, 2) & (2, 3, 4) are the two 3x3 kernels
+    // applied with stride 2 on 6x6 dx 5th is dropped / unused due to stride
     auto xTensor = std::make_shared<TensorAttributes>();
     xTensor->set_dim({1, 3, 6, 6}); // Input 6x6
     xTensor->set_stride({108, 36, 6, 1});

--- a/projects/hipdnn/frontend/tests/TestConvolutionWgradNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestConvolutionWgradNode.cpp
@@ -1763,3 +1763,169 @@ TEST(TestConvolutionWgradNode, InferPropertiesStrideDimensionMismatch)
     auto error = node.infer_properties_node();
     EXPECT_EQ(error.code, error_code_t::ATTRIBUTE_NOT_SET);
 }
+
+TEST(TestConvolutionWgradNode, InferPropertiesWithDroppedPixelsAndDilation)
+{
+    ConvWgradAttributes convAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({1, 32, 16, 16});
+    xTensor->set_stride({8192, 256, 16, 1});
+    convAttributes.set_x(xTensor);
+
+    auto dyTensor = std::make_shared<TensorAttributes>();
+    dyTensor->set_dim({1, 4, 5, 5});
+    dyTensor->set_stride({100, 25, 5, 1});
+    convAttributes.set_dy(dyTensor);
+
+    auto dwTensor = std::make_shared<TensorAttributes>();
+    convAttributes.set_dw(dwTensor);
+
+    convAttributes.set_pre_padding({0, 0});
+    convAttributes.set_post_padding({0, 0});
+    convAttributes.set_stride({2, 2});
+    convAttributes.set_dilation({3, 3});
+
+    GraphAttributes graphAttributes;
+    ConvolutionWgradNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, error_code_t::OK) << error.err_msg;
+
+    auto inferredDims = dwTensor->get_dim();
+    EXPECT_EQ(inferredDims.size(), 4);
+    EXPECT_EQ(inferredDims[0], 4); // Output channels
+    EXPECT_EQ(inferredDims[1], 32); // Input channels
+    EXPECT_EQ(inferredDims[2], 3);
+    EXPECT_EQ(inferredDims[3], 3);
+}
+
+TEST(TestConvolutionWgradNode, InferPropertiesIncompatibleStrideDilationCombination)
+{
+    ConvWgradAttributes convAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    // xSize = 5
+    xTensor->set_dim({1, 1, 5, 5});
+    xTensor->set_stride({25, 25, 5, 1});
+    convAttributes.set_x(xTensor);
+
+    auto dyTensor = std::make_shared<TensorAttributes>();
+    // dySize = 2
+    dyTensor->set_dim({1, 1, 2, 2});
+    dyTensor->set_stride({4, 4, 2, 1});
+    convAttributes.set_dy(dyTensor);
+
+    auto dwTensor = std::make_shared<TensorAttributes>();
+    convAttributes.set_dw(dwTensor);
+
+    convAttributes.set_pre_padding({0, 0});
+    convAttributes.set_post_padding({0, 0});
+    convAttributes.set_stride({2, 2});
+    convAttributes.set_dilation({3, 3});
+
+    // numerator = 5 + 0 + 0 - (2 * (2 - 1)) - 1 = 2
+    // remainder = 2 % 3 = 2
+    // remainder (2) >= stride (2) -> Error because dropped pixels cannot exceed stride
+
+    GraphAttributes graphAttributes;
+    ConvolutionWgradNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
+}
+
+TEST(TestConvolutionWgradNode, PreValidateNodeInvalidSpatialDimensions)
+{
+    ConvWgradAttributes convAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({1, 3, 32, 32});
+    xTensor->set_stride({3072, 1024, 32, 1});
+    convAttributes.set_x(xTensor);
+
+    auto dyTensor = std::make_shared<TensorAttributes>();
+    dyTensor->set_dim({1, 64, 30, 30}); // Incorrect dy size (should be 32x32)
+    dyTensor->set_stride({57600, 900, 30, 1});
+    convAttributes.set_dy(dyTensor);
+
+    auto dwTensor = std::make_shared<TensorAttributes>();
+    dwTensor->set_dim({64, 3, 3, 3});
+    dwTensor->set_stride({27, 9, 3, 1});
+    convAttributes.set_dw(dwTensor);
+
+    convAttributes.set_pre_padding({1, 1});
+    convAttributes.set_post_padding({1, 1});
+    convAttributes.set_stride({1, 1});
+    convAttributes.set_dilation({1, 1});
+
+    GraphAttributes graphAttributes;
+    ConvolutionWgradNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
+}
+
+TEST(TestConvolutionWgradNode, PreValidateNodeWithDroppedPixels)
+{
+    ConvWgradAttributes convAttributes;
+
+    // Index (0, 1, 2) & (2, 3, 4) are the two 3x3 kernels applied with stride 2 on 6x6 input
+    // 5th is dropped / unused due to stride
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({1, 3, 6, 6}); // Input 6x6
+    xTensor->set_stride({108, 36, 6, 1});
+    convAttributes.set_x(xTensor);
+
+    auto dyTensor = std::make_shared<TensorAttributes>();
+    dyTensor->set_dim({1, 64, 2, 2}); // Output 2x2
+    dyTensor->set_stride({256, 4, 2, 1});
+    convAttributes.set_dy(dyTensor);
+
+    auto dwTensor = std::make_shared<TensorAttributes>();
+    dwTensor->set_dim({64, 3, 3, 3}); // Kernel 3x3
+    dwTensor->set_stride({27, 9, 3, 1});
+    convAttributes.set_dw(dwTensor);
+
+    convAttributes.set_pre_padding({0, 0});
+    convAttributes.set_post_padding({0, 0});
+    convAttributes.set_stride({2, 2});
+    convAttributes.set_dilation({1, 1});
+
+    GraphAttributes graphAttributes;
+    ConvolutionWgradNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, error_code_t::OK) << error.err_msg;
+}
+
+TEST(TestConvolutionWgradNode, PreValidateNodeInputTooSmall)
+{
+    ConvWgradAttributes convAttributes;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({1, 3, 2, 2}); // Input smaller than kernel
+    xTensor->set_stride({12, 4, 2, 1});
+    convAttributes.set_x(xTensor);
+
+    auto dyTensor = std::make_shared<TensorAttributes>();
+    dyTensor->set_dim({1, 64, 1, 1});
+    dyTensor->set_stride({64, 1, 1, 1});
+    convAttributes.set_dy(dyTensor);
+
+    auto dwTensor = std::make_shared<TensorAttributes>();
+    dwTensor->set_dim({64, 3, 3, 3}); // Kernel 3x3
+    dwTensor->set_stride({27, 9, 3, 1});
+    convAttributes.set_dw(dwTensor);
+
+    convAttributes.set_pre_padding({0, 0});
+    convAttributes.set_post_padding({0, 0});
+    convAttributes.set_stride({1, 1});
+    convAttributes.set_dilation({1, 1});
+
+    GraphAttributes graphAttributes;
+    ConvolutionWgradNode node(std::move(convAttributes), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, error_code_t::INVALID_VALUE);
+}


### PR DESCRIPTION
## Motivation

As I was swapping integration tests to rely on inferring logic instead of hardset parameters I found a few edge cases that weren't being handled well. In particular cases that result in dropped pixels weren't able to be inferred, and that also lead to cases where an invalid problem would not fail validation (negative, or 0 output dims). 

This update fixes these checks, and adds additional tests to ensure only valid convolutions are allowed through / inferred, and also improves the inferring logic to handle dropped value cases.

## Technical Details

Update convolution node validation & inferring logic + update tests to handle above edge cases, and checks.

## Test Plan

CI & tests covering this.

## Test Result

CI & tests covering this pass.