### PR TITLE
Replace magic numbers with enums in rocprim tests

### DIFF
--- a/projects/rocprim/test/rocprim/test_block_adjacent_difference.hpp
+++ b/projects/rocprim/test/rocprim/test_block_adjacent_difference.hpp
@@ -42,9 +42,9 @@ typed_test_def(RocprimBlockAdjacentDifference, name_suffix, SubtractLeft)
     constexpr size_t block_size = TestFixture::params::block_size;
 
     // clang-format off
-    static_for<0, 2,       T, T, op_type_1, MethodType::LEFT, block_size>::run();
-    static_for<2, 4,       T, T, op_type_2, MethodType::LEFT, block_size>::run();
-    static_for<4, n_items, T, T, op_type_3, MethodType::LEFT, block_size>::run();
+    static_for<0, 2,       T, T, op_type_1, TestBlockAdjacentDifferenceMethod::LEFT, block_size>::run();
+    static_for<2, 4,       T, T, op_type_2, TestBlockAdjacentDifferenceMethod::LEFT, block_size>::run();
+    static_for<4, n_items, T, T, op_type_3, TestBlockAdjacentDifferenceMethod::LEFT, block_size>::run();
     // clang-format on
 }
 
@@ -59,9 +59,9 @@ typed_test_def(RocprimBlockAdjacentDifference, name_suffix, SubtractRight)
     constexpr size_t block_size = TestFixture::params::block_size;
 
     // clang-format off
-    static_for<0, 2,       T, T, op_type_1, MethodType::RIGHT, block_size>::run();
-    static_for<2, 4,       T, T, op_type_2, MethodType::RIGHT, block_size>::run();
-    static_for<4, n_items, T, T, op_type_3, MethodType::RIGHT, block_size>::run();
+    static_for<0, 2,       T, T, op_type_1, TestBlockAdjacentDifferenceMethod::RIGHT, block_size>::run();
+    static_for<2, 4,       T, T, op_type_2, TestBlockAdjacentDifferenceMethod::RIGHT, block_size>::run();
+    static_for<4, n_items, T, T, op_type_3, TestBlockAdjacentDifferenceMethod::RIGHT, block_size>::run();
     // clang-format on
 }
 
@@ -76,9 +76,9 @@ typed_test_def(RocprimBlockAdjacentDifference, name_suffix, SubtractLeftPartial)
     constexpr size_t block_size = TestFixture::params::block_size;
 
     // clang-format off
-    static_for<0, 2,       T, T, op_type_1, MethodType::LEFT_PARTIAL, block_size>::run();
-    static_for<2, 4,       T, T, op_type_2, MethodType::LEFT_PARTIAL, block_size>::run();
-    static_for<4, n_items, T, T, op_type_3, MethodType::LEFT_PARTIAL, block_size>::run();
+    static_for<0, 2,       T, T, op_type_1, TestBlockAdjacentDifferenceMethod::LEFT_PARTIAL, block_size>::run();
+    static_for<2, 4,       T, T, op_type_2, TestBlockAdjacentDifferenceMethod::LEFT_PARTIAL, block_size>::run();
+    static_for<4, n_items, T, T, op_type_3, TestBlockAdjacentDifferenceMethod::LEFT_PARTIAL, block_size>::run();
     // clang-format on
 }
 
@@ -93,8 +93,8 @@ typed_test_def(RocprimBlockAdjacentDifference, name_suffix, SubtractRightPartial
     constexpr size_t block_size = TestFixture::params::block_size;
 
     // clang-format off
-    static_for<0, 2,       T, T, op_type_1, MethodType::RIGHT_PARTIAL, block_size>::run();
-    static_for<2, 4,       T, T, op_type_2, MethodType::RIGHT_PARTIAL, block_size>::run();
-    static_for<4, n_items, T, T, op_type_3, MethodType::RIGHT_PARTIAL, block_size>::run();
+    static_for<0, 2,       T, T, op_type_1, TestBlockAdjacentDifferenceMethod::RIGHT_PARTIAL, block_size>::run();
+    static_for<2, 4,       T, T, op_type_2, TestBlockAdjacentDifferenceMethod::RIGHT_PARTIAL, block_size>::run();
+    static_for<4, n_items, T, T, op_type_3, TestBlockAdjacentDifferenceMethod::RIGHT_PARTIAL, block_size>::run();
     // clang-format on
 }

