### PR TITLE
add pk_add_fp32

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -432,12 +432,15 @@ class LocalReadMFMA(LocalRead):
                                         packCodeT.add(PVCvtBF16toFP32(dst=vgpr(tmp), src=vHi1))
 
                                     # We use cvt+sub pair since dot2 requires adding 4 wait states.
-                                    packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp+1), src=vHi1, vgprMask=None, vi=1))
-                                    packCodeT.add(VAddPKF32(dst=v23t_pk, src0=v23t_pk, \
-                                            src1=vgpr(tmp, 2), vop3=VOP3PModifiers(neg_lo=[0,1],neg_hi=[0,1]), comment="for v2t, v3t"))
                                     if kernel["UseDot2F32XEmulation"]:
+                                        packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp), src=vHi1, vgprMask=None, vi=1))
+                                        packCodeT.add(VSubF32(dst=v3t, src0=v3t, src1=vgpr(tmp), comment="end"))
                                         packCodeT.add(VMovB32(dst=vgpr(tmp), src=0))
                                         packCodeT.add(VMovB32(dst=vgpr(tmp), src=0))
+                                    else:
+                                        packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp+1), src=vHi1, vgprMask=None, vi=1))
+                                        packCodeT.add(VAddPKF32(dst=v23t_pk, src0=v23t_pk, \
+                                                src1=vgpr(tmp, 2), vop3=VOP3PModifiers(neg_lo=[0,1],neg_hi=[0,1]), comment="for v2t, v3t"))
 
                                     for val in tmpvgpr:
                                         writer.vgprPool.checkIn(val)

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -27,7 +27,7 @@ from rocisa.container import DSModifiers, vgpr, sgpr, SDWAModifiers, VOP3PModifi
 from rocisa.enum import SelectBit
 from rocisa.instruction import SMovB32, SWaitCnt, VOrB32, VPermB32, VLShiftLeftOrB32, \
                             VMovB32, VMovB64,VLShiftRightB32, VCvtPkFP8toF32, VCvtF32toF16, VCvtFP8toF32,VCvtScaleFP8toF16,VCvtScalePkFP8toF16, \
-                            VCvtPkF32toBF16, VCvtBF16toFP32, PVCvtBF16toFP32, VDot2CF32BF16, SNop, VSubF32, VSwapB32
+                            VCvtPkF32toBF16, VCvtBF16toFP32, PVCvtBF16toFP32, VDot2CF32BF16, SNop, VSubF32, VSwapB32, VAddPKF32
 
 from ..Component import LocalRead
 
@@ -373,7 +373,7 @@ class LocalReadMFMA(LocalRead):
                                     self.pack4HiBits(kernel, tc, 4, bufferIdx, baseValuiIdx, iui, writer, packCodeT, tmpvgprFP32)
                                 if valuiIdx % 4 == 0:
                                     tmpvgpr = []
-                                    tmp = writer.vgprPool.checkOut(1)
+                                    tmp = writer.vgprPool.checkOut(2)  # Need 2 VGPRs for PVCvtBF16toFP32
                                     tmpvgpr.append(tmp)
                                     # tmp vgprs need to be unique across A/B, so we store in writer state
                                     if not baseValuiIdx in writer.states.tmpvgpr:
