### PR TITLE
[hipblaslt] [CMS] Refactor validators to operate on one code path at a time

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -215,9 +215,9 @@ def verify_global_reads_not_too_early_single_code_path(
     return True, ""
 
 
-def verify_global_reads_not_too_early(scheduleInfo, context: dict):
+def verify_global_reads_not_too_early(scheduleInfo, context: dict, code_path: int) -> tuple[bool, str]:
     """
-    We require the sequence of instructions to be of the form:
+    We require the sequence of instructions to be of the form for a single code path:
 
     last LRA0 instruction
     [...]
@@ -264,49 +264,42 @@ def verify_global_reads_not_too_early(scheduleInfo, context: dict):
             return l[0]
         return l[codePath]
 
-    nCodePaths = scheduleInfo.numCodePaths
-    if not nCodePaths:
-        nCodePaths = 1
-    for codePath in range(nCodePaths):
-        globalReadA = get("GRA", codePath)
-        globalReadB = get("GRB", codePath)
-        if context.get("kernel", {}).get("SwapGlobalReadOrder", False):
-            globalReadA, globalReadB = globalReadB, globalReadA
+    globalReadA = get("GRA", code_path)
+    globalReadB = get("GRB", code_path)
+    if context.get("kernel", {}).get("SwapGlobalReadOrder", False):
+        globalReadA, globalReadB = globalReadB, globalReadA
 
-        kernel = context.get("kernel", {})
-        aDirect = kernel.get("DirectToLdsA", False) or kernel.get("DirectToLds", False)
-        bDirect = kernel.get("DirectToLdsB", False) or kernel.get("DirectToLds", False)
+    kernel = context.get("kernel", {})
+    aDirect = kernel.get("DirectToLdsA", False) or kernel.get("DirectToLds", False)
+    bDirect = kernel.get("DirectToLdsB", False) or kernel.get("DirectToLds", False)
 
-        # The actual buffer loads correspond to the indices of the lists
-        # if using DirectToLDS.
-        if aDirect:
-            globalReadA = globalReadA[1::2]
+    # The actual buffer loads correspond to the indices of the lists
+    # if using DirectToLDS.
+    if aDirect:
+        globalReadA = globalReadA[1::2]
 
-        if bDirect:
-            globalReadB = globalReadB[1::2]
+    if bDirect:
+        globalReadB = globalReadB[1::2]
 
-        localReadA0 = get("LRA0", codePath)
-        localReadB0 = get("LRB0", codePath)
-        localReadA1 = get("LRA1", codePath)
-        localReadB1 = get("LRB1", codePath)
-        syncIndices = get("SYNC", codePath)
-        syncCodes = scheduleInfo.syncCode
+    localReadA0 = get("LRA0", code_path)
+    localReadB0 = get("LRB0", code_path)
+    localReadA1 = get("LRA1", code_path)
+    localReadB1 = get("LRB1", code_path)
+    syncIndices = get("SYNC", code_path)
+    syncCodes = scheduleInfo.syncCode
 
-        status, message = verify_global_reads_not_too_early_single_code_path(
-            globalReadA,
-            globalReadB,
-            localReadA0,
-            localReadB0,
-            localReadA1,
-            localReadB1,
-            syncIndices,
-            syncCodes,
-            context,
-            positions,
-        )
-        if status is False:
-            return status, message
-
+    status, message = verify_global_reads_not_too_early_single_code_path(
+        globalReadA,
+        globalReadB,
+        localReadA0,
+        localReadB0,
+        localReadA1,
+        localReadB1,
+        syncIndices,
+        syncCodes,
+        context,
+        positions,
+    )
     return status, message
 
 class ValidatorInstruction(ABC):
@@ -839,9 +832,9 @@ class GRIncData:
     intervals: list[tuple[int, int]]
     insts: list[int]
 
-def verify_scc_overlap(scheduleInfo, context: dict = {}):
+def verify_scc_overlap(scheduleInfo, context: dict, code_path: int) -> tuple[bool, str]:
     """
-    Ensure we don't overlap scalar instructions modifying SCC.
+    Ensure we don't overlap scalar instructions modifying SCC for a single code path.
     This can happen:
         - between GRIncA and GRIncB
         - between GRInc and GR when DLT is activated
@@ -889,53 +882,49 @@ def verify_scc_overlap(scheduleInfo, context: dict = {}):
     def getDeclarationIndex(name):
         return list(scheduleInfo.optSchedule).index(name)
 
-    def verify(scheduleInfo: 'ScheduleInfo', codePath: int) -> tuple[bool, str]:
-        GRIncNames = ["GRIncA", "GRIncB"]
-        names = ["LWSA", "LWSB"]
-        # We only care about GRA/B when DTL is activated (m0 usage)
-        if DTL:
-            names += ["GRA", "GRB"]
+    GRIncNames = ["GRIncA", "GRIncB"]
+    names = ["LWSA", "LWSB"]
+    # We only care about GRA/B when DTL is activated (m0 usage)
+    if DTL:
+        names += ["GRA", "GRB"]
 
-        def verifyIndices(grIncData : GRIncData, name : str, indices : list[int]) -> tuple[bool, str]:
-            dclIndex = getDeclarationIndex(name)
-            dclIndexGrInc = getDeclarationIndex(grIncData.name)
-            for v in indices:
-                for interval in grIncData.intervals:
-                    if inInterval(v,interval, dclIndex<dclIndexGrInc):
-                        return False, f"{name} at index {v} can't be between {grIncData.name} {interval[0]}-{interval[1]} due to SCC usage."
+    def verifyIndices(grIncData : GRIncData, name : str, indices : list[int]) -> str | None:
+        dclIndex = getDeclarationIndex(name)
+        dclIndexGrInc = getDeclarationIndex(grIncData.name)
+        for v in indices:
+            for interval in grIncData.intervals:
+                if inInterval(v,interval, dclIndex<dclIndexGrInc):
+                    return f"{name} at index {v} can't be between {grIncData.name} {interval[0]}-{interval[1]} due to SCC usage."
+        return None
 
-        GRIncs = []
-        for GRIncName in GRIncNames:
-            GRInc = schedule_get(GRIncName, codePath, scheduleInfo)
-            assert numElements==len(GRInc), f"{GRIncName} expected size if {numElements}, given {len(GRInc)}."
-            GRIncs.append(GRIncData(name = GRIncName, insts = GRInc, intervals = getIntervals(GRInc)))
+    GRIncs = []
+    for GRIncName in GRIncNames:
+        GRInc = schedule_get(GRIncName, code_path, scheduleInfo)
+        assert numElements==len(GRInc), f"{GRIncName} expected size if {numElements}, given {len(GRInc)}."
+        GRIncs.append(GRIncData(name = GRIncName, insts = GRInc, intervals = getIntervals(GRInc)))
 
-        # First check GRIncA&B together
-        errorMessage = verifyIndices(GRIncs[0],GRIncs[1].name, GRIncs[1].insts)
-        if errorMessage:
-            return errorMessage
+    # First check GRIncA&B together
+    errorMessage = verifyIndices(GRIncs[0],GRIncs[1].name, GRIncs[1].insts)
+    if errorMessage:
+        return False, errorMessage
 
-        # Then, check GR and LW on all GRIncs
-        for grIncData in GRIncs:
-            for name in names:
-                insts = schedule_get(name, codePath, scheduleInfo)
-                # In case of GRA/GRB, just take m0 updates indices
-                if name.startswith("GR"):
-                    insts = insts[0::2]
-                errorMessage = verifyIndices(grIncData, name, insts)
-                if errorMessage:
-                    return errorMessage
-
-    for codePath in range(scheduleInfo.numCodePaths):
-            errorMessage = verify(scheduleInfo, codePath)
+    # Then, check GR and LW on all GRIncs
+    for grIncData in GRIncs:
+        for name in names:
+            insts = schedule_get(name, code_path, scheduleInfo)
+            # In case of GRA/GRB, just take m0 updates indices
+            if name.startswith("GR"):
+                insts = insts[0::2]
+            errorMessage = verifyIndices(grIncData, name, insts)
             if errorMessage:
-                return False, f"Code path {codePath}: {errorMessage}"
+                return False, errorMessage
+
     return True, ""
 
 
-def verify_gr_inc_order(scheduleInfo, context: dict = {}):
+def verify_gr_inc_order(scheduleInfo, context: dict, code_path: int) -> tuple[bool, str]:
     """
-    Ensure GRInc A and B are done before GR A & B.
+    Ensure GRInc A and B are done before GR A & B for a single code path.
     When using `SwapGlobalReadOrder=True`, one should check GRIncB is done before GRA (and GRIncA before GRB)
     """
     SwapGR = context["kernel"]["SwapGlobalReadOrder"]
@@ -943,64 +932,54 @@ def verify_gr_inc_order(scheduleInfo, context: dict = {}):
     def getDeclarationIndex(name):
         return list(scheduleInfo.optSchedule).index(name)
 
-    def verify(scheduleInfo: 'ScheduleInfo', codePath: int) -> tuple[bool, str]:
-        GRIncNames = ["GRIncA", "GRIncB"]
-        GRNames = ["GRA", "GRB"] if not SwapGR else ["GRB", "GRA"]
+    GRIncNames = ["GRIncA", "GRIncB"]
+    GRNames = ["GRA", "GRB"] if not SwapGR else ["GRB", "GRA"]
 
-        for [grIncName, grName] in zip(GRIncNames, GRNames):
-            grInc = schedule_get(grIncName, codePath, scheduleInfo)
-            gr = schedule_get(grName, codePath, scheduleInfo)[1::2] # ignore m0
-            grIncDclAfter = getDeclarationIndex(grIncName)>getDeclarationIndex(grName)
-            # Fails if GrInc is after Gr or if same index but grInc is declared after.
-            if max(grInc)>min(gr) or (grIncDclAfter and max(grInc) == min(gr)):
-                 return False, f"{grIncName} finishes after {grName} starts ({max(grInc)} vs {min(gr)})"
+    for [grIncName, grName] in zip(GRIncNames, GRNames):
+        grInc = schedule_get(grIncName, code_path, scheduleInfo)
+        gr = schedule_get(grName, code_path, scheduleInfo)[1::2] # ignore m0
+        grIncDclAfter = getDeclarationIndex(grIncName)>getDeclarationIndex(grName)
+        # Fails if GrInc is after Gr or if same index but grInc is declared after.
+        if max(grInc)>min(gr) or (grIncDclAfter and max(grInc) == min(gr)):
+             return False, f"{grIncName} finishes after {grName} starts ({max(grInc)} vs {min(gr)})"
 
-    for codePath in range(scheduleInfo.numCodePaths):
-            errorMessage = verify(scheduleInfo, codePath)
-            if errorMessage:
-                return False, f"Code path {codePath}: {errorMessage}"
-    
     return True, ""
 
-def verify_lrs_and_grs(schedule_info: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
+def verify_lrs_and_grs(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
-    Ensure several properties are valid of LRs and GRs:
+    Ensure several properties are valid of LRs and GRs for a single code path:
     1. The GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LRA1/LRB1 of this iteration.
     2. The LR1s and LR0s are guaranteed to be complete before the first VMFMA that uses their data.
     """
-    def verify(schedule_info: 'ScheduleInfo', code_path: int) -> str | None:
-        if len(schedule_info.mfmaReorder) != 0:
-            printWarning("Do not currently support mfmaReorder in CMS validation, cannot guarantee that LR1s will be correct.")
-            return None
+    if len(schedule_info.mfmaReorder) != 0:
+        printWarning("Do not currently support mfmaReorder in CMS validation, cannot guarantee that LR1s will be correct.")
+        return True, ""
 
-        available_keys = schedule_info.optSchedule.keys()
-        if "LRA1" not in available_keys and "LRA3" in available_keys:
-            printWarning("LRA3 is present in schedule, but LRA1 is not. This is not yet supported in CMS validation")
-            return None
-        if "LRB1" not in available_keys and "LRB3" in available_keys:
-            printWarning("LRB3 is present in schedule, but LRB1 is not. This is not yet supported in CMS validation")
-            return None
+    available_keys = schedule_info.optSchedule.keys()
+    if "LRA1" not in available_keys and "LRA3" in available_keys:
+        printWarning("LRA3 is present in schedule, but LRA1 is not. This is not yet supported in CMS validation")
+        return True, ""
+    if "LRB1" not in available_keys and "LRB3" in available_keys:
+        printWarning("LRB3 is present in schedule, but LRB1 is not. This is not yet supported in CMS validation")
+        return True, ""
 
-        relevant_names = ["GRA", "GRB", "LRA0", "LRB0", "LRA1", "LRB1", "SYNC"]
-        kernel = context["kernel"]
-        timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
-        
-        # Apply standalone functions to populate timeline fields
-        set_gr_needed_by_from_lr1s(timeline, kernel["SwapGlobalReadOrder"])
-        apply_swaits(timeline)
-        apply_barriers(timeline)
+    relevant_names = ["GRA", "GRB", "LRA0", "LRB0", "LRA1", "LRB1", "SYNC"]
+    kernel = context["kernel"]
+    timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
+    
+    # Apply standalone functions to populate timeline fields
+    set_gr_needed_by_from_lr1s(timeline, kernel["SwapGlobalReadOrder"])
+    apply_swaits(timeline)
+    apply_barriers(timeline)
 
-        return validate_timeline(timeline)
-
-    for code_path in range(schedule_info.numCodePaths):
-        error_message = verify(schedule_info, code_path)
-        if error_message:
-            return False, f"Code path {code_path}: {error_message}"
+    message = validate_timeline(timeline)
+    if message:
+        return False, message
     return True, ""
 
-def verify_correct_number_of_instructions(schedule_info: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
+def verify_correct_number_of_instructions(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
-    Verify that the number of instructions in the schedule is correct.
+    Verify that the number of instructions in the schedule is correct for a single code path.
     """
     if "idMap" not in context:
         # NOTE: Only skipping because the idMap is hard to construct in testing, but will always be present
@@ -1008,26 +987,19 @@ def verify_correct_number_of_instructions(schedule_info: 'ScheduleInfo', context
         printWarning("idMap not found in context. Skipping CMS validation for correct number of instructions.")
         return True, ""
 
-    def verify(schedule_info: 'ScheduleInfo', code_path: int) -> str | None:
-        for instruction_name in schedule_info.optSchedule.keys():
-            schedule = schedule_get(instruction_name, code_path, schedule_info)
+    for instruction_name in schedule_info.optSchedule.keys():
+        schedule = schedule_get(instruction_name, code_path, schedule_info)
 
-            len_actual = len(schedule)
-            len_expected = len(context["idMap"][instruction_name])
-            if len_actual != len_expected:
-                return f"{instruction_name} has {len_actual} instructions, but {len_expected} instructions are required."
-        return None
-
-    for code_path in range(schedule_info.numCodePaths):
-        error_message = verify(schedule_info, code_path)
-        if error_message:
-            return False, f"Code path {code_path}: {error_message}"
+        len_actual = len(schedule)
+        len_expected = len(context["idMap"][instruction_name])
+        if len_actual != len_expected:
+            return False, f"{instruction_name} has {len_actual} instructions, but {len_expected} instructions are required."
     return True, ""
 
 
-def verify_ascending_order(scheduleInfo, context: dict = {}):
+def verify_ascending_order(scheduleInfo, context: dict, code_path: int) -> tuple[bool, str]:
     """
-    Ensure that all sequences of scheduleInfo.optSchedule are non-decreasing.
+    Ensure that all sequences of scheduleInfo.optSchedule are non-decreasing for a single code path.
 
     Context and example: There will be a sequence of N 'GRIncA' instructions
     for incrementing the memory address that the A macro tile is read from.
@@ -1044,16 +1016,17 @@ def verify_ascending_order(scheduleInfo, context: dict = {}):
     instructions are non-decreasing. This rule is true for all groups of instructions,
     not just the 'GRIncA' instructions.
     """
-    for k, sequences in scheduleInfo.optSchedule.items():
-        for seq in sequences:
-            for i in range(1, len(seq)):
-                if seq[i] < seq[i - 1]:
-                    return False, (
-                        f"Non-descending-order rule failed, "
-                        f"schedule key '{k}', sequence {seq}: "
-                        f"value {seq[i]} at index {i} is less than "
-                        f"{seq[i-1]} at index {i-1}."
-                    )
+    for k in scheduleInfo.optSchedule.keys():
+        seq = schedule_get(k, code_path, scheduleInfo)
+        for i in range(1, len(seq)):
+            if seq[i] < seq[i - 1]:
+                return (
+                    False,
+                    f"Non-descending-order rule failed, "
+                    f"schedule key '{k}', sequence {seq}: "
+                    f"value {seq[i]} at index {i} is less than "
+                    f"{seq[i-1]} at index {i-1}."
+                )
     return True, ""
 
 
@@ -1083,7 +1056,7 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
         # All rules bypassed, considered valid.
         return True, message
 
-    # The set of validation rules to run
+    # The set of validation rules to run (code-path aware)
     rules = [
         verify_correct_number_of_instructions,
         verify_ascending_order,
@@ -1093,10 +1066,11 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
         verify_gr_inc_order
     ]
 
-    for rule in rules:
-        status, message = rule(scheduleInfo, context)
-        if status is False:
-            return False, message
+    for code_path in range(scheduleInfo.numCodePaths):
+        for rule in rules:
+            status, message = rule(scheduleInfo, context, code_path)
+            if not status:
+                return False, f"Code path {code_path}: {message}"
 
     # All rules passed, considered valid.
     return True, ""

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -557,7 +557,7 @@ class TestCustomScheduleValidation:
 
         # No verification message means that the schedule info is considered valid.
         scheduleInfo = ScheduleInfo(
-            None, None, invalid_schedule, None, None, None, None
+            1, None, invalid_schedule, None, None, None, None
         )
         scheduleInfo.disableValidation()
         status, message = isValid(scheduleInfo, {"kernel" : {"DepthU": 42}})
@@ -566,6 +566,6 @@ class TestCustomScheduleValidation:
 
         # A non-empty verification message means that the schedule info is considered invalid.
         status, message = isValid(
-            ScheduleInfo(None, None, invalid_schedule, None, None, None, None), {}
+            ScheduleInfo(1, None, invalid_schedule, None, None, None, None), {}
         )
         assert status == False

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomScheduleGlobalReadValidation.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomScheduleGlobalReadValidation.py
@@ -255,7 +255,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("grb", 11),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -275,7 +275,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -295,7 +295,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("grb", 10),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -315,7 +315,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("gra", 10),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
             "Last local read for B issued at vmfma_index:0. "
@@ -341,7 +341,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("gra", 10),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -364,7 +364,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -384,7 +384,13 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        # Check code path 0 - should pass
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
+        assert message == ""
+        assert status is True
+        
+        # Check code path 1 - should fail (LRA0 is late)
+        status, message = verify_global_reads_not_too_early(schedule, {}, 1)
         assert message == (
             "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
             "Last local read for A issued at vmfma_index:6. "
@@ -404,7 +410,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("grb", 11),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
             "Last local read for B issued at vmfma_index:1. "
@@ -424,7 +430,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("grb", 11),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that a barrier (to sync waves) exists between completion of local reads for A and the first global read for A. "
             "Last local read of A issued at vmfma_index 0, first global read of A issued at vmfma_index 10, wave completion at vmfma_index 5. "
@@ -445,7 +451,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("grb", 10),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -465,7 +471,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("grb", 10),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -485,7 +491,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("grb", 10),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
             "Last local read for A issued at vmfma_index:2. "
@@ -514,7 +520,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("grb", 100),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -535,7 +541,7 @@ class TestCustomScheduleGlobalReadValidation:
                 ("grb", 100),
             ]
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -558,13 +564,13 @@ class TestCustomScheduleGlobalReadValidation:
         )
 
         status, message = verify_global_reads_not_too_early(
-            schedule, {"kernel": {"DirectToLdsA": True}}
+            schedule, {"kernel": {"DirectToLdsA": True}}, 0
         )
         assert message == ""
         assert status is True
 
         status, message = verify_global_reads_not_too_early(
-            schedule, {"kernel": {"DirectToLds": True}}
+            schedule, {"kernel": {"DirectToLds": True}}, 0
         )
         assert message == ""
         assert status is True
@@ -575,7 +581,7 @@ class TestCustomScheduleGlobalReadValidation:
         )
 
         status, message = verify_global_reads_not_too_early(
-            schedule, {"kernel": {"DirectToLdsB": True}}
+            schedule, {"kernel": {"DirectToLdsB": True}}, 0
         )
         assert "First global read for B issued at vmfma_index:4" in message
         assert message == (
@@ -600,7 +606,7 @@ class TestCustomScheduleGlobalReadValidation:
             ]
         )
         status, message = verify_global_reads_not_too_early(
-            schedule, {"kernel": {"SwapGlobalReadOrder": True}}
+            schedule, {"kernel": {"SwapGlobalReadOrder": True}}, 0
         )
         assert message == ""
         assert status is True
@@ -619,7 +625,7 @@ class TestCustomScheduleGlobalReadValidation:
             ]
         )
         status, message = verify_global_reads_not_too_early(
-            schedule, {"kernel": {"SwapGlobalReadOrder": True}}
+            schedule, {"kernel": {"SwapGlobalReadOrder": True}}, 0
         )
         assert message == (
             "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
@@ -655,7 +661,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
             "Last local read for B issued at vmfma_index:5. "
@@ -689,7 +695,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
             "Last local read for A issued at vmfma_index:5. "
@@ -721,7 +727,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert (
             "Failed to verify that a barrier (to sync waves) exists between completion of local reads"
             in message
@@ -750,7 +756,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert (
             "Failed to verify that a barrier (to sync waves) exists between completion of local reads for B"
             in message
@@ -779,7 +785,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -799,7 +805,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
             "Last local read for B issued at vmfma_index:5. "
@@ -824,7 +830,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             (
                 "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
@@ -856,7 +862,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
             "Last local read for A issued at vmfma_index:5. "
@@ -882,7 +888,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that a barrier (to sync waves) exists between completion of local reads for A and the first global read for A. "
             "Last local read of A issued at vmfma_index 5, first global read of A issued at vmfma_index 10, wave completion at vmfma_index 5. "
@@ -911,7 +917,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -936,7 +942,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
             "Last local read for A issued at vmfma_index:3. First global read for A issued at vmfma_index:4. "
@@ -966,7 +972,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == ""
         assert status is True
 
@@ -992,7 +998,7 @@ class TestCustomScheduleGlobalReadValidation:
             None,
             None,
         )
-        status, message = verify_global_reads_not_too_early(schedule, {})
+        status, message = verify_global_reads_not_too_early(schedule, {}, 0)
         assert message == (
             "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
             "Last local read for A issued at vmfma_index:3. "

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateDescendingOrder.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateDescendingOrder.py
@@ -34,7 +34,7 @@ class TestValidateDescendingOrder:
         sched = ScheduleInfo(
             None, None, {"P": [[3, 2, 1]]}, None, None, None, None
         )
-        status, message = verify_ascending_order(sched)
+        status, message = verify_ascending_order(sched, {}, 0)
 
         expected = "Non-descending-order rule failed, schedule key 'P', sequence [3, 2, 1]: value 2 at index 1 is less than 3 at index 0."
         assert status == False
@@ -43,6 +43,6 @@ class TestValidateDescendingOrder:
         sched = ScheduleInfo(
             None, None, {"P": [[1, 1, 2]]}, None, None, None, None
         )
-        status, message = verify_ascending_order(sched)
+        status, message = verify_ascending_order(sched, {}, 0)
         assert status == True
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -66,7 +66,7 @@ class TestValidateNglAndNll(unittest.TestCase):
         """
         shift_value = 3 + 3  # 3 GRAs and 3 GRBs
         schedule = self.make_simple_schedule(shift_value)
-        status, message = verify_lrs_and_grs(schedule, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(schedule, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_simple_case_failure(self):
@@ -75,9 +75,9 @@ class TestValidateNglAndNll(unittest.TestCase):
         """
         shift_value = 3 + 3 - 1  # 3 GRAs and 3 GRBs - 1
         schedule = self.make_simple_schedule(shift_value)
-        status, message = verify_lrs_and_grs(schedule, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(schedule, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but passed. {message}"
-        assert message == "Code path 0: GRB at index 2 is not valid. There are no guarantees on when it will be done."
+        assert message == "GRB at index 2 is not valid. There are no guarantees on when it will be done."
 
     def test_simple_case_success_too_high(self):
         """
@@ -85,7 +85,7 @@ class TestValidateNglAndNll(unittest.TestCase):
         """
         shift_value = 3 + 3 + 1  # 3 GRAs and 3 GRBs + 1
         schedule = self.make_simple_schedule(shift_value)
-        status, message = verify_lrs_and_grs(schedule, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(schedule, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_lr0_swait_depends_on_lr1(self):
@@ -105,9 +105,9 @@ class TestValidateNglAndNll(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but passed. {message}"
-        assert message == "Code path 0: Loop NLL: LRB0 at index 0 is not valid. Needed before index 6 (of next iteration), but only guaranteed at index 7."
+        assert message == "Loop NLL: LRB0 at index 0 is not valid. Needed before index 6 (of next iteration), but only guaranteed at index 7."
 
     def test_lr0_swait_depends_on_lr1_realistic(self, useZeroDscnt = False):
         """
@@ -153,12 +153,12 @@ class TestValidateNglAndNll(unittest.TestCase):
         # We need to set nglshift and nllshift for the vlcnt adjustments
         num_gr = 2  # 2 GRs total (1 GRA + 1 GRB, but we only count the actual reads not the increments)
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncTable[1::2], num_gr, num_gr, useZeroDscnt)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         if useZeroDscnt:
             assert status, f"Schedule should have passed validation but failed. {message}"
         else:
             assert not status, f"Schedule should have failed validation but passed. {message}"
-            assert message == "Code path 0: Loop NLL: LRB0 at index 3 is not valid. Needed before index 28 (of next iteration), but only guaranteed at index 31."
+            assert message == "Loop NLL: LRB0 at index 3 is not valid. Needed before index 28 (of next iteration), but only guaranteed at index 31."
 
     def test_lr0_swait_depends_on_lr1_realistic_zero_dscnt(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_VerifyGRsCompleteBeforeLr1s.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_VerifyGRsCompleteBeforeLr1s.py
@@ -58,7 +58,7 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_grs_not_swait(self):
@@ -84,9 +84,9 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (GRA is not guaranteed before LRA1), but passed. {message}"
-        assert message == "Code path 0: GRA at index 0 is not valid. There are no guarantees on when it will be done."
+        assert message == "GRA at index 0 is not valid. There are no guarantees on when it will be done."
 
     def test_no_sbarrier(self): 
         """
@@ -110,9 +110,9 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (GRA is not guaranteed before LRA1), but passed. {message}"
-        assert message == "Code path 0: GRA at index 0 is not valid. There is no SBarrier acting on it."
+        assert message == "GRA at index 0 is not valid. There is no SBarrier acting on it."
 
     def test_swait_after_sbarrier(self):
         """
@@ -137,9 +137,9 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (no barrier between GRA and LRA1), but passed. {message}"
-        assert message == "Code path 0: GRA at index 0 is not valid. No SBarrier between SWait @ idx=3 and LR1 @ idx=6. Order must be GR -> SWait -> SBarrier -> LR1."
+        assert message == "GRA at index 0 is not valid. No SBarrier between SWait @ idx=3 and LR1 @ idx=6. Order must be GR -> SWait -> SBarrier -> LR1."
 
     def test_guaranteed_after_first_lr1(self):
         """
@@ -165,9 +165,9 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
         ]
 
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 4, 4)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (first LRA1 before last GRA), but passed. {message}"
-        assert message == "Code path 0: GRA at index 0 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=3. Order must be GR -> SWait -> SBarrier -> LR1."
+        assert message == "GRA at index 0 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=3. Order must be GR -> SWait -> SBarrier -> LR1."
 
     def test_less_than_1_full_iteration_to_complete(self):
         """
@@ -192,7 +192,7 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_some_grs_less_than_1_full_iteration_to_complete(self):
@@ -218,7 +218,7 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 6, 6)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_swait_and_sbarrier_in_preloop(self):
@@ -244,7 +244,7 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_grs_in_preloop(self):
@@ -269,7 +269,7 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_last_gr_swait_sbarrier_in_same_index(self):
@@ -296,8 +296,8 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
-        assert status, f"Schedule should have passed validation but did not. {message}"
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
+        assert status == True, f"Schedule should have passed validation but did not. {message}"
 
     def test_swait_sbarrier_first_lr1_in_same_index(self):
         """
@@ -323,7 +323,7 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_swap_global_read_order_success(self):
@@ -352,7 +352,7 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_swap_global_read_order_failure(self):
@@ -382,9 +382,9 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LR1s"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but passed. {message}"
-        assert message == "Code path 0: GRB (Swapped, loading A) at index 3 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=2. Order must be GR -> SWait -> SBarrier -> LR1."
+        assert message == "GRB (Swapped, loading A) at index 3 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=2. Order must be GR -> SWait -> SBarrier -> LR1."
 
     def test_fail_with_odd_number_of_grs(self):
         """
@@ -411,6 +411,6 @@ class TestVerifyGRsCompleteBeforeLr1s(unittest.TestCase):
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, 2, 2)
 
         with pytest.raises(AssertionError) as excinfo:
-            verify_lrs_and_grs(sched, {"kernel": self.kernel})
+            verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         
         assert str(excinfo.value) == "Code path 0: GRA has an odd number of indices. Must be even if DirectToLds is True."

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_VerifyLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_VerifyLRsCompleteBeforeVMFMA.py
@@ -49,19 +49,19 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         optSchedule["LRA0"] = [[1, 6]]
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (LRA0 issued after halfway point), but passed."
-        assert message == "Code path 0: LRA0 at index 6 is not valid. Needed before index 5, but only guaranteed at index 3."
+        assert message == "LRA0 at index 6 is not valid. Needed before index 5, but only guaranteed at index 3."
 
         optSchedule["LRA0"] = [[1, 2]]
         optSchedule["LRB0"] = [[3, 6]]
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (LRB0 issued after halfway point), but passed."
-        assert message == "Code path 0: LRB0 at index 3 is not valid. Needed before index 4, but only guaranteed at index 3."
+        assert message == "LRB0 at index 3 is not valid. Needed before index 4, but only guaranteed at index 3."
 
     def test_simple_LR0_w_LR1(self):
         """
@@ -80,7 +80,7 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation 1/2 but did not. {message}"
 
     def test_complex_LR0(self):
@@ -99,7 +99,7 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_simple_LR1(self):
@@ -120,7 +120,7 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_pre_loop_SWaitCnt(self):
@@ -141,7 +141,7 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_pre_loop_LR(self):
@@ -159,7 +159,7 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="")
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_simple_LR1_never_guaranteed(self):
@@ -178,9 +178,9 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (LRA1 never guaranteed), but passed. {message}"
-        assert message == "Code path 0: LRA1 at index 4 is not valid. Needed before index 0, but only guaranteed at index 1."
+        assert message == "LRA1 at index 4 is not valid. Needed before index 0, but only guaranteed at index 1."
 
     def test_complex_LR1(self):
         """
@@ -201,14 +201,14 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="2/2 LRA1 and 1/2 LRB1"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         # Failing case: LRA1 finishes too late
         optSchedule["LRA1"] = [[4, 5]]
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (LRA1 finishes too late), but passed. {message}"
-        assert message == "Code path 0: LRA1 at index 5 is not valid. Needed before index 1 (of next iteration), but only guaranteed at index 1."
+        assert message == "LRA1 at index 5 is not valid. Needed before index 1 (of next iteration), but only guaranteed at index 1."
 
     def test_more_LRs(self):
         """
@@ -233,7 +233,7 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="2/4 LRA1 and 2/4 LRB1"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
     def test_more_LRs_failure(self):
@@ -255,21 +255,21 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
         
         # Failure case 1: Don't wait for any LRA0
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (incorrectly wait for only LRB0), but passed. {message}"
-        assert message == "Code path 0: LRA0 at index 1 is not valid. Needed before index 4, but only guaranteed at index 4."
+        assert message == "LRA0 at index 1 is not valid. Needed before index 4, but only guaranteed at index 4."
 
         # Failure case 2: Wait for only 1/4 LRA0 (need at least 2/4 LRA0) to do VMFMA 4.
         syncCode[0].dscnt = 3
         syncCode[0].comment = "Wait for LRB0 and 1/4 LRA0"
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (incorrectly wait for only 1/4 LRA0), but passed. {message}"
-        assert message == "Code path 0: LRA0 at index 1 is not valid. Needed before index 4, but only guaranteed at index 4."
+        assert message == "LRA0 at index 1 is not valid. Needed before index 4, but only guaranteed at index 4."
 
         # Passing case: Correctly SWaitCnt for 2/4 LRA0 (i.e. 1/2 As) in time for VMFMA 4.
         syncCode[0].dscnt = 2
         syncCode[0].comment = "Wait for LRB0 and 2/4 LRA0"
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
     
     def test_less_LRs(self):
@@ -296,14 +296,14 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="LRA1 and 1/2 LRB1"),
         ]
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         # Failure case
         optSchedule["SYNC"][0][0] = 8
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (LRB0 not finished before being needed), but passed. {message}"
-        assert message == "Code path 0: LRB1 at index 19 is not valid. Needed before index 8 (of next iteration), but only guaranteed at index 8."
+        assert message == "LRB1 at index 19 is not valid. Needed before index 8 (of next iteration), but only guaranteed at index 8."
 
     def test_handling_instruction_order(self):
         """
@@ -326,9 +326,9 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             "LRB1": [[7]],
         }
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (LRA0 not finished before being needed), but passed. {message}"
-        assert message == "Code path 0: LRA0 at index 3 is not valid. Needed before index 4, but only guaranteed at index 7."
+        assert message == "LRA0 at index 3 is not valid. Needed before index 4, but only guaranteed at index 7."
 
         # 2. SwaitCnt after LR0s but before LR1s
         # LR0s will now pass, but LR1s will fail
@@ -340,9 +340,9 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             "LRB1": [[7]],
         }
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed (LRA1 not finished before being needed), but passed. {message}"
-        assert message == "Code path 0: LRA1 at index 7 is not valid. Needed before index 0, but only guaranteed at index 3."
+        assert message == "LRA1 at index 7 is not valid. Needed before index 0, but only guaranteed at index 3."
 
         # 3. SwaitCnt after all LRs
         optSchedule = {
@@ -353,5 +353,5 @@ class TestVerifyLRsCompleteBeforeVMFMA(unittest.TestCase):
             "SYNC": [[3, 7]],
         }
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel})
+        status, message = verify_lrs_and_grs(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_gr_inc_order.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_gr_inc_order.py
@@ -55,29 +55,29 @@ class TestGRIncOrder(unittest.TestCase):
         ]
 
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel})
+        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         # GRA before GRIncA
         optSchedule["GRA"] = [[0, 0]]
-        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel})
+        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         # GRA before GRIncB
         optSchedule["GRA"] = [[11, 11]]
         optSchedule["GRB"] = [[6, 6]]
-        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel})
+        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         # GRA Pass with same index
         optSchedule["GRA"] = [[5, 5]]
         optSchedule["GRB"] = [[12, 12]]
-        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel})
+        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel}, 0)
         assert  status, f"Schedule should have passed validation but did not. {message}"
 
         # GRB Fail with same index
         optSchedule["GRB"] = [[10, 10]]
-        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel})
+        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel}, 0)
         assert  not status, f"Schedule should have failed validation but did not. {message}"
 
 
@@ -98,16 +98,16 @@ class TestGRIncOrder(unittest.TestCase):
         ]
 
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel})
+        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         # GRA before GRIncB
         optSchedule["GRA"] = [[0, 0]]
-        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel})
+        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         # GRB before GRIncA
         optSchedule["GRA"] = [[11, 11]]
         optSchedule["GRB"] = [[6, 6]]
-        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel})
+        status, message = verify_gr_inc_order(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_verifySCCoverlap.py
@@ -55,18 +55,18 @@ class TestVerifySCCOverlap(unittest.TestCase):
         ]
 
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         # GRA in GRIncA
         optSchedule["GRA"] = [[2, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         # GRB in GRIncB
         optSchedule["GRA"] = [[10, 11]]
         optSchedule["GRB"] = [[6, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
     def test_gr_declaration_order(self):
@@ -92,29 +92,29 @@ class TestVerifySCCOverlap(unittest.TestCase):
         ]
 
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         # GRA just before GRIncA
         optSchedule["GRA"] = [[0, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert  status, f"Schedule should have passed validation but did not. {message}"
 
         # GRB just before GRIncB
         optSchedule["GRB"] = [[8, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         # GRA just after GRIncA
         optSchedule["GRB"] = [[12, 13]]
         optSchedule["GRA"] = [[1, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         # GRB just after GRIncA
         optSchedule["GRA"] = [[10, 11]]
         optSchedule["GRB"] = [[1, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
 
@@ -141,23 +141,23 @@ class TestVerifySCCOverlap(unittest.TestCase):
         ]
 
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         optSchedule["GRA"] = [[0, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert  not status, f"Schedule should have failed validation but did not. {message}"
 
         optSchedule["GRA"] = [[2, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         optSchedule["GRA"] = [[3, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert  status, f"Schedule should have passed validation but did not. {message}"
 
         optSchedule["GRB"] = [[6, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
 
@@ -182,27 +182,27 @@ class TestVerifySCCOverlap(unittest.TestCase):
         ]
 
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         # GRA inside GRInc interval
         optSchedule["GRA"] = [[0, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         # GRA just after GRInc interval
         optSchedule["GRA"] = [[1, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         # GRB after GRIncB-10 
         optSchedule["GRB"] = [[10, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         # GRA before GRIncB-10 -> middle of interval
         optSchedule["GRA"] = [[10, 11]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
     def test_lws(self):
@@ -226,23 +226,23 @@ class TestVerifySCCOverlap(unittest.TestCase):
         ]
 
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         optSchedule["LWSA"] = [[0]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         optSchedule["LWSA"] = [[1]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         optSchedule["LWSA"] = [[2]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         optSchedule["LWSB"] = [[9]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         
@@ -267,19 +267,19 @@ class TestVerifySCCOverlap(unittest.TestCase):
         ]
 
         sched = ScheduleInfo(1, self.num_vmfma, optSchedule, syncCode, None, None)
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
         optSchedule["GRIncB"] = [[0, 0, 1,
                                   9, 10,
                                   10]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert not status, f"Schedule should have failed validation but did not. {message}"
 
         optSchedule["GRIncB"] = [[1, 1, 2,
                             9, 10,
                             10]]
-        status, message = verify_scc_overlap(sched, {"kernel": self.kernel})
+        status, message = verify_scc_overlap(sched, {"kernel": self.kernel}, 0)
         assert status, f"Schedule should have passed validation but did not. {message}"
 
 


### PR DESCRIPTION
## Motivation

Instead of writing the validators each with an internal verify function and a for-loop, refactor them to operate on one codepath at a time and move the for-loop into isValid.

## Technical Details

See above.

## Test Plan

Run existing tests.

## Test Result

Existing tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
