### PR TITLE
[hipblaslt] Add option in CMS to set lgkmcnt to zero for NLL

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -470,6 +470,7 @@ class Timeline:
         self.vlcnt_shift = defaultdict(int)
         self.vlcnt_shift[NO_GLOBAL_LOAD_LOOP] = schedule_info.nglshift
         self.vlcnt_shift[NO_LOCAL_LOAD_LOOP] = schedule_info.nllshift
+        self.ngl_nll_zero_dscnt = schedule_info.nglnllZeroDscnt
 
         self.loops = [MAIN_LOOP_PREV, MAIN_LOOP, NO_GLOBAL_LOAD_LOOP, NO_LOCAL_LOAD_LOOP]
         # NOTE: num_vmfma + 1 to account for special idx=-1.
@@ -589,7 +590,10 @@ class Timeline:
                     if _instruction.vlcnt != -1:
                         vlcnt = max(0, _instruction.vlcnt - self.vlcnt_shift[loop])
                         _instruction.vlcnt = vlcnt
-                    
+                    if _instruction.dscnt != -1 and self.ngl_nll_zero_dscnt \
+                       and loop in [NO_GLOBAL_LOAD_LOOP, NO_LOCAL_LOAD_LOOP]:
+                        _instruction.dscnt = 0
+
                 # Other fields on other instructions are calculated later based on the issued_at index and LR.needed_by.
                 if isinstance(_instruction, LocalRead):
                     _instruction.needed_by += adjust

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -470,7 +470,7 @@ class Timeline:
         self.vlcnt_shift = defaultdict(int)
         self.vlcnt_shift[NO_GLOBAL_LOAD_LOOP] = schedule_info.nglshift
         self.vlcnt_shift[NO_LOCAL_LOAD_LOOP] = schedule_info.nllshift
-        self.ngl_nll_zero_dscnt = schedule_info.nglnllZeroDscnt
+        self.nll_zero_dscnt = schedule_info.nllZeroDscnt
 
         self.loops = [MAIN_LOOP_PREV, MAIN_LOOP, NO_GLOBAL_LOAD_LOOP, NO_LOCAL_LOAD_LOOP]
         # NOTE: num_vmfma + 1 to account for special idx=-1.
@@ -590,8 +590,8 @@ class Timeline:
                     if _instruction.vlcnt != -1:
                         vlcnt = max(0, _instruction.vlcnt - self.vlcnt_shift[loop])
                         _instruction.vlcnt = vlcnt
-                    if _instruction.dscnt != -1 and self.ngl_nll_zero_dscnt \
-                       and loop in [NO_GLOBAL_LOAD_LOOP, NO_LOCAL_LOAD_LOOP]:
+                    if _instruction.dscnt != -1 and self.nll_zero_dscnt \
+                       and loop in [NO_LOCAL_LOAD_LOOP]:
                         _instruction.dscnt = 0
 
                 # Other fields on other instructions are calculated later based on the issued_at index and LR.needed_by.

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -114,6 +114,7 @@ class ScheduleInfo:
         syncCode,
         nglshift,
         nllshift,
+        nglnllZeroDscnt=False,
         mfmaReorder=[],
     ):
         self.numCodePaths = numCodePaths
@@ -122,6 +123,7 @@ class ScheduleInfo:
         self.syncCode = syncCode
         self.nglshift = nglshift  # vmcnt shift for noglobalload loop
         self.nllshift = nllshift  # vmcnt shift for nolocalload loop
+        self.nglnllZeroDscnt = nglnllZeroDscnt
         self.mfmaReorder = mfmaReorder
         self.__skipValidation__ = False
 
@@ -321,19 +323,27 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
                 needIfMacro = True
 
         def nllvmcntHandling(inst, shift0, shift1):
-            if isinstance(inst, SWaitCnt) and inst.vlcnt != -1:
+            if isinstance(inst, SWaitCnt) and (inst.vlcnt != -1 or (inst.dscnt != -1 and opt1.nglnllZeroDscnt)):
                 macro.add(ValueIf("\\useGR == 1 && \\usePLR == 1")) # in main loop
                 macro.addComment0("vmcnt used in main loop")
                 macro.add(inst)
                 macro.add(ValueElseIf("\\useGR == 0 && \\usePLR == 1")) # in NGL
