### PR TITLE
[hipDNN] Fix clang tidy path detection

### DIFF
--- a/.github/workflows/hipdnn-clang-tidy.yml
+++ b/.github/workflows/hipdnn-clang-tidy.yml
@@ -3,7 +3,11 @@ name: hipDNN Clang Tidy
 on:
   pull_request:
     paths:
-      - 'projects/hipdnn/**/*.{hpp,h,cpp,c}'
+      - 'projects/hipdnn/**/*.hpp'
+      - 'projects/hipdnn/**/*.h'
+      - 'projects/hipdnn/**/*.cpp'
+      - 'projects/hipdnn/**/*.c'
+      - 'projects/hipdnn/cmake/ClangTidy.cmake'
       - '.github/workflows/hipdnn-clang-tidy.yml'
   workflow_dispatch:
 

--- a/.github/workflows/hipdnn-clang-tidy.yml
+++ b/.github/workflows/hipdnn-clang-tidy.yml
@@ -3,10 +3,7 @@ name: hipDNN Clang Tidy
 on:
   pull_request:
     paths:
-      - 'projects/hipdnn/**/*.hpp'
-      - 'projects/hipdnn/**/*.h'
-      - 'projects/hipdnn/**/*.cpp'
-      - 'projects/hipdnn/**/*.c'
+      - 'projects/hipdnn/**/*.[ch]p?p?'
       - 'projects/hipdnn/cmake/ClangTidy.cmake'
       - '.github/workflows/hipdnn-clang-tidy.yml'
   workflow_dispatch:


### PR DESCRIPTION
## Motivation

GitHub Actions isn't compatible with curly brace regex, so switched to list each file extensions on new lines.

Test PR to show it triggers on an applicable file change: https://github.com/ROCm/rocm-libraries/pull/3374

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