--- a/projects/rocprim/test/rocprim/test_block_adjacent_difference.hpp
+++ b/projects/rocprim/test/rocprim/test_block_adjacent_difference.hpp
@@ -42,9 +42,9 @@ typed_test_def(RocprimBlockAdjacentDifference, name_suffix, SubtractLeft)
     constexpr size_t block_size = TestFixture::params::block_size;
 
     // clang-format off
-    static_for<0, 2,       T, T, op_type_1, 0, block_size>::run();
-    static_for<2, 4,       T, T, op_type_2, 0, block_size>::run();
-    static_for<4, n_items, T, T, op_type_3, 0, block_size>::run();
+    static_for<0, 2,       T, T, op_type_1, MethodType::LEFT, block_size>::run();
+    static_for<2, 4,       T, T, op_type_2, MethodType::LEFT, block_size>::run();
+    static_for<4, n_items, T, T, op_type_3, MethodType::LEFT, block_size>::run();
     // clang-format on
 }
 
@@ -59,9 +59,9 @@ typed_test_def(RocprimBlockAdjacentDifference, name_suffix, SubtractRight)
     constexpr size_t block_size = TestFixture::params::block_size;
 
     // clang-format off
-    static_for<0, 2,       T, T, op_type_1, 1, block_size>::run();
-    static_for<2, 4,       T, T, op_type_2, 1, block_size>::run();
-    static_for<4, n_items, T, T, op_type_3, 1, block_size>::run();
+    static_for<0, 2,       T, T, op_type_1, MethodType::RIGHT, block_size>::run();
+    static_for<2, 4,       T, T, op_type_2, MethodType::RIGHT, block_size>::run();
+    static_for<4, n_items, T, T, op_type_3, MethodType::RIGHT, block_size>::run();
     // clang-format on
 }
 
@@ -76,9 +76,9 @@ typed_test_def(RocprimBlockAdjacentDifference, name_suffix, SubtractLeftPartial)
     constexpr size_t block_size = TestFixture::params::block_size;
 
     // clang-format off
-    static_for<0, 2,       T, T, op_type_1, 2, block_size>::run();
-    static_for<2, 4,       T, T, op_type_2, 2, block_size>::run();
-    static_for<4, n_items, T, T, op_type_3, 2, block_size>::run();
+    static_for<0, 2,       T, T, op_type_1, MethodType::LEFT_PARTIAL, block_size>::run();
+    static_for<2, 4,       T, T, op_type_2, MethodType::LEFT_PARTIAL, block_size>::run();
+    static_for<4, n_items, T, T, op_type_3, MethodType::LEFT_PARTIAL, block_size>::run();
     // clang-format on
 }
 
@@ -93,8 +93,8 @@ typed_test_def(RocprimBlockAdjacentDifference, name_suffix, SubtractRightPartial
     constexpr size_t block_size = TestFixture::params::block_size;
 
     // clang-format off
-    static_for<0, 2,       T, T, op_type_1, 3, block_size>::run();
-    static_for<2, 4,       T, T, op_type_2, 3, block_size>::run();
-    static_for<4, n_items, T, T, op_type_3, 3, block_size>::run();
+    static_for<0, 2,       T, T, op_type_1, MethodType::RIGHT_PARTIAL, block_size>::run();
+    static_for<2, 4,       T, T, op_type_2, MethodType::RIGHT_PARTIAL, block_size>::run();
+    static_for<4, n_items, T, T, op_type_3, MethodType::RIGHT_PARTIAL, block_size>::run();
     // clang-format on
 }

--- a/projects/rocprim/test/rocprim/test_block_adjacent_difference.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_adjacent_difference.kernels.hpp
@@ -34,6 +34,14 @@
 #include <rocprim/block/block_load_func.hpp>
 #include <rocprim/block/block_store.hpp>
 
