### PR TITLE
[hipblaslt][testing] Lockfree parallel experiment omp on

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/Parallel.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/Parallel.py
@@ -53,7 +53,7 @@ def CPUThreadCount(enable=True):
             # is actually 64, but some handles are needed for accounting).
             cpu_count = min(os.cpu_count(), 61)
         else:
-            cpu_count = len(os.sched_getaffinity(0))
+            cpu_count = 1 #len(os.sched_getaffinity(0))
         cpuThreads = globalParameters["CpuThreads"]
         if cpuThreads == -1:
             return cpu_count

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/conftest.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/conftest.py
@@ -79,7 +79,7 @@ def worker_lock_path(tmp_path_factory, worker_id):
     if not worker_id:
         return None
 
-    return tmp_path_factory.getbasetemp().parent / "client_execution.lock"
+    return tmp_path_factory.getbasetemp().parent / f"client_execution_{worker_id}.lock"
 
 @pytest.fixture
 def tensile_script_path():

--- a/projects/hipblaslt/tensilelite/client/src/Reference.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/Reference.cpp
@@ -33,7 +33,7 @@
 #include <cstddef>
 #include <omp.h>
 
-#define MAX_OMP_THREADS 64
+#define MAX_OMP_THREADS 1
 
 namespace TensileLite
 {

--- a/projects/hipblaslt/tensilelite/client/src/Reference.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/Reference.cpp
@@ -33,7 +33,7 @@
 #include <cstddef>
 #include <omp.h>
 
-#define MAX_OMP_THREADS 1
+#define MAX_OMP_THREADS 64
 
 namespace TensileLite
 {

--- a/projects/hipblaslt/tensilelite/tox.ini
+++ b/projects/hipblaslt/tensilelite/tox.ini
@@ -27,7 +27,7 @@ commands =
     pip install --no-build-isolation {toxinidir}/rocisa/
     pip install pytest-cov
     invoke build-client --build-dir {toxinidir}/build_tmp {env:TENSILELITE_CLIENT_ARGS}
-    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 4 --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
+    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 32 --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
 allowlist_externals =
     mkdir
     sh

--- a/projects/hipblaslt/tensilelite/tox.ini
+++ b/projects/hipblaslt/tensilelite/tox.ini
@@ -27,7 +27,7 @@ commands =
     pip install --no-build-isolation {toxinidir}/rocisa/
     pip install pytest-cov
     invoke build-client --build-dir {toxinidir}/build_tmp {env:TENSILELITE_CLIENT_ARGS}
-    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 32 --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
+    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 64 --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
 allowlist_externals =
     mkdir
     sh


### PR DESCRIPTION
## Experiment

In this test, python parallelism is turned off (so hipcc is serialized for a worker), and the lock is removed. 

## Results

3 hr 58. So this is effectively a 'no-PR'. 

<img width="1695" height="109" alt="{6062743E-70A7-442E-A6AD-D65A921C379F}" src="https://github.com/user-attachments/assets/94d0d07c-9bc9-403a-95c1-a22afcedca8d" />

## Conclusion

Between OMP and python parallelism, OMP is the more effective at reducing compile time. TODO(newling) link to experiment where disabling both results in 11 hours.