### PR TITLE
[hipblaslt] Enable fp64 compute type support in solution validation

### DIFF
--- a/projects/hipblaslt/clients/tests/data/matmul_common.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_common.yaml
@@ -68,12 +68,14 @@ Definitions:
 
   - &grid_limit_matrix_size_double
     - { M: 2, N: 1048576, K:1 }
+    - { M: 3, N: 2, K: 1, lda: 4, ldb: 5, ldc: 6, ldd: 6}
     - { M: 64, N: 1048576, K: 1 }
     - { M: 256, N: 1048576, K: 1 }
     - { M: 1024, N: 524288, K: 1 }
     - { M: 2048, N: 262144, K: 1 }
     - { M: 3072, N: 131072, K: 1 }
     - { M: 4096, N: 131072, K: 1 }
+
 
   - &deepbench_sizes
     - { M: 192, N: 64, K: 784 }

--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -160,6 +160,7 @@ Tests:
   transA_transB: *transA_transB_range
   alpha: 1
   beta: 0
+  api_method: [0, 2]
   gpu_arch: '120[0-1]'
 
 - name: matmul_deepbench

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -4066,6 +4066,12 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle              handle,
                                    std::get_if<float>(&data->inputs.alpha),
                                    std::get_if<float>(&data->inputs.beta));
         }
+        else if (data->problem.computeType() == rocisa::DataType::Double)
+        {
+            setRestrictions<double>(data->problem,
+                                   std::get_if<double>(&data->inputs.alpha),
+                                   std::get_if<double>(&data->inputs.beta));
+        }
         else
         {
             return rocblaslt_status_not_implemented;
@@ -4085,6 +4091,16 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle              handle,
                 setRestrictions<float>(tensile_prob,
                                        std::get_if<float>(&data->inputs.grouped[i].alpha),
                                        std::get_if<float>(&data->inputs.grouped[i].beta));
+            }
+        }
+        else if (data->problem.gemms[0].computeType() == rocisa::DataType::Double)
+        {
+            for(int i = 0; i < data->problem.gemms.size(); i++)
+            {
+                auto& tensile_prob = data->problem.gemms[i];
+                setRestrictions<double>(tensile_prob,
+                                       std::get_if<double>(&data->inputs.grouped[i].alpha),
+                                       std::get_if<double>(&data->inputs.grouped[i].beta));
             }
         }
         else

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -4049,6 +4049,23 @@ void setRestrictions(TensileLite::ContractionProblemGemm& tensile_prob,
     tensile_prob.setBetaRestriction(TensileLite::toScalarValueEnum(*beta));
 }
 
