### PR TITLE
[rocsparse] Add Memory-Based Test Filtering

### DIFF
--- a/projects/rocsparse/clients/include/rocsparse_arguments.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_arguments.hpp
@@ -166,7 +166,6 @@ struct Arguments
     char hardware[32];
     char skip_hardware[32];
 
-    uint32_t req_memory;
     uint32_t host_memory_gb;
     uint32_t device_memory_gb;
 
@@ -315,7 +314,6 @@ struct Arguments
         ROCSPARSE_FORMAT_CHECK(category);
         ROCSPARSE_FORMAT_CHECK(hardware);
         ROCSPARSE_FORMAT_CHECK(skip_hardware);
-        ROCSPARSE_FORMAT_CHECK(req_memory);
         ROCSPARSE_FORMAT_CHECK(host_memory_gb);
         ROCSPARSE_FORMAT_CHECK(device_memory_gb);
     }
@@ -536,7 +534,8 @@ private:
         print("category", arg.category);
         print("hardware", arg.hardware);
         print("skip_hardware", arg.skip_hardware);
-        print("req_memory", arg.req_memory);
+        print("host_memory_gb", arg.host_memory_gb);
+        print("device_memory_gb", arg.device_memory_gb);
         print("unit_check", arg.unit_check);
         print("timing", arg.timing);
         print("iters", arg.iters);

--- a/projects/rocsparse/clients/include/rocsparse_arguments.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_arguments.hpp
@@ -167,6 +167,8 @@ struct Arguments
     char skip_hardware[32];
 
     uint32_t req_memory;
+    uint32_t host_memory_gb;
+    uint32_t device_memory_gb;
 
     // Validate input format.
     // rocsparse_gentest.py is expected to conform to this format.
@@ -314,6 +316,8 @@ struct Arguments
         ROCSPARSE_FORMAT_CHECK(hardware);
         ROCSPARSE_FORMAT_CHECK(skip_hardware);
         ROCSPARSE_FORMAT_CHECK(req_memory);
+        ROCSPARSE_FORMAT_CHECK(host_memory_gb);
+        ROCSPARSE_FORMAT_CHECK(device_memory_gb);
     }
 
     template <typename T>

--- a/projects/rocsparse/clients/include/rocsparse_common.yaml
+++ b/projects/rocsparse/clients/include/rocsparse_common.yaml
@@ -609,6 +609,8 @@ Arguments:
   - hardware: c_char*32
   - skip_hardware: c_char*32
   - req_memory: c_uint
+  - host_memory_gb: c_uint
+  - device_memory_gb: c_uint
 
 # These named dictionary lists [ {dict1}, {dict2}, etc. ] supply subsets of
 # test arguments in a structured way. The dictionaries are applied to the test
@@ -760,5 +762,7 @@ Defaults:
   hardware: all
   skip_hardware: none
   req_memory: 4
+  host_memory_gb: 2
+  device_memory_gb: 2
   filename: '*'
   name: '*'

--- a/projects/rocsparse/clients/include/rocsparse_common.yaml
+++ b/projects/rocsparse/clients/include/rocsparse_common.yaml
@@ -608,7 +608,6 @@ Arguments:
   - category: c_char*32
   - hardware: c_char*32
   - skip_hardware: c_char*32
-  - req_memory: c_uint
   - host_memory_gb: c_uint
   - device_memory_gb: c_uint
 
@@ -761,8 +760,7 @@ Defaults:
   category: nightly
   hardware: all
   skip_hardware: none
-  req_memory: 4
-  host_memory_gb: 2
-  device_memory_gb: 2
+  host_memory_gb: 4
+  device_memory_gb: 4
   filename: '*'
   name: '*'

