### PR TITLE
[Hipblaslt] [CMS] Remove validation-related functionality from ScheduleInfo

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1033,3 +1033,48 @@ def verify_ascending_order(scheduleInfo, context: dict = {}):
                     )
     return True, ""
 
+
+def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
+    """
+    Return True if all the validation rules pass, False otherwise.
+    If validation fails, a string containing the reason is returned.
+
+    Note 1: If True is returned, this is not proof that this schedule
+    is valid. It may be a false negative.
+
+    Note 2: if False is returned, this is not proof that the schedule
+    is invalid. It may be a false positive.
+    """
+
+    if scheduleInfo.__skipValidation__:
+        mt0 = context.get("kernel", {}).get("MacroTile0", "?")
+        mt1 = context.get("kernel", {}).get("MacroTile1", "?")
+        du = context.get("kernel", {}).get("DepthU", "?")
+        transA = context.get("kernel", {}).get("TransA")
+        transB = context.get("kernel", {}).get("TransB")
+        transA = "T" if transA else "N"
+        transB = "T" if transB else "N"
+        message = f"CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = {mt0}x{mt1}x{du} {transA}{transB}"
+        print(f"WARNING: {message}")
+
+        # All rules bypassed, considered valid.
+        return True, message
+
+    # The set of validation rules to run
+    rules = [
+        verify_correct_number_of_instructions,
+        verify_ascending_order,
+        verify_global_reads_not_too_early,
+        verify_lrs_and_grs,
+        verify_scc_overlap,
+        verify_gr_inc_order
+    ]
+
+    for rule in rules:
+        status, message = rule(scheduleInfo, context)
+        if status is False:
+            return False, message
+
+    # All rules passed, considered valid.
+    return True, ""
+

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -138,52 +138,8 @@ class ScheduleInfo:
         self.mfmaReorder = mfmaReorder
         self.__skipValidation__ = False
 
-        # The set of validation rules to run inside `isValid`.
-        self.rules: list[Callable[[ScheduleInfo, dict], [bool, str]]] = [
-            cmsv.verify_correct_number_of_instructions,
-            cmsv.verify_ascending_order,
-            cmsv.verify_global_reads_not_too_early,
-            cmsv.verify_lrs_and_grs,
-            cmsv.verify_scc_overlap,
-            cmsv.verify_gr_inc_order
-        ]
-
     def disableValidation(self):
         self.__skipValidation__ = True
-
-    def isValid(self, context: dict):
-        """
-        Return True if all the validation rules pass, False otherwise.
-        If validation fails, a string containing the reason is returned.
-
-        Note 1: If True is returned, this is not proof that this schedule
-        is valid. It may be a false negative.
-
-        Note 2: if False is returned, this is not proof that the schedule
-        is invalid. It may be a false positive.
-        """
-
-        if self.__skipValidation__:
-            mt0 = context.get("kernel", {}).get("MacroTile0", "?")
-            mt1 = context.get("kernel", {}).get("MacroTile1", "?")
-            du = context.get("kernel", {}).get("DepthU", "?")
-            transA = context.get("kernel", {}).get("TransA")
-            transB = context.get("kernel", {}).get("TransB")
-            transA = "T" if transA else "N"
-            transB = "T" if transB else "N"
-            message = f"CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = {mt0}x{mt1}x{du} {transA}{transB}"
-            print(f"WARNING: {message}")
-
-            # All rules bypassed, considered valid.
-            return True, message
-
-        for rule in self.rules:
-            status, message = rule(self, context)
-            if status is False:
-                return False, message
-
-        # All rules passed, considered valid.
-        return True, ""
 
 
 def removeComments(module):
@@ -282,7 +238,7 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
 
     idMap['SYNC'] = opt1.syncCode
 
-    status, message = opt1.isValid({'kernel' : kernel, "idMap": idMap})
+    status, message = cmsv.isValid(opt1, {'kernel' : kernel, "idMap": idMap})
     # create the case str (TN, NT, TT, or NN)
     if isTN(kernel):
         case_str = "TN"

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -24,6 +24,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from Tensile.Components.CustomSchedule import hasCustomSchedule, ScheduleInfo
+from Tensile.Components.CMSValidator import isValid
 from Tensile.Common import IsaVersion
 
 # Helper to create a mock data type
@@ -105,7 +106,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 128
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
         if TN:
             assert 'PackA0' not in schedule_info.optSchedule
@@ -147,7 +148,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 1
         assert schedule_info.numMfma == 64
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     def test_schedule_256x96x64_16bit_TN(self):
@@ -171,7 +172,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 48
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize("transA, transB", [(False, False), (False, True), (True, False)])
@@ -200,7 +201,7 @@ class TestCustomSchedule:
         assert schedule_info.numMfma == 96
         if NN:
             assert kernel["SwapGlobalReadOrder"]
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize(
@@ -233,7 +234,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 96
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize("transA, transB", [(True, False), (False, False), (False, True)])
@@ -258,7 +259,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 80
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize("transA, transB", [(False, False), (False, True)])
@@ -284,7 +285,7 @@ class TestCustomSchedule:
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 80
         assert kernel["SwapGlobalReadOrder"]
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize("transA, transB", [(True, False), (False, True), (False, False)])
@@ -309,7 +310,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 1
         assert schedule_info.numMfma == 120
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize("transA, transB", [(True, False), (False, False)])
@@ -334,7 +335,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 1
         assert schedule_info.numMfma == 104
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     def test_schedule_224x256x64_16bit_TN(self):
@@ -358,7 +359,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 112
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize(
@@ -390,7 +391,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 1
         assert schedule_info.numMfma == 120
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     def test_schedule_256x224x64_16bit_TN(self):
@@ -414,7 +415,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 112
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize("transA, transB", [(False, False), (False, True)])
@@ -443,7 +444,7 @@ class TestCustomSchedule:
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 120
         assert kernel["SwapGlobalReadOrder"]
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize(
@@ -479,7 +480,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == (1 if NT else 2)
         assert schedule_info.numMfma == 120
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize(
@@ -511,7 +512,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 1
         assert schedule_info.numMfma == 104
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
     @pytest.mark.parametrize(
@@ -541,7 +542,7 @@ class TestCustomSchedule:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 56
-        valid, message = schedule_info.isValid({"kernel" : kernel})
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
 
@@ -559,12 +560,12 @@ class TestCustomScheduleValidation:
             None, None, invalid_schedule, None, None, None, None
         )
         scheduleInfo.disableValidation()
-        status, message = scheduleInfo.isValid({"kernel" : {"DepthU": 42}})
+        status, message = isValid(scheduleInfo, {"kernel" : {"DepthU": 42}})
         assert status == True
         assert message == "CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = ?x?x42 NN"
 
         # A non-empty verification message means that the schedule info is considered invalid.
-        status, message = ScheduleInfo(
-            None, None, invalid_schedule, None, None, None, None
-        ).isValid({})
+        status, message = isValid(
+            ScheduleInfo(None, None, invalid_schedule, None, None, None, None), {}
+        )
         assert status == False


### PR DESCRIPTION
## Motivation

Further separate out Validator functionality out of CMS implementation files.

## Technical Details

Moved as standalone functions in CMSValidation.

Leaving only `disableValidation()` to continue allowing individual schedules to opt out of validation.

## Test Plan

Run existing tests.

## Test Result

Passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
