### PR TITLE
[FFT shared][hipFFT tests] fix typo in definition of hipfft_ionembed_t type

### DIFF
--- a/projects/hipfft/clients/hipfft_params.h
+++ b/projects/hipfft/clients/hipfft_params.h
@@ -331,8 +331,8 @@ public:
 
         try
         {
-            (void)get_ionembed<int>();
-            (void)get_ionembed<long long int>();
+            (void)get_advanced_layout_args<int>();
+            (void)get_advanced_layout_args<long long int>();
         }
         catch(const ionembed_exception& e)
         {
@@ -1040,32 +1040,34 @@ private:
         }
         case CREATE_MAKE_PLAN_MANY:
         {
-            auto ionembed = get_ionembed<int>();
+            auto layout_args = get_advanced_layout_args<int>();
             if(plan == INVALID_PLAN_HANDLE)
-                ret = hipfftEstimateMany(dim(),
-                                         int_length.data(),
-                                         const_cast<int*>(ionembed.get_nembed(fft_io::fft_io_in)),
-                                         ionembed.get_elementary_stride(fft_io::fft_io_in),
-                                         idist,
-                                         const_cast<int*>(ionembed.get_nembed(fft_io::fft_io_out)),
-                                         ionembed.get_elementary_stride(fft_io::fft_io_out),
-                                         odist,
-                                         *hipfft_transform_type,
-                                         nbatch,
-                                         worksize_estimate.data());
+                ret = hipfftEstimateMany(
+                    dim(),
+                    int_length.data(),
+                    const_cast<int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_in)),
+                    layout_args.istride_arg,
+                    layout_args.idist_arg,
+                    const_cast<int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_out)),
+                    layout_args.ostride_arg,
+                    layout_args.odist_arg,
+                    *hipfft_transform_type,
+                    nbatch,
+                    worksize_estimate.data());
             else
-                ret = hipfftGetSizeMany(plan,
-                                        dim(),
-                                        int_length.data(),
-                                        const_cast<int*>(ionembed.get_nembed(fft_io::fft_io_in)),
-                                        ionembed.get_elementary_stride(fft_io::fft_io_in),
-                                        idist,
-                                        const_cast<int*>(ionembed.get_nembed(fft_io::fft_io_out)),
-                                        ionembed.get_elementary_stride(fft_io::fft_io_out),
-                                        odist,
-                                        *hipfft_transform_type,
-                                        nbatch,
-                                        worksize_estimate.data());
+                ret = hipfftGetSizeMany(
+                    plan,
+                    dim(),
+                    int_length.data(),
+                    const_cast<int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_in)),
+                    layout_args.istride_arg,
+                    layout_args.idist_arg,
+                    const_cast<int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_out)),
+                    layout_args.ostride_arg,
+                    layout_args.odist_arg,
+                    *hipfft_transform_type,
+                    nbatch,
+                    worksize_estimate.data());
             break;
         }
         case CREATE_MAKE_PLAN_MANY64:
@@ -1080,17 +1082,18 @@ private:
             }
             else
             {
-                auto ionembed = get_ionembed<long long int>();
-                ret           = hipfftGetSizeMany64(
+                auto layout_args = get_advanced_layout_args<long long int>();
+                ret              = hipfftGetSizeMany64(
                     plan,
                     dim(),
                     ll_length.data(),
-                    const_cast<long long int*>(ionembed.get_nembed(fft_io::fft_io_in)),
-                    ionembed.get_elementary_stride(fft_io::fft_io_in),
-                    idist,
-                    const_cast<long long int*>(ionembed.get_nembed(fft_io::fft_io_out)),
-                    ionembed.get_elementary_stride(fft_io::fft_io_out),
-                    odist,
+                    const_cast<long long int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_in)),
+                    layout_args.istride_arg,
+                    layout_args.idist_arg,
+                    const_cast<long long int*>(
+                        layout_args.io_nembed.get_nembed(fft_io::fft_io_out)),
+                    layout_args.ostride_arg,
+                    layout_args.odist_arg,
                     *hipfft_transform_type,
                     nbatch,
                     worksize_estimate.data());