--- a/projects/rocsparse/clients/include/rocsparse_memory_check.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_memory_check.hpp
@@ -1,0 +1,213 @@
+/*! \file */
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+/*! \file
+ *  \brief rocsparse_memory_check.hpp provides utilities to detect available memory
+ *  on host and device to filter tests based on memory requirements.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <hip/hip_runtime.h>
+#include <iostream>
+#include <mutex>
+
+// For host memory detection on Linux
+#ifdef __linux__
+#include <sys/sysinfo.h>
+#include <unistd.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#endif
+
+namespace rocsparse_memory_check
+{
+    // Detect available host memory by querying system APIs
+    // Returns available memory in GB
+    inline size_t detect_host_memory_gb()
+    {
+        constexpr size_t GB = 1024ULL * 1024ULL * 1024ULL;
+
+#ifdef __linux__
+        // Use sysinfo to get available memory on Linux
+        struct sysinfo info;
+        if(sysinfo(&info) == 0)
+        {
+            // info.freeram gives free RAM, info.bufferram gives buffer cache
+            // For test filtering, use available memory (free + buffers + cached)
+            // This is a more conservative estimate
+            unsigned long available_bytes = info.freeram * info.mem_unit;
+            size_t        available_gb    = available_bytes / GB;
+
+            // Return at least 1GB even if system reports less
+            return (available_gb > 0) ? available_gb : 1;
+        }
+
+        // Fallback: try to read /proc/meminfo for MemAvailable
+        FILE* meminfo = fopen("/proc/meminfo", "r");
+        if(meminfo != nullptr)
+        {
+            char line[256];
+            while(fgets(line, sizeof(line), meminfo))
+            {
+                unsigned long mem_available_kb = 0;
+                if(sscanf(line, "MemAvailable: %lu kB", &mem_available_kb) == 1)
+                {
+                    fclose(meminfo);
+                    size_t available_gb = (mem_available_kb * 1024ULL) / GB;
+                    return (available_gb > 0) ? available_gb : 1;
+                }
+            }
+            fclose(meminfo);
+        }
+#elif defined(_WIN32)
+        // Use GlobalMemoryStatusEx on Windows
+        MEMORYSTATUSEX statex;
+        statex.dwLength = sizeof(statex);
+        if(GlobalMemoryStatusEx(&statex))
+        {
+            size_t available_gb = statex.ullAvailPhys / GB;
+            return (available_gb > 0) ? available_gb : 1;
+        }
+#endif
+
+        // Fallback: return 2GB as a safe default if we can't detect
+        return 2;
+    }
+
+    // Detect available device memory by querying HIP memory info
+    // Returns available memory in GB
+    inline size_t detect_device_memory_gb()
+    {
+        constexpr size_t GB = 1024ULL * 1024ULL * 1024ULL;
+
+        size_t free_mem  = 0;
+        size_t total_mem = 0;
+
+        // Query device memory using hipMemGetInfo
+        hipError_t err = hipMemGetInfo(&free_mem, &total_mem);
+        if(err == hipSuccess)
+        {
+            // Use free memory for conservative estimate
+            size_t available_gb = free_mem / GB;
+            return (available_gb > 0) ? available_gb : 1;
+        }
+
+        // If hipMemGetInfo fails, try to get device properties
+        int device_id = 0;
+        err           = hipGetDevice(&device_id);
+        if(err == hipSuccess)
+        {
+            hipDeviceProp_t prop;
+            err = hipGetDeviceProperties(&prop, device_id);
+            if(err == hipSuccess)
+            {
+                // Use total memory as fallback (less conservative)
+                size_t available_gb = prop.totalGlobalMem / GB;
+                return (available_gb > 0) ? available_gb : 1;
+            }
+        }
+
+        // Fallback: return 2GB as a safe default if we can't detect
+        return 2;
+    }
+
+    // Global variables to cache detected memory (initialized on first use)
+    // Use inline to avoid ODR violations across translation units
+    inline size_t     g_available_host_memory_gb   = 0;
+    inline size_t     g_available_device_memory_gb = 0;
+    inline bool       g_memory_detected            = false;
+    inline std::mutex g_memory_mutex;
+
+    // Initialize memory detection (thread-safe, called once)
+    inline void ensure_memory_detected()
+    {
+        if(!g_memory_detected)
+        {
+            // Creates a scoped lock guard that acquires the global memory mutex (g_memory_mutex)
+            // upon construction and automatically releases it when the lock goes out of scope.
+            // This ensures thread-safe access to shared memory resources by preventing
+            // concurrent access from multiple threads. The RAII pattern guarantees the mutex
+            // is unlocked even if an exception is thrown within the protected scope.
+            std::lock_guard<std::mutex> lock(g_memory_mutex);
+            // Double-check after acquiring lock
+            if(!g_memory_detected)
+            {
+                g_available_host_memory_gb   = detect_host_memory_gb();
+                g_available_device_memory_gb = detect_device_memory_gb();
+                g_memory_detected            = true;
+
+                // Only print if ROCSPARSE_VERBOSE_MEMORY is set
+                const char* verbose_env = std::getenv("ROCSPARSE_VERBOSE_MEMORY");
+                if(verbose_env != nullptr && verbose_env[0] != '0')
+                {
+                    std::cout << "========================================" << std::endl;
+                    std::cout << "Memory Detection Results:" << std::endl;
+                    std::cout << "  Available host memory:   " << g_available_host_memory_gb
+                              << " GB" << std::endl;
+                    std::cout << "  Available device memory: " << g_available_device_memory_gb
+                              << " GB" << std::endl;
+                    std::cout << "========================================" << std::endl;
+                }
+            }
+        }
+    }
+
+    // Get available host memory in GB (cached after first call)
+    inline size_t get_available_host_memory_gb()
+    {
+        ensure_memory_detected();
+        return g_available_host_memory_gb;
+    }
+
+    // Get available device memory in GB (cached after first call)
+    inline size_t get_available_device_memory_gb()
+    {
+        ensure_memory_detected();
+        return g_available_device_memory_gb;
+    }
+
+    // Check if a test should be run based on memory requirements
+    inline bool should_run_test(size_t required_host_gb, size_t required_device_gb)
+    {
+        size_t available_host   = get_available_host_memory_gb();
+        size_t available_device = get_available_device_memory_gb();
+
+        bool can_run
+            = (required_host_gb <= available_host) && (required_device_gb <= available_device);
+
+        if(!can_run)
+        {
+            std::cout << "SKIPPING TEST: Insufficient memory" << std::endl;
+            std::cout << "  Required host:   " << required_host_gb
+                      << " GB (available: " << available_host << " GB)" << std::endl;
+            std::cout << "  Required device: " << required_device_gb
+                      << " GB (available: " << available_device << " GB)" << std::endl;
+        }
+
+        return can_run;
+    }
+
+} // namespace rocsparse_memory_check

--- a/projects/rocsparse/clients/include/rocsparse_memory_check.hpp
+++ b/projects/rocsparse/clients/include/rocsparse_memory_check.hpp
@@ -189,25 +189,4 @@ namespace rocsparse_memory_check
         return g_available_device_memory_gb;
     }
 
-    // Check if a test should be run based on memory requirements
-    inline bool should_run_test(size_t required_host_gb, size_t required_device_gb)
-    {
-        size_t available_host   = get_available_host_memory_gb();
-        size_t available_device = get_available_device_memory_gb();
-
-        bool can_run
-            = (required_host_gb <= available_host) && (required_device_gb <= available_device);
-
-        if(!can_run)
-        {
-            std::cout << "SKIPPING TEST: Insufficient memory" << std::endl;
-            std::cout << "  Required host:   " << required_host_gb
-                      << " GB (available: " << available_host << " GB)" << std::endl;
-            std::cout << "  Required device: " << required_device_gb
-                      << " GB (available: " << available_device << " GB)" << std::endl;
-        }
-
-        return can_run;
-    }
-
 } // namespace rocsparse_memory_check

--- a/projects/rocsparse/clients/tests/rocsparse_test_template.hpp
+++ b/projects/rocsparse/clients/tests/rocsparse_test_template.hpp
@@ -23,6 +23,7 @@
 * ************************************************************************ */
 #pragma once
 
