### PR TITLE
[hipDNN] Update test and coverage targets.

### DIFF
--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -274,22 +274,22 @@ if(HIPDNN_ENABLE_COVERAGE)
             WARNING
                 "\nThe code coverage targets depend on test targets but test targets don't exist because HIP_DNN_SKIP_TESTS is enabled."
         )
-    endif()
+    else()
+        add_custom_coverage_target(code_coverage check) # code_coverage depends on 'check'
+        add_custom_coverage_target(unit-coverage unit-check) # unit-coverage depends on 'unit-check'
+        add_custom_coverage_target(integration-coverage integration-check) # ... 'integration-check'
 
-    add_custom_coverage_target(code_coverage check) # code_coverage depends on 'check'
-    add_custom_coverage_target(unit-coverage unit-check) # unit-coverage depends on 'unit-check'
-    add_custom_coverage_target(integration-coverage integration-check) # unit-coverage depends on
-                                                                       # 'unit-check'
+        # Make alias to target coverage
+        add_custom_target(
+            coverage DEPENDS code_coverage COMMENT "Alias for code_coverage to match mathci"
+        )
+    endif()
 
     # Create a coverage target that does not depend on any other target and will use the coverage
     # data that already exists on disk from prior / manual target runs performed before this target
     # is run.
     add_custom_coverage_target(current-coverage "")
 
-    # Make alias to target coverage
-    add_custom_target(
-        coverage DEPENDS code_coverage COMMENT "Alias for code_coverage to match mathci"
-    )
 endif()
 
 if(NOT HIP_DNN_SKIP_TESTS)

--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -132,6 +132,7 @@ include(cmake/Tests.cmake)
 set(EXTRA_COMPILE_OPTIONS)
 set(EXTRA_LINK_OPTIONS)
 if(HIPDNN_ENABLE_COVERAGE)
+    message(VERBOSE "Enabling compile flags for coverage-mapping")
     list(PREPEND EXTRA_COMPILE_OPTIONS -fprofile-instr-generate -fcoverage-mapping)
     list(PREPEND EXTRA_LINK_OPTIONS -fprofile-instr-generate -fcoverage-mapping)
 endif()
@@ -184,18 +185,10 @@ if(HIP_DNN_BUILD_PLUGINS)
     add_subdirectory(plugins)
 endif()
 
-# keep this after all build folder have been added so they have a chance to register their tests
-# using append_test_to_check_target
-
 if(NOT HIP_DNN_SKIP_TESTS)
-    create_test_name_validation_target()
-
-    finalize_custom_check_target()
-    finalize_unit_check_target()
-    finalize_integration_check_target()
-
-    add_dependencies(check validate_test_names)
-    add_dependencies(check_ctest validate_test_names)
+    # keep this after all build folder have been added so they have a chance to register their tests
+    # using append_test_to_check_target
+    finalize_test_targets()
 endif()
 
 # keep this after all the targets have been added that could use the HIP language compiler.
@@ -234,31 +227,69 @@ if(HIPDNN_ENABLE_COVERAGE)
         ${MIOPEN_PLUGIN_CODE_COVERAGE_OBJECT}
     )
 
