### PR TITLE
[hipblaslt] Set HasSchedMode from device attribute instead of ISA version

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 45d3ea3dd2ecc8d5627630c57baf37a54ba276a8 # 2026-02-03 commit
+          ref: 56d71ec3450f87a888ef56da0673ca09a6b56450 # 2026-01-27 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 56d71ec3450f87a888ef56da0673ca09a6b56450 # 2026-01-27 commit
+          ref: 45d3ea3dd2ecc8d5627630c57baf37a54ba276a8 # 2026-02-03 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/projects/hipblaslt/tensilelite/rocisa/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/rocisa/CMakeLists.txt
@@ -17,6 +17,8 @@ target_include_directories(rocisa-cpp
 )
 
 if(HIPBLASLT_BUNDLE_PYTHON_DEPS)
+    find_package(hip REQUIRED)
+
     include(FetchContent)
     FetchContent_Declare(
       nanobind
@@ -60,5 +62,6 @@ if(HIPBLASLT_BUNDLE_PYTHON_DEPS)
                             ${ROCISAPASS_SOURCE}
                             ${ROCISAFUNC_SOURCE})
     target_include_directories(rocisa PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rocisa/include")
+    target_link_libraries(rocisa PRIVATE hip::host)
     set_target_properties(rocisa PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
 endif()

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
@@ -391,9 +391,13 @@ inline std::map<std::string, int> initArchCaps(const IsaVersion& isaVersion, int
     rv["DeviceLDS"]          = deviceLDS;
     rv["CMPXWritesSGPR"]     = checkNotInList(isaVersion[0], {10, 11, 12});
     rv["HasWave32"]          = checkInList(isaVersion[0], {10, 11, 12});
-    rv["HasSchedMode"]       = checkInList(isaVersion[0], {12})
-                                   ? getDeviceAttribute(hipDeviceAttributeExpertSchedMode, deviceId, 0)
-                                   : 0;
+#if HIP_VERSION >= 70200000
+    rv["HasSchedMode"] = checkInList(isaVersion[0], {12})
+                             ? getDeviceAttribute(hipDeviceAttributeExpertSchedMode, deviceId, 0)
+                             : 0;
+#else
+    rv["HasSchedMode"] = 0;
+#endif
     rv["HasAccCD"]           = checkInList(isaVersion, {{9, 0, 10}, {9, 4, 2}, {9, 5, 0}});
     rv["ArchAccUnifiedRegs"] = checkInList(isaVersion, {{9, 0, 10}, {9, 4, 2}, {9, 5, 0}});
     rv["CrosslaneWait"]      = checkInList(isaVersion, {{9, 4, 2}, {9, 5, 0}});

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
@@ -378,7 +378,7 @@ inline std::map<std::string, int>
     return rv;
 }
 
-inline std::map<std::string, int> initArchCaps(const IsaVersion& isaVersion)
+inline std::map<std::string, int> initArchCaps(const IsaVersion& isaVersion, int deviceId = 0)
 {
     std::vector<std::array<int, 3>> b = {{9, 0, 6}, {9, 0, 8}, {9, 0, 10}, {9, 4, 2}};
     std::map<std::string, int>      rv;
@@ -388,10 +388,16 @@ inline std::map<std::string, int> initArchCaps(const IsaVersion& isaVersion)
     int deviceLDS          = 65536;
     if(checkInList(isaVersion, {{9, 5, 0}}))
         deviceLDS = 163840;
-    rv["DeviceLDS"]          = deviceLDS;
-    rv["CMPXWritesSGPR"]     = checkNotInList(isaVersion[0], {10, 11, 12});
-    rv["HasWave32"]          = checkInList(isaVersion[0], {10, 11, 12});
-    rv["HasSchedMode"]       = checkInList(isaVersion[0], {}); //TODO: https://github.com/ROCm/rocm-libraries/issues/3211
+    rv["DeviceLDS"]      = deviceLDS;
+    rv["CMPXWritesSGPR"] = checkNotInList(isaVersion[0], {10, 11, 12});
+    rv["HasWave32"]      = checkInList(isaVersion[0], {10, 11, 12});
+    rv["HasSchedMode"]
+        = checkInList(isaVersion[0], {12})
+              ? getDeviceProperty<int>(
+                    deviceId,
+                    [](const hipDeviceProp_t& prop) { return prop.hasExpertSchedMode; },
+                    0)
+              : 0;
     rv["HasAccCD"]           = checkInList(isaVersion, {{9, 0, 10}, {9, 4, 2}, {9, 5, 0}});
     rv["ArchAccUnifiedRegs"] = checkInList(isaVersion, {{9, 0, 10}, {9, 4, 2}, {9, 5, 0}});
     rv["CrosslaneWait"]      = checkInList(isaVersion, {{9, 4, 2}, {9, 5, 0}});

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
@@ -391,7 +391,7 @@ inline std::map<std::string, int> initArchCaps(const IsaVersion& isaVersion, int
     rv["DeviceLDS"]          = deviceLDS;
     rv["CMPXWritesSGPR"]     = checkNotInList(isaVersion[0], {10, 11, 12});
     rv["HasWave32"]          = checkInList(isaVersion[0], {10, 11, 12});
-#if HIP_VERSION >= 70200000
+#if HIP_VERSION >= 70353390
     rv["HasSchedMode"] = checkInList(isaVersion[0], {12})
                              ? getDeviceAttribute(hipDeviceAttributeExpertSchedMode, deviceId, 0)
                              : 0;

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
@@ -388,16 +388,12 @@ inline std::map<std::string, int> initArchCaps(const IsaVersion& isaVersion, int
     int deviceLDS          = 65536;
     if(checkInList(isaVersion, {{9, 5, 0}}))
         deviceLDS = 163840;
-    rv["DeviceLDS"]      = deviceLDS;
-    rv["CMPXWritesSGPR"] = checkNotInList(isaVersion[0], {10, 11, 12});
-    rv["HasWave32"]      = checkInList(isaVersion[0], {10, 11, 12});
-    rv["HasSchedMode"]
-        = checkInList(isaVersion[0], {12})
-              ? getDeviceProperty<int>(
-                    deviceId,
-                    [](const hipDeviceProp_t& prop) { return prop.hasExpertSchedMode; },
-                    0)
-              : 0;
+    rv["DeviceLDS"]          = deviceLDS;
+    rv["CMPXWritesSGPR"]     = checkNotInList(isaVersion[0], {10, 11, 12});
+    rv["HasWave32"]          = checkInList(isaVersion[0], {10, 11, 12});
+    rv["HasSchedMode"]       = checkInList(isaVersion[0], {12})
+                                   ? getDeviceAttribute(hipDeviceAttributeExpertSchedMode, deviceId, 0)
+                                   : 0;
     rv["HasAccCD"]           = checkInList(isaVersion, {{9, 0, 10}, {9, 4, 2}, {9, 5, 0}});
     rv["ArchAccUnifiedRegs"] = checkInList(isaVersion, {{9, 0, 10}, {9, 4, 2}, {9, 5, 0}});
     rv["CrosslaneWait"]      = checkInList(isaVersion, {{9, 4, 2}, {9, 5, 0}});

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include <Tensile/hip/HipUtils.hpp>
+
 using IsaVersion = std::array<int, 3>;
 
 std::pair<int, std::string>
@@ -65,9 +67,6 @@ bool checkNotInList(const T& a, const std::vector<T> b)
 inline int getDeviceAttribute(hipDeviceAttribute_t attr, int deviceId, int defaultValue = 0)
 {
     int value = defaultValue;
-    if(hipDeviceGetAttribute(&value, attr, deviceId) == hipSuccess)
-    {
-        return value;
-    }
-    return defaultValue;
+    HIP_CHECK_EXC(hipDeviceGetAttribute(&value, attr, deviceId));
+    return value;
 }

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
@@ -28,8 +28,6 @@
 #include <string>
 #include <vector>
 
-#include <Tensile/hip/HipUtils.hpp>
-
 using IsaVersion = std::array<int, 3>;
 
 std::pair<int, std::string>
@@ -67,6 +65,9 @@ bool checkNotInList(const T& a, const std::vector<T> b)
 inline int getDeviceAttribute(hipDeviceAttribute_t attr, int deviceId, int defaultValue = 0)
 {
     int value = defaultValue;
-    HIP_CHECK_EXC(hipDeviceGetAttribute(&value, attr, deviceId));
-    return value;
+    if(hipDeviceGetAttribute(&value, attr, deviceId) == hipSuccess)
+    {
+        return value;
+    }
+    return defaultValue;
 }

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
@@ -23,6 +23,7 @@
 #pragma once
 #include <algorithm>
 #include <array>
+#include <hip/hip_runtime.h>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -58,4 +59,16 @@ template <typename T>
 bool checkNotInList(const T& a, const std::vector<T> b)
 {
     return std::find(b.begin(), b.end(), a) == b.end();
+}
+
+// Helper to get device properties from HIP runtime
+template <typename T, typename Func>
+inline T getDeviceProperty(int deviceId, Func propertyGetter, T defaultValue = T{})
+{
+    hipDeviceProp_t prop;
+    if(hipGetDeviceProperties(&prop, deviceId) == hipSuccess)
+    {
+        return propertyGetter(prop);
+    }
+    return defaultValue;
 }

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/helper.hpp
@@ -61,14 +61,13 @@ bool checkNotInList(const T& a, const std::vector<T> b)
     return std::find(b.begin(), b.end(), a) == b.end();
 }
 
-// Helper to get device properties from HIP runtime
-template <typename T, typename Func>
-inline T getDeviceProperty(int deviceId, Func propertyGetter, T defaultValue = T{})
+// Helper to get device attribute from HIP runtime
+inline int getDeviceAttribute(hipDeviceAttribute_t attr, int deviceId, int defaultValue = 0)
 {
-    hipDeviceProp_t prop;
-    if(hipGetDeviceProperties(&prop, deviceId) == hipSuccess)
+    int value = defaultValue;
+    if(hipDeviceGetAttribute(&value, attr, deviceId) == hipSuccess)
     {
-        return propertyGetter(prop);
+        return value;
     }
     return defaultValue;
 }


### PR DESCRIPTION
Set HasSchedMode from device attribute instead of ISA version.
Motivation for this is described here: https://github.com/ROCm/rocm-libraries/issues/3211
Also, it adds a functionality for setting other props this way if needed in the future.
This PR depends on: https://github.com/ROCm/rocm-systems/pull/2435
