### PR TITLE
[rocPRIM] Add gfx1151 target arch details

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/config.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/config.hpp
@@ -169,6 +169,7 @@
         __builtin_amdgcn_processor_is("gfx1100") || __builtin_amdgcn_processor_is("gfx1101") \
             || __builtin_amdgcn_processor_is("gfx1102")                                      \
             || __builtin_amdgcn_processor_is("gfx1103")                                      \
+            || __builtin_amdgcn_processor_is("gfx1151")                                      \
             || __builtin_amdgcn_processor_is("gfx1152")                                      \
             || __builtin_amdgcn_processor_is("gfx1153")                                      \
             || __builtin_amdgcn_processor_is("gfx11-generic")

--- a/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/config_types.hpp
@@ -173,6 +173,7 @@ enum class target_arch : unsigned int
     gfx1030 = 1030,
     gfx1100 = 1100,
     gfx1102 = 1102,
+    gfx1151 = 1151,
     gfx1152 = 1152,
     gfx1153 = 1153,
     gfx1200 = 1200,
@@ -224,6 +225,7 @@ constexpr auto target_arch_descriptors = std::array{
     X(gfx1030),
     X(gfx1100),
     X(gfx1102),
+    X(gfx1151),
     X(gfx1152),
     X(gfx1153),
     X(gfx1200),
@@ -271,6 +273,7 @@ constexpr arch::wavefront::target arch_wavefront_size(const target_arch target_a
         case target_arch::gfx1030: return arch::wavefront::target::size32;
         case target_arch::gfx1100: return arch::wavefront::target::size32;
         case target_arch::gfx1102: return arch::wavefront::target::size32;
+        case target_arch::gfx1151: return arch::wavefront::target::size32;
         case target_arch::gfx1152: return arch::wavefront::target::size32;
         case target_arch::gfx1153: return arch::wavefront::target::size32;
         case target_arch::gfx1200: return arch::wavefront::target::size32;
@@ -505,6 +508,7 @@ auto dispatch_target_arch([[maybe_unused]] const target_arch target_arch)
             X(gfx1030);
             X(gfx1100);
             X(gfx1102);
+            X(gfx1151);
             X(gfx1152);
             X(gfx1153);
             X(gfx1200);


### PR DESCRIPTION
## Motivation

Previously we added the gfx1151 build target to rocPRIM's CMakeLists.txt, but hadn't yet added the target_arch enum definition, wavefront size details, etc. This change adds in those remaining details.

## Technical Details

Adds gfx1151 to the necessary locations in config.hpp and config_types.hpp.
We don't yet have any tuning configs for gfx1151, but when we do, this will be
needed in order to pick them up.

## Test Plan

Build rocPRIM with cmake option -DAMDGPU_TARGETS=gfx1151. Then build tests and benchmarks. Ensure everything builds correctly.

## Test Result

The build succeeds.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