+enum MethodType {
+    LEFT = 0,
+    RIGHT = 1,
+    LEFT_PARTIAL = 2,
+    RIGHT_PARTIAL = 3
+};
+
+
 // Host (CPU) implementaions of the wrapping function that allows to pass 3 args
 template<class T, class FlagType, class FlagOp>
 auto apply(FlagOp flag_op, const T& a, const T& b, unsigned int b_index)
@@ -222,7 +230,7 @@ template<typename T,
          unsigned int Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == 0>::type
+auto test_block_adjacent_difference() -> typename std::enable_if<Method == MethodType::LEFT>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -309,7 +317,7 @@ template<typename T,
          unsigned int Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == 1>::type
+auto test_block_adjacent_difference() -> typename std::enable_if<Method == MethodType::RIGHT>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -396,7 +404,7 @@ template<typename T,
          unsigned int Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == 2>::type
+auto test_block_adjacent_difference() -> typename std::enable_if<Method == MethodType::LEFT_PARTIAL>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -498,7 +506,7 @@ template<typename T,
          unsigned int Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == 3>::type
+auto test_block_adjacent_difference() -> typename std::enable_if<Method == MethodType::RIGHT_PARTIAL>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 

--- a/projects/rocprim/test/rocprim/test_block_adjacent_difference.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_adjacent_difference.kernels.hpp
@@ -34,13 +34,12 @@
 #include <rocprim/block/block_load_func.hpp>
 #include <rocprim/block/block_store.hpp>
 