@@ -1110,18 +1113,19 @@ private:
             else
             {
                 auto executionType = get_xt_api_execution_type();
-                auto ionembed      = get_ionembed<long long int>();
+                auto layout_args   = get_advanced_layout_args<long long int>();
                 ret                = hipfftXtGetSizeMany(
                     plan,
                     dim(),
                     ll_length.data(),
-                    const_cast<long long int*>(ionembed.get_nembed(fft_io::fft_io_in)),
-                    ionembed.get_elementary_stride(fft_io::fft_io_in),
-                    idist,
+                    const_cast<long long int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_in)),
+                    layout_args.istride_arg,
+                    layout_args.idist_arg,
                     inputType,
-                    const_cast<long long int*>(ionembed.get_nembed(fft_io::fft_io_out)),
-                    ionembed.get_elementary_stride(fft_io::fft_io_out),
-                    odist,
+                    const_cast<long long int*>(
+                        layout_args.io_nembed.get_nembed(fft_io::fft_io_out)),
+                    layout_args.ostride_arg,
+                    layout_args.odist_arg,
                     outputType,
                     nbatch,
                     worksize_estimate.data(),
@@ -1294,18 +1298,19 @@ private:
     }
     hipfftResult_t create_plan_many()
     {
-        auto ionembed = get_ionembed<int>();
-        auto ret      = hipfftPlanMany(&plan,
-                                  dim(),
-                                  int_length.data(),
-                                  const_cast<int*>(ionembed.get_nembed(fft_io::fft_io_in)),
-                                  ionembed.get_elementary_stride(fft_io::fft_io_in),
-                                  idist,
-                                  const_cast<int*>(ionembed.get_nembed(fft_io::fft_io_out)),
-                                  ionembed.get_elementary_stride(fft_io::fft_io_out),
-                                  odist,
-                                  *hipfft_transform_type,
-                                  nbatch);
+        auto layout_args = get_advanced_layout_args<int>();
+        auto ret
+            = hipfftPlanMany(&plan,
+                             dim(),
+                             int_length.data(),
+                             const_cast<int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_in)),
+                             layout_args.istride_arg,
+                             layout_args.idist_arg,
+                             const_cast<int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_out)),
+                             layout_args.ostride_arg,
+                             layout_args.odist_arg,
+                             *hipfft_transform_type,
+                             nbatch);
         return ret;
     }
 
@@ -1458,19 +1463,21 @@ private:
                                                ? tmp_worksize.data()
                                                : auto_allocated_worksizes.data();
 
-        auto ionembed = get_ionembed<int>();
-        return hipfftMakePlanMany(plan,
-                                  dim(),
-                                  int_length.data(),
-                                  const_cast<int*>(ionembed.get_nembed(fft_io::fft_io_in)),
-                                  ionembed.get_elementary_stride(fft_io::fft_io_in),
-                                  idist,
-                                  const_cast<int*>(ionembed.get_nembed(fft_io::fft_io_out)),
-                                  ionembed.get_elementary_stride(fft_io::fft_io_out),
-                                  odist,
-                                  *hipfft_transform_type,
-                                  nbatch,
-                                  worksize_ptr);
+        auto layout_args = get_advanced_layout_args<int>();
+
+        return hipfftMakePlanMany(
+            plan,
+            dim(),
+            int_length.data(),
+            const_cast<int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_in)),
+            layout_args.istride_arg,
+            layout_args.idist_arg,
+            const_cast<int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_out)),
+            layout_args.ostride_arg,
+            layout_args.odist_arg,
+            *hipfft_transform_type,
+            nbatch,
+            worksize_ptr);
     }
 
     hipfftResult_t create_make_plan_many64()
@@ -1484,17 +1491,17 @@ private:
         size_t*             worksize_ptr = is_preventing_auto_allocation_at_generation()
                                                ? tmp_worksize.data()
                                                : auto_allocated_worksizes.data();