@@ -393,17 +393,26 @@ class LocalReadMFMA(LocalRead):
                                             v1t = vgpr("Valu%s_T%u_I%u+%u+1"%(tc, bufferIdx, iui, valuiIdx // 2))
                                             v2t = vgpr("Valu%s_T%u_I%u+%u+2"%(tc, bufferIdx, iui, valuiIdx // 2))
                                             v3t = vgpr("Valu%s_T%u_I%u+%u+3"%(tc, bufferIdx, iui, valuiIdx // 2))
+                                            # For packed ops (regNum=2)
+                                            v01t_pk = vgpr("Valu%s_T%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx // 2), 2)
+                                            v23t_pk = vgpr("Valu%s_T%u_I%u+%u+2"%(tc, bufferIdx, iui, valuiIdx // 2), 2)
                                         else:
                                             tmpIdx = len(tmpvgprFP32) - 2
                                             v0t = vgpr(tmpvgprFP32[tmpIdx + 0])
                                             v1t = vgpr(tmpvgprFP32[tmpIdx] + 1)
                                             v2t = vgpr(tmpvgprFP32[tmpIdx + 1])
                                             v3t = vgpr(tmpvgprFP32[tmpIdx + 1] + 1)
+                                            # For packed ops (regNum=2)
+                                            v01t_pk = vgpr(tmpvgprFP32[tmpIdx + 0], 2)
+                                            v23t_pk = vgpr(tmpvgprFP32[tmpIdx + 1], 2)
                                     else:
                                         v0t = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx))
                                         v1t = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, valuiIdx))
                                         v2t = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, valuiIdx))
                                         v3t = vgpr("Valu%s_X%u_I%u+%u+3"%(tc, bufferIdx, iui, valuiIdx))
+                                        # For packed ops (regNum=2)
+                                        v01t_pk = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, valuiIdx), 2)
+                                        v23t_pk = vgpr("Valu%s_X%u_I%u+%u+2"%(tc, bufferIdx, iui, valuiIdx), 2)
                                     vHi0 = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, (valuiIdx-baseValuiIdx)/2 + baseValuiIdx))
                                     vHi1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, (valuiIdx-baseValuiIdx)/2 + baseValuiIdx))
 
@@ -412,21 +421,20 @@ class LocalReadMFMA(LocalRead):
                                         packCodeT.add(VDot2CF32BF16(dst=v0t, src0=hex(0x8000bf80), src1=vHi0))
                                         packCodeT.add(VDot2CF32BF16(dst=v1t, src0=hex(0xbf800000), src1=vHi0))
                                     else:
-                                        packCodeT.add(PVCvtBF16toFP32(dst=vgpr(tmp), src=vHi0, comment="begin"+str(valuiIdx)))
-                                        packCodeT.add(VSubF32(dst=v0t, src0=v0t, src1=vgpr(tmp)))
-                                        packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp), src=vHi0, vgprMask=None, vi=1))
-                                        packCodeT.add(VSubF32(dst=v1t, src0=v1t, src1=vgpr(tmp)))
+                                        packCodeT.add(PVCvtBF16toFP32(dst=vgpr(tmp), src=vHi0, comment="begin "+str(valuiIdx)))
+                                        packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp+1), src=vHi0, vgprMask=None, vi=1))
+                                        packCodeT.add(VAddPKF32(dst=v01t_pk, src0=v01t_pk, \
+                                            src1=vgpr(tmp, 2), vop3=VOP3PModifiers(neg_lo=[0,1],neg_hi=[0,1]), comment="for v0t, v1t"))
 
                                     if kernel["UseDot2F32XEmulation"]:
                                         packCodeT.add(VDot2CF32BF16(dst=v2t, src0=hex(0x8000bf80), src1=vHi1))
                                     else:
                                         packCodeT.add(PVCvtBF16toFP32(dst=vgpr(tmp), src=vHi1))
-                                        packCodeT.add(VSubF32(dst=v2t, src0=v2t, src1=vgpr(tmp)))
 
                                     # We use cvt+sub pair since dot2 requires adding 4 wait states.