-enum MethodType {
+enum TestBlockAdjacentDifferenceMethod {
     LEFT = 0,
     RIGHT = 1,
     LEFT_PARTIAL = 2,
     RIGHT_PARTIAL = 3
 };
-
 
 // Host (CPU) implementaions of the wrapping function that allows to pass 3 args
 template<class T, class FlagType, class FlagOp>
@@ -230,7 +229,7 @@ template<typename T,
          unsigned int Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == MethodType::LEFT>::type
+auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::LEFT>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -317,7 +316,7 @@ template<typename T,
          unsigned int Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == MethodType::RIGHT>::type
+auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::RIGHT>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -404,7 +403,7 @@ template<typename T,
          unsigned int Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == MethodType::LEFT_PARTIAL>::type
+auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::LEFT_PARTIAL>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -506,7 +505,7 @@ template<typename T,
          unsigned int Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == MethodType::RIGHT_PARTIAL>::type
+auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::RIGHT_PARTIAL>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 

--- a/projects/rocprim/test/rocprim/test_block_adjacent_difference.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_adjacent_difference.kernels.hpp
@@ -34,7 +34,7 @@
 #include <rocprim/block/block_load_func.hpp>
 #include <rocprim/block/block_store.hpp>
 
-enum TestBlockAdjacentDifferenceMethod {
+enum class TestBlockAdjacentDifferenceMethod {
     LEFT = 0,
     RIGHT = 1,
     LEFT_PARTIAL = 2,
@@ -226,7 +226,7 @@ __global__ __launch_bounds__(
 template<typename T,
          typename Output,
          typename BinaryFunction,
-         unsigned int Method,
+         TestBlockAdjacentDifferenceMethod Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
 auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::LEFT>::type
@@ -313,7 +313,7 @@ auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestB
 template<typename T,
          typename Output,
          typename BinaryFunction,
-         unsigned int Method,
+         TestBlockAdjacentDifferenceMethod Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
 auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::RIGHT>::type
@@ -400,7 +400,7 @@ auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestB
 template<typename T,
          typename Output,
          typename BinaryFunction,
-         unsigned int Method,
+         TestBlockAdjacentDifferenceMethod Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
 auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::LEFT_PARTIAL>::type
@@ -502,7 +502,7 @@ auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestB
 template<typename T,
          typename Output,
          typename BinaryFunction,
-         unsigned int Method,
+         TestBlockAdjacentDifferenceMethod Method,
          unsigned int BlockSize,
          unsigned int ItemsPerThread>
 auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::RIGHT_PARTIAL>::type
@@ -612,7 +612,7 @@ template<unsigned int First,
          class Type,
          class FlagType,
          class FlagOpType,
-         unsigned int Method,
+         TestBlockAdjacentDifferenceMethod Method,
          unsigned int BlockSize = 256U>
 struct static_for
 {
@@ -639,7 +639,7 @@ template<unsigned int N,
          class Type,
          class FlagType,
          class FlagOpType,
-         unsigned int Method,
+         TestBlockAdjacentDifferenceMethod Method,
          unsigned int BlockSize>
 struct static_for<N, N, Type, FlagType, FlagOpType, Method, BlockSize>
 {

--- a/projects/rocprim/test/rocprim/test_block_adjacent_difference.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_adjacent_difference.kernels.hpp
@@ -34,10 +34,11 @@
 #include <rocprim/block/block_load_func.hpp>
 #include <rocprim/block/block_store.hpp>
 
-enum class TestBlockAdjacentDifferenceMethod {
-    LEFT = 0,
-    RIGHT = 1,
-    LEFT_PARTIAL = 2,
+enum class TestBlockAdjacentDifferenceMethod
+{
+    LEFT          = 0,
+    RIGHT         = 1,
+    LEFT_PARTIAL  = 2,
     RIGHT_PARTIAL = 3
 };
 
@@ -227,9 +228,10 @@ template<typename T,
          typename Output,
          typename BinaryFunction,
          TestBlockAdjacentDifferenceMethod Method,
-         unsigned int BlockSize,
-         unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::LEFT>::type
+         unsigned int                      BlockSize,
+         unsigned int                      ItemsPerThread>
+auto test_block_adjacent_difference() ->
+    typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::LEFT>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -314,9 +316,10 @@ template<typename T,
          typename Output,
          typename BinaryFunction,
          TestBlockAdjacentDifferenceMethod Method,
-         unsigned int BlockSize,
-         unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::RIGHT>::type
+         unsigned int                      BlockSize,
+         unsigned int                      ItemsPerThread>
+auto test_block_adjacent_difference() ->
+    typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::RIGHT>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -401,9 +404,10 @@ template<typename T,
          typename Output,
          typename BinaryFunction,
          TestBlockAdjacentDifferenceMethod Method,
-         unsigned int BlockSize,
-         unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::LEFT_PARTIAL>::type
+         unsigned int                      BlockSize,
+         unsigned int                      ItemsPerThread>
+auto test_block_adjacent_difference() ->
+    typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::LEFT_PARTIAL>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -503,9 +507,10 @@ template<typename T,
          typename Output,
          typename BinaryFunction,
          TestBlockAdjacentDifferenceMethod Method,
-         unsigned int BlockSize,
-         unsigned int ItemsPerThread>
-auto test_block_adjacent_difference() -> typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::RIGHT_PARTIAL>::type
+         unsigned int                      BlockSize,
+         unsigned int                      ItemsPerThread>
+auto test_block_adjacent_difference() ->
+    typename std::enable_if<Method == TestBlockAdjacentDifferenceMethod::RIGHT_PARTIAL>::type
 {
     using stored_type = std::conditional_t<std::is_same<Output, bool>::value, int, Output>;
 
@@ -613,7 +618,7 @@ template<unsigned int First,
          class FlagType,
          class FlagOpType,
          TestBlockAdjacentDifferenceMethod Method,
-         unsigned int BlockSize = 256U>
+         unsigned int                      BlockSize = 256U>
 struct static_for
 {
     static void run()
@@ -640,7 +645,7 @@ template<unsigned int N,
          class FlagType,
          class FlagOpType,
          TestBlockAdjacentDifferenceMethod Method,
-         unsigned int BlockSize>
+         unsigned int                      BlockSize>
 struct static_for<N, N, Type, FlagType, FlagOpType, Method, BlockSize>
 {
     static void run() {}

--- a/projects/rocprim/test/rocprim/test_block_discontinuity.hpp
+++ b/projects/rocprim/test/rocprim/test_block_discontinuity.hpp
@@ -41,10 +41,34 @@ typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagHeads)
     using flag_op_type_4        = rocprim::not_equal_to<type>;
     constexpr size_t block_size = TestFixture::params::block_size;
 
-    static_for<0, 2, type, flag_type, flag_op_type_1, TestBlockDiscontinuityMethod::HEADS, block_size>::run();
-    static_for<2, 4, type, flag_type, flag_op_type_2, TestBlockDiscontinuityMethod::HEADS, block_size>::run();
-    static_for<4, 6, type, flag_type, flag_op_type_3, TestBlockDiscontinuityMethod::HEADS, block_size>::run();
-    static_for<6, n_items, type, flag_type, flag_op_type_4, TestBlockDiscontinuityMethod::HEADS, block_size>::run();
+    static_for<0,
+               2,
+               type,
+               flag_type,
+               flag_op_type_1,
+               TestBlockDiscontinuityMethod::HEADS,
+               block_size>::run();
+    static_for<2,
+               4,
+               type,
+               flag_type,
+               flag_op_type_2,
+               TestBlockDiscontinuityMethod::HEADS,
+               block_size>::run();
+    static_for<4,
+               6,
+               type,
+               flag_type,
+               flag_op_type_3,
+               TestBlockDiscontinuityMethod::HEADS,
+               block_size>::run();
+    static_for<6,
+               n_items,
+               type,
+               flag_type,
+               flag_op_type_4,
+               TestBlockDiscontinuityMethod::HEADS,
+               block_size>::run();
 }
 
 typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagTails)
@@ -57,10 +81,34 @@ typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagTails)
     using flag_op_type_4        = rocprim::not_equal_to<type>;
     constexpr size_t block_size = TestFixture::params::block_size;
 
-    static_for<0, 2, type, flag_type, flag_op_type_1, TestBlockDiscontinuityMethod::TAILS, block_size>::run();
-    static_for<2, 4, type, flag_type, flag_op_type_2, TestBlockDiscontinuityMethod::TAILS, block_size>::run();
-    static_for<4, 6, type, flag_type, flag_op_type_3, TestBlockDiscontinuityMethod::TAILS, block_size>::run();
-    static_for<6, n_items, type, flag_type, flag_op_type_4, TestBlockDiscontinuityMethod::TAILS, block_size>::run();
+    static_for<0,
+               2,
+               type,
+               flag_type,
+               flag_op_type_1,
+               TestBlockDiscontinuityMethod::TAILS,
+               block_size>::run();
+    static_for<2,
+               4,
+               type,
+               flag_type,
+               flag_op_type_2,
+               TestBlockDiscontinuityMethod::TAILS,
+               block_size>::run();
+    static_for<4,
+               6,
+               type,
+               flag_type,
+               flag_op_type_3,
+               TestBlockDiscontinuityMethod::TAILS,
+               block_size>::run();
+    static_for<6,
+               n_items,
+               type,
+               flag_type,
+               flag_op_type_4,
+               TestBlockDiscontinuityMethod::TAILS,
+               block_size>::run();
 }
 
 typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagHeadsAndTails)
@@ -73,8 +121,32 @@ typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagHeadsAndTails)
     using flag_op_type_4        = rocprim::not_equal_to<type>;
     constexpr size_t block_size = TestFixture::params::block_size;
 
-    static_for<0, 2, type, flag_type, flag_op_type_1, TestBlockDiscontinuityMethod::HEADS_AND_TAILS, block_size>::run();
-    static_for<2, 4, type, flag_type, flag_op_type_2, TestBlockDiscontinuityMethod::HEADS_AND_TAILS, block_size>::run();
-    static_for<4, 6, type, flag_type, flag_op_type_3, TestBlockDiscontinuityMethod::HEADS_AND_TAILS, block_size>::run();
-    static_for<6, n_items, type, flag_type, flag_op_type_4, TestBlockDiscontinuityMethod::HEADS_AND_TAILS, block_size>::run();
+    static_for<0,
+               2,
+               type,
+               flag_type,
+               flag_op_type_1,
+               TestBlockDiscontinuityMethod::HEADS_AND_TAILS,
+               block_size>::run();
+    static_for<2,
+               4,
+               type,
+               flag_type,
+               flag_op_type_2,
+               TestBlockDiscontinuityMethod::HEADS_AND_TAILS,
+               block_size>::run();
+    static_for<4,
+               6,
+               type,
+               flag_type,
+               flag_op_type_3,
+               TestBlockDiscontinuityMethod::HEADS_AND_TAILS,
+               block_size>::run();
+    static_for<6,
+               n_items,
+               type,
+               flag_type,
+               flag_op_type_4,
+               TestBlockDiscontinuityMethod::HEADS_AND_TAILS,
+               block_size>::run();
 }

--- a/projects/rocprim/test/rocprim/test_block_discontinuity.hpp
+++ b/projects/rocprim/test/rocprim/test_block_discontinuity.hpp
@@ -41,10 +41,10 @@ typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagHeads)
     using flag_op_type_4        = rocprim::not_equal_to<type>;
     constexpr size_t block_size = TestFixture::params::block_size;
 
-    static_for<0, 2, type, flag_type, flag_op_type_1, 0, block_size>::run();
-    static_for<2, 4, type, flag_type, flag_op_type_2, 0, block_size>::run();
-    static_for<4, 6, type, flag_type, flag_op_type_3, 0, block_size>::run();
-    static_for<6, n_items, type, flag_type, flag_op_type_4, 0, block_size>::run();
+    static_for<0, 2, type, flag_type, flag_op_type_1, TestBlockDiscontinuityMethod::HEADS, block_size>::run();
+    static_for<2, 4, type, flag_type, flag_op_type_2, TestBlockDiscontinuityMethod::HEADS, block_size>::run();
+    static_for<4, 6, type, flag_type, flag_op_type_3, TestBlockDiscontinuityMethod::HEADS, block_size>::run();
+    static_for<6, n_items, type, flag_type, flag_op_type_4, TestBlockDiscontinuityMethod::HEADS, block_size>::run();
 }
 
 typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagTails)
