### PR TITLE
[miopen] send math-ci status checks for status gating

### DIFF
--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -954,12 +954,12 @@ pipeline {
     post {
         success {
             githubNotify context: 'Math CI Summary',
-                         status: 'success',
+                         status: 'SUCCESS',
                          description: 'All checks have passed'
         }
         failure {
             githubNotify context: 'Math CI Summary',
-                         status: 'failure',
+                         status: 'FAILURE',
                          description: 'Some checks have failed'
         }
     }

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -950,4 +950,17 @@ pipeline {
             }
         }
     }
+
+    post {
+        success {
+            githubNotify context: 'Math CI Summary',
+                         status: 'success',
+                         description: 'All checks have passed'
+        }
+        failure {
+            githubNotify context: 'Math CI Summary',
+                         status: 'failure',
+                         description: 'Some checks have failed'
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

We want to produce Math CI Summary checks when MIOpen passes or fails the pipeline

## Technical Details

This PR introduces an explicit step at the end of the pipeline where we produce a "Math CI Summary" of success of failure, for the status gate.

## Test Plan

This PR should produce a Math CI Summary other than "Skipped"