+
+// Centralized type dispatch: maps rocisa::DataType to a pointer tag.
+template <typename F>
+rocblaslt_status dispatchByComputeType(rocisa::DataType dt, F&& f)
+{
+    switch (dt)
+    {
+    case rocisa::DataType::Float:
+        return f(static_cast<float*>(nullptr));
+    case rocisa::DataType::Double:
+        return f(static_cast<double*>(nullptr));
+    // Extend as needed:
+    default:
+        return rocblaslt_status_not_implemented;
+    }
+}
+
 template <typename Tuning>
 rocblaslt_status isSolutionSupported(rocblaslt_handle              handle,
                                      const rocblaslt::RocGemmType& gemmType,
@@ -4057,58 +4074,70 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle              handle,
                                      const Tuning*                 tuning,
                                      size_t&                       workspaceSizeInBytes)
 {
+    if (!gemmData)
+        return rocblaslt_status_invalid_pointer;
     if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GEMM)
     {
-        std::shared_ptr<TensileDataGemm> data = std::static_pointer_cast<TensileDataGemm>(gemmData);
-        if(data->problem.computeType() == rocisa::DataType::Float)
-        {
-            setRestrictions<float>(data->problem,
-                                   std::get_if<float>(&data->inputs.alpha),
-                                   std::get_if<float>(&data->inputs.beta));
-        }
-        else if (data->problem.computeType() == rocisa::DataType::Double)
-        {
-            setRestrictions<double>(data->problem,
-                                   std::get_if<double>(&data->inputs.alpha),
-                                   std::get_if<double>(&data->inputs.beta));
-        }
-        else
-        {
-            return rocblaslt_status_not_implemented;
-        }
-        return isSolutionSupported(
-            handle, data->problem, data->inputs, &algo, tuning, &workspaceSizeInBytes);
+        auto data = std::static_pointer_cast<TensileDataGemm>(gemmData);
+        if (!data)
+            return rocblaslt_status_invalid_pointer;
+
+        auto checkSupportForTypeTag = [&](auto tag) -> rocblaslt_status {
+            using T = std::remove_pointer_t<decltype(tag)>;
+
+            const T* a = std::get_if<T>(&data->inputs.alpha);
+            const T* b = std::get_if<T>(&data->inputs.beta);
+            if (!a || !b)
+                return rocblaslt_status_not_implemented;
+
+            setRestrictions<T>(data->problem, a, b);
+
+            return isSolutionSupported(handle, data->problem, data->inputs, &algo, tuning, &workspaceSizeInBytes);
+        };
+
+        return dispatchByComputeType(data->problem.computeType(), checkSupportForTypeTag);
     }
     else if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GROUPED_GEMM)
     {
-        std::shared_ptr<TensileDataGroupedGemm> data
-            = std::static_pointer_cast<TensileDataGroupedGemm>(gemmData);
-        if(data->problem.gemms[0].computeType() == rocisa::DataType::Float)
+       auto data = std::static_pointer_cast<TensileDataGroupedGemm>(gemmData);
+        if (!data)
+            return rocblaslt_status_invalid_pointer;
+
+        if (data->problem.gemms.empty())
+            return rocblaslt_status_invalid_size;
+
+        const rocisa::DataType dt = data->problem.gemms[0].computeType();
+
+        // If mixed compute types are unsupported, enforce uniformity.
+        for (const auto& p : data->problem.gemms)
         {
-            for(int i = 0; i < data->problem.gemms.size(); i++)
+            if (p.computeType() != dt)
+                return rocblaslt_status_not_implemented;
+        }
+
+        auto checkGroupedSupportForTypeTag = [&](auto tag) -> rocblaslt_status {
+            using T = std::remove_pointer_t<decltype(tag)>;
+
+            if (data->problem.gemms.size() != data->inputs.grouped.size())
+                return rocblaslt_status_invalid_size;
+
+            for (size_t i = 0; i < data->problem.gemms.size(); ++i)
             {
-                auto& tensile_prob = data->problem.gemms[i];
-                setRestrictions<float>(tensile_prob,
-                                       std::get_if<float>(&data->inputs.grouped[i].alpha),
-                                       std::get_if<float>(&data->inputs.grouped[i].beta));
+                TensileLite::ContractionProblemGemm& prob = data->problem.gemms[i];
+                const TensileLite::ContractionInputs& in   = data->inputs.grouped[i];
+
+                const T* a = std::get_if<T>(&in.alpha);
+                const T* b = std::get_if<T>(&in.beta);
+                if (!a || !b)
+                    return rocblaslt_status_not_implemented;
+
+                setRestrictions<T>(prob, a, b);
             }
-        }
-        else if (data->problem.gemms[0].computeType() == rocisa::DataType::Double)
-        {
-            for(int i = 0; i < data->problem.gemms.size(); i++)
-            {
-                auto& tensile_prob = data->problem.gemms[i];
-                setRestrictions<double>(tensile_prob,
-                                       std::get_if<double>(&data->inputs.grouped[i].alpha),
-                                       std::get_if<double>(&data->inputs.grouped[i].beta));
-            }
-        }
-        else
-        {
-            return rocblaslt_status_not_implemented;
-        }
-        return isSolutionSupported(
-            handle, data->problem, data->inputs, &algo, tuning, &workspaceSizeInBytes);
+
+            return isSolutionSupported(handle, data->problem, data->inputs, &algo, tuning, &workspaceSizeInBytes);
+        };
+
+        return dispatchByComputeType(dt, checkGroupedSupportForTypeTag);
     }
     return rocblaslt_status_not_implemented;
 }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Currently, solutions with compute type = fp64 (Double) are skipped in `isSolutionSupported`, meaning GEMM and Grouped GEMM paths cannot validate or apply restrictions for fp64. This limits functionality for workloads requiring double precision.
The goal of this change is to enable fp64 support by ensuring the solution validation logic handles Double compute type consistently with other types.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Centralized compute-type handling into a single dispatch mechanism to avoid duplicated logic for Float and Double.
- Extended the dispatch to include fp64 (Double) so restrictions and solution checks apply correctly.
- Updated GEMM and Grouped GEMM flows to:
  - Apply alpha/beta restrictions for fp64.
  - Validate inputs and delegate to the existing solution-checking logic.
- Added guards for grouped GEMM:
  - Ensure uniform compute type across all gemms.
  - Validate size consistency between gemms and grouped inputs.
- This design also makes it easy to add future types by extending the dispatch logic.
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Local rocblas-test with the failed case.
- CI/CD

## Test Result

<!-- Briefly summarize test outcomes. -->
**Local rocblas-test with the fail case. -> pass**
`./rocblas-test --gtest_filter='*quick_logging_mode_internal_f64_r_hostptr*'`
<img width="647" height="167" alt="image" src="https://github.com/user-attachments/assets/f26f4d26-d6bf-4828-b035-b637942ac320" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