@@ -57,10 +57,10 @@ typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagTails)
     using flag_op_type_4        = rocprim::not_equal_to<type>;
     constexpr size_t block_size = TestFixture::params::block_size;
 
-    static_for<0, 2, type, flag_type, flag_op_type_1, 1, block_size>::run();
-    static_for<2, 4, type, flag_type, flag_op_type_2, 1, block_size>::run();
-    static_for<4, 6, type, flag_type, flag_op_type_3, 1, block_size>::run();
-    static_for<6, n_items, type, flag_type, flag_op_type_4, 1, block_size>::run();
+    static_for<0, 2, type, flag_type, flag_op_type_1, TestBlockDiscontinuityMethod::TAILS, block_size>::run();
+    static_for<2, 4, type, flag_type, flag_op_type_2, TestBlockDiscontinuityMethod::TAILS, block_size>::run();
+    static_for<4, 6, type, flag_type, flag_op_type_3, TestBlockDiscontinuityMethod::TAILS, block_size>::run();
+    static_for<6, n_items, type, flag_type, flag_op_type_4, TestBlockDiscontinuityMethod::TAILS, block_size>::run();
 }
 
 typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagHeadsAndTails)
@@ -73,8 +73,8 @@ typed_test_def(RocprimBlockDiscontinuity, name_suffix, FlagHeadsAndTails)
     using flag_op_type_4        = rocprim::not_equal_to<type>;
     constexpr size_t block_size = TestFixture::params::block_size;
 