-                                    packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp), src=vHi1, vgprMask=None, vi=1))
-                                    packCodeT.add(VSubF32(dst=v3t, src0=v3t, src1=vgpr(tmp), comment="end"))
-
+                                    packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp+1), src=vHi1, vgprMask=None, vi=1))
+                                    packCodeT.add(VAddPKF32(dst=v23t_pk, src0=v23t_pk, \
+                                            src1=vgpr(tmp, 2), vop3=VOP3PModifiers(neg_lo=[0,1],neg_hi=[0,1]), comment="for v2t, v3t"))
                                     if kernel["UseDot2F32XEmulation"]:
                                         packCodeT.add(VMovB32(dst=vgpr(tmp), src=0))
                                         packCodeT.add(VMovB32(dst=vgpr(tmp), src=0))

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/container.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/container.hpp
@@ -451,11 +451,15 @@ namespace rocisa
     {
         VOP3PModifiers(const std::vector<int>& op_sel    = {},
                        const std::vector<int>& op_sel_hi = {},
-                       const std::vector<int>& byte_sel  = {})
+                       const std::vector<int>& byte_sel  = {},
+                       const std::vector<int>& neg_lo    = {},
+                       const std::vector<int>& neg_hi    = {})
             : Container()
             , op_sel(op_sel)
             , op_sel_hi(op_sel_hi)
             , byte_sel(byte_sel)
+            , neg_lo(neg_lo)
+            , neg_hi(neg_hi)
         {
         }
 
@@ -464,6 +468,8 @@ namespace rocisa
             , op_sel(other.op_sel)
             , op_sel_hi(other.op_sel_hi)
             , byte_sel(other.byte_sel)
+            , neg_lo(other.neg_lo)
+            , neg_hi(other.neg_hi)
         {
         }
 
@@ -487,12 +493,22 @@ namespace rocisa
             {
                 kStr += " byte_sel:" + vectorToString(byte_sel);
             }
+            if(!neg_lo.empty())
+            {
+                kStr += " neg_lo:" + vectorToString(neg_lo);
+            }
+            if(!neg_hi.empty())
+            {
+                kStr += " neg_hi:" + vectorToString(neg_hi);
+            }
             return kStr;
         }
 
         std::vector<int> op_sel;
         std::vector<int> op_sel_hi;
         std::vector<int> byte_sel;
