### PR TITLE
[rocThrust] Add gfx1152 and gfx1153

### DIFF
--- a/projects/rocthrust/CMakeLists.txt
+++ b/projects/rocthrust/CMakeLists.txt
@@ -147,7 +147,7 @@ else()
       )
     else()
       rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-        TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
+        TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201"
       )
     endif()
     set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)


### PR DESCRIPTION
## Motivation

Enable gfx1152 and gfx1153.

## Technical Details

Extend list of default cmake targets.

## Test Plan

Build existing ctests for, and run them on, gfx1152 and gfx1153.

## Test Result

- [x] pass on gfx1152 (@eble-amd)
- [x] pass on gfx1153 (@eble-amd)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
