### PR TITLE
[hipblaslt][tensilelite] Simple parallelization experiment: cpu_count = 1

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/Parallel.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/Parallel.py
@@ -53,7 +53,7 @@ def CPUThreadCount(enable=True):
             # is actually 64, but some handles are needed for accounting).
             cpu_count = min(os.cpu_count(), 61)
         else:
-            cpu_count = len(os.sched_getaffinity(0))
+            cpu_count = 1 # len(os.sched_getaffinity(0))
         cpuThreads = globalParameters["CpuThreads"]
         if cpuThreads == -1:
             return cpu_count


### PR DESCRIPTION
## Experiment 

Eliminate parallelization of hipcc across different kernels, and kernel generation. 

## Results

<img width="1667" height="109" alt="{5F11259C-47E6-498E-8845-84D3FDC587B2}" src="https://github.com/user-attachments/assets/9c69d91d-981f-480e-a0b9-96c276b3cc15" />

## Conclusion

Not much change -- this parallelization doesn't provide as big gains. 