### PR TITLE
[hipblaslt] [CMS] Enable most CMS validator passes for TF32 

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -467,6 +467,16 @@ class Timeline:
             num_iterations:             Number of iterations to consider for cross-iteration effects (default 2).
         """
         
+        available_keys = schedule_info.optSchedule.keys()
+        if "LRA1" in available_keys:
+            assert "LRA3" not in available_keys, "LRA1 and LRA3 cannot both be present in the schedule."
+        if "LRA3" in available_keys:
+            assert "LRA1" not in available_keys, "LRA1 and LRA3 cannot both be present in the schedule."
+        if "LRB1" in available_keys:
+            assert "LRB3" not in available_keys, "LRB1 and LRB3 cannot both be present in the schedule."
+        if "LRB3" in available_keys:
+            assert "LRB1" not in available_keys, "LRB1 and LRB3 cannot both be present in the schedule."
+
         self.num_vmfma = schedule_info.numMfma
         self.vlcnt_shift = defaultdict(int)
         self.vlcnt_shift[NO_GLOBAL_LOAD_LOOP] = schedule_info.nglshift
@@ -733,19 +743,24 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution') -> None:
                 lr.needed_by = base_needed_by + loop_offset
 
 
-def set_gr_needed_by_from_lr1s(timeline: Timeline, swap_global_read_order: bool) -> None:
+def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) -> None:
     """
-    Set the needed_by field of GlobalReads based on the LRA1/LRB1 instructions.
+    Set the needed_by field of GlobalReads based on the LR1/3 instructions.
     If GRA or GRB is missing, this function will NOT error out.
-    If either GRA or GRB is present, the corresponding LR1 instruction must be present.
+    If either GRA or GRB is present, the corresponding LR1/3 instruction must be present.
     
     Args:
         timeline: The Timeline object containing the instructions.
         swap_global_read_order: Whether global read order is swapped.
     """
     # If the global read order is swapped, we need to swap the target indices since GRAs actually load B and GRBs actually load A.
-    # TODO: Hardcoded for now, can't support LRA3/LRB3 yet.
     target_names = {"GRA": "LRA1", "GRB": "LRB1"}
+    
+    if "LRA1" not in timeline.get_instruction_names():
+        assert "LRA3" in timeline.get_instruction_names(), "LRA3 must be present if LRA1 is not"
+        target_names["GRA"] = "LRA3"
+        target_names["GRB"] = "LRB3"
+    
     if swap_global_read_order:
         target_names["GRA"], target_names["GRB"] = target_names["GRB"], target_names["GRA"]
 
@@ -975,28 +990,16 @@ def verify_gr_inc_order(scheduleInfo, context: dict, code_path: int) -> tuple[bo
 
     return True, ""
 
-def verify_grs_finish_before_lr1s(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
+def verify_grs_finish_before_lrs(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
-    Ensure that the GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LRA1/LRB1 of this iteration.
+    Ensure that the GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LR1/3 of this iteration.
     """
-    if context.get("kernel", {}).get("UseF32XEmulation", False):
-        message = "CMS validation is currently disabled for F32X emulation"
-        printWarning(f"{message}")
-        return True, message
-    available_keys = schedule_info.optSchedule.keys()
-    if "LRA1" not in available_keys and "LRA3" in available_keys:
-        printWarning("LRA3 is present in schedule, but LRA1 is not. This is not yet supported in CMS validation")
-        return True, ""
-    if "LRB1" not in available_keys and "LRB3" in available_keys:
-        printWarning("LRB3 is present in schedule, but LRB1 is not. This is not yet supported in CMS validation")
-        return True, ""
-
-    relevant_names = ["GRA", "GRB", "LRA1", "LRB1", "SYNC"]
+    relevant_names = ["GRA", "GRB", "LRA1", "LRB1", "LRA3", "LRB3", "SYNC"]
     kernel = context["kernel"]
     timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
     
     # Apply standalone functions to populate timeline fields
-    set_gr_needed_by_from_lr1s(timeline, kernel["SwapGlobalReadOrder"])
+    set_gr_needed_by_from_lrs(timeline, kernel["SwapGlobalReadOrder"])
     apply_swaits(timeline)
     apply_barriers(timeline)
 
@@ -1116,7 +1119,7 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
         verify_ascending_order,
         verify_lrs_finished_before_vmfma,
         verify_global_reads_not_too_early,