-                macro.addComment0("vmcnt used in ngl, applying %u shift"%shift0)
                 instModified = deepcopy(inst)
-                instModified.vlcnt = max(0, instModified.vlcnt - shift0)
+                if inst.vlcnt != -1:
+                    macro.addComment0("vmcnt used in ngl, applying %u shift"%shift0)
+                    instModified.vlcnt = max(0, instModified.vlcnt - shift0)
+                if (inst.dscnt != -1 and opt1.nglnllZeroDscnt):
+                    macro.addComment0("setting dscnt = 0 for NGL/NLL")
+                    instModified.dscnt = 0
                 macro.add(instModified)
                 macro.add(ValueElseIf("\\useGR == 0 && \\usePLR == 0")) # in NLL
-                macro.addComment0("vmcnt used in nll, applying %u shift"%shift1)
                 instModified = deepcopy(inst)
-                instModified.vlcnt = max(0, instModified.vlcnt - shift1)
+                if inst.vlcnt != -1:
+                    macro.addComment0("vmcnt used in nll, applying %u shift"%shift1)
+                    instModified.vlcnt = max(0, instModified.vlcnt - shift1)
+                if (inst.dscnt != -1 and opt1.nglnllZeroDscnt):
+                    macro.addComment0("setting dscnt = 0 for NGL/NLL")
+                    instModified.dscnt = 0
                 macro.add(instModified)
                 macro.add(ValueEndif())
             else:
@@ -1391,6 +1401,7 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
     kernel["MfmaInitCVgprs"] = True
     kernel["SwapGlobalReadOrder"] = False
     numMfma = 120
+    nglnllZeroDscnt = False
     syncs = SyncSchedule()
     gr_inc_step = 0
 
@@ -1443,7 +1454,7 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
         lwsb   = [95]
 
         gr_inc_step = 1
-    
+
     elif isNT(kernel) and useLDSTr and TLDS == 0:
         lra0   = [0,1,3,5,7, 9,10,12,14,16, 18,19] # 12 loads
         lrb0   = [21,23,25,27,28, 30,32,34,36,37, 39,41,43,45,46, 48,50,52,54,55] # 20 loads
@@ -1452,7 +1463,7 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
         syncs.add(-1, dscnt=len(lrb0)-2, comment="wait for all LRA1 and two items from LRB1 before starting the sub-iteration")
 
         i = 5 # next LRB1 is needed at index 6, so insert wait at 5
-        syncs.add(i, dscnt=count_items(lra0,ev=i), comment="wait for the rest of LRB1 to complete") 
+        syncs.add(i, dscnt=count_items(lra0,ev=i), comment="wait for the rest of LRB1 to complete")
         grinca = [0,1,2,3,4,5,6,7,8]
         grincb = [9,10,12,13,14,15,16,17,18]
 
@@ -1469,8 +1480,8 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
         lra1   = [61,62,63,64,65, 66,67,69,71,73, 75,76] # 12 loads
 
         i = 65 # next LRB0 is needed at index 66, so insert wait at 65
-        syncs.add(i, dscnt=count_items(lra1,ev=i), barrier=True, 
-                  comment="wait for the rest of LRB0 to complete across all waves before GRB start") 
+        syncs.add(i, dscnt=count_items(lra1,ev=i), barrier=True,
+                  comment="wait for the rest of LRB0 to complete across all waves before GRB start")
         grb    = [66,70,75,79,84, 88,93,97,102,106] # one index for two instructions
         num_gr = len(gra) + len(grb)
 
@@ -1479,6 +1490,7 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
         lrb1   = [78,80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,110,112,114,116] # 20 loads
 
         gr_inc_step = 1
+        nglnllZeroDscnt = True
     else:
         return False, None
 
@@ -1501,8 +1513,8 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
     }
     syncCode = syncs.get_code()
     nglshift = nllshift = num_gr