+#include "rocsparse_memory_check.hpp"
 #include "rocsparse_test_call.hpp"
 #include "rocsparse_test_check.hpp"
 #include "rocsparse_test_dispatch.hpp"
@@ -164,40 +165,22 @@ namespace
 
             static bool memory_filter(const Arguments& arg)
             {
-                static double available_memory_in_GB = 0.0;
-                static bool   query_device_memory    = true;
-                if(query_device_memory)
+                size_t available_host   = rocsparse_memory_check::get_available_host_memory_gb();
+                size_t available_device = rocsparse_memory_check::get_available_device_memory_gb();
+
+                bool can_run = (arg.host_memory_gb <= available_host)
+                               && (arg.device_memory_gb <= available_device);
+
+                if(!can_run)
                 {
-                    size_t available_memory;
-                    size_t total_memory;
-
-                    if(hipDeviceSynchronize() != hipSuccess)
-                    {
-                        return false;
-                    }
-
-                    if(hipMemGetInfo(&available_memory, &total_memory) != hipSuccess)
-                    {
-                        return false;
-                    }
-
-                    available_memory_in_GB = (double)available_memory / (1024 * 1024 * 1024);
-
-                    query_device_memory = false;
+                    std::cout << "SKIPPING TEST: Insufficient memory" << std::endl;
+                    std::cout << "  Required host:   " << arg.host_memory_gb
+                              << " GB (available: " << available_host << " GB)" << std::endl;
+                    std::cout << "  Required device: " << arg.device_memory_gb
+                              << " GB (available: " << available_device << " GB)" << std::endl;
                 }
 
-                if(available_memory_in_GB < arg.req_memory)
-                {
-                    std::cout << "Skipping test "
-                              << (std::string(arg.category) + "/" + std::string(arg.function) + "/"
-                                  + name_suffix(arg))
-                              << " because insufficient memory avaiable. Required: "
-                              << arg.req_memory << "GB. Available: " << available_memory_in_GB
-                              << "GB." << std::endl;
-                    return false;
-                }
-
-                return true;
+                return can_run;
             }
 
             static std::string name_suffix(const Arguments& arg)

