### PR TITLE
add snopCode support

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -127,6 +127,7 @@ class ScheduleInfo:
         nllshift,
         nllZeroDscnt=False,
         mfmaReorder=[],
+        snopCode = [],
     ):
         self.numCodePaths = numCodePaths
         self.numMfma = numMfma
@@ -136,6 +137,7 @@ class ScheduleInfo:
         self.nllshift = nllshift  # vmcnt shift for nolocalload loop
         self.nllZeroDscnt = nllZeroDscnt
         self.mfmaReorder = mfmaReorder
+        self.snopCode = snopCode
         self.__skipValidation__ = False
 
     def disableValidation(self):
@@ -237,6 +239,7 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
         idMap["PackB%u"%uIdx] = PackCodeB[uIdx]
 
     idMap['SYNC'] = opt1.syncCode
+    idMap['SNOP'] = opt1.snopCode
 
     status, message = cmsv.isValid(opt1, {'kernel' : kernel, "idMap": idMap})
     # create the case str (TN, NT, TT, or NN)


### PR DESCRIPTION
## Motivation

Adding in a special `snop` attribute to `ScheduleInfo` so we can handle codegen'd TF32 kernels in CMS. It is likely that the most optimal TF32 CMS schedules will *not* feature these `s_nop` instructions, but this attribute will permit mechanical translation of codegen -> working CMS schedule to help scale out creation of TF32 CMS schedules.

Target branch is `hipblaslt_common_cms_phase2` - set to HEAD of `hipblaslt_common_cms_dev`. The idea would be to begin landing TF32 CMS schedules *and* additional bf16 schedules. 

- a single branch approach allows us to continue uninterrupted development of validator rules
- for "phase 2 bf16", it is advantageous to have those additional bf16 CMS schedules hit the same commit history (and the same Library Logic yamls files) as the phase 1, because the tuning activities need to be done on the full 54 tiles. Thus we want that tuning to happen on our full Equality Library Logic yaml
- Every commit before `_phase2` branch has now landed in `develop` so it's easier to keep track of what schedules have landed and what have not.

## Technical Details

Cherry-pick @jfactory07 's commit to enable additional TF32 CMS work in this branch.

