### PR TITLE
[Origami] fp4 fix

### DIFF
--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -95,8 +95,8 @@ int datatype_to_bits(data_type_t type);
  * @param type Data type
  * @return int Number of bytes
  */
-inline int data_type_to_bytes(data_type_t type) {
-  return math::safe_ceil_div(datatype_to_bits(type), 8);
+inline double data_type_to_bytes(data_type_t type) {
+  return static_cast<double>(datatype_to_bits(type)) / 8.0;
 }
 
 /**

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -272,8 +272,8 @@ static inline double compute_cvt_overhead(const problem_t& problem,
   // const double mfma_cycles = num_mfma * L_MI_bf16;
 
   // 2) Bytes (per K-slice), using ceil-div to whole bytes
-  int a_bytes = data_type_to_bytes(problem.a_dtype);
-  int b_bytes = data_type_to_bytes(problem.b_dtype);
+  auto a_bytes = data_type_to_bytes(problem.a_dtype);
+  auto b_bytes = data_type_to_bytes(problem.b_dtype);
 
   const double bytesA = static_cast<double>(wave_tile_m) * config.mt.k * a_bytes;
   const double bytesB = static_cast<double>(wave_tile_n) * config.mt.k * b_bytes;
@@ -342,10 +342,10 @@ bool check_lds_capacity(const hardware_t& hardware,
                         data_type_t a_dtype,
                         data_type_t b_dtype) {
   // A and B size
-  size_t a_loads_in_bytes = mt.mk() * data_type_to_bytes(a_dtype);
-  size_t b_loads_in_bytes = mt.nk() * data_type_to_bytes(b_dtype);
+  auto a_loads_in_bytes = mt.mk() * data_type_to_bytes(a_dtype);
+  auto b_loads_in_bytes = mt.nk() * data_type_to_bytes(b_dtype);
   // Size of those in bytes
-  size_t LDS_usage = a_loads_in_bytes + b_loads_in_bytes;
+  auto LDS_usage = a_loads_in_bytes + b_loads_in_bytes;
 
   if (LDS_usage > hardware.lds_capacity) {
     return false;  // Exceeds LDS capacity
@@ -403,11 +403,11 @@ double estimate_l2_hit(const problem_t& problem,
   l2_tile_n = std::max(std::min(workgroups_n, l2_tile_n), static_cast<size_t>(1));
 
   // Calculate memory footprint in bytes.
-  const size_t a_bytes     = static_cast<size_t>(data_type_to_bytes(problem.a_dtype));
-  const size_t b_bytes     = static_cast<size_t>(data_type_to_bytes(problem.b_dtype));
-  auto calculate_footprint = [&](size_t tile_m, size_t tile_n) {
-    size_t a_footprint = tile_m * config.mt.mk() * a_bytes;
-    size_t b_footprint = tile_n * config.mt.nk() * b_bytes;
+  const auto a_bytes     = data_type_to_bytes(problem.a_dtype);
+  const auto b_bytes     = data_type_to_bytes(problem.b_dtype);
+  auto calculate_footprint = [&](auto tile_m, auto tile_n) {
+    auto a_footprint = tile_m * config.mt.mk() * a_bytes;
+    auto b_footprint = tile_n * config.mt.nk() * b_bytes;
     return a_footprint + b_footprint;
   };
 
@@ -480,12 +480,12 @@ double estimate_mall_hit(const problem_t& problem,
   mall_tile_n = std::max(std::min(workgroups_n, mall_tile_n), static_cast<size_t>(1));
 
   // --- CRITICAL: Shrink tile to fit into MALL Capacity ---
-  const size_t a_bytes = static_cast<size_t>(data_type_to_bytes(problem.a_dtype));
-  const size_t b_bytes = static_cast<size_t>(data_type_to_bytes(problem.b_dtype));
+  const auto a_bytes = data_type_to_bytes(problem.a_dtype);
+  const auto b_bytes = data_type_to_bytes(problem.b_dtype);
 
-  auto calculate_footprint = [&](size_t tile_m, size_t tile_n) {
-    size_t a_footprint = tile_m * config.mt.mk() * a_bytes;
-    size_t b_footprint = tile_n * config.mt.nk() * b_bytes;
+  auto calculate_footprint = [&](auto tile_m, auto tile_n) {
+    auto a_footprint = tile_m * config.mt.mk() * a_bytes;
+    auto b_footprint = tile_n * config.mt.nk() * b_bytes;
     return a_footprint + b_footprint;
   };
 
@@ -533,8 +533,8 @@ double compute_l2_hit_rate_global(const problem_t& problem,
 
   // 2. Calculate the working set size for one full pass of global reuse
   // This is the data needed by one full column of CUs (for A) and one full row (for B).
-  const double a_bytes = static_cast<double>(data_type_to_bytes(problem.a_dtype));
-  const double b_bytes = static_cast<double>(data_type_to_bytes(problem.b_dtype));
+  const double a_bytes = data_type_to_bytes(problem.a_dtype);
+  const double b_bytes = data_type_to_bytes(problem.b_dtype);
 
   const double a_working_set           = static_cast<double>(grid_m * config.mt.mk()) * a_bytes;
   const double b_working_set           = static_cast<double>(grid_n * config.mt.nk()) * b_bytes;
@@ -630,8 +630,8 @@ double compute_memory_latency(const problem_t& problem,
 
   size_t Ld_A_value  = MT_M_rounded_128bytes * MT_K_rounded_128bytes;
   size_t Ld_B_value  = MT_N_rounded_128bytes * MT_K_rounded_128bytes;
-  size_t Ld_CU_bytes = (Ld_A_value * static_cast<size_t>(a_bytes))     // A Bytes
-                       + (Ld_B_value * static_cast<size_t>(b_bytes));  // B Bytes
+  auto Ld_CU_bytes = (Ld_A_value * a_bytes)     // A Bytes
+                       + (Ld_B_value * b_bytes);  // B Bytes
 
   // Logic for block scaled datatypes (Assuming BS=32 and 8-bit scales)
   // TODO This is technically wrong, need separate flag to enable MX so we can differentiate FP8
@@ -755,8 +755,7 @@ double compute_tile_latency(const problem_t& problem,
 
   const auto a_bits    = datatype_to_bits(problem.a_dtype);
   const auto b_bits    = datatype_to_bits(problem.b_dtype);
-  const size_t a_bytes = static_cast<size_t>(data_type_to_bytes(problem.a_dtype));
-  const size_t d_bytes = static_cast<size_t>(data_type_to_bytes(problem.d_dtype));
+  const auto d_bytes = data_type_to_bytes(problem.d_dtype);
 
   // 1) Compute per-tile latencies
   double L_compute = compute_mt_compute_latency(problem, hardware, config);
@@ -786,7 +785,7 @@ double compute_tile_latency(const problem_t& problem,
   size_t MT_M_rounded_128bytes = round_elements_to_128B(MT_M, datatype_to_bits(problem.a_dtype));
 
   double L_epilogue = (static_cast<double>(num_active_cus / splitting_factor) *
-                       MT_M_rounded_128bytes * MT_N * static_cast<double>(d_bytes)) /
+                       MT_M_rounded_128bytes * MT_N * d_bytes) /
                       mem_bw_occ_limited;
   // One compute iteration happens in the prologue
   L_epilogue += L_compute * effective_tile_penalty;
@@ -936,7 +935,6 @@ double compute_total_latency(const problem_t& problem,
   const int a_bits  = datatype_to_bits(problem.a_dtype);
   const int b_bits  = datatype_to_bits(problem.b_dtype);
   const int a_bytes = data_type_to_bytes(problem.a_dtype);
-  const int d_bytes = data_type_to_bytes(problem.d_dtype);
 
   if (get_runtime_options(config).debug_enabled) {
     config.logger.log(
@@ -964,8 +962,8 @@ double compute_total_latency(const problem_t& problem,
     // Use Dot2 only for M < 3
     if (MI_M == 1 && MI_N == 1 && MI_K == 64 && M > 2) return std::numeric_limits<double>::max();
 
-    size_t K_mod_128bytes    = K * a_bytes % 128;
-    size_t MT_K_mod_128bytes = MT_K * a_bytes % 128;
+    size_t K_mod_128bytes    = K * a_bits % 1024;
+    size_t MT_K_mod_128bytes = MT_K * a_bits % 1024;
     if (K_mod_128bytes == 0 && MT_K_mod_128bytes == 0) {
       // avoid division by 0 if K == 0
       if (M <= MT_M * 2 && !b_trans && ((N * b_bits) / (M * a_bits) > 5)) {
@@ -1017,7 +1015,7 @@ double compute_total_latency(const problem_t& problem,
 
     //  Heuristics for TF32
     if (tf32_emu) {
-      double bytes_per_element = static_cast<double>(a_bytes);
+      double bytes_per_element = a_bytes;
       double arith             = emulated_tf32_arithmetic_intensity(M, N, K, bytes_per_element);
       double compute_threshold = 1000;  // threshold empirically determined.
 

--- a/shared/origami/tests/test_origami.cpp
+++ b/shared/origami/tests/test_origami.cpp
@@ -115,6 +115,40 @@ TEST_CASE("Origami: best_macro_tile_size", "[origami]") {
   }
 }
 
+TEST_CASE("Origami: best_macro_tile_size mxfp4", "[origami]") {
+  for (int gpu_arch : test_architectures) {
+    DYNAMIC_SECTION("gfx" << gpu_arch << " - rank configs by latency") {
+      auto hardware = make_hardware(gpu_arch);
+      hardware.lds_capacity = 400000;
+      auto problem  = make_problem(4096, 4096, 32768);
+
+      // List 1: config A first, then config B
+      std::vector<origami::config_t> configs;
+
+      // config A[0]
+      configs.push_back(make_config(128, 128, 512, 16, 16, 128));
+      // config A[1]
+      configs.push_back(make_config(256, 256, 512, 16, 16, 128));
+      // config A[2]
+      configs.push_back(make_config(64, 64, 128, 32, 32, 64));
+
+      problem.a_dtype = origami::data_type_t::Float4;
+      problem.b_dtype = origami::data_type_t::Float4;
+      problem.a_mx_block_size = 32;
+      problem.b_mx_block_size = 32;
+
+      auto results = origami::rank_configs(problem, hardware, configs);
+
+      REQUIRE(results.size() == configs.size());
+      // Results should be ranked, so latencies should be in ascending order (best first)
+      REQUIRE(results[0].config.mt.m == 256);
+      REQUIRE(results[1].config.mt.m == 128);
+      REQUIRE(results[2].config.mt.m == 64);
+
+    }
+  }
+}
+
 TEST_CASE("Origami: select_workgroup_mapping", "[origami]") {
   for (int gpu_arch : test_architectures) {
     DYNAMIC_SECTION("gfx" << gpu_arch << " - workgroup mapping selection") {


### PR DESCRIPTION
## Motivation

The use of `data_type_to_bytes` in Origami is causing incorrect calculations in sub-byte datatypes (such as FP4). This has caused a regression in hipBLASLt performance.

## Technical Details

`data_type_to_bytes` currently returns an integer, and sub-byte datatypes sizes are rounded up to 1. This PR changes `data_type_to_bytes` to return a `double`, so FP4 will be represented as `0.5` bytes.

## Test Plan

A new test was added to check for a few FP4 calculations of `rank_configs`. #3301 should also be updated to added some more fp4 unit tests.

## Test Result

All Origami tests passing locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
