### PR TITLE
[rocPRIM][hipCUB][rocThrust][rocRAND] CP Versioning and changelog updates for 7.2 release

### DIFF
--- a/projects/hipcub/CHANGELOG.md
+++ b/projects/hipcub/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for hipCUB is available at [https://rocm.docs.amd.com/projects/hipCUB/en/latest/](https://rocm.docs.amd.com/projects/hipCUB/en/latest/).
 
+## hipCUB-4.2.0 for ROCm 7.2
+ 
+### Resolved issues
+ 
+* Fixed memory leak issues with some unit tests.
+
 ## hipCUB-4.1.0 for ROCm 7.1
 
 ### Added

--- a/projects/hipcub/CHANGELOG.md
+++ b/projects/hipcub/CHANGELOG.md
@@ -4,6 +4,9 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
 
 ## hipCUB-4.2.0 for ROCm 7.2.0
  
+### Added
+* Experimental SPIR-V support.
+
 ### Resolved issues
  
 * Fixed memory leak issues with some unit tests.

--- a/projects/hipcub/CHANGELOG.md
+++ b/projects/hipcub/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for hipCUB is available at [https://rocm.docs.amd.com/projects/hipCUB/en/latest/](https://rocm.docs.amd.com/projects/hipCUB/en/latest/).
 
-## hipCUB-4.2.0 for ROCm 7.2
+## hipCUB-4.2.0 for ROCm 7.2.0
  
 ### Resolved issues
  

--- a/projects/hipcub/CMakeLists.txt
+++ b/projects/hipcub/CMakeLists.txt
@@ -27,11 +27,11 @@ cmake_policy(VERSION 3.18...3.25)
 # Update these variables at release time
 #
 # Set the library version
-set(VERSION_STRING "4.1.0")
+set(VERSION_STRING "4.2.0")
 # Set the minimum required rocPRIM version
 set(MIN_ROCPRIM_PACKAGE_VERSION "4.1.0" CACHE STRING "Minimum version of rocPRIM to search for when ROCPRIM_FETCH_METHOD is set to PACKAGE.")
 # Set download branch for dependency rocPRIM
-set(ROCM_DEP_RELEASE_BRANCH "release/rocm-rel-7.1" CACHE STRING "Download branch for ROCm dependencies")
+set(ROCM_DEP_RELEASE_BRANCH "release/rocm-rel-7.2" CACHE STRING "Download branch for ROCm dependencies")
 # --------------------------------------
 
 # Install prefix

--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projects/rocPRIM/en/latest/](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/).
 
+## rocPRIM 4.2.0 for ROCm 7.2
+
+### Added
+
+* Added missing benchmarks, such that every autotuned specialization is now benchmarked.
+* Added a new cmake option, `BENCHMARK_USE_AMDSMI`. It is set to `OFF` by default. When this option is set to `ON`, it lets benchmarks use AMD SMI to output more GPU statistics.
+* Added the first tested example program for `device_search`, which is linked in the documentation.
+* Added `apply_config_improvements.py`, which generates improved configs by taking the best specializations from old and new configs.
+  * Run the script with `--help` for usage instructions, and see `projects/rocprim/docs/concepts/tuning.rst` for documentation.
+* Kernel Tuner proof-of-concept.
+* Enhanced SPIR-V support and performance.
+  
+### Optimizations
+
+* Improved performance of `device_radix_sort` onesweep variant 
+
+### Resolved issues
+
+* Fixed the issue where `rocprim::device_scan_by_key` failed when performing an "in-place" inclusive scan by reusing "keys" as output, by adding a buffer to store the last keys of each block (excluding the last block). This fix only affects the specific case of reusing "keys" as output in an inclusive scan, and does not affect other cases.
+* Fixed benchmark build error on Windows.
+* Fixed offload compress build option.
+* Fixed `float_bit_mask` for `rocprim::half`. 
+* Fixed handling of undefined behaviour when `__builtin_clz`, `__builtin_ctz`, and similar builtins are called.
+* Fixed potential build error with `rocprim::detail::histogram_impl`.
+
+### Known issues
+
+* Potential hang with `rocprim::partition_threeway` with large input data sizes on later ROCm builds. A workaround is currently in place.
+
 ## rocPRIM 4.1.0 for ROCm 7.1
 
 ### Added
@@ -12,11 +41,7 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Added a new cmake option, `BUILD_OFFLOAD_COMPRESS`. When rocPRIM is build with this option enabled, the `--offload-compress` switch is passed to the compiler. This causes the compiler to compress the binary that it generates. Compression can be useful in cases where you are compiling for a large number of targets, since this often results in a large binary. Without compression, in some cases, the generated binary may become so large symbols are placed out of range, resulting in linking errors. The new `BUILD_OFFLOAD_COMPRESS` option is set to `ON` by default.
 * Added a new CMake option `-DUSE_SYSTEM_LIB` to allow tests to be built from `ROCm` libraries provided by the system.
 * Added `rocprim::apply` which applies a function to a `rocprim::tuple`.
-* Added a new cmake option, `BENCHMARK_USE_AMDSMI`. It is set to `OFF` by default. When this option is set to `ON`, it lets benchmarks use AMD SMI to output more GPU statistics.
-* Added missing benchmarks, such that every autotuned specialization is now benchmarked.
-* Added `apply_config_improvements.py`, which generates improved configs by taking the best specializations from old and new configs.
-  * Run the script with `--help` for usage instructions, and see `projects/rocprim/docs/concepts/tuning.rst` for documentation.
-* Added the first tested example program for `device_search`, which is linked in the documentation.
+
 
 ### Changed
 
@@ -37,7 +62,6 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Fixed `device_select`, `device_merge`, and `device_merge_sort` not allocating the correct amount of virtual shared memory on the host.
 * Fixed the `->` operator for the `transform_iterator`, the `texture_cache_iterator` and the `arg_index_iterator`, by now returning a proxy pointer.
   * The `arg_index_iterator` also now only returns the internal iterator for the `->`.
-* Fixed the issue where `rocprim::device_scan_by_key` failed when performing an "in-place" inclusive scan by reusing "keys" as output, by adding a buffer to store the last keys of each block (excluding the last block). This fix only affects the specific case of reusing "keys" as output in an inclusive scan, and does not affect other cases.
 
 ## rocPRIM 4.0.1 for ROCm 7.0.2
 
@@ -687,5 +711,3 @@ when the input or inital type was smaller than the output type.
 
 * Switched to HIP-Clang as the default compiler
 * CMake searches for rocPRIM locally first; if t's not found, CMake downloads it from GitHub
-
-

--- a/projects/rocprim/CMakeLists.txt
+++ b/projects/rocprim/CMakeLists.txt
@@ -184,7 +184,7 @@ list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} ${ROCM_PATH}/hip ${ROCM_PATH}/llvm ${
 find_package(hip REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm)
 
 # Setup VERSION
-set(VERSION_STRING "4.1.0")
+set(VERSION_STRING "4.2.0")
 rocm_setup_version(VERSION ${VERSION_STRING})
 math(EXPR rocprim_VERSION_NUMBER "${rocprim_VERSION_MAJOR} * 100000 + ${rocprim_VERSION_MINOR} * 100 + ${rocprim_VERSION_PATCH}")
 

--- a/projects/rocrand/CHANGELOG.md
+++ b/projects/rocrand/CHANGELOG.md
@@ -12,6 +12,7 @@ Documentation for rocRAND is available at
 ### Added
 
 * Added a new CMake option `-DUSE_SYSTEM_LIB` to allow tests to be built from `ROCm` libraries provided by the system.
+* Experimental SPIR-V support.
 
 ### Changed
 

--- a/projects/rocrand/CMakeLists.txt
+++ b/projects/rocrand/CMakeLists.txt
@@ -179,7 +179,7 @@ if(BUILD_ADDRESS_SANITIZER AND BUILD_SHARED_LIBS)
 endif()
 
 # Set version variables
-rocm_setup_version( VERSION "4.1.0" )
+rocm_setup_version( VERSION "4.2.0" )
 set ( rocrand_VERSION ${rocRAND_VERSION} )
 # Old-style version number used within the library's API. rocrand_get_version should be modified.
 math(EXPR rocrand_VERSION_NUMBER "${rocRAND_VERSION_MAJOR} * 100000 + ${rocRAND_VERSION_MINOR} * 100 + ${rocRAND_VERSION_PATCH}")

--- a/projects/rocthrust/CHANGELOG.md
+++ b/projects/rocthrust/CHANGELOG.md
@@ -9,6 +9,7 @@ Documentation for rocThrust available at
 
 * Added `thrust::unique_ptr` - a smart pointer for managing device memory with automatic cleanup.
 * Added a new cmake option, `BUILD_OFFLOAD_COMPRESS`. When rocThrust is build with this option enabled, the `--offload-compress` switch is passed to the compiler. This causes the compiler to compress the binary that it generates. Compression can be useful in cases where you are compiling for a large number of targets, since this often results in a large binary. Without compression, in some cases, the generated binary may become so large symbols are placed out of range, resulting in linking errors. The new `BUILD_OFFLOAD_COMPRESS` option is set to `ON` by default.
+* Experimental SPIR-V support.
 
 ## rocThrust 4.1.0 for ROCm 7.1
 

--- a/projects/rocthrust/CMakeLists.txt
+++ b/projects/rocthrust/CMakeLists.txt
@@ -8,13 +8,13 @@ cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 # Update these variables at release time
 #
 # Set the library version
-set(VERSION_STRING "4.1.0")
+set(VERSION_STRING "4.2.0")
 # Set the minimum required rocPRIM version
 set(MIN_ROCPRIM_PACKAGE_VERSION "4.0.0" CACHE STRING "Minimum version of rocPRIM to search for when ROCPRIM_FETCH_METHOD is set to PACKAGE.")
 # Set the minimum required rocRAND version
 set(MIN_ROCRAND_PACKAGE_VERSION "4.0.0" CACHE STRING "Minimum version of rocRAND to search for when ROCRAND_FETCH_METHOD is set to PACKAGE.")
 # Set download branch for dependencies rocPRIM and rocRAND
-set(ROCM_DEP_RELEASE_BRANCH "release/rocm-rel-7.1" CACHE STRING "Download branch for ROCm dependencies")
+set(ROCM_DEP_RELEASE_BRANCH "release/rocm-rel-7.2" CACHE STRING "Download branch for ROCm dependencies")
 # --------------------------------------
 
 # Install prefix


### PR DESCRIPTION
## Motivation

Changelog entries, internal version numbers, and rocPRIM/rocRAND dependency release branches need to be updated for the 7.2 release.

## Technical Details

Updates the items mentioned above. Note that hipRAND has not noteworthy changes for 7.2.

## Test Plan

Run a build, make sure there are no cmake errors. View the changelogs to make sure there are no formatting errors.

## Test Result

No build issues.

## Submission Checklist
