### PR TITLE
[hipblaslt] Add option to use 4x4x4_16b MFMA for TF32 low bits computation

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -407,29 +407,41 @@ class LocalReadMFMA(LocalRead):
                                     vHi0 = vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, (valuiIdx-baseValuiIdx)/2 + baseValuiIdx))
                                     vHi1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, (valuiIdx-baseValuiIdx)/2 + baseValuiIdx))
 
-                                    # Compute low bits = fp32(highBF16(A/B)) - fp32(A/B)
-                                    if kernel["UseDot2F32XEmulation"]:
-                                        packCodeT.add(VDot2CF32BF16(dst=v0t, src0=hex(0x8000bf80), src1=vHi0))
-                                        packCodeT.add(VDot2CF32BF16(dst=v1t, src0=hex(0xbf800000), src1=vHi0))
+                                    if kernel["UseMFMAF32XEmulation"]:
+                                        vTBase = str(v0t.regName)
+                                        vHiBase = str(vHi0.regName)
+                                        idMat = vgpr(writer.states.startVgprIdentityMatrix,2)
+                                        tmpDelay = writer.vgprPool.checkOut(1)
+                                        # We use a single MFMA 4x4x4_16b to perform 4 `vT - vHi` operations. 
+                                        # - A is set to negative identity matrix
+                                        # - no need for DPP as B has the same layout as C & D
+                                        packCodeT.add(MFMAInstruction(instType=InstType.INST_BF16, accType=InstType.INST_F32, variant=[4,4,4,16], mfma1k=False,acc=vgpr(vTBase,4), a=idMat, b=vgpr(vHiBase,2), acc2=vgpr(vTBase,4), 
+                                        comment="Calculate low bits for TF32 emulation"))
+                                        writer.vgprPool.checkIn(tmpDelay)
                                     else:
-                                        packCodeT.add(PVCvtBF16toFP32(dst=vgpr(tmp), src=vHi0, comment="begin"+str(valuiIdx)))
-                                        packCodeT.add(VSubF32(dst=v0t, src0=v0t, src1=vgpr(tmp)))
-                                        packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp), src=vHi0, vgprMask=None, vi=1))
-                                        packCodeT.add(VSubF32(dst=v1t, src0=v1t, src1=vgpr(tmp)))
+                                        # Compute low bits = fp32(highBF16(A/B)) - fp32(A/B)
+                                        if kernel["UseDot2F32XEmulation"]:
+                                            packCodeT.add(VDot2CF32BF16(dst=v0t, src0=hex(0x8000bf80), src1=vHi0))
+                                            packCodeT.add(VDot2CF32BF16(dst=v1t, src0=hex(0xbf800000), src1=vHi0))
+                                        else:
+                                            packCodeT.add(PVCvtBF16toFP32(dst=vgpr(tmp), src=vHi0, comment="begin"+str(valuiIdx)))
+                                            packCodeT.add(VSubF32(dst=v0t, src0=v0t, src1=vgpr(tmp)))
+                                            packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp), src=vHi0, vgprMask=None, vi=1))
+                                            packCodeT.add(VSubF32(dst=v1t, src0=v1t, src1=vgpr(tmp)))
 
-                                    if kernel["UseDot2F32XEmulation"]:
-                                        packCodeT.add(VDot2CF32BF16(dst=v2t, src0=hex(0x8000bf80), src1=vHi1))
-                                    else:
-                                        packCodeT.add(PVCvtBF16toFP32(dst=vgpr(tmp), src=vHi1))
-                                        packCodeT.add(VSubF32(dst=v2t, src0=v2t, src1=vgpr(tmp)))
+                                        if kernel["UseDot2F32XEmulation"]:
+                                            packCodeT.add(VDot2CF32BF16(dst=v2t, src0=hex(0x8000bf80), src1=vHi1))
+                                        else:
+                                            packCodeT.add(PVCvtBF16toFP32(dst=vgpr(tmp), src=vHi1))
+                                            packCodeT.add(VSubF32(dst=v2t, src0=v2t, src1=vgpr(tmp)))
 