--- a/projects/rocsparse/clients/tests/test.hpp
+++ b/projects/rocsparse/clients/tests/test.hpp
@@ -24,7 +24,6 @@
 #pragma once
 
 #include "rocsparse_data.hpp"
-#include "rocsparse_memory_check.hpp"
 #include "rocsparse_reproducibility.hpp"
 #include "rocsparse_reproducibility_test_label.hpp"
 #include "rocsparse_test.hpp"
@@ -294,14 +293,8 @@ using test_dispatch_t = rocsparse_test_dispatch<rocsparse_test_traits<ROUTINE>::
     /**/                                                                                       \
     /**/ TEST_P(ROUTINE, CATEGORY)                                                             \
     /**/ {                                                                                     \
-        /**/ const Arguments& param = GetParam();                                              \
-        /**/ if(!rocsparse_memory_check::should_run_test(param.host_memory_gb,                 \
-                                                         param.device_memory_gb))              \
-        /**/ {                                                                                 \
-            /**/ GTEST_SKIP() << "Skipping test due to insufficient memory";                   \
-        /**/ }                                                                                 \
         /**/ test_dispatch_t<rocsparse_test_enum::ROUTINE>::template dispatch<ROUTINE##_call>( \
-            param);                                                                            \
+            GetParam());                                                                       \
     /**/ }                                                                                     \
     /**/                                                                                       \
     /**/ INSTANTIATE_TEST_CATEGORIES(ROUTINE)

--- a/projects/rocsparse/clients/tests/test.hpp
+++ b/projects/rocsparse/clients/tests/test.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "rocsparse_data.hpp"
+#include "rocsparse_memory_check.hpp"
 #include "rocsparse_reproducibility.hpp"
 #include "rocsparse_reproducibility_test_label.hpp"
 #include "rocsparse_test.hpp"
@@ -293,8 +294,14 @@ using test_dispatch_t = rocsparse_test_dispatch<rocsparse_test_traits<ROUTINE>::
     /**/                                                                                       \
     /**/ TEST_P(ROUTINE, CATEGORY)                                                             \
     /**/ {                                                                                     \
+        /**/ const Arguments& param = GetParam();                                              \
+        /**/ if(!rocsparse_memory_check::should_run_test(param.host_memory_gb,                 \
+                                                         param.device_memory_gb))              \
+        /**/ {                                                                                 \
+            /**/ GTEST_SKIP() << "Skipping test due to insufficient memory";                   \
+        /**/ }                                                                                 \
         /**/ test_dispatch_t<rocsparse_test_enum::ROUTINE>::template dispatch<ROUTINE##_call>( \
-            GetParam());                                                                       \
+            param);                                                                            \
     /**/ }                                                                                     \
     /**/                                                                                       \
     /**/ INSTANTIATE_TEST_CATEGORIES(ROUTINE)