-        auto                ionembed     = get_ionembed<long long int>();
+        auto                layout_args  = get_advanced_layout_args<long long int>();
         return hipfftMakePlanMany64(
             plan,
             dim(),
             ll_length.data(),
-            const_cast<long long int*>(ionembed.get_nembed(fft_io::fft_io_in)),
-            ionembed.get_elementary_stride(fft_io::fft_io_in),
-            idist,
-            const_cast<long long int*>(ionembed.get_nembed(fft_io::fft_io_out)),
-            ionembed.get_elementary_stride(fft_io::fft_io_out),
-            odist,
+            const_cast<long long int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_in)),
+            layout_args.istride_arg,
+            layout_args.idist_arg,
+            const_cast<long long int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_out)),
+            layout_args.ostride_arg,
+            layout_args.odist_arg,
             *hipfft_transform_type,
             nbatch,
             worksize_ptr);
@@ -1535,18 +1542,18 @@ private:
                                                 ? tmp_worksize.data()
                                                 : auto_allocated_worksizes.data();
         auto                executionType = get_xt_api_execution_type();
-        auto                ionembed      = get_ionembed<long long int>();
+        auto                layout_args   = get_advanced_layout_args<long long int>();
         return hipfftXtMakePlanMany(
             plan,
             dim(),
             ll_length.data(),
-            const_cast<long long int*>(ionembed.get_nembed(fft_io::fft_io_in)),
-            ionembed.get_elementary_stride(fft_io::fft_io_in),
-            idist,
+            const_cast<long long int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_in)),
+            layout_args.istride_arg,
+            layout_args.idist_arg,
             inputType,
-            const_cast<long long int*>(ionembed.get_nembed(fft_io::fft_io_out)),
-            ionembed.get_elementary_stride(fft_io::fft_io_out),
-            odist,
+            const_cast<long long int*>(layout_args.io_nembed.get_nembed(fft_io::fft_io_out)),
+            layout_args.ostride_arg,
+            layout_args.odist_arg,
             outputType,
             nbatch,
             worksize_ptr,
@@ -1558,39 +1565,70 @@ private:
     size_t get_num_used_gpus() const
     {
         return multiGPU > 1 ? multiGPU : 1;
-    };
+    }
 
     template <
         typename T,
         std::enable_if_t<std::is_same_v<T, int> || std::is_same_v<T, long long int>, bool> = true>
-    hipfft_ionembed_t<T> get_ionembed()
+    struct advanced_layout_args
     {
-        // Allow nullptr to be use ~50% of the time it can be used to enable testing thereof.
+        hipfft_ionembed_t<T> io_nembed;
+        T                    istride_arg, ostride_arg, idist_arg, odist_arg;
+    };
+
+    template <typename T>
+    advanced_layout_args<T> get_advanced_layout_args()
+    {
+        // Allow nullptr to be used for inembed and onembed ~50% of the time it can be
+        // used to ensure testing thereof.
         // (using a hash of the token as "random" variable to avoid dependencies on
         // externally-defined variables and repeatability)
         std::hash<std::string> hasher;
         // NOTES:
         // - hipFFT requires (inembed == nullptr) == (onembed == nullptr);
         // - {i,o}stride are ignored if (inembed == nullptr) && (onembed == nullptr).
-        //   (That is accounted for by the hipfft_ionembed_t<T> objects)
+        //   (That is accounted for by the constructor of hipfft_ionembed_t<T> objects)
         // - {i,o}dist are ignored if (inembed == nullptr) && (onembed == nullptr).
-        //   (That is NOT accounted for by the hipfft_ionembed_t<T> objects which is unaware
-        //    of intended distances)
+        //   (That is NOT accounted for by the constructor of hipfft_ionembed_t<T> objects
+        //    which is unaware of intended distances)
+        auto       tmp = token();
         const bool use_nullptr_for_default_nembed
             = idist
                   == default_distance(transform_type, placement, fft_io::fft_io_in, length, nbatch)
               && odist
                      == default_distance(
                          transform_type, placement, fft_io::fft_io_out, length, nbatch)
-              && hasher(token()) % 2 == 1;
+              && hasher(tmp) % 2 == 1;
 
-        return hipfft_ionembed_t<T>(istride,
-                                    ostride,
-                                    length,
-                                    transform_type,
-                                    placement,
-                                    use_nullptr_for_default_nembed,
-                                    use_nullptr_for_default_nembed);
+        advanced_layout_args<T> ret;
+        ret.io_nembed = hipfft_ionembed_t<T>(istride,
+                                             ostride,
+                                             length,
+                                             transform_type,
+                                             placement,
+                                             use_nullptr_for_default_nembed,
+                                             use_nullptr_for_default_nembed);
+        if(!ret.io_nembed.get_nembed(fft_io::fft_io_in)
+           && !ret.io_nembed.get_nembed(fft_io::fft_io_out))
+        {
+            // istride, ostride, idist, and odist arguments are supposed to be *ignored*
+            // by hipFFT if inembed and onembed arguments are both null.
+            // --> use completely arbitrary (positive) values to test that behavior
+            std::uniform_int_distribution<T> positive_int_distr(1, std::numeric_limits<T>::max());
+            std::mt19937                     prng(hasher(tmp));
+            ret.istride_arg = positive_int_distr(prng);
+            ret.ostride_arg = positive_int_distr(prng);
+            ret.idist_arg   = positive_int_distr(prng);
+            ret.odist_arg   = positive_int_distr(prng);
+        }
+        else
+        {
+            ret.istride_arg = ret.io_nembed.get_elementary_stride(fft_io::fft_io_in);
+            ret.ostride_arg = ret.io_nembed.get_elementary_stride(fft_io::fft_io_out);
+            ret.idist_arg   = idist;
+            ret.odist_arg   = odist;
+        }
+        return ret;
     }
 };
 

