### PR TITLE
[hipblaslt][testing] No sharding. This'll show what tests are slow more reliably.

### DIFF
--- a/projects/hipblaslt/tensilelite/tox.ini
+++ b/projects/hipblaslt/tensilelite/tox.ini
@@ -27,7 +27,7 @@ commands =
     pip install --no-build-isolation {toxinidir}/rocisa/
     pip install pytest-cov
     invoke build-client --build-dir {toxinidir}/build_tmp {env:TENSILELITE_CLIENT_ARGS}
-    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 4 --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
+    pytest -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 1 --prebuilt-client={toxinidir}/build_tmp/tensilelite/client/tensilelite-client {posargs}
 allowlist_externals =
     mkdir
     sh


### PR DESCRIPTION
## Experiment 

Just turn off sharding. i.e. tox will only have 1 worker, not 4. The motivation is that the time reported for each test will really be the time that test is running -- no waiting for other workers using CPU resources or waiting to claim a lock. 

## Results 

Total time, 4 hr 30. Slightly slower than with 4 workers and no lock, maybe?

<img width="1686" height="113" alt="{A57015F5-64B5-4D6F-A3C0-987DCF8F8F5C}" src="https://github.com/user-attachments/assets/b53941cc-24f7-4b57-b746-c07c4a7a43c4" />


This was a new experiment and so we can see which tests are slow:

```
============================== slowest durations ===============================
4446.35s call     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/plr_zero.yaml]
1251.24s call     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_f16.yaml]
995.87s call     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_f16_sb.yaml]
933.77s call     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/dtl.yaml]
773.38s call     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml]
767.86s call     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/streamk/sk_f8gemm_quick.yaml]
632.20s call     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/streamk/sk_hgemm_race.yaml]
389.31s call     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/streamk/sk_reduction.yaml]
279.45s call     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/custom_xfp32.yaml]
```

## Conclusion

prl_zero.yaml is problematically slow. 

A related PR: https://github.com/ROCm/rocm-libraries/pull/3415 will show if the slowness is because of the C++ rand() issue with multithreading. 
