### PR TITLE
[hipblaslt][CMS] Enable validation for schedules with mfmaReorder

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -721,7 +721,10 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution', mfma_reor
     For LRA1/LRB1, the data is needed at a VMFMA index offset by num_vmfma (next iteration).
     
     Args:
-        timeline: The Timeline object containing the instructions.
+        timeline:       The Timeline object containing the instructions.
+        kernel:         Solution object containing the kernel metadata.
+        mfma_reorder:   List of indices representing the reordering of the MFMA indices.
+                        Index into it using mfma index are scheduled by default for this kernel, value is the new 0-based position in the order.
     """
 
     if mfma_reorder and len(mfma_reorder) != timeline.num_vmfma:
@@ -841,9 +844,10 @@ def lr_needed_by_mfma(
     Helper function to calculate the index of the MFMA at which the given LRA/LRB will be needed by.
 
     Args:
+        local_read: The LocalRead object to calculate the needed_by index for.
         lr_idx: The index of the LRA/LRB in the list of LRAs/LRBs for the given code path.
         num_vmfma: The number of MFMA indices.
-        mfma_reorder: The reordering of the MFMA indices.
+        mfma_reorder: The reordering mapping for MFMA indices.
         n_tiles_a: The number of tiles in the A dimension.
         n_tiles_b: The number of tiles in the B dimension.
         n_local_reads_a: The number of local reads in the A dimension.

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -723,8 +723,7 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution', mfma_reor
     Args:
         timeline:       The Timeline object containing the instructions.
         kernel:         Solution object containing the kernel metadata.
-        mfma_reorder:   List of indices representing the reordering of the MFMA indices.
-                        Index into it using mfma index are scheduled by default for this kernel, value is the new 0-based position in the order.
+        mfma_reorder:   Mapping between the index of a default-scheduled MFMA and its new custom assigned index.
     """
 
     if mfma_reorder and len(mfma_reorder) != timeline.num_vmfma:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -712,7 +712,7 @@ def apply_swaits(timeline: Timeline) -> None:
             apply(timeline.combined_timeline[i_swait-1::-1], swait, GlobalRead, swait.vlcnt)
 
 
-def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution') -> None:
+def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int]) -> None:
     """
     Set the needed_by field of LocalReads based on the VMFMA index they are required for.
     Timeline is modified in place.
@@ -723,6 +723,13 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution') -> None:
     Args:
         timeline: The Timeline object containing the instructions.
     """
+
+    if mfma_reorder and len(mfma_reorder) != timeline.num_vmfma:
+        return False, f"Incorrect number of VMFMA indices in mfmaReorder. Expected {timeline.num_vmfma}, given {len(mfma_reorder)}."
+
+    n_local_reads_a = len(timeline.get_instructions("LRA0", MAIN_LOOP))
+    n_local_reads_b = len(timeline.get_instructions("LRB0", MAIN_LOOP))
+
     for i_loop, loop in enumerate(timeline.loops):
         loop_offset = timeline.num_vmfma * i_loop
         for instruction_name in timeline.get_instruction_names():
@@ -730,8 +737,15 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution') -> None:
                 continue
             local_reads = timeline.get_instructions(instruction_name, loop)
             for lr_idx, (_, lr) in enumerate(local_reads):
-                base_needed_by = lr_needed_by_mfma(lr, lr_idx, timeline, kernel)
-                lr.needed_by = base_needed_by + loop_offset
+                needed_by = lr_needed_by_mfma(
+                    local_read=lr,
+                    lr_idx=lr_idx,
+                    num_vmfma=timeline.num_vmfma,
+                    mfma_reorder=mfma_reorder,
+                    n_tiles_a=kernel["MIWaveTileA"], n_tiles_b=kernel["MIWaveTileB"],
+                    n_local_reads_a=n_local_reads_a,
+                    n_local_reads_b=n_local_reads_b)                
+                lr.needed_by = needed_by + loop_offset
 
 
 def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) -> None:
@@ -813,50 +827,61 @@ def schedule_get(name: str, code_path: int, schedule_info: 'ScheduleInfo') -> li
     return schedules[0] if len(schedules) == 1 else schedules[code_path]
 
 