-                                    # We use cvt+sub pair since dot2 requires adding 4 wait states.
-                                    packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp), src=vHi1, vgprMask=None, vi=1))
-                                    packCodeT.add(VSubF32(dst=v3t, src0=v3t, src1=vgpr(tmp), comment="end"))
+                                        # We use cvt+sub pair since dot2 requires adding 4 wait states.
+                                        packCodeT.add(VCvtBF16toFP32(dst=vgpr(tmp), src=vHi1, vgprMask=None, vi=1))
+                                        packCodeT.add(VSubF32(dst=v3t, src0=v3t, src1=vgpr(tmp), comment="end"))
 
-                                    if kernel["UseDot2F32XEmulation"]:
-                                        packCodeT.add(VMovB32(dst=vgpr(tmp), src=0))
-                                        packCodeT.add(VMovB32(dst=vgpr(tmp), src=0))
+                                        if kernel["UseDot2F32XEmulation"]:
+                                            packCodeT.add(VMovB32(dst=vgpr(tmp), src=0))
+                                            packCodeT.add(VMovB32(dst=vgpr(tmp), src=0))
 
                                     for val in tmpvgpr:
                                         writer.vgprPool.checkIn(val)
@@ -453,6 +465,9 @@ class LocalReadMFMA(LocalRead):
                                         v5 = vgpr("Valu%s_X%u_I%u+%u+5"%(tc, bufferIdx, iui, baseValuiIdx))
                                         v6 = vgpr("Valu%s_X%u_I%u+%u+6"%(tc, bufferIdx, iui, baseValuiIdx))
                                         v7 = vgpr("Valu%s_X%u_I%u+%u+7"%(tc, bufferIdx, iui, baseValuiIdx))
+                                        if kernel["UseMFMAF32XEmulation"]:
+                                            # 5 wait states needed before the following CVT instructions
+                                            packCodeT.add(SNop(waitState = 4))
                                         packCodeT.add(VCvtPkF32toBF16(dst=v7, src0=v6, src1=v7, comment="pack final begin"))
                                         packCodeT.add(VCvtPkF32toBF16(dst=v6, src0=v4, src1=v5))
                                         packCodeT.add(VCvtPkF32toBF16(dst=v5, src0=v2, src1=v3))

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -24,10 +24,10 @@
 
 from rocisa.code import Module
 from rocisa.container import DSModifiers, vgpr, sgpr, SDWAModifiers, VOP3PModifiers, ContinuousRegister
-from rocisa.enum import SelectBit
+from rocisa.enum import SelectBit, InstType
 from rocisa.instruction import SMovB32, SWaitCnt, VOrB32, VPermB32, VLShiftLeftOrB32, \
                             VMovB32, VMovB64,VLShiftRightB32, VCvtPkFP8toF32, VCvtF32toF16, VCvtFP8toF32,VCvtScaleFP8toF16,VCvtScalePkFP8toF16, \
-                            VCvtPkF32toBF16, VCvtBF16toFP32, PVCvtBF16toFP32, VDot2CF32BF16, SNop, VSubF32, VSwapB32
+                            VCvtPkF32toBF16, VCvtBF16toFP32, PVCvtBF16toFP32, VDot2CF32BF16, SNop, VSubF32, VSwapB32, MFMAInstruction
 
 from ..Component import LocalRead
 

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -36,7 +36,7 @@ from rocisa.instruction import BufferLoadB128, BufferLoadB32, BufferLoadB64, \
   FlatLoadB64, FlatStoreB128, FlatStoreB32, FlatStoreB64, Instruction, MacroInstruction, \
   MFMAInstruction, SBarrier, SBranch, SCBranchSCC0, SCBranchSCC1, SCBranchVCCNZ, SCmpLeU32, \
   SMFMAInstruction, SNop, SSetPrior, SSetRegIMM32B32, SSubU32, SWaitCnt, SWaitAlu, \
-  SLongBranchPositive, VFmaMixF32, VMadMixF32, VMovB32, VAndB32, VCmpEQU32, VCndMaskB32
+  SLongBranchPositive, VFmaMixF32, VMadMixF32, VMovB32, VAndB32, VCmpEQU32, VCndMaskB32, VMovB64
 from rocisa.register import RegisterPool
 from rocisa.enum import RegisterType
 
@@ -2882,8 +2882,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     module.addComment0("Create a negative identity matrix used by TF32 MFMA emulation.")
     module.add(VAndB32(dst=vgpr(lane4),src0=3, src1=vgpr("Serial"), comment="lane % 4"))