-    static_for<0, 2, type, flag_type, flag_op_type_1, 2, block_size>::run();
-    static_for<2, 4, type, flag_type, flag_op_type_2, 2, block_size>::run();
-    static_for<4, 6, type, flag_type, flag_op_type_3, 2, block_size>::run();
-    static_for<6, n_items, type, flag_type, flag_op_type_4, 2, block_size>::run();
+    static_for<0, 2, type, flag_type, flag_op_type_1, TestBlockDiscontinuityMethod::HEADS_AND_TAILS, block_size>::run();
+    static_for<2, 4, type, flag_type, flag_op_type_2, TestBlockDiscontinuityMethod::HEADS_AND_TAILS, block_size>::run();
+    static_for<4, 6, type, flag_type, flag_op_type_3, TestBlockDiscontinuityMethod::HEADS_AND_TAILS, block_size>::run();
+    static_for<6, n_items, type, flag_type, flag_op_type_4, TestBlockDiscontinuityMethod::HEADS_AND_TAILS, block_size>::run();
 }

--- a/projects/rocprim/test/rocprim/test_block_discontinuity.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_discontinuity.kernels.hpp
@@ -39,7 +39,7 @@
 #include <type_traits>
 #include <vector>
 
-enum TestBlockDiscontinuityMethod {
+enum class TestBlockDiscontinuityMethod {
     HEADS = 0,
     TAILS = 1,
     HEADS_AND_TAILS = 2
@@ -208,7 +208,7 @@ template<
     class Type,
     class FlagType,
     class FlagOpType,
-    unsigned int Method,
+    TestBlockDiscontinuityMethod Method,
     unsigned int BlockSize,
     unsigned int ItemsPerThread
 >
@@ -294,7 +294,7 @@ template<
     class Type,
     class FlagType,
     class FlagOpType,
-    unsigned int Method,
+    TestBlockDiscontinuityMethod Method,
     unsigned int BlockSize,
     unsigned int ItemsPerThread
 >
@@ -379,7 +379,7 @@ template<
     class Type,
     class FlagType,
     class FlagOpType,
-    unsigned int Method,
+    TestBlockDiscontinuityMethod Method,
     unsigned int BlockSize,
     unsigned int ItemsPerThread
 >
@@ -489,7 +489,7 @@ template <
     class Type,
     class FlagType,
     class FlagOpType,
-    unsigned int Method,
+    TestBlockDiscontinuityMethod Method,
     unsigned int BlockSize = 256U
 >
 struct static_for
@@ -513,7 +513,7 @@ template <
     class Type,
     class FlagType,
     class FlagOpType,
-    unsigned int Method,
+    TestBlockDiscontinuityMethod Method,
     unsigned int BlockSize
 >
 struct static_for<N, N, Type, FlagType, FlagOpType, Method, BlockSize>

--- a/projects/rocprim/test/rocprim/test_block_discontinuity.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_discontinuity.kernels.hpp
@@ -39,9 +39,10 @@
 #include <type_traits>
 #include <vector>
 
-enum class TestBlockDiscontinuityMethod {
-    HEADS = 0,
-    TAILS = 1,
+enum class TestBlockDiscontinuityMethod
+{
+    HEADS           = 0,
+    TAILS           = 1,
     HEADS_AND_TAILS = 2
 };
 
@@ -204,16 +205,14 @@ void flag_heads_and_tails_kernel(Type* device_input, FlagType* device_heads, Fla
     rocprim::block_store_direct_blocked(lid, device_tails + block_offset, tail_flags);
 }
 
-template<
-    class Type,
-    class FlagType,
-    class FlagOpType,
-    TestBlockDiscontinuityMethod Method,
-    unsigned int BlockSize,
-    unsigned int ItemsPerThread
->
-auto test_block_discontinuity()
--> typename std::enable_if<Method == TestBlockDiscontinuityMethod::HEADS>::type
+template<class Type,
+         class FlagType,
+         class FlagOpType,
+         TestBlockDiscontinuityMethod Method,
+         unsigned int                 BlockSize,
+         unsigned int                 ItemsPerThread>
+auto test_block_discontinuity() ->
+    typename std::enable_if<Method == TestBlockDiscontinuityMethod::HEADS>::type
 {
     using type                               = Type;
     using flag_type = FlagType;
@@ -290,16 +289,14 @@ auto test_block_discontinuity()
     }
 }
 
-template<
-    class Type,
-    class FlagType,
-    class FlagOpType,
-    TestBlockDiscontinuityMethod Method,
-    unsigned int BlockSize,
-    unsigned int ItemsPerThread
->
-auto test_block_discontinuity()
--> typename std::enable_if<Method == TestBlockDiscontinuityMethod::TAILS>::type
+template<class Type,
+         class FlagType,
+         class FlagOpType,
+         TestBlockDiscontinuityMethod Method,
+         unsigned int                 BlockSize,
+         unsigned int                 ItemsPerThread>
+auto test_block_discontinuity() ->
+    typename std::enable_if<Method == TestBlockDiscontinuityMethod::TAILS>::type
 {
     using type                               = Type;
     using flag_type = FlagType;
@@ -375,16 +372,14 @@ auto test_block_discontinuity()
     }
 }
 
-template<
-    class Type,
-    class FlagType,
-    class FlagOpType,
-    TestBlockDiscontinuityMethod Method,
-    unsigned int BlockSize,
-    unsigned int ItemsPerThread
->
-auto test_block_discontinuity()
--> typename std::enable_if<Method == TestBlockDiscontinuityMethod::HEADS_AND_TAILS>::type
+template<class Type,
+         class FlagType,
+         class FlagOpType,
+         TestBlockDiscontinuityMethod Method,
+         unsigned int                 BlockSize,
+         unsigned int                 ItemsPerThread>
+auto test_block_discontinuity() ->
+    typename std::enable_if<Method == TestBlockDiscontinuityMethod::HEADS_AND_TAILS>::type
 {
     using type                               = Type;
     using flag_type = FlagType;
@@ -483,15 +478,13 @@ auto test_block_discontinuity()
 }
 
 // Static for-loop
-template <
-    unsigned int First,
-    unsigned int Last,
-    class Type,
-    class FlagType,
-    class FlagOpType,
-    TestBlockDiscontinuityMethod Method,
-    unsigned int BlockSize = 256U
->
+template<unsigned int First,
+         unsigned int Last,
+         class Type,
+         class FlagType,
+         class FlagOpType,
+         TestBlockDiscontinuityMethod Method,
+         unsigned int                 BlockSize = 256U>
 struct static_for
 {
     static void run()
@@ -508,14 +501,12 @@ struct static_for
     }
 };
 