-def lr_needed_by_mfma(local_read: LocalRead, lr_idx: int, timeline: Timeline, kernel: 'Solution') -> int:
+def lr_needed_by_mfma(
+    local_read: LocalRead,
+    lr_idx: int,
+    num_vmfma: int,
+    mfma_reorder: list[int],
+    n_tiles_a: int,
+    n_tiles_b: int,
+    n_local_reads_a: int,
+    n_local_reads_b: int,
+    ) -> int:
     """
     Helper function to calculate the index of the MFMA at which the given LRA/LRB will be needed by.
 
     Args:
         lr_idx: The index of the LRA/LRB in the list of LRAs/LRBs for the given code path.
-        offset: The offset from the halfway point of the main loop.
-        schedule_info: The schedule information (ScheduleInfo object)
-        kernel: The kernel (Solution object)
+        num_vmfma: The number of MFMA indices.
+        mfma_reorder: The reordering of the MFMA indices.
+        n_tiles_a: The number of tiles in the A dimension.
+        n_tiles_b: The number of tiles in the B dimension.
+        n_local_reads_a: The number of local reads in the A dimension.
+        n_local_reads_b: The number of local reads in the B dimension.
 
     Returns:
         The index of the MFMA at which the given LRA/LRB will be needed by.
     """
-    offset = local_read.num_vmfma
-    if "0" in local_read.name:
-        offset //= 2
-
-    n_tiles_a = kernel['MIWaveTileA']
-    n_tiles_b = kernel['MIWaveTileB']
-    # NOTE: This calculation will produce incorrect results if the user provided the wrong number of LRs.
-    n_lr_a = len(timeline.get_instructions("LRA0", MAIN_LOOP))
-    n_lr_b = len(timeline.get_instructions("LRB0", MAIN_LOOP))
-
     # How many MFMA worth of data is loaded by each LRA/LRB
-    n_tiles_per_lra = n_tiles_a / n_lr_a
-    n_tiles_per_lrb = n_tiles_b / n_lr_b
+    n_tiles_per_lra = n_tiles_a / n_local_reads_a
+    n_tiles_per_lrb = n_tiles_b / n_local_reads_b
 
-    # NOTE: This is based on the current bahaviour where we iterate through A faster than B.
-    def index_lra_needed_by_mfma(lra_idx: int, offset: int) -> int:
-        """
-        Calculate the index of the MFMA at which the given LRA will be needed by.
-        """
-        return int(lra_idx * n_tiles_per_lra) + offset
-
-    def index_lrb_needed_by_mfma(lrb_idx: int, offset: int) -> int:
-        """
-        Calculate the index of the MFMA at which the given LRB will be needed by.
-        """
-        return n_tiles_a * int(lrb_idx * n_tiles_per_lrb) + offset
+    # NOTE: This is based on the current bahaviour where we iterate through MFMAs in column-major order (A faster than B).
+    def index_lra_needed_by_mfma(lra_idx: int) -> int:
+        return int(lra_idx * n_tiles_per_lra)
+    def index_lrb_needed_by_mfma(lrb_idx: int) -> int:
+        return n_tiles_a * int(lrb_idx * n_tiles_per_lrb)
 
     if local_read.name.startswith("LRA"):
-        return index_lra_needed_by_mfma(lr_idx, offset)
+        needed_by = index_lra_needed_by_mfma(lr_idx)
     else:
-        return index_lrb_needed_by_mfma(lr_idx, offset)
+        needed_by = index_lrb_needed_by_mfma(lr_idx)
+    
+    # Account for mfmaReorder.
+    is_lr0 = local_read.name == "LRA0" or local_read.name == "LRB0"
+    if is_lr0:
+        # LR0: reading data for 2nd half of this iteration.
+        needed_by += num_vmfma // 2
+    else:
+        # LR1/3: will add after reordering to since we need index in next iteration 
+        pass
+    if mfma_reorder:
+        needed_by = mfma_reorder[needed_by]
+    if not is_lr0:
+        # LR1/3 is reading data for next iteration.
+        needed_by += num_vmfma
+    
+    return needed_by
 
 
 @dataclass