--- a/projects/rocsparse/clients/tests/test_ellmv.yaml
+++ b/projects/rocsparse/clients/tests/test_ellmv.yaml
@@ -58,6 +58,8 @@ Tests:
   category: nightly
   hardware: [gfx908, gfx90a]
   function: ellmv_extra
+  host_memory_gb: 32
+  device_memory_gb: 5
 
 - name: ellmv
   category: quick
@@ -98,6 +100,8 @@ Tests:
   precision: *double_only_precisions_complex
   M: [39385, 193482, 639102]
   N: [29348, 340123, 710341]
+  host_memory_gb: 32
+  device_memory_gb: 8
   alpha_beta: *alpha_beta_range_nightly
   transA: [rocsparse_operation_none, rocsparse_operation_conjugate_transpose]
   baseA: [rocsparse_index_base_zero, rocsparse_index_base_one]

--- a/projects/rocsparse/clients/tests/test_spmm_bsr.yaml
+++ b/projects/rocsparse/clients/tests/test_spmm_bsr.yaml
@@ -512,7 +512,7 @@ Tests:
   orderB: [rocsparse_order_column]
   orderC: [rocsparse_order_column]
   filename: [Chevron4]
-  req_memory: 18
+  device_memory_gb: 18
 
 - name: spmm_bsr_file
   category: nightly

--- a/projects/rocsparse/clients/tests/test_spmm_csr.yaml
+++ b/projects/rocsparse/clients/tests/test_spmm_csr.yaml
@@ -722,6 +722,8 @@ Tests:
   spmm_alg: [rocsparse_spmm_alg_csr_row_split]
   orderB: [rocsparse_order_row]
   orderC: [rocsparse_order_row]
+  host_memory_gb: 16
+  device_memory_gb: 16
 
 - name: spmm_csr_file
   category: stress
@@ -744,6 +746,8 @@ Tests:
   orderC: [rocsparse_order_row, rocsparse_order_column]
   filename: [sme3Dc,
              bmwcra_1]
+  host_memory_gb: 32
+  device_memory_gb: 16
 
 - name: spmm_csr_file
   category: stress
@@ -765,3 +769,5 @@ Tests:
   orderB: [rocsparse_order_row]
   orderC: [rocsparse_order_row, rocsparse_order_column]
   filename: [shipsec1]
+  host_memory_gb: 32
+  device_memory_gb: 16

--- a/projects/rocsparse/clients/tests/test_spmv_coo.yaml
+++ b/projects/rocsparse/clients/tests/test_spmv_coo.yaml
@@ -257,6 +257,8 @@ Tests:
   matrix: [rocsparse_matrix_pentadiagonal]
   storage: [rocsparse_storage_mode_sorted]
   spmv_alg: [rocsparse_spmv_alg_coo, rocsparse_spmv_alg_coo_atomic]
+  host_memory_gb: 45
+  device_memory_gb: 45
 
 #
 # mixed precision

--- a/projects/rocsparse/clients/tests/test_spsm_coo.yaml
+++ b/projects/rocsparse/clients/tests/test_spsm_coo.yaml
@@ -275,7 +275,7 @@ Tests:
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [Chevron3]
   skip_hardware: gfx1151
-  req_memory: 14
+  device_memory_gb: 14
 
 - name: spsm_coo_file
   category: pre_checkin

--- a/projects/rocsparse/clients/tests/test_spsm_csr.yaml
+++ b/projects/rocsparse/clients/tests/test_spsm_csr.yaml
@@ -416,7 +416,6 @@ Tests:
 - name: spsm_csr_file
   category: stress
   function: spsm_csr
-  hardware: [gfx90a]
   indextype: *i32
   precision: *double_only_precisions
   M: 1
@@ -438,6 +437,8 @@ Tests:
              sme3Dc,
              shipsec1,
              bmwcra_1]
+  host_memory_gb: 64
+  device_memory_gb: 32
 
 - name: spsm_csr
   category: quick