--- a/projects/hipfft/shared/data_layout.h
+++ b/projects/hipfft/shared/data_layout.h
@@ -573,7 +573,7 @@ private:
 // @ elementary strides are ignored when implicit default inembed/onembed are used
 //   --> "true" template specialization value for second template arg of ionembed_t
 template <typename T>
-using hipfft_ionembed_t = ionembed_t<T, false>;
+using hipfft_ionembed_t = ionembed_t<T, true>;
 
 // in FFTW3/hipFFTW
 // @ T := int

--- a/projects/rocfft/shared/data_layout.h
+++ b/projects/rocfft/shared/data_layout.h
@@ -573,7 +573,7 @@ private:
 // @ elementary strides are ignored when implicit default inembed/onembed are used
 //   --> "true" template specialization value for second template arg of ionembed_t
 template <typename T>
-using hipfft_ionembed_t = ionembed_t<T, false>;
+using hipfft_ionembed_t = ionembed_t<T, true>;
 
 // in FFTW3/hipFFTW
 // @ T := int


### PR DESCRIPTION
## Motivation

This addresses a typo in the definition of `hipfft_ionembed_t` (introduced in https://github.com/ROCm/rocm-libraries/pull/2144), which would make hipFFT depart from its documented behavior in a corner case usage with non-unit elementary strides with null `inembed` and null `onembed`.

## Technical Details

hipFFT is supposed (_i.e._, documented) to ignore the elementary strides and distances when `inembed` and `onembed` are both null (enforcing default layouts regardless of the unit stride and distance values being used in such cases). This particularity was the motivation for introducing the `ignore_elementary_stride_if_null_nembed` [boolean parameter templating](https://github.com/ROCm/rocm-libraries/blob/5a90f5fa7fea7a9696a72fea682713b6bd74d94c/projects/hipfft/shared/data_layout.h#L216C16-L216C55) `ionembed_t`. Unfortunately,  the incorrect specialization value has been used for [hipfft_ionembed_t](https://github.com/ROCm/rocm-libraries/blob/5a90f5fa7fea7a9696a72fea682713b6bd74d94c/projects/hipfft/shared/data_layout.h#L576) as of now, due to a bad copy-paste in https://github.com/ROCm/rocm-libraries/pull/2144.

## Test Plan

This mistake has lived undetected because the corner-case behavior was omitted from testing. Changes in `hipfft_params` are suggested to cover the documented behavior: token-related pseudo-random (positive) values are generated for the  `istride`, `ostride`, `idist`, and `odist` arguments in functional tests whenever `nullptr` values are being used for `inembed` and `onembed`.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