@@ -1004,20 +1029,17 @@ def verify_lrs_finished_before_vmfma(schedule_info: 'ScheduleInfo', context: dic
     """
     Ensure that the LocalReads are guaranteed to be complete before the first VMFMA that uses their data.
     """
-    if context.get("kernel", {}).get("UseF32XEmulation", False) or context.get("kernel", {}).get("ForceUnrollSubIter", False):
-        message = "LR completion before vmfma validation is disabled for F32X emulation or ForceUnrollSubIter"
+    if context.get("kernel", {}).get("UseF32XEmulation", False):
+        message = "LR completion before vmfma validation is disabled for F32X emulation"
         printWarning(f"{message}")
         return True, message
     
-    if len(schedule_info.mfmaReorder) != 0:
-        printWarning("CMS Validation does not currently support mfmaReorder, cannot guarantee that LRs will be correct.")
-        return True, ""
+    kernel = context["kernel"]
 
     relevant_names = ["LRA0", "LRB0", "LRA1", "LRB1", "SYNC"]
-    kernel = context["kernel"]
     timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
 
-    set_lr_needed_by_for_VMFMA(timeline, kernel)
+    set_lr_needed_by_for_VMFMA(timeline, kernel, schedule_info.mfmaReorder)
     apply_swaits(timeline)
     apply_barriers(timeline)
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
@@ -70,7 +70,9 @@ class CMSValidationTestBase(unittest.TestCase):
         nllshift: int,
         codePathIdx: int,
         expected_message: str | None,
-        nllZeroDscnt: bool = False
+        nllZeroDscnt: bool = False,
+        mfmaReorder: list[int] = None,
+        snopCode: list[Any] = None,
     ):
         """
         Creates a ScheduleInfo and validates it using the validation function from the subclass.
@@ -84,8 +86,15 @@ class CMSValidationTestBase(unittest.TestCase):
             codePathIdx: Code path index to validate
             expected_message: Expected error message (None if validation should pass, str if validation should fail)
             nllZeroDscnt: Whether to use zero dscnt for NLL loop (default: False)
+            mfmaReorder: List of MFMA reorder indices
+            snopCode: List of SNOP instructions
         """
-        sched = ScheduleInfo(numCodePaths, self.num_vmfma, optSchedule, syncCode, nglshift, nllshift, nllZeroDscnt)
+        if mfmaReorder is None:
+            mfmaReorder = []
+        if snopCode is None:
+            snopCode = []
+        
+        sched = ScheduleInfo(numCodePaths, self.num_vmfma, optSchedule, syncCode, nglshift, nllshift, nllZeroDscnt, mfmaReorder, snopCode)
 
         status, message = self.validation_function(sched, {"kernel": self.kernel}, codePathIdx)
         

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -338,3 +338,60 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
             "SYNC": [[3, 7]],
         }
         self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+
+class TestValidateLRsCompleteBeforeVMFMA_MfmaReorder(CMSValidationTestBase):
+    def validation_function(self, sched, kernel_dict, codePathIdx):
+        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
+
+    def test_simple_bf16(self):
+        """
+        Simple test when the indices are fully reversed. 
+        """
+        assert self.num_vmfma == 8
+        
+        mfmaReorder = list(range(self.num_vmfma-1, -1, -1))
+        optSchedule = { 
+            # LR0s needed for first half
+            "LRA0": [[-1, -1]],
+            "LRB0": [[-1, -1]],
+            # LR1s needed for second half
+            "LRA1": [[0, 0]],
+            "LRB1": [[0, 0]],
+            "SYNC": [[-1, self.num_vmfma // 2 - 1]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LR0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LR1s"),
+        ]
+
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None, mfmaReorder=mfmaReorder)
+
+    def test_complex_bf16(self):
+        """
+        Change from column-major to row-major.
+
+        | 0 2 | -> | 0 1 |
+        | 1 3 | -> | 2 3 |
+        """
+        assert self.num_vmfma == 8
+
+        mfmaReorder = [0, 2, 1, 3, 4, 6, 5, 7]
+        optSchedule = {
+            "LRB0": [[3, 4]],
+            "LRA0": [[3, 5]],
+            "LRB1": [[5, 6]],
+            "LRA1": [[5, 7]],
+            "SYNC": [[0, 1, 3, 4, 5, 7]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="2/2 LRB1"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="2/2 LRA1"),
+
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="1/2 LRB0 and 1/2 LRA0."),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="2/2 LRB0"),
+            SWaitCnt(dscnt=0+1, vlcnt=-1, vscnt=-1, comment="2/2 LRA0"),
+
+            SWaitCnt(dscnt=2,vlcnt=-1, vscnt=-1, comment="1/2 LRB1 and 1/2 LRA1."),
+        ]
+
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None, nllZeroDscnt=True, mfmaReorder=mfmaReorder)


### PR DESCRIPTION
## Motivation

Extend validator to work with schedules that use mfmaReorder. Setup work for supporting force_unroll_sub_iter and tf32 emulation.

## Technical Details

Refactor functions and hookup for ability to use mappings.

## Test Plan

1. Add and run new tests.
2. Run existing tests.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
