### PR TITLE
[MIOpen] Fix static analysis error in ConvFFT

### DIFF
--- a/projects/miopen/src/solver/conv/fft.cpp
+++ b/projects/miopen/src/solver/conv/fft.cpp
@@ -463,7 +463,7 @@ ConvSolution fft::GetSolution(const ExecutionContext& ctx, const ProblemDescript
                 case 4: {
                     k(workSpace0,
                       reinterpret_cast<const char*>(workSpace1) +
-                          N * (in_n * in_c + padding) * (sizeof(float) * 2),
+                          sizeof(float) * 2 * N * (in_n * in_c + padding),
                       workSpace1,
                       out_c,
                       out_n * out_c + padding,


### PR DESCRIPTION
## Motivation

A fix for a warning introduced in https://github.com/ROCm/rocm-libraries/pull/2953:
```
/projects/miopen/src/solver/conv/fft.cpp:466:27: error: performing an implicit widening conversion to type 'unsigned long' of a multiplication performed in type 'int' [bugprone-implicit-widening-of-multiplication-result,-warnings-as-errors]
  466 |                           N * (in_n * in_c + padding) * (sizeof(float) * 2),
      |                           ^
/projects/miopen/src/solver/conv/fft.cpp:466:27: note: make conversion explicit to silence this warning
   27 |                           N * (in_n * in_c + padding) * (sizeof(float) * 2),
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                           static_cast<unsigned long>()
/projects/miopen/src/solver/conv/fft.cpp:466:27: note: perform multiplication in a wider type
  466 |                           N * (in_n * in_c + padding) * (sizeof(float) * 2),
      |                           ^
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