+        std::vector<int> neg_lo;
+        std::vector<int> neg_hi;
 
         std::string vectorToString(const std::vector<int>& vec) const
         {

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/common.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/instruction/common.hpp
@@ -2441,8 +2441,10 @@ namespace rocisa
         VAddPKF32(const std::shared_ptr<Container>& dst,
                   const InstructionInput&           src0,
                   const InstructionInput&           src1,
+                  std::optional<VOP3PModifiers>     vop3    = std::nullopt,
                   const std::string&                comment = "")
             : CompositeInstruction(InstType::INST_F32, dst, {src0, src1}, comment)
+            , vop3(vop3)
         {
             setInst("v_pk_add_f32");
         }
@@ -2452,7 +2454,7 @@ namespace rocisa
             std::vector<std::shared_ptr<Instruction>> instructions;
             if(getAsmCaps()["v_pk_add_f32"])
             {
-                instructions = {std::make_shared<_VAddPKF32>(dst, srcs, std::nullopt, comment)};
+                instructions = {std::make_shared<_VAddPKF32>(dst, srcs, vop3, comment)};
             }
             else
             {
@@ -2470,6 +2472,7 @@ namespace rocisa
 
         VAddPKF32(const VAddPKF32& other)
             : CompositeInstruction(other)
+            , vop3(other.vop3)
         {
         }
 
@@ -2477,6 +2480,8 @@ namespace rocisa
         {
             return std::make_shared<VAddPKF32>(*this);
         }
+
+        std::optional<VOP3PModifiers> vop3;
     };
 
     struct VAdd3U32 : public CommonInstruction

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/container.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/container.cpp
@@ -434,13 +434,18 @@ void init_containers(nb::module_ m)
         .def("__str__", &rocisa::DPPModifiers::toString);
 
     nb::class_<rocisa::VOP3PModifiers, rocisa::Container>(m_con, "VOP3PModifiers")
-        .def(nb::init<const std::vector<int>&, const std::vector<int>&, const std::vector<int>&>(),
+        .def(nb::init<const std::vector<int>&, const std::vector<int>&, const std::vector<int>&,
+                      const std::vector<int>&, const std::vector<int>&>(),
              nb::arg("op_sel")    = std::vector<int>{},
              nb::arg("op_sel_hi") = std::vector<int>{},
-             nb::arg("byte_sel")  = std::vector<int>{})
+             nb::arg("byte_sel")  = std::vector<int>{},
+             nb::arg("neg_lo")    = std::vector<int>{},
+             nb::arg("neg_hi")    = std::vector<int>{})
         .def_rw("op_sel", &rocisa::VOP3PModifiers::op_sel)
         .def_rw("op_sel_hi", &rocisa::VOP3PModifiers::op_sel_hi)
         .def_rw("byte_sel", &rocisa::VOP3PModifiers::byte_sel)
+        .def_rw("neg_lo", &rocisa::VOP3PModifiers::neg_lo)
+        .def_rw("neg_hi", &rocisa::VOP3PModifiers::neg_hi)
         .def("__str__", &rocisa::VOP3PModifiers::toString)
         .def("__deepcopy__",
              [](const rocisa::VOP3PModifiers& self, nb::dict&) {
@@ -448,12 +453,12 @@ void init_containers(nb::module_ m)
              })
         .def("__getstate__",
              [](const rocisa::VOP3PModifiers& self) {
-                 return std::make_tuple(self.op_sel, self.op_sel_hi, self.byte_sel);
+                 return std::make_tuple(self.op_sel, self.op_sel_hi, self.byte_sel, self.neg_lo, self.neg_hi);
              })
         .def("__setstate__",
              [](rocisa::VOP3PModifiers&                                          self,
-                std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> t) {
-                 new(&self) rocisa::VOP3PModifiers(std::get<0>(t), std::get<1>(t), std::get<2>(t));
+                std::tuple<std::vector<int>, std::vector<int>, std::vector<int>, std::vector<int>, std::vector<int>> t) {
+                 new(&self) rocisa::VOP3PModifiers(std::get<0>(t), std::get<1>(t), std::get<2>(t), std::get<3>(t), std::get<4>(t));
              });
 
     nb::class_<rocisa::EXEC, rocisa::Container>(m_con, "EXEC")

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/instruction/common.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/instruction/common.cpp
@@ -910,10 +910,12 @@ void common_inst(nb::module_ m_common)
         .def(nb::init<const std::shared_ptr<rocisa::Container>&,
                       const InstructionInput&,
                       const InstructionInput&,
+                      std::optional<rocisa::VOP3PModifiers>,
                       const std::string&>(),
              nb::arg("dst"),
              nb::arg("src0"),
              nb::arg("src1"),
+             nb::arg("vop3") = std::nullopt,
              nb::arg("comment") = "")
         .def("__deepcopy__",
              [](const rocisa::VAddPKF32& self, nb::dict&) { return new rocisa::VAddPKF32(self); });


### PR DESCRIPTION
## Motivation

use v_pk_add_f32 to replace two v_sub_f32 ?

## Technical Details

**original**
v_cvt_f32_bf16 v186, v[vgprValuA_X0_I0+0]          // begin0
**v_sub_f32** v[vgprValuA_T0_I0+0], v[vgprValuA_T0_I0+0], v186
v_cvt_f32_bf16 v186, v[vgprValuA_X0_I0+0] src0_sel:WORD_1 // cvt bf16 to f32
**v_sub_f32** v[vgprValuA_T0_I0+0+1], v[vgprValuA_T0_I0+0+1], v186
 
**with v_pk_add_f32, save 4 instructions for each 24 instructions blocks with extra one vgpr (v187).**
v_cvt_f32_bf16 v186, v[vgprValuA_X0_I0+0]
v_cvt_f32_bf16 v187, v[vgprValuA_X0_I0+0] src0_sel:WORD_1
**v_pk_add_f32** v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+1],  v[vgprValuA_X0_I0+0:vgprValuA_X0_I0+0+1],  v[186:187] neg_lo:[0, 1] neg_hi:[0, 1]


## Test Plan

local test for 2048x4096x8192TN w/ hipblashlt-bench

## Test Result

test pass and got 2% uplift with this PR.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
