### PR TITLE
fft: bump versions for ROCm 7.2 release

### DIFF
--- a/projects/hipfft/CHANGELOG.md
+++ b/projects/hipfft/CHANGELOG.md
@@ -23,10 +23,6 @@ Documentation for hipFFT is available at
   * fftw_execute_dft_c2r
   * fftwf_execute_dft_c2r
 
-### Resolved issues
-
-* Fixed a case where hipFFTW could throw a C++ exception to callers.
-
 ## hipFFT 1.0.21 for ROCm 7.1.0
 
 ### Added

--- a/projects/hipfft/CHANGELOG.md
+++ b/projects/hipfft/CHANGELOG.md
@@ -3,11 +3,29 @@
 Documentation for hipFFT is available at
 [https://rocm.docs.amd.com/projects/hipFFT/en/latest/](https://rocm.docs.amd.com/projects/hipFFT/en/latest/).
 
-## hipFFT 1.0.22 (unreleased)
+## hipFFT 1.0.23 (unreleased)
 
 ### Resolved issues
 
 * Fixed potential launch failure of data generation kernels in test and benchmark programs.
+
+## hipFFT 1.0.22 for ROCm 7.2.0
+
+### Added
+
+* hipFFTW execution functions, where input and output data buffers differ from the
+  buffers specified at plan creation:
+
+  * fftw_execute_dft
+  * fftwf_execute_dft
+  * fftw_execute_dft_r2c
+  * fftwf_execute_dft_r2c
+  * fftw_execute_dft_c2r
+  * fftwf_execute_dft_c2r
+
+### Resolved issues
+
+* Fixed a case where hipFFTW could throw a C++ exception to callers.
 
 ## hipFFT 1.0.21 for ROCm 7.1.0
 

--- a/projects/hipfft/CHANGELOG.md
+++ b/projects/hipfft/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for hipFFT is available at
 [https://rocm.docs.amd.com/projects/hipFFT/en/latest/](https://rocm.docs.amd.com/projects/hipFFT/en/latest/).
 
-## hipFFT 1.0.23 (unreleased)
+## (Unreleased) hipFFT 1.0.23
 
 ### Resolved issues
 

--- a/projects/hipfft/CMakeLists.txt
+++ b/projects/hipfft/CMakeLists.txt
@@ -175,7 +175,7 @@ endif()
 message(STATUS "BUILD_WITH_COMPILER = " ${BUILD_WITH_COMPILER})
 
 # Version
-set( VERSION_STRING "1.0.22" )
+set( VERSION_STRING "1.0.23" )
 set( hipfft_SOVERSION 0.1 )
 set( hipfftw_SOVERSION 0.1 )
 

--- a/projects/hipfft/docs/doxygen/Doxyfile
+++ b/projects/hipfft/docs/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "hipFFT"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v1.0.22
+PROJECT_NUMBER         = v1.0.23
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/projects/rocfft/CHANGELOG.md
+++ b/projects/rocfft/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocFFT is available at
 [https://rocm.docs.amd.com/projects/rocFFT/en/latest/](https://rocm.docs.amd.com/projects/rocFFT/en/latest/).
 
-## rocFFT 1.0.37 (unreleased)
+## (Unreleased) rocFFT 1.0.37
 
 * Fixed potential issue with data generation for multidimensional transforms in rocfft-tests and rocfft-bench.
 * Fixed issue that sometimes blocked complex-to-complex FFT plan creation when using noncontiguous strides in multiple dimensions.

--- a/projects/rocfft/CHANGELOG.md
+++ b/projects/rocfft/CHANGELOG.md
@@ -3,7 +3,16 @@
 Documentation for rocFFT is available at
 [https://rocm.docs.amd.com/projects/rocFFT/en/latest/](https://rocm.docs.amd.com/projects/rocFFT/en/latest/).
 
-## rocFFT 1.0.36 (unreleased)
+## rocFFT 1.0.37 (unreleased)
+
+* Fixed potential issue with data generation for multidimensional transforms in rocfft-tests and rocfft-bench.
+* Fixed issue that sometimes blocked complex-to-complex FFT plan creation when using noncontiguous strides in multiple dimensions.
+* Fixed issue that sometimes blocked complex-to-real FFT plan creation when using noncontiguous strides in multiple dimensions.
+* Fixed issue that sometimes blocked complex-to-real FFT plan creation when using noncontiguous strides with small lengths on the two fastest dimensions.
+* Fixed potential launch failure of data generation kernels in test and benchmark programs.
+* Fixed incorrect results on some strided real-complex FFTs on gfx90a.
+
+## rocFFT 1.0.36 for ROCm 7.2.0
 
 ### Optimized
 
@@ -15,12 +24,6 @@ Documentation for rocFFT is available at
 * Fixed potential division by zero when constructing plans using dimensions of length 1.
 * Fixed result scaling on multi-device transforms.
 * Fixed callbacks on multi-device transforms.
-* Fixed potential issue with data generation for multidimensional transforms in rocfft-tests and rocfft-bench.
-* Fixed issue that sometimes blocked complex-to-complex FFT plan creation when using noncontiguous strides in multiple dimensions.
-* Fixed issue that sometimes blocked complex-to-real FFT plan creation when using noncontiguous strides in multiple dimensions.
-* Fixed issue that sometimes blocked complex-to-real FFT plan creation when using noncontiguous strides with small lengths on the two fastest dimensions.
-* Fixed potential launch failure of data generation kernels in test and benchmark programs.
-* Fixed incorrect results on some strided real-complex FFTs on gfx90a.
 
 ## rocFFT 1.0.35 for ROCM 7.1.0
 

--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -85,7 +85,7 @@ if( ROCM_PATH )
 endif()
 
 # Using standardized versioning from rocm-cmake
-set ( VERSION_STRING "1.0.36" )
+set ( VERSION_STRING "1.0.37" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # Append our library helper cmake path and the cmake path for hip (for

--- a/projects/rocfft/docs/doxygen/Doxyfile
+++ b/projects/rocfft/docs/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "rocFFT"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v1.0.36
+PROJECT_NUMBER         = v1.0.37
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
## Motivation

Update FFT changelogs for 7.2 release and bump versions for the next release.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