-        verify_grs_finish_before_lr1s,
+        verify_grs_finish_before_lrs,
         verify_scc_overlap,
         verify_gr_inc_order
     ]

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -242,6 +242,10 @@ def verify_global_reads_not_too_early(scheduleInfo, context: dict, code_path: in
     constraints between LRA0 and GRB, or between LRB0 and GRA, because the LDS
     used for A and B are completely separate.
     """
+    if context.get("kernel", {}).get("UseF32XEmulation", False):
+        message = "CMS validation is currently disabled for F32X emulation"
+        printWarning(f"{message}")
+        return True, message
 
     # Get the relative order of the relevant operations within a vmfma index.
     positions = {
@@ -975,6 +979,10 @@ def verify_grs_finish_before_lr1s(schedule_info: 'ScheduleInfo', context: dict, 
     """
     Ensure that the GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LRA1/LRB1 of this iteration.
     """
+    if context.get("kernel", {}).get("UseF32XEmulation", False):
+        message = "CMS validation is currently disabled for F32X emulation"
+        printWarning(f"{message}")
+        return True, message
     available_keys = schedule_info.optSchedule.keys()
     if "LRA1" not in available_keys and "LRA3" in available_keys:
         printWarning("LRA3 is present in schedule, but LRA1 is not. This is not yet supported in CMS validation")
@@ -1002,6 +1010,10 @@ def verify_lrs_finished_before_vmfma(schedule_info: 'ScheduleInfo', context: dic
     """
     Ensure that the LocalReads are guaranteed to be complete before the first VMFMA that uses their data.
     """
+    if context.get("kernel", {}).get("UseF32XEmulation", False):
+        message = "CMS validation is currently disabled for F32X emulation"
+        printWarning(f"{message}")
+        return True, message
     if len(schedule_info.mfmaReorder) != 0:
         printWarning("CMS Validation does not currently support mfmaReorder, cannot guarantee that LRs will be correct.")
         return True, ""
@@ -1083,13 +1095,6 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
     Note 2: if False is returned, this is not proof that the schedule
     is invalid. It may be a false positive.
     """
-
-    # Cases where validation is not currently possible.
-    if context.get("kernel", {}).get("UseF32XEmulation", False):
-        message = "CMS validation is currently disabled for F32X emulation"
-        printWarning(f"{message}")
-        return True, message
-
     # Case where there was an explicit request to skip validation.
     if scheduleInfo.__skipValidation__:
         mt0 = context.get("kernel", {}).get("MacroTile0", "?")

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -464,20 +464,9 @@ class Timeline:
         """
         
         available_keys = schedule_info.optSchedule.keys()
-        if "LRA1" in available_keys:
-            assert "LRA3" not in available_keys, "LRA1 and LRA3 cannot both be present in the schedule."
-        elif "LRA3" in available_keys:
-            assert "LRA1" not in available_keys, "LRA1 and LRA3 cannot both be present in the schedule."
-
-        if "LRB1" in available_keys:
-            assert "LRB3" not in available_keys, "LRB1 and LRB3 cannot both be present in the schedule."
-        elif "LRB3" in available_keys:
-            assert "LRB1" not in available_keys, "LRB1 and LRB3 cannot both be present in the schedule."
-        
-        if "LRA1" in available_keys:
-            assert "LRB3" not in available_keys, "Can't mix LR1s and LR3s."
-        if "LRB1" in available_keys:
-            assert "LRA3" not in available_keys, "Can't mix LR1s and LR3s."
+        has_lr1s = "LRA1" in available_keys or "LRB1" in available_keys
+        has_lr3s = "LRA3" in available_keys or "LRB3" in available_keys
+        assert not (has_lr1s and has_lr3s), "Can't mix LR1s and LR3s."
 
         self.num_vmfma = schedule_info.numMfma
         self.vlcnt_shift = defaultdict(int)

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1015,10 +1015,11 @@ def verify_lrs_finished_before_vmfma(schedule_info: 'ScheduleInfo', context: dic
     """
     Ensure that the LocalReads are guaranteed to be complete before the first VMFMA that uses their data.
     """
-    if context.get("kernel", {}).get("UseF32XEmulation", False):
-        message = "CMS validation is currently disabled for F32X emulation"
+    if context.get("kernel", {}).get("UseF32XEmulation", False) or context.get("kernel", {}).get("ForceUnrollSubIter", False):
+        message = "LR completion before vmfma validation is disabled for F32X emulation or ForceUnrollSubIter"
         printWarning(f"{message}")
         return True, message
+    
     if len(schedule_info.mfmaReorder) != 0:
         printWarning("CMS Validation does not currently support mfmaReorder, cannot guarantee that LRs will be correct.")
         return True, ""

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -465,12 +465,18 @@ class Timeline:
         available_keys = schedule_info.optSchedule.keys()
         if "LRA1" in available_keys:
             assert "LRA3" not in available_keys, "LRA1 and LRA3 cannot both be present in the schedule."
-        if "LRA3" in available_keys:
+        elif "LRA3" in available_keys:
             assert "LRA1" not in available_keys, "LRA1 and LRA3 cannot both be present in the schedule."
+
         if "LRB1" in available_keys:
             assert "LRB3" not in available_keys, "LRB1 and LRB3 cannot both be present in the schedule."
-        if "LRB3" in available_keys:
+        elif "LRB3" in available_keys:
             assert "LRB1" not in available_keys, "LRB1 and LRB3 cannot both be present in the schedule."
+        
+        if "LRA1" in available_keys:
+            assert "LRB3" not in available_keys, "Can't mix LR1s and LR3s."
+        if "LRB1" in available_keys:
+            assert "LRA3" not in available_keys, "Can't mix LR1s and LR3s."
 
         self.num_vmfma = schedule_info.numMfma
         self.vlcnt_shift = defaultdict(int)

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -242,11 +242,6 @@ def verify_global_reads_not_too_early(scheduleInfo, context: dict, code_path: in
     constraints between LRA0 and GRB, or between LRB0 and GRA, because the LDS
     used for A and B are completely separate.
     """
-    if context.get("kernel", {}).get("UseF32XEmulation", False):
-        message = "CMS validation is currently disabled for F32X emulation"
-        printWarning(f"{message}")
-        return True, message
-
     # Get the relative order of the relevant operations within a vmfma index.
     positions = {
         "SYNC": -1,

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -242,6 +242,7 @@ def verify_global_reads_not_too_early(scheduleInfo, context: dict, code_path: in
     constraints between LRA0 and GRB, or between LRB0 and GRA, because the LDS
     used for A and B are completely separate.
     """
+
     # Get the relative order of the relevant operations within a vmfma index.
     positions = {
         "SYNC": -1,

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -603,7 +603,7 @@ class TestCustomScheduleValidation:
         # Create what should be an invalid schedule:
         invalid_schedule = {"P": [[3, 2, 1]]}
         scheduleInfo = ScheduleInfo(
-            None, None, invalid_schedule, None, None, None, None
+            1, None, invalid_schedule, None, None, None, None
         )
         # Verify that this invalid schedule passes when this specific flag is true.
         # Currently a warning message is printed.

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -71,7 +71,7 @@ def create_base_kernel():
     }
     return kernel
 
-class TestCustomSchedule:
+class TestCustomScheduleBF16:
     def test_no_custom_schedule(self):
         """Test that a kernel that doesn't match any condition returns False."""
         kernel = create_base_kernel()
@@ -544,6 +544,33 @@ class TestCustomSchedule:
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 56
         valid, message = isValid(schedule_info, {"kernel" : kernel})
+        assert valid, message
+
+
+class TestCustomScheduleTF32:
+    def test_schedule_192x256x32_TF32(self):
+        """Tests the 192x256x32 TF32 TN schedule."""
+        kernel = create_base_kernel()
+        kernel["ProblemType"].update({
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "UseF32XEmulation": True,
+            "MacroTile0": 192, "MacroTile1": 256, "DepthU": 32,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
+            "DirectToLds": True,
+            "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,
+            "MatrixInstruction": [16, 16, 32, 1], "MIWaveGroup": [2, 2],
+            "LDSTrInst": False, "TransposeLDS": 1, "MIWaveTileA": 6, "MIWaveTileB": 8,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 144
+        assert kernel["UsePLRPack"]
+        valid, message = isValid(schedule_info, {"kernel": kernel})
         assert valid, message
 
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -598,17 +598,3 @@ class TestCustomScheduleValidation:
         )
         assert status == False
 
-    def test_f32_emulation_disabled(self):
-        kernel = create_base_kernel()
-        # Create what should be an invalid schedule:
-        invalid_schedule = {"P": [[3, 2, 1]]}
-        scheduleInfo = ScheduleInfo(
-            1, None, invalid_schedule, None, None, None, None
-        )
-        # Verify that this invalid schedule passes when this specific flag is true.
-        # Currently a warning message is printed.
-        status, message = isValid(scheduleInfo, {"kernel": {"UseF32XEmulation": True}})
-        assert status == True
-        assert message == "CMS validation is currently disabled for F32X emulation"
-
-

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
@@ -24,12 +24,12 @@
 ################################################################################
 from rocisa.instruction import SWaitCnt, SBarrier
 
-from Tensile.Components.CMSValidator import verify_grs_finish_before_lr1s
+from Tensile.Components.CMSValidator import verify_grs_finish_before_lrs
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
     def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_grs_finish_before_lr1s(sched, kernel_dict, codePathIdx)
+        return verify_grs_finish_before_lrs(sched, kernel_dict, codePathIdx)
 
     def test_simple_case_success(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -22,12 +22,12 @@
 
 from rocisa.instruction import SWaitCnt, SBarrier
 
-from Tensile.Components.CMSValidator import verify_grs_finish_before_lr1s, verify_lrs_finished_before_vmfma
+from Tensile.Components.CMSValidator import verify_grs_finish_before_lrs, verify_lrs_finished_before_vmfma
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateNgl(CMSValidationTestBase):
     def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_grs_finish_before_lr1s(sched, kernel_dict, codePathIdx)
+        return verify_grs_finish_before_lrs(sched, kernel_dict, codePathIdx)
 
     def make_simple_schedule_and_sync(self) -> tuple[dict[str, list[list[int]]], list[SWaitCnt | SBarrier]]:
         """


### PR DESCRIPTION
## Motivation

Most of our validators are ready to be enabled for TF32 (only the LR validation needs more work). Enable those now while working on the rest.

## Technical Details

1. Move TF32 disable check inside the validator pass that isn't yet implemented.
2. Minor rework of verify_grs_finish_before_lr1s to work for TF32.

## Test Plan

Run existing tests.

## Test Result

Passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