-    module.add(VMovB32(dst=mfmaHigh,src=0))
-    module.add(VMovB32(dst=mfmaLow,src=0))
+    module.add(VMovB64(dst=vgpr(self.states.startVgprIdentityMatrix,2),src=0))
     module.add(VMovB32(dst=vgpr(tmp), src="0xbf80", comment=""))
 
     module.add(VCmpEQU32(dst=VCC(), src0=0, src1=vgpr(lane4), comment="Lane %4 == 0 ?"))

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -4770,6 +4770,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.states.b.startVgprLocalWriteSwapAddr = vgprIdx
       vgprIdx += 1
 
+    if kernel["UseMFMAF32XEmulation"]:
+      vgprIdx = ((vgprIdx+1)//2)*2 #align 64 bit
+      self.states.startVgprIdentityMatrix = vgprIdx
+      vgprIdx+=2
+      
     # TODO: Serial is always the first/last register in the pool so the store
     # code doesn't have to deal with fragmentation
     self.states.startVgprSerial = vgprIdx
@@ -4786,9 +4791,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         self.states.startVgprCvt = vgprIdx
         vgprIdx += numVgprsEmu # for vgpr 32XEmulation
 
-    if kernel["UseMFMAF32XEmulation"]:
-      self.states.startVgprIdentityMatrix = vgprIdx
-      vgprIdx+=2
+
 
     self.states.totalVgprs = max(vgprIdx, self.states.c.numVgprValu)
     if self.states.totalVgprs < 0 or self.states.totalVgprs > self.states.regCaps["MaxVgpr"]:

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -2935,6 +2935,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
     skComponent = Component.StreamK.find(self)
     module.add(skComponent.preLoop(self, kernel))
 
+    # MFMA F32XEmulation negative identity matrix
+    if kernel["UseMFMAF32XEmulation"]:
+      module.add(self.createNegIdentityMatrix(kernel))
 
     # Open persistent loop
     loopComponent = Component.PersistentLoop.find(self)
@@ -3071,8 +3074,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
               if kernel["UsePLRPack"] and self.states.numItersPLR:
                 module.add(SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA and LRB to complete"))
                 module.add(pack[plrIdx])
-              if kernel["UseMFMAF32XEmulation"]:
-                module.add(self.createNegIdentityMatrix(kernel))
 
         self.states.SubTileIdx = (self.states.SubTileIdx + 1) % kernel["numSubTiles"]
       elif self.states.numItersPLR == 0 and kernel["UseCustomMainLoopSchedule"]:

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -225,6 +225,7 @@ class StateValues:
   startVgprAlphaTmp: int                 = -1
   startVgprSerial: int                   = -1
   startVgprCvt: int                      = -1
+  startVgprIdentityMatrix: int           = -1 
 
   numSgprSizesSum: int                   = 0
   numSgprSizesFree: int                  = 0
@@ -2866,6 +2867,48 @@ class KernelWriter(metaclass=abc.ABCMeta):
     return module
 
   ##############################################################################
+  # Creates a negative identity matrix for 4x4x4_16b MFMA
+  # Each 4x4 block is set to this:
+  # -1  0  0
+  #  0 -1  0 
+  #  0  0 -1
+  ##############################################################################
+  def createNegIdentityMatrix(self, kernel):
+    module = Module("NegIdentityMatrix")
+    tmp = self.vgprPool.checkOut(1)
+    lane4 = self.vgprPool.checkOut(1)
+    mfmaHigh = vgpr(self.states.startVgprIdentityMatrix)
+    mfmaLow = vgpr(self.states.startVgprIdentityMatrix+1)
+
+    module.addComment0("Create a negative identity matrix used by TF32 MFMA emulation.")
+    module.add(VAndB32(dst=vgpr(lane4),src0=3, src1=vgpr("Serial"), comment="lane % 4"))
+    module.add(VMovB32(dst=mfmaHigh,src=0))
+    module.add(VMovB32(dst=mfmaLow,src=0))
+    module.add(VMovB32(dst=vgpr(tmp), src="0xbf80", comment=""))
+
+    module.add(VCmpEQU32(dst=VCC(), src0=0, src1=vgpr(lane4), comment="Lane %4 == 0 ?"))
+    module.add(SNop(1, comment=""))
+    module.add(VCndMaskB32(dst=mfmaHigh, src0=mfmaHigh, src1=vgpr(tmp), src2= VCC(), comment=""))
+
+    module.add(VCmpEQU32(dst=VCC(), src0=2, src1=vgpr(lane4), comment="Lane %4 == 2 ?"))
+    module.add(SNop(1, comment=""))
+    module.add(VCndMaskB32(dst=mfmaLow, src0=mfmaLow, src1=vgpr(tmp), src2= VCC(), comment=""))
+
+    module.add(VMovB32(dst=vgpr(tmp), src="0xbf800000", comment=""))
+
+    module.add(VCmpEQU32(dst=VCC(), src0=1, src1=vgpr(lane4), comment="Lane %4 == 1 ?"))
+    module.add(SNop(1, comment=""))
+    module.add(VCndMaskB32(dst=mfmaHigh, src0=mfmaHigh, src1=vgpr(tmp), src2= VCC(), comment=""))
+
+    module.add(VCmpEQU32(dst=VCC(), src0=3, src1=vgpr(lane4), comment="Lane %4 == 3 ?"))
+    module.add(SNop(1, comment=""))
+    module.add(VCndMaskB32(dst=mfmaLow, src0=mfmaLow, src1=vgpr(tmp), src2= VCC(), comment=""))
+
+    self.vgprPool.checkIn(tmp)
+    self.vgprPool.checkIn(lane4)
+    return module
+
+  ##############################################################################
   # Kernel Body
   ##############################################################################
   def kernelBody( self, kernel, tensorParametersA, tensorParametersB ):
@@ -3028,6 +3071,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
               if kernel["UsePLRPack"] and self.states.numItersPLR:
                 module.add(SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA and LRB to complete"))
                 module.add(pack[plrIdx])
+              if kernel["UseMFMAF32XEmulation"]:
+                module.add(self.createNegIdentityMatrix(kernel))
+                
         self.states.SubTileIdx = (self.states.SubTileIdx + 1) % kernel["numSubTiles"]
       elif self.states.numItersPLR == 0 and kernel["UseCustomMainLoopSchedule"]:
         # For numItersPLR=0 and CMS we prefetch only half the local reads
@@ -4739,6 +4785,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
         vgprIdx = ((vgprIdx+1)//2)*2
         self.states.startVgprCvt = vgprIdx
         vgprIdx += numVgprsEmu # for vgpr 32XEmulation
+
+    if kernel["UseMFMAF32XEmulation"]:
+      self.states.startVgprIdentityMatrix = vgprIdx
+      vgprIdx+=2
 
     self.states.totalVgprs = max(vgprIdx, self.states.c.numVgprValu)
     if self.states.totalVgprs < 0 or self.states.totalVgprs > self.states.regCaps["MaxVgpr"]:

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -4775,11 +4775,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.states.startVgprIdentityMatrix = vgprIdx
       vgprIdx+=2
       
-    # TODO: Serial is always the first/last register in the pool so the store
-    # code doesn't have to deal with fragmentation
-    self.states.startVgprSerial = vgprIdx
-    vgprIdx += 1 # for vgpr serial id
-
     if kernel["UseDirect32XEmulation"]:
       numVgprsEmu = (self.states.a.numVgprValu + self.states.b.numVgprValu) // 2
       if (vgprIdx >= (self.states.regCaps["MaxVgpr"] - numVgprsEmu)):
@@ -4791,7 +4786,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
         self.states.startVgprCvt = vgprIdx
         vgprIdx += numVgprsEmu # for vgpr 32XEmulation
 
-
+    # TODO: Serial is always the first/last register in the pool so the store
+    # code doesn't have to deal with fragmentation
+    self.states.startVgprSerial = vgprIdx
+    vgprIdx += 1 # for vgpr serial id
 
     self.states.totalVgprs = max(vgprIdx, self.states.c.numVgprValu)
     if self.states.totalVgprs < 0 or self.states.totalVgprs > self.states.regCaps["MaxVgpr"]:

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -25,7 +25,7 @@
 from rocisa import rocIsa, countInstruction, countGlobalRead, \
             countLocalRead, countLocalWrite, countDSStoreB256, getMFMAs
 from rocisa.code import Module, TextBlock, StructuredModule, KernelBody
-from rocisa.container import RegisterContainer, replaceHolder, HWRegContainer
+from rocisa.container import RegisterContainer, replaceHolder, HWRegContainer, VCC
 from rocisa.label import LabelManager
 from rocisa.asmpass import rocIsaPass, rocIsaPassOption
 from rocisa.instruction import BufferLoadB128, BufferLoadB32, BufferLoadB64, \
@@ -36,7 +36,7 @@ from rocisa.instruction import BufferLoadB128, BufferLoadB32, BufferLoadB64, \
   FlatLoadB64, FlatStoreB128, FlatStoreB32, FlatStoreB64, Instruction, MacroInstruction, \
   MFMAInstruction, SBarrier, SBranch, SCBranchSCC0, SCBranchSCC1, SCBranchVCCNZ, SCmpLeU32, \
   SMFMAInstruction, SNop, SSetPrior, SSetRegIMM32B32, SSubU32, SWaitCnt, SWaitAlu, \
-  SLongBranchPositive, VFmaMixF32, VMadMixF32, VMovB32
+  SLongBranchPositive, VFmaMixF32, VMadMixF32, VMovB32, VAndB32, VCmpEQU32, VCndMaskB32
 from rocisa.register import RegisterPool
 from rocisa.enum import RegisterType
 
@@ -3073,7 +3073,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
                 module.add(pack[plrIdx])
               if kernel["UseMFMAF32XEmulation"]:
                 module.add(self.createNegIdentityMatrix(kernel))
-                
+
         self.states.SubTileIdx = (self.states.SubTileIdx + 1) % kernel["numSubTiles"]
       elif self.states.numItersPLR == 0 and kernel["UseCustomMainLoopSchedule"]:
         # For numItersPLR=0 and CMS we prefetch only half the local reads

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -415,6 +415,7 @@ class Solution(collections.abc.Mapping):
     state["UsePLRPack"] = False
     state["SwapGlobalReadOrder"] = False
     state["MfmaInitCVgprs"] = False
+    state["UseMFMAF32XEmulation"] = False
 
     # done
     state["AssignedProblemIndependentDerivedParameters"] = True


### PR DESCRIPTION
## Motivation

Current support for TF32 on gfx950 is emulated using BF16 MFMAs. Each emulated TF32 instruction is performed with 3 BF16 MFMAs.
To feed these instructions,  it is necessary to extract the high and low bits from the FP32 input values.

Default path is done as follow :
- 4 v_cvt_pk_bf16_f32 for the high bits : 4 quad-cycles
- 8 v_cvt_f32_bf16/v_sub_f32 to compute the low bits in FP32: 16 quad-cycles
- 4 v_cvt_pk_bf16_f32 to convert low bits to BF16: 4 quad-cycles
Total : **24 quad-cycles** 

This results in a high number of VALU instructions, which are difficult (or impossible) to hide in the CMS implementations.

This PRs introduce the use of the 4x4x4_16b MFMA (BF16) to replace the 8 v_cvt_f32_bf16/v_sub_f32 by 2 MFMA instructions.
- 4 v_cvt_pk_bf16_f32 : 4 quad-cycles
- 2 MFMA 4x4x4_16B:  4 quad-cycles (MFMA 4x4x4_16B has 8 clk latency)
- 4 v_cvt_pk_bf16_f32 : 4 quad-cycles
Total : **12 quad-cycles** (4 not hidden by other MFMAs)

## Technical Details

We reserve 2 VGPRs to initialize a negative identity matrix. Each MFMA will perform `D = AxB + C` where: 
- A is the negative Identity matrix.
- B is the high bits VGPRs from the TF32 code.
- C and D the FP32 VGPRs from the TF32 code.

By using B for the high bits, we eliminate any cross-thread communication after the MFMA (such as DPP). There is a direct match in matrix coordinates between B and C/D.

This new option can be enabled with the internal parameter: `UseMFMAF32XEmulation`. The default implementation adds 5 wait states after each pair of 4x4x4_16b MFMAs for correctness, but this can easily be eliminated in a custom main loop implementation by interleaving CVT/MFMA blocks.