-    add_custom_target(
-        code_coverage
-        COMMAND find . -name \"*.profraw\" -print0 | xargs -0 ${LLVM_PROFDATA_BINARY} merge -sparse
-                -o ./coverage_report/hipdnn.profdata
-        COMMAND
-            ${LLVM_COV_BINARY} report ${CODE_COVERAGE_OBJECTS}
-            -instr-profile=./coverage_report/hipdnn.profdata
-            -ignore-filename-regex=\"${CODE_COVERAGE_IGNORE_REGEX}\" >
-            ./coverage_report/code_cov_hipdnn.report
-        COMMAND
-            ${LLVM_COV_BINARY} show -Xdemangler=${LLVM_CXXFILT_BINARY} ${CODE_COVERAGE_OBJECTS}
-            -instr-profile=./coverage_report/hipdnn.profdata
-            -ignore-filename-regex=\"${CODE_COVERAGE_IGNORE_REGEX}\" --format=html
-            --output-dir=coverage_report
-        COMMAND
-            ${LLVM_COV_BINARY} export ${CODE_COVERAGE_OBJECTS}
-            -instr-profile=./coverage_report/hipdnn.profdata --format=lcov >
-            ./coverage_report/coverage.info
-        DEPENDS check
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMENT "Generating code coverage report"
-    )
+    # Helper function to create a code coverage target
+    # ~~~
+    # Parameters:
+    #   TARGET_NAME - Name of the coverage target to create
+    #   DEPENDS_TARGET - The target that must be built before generating
+    #                    coverage (required, use "" for no dependency)
+    # ~~~
+    function(add_custom_coverage_target TARGET_NAME DEPENDS_TARGET)
+        # Build the DEPENDS clause
+        set(DEPENDS_CLAUSE "")
+        if(NOT "${DEPENDS_TARGET}" STREQUAL "")
+            set(DEPENDS_CLAUSE DEPENDS ${DEPENDS_TARGET})
+        endif()
+
+        # cmake-format: off
+        add_custom_target(
+            ${TARGET_NAME}
+            COMMAND find . -name "*.profraw" -print0 | xargs -0 ${LLVM_PROFDATA_BINARY} merge
+                    -sparse -o ./coverage_report/hipdnn.profdata
+            COMMAND
+                ${LLVM_COV_BINARY} report ${CODE_COVERAGE_OBJECTS}
+                -instr-profile=./coverage_report/hipdnn.profdata
+                -ignore-filename-regex=\"${CODE_COVERAGE_IGNORE_REGEX}\" >
+                ./coverage_report/code_cov_hipdnn.report
+            COMMAND
+                ${LLVM_COV_BINARY} show -Xdemangler=${LLVM_CXXFILT_BINARY} ${CODE_COVERAGE_OBJECTS}
+                -instr-profile=./coverage_report/hipdnn.profdata
+                -ignore-filename-regex=\"${CODE_COVERAGE_IGNORE_REGEX}\" --format=html
+                --output-dir=coverage_report
+            COMMAND
+                ${LLVM_COV_BINARY} export ${CODE_COVERAGE_OBJECTS}
+                -instr-profile=./coverage_report/hipdnn.profdata --format=lcov >
+                ./coverage_report/coverage.info
+            ${DEPENDS_CLAUSE}
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            COMMENT "Generating code coverage report"
+            VERBATIM
+            USES_TERMINAL
+        )
+        # cmake-format: on
+    endfunction()
+
+    if(HIP_DNN_SKIP_TESTS)
+        message(
+            WARNING
+                "\nThe code coverage targets depend on test targets but test targets don't exist because HIP_DNN_SKIP_TESTS is enabled."
+        )
+    endif()
+
+    add_custom_coverage_target(code_coverage check) # code_coverage depends on 'check'
+    add_custom_coverage_target(unit-coverage unit-check) # unit-coverage depends on 'unit-check'
+    add_custom_coverage_target(integration-coverage integration-check) # unit-coverage depends on
+                                                                       # 'unit-check'
+
+    # Create a coverage target that does not depend on any other target and will use the coverage
+    # data that already exists on disk from prior / manual target runs performed before this target
+    # is run.
+    add_custom_coverage_target(current-coverage "")
 
     # Make alias to target coverage
-    add_custom_target(coverage DEPENDS code_coverage COMMENT "Alias to match mathci")
+    add_custom_target(
+        coverage DEPENDS code_coverage COMMENT "Alias for code_coverage to match mathci"
+    )
 endif()
 
 if(NOT HIP_DNN_SKIP_TESTS)

