### PR TITLE
[rocroller] Skip reporting register counts when loading from a code object

### DIFF
--- a/shared/rocroller/client/src/gemm.cpp
+++ b/shared/rocroller/client/src/gemm.cpp
@@ -440,10 +440,17 @@ namespace rocRoller::Client::GEMMClient
         if(commandKernel->getContext() && commandKernel->getContext()->kernel())
         {
             auto assemblyKernel = commandKernel->getContext()->kernel();
-            result.sgprCount    = assemblyKernel->sgpr_count();
-            result.vgprCount    = assemblyKernel->vgpr_count();
-            result.agprCount    = assemblyKernel->agpr_count();
-            result.ldsBytes     = assemblyKernel->group_segment_fixed_size();
+
+            // Only query register counts if kernel was generated (not loaded from code object).
+            // When loaded, generation timer is 0; when generated, it records the time spent.
+            // TODO: Load these when deserializing the kernel from a code object.
+            if(result.kernelGenerate > 0)
+            {
+                result.sgprCount = assemblyKernel->sgpr_count();
+                result.vgprCount = assemblyKernel->vgpr_count();
+                result.agprCount = assemblyKernel->agpr_count();
+                result.ldsBytes  = assemblyKernel->group_segment_fixed_size();
+            }
         }
 
         if(benchmarkParams.check)

--- a/shared/rocroller/lib/include/rocRoller/AssemblyKernel_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/AssemblyKernel_impl.hpp
@@ -174,17 +174,35 @@ namespace rocRoller
 
     inline int AssemblyKernel::sgpr_count() const
     {
-        return m_context.lock()->allocator(Register::Type::Scalar)->useCount();
+        auto ctx = m_context.lock();
+        AssertFatal(ctx, "AssemblyKernel::sgpr_count() called with invalid context");
+
+        auto allocator = ctx->allocator(Register::Type::Scalar);
+        AssertFatal(allocator, "AssemblyKernel::sgpr_count() allocator is null");
+
+        return allocator->useCount();
     }
 
     inline int AssemblyKernel::vgpr_count() const
     {
-        return m_context.lock()->allocator(Register::Type::Vector)->useCount();
+        auto ctx = m_context.lock();
+        AssertFatal(ctx, "AssemblyKernel::vgpr_count() called with invalid context");
+
+        auto allocator = ctx->allocator(Register::Type::Vector);
+        AssertFatal(allocator, "AssemblyKernel::vgpr_count() allocator is null");
+
+        return allocator->useCount();
     }
 
     inline int AssemblyKernel::agpr_count() const
     {
-        return m_context.lock()->allocator(Register::Type::Accumulator)->useCount();
+        auto ctx = m_context.lock();
+        AssertFatal(ctx, "AssemblyKernel::agpr_count() called with invalid context");
+
+        auto allocator = ctx->allocator(Register::Type::Accumulator);
+        AssertFatal(allocator, "AssemblyKernel::agpr_count() allocator is null");
+
+        return allocator->useCount();
     }
 
     inline int AssemblyKernel::accum_offset() const

--- a/shared/rocroller/lib/source/CommandSolution.cpp
+++ b/shared/rocroller/lib/source/CommandSolution.cpp
@@ -635,7 +635,7 @@ namespace rocRoller
         auto yaml   = readMetaDataFromCodeObject(fileName);
         auto kernel = AssemblyKernels::fromYAML(yaml).kernels[0];
 
-        // XXX Instead of adding `setKernel`, should the context load from a code object?
+        // TODO: Instead of adding `setKernel`, should the context load from a code object?
         auto kernelPtr = std::make_shared<AssemblyKernel>(kernel);
         m_context->setKernel(kernelPtr);
         return kernelPtr;


### PR DESCRIPTION
## Motivation

The client reports kernel register counts from the various types of allocators. This is currently broken (segmentation faults) when loading a kernel from a Code Object file i.e. via `rocroller-gemm validate --load ...` because the context and allocators are not set up properly for the loaded kernel. 

## Technical Details

- Skip erroneously trying to report register counts (temporarily) when the kernel isn't generated i.e. for CO-loaded kernels

## Test Plan

- `rocroller-gemm validate --load ...`

## Test Result

- `rocroller-gemm validate --load ...` no longer segfaults
