### PR TITLE
[hipblaslt] Testing hypothesis that multithreading at this level is detrimental

### DIFF
--- a/projects/hipblaslt/tensilelite/tox.ini
+++ b/projects/hipblaslt/tensilelite/tox.ini
@@ -27,7 +27,7 @@ commands =
     pip install --no-build-isolation {toxinidir}/rocisa/
     pip install pytest-cov
     invoke build-client --build-dir {toxinidir}/build_tmp {env:TENSILELITE_CLIENT_ARGS}
-    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 4 --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
+    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 1 --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
 allowlist_externals =
     mkdir
     sh


### PR DESCRIPTION
## Experiment

Removing tox level sharding. Watch the preliminary testing of math-ci. Is it faster than 3h45? Nope. 

## Results

<img width="1672" height="105" alt="{4055A94F-76E7-4E3D-8F78-27A23CA772CA}" src="https://github.com/user-attachments/assets/3309ab04-c5aa-456b-b0cc-33485792ce41" />

## Conclusion

Just sharding doesn't help (need to check locks etc)