### PR TITLE
[rocthrust] Fix an out-of-memory exception in benchmark_thrust_transform_basic

### DIFF
--- a/projects/rocthrust/benchmark/bench/transform/basic.cu
+++ b/projects/rocthrust/benchmark/bench/transform/basic.cu
@@ -294,7 +294,17 @@ void run_babelstream(benchmark::State& state, const std::size_t n)
     thrust::fill(b.begin(), b.end(), startB);
     thrust::fill(c.begin(), c.end(), startC);
 
-    auto duration = Benchmark::template run<T>(a, b, c);
+    float64_t duration;
+    try
+    {
+      duration = Benchmark::template run<T>(a, b, c);
+    }
+    catch(const ::thrust::system::detail::bad_alloc& e)
+    {
+      (void) hipGetLastError();
+      state.SkipWithError(("thrust::system::detail::bad_alloc: " + std::string(e.what())).c_str());
+      return;
+    }
     state.SetIterationTime(duration);
     gpu_times.push_back(duration);
   }
@@ -318,16 +328,16 @@ void run_babelstream(benchmark::State& state, const std::size_t n)
 // Different benchmarks use a different number of buffers. H200/B200 can fit 2^31 elements for all benchmarks and types.
 // Upstream BabelStream uses 2^25. Allocation failure just skips the benchmark
 #define BENCHMARK_BABELSTREAM_TYPE(type)              \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 25, mul),   \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 31, mul),   \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 25, add),   \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 31, add),   \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 25, triad), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 31, triad), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 25, nstream), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 31, nstream), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 25, nstream_stable), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1 << 31, nstream_stable)
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, mul),   \
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, mul),   \
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, add),   \
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, add),   \
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, triad), \
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, triad), \
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, nstream), \
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, nstream), \
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, nstream_stable), \
+  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, nstream_stable)
 // clang-format on
 
 void add_benchmarks(const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Benchmarks tend to use a variety of buffer sizes and are prepared to handle the situation of running out of memory, in which case they will be skipped. But sometimes programming errors can cause the requested buffer size to be unintentionally large which also leads to out of memory hence test cases being incorrectly skipped. This PR fixes such an issue.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
One of the test cases of benchmark_thrust_transform_basic has an integer overflow, causing the requested buffer size to be unrealistically large. After fixing this, more test cases can continue, but we need another try-catch block to capture the possible exceptions of out of memory while running these cases.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Test cases of benchmark_thrust_transform_basic should no longer be incorrectly skipped.

## Test Result

<!-- Briefly summarize test outcomes. -->
Verified that by fixing the interger overflow, previously skipped test cases can now run.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