-template <
-    unsigned int N,
-    class Type,
-    class FlagType,
-    class FlagOpType,
-    TestBlockDiscontinuityMethod Method,
-    unsigned int BlockSize
->
+template<unsigned int N,
+         class Type,
+         class FlagType,
+         class FlagOpType,
+         TestBlockDiscontinuityMethod Method,
+         unsigned int                 BlockSize>
 struct static_for<N, N, Type, FlagType, FlagOpType, Method, BlockSize>
 {
     static void run()

--- a/projects/rocprim/test/rocprim/test_block_discontinuity.kernels.hpp
+++ b/projects/rocprim/test/rocprim/test_block_discontinuity.kernels.hpp
@@ -39,6 +39,12 @@
 #include <type_traits>
 #include <vector>
 
+enum TestBlockDiscontinuityMethod {
+    HEADS = 0,
+    TAILS = 1,
+    HEADS_AND_TAILS = 2
+};
+
 template<class T>
 struct custom_flag_op1
 {
@@ -207,7 +213,7 @@ template<
     unsigned int ItemsPerThread
 >
 auto test_block_discontinuity()
--> typename std::enable_if<Method == 0>::type
+-> typename std::enable_if<Method == TestBlockDiscontinuityMethod::HEADS>::type
 {
     using type                               = Type;
     using flag_type = FlagType;
@@ -293,7 +299,7 @@ template<
     unsigned int ItemsPerThread
 >
 auto test_block_discontinuity()
--> typename std::enable_if<Method == 1>::type
+-> typename std::enable_if<Method == TestBlockDiscontinuityMethod::TAILS>::type
 {
     using type                               = Type;
     using flag_type = FlagType;
@@ -378,7 +384,7 @@ template<
     unsigned int ItemsPerThread
 >
 auto test_block_discontinuity()
--> typename std::enable_if<Method == 2>::type
+-> typename std::enable_if<Method == TestBlockDiscontinuityMethod::HEADS_AND_TAILS>::type
 {
     using type                               = Type;
     using flag_type = FlagType;


### PR DESCRIPTION
## Motivation

Currently a set of magic numbers (0,1,2,3) are used to indicate which method to use in two tests.
By replacing these with enums we can improve maintainability, by avoiding various issues which can now be caught by the compiler.
## Technical Details

Magic numbers were replaced with class enums in
- projects/rocprim/test/rocprim/test_block_discontinuity.kernels.hpp
- projects/rocprim/test/rocprim/test_block_adjacent_difference.kernels.hpp


## Test Plan
Run the following tests after modification:
- test_block_discontinuity.kernels.hpp
- test_block_adjacent_difference.kernels.hpp

## Test Result

Both tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