-    opt1 = ScheduleInfo(1, numMfma, optSchedule, syncCode, nglshift, nllshift)
-    
+    opt1 = ScheduleInfo(1, numMfma, optSchedule, syncCode, nglshift, nllshift, nglnllZeroDscnt)
+
     if isNT(kernel):
         opt1.disableValidation()  # TODO: https://github.com/ROCm/rocm-libraries/issues/3287
     return True, opt1
@@ -1754,7 +1766,7 @@ def _get_schedule_240x256x64_16bit(kernel, useLDSTr, TLDS):
         ]
         numMfma = 120
         nglshift = nllshift = len(optSchedule["GRA"][0])/2 + len(optSchedule["GRB"][0])/2
-        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)    
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     else:
         return False, None
     return True, opt1

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -101,6 +101,7 @@ def count_items(input_list: list[int], sv:int|None = None, ev:int|None = None):
             count += 1
     return count
 
+
 class ScheduleInfo:
     numCodePaths: int
     numMfma: int
@@ -1515,8 +1516,6 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
     nglshift = nllshift = num_gr
     opt1 = ScheduleInfo(1, numMfma, optSchedule, syncCode, nglshift, nllshift, nglnllZeroDscnt)
 
-    if isNT(kernel):
-        opt1.disableValidation()  # TODO: https://github.com/ROCm/rocm-libraries/issues/3287
     return True, opt1
 
 def _get_schedule_256x224x64_16bit(kernel, userLDSTr, TLDS):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -115,7 +115,7 @@ class ScheduleInfo:
         syncCode,
         nglshift,
         nllshift,
-        nglnllZeroDscnt=False,
+        nllZeroDscnt=False,
         mfmaReorder=[],
     ):
         self.numCodePaths = numCodePaths
@@ -124,7 +124,7 @@ class ScheduleInfo:
         self.syncCode = syncCode
         self.nglshift = nglshift  # vmcnt shift for noglobalload loop
         self.nllshift = nllshift  # vmcnt shift for nolocalload loop
-        self.nglnllZeroDscnt = nglnllZeroDscnt
+        self.nllZeroDscnt = nllZeroDscnt
         self.mfmaReorder = mfmaReorder
         self.__skipValidation__ = False
 
@@ -324,7 +324,7 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
                 needIfMacro = True
 
         def nllvmcntHandling(inst, shift0, shift1):
-            if isinstance(inst, SWaitCnt) and (inst.vlcnt != -1 or (inst.dscnt != -1 and opt1.nglnllZeroDscnt)):
+            if isinstance(inst, SWaitCnt) and (inst.vlcnt != -1 or (inst.dscnt != -1 and opt1.nllZeroDscnt)):
                 macro.add(ValueIf("\\useGR == 1 && \\usePLR == 1")) # in main loop
                 macro.addComment0("vmcnt used in main loop")
                 macro.add(inst)
@@ -339,7 +339,7 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
                 if inst.vlcnt != -1:
                     macro.addComment0("vmcnt used in nll, applying %u shift"%shift1)
                     instModified.vlcnt = max(0, instModified.vlcnt - shift1)
-                if (inst.dscnt != -1 and opt1.nglnllZeroDscnt):
+                if (inst.dscnt != -1 and opt1.nllZeroDscnt):
                     macro.addComment0("setting dscnt = 0 for NLL")
                     instModified.dscnt = 0
                 macro.add(instModified)
@@ -1399,7 +1399,7 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
     kernel["MfmaInitCVgprs"] = True
     kernel["SwapGlobalReadOrder"] = False
     numMfma = 120
-    nglnllZeroDscnt = False
+    nllZeroDscnt = False
     syncs = SyncSchedule()
     gr_inc_step = 0
 
@@ -1488,7 +1488,7 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
         lrb1   = [78,80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,110,112,114,116] # 20 loads
 
         gr_inc_step = 1
-        nglnllZeroDscnt = True
+        nllZeroDscnt = True
     else:
         return False, None
 
@@ -1511,7 +1511,7 @@ def _get_schedule_192x320x64_16bit(kernel, useLDSTr, TLDS):
     }
     syncCode = syncs.get_code()
     nglshift = nllshift = num_gr