--- a/projects/rocsparse/clients/tests/test_spsm_csr.yaml
+++ b/projects/rocsparse/clients/tests/test_spsm_csr.yaml
@@ -207,7 +207,7 @@ Tests:
   matrix: [rocsparse_matrix_file_rocalution]
   filename: [Chevron3]
   skip_hardware: gfx1151
-  req_memory: 14
+  device_memory_gb: 14
 
 - name: spsm_csr_file
   category: pre_checkin

--- a/projects/rocsparse/clients/tests/test_sptrsm_coo.yaml
+++ b/projects/rocsparse/clients/tests/test_sptrsm_coo.yaml
@@ -397,6 +397,8 @@ Tests:
              sme3Dc,
              shipsec1,
              bmwcra_1]
+  host_memory_gb: 32
+  device_memory_gb: 32
 
 - name: sptrsm_coo
   category: quick

--- a/projects/rocsparse/clients/tests/test_sptrsm_csr.yaml
+++ b/projects/rocsparse/clients/tests/test_sptrsm_csr.yaml
@@ -397,6 +397,8 @@ Tests:
              sme3Dc,
              shipsec1,
              bmwcra_1]
+  host_memory_gb: 32
+  device_memory_gb: 32
 
 - name: sptrsm_csr
   category: quick

--- a/projects/rocsparse/clients/tests/test_v2_spmv_coo.yaml
+++ b/projects/rocsparse/clients/tests/test_v2_spmv_coo.yaml
@@ -255,6 +255,8 @@ Tests:
   matrix: [rocsparse_matrix_pentadiagonal]
   storage: [rocsparse_storage_mode_sorted]
   spmv_alg: [rocsparse_spmv_alg_coo, rocsparse_spmv_alg_coo_atomic]
+  host_memory_gb: 45
+  device_memory_gb: 45
 
 #
 # mixed precision


### PR DESCRIPTION
### Summary
This PR introduces memory-based test filtering to prevent out-of-memory (OOM) or failing allocations failures during test execution. Tests can now specify memory requirements, and the framework automatically skips tests that exceed available host or device memory.

### Changes

#### Core Implementation
- **New header**: `rocsparse_memory_check.hpp`
  - Cross-platform memory detection (Linux via sysinfo/procfs, Windows via GlobalMemoryStatusEx)
  - HIP device memory detection via hipMemGetInfo
  - Thread-safe caching mechanism with double-checked locking
  - Configurable verbosity via `ROCSPARSE_VERBOSE_MEMORY` environment variable

#### Test Framework Integration
- **`rocsparse_arguments.hpp`**: Added `host_memory_gb` and `device_memory_gb` parameters
- **`rocsparse_common.yaml`**: Set default memory requirements (2GB host, 2GB device)
- **`test.hpp`**: Integrated `should_run_test()` check with GTEST_SKIP

#### Test Configuration Updates
Updated memory requirements for resource-intensive tests:
- `test_ellmv.yaml`: 32GB host, 5-8GB device for large matrices
- `test_spmm_csr.yaml`: 16-32GB host/device for stress tests
- `test_spmv_coo.yaml`: 45GB host/device for large pentadiagonal matrices
- `test_spsm_csr.yaml`: 64GB host, 32GB device for file-based stress tests
- `test_sptrsm_coo.yaml`: 32GB host/device for file-based tests
- `test_sptrsm_csr.yaml`: 32GB host/device for file-based tests
- `test_v2_spmv_coo.yaml`: 45GB host/device for large matrices

### Implementation Details

#### Memory Detection
```cpp
// Automatic detection on first use
size_t host_mem = rocsparse_memory_check::get_available_host_memory_gb();
size_t device_mem = rocsparse_memory_check::get_available_device_memory_gb();

// Test filtering
bool can_run = rocsparse_memory_check::should_run_test(required_host_gb, required_device_gb);
```

#### Thread Safety
- Uses `std::mutex` with double-checked locking pattern
- Safe for parallel test execution
- One-time initialization with cached results

#### Configurable Output
```bash
# Normal operation (no memory detection output)
./rocsparse-test

# Verbose mode (shows detected memory)
export ROCSPARSE_VERBOSE_MEMORY=1
./rocsparse-test
```
