### PR TITLE
[hipblaslt] [CMS] Split Validation of LRs and GRs into separate passes

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -971,16 +971,10 @@ def verify_gr_inc_order(scheduleInfo, context: dict, code_path: int) -> tuple[bo
 
     return True, ""
 
-def verify_lrs_and_grs(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
+def verify_grs_finish_before_lr1s(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
-    Ensure several properties are valid of LRs and GRs for a single code path:
-    1. The GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LRA1/LRB1 of this iteration.
-    2. The LR1s and LR0s are guaranteed to be complete before the first VMFMA that uses their data.
+    Ensure that the GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LRA1/LRB1 of this iteration.
     """
-    if len(schedule_info.mfmaReorder) != 0:
-        printWarning("Do not currently support mfmaReorder in CMS validation, cannot guarantee that LR1s will be correct.")
-        return True, ""
-
     available_keys = schedule_info.optSchedule.keys()
     if "LRA1" not in available_keys and "LRA3" in available_keys:
         printWarning("LRA3 is present in schedule, but LRA1 is not. This is not yet supported in CMS validation")
@@ -989,13 +983,34 @@ def verify_lrs_and_grs(schedule_info: 'ScheduleInfo', context: dict, code_path: 
         printWarning("LRB3 is present in schedule, but LRB1 is not. This is not yet supported in CMS validation")
         return True, ""
 
-    relevant_names = ["GRA", "GRB", "LRA0", "LRB0", "LRA1", "LRB1", "SYNC"]
+    relevant_names = ["GRA", "GRB", "LRA1", "LRB1", "SYNC"]
     kernel = context["kernel"]
     timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
     
     # Apply standalone functions to populate timeline fields
-    set_lr_needed_by_for_VMFMA(timeline, kernel)
     set_gr_needed_by_from_lr1s(timeline, kernel["SwapGlobalReadOrder"])
+    apply_swaits(timeline)
+    apply_barriers(timeline)
+
+    message = validate_timeline(timeline)
+    if message:
+        return False, message
+    return True, ""
+
+
+def verify_lrs_finished_before_vmfma(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
+    """
+    Ensure that the LocalReads are guaranteed to be complete before the first VMFMA that uses their data.
+    """
+    if len(schedule_info.mfmaReorder) != 0:
+        printWarning("CMS Validation does not currently support mfmaReorder, cannot guarantee that LRs will be correct.")
+        return True, ""
+
+    relevant_names = ["LRA0", "LRB0", "LRA1", "LRB1", "SYNC"]
+    kernel = context["kernel"]
+    timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
+
+    set_lr_needed_by_for_VMFMA(timeline, kernel)
     apply_swaits(timeline)
     apply_barriers(timeline)
 
@@ -1094,8 +1109,9 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
     rules = [
         verify_correct_number_of_instructions,
         verify_ascending_order,
+        verify_lrs_finished_before_vmfma,
         verify_global_reads_not_too_early,
-        verify_lrs_and_grs,
+        verify_grs_finish_before_lr1s,
         verify_scc_overlap,
         verify_gr_inc_order
     ]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
@@ -24,12 +24,12 @@
 ################################################################################
 from rocisa.instruction import SWaitCnt, SBarrier
 
-from Tensile.Components.CMSValidator import verify_lrs_and_grs
+from Tensile.Components.CMSValidator import verify_grs_finish_before_lr1s
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
     def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_lrs_and_grs(sched, kernel_dict, codePathIdx)
+        return verify_grs_finish_before_lr1s(sched, kernel_dict, codePathIdx)
 
     def test_simple_case_success(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -24,12 +24,12 @@
 ################################################################################
 from rocisa.instruction import SWaitCnt
 
-from Tensile.Components.CMSValidator import verify_lrs_and_grs
+from Tensile.Components.CMSValidator import verify_lrs_finished_before_vmfma
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
     def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_lrs_and_grs(sched, kernel_dict, codePathIdx)
+        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
 
     def test_simple_LR0(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -22,12 +22,12 @@
 
 from rocisa.instruction import SWaitCnt, SBarrier
 
-from Tensile.Components.CMSValidator import verify_lrs_and_grs
+from Tensile.Components.CMSValidator import verify_grs_finish_before_lr1s, verify_lrs_finished_before_vmfma
 from cms_validation_base import CMSValidationTestBase
 
-class TestValidateNglAndNll(CMSValidationTestBase):
+class TestValidateNgl(CMSValidationTestBase):
     def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_lrs_and_grs(sched, kernel_dict, codePathIdx)
+        return verify_grs_finish_before_lr1s(sched, kernel_dict, codePathIdx)
 
     def make_simple_schedule_and_sync(self) -> tuple[dict[str, list[list[int]]], list[SWaitCnt | SBarrier]]:
         """
@@ -80,6 +80,10 @@ class TestValidateNglAndNll(CMSValidationTestBase):
         shift_value = 3 + 3 + 1  # 3 GRAs and 3 GRBs + 1
         optSchedule, syncCode = self.make_simple_schedule_and_sync()
         self.validate(optSchedule, syncCode, 1, shift_value, shift_value, 0, None)
+
+class TestValidateNll(CMSValidationTestBase):
+    def validation_function(self, sched, kernel_dict, codePathIdx):
+        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
 
     def test_lr0_swait_depends_on_lr1(self):
         """


### PR DESCRIPTION
## Motivation

Existing GlobalRead validation passes can be applied to TF32 kernels as is, LocalRead validation requires extra work, and one should not hold back the other. Splitting them back up also allows for easier testing of individual passes and makes test smaller by allowing us to include fewer items in the schedule (schedule needs to be valid only for 1 rules rather than 2).

Depends on #3362 and #3382.

## Technical Details

Split into separate passes to allow them to be brought up for new kernels, and tested, independently.

## Test Plan

Run existing tests.

## Test Result

Passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