-    opt1 = ScheduleInfo(1, numMfma, optSchedule, syncCode, nglshift, nllshift, nglnllZeroDscnt)
+    opt1 = ScheduleInfo(1, numMfma, optSchedule, syncCode, nglshift, nllshift, nllZeroDscnt)
 
     return True, opt1
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -333,9 +333,6 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
                 if inst.vlcnt != -1:
                     macro.addComment0("vmcnt used in ngl, applying %u shift"%shift0)
                     instModified.vlcnt = max(0, instModified.vlcnt - shift0)
-                if (inst.dscnt != -1 and opt1.nglnllZeroDscnt):
-                    macro.addComment0("setting dscnt = 0 for NGL/NLL")
-                    instModified.dscnt = 0
                 macro.add(instModified)
                 macro.add(ValueElseIf("\\useGR == 0 && \\usePLR == 0")) # in NLL
                 instModified = deepcopy(inst)
@@ -343,7 +340,7 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
                     macro.addComment0("vmcnt used in nll, applying %u shift"%shift1)
                     instModified.vlcnt = max(0, instModified.vlcnt - shift1)
                 if (inst.dscnt != -1 and opt1.nglnllZeroDscnt):
-                    macro.addComment0("setting dscnt = 0 for NGL/NLL")
+                    macro.addComment0("setting dscnt = 0 for NLL")
                     instModified.dscnt = 0
                 macro.add(instModified)
                 macro.add(ValueEndif())

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -59,7 +59,7 @@ class TestValidateNglAndNll(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         return ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, nglshift, nllshift)
-    
+
     def test_simple_case_success(self):
         """
         Test the simple schedule using the exact amount of shift required to avoid race conditions.
@@ -68,7 +68,7 @@ class TestValidateNglAndNll(unittest.TestCase):
         schedule = self.make_simple_schedule(shift_value)
         status, message = verify_lrs_and_grs(schedule, {"kernel": self.kernel})
         assert status, f"Schedule should have passed validation but did not. {message}"
-    
+
     def test_simple_case_failure(self):
         """
         Test the simple schedule using a shift value that is too small to avoid race conditions.
@@ -78,7 +78,7 @@ class TestValidateNglAndNll(unittest.TestCase):
         status, message = verify_lrs_and_grs(schedule, {"kernel": self.kernel})
         assert not status, f"Schedule should have failed validation but passed. {message}"
         assert message == "Code path 0: GRB at index 2 is not valid. There are no guarantees on when it will be done."
-    
+
     def test_simple_case_success_too_high(self):
         """
         Test the simple schedule using a shift value larger than needed, ensure that we don't add in negative values.
@@ -87,7 +87,7 @@ class TestValidateNglAndNll(unittest.TestCase):
         schedule = self.make_simple_schedule(shift_value)
         status, message = verify_lrs_and_grs(schedule, {"kernel": self.kernel})
         assert status, f"Schedule should have passed validation but did not. {message}"
-    
+
     def test_lr0_swait_depends_on_lr1(self):
         """
         Simple failure case where the SWaitCnt for LRB0 depends on the LRA1.
@@ -108,10 +108,10 @@ class TestValidateNglAndNll(unittest.TestCase):
         status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
         assert not status, f"Schedule should have failed validation but passed. {message}"
         assert message == "Code path 0: Loop NLL: LRB0 at index 0 is not valid. Needed before index 6 (of next iteration), but only guaranteed at index 7."
-    
-    def test_lr0_swait_depends_on_lr1_realistic(self):
+
+    def test_lr0_swait_depends_on_lr1_realistic(self, useZeroDscnt = True):
         """
-        A more realistic version of `test_lr0_swait_depends_on_lr1`. GRs are now present.
+        A more realistic version of `test_lr0_swait_depends_on_lr1`. GRs are now present. Optionally checks zero dscnt option for NGL/NLL
         """
         self.kernel = create_base_kernel()
         self.kernel["MIWaveTileA"] = 4