--- a/projects/hipdnn/CMakePresets.json
+++ b/projects/hipdnn/CMakePresets.json
@@ -121,7 +121,7 @@
       "inherits": ["base-test"],
       "filter": {
         "include": {
-          "name": "hipdnn_backend_tests|hipdnn_frontend_tests|hipdnn_sdk_tests|hipdnn_plugin_sdk_tests|miopen_legacy_plugin_tests|hipdnn_test_sdk_tests"
+          "name": "hipdnn_backend_tests|hipdnn_data_sdk_tests|hipdnn_frontend_tests|hipdnn_plugin_sdk_tests|miopen_legacy_plugin_tests|hipdnn_sdk_tests|hipdnn_test_sdk_tests"
         }
       },
       "execution": {
@@ -135,7 +135,7 @@
       "inherits": ["base-test"],
       "filter": {
         "include": {
-          "name": "hipdnn_backend_tests|hipdnn_frontend_tests|hipdnn_sdk_tests|hipdnn_plugin_sdk_tests|miopen_legacy_plugin_tests|hipdnn_test_sdk_tests"
+          "name": "hipdnn_backend_tests|hipdnn_data_sdk_tests|hipdnn_frontend_tests|hipdnn_plugin_sdk_tests|miopen_legacy_plugin_tests|hipdnn_sdk_tests|hipdnn_test_sdk_tests"
         }
       },
       "execution": {

--- a/projects/hipdnn/backend/tests/CMakeLists.txt
+++ b/projects/hipdnn/backend/tests/CMakeLists.txt
@@ -3,6 +3,11 @@
 
 include(GoogleTest)
 
+if(HIP_DNN_SKIP_TESTS)
+    message(STATUS "Skipping HIP-DNN Backend Unit tests")
+    return()
+endif()
+
 find_package(hip REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -11,11 +16,6 @@ find_package(Threads REQUIRED)
 enable_language(HIP)
 # Verify that we're using AMD/ROCm HIP compiler.
 verifyamdrocmcompiler(${CMAKE_HIP_COMPILER} "HIP")
-
-if(HIP_DNN_SKIP_TESTS)
-    message(STATUS "Skipping HIP-DNN Backend Unit tests")
-    return()
-endif()
 
 set(TEST_PLUGIN1_NAME "hipdnn_test_plugin1")
 set(TEST_PLUGIN2_NAME "hipdnn_test_plugin2")

--- a/projects/hipdnn/cmake/Tests.cmake
+++ b/projects/hipdnn/cmake/Tests.cmake
@@ -36,8 +36,33 @@ set(INTEGRATION_CHECK_DEPENDS_GLOBAL "" CACHE INTERNAL "Accumulated integration 
                                               FORCE
 )
 
+# Builds the test environment list with optional code coverage support
+# ~~~
+# Parameters:
+#   OUT_VAR - The name of the variable to store the result in (will be set in PARENT_SCOPE)
+# ~~~
+function(_build_test_environment_list_internal OUT_VAR)
+    set(ENVIRONMENT_LIST "")
+    if(DEFINED TEST_ENVIRONMENT)
+        set(ENVIRONMENT_LIST ${TEST_ENVIRONMENT})
+    endif()
+
+    if(HIPDNN_ENABLE_COVERAGE)
+        # Ensure coverage report directory exists
+        file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/coverage_report/profraw")
+
+        # For code coverage builds, we want each profraw file to have a unique name.  The %m in the
+        # LLVM_PROFILE_FILE environment variable will auto generate a unique id.
+        list(APPEND ENVIRONMENT_LIST
+             "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage_report/profraw/%m.profraw"
+        )
+    endif()
+
+    set(${OUT_VAR} ${ENVIRONMENT_LIST} PARENT_SCOPE)
+endfunction() # _build_test_environment_list_internal
+
 # Creates a custom target to validate test names using a Python script
-function(create_test_name_validation_target)
+function(_create_test_name_validation_target_internal)
     if(Python3_FOUND)
         # Write list of test executables with their paths to a file
         set(TEST_EXECUTABLES_FILE ${CMAKE_BINARY_DIR}/test_executables.txt)
@@ -71,7 +96,7 @@ function(create_test_name_validation_target)
             COMMENT "Skipping test name validation"
         )
     endif() # Python3_FOUND
-endfunction() # create_test_name_validation_target
+endfunction() # _create_test_name_validation_target_internal
 
 # Generic internal function to append tests to check targets
 function(_append_test_to_check_target_internal TARGET WORKING_DIR TEST_TYPE STATUS_MESSAGE)
@@ -94,21 +119,7 @@ function(_append_test_to_check_target_internal TARGET WORKING_DIR TEST_TYPE STAT
     endif()
 
     # Build environment list properly
-    set(ENVIRONMENT_LIST "")
-    if(DEFINED TEST_ENVIRONMENT)
-        set(ENVIRONMENT_LIST ${TEST_ENVIRONMENT})
-    endif()
-
-    if(HIPDNN_ENABLE_COVERAGE)
-        # Ensure coverage report directory exists
-        file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/coverage_report/profraw")
-
-        # For code coverage builds, we want each profraw file to have a unique name.  The %m in the
-        # LLVM_PROFILE_FILE environment variable will auto generate a unique id.
-        list(APPEND ENVIRONMENT_LIST
-             "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage_report/profraw/%m.profraw"
-        )
-    endif()
+    _build_test_environment_list_internal(ENVIRONMENT_LIST)
 
     set(NEW_COMMAND "")
     if("${${COMMAND_VAR}}" STREQUAL "")
@@ -133,7 +144,7 @@ function(_append_test_to_check_target_internal TARGET WORKING_DIR TEST_TYPE STAT
     )
 endfunction() # _append_test_to_check_target_internal
 
-# Generic internal function to finalize check targets
+# Generic internal function to finalize DIY check targets
 function(_finalize_check_target_internal TARGET_NAME COMMAND_VAR DEPENDS_VAR)
     add_custom_target(
         ${TARGET_NAME}
@@ -142,42 +153,121 @@ function(_finalize_check_target_internal TARGET_NAME COMMAND_VAR DEPENDS_VAR)
         DEPENDS ${${DEPENDS_VAR}}
         VERBATIM
         COMMENT "Running ${TARGET_NAME}"
+        USES_TERMINAL
     )
-    message(STATUS "Created ${TARGET_NAME} target")
+    message(VERBOSE "Created ${TARGET_NAME} target")
 endfunction() # _finalize_check_target_internal
 
-# Finalizes the custom check target
-function(finalize_custom_check_target)
-    _finalize_check_target_internal("check" "CHECK_COMMAND_GLOBAL" "CHECK_DEPENDS_GLOBAL")
-endfunction() # finalize_custom_check_target
+# Internal function to finalize the DIY unclassified check-old target
+function(_finalize_unclassified_check_target_internal)
+    _finalize_check_target_internal("check-old" "CHECK_COMMAND_GLOBAL" "CHECK_DEPENDS_GLOBAL")
+endfunction() # _finalize_unclassified_check_target_internal
 
-# Finalizes the unit check target
-function(finalize_unit_check_target)
+# Internal function to finalize the DIY unit-check-old target
+function(_finalize_unit_check_target_internal)
     _finalize_check_target_internal(
-        "unit-check" "UNIT_CHECK_COMMAND_GLOBAL" "UNIT_CHECK_DEPENDS_GLOBAL"
+        "unit-check-old" "UNIT_CHECK_COMMAND_GLOBAL" "UNIT_CHECK_DEPENDS_GLOBAL"
     )
-endfunction() # finalize_unit_check_target
+endfunction() # _finalize_unit_check_target_internal
 
-# Finalizes the integration check target
-function(finalize_integration_check_target)
+# Internal function to finalize the DIY integration-check-old target
+function(_finalize_integration_check_target_internal)
     _finalize_check_target_internal(
-        "integration-check" "INTEGRATION_CHECK_COMMAND_GLOBAL" "INTEGRATION_CHECK_DEPENDS_GLOBAL"
+        "integration-check-old" "INTEGRATION_CHECK_COMMAND_GLOBAL"
+        "INTEGRATION_CHECK_DEPENDS_GLOBAL"
     )
-endfunction() # finalize_integration_check_target
+endfunction() # _finalize_integration_check_target_internal
 
 enable_testing() # Cmake wont discover or run tests without this line
 
-# Add a check_ctest target which will run all tests discovered by gtest_discover_tests via ctest.
-add_custom_target(
-    check_ctest COMMAND ${CMAKE_COMMAND} -E env ${TEST_ENVIRONMENT} ${CMAKE_CTEST_COMMAND}
-                        --output-on-failure -C ${CMAKE_CFG_INTDIR}
-    COMMENT "Running tests via ctest"
-)
+# Internal helper function to create a ctest target
+# ~~~
+# Parameters:
+#   TARGET_NAME - Name of the ctest target to create
+#   LABEL - Optional label filter for ctest (empty string for no filter)
+#   VERBOSE - Set to TRUE to add --verbose flag, FALSE otherwise
+#   COMMENT - Comment describing the target
+# ~~~
+function(_add_ctest_target_internal TARGET_NAME LABEL VERBOSE COMMENT)
+    # Build the ctest command
+    set(CTEST_CMD ${CMAKE_COMMAND} -E env ${CTEST_ENV} ${CMAKE_CTEST_COMMAND})
 
-# Internal function to add a GTest target
+    # Add label filter if specified
+    if(NOT "${LABEL}" STREQUAL "")
+        list(APPEND CTEST_CMD -L "${LABEL}")
+    endif()
+
+    # Always add --output-on-failure
+    list(APPEND CTEST_CMD --output-on-failure)
+
+    # Add --verbose if requested
+    if(VERBOSE)
+        list(APPEND CTEST_CMD --verbose)
+    endif()
+
+    # Add configuration
+    list(APPEND CTEST_CMD -C ${CMAKE_CFG_INTDIR})
+
+    # Create the target
+    add_custom_target(${TARGET_NAME} COMMAND ${CTEST_CMD} COMMENT "${COMMENT}" USES_TERMINAL)
+    add_dependencies(${TARGET_NAME} validate_test_names)
+    message(VERBOSE "Created ${TARGET_NAME} target")
+endfunction() # _add_ctest_target_internal
+
+# Internal helper function to create the (new) check targets for running tests via ctest
+function(_create_ctest_targets_internal)
+    # cmake-format: off
+    # Build test environment once for all ctest targets
+    _build_test_environment_list_internal(CTEST_ENV)
+
+    # Regular targets (without --verbose)
+    _add_ctest_target_internal(check_ctest "" FALSE "Running unclassified tests via ctest")
+    _add_ctest_target_internal(unit-check_ctest "unit_test" FALSE "Running unit tests via ctest")
+    _add_ctest_target_internal(integration-check_ctest "integration_test" FALSE "Running integration tests via ctest")
+
+    # Verbose targets (with --verbose)
+    _add_ctest_target_internal(check_ctest-verbose "" TRUE "Running unclassified tests via ctest (verbose)")
+    _add_ctest_target_internal(unit-check_ctest-verbose "unit_test" TRUE "Running unit tests via ctest (verbose)")
+    _add_ctest_target_internal(integration-check_ctest-verbose "integration_test" TRUE "Running integration tests via ctest (verbose)")
+    # cmake-format: on
+endfunction() # create_ctest_targets
+
+# Finalizes and creates all of the test targets
+function(finalize_test_targets)
+    _create_test_name_validation_target_internal()
+
+    _create_ctest_targets_internal()
+
+    _finalize_unclassified_check_target_internal()
+    _finalize_unit_check_target_internal()
+    _finalize_integration_check_target_internal()
+
+    add_dependencies(check-old validate_test_names)
+
+    # cmake-format: off
+    # Create alias test targets without '_ctest' in the name
+    # Regular targets (without --verbose)
+    add_custom_target(check DEPENDS check_ctest COMMENT "Running unclassified tests via ctest")
+    add_custom_target(unit-check DEPENDS unit-check_ctest COMMENT "Running unit tests via ctest")
+    add_custom_target(integration-check DEPENDS integration-check_ctest COMMENT "Running integration tests via ctest")
+    message(STATUS "Created ctest targets: check, unit-check, integration-check")
+    # Verbose targets (with --verbose)
+    add_custom_target(check-verbose DEPENDS check_ctest-verbose COMMENT "Running unclassified tests via ctest (verbose)")
+    add_custom_target(unit-check-verbose DEPENDS unit-check_ctest-verbose COMMENT "Running unit tests via ctest (verbose)")
+    add_custom_target(integration-check-verbose DEPENDS integration-check_ctest-verbose COMMENT "Running integration tests via ctest (verbose)")
+    message(STATUS "Created ctest verbose targets: check-verbose, unit-check-verbose, integration-check-verbose")
+    # cmake-format: on
+endfunction() # finalize_test_targets
+
+# Internal (old) DIY function to add a test target (assumes the test executable is a gtest
+# executable) Still needed for collecting list of test executables in HIPDNN_TEST_TARGETS and
+# setting test-type labels. TODO: Deprecate this funcion and remove manual test collection once new
+# ctest-based method is proven.
 function(_add_gtest_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
     if("${APPEND_FUNCTION_SUFFIX}" STREQUAL "test")
-        _append_test_to_check_target_internal(${TARGET} ${WORKING_DIR} "" "Appending check target")
+        _append_test_to_check_target_internal(
+            ${TARGET} ${WORKING_DIR} "" "Appending unclassified check target"
+        )
     elseif("${APPEND_FUNCTION_SUFFIX}" STREQUAL "unit_test")
         _append_test_to_check_target_internal(
             ${TARGET} ${WORKING_DIR} "UNIT" "Appending unit check target"
@@ -213,14 +303,14 @@ function(_add_gtest_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
     # Install test executables to bin directory
     install(TARGETS ${TARGET} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-    add_dependencies(check_ctest ${TARGET})
     add_test(NAME ${TARGET} COMMAND ${TARGET} WORKING_DIRECTORY ${WORKING_DIR})
+    set_tests_properties(${TARGET} PROPERTIES LABELS ${APPEND_FUNCTION_SUFFIX})
 endfunction() # _add_gtest_target_internal
 
 # Adds a generic test target
-function(add_target_to_check_targets TARGET WORKING_DIR)
+function(add_unclassified_test_target TARGET WORKING_DIR)
     _add_gtest_target_internal(test ${TARGET} ${WORKING_DIR})
-endfunction() # add_target_to_check_targets
+endfunction() # add_unclassified_test_target
 
 # Adds a unit test target
 function(add_unit_test_target TARGET WORKING_DIR)
@@ -232,12 +322,12 @@ function(add_integration_test_target TARGET WORKING_DIR)
     _add_gtest_target_internal(integration_test ${TARGET} ${WORKING_DIR})
 endfunction() # add_integration_test_target
 
-# Define the CTest installation directory
-set(HIPDNN_CTEST_FILE_INSTALL_PATH "${CMAKE_INSTALL_BINDIR}/hipdnn")
-
 # Install CTest configuration files for direct test execution This should be called once at the end
 # of the main CMakeLists.txt after all tests are registered
 function(install_hipdnn_ctest_files)
+    # Define the CTest installation directory
+    set(HIPDNN_CTEST_FILE_INSTALL_PATH "${CMAKE_INSTALL_BINDIR}/hipdnn")
+
     # Generate a new CTestTestfile.cmake that references installed test executables
     set(INSTALLED_CTEST_FILE "${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake.install")
 

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/cmake/Tests.cmake
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/cmake/Tests.cmake
@@ -138,6 +138,7 @@ function(_finalize_check_target_internal TARGET_NAME COMMAND_VAR DEPENDS_VAR)
         DEPENDS ${${DEPENDS_VAR}}
         VERBATIM
         COMMENT "Running ${TARGET_NAME}"
+        USES_TERMINAL
     )
     message(STATUS "Created ${TARGET_NAME} target")
 endfunction() # _finalize_check_target_internal
@@ -166,8 +167,8 @@ enable_testing() # Cmake wont discover or run tests without this line
 # Add a check_ctest target which will run all tests discovered by gtest_discover_tests via ctest.
 add_custom_target(
     check_ctest COMMAND ${CMAKE_COMMAND} -E env ${TEST_ENVIRONMENT} ${CMAKE_CTEST_COMMAND}
-                        --output-on-failure -C ${CMAKE_CFG_INTDIR}
-    COMMENT "Running tests via ctest"
+                        --output-on-failure -C ${CMAKE_CFG_INTDIR} COMMENT "Running tests via ctest"
+    USES_TERMINAL
 )
 
 # Internal function to add a GTest target
@@ -214,9 +215,9 @@ function(_add_gtest_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
 endfunction() # _add_gtest_target_internal
 
 # Adds a generic test target
-function(add_target_to_check_targets TARGET WORKING_DIR)
+function(add_unclassified_test_target TARGET WORKING_DIR)
     _add_gtest_target_internal(test ${TARGET} ${WORKING_DIR})
-endfunction() # add_target_to_check_targets
+endfunction() # add_unclassified_test_target
 
 # Adds a unit test target
 function(add_unit_test_target TARGET WORKING_DIR)


### PR DESCRIPTION
## Motivation

Test targets were not consistent in how they were implemented, causing confusion in figuring out which targets to use.

## Technical Details

Converted the existing test targets to have a '-old' suffix: check-old, check_ctest-old, unit-check-old, and integration-check-old.
Created new test targets that have consistent behavior driven by ctest: check, unit-check, and integration-check.
Added verbose variants to the new test targets: ctest-verbose, unit-check-verbose, and integraiton-check-verbose.

TBD: The '*-old' targets can be removed once the new test targets are proven to be stable.

In addition, the single 'code_coverage' target required all tests to run (it depends on the 'check' target), both unit tests and integration tests. The following coverage targets have been added to reduce the amount of churn when testing code coverage changes:
* unit-coverage: depends on 'unit-check'
* integration-coverage: depends on 'integration-check'
* current-coverage: does not depend on any target and instead relies on the coverage-mapping data files present on disk that were created by prior tests runs with coverage-mapping enabled.

Improved overall user experience when running test targets by adding the `USES_TERMINAL` flag so that cmake/ninja will forward the command output to the terminal as it is produced instead of buffering it until the command completes.

## Test Plan

Running the check targets to ensure they produce the desired output.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