@@ -138,21 +138,30 @@ class TestValidateNglAndNll(unittest.TestCase):
         ]
         optSchedule = {
             "SYNC": [syncTable[::2]],
-            
+
             "LRA0": [[0]],
             "GRA":  [[2, 2]],
 
             "LRB0": [[3, 3, 3, 3]],
 
             "LRA1": [[22]],
-            
+
             # Irrelevant, but need to schedule for correctness
             "GRB":  [[28, 28]],
             "LRB1": [[30, 30, 30, 30]],
         }
         # We need to set nglshift and nllshift for the vlcnt adjustments
         num_gr = 2  # 2 GRs total (1 GRA + 1 GRB, but we only count the actual reads not the increments)
-        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncTable[1::2], num_gr, num_gr)
+        sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncTable[1::2], num_gr, num_gr, useZeroDscnt)
         status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
-        assert not status, f"Schedule should have failed validation but passed. {message}"
-        assert message == "Code path 0: Loop NLL: LRB0 at index 3 is not valid. Needed before index 28 (of next iteration), but only guaranteed at index 31."
+        if useZeroDscnt:
+            assert status, f"Schedule should have passed validation but failed. {message}"
+        else:
+            assert not status, f"Schedule should have failed validation but passed. {message}"
+            assert message == "Code path 0: Loop NLL: LRB0 at index 3 is not valid. Needed before index 28 (of next iteration), but only guaranteed at index 31."
+
+    def test_lr0_swait_depends_on_lr1_realistic_zero_dscnt(self):
+        """
+        A more realistic version of `test_lr0_swait_depends_on_lr1`. GRs are now present also checks zero dscnt option for NGL/NLL
+        """
+        self.test_lr0_swait_depends_on_lr1_realistic(useZeroDscnt = True)

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -109,7 +109,7 @@ class TestValidateNglAndNll(unittest.TestCase):
         assert not status, f"Schedule should have failed validation but passed. {message}"
         assert message == "Code path 0: Loop NLL: LRB0 at index 0 is not valid. Needed before index 6 (of next iteration), but only guaranteed at index 7."
 
-    def test_lr0_swait_depends_on_lr1_realistic(self, useZeroDscnt = True):
+    def test_lr0_swait_depends_on_lr1_realistic(self, useZeroDscnt = False):
         """
         A more realistic version of `test_lr0_swait_depends_on_lr1`. GRs are now present. Optionally checks zero dscnt option for NGL/NLL
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -111,7 +111,7 @@ class TestValidateNglAndNll(unittest.TestCase):
 
     def test_lr0_swait_depends_on_lr1_realistic(self, useZeroDscnt = False):
         """
-        A more realistic version of `test_lr0_swait_depends_on_lr1`. GRs are now present. Optionally checks zero dscnt option for NGL/NLL
+        A more realistic version of `test_lr0_swait_depends_on_lr1`. GRs are now present. Optionally checks zero dscnt option for NLL
         """
         self.kernel = create_base_kernel()
         self.kernel["MIWaveTileA"] = 4
@@ -162,6 +162,6 @@ class TestValidateNglAndNll(unittest.TestCase):
 
     def test_lr0_swait_depends_on_lr1_realistic_zero_dscnt(self):
         """
-        A more realistic version of `test_lr0_swait_depends_on_lr1`. GRs are now present also checks zero dscnt option for NGL/NLL
+        A more realistic version of `test_lr0_swait_depends_on_lr1`. GRs are now present also checks zero dscnt option for NLL
         """
         self.test_lr0_swait_depends_on_lr1_realistic(useZeroDscnt = True)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Add option in CMS schedule to set all lgkmcnt to zero for NLL.

Setting the `nglnllZeroDscnt` to True will enable the option, default value is False.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

This is a quick workaround for some CMS schedules which have lgkmcnt which depends on local reads for the next iteration. In the current implementation, in those cases, the lgkmcnt for NLL may not be correct. 

A proper fix which modifies a subset of the lgkmcnts will be added later - some refactoring work required.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->
Local testing pass, inspected generated asm to confirm macro supports zeroing out lgkmcnts in NLL

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
