### PR TITLE
[hipblaslt][CMS] Enable LR validation for TF32 and ForceUnrollSubIter kernels 

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -729,6 +729,9 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution', mfma_reor
     if mfma_reorder and len(mfma_reorder) != timeline.num_vmfma:
         return False, f"Incorrect number of VMFMA indices in mfmaReorder. Expected {timeline.num_vmfma}, given {len(mfma_reorder)}."
 
+    n_tiles_a = kernel["MIWaveTileA"]
+    n_tiles_b = kernel["MIWaveTileB"]
+
     n_local_reads_a = len(timeline.get_instructions("LRA0", MAIN_LOOP))
     n_local_reads_b = len(timeline.get_instructions("LRB0", MAIN_LOOP))
 
@@ -740,13 +743,15 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution', mfma_reor
             local_reads = timeline.get_instructions(instruction_name, loop)
             for lr_idx, (_, lr) in enumerate(local_reads):
                 needed_by = lr_needed_by_mfma(
-                    local_read=lr,
+                    local_read_name=lr.name,
                     lr_idx=lr_idx,
                     num_vmfma=timeline.num_vmfma,
                     mfma_reorder=mfma_reorder,
-                    n_tiles_a=kernel["MIWaveTileA"], n_tiles_b=kernel["MIWaveTileB"],
+                    n_tiles_a=n_tiles_a, n_tiles_b=n_tiles_b,
                     n_local_reads_a=n_local_reads_a,
-                    n_local_reads_b=n_local_reads_b)                
+                    n_local_reads_b=n_local_reads_b,
+                    force_unroll_sub_iter=kernel.get("ForceUnrollSubIter", False),
+                    use_f32x_emulation=kernel.get("UseF32XEmulation", False))                
                 lr.needed_by = needed_by + loop_offset
 
 
@@ -829,8 +834,69 @@ def schedule_get(name: str, code_path: int, schedule_info: 'ScheduleInfo') -> li
     return schedules[0] if len(schedules) == 1 else schedules[code_path]
 
 
+def _transform_index_with_force_unroll_sub_iter(
+    needed_by: int,
+    is_lr0: bool,
+    is_lra: bool,
+    n_tiles_a: int,
+    n_tiles_b: int,
+    use_f32x_emulation: bool,
+    mfma_reorder: list[int],
+    num_vmfma: int,
+) -> int:
+    """
+    Convert column-major linear index into needed_by mfma index when ForceUnrollSubIter is enabled.
+    """
+    # For LR0s, add offset for second half of tiles
+    if is_lr0:
+        if is_lra:
+            needed_by += n_tiles_a // 2
+        else:  # LRB0
+            needed_by += n_tiles_a * (n_tiles_b // 2)
+    
+    # Apply ForceUnrollSubIter reordering on TILE indices first,
+    # then convert to MFMA indices for F32X emulation
+    needed_by = index_for_force_unroll_sub_iter(needed_by, n_tiles_a, n_tiles_b)
+    
+    if use_f32x_emulation:  # Each tile requires 3 MFMAs
+        needed_by *= 3
+    
+    if mfma_reorder:
+        needed_by = mfma_reorder[needed_by]
+    
+    if not is_lr0:  # LR1/LR3 reads data for next iteration.
+        needed_by += num_vmfma
+    
+    return needed_by
+
+
+def _transform_index_standard(
+    needed_by: int,
+    is_lr0: bool,
+    use_f32x_emulation: bool,
+    mfma_reorder: list[int],
+    num_vmfma: int,
+) -> int:
+    """
+    Convert column-major linear index into needed_by mfma index when ForceUnrollSubIter is disabled.
+    """
+    if use_f32x_emulation:  # Each tile requires 3 MFMAs
+        needed_by *= 3
+    
+    if is_lr0:  # LR0 reads data for 2nd half of this iteration
+        needed_by += num_vmfma // 2
+    
+    if mfma_reorder:
+        needed_by = mfma_reorder[needed_by]
+    
+    if not is_lr0:  # LR1/LR3 reads data for first half of next iteration
+        needed_by += num_vmfma
+    
+    return needed_by
+
+
 def lr_needed_by_mfma(
-    local_read: LocalRead,
+    local_read_name: str,
     lr_idx: int,
     num_vmfma: int,
     mfma_reorder: list[int],
@@ -838,12 +904,14 @@ def lr_needed_by_mfma(
     n_tiles_b: int,
     n_local_reads_a: int,
     n_local_reads_b: int,
+    force_unroll_sub_iter: bool,
+    use_f32x_emulation: bool,
     ) -> int:
     """
     Helper function to calculate the index of the MFMA at which the given LRA/LRB will be needed by.
 
     Args:
-        local_read: The LocalRead object to calculate the needed_by index for.
+        local_read_name: The name of the local read to calculate the needed_by index for.
         lr_idx: The index of the LRA/LRB in the list of LRAs/LRBs for the given code path.
         num_vmfma: The number of MFMA indices.
         mfma_reorder: The reordering mapping for MFMA indices.
@@ -851,6 +919,8 @@ def lr_needed_by_mfma(
         n_tiles_b: The number of tiles in the B dimension.
         n_local_reads_a: The number of local reads in the A dimension.
         n_local_reads_b: The number of local reads in the B dimension.
+        force_unroll_sub_iter: Whether to force unroll the sub-iter.
+        use_f32x_emulation: Whether TF32 emulation is enabled (3 MFMAs per tile).
 
     Returns:
         The index of the MFMA at which the given LRA/LRB will be needed by.
@@ -859,30 +929,39 @@ def lr_needed_by_mfma(
     n_tiles_per_lra = n_tiles_a / n_local_reads_a
     n_tiles_per_lrb = n_tiles_b / n_local_reads_b
 
+    if force_unroll_sub_iter:
+        # Without the unroll, the LRs are for half of the vmfmas.
+        # But the number of vmfmas == 2 * n_tiles_a * n_tiles_b.
+        # So each LR loads n_tiles tiles.
+        # For force_unroll_sub_iter, there are only n_tiles_a * n_tiles_b vmfmas.
+        # So each LR only loads half as many tiles.
+        n_tiles_per_lra /= 2
+        n_tiles_per_lrb /= 2
+
     # NOTE: This is based on the current bahaviour where we iterate through MFMAs in column-major order (A faster than B).
     def index_lra_needed_by_mfma(lra_idx: int) -> int:
         return int(lra_idx * n_tiles_per_lra)
     def index_lrb_needed_by_mfma(lrb_idx: int) -> int:
         return n_tiles_a * int(lrb_idx * n_tiles_per_lrb)
 
-    if local_read.name.startswith("LRA"):
-        needed_by = index_lra_needed_by_mfma(lr_idx)
+    # Calculate base tile index in column-major order
+    is_lra = local_read_name.startswith("LRA")
+    if is_lra:
+        linear_index = index_lra_needed_by_mfma(lr_idx)
     else:
-        needed_by = index_lrb_needed_by_mfma(lr_idx)
+        linear_index = index_lrb_needed_by_mfma(lr_idx)
     
-    # Account for mfmaReorder.
-    is_lr0 = local_read.name == "LRA0" or local_read.name == "LRB0"
-    if is_lr0:
-        # LR0: reading data for 2nd half of this iteration.
-        needed_by += num_vmfma // 2
+    # Apply transformations based on scheduling mode
+    is_lr0 = local_read_name == "LRA0" or local_read_name == "LRB0"
+    if force_unroll_sub_iter:
+        needed_by = _transform_index_with_force_unroll_sub_iter(
+            linear_index, is_lr0, is_lra, n_tiles_a, n_tiles_b,
+            use_f32x_emulation, mfma_reorder, num_vmfma
+        )
     else:
-        # LR1/3: will add after reordering to since we need index in next iteration 
-        pass
-    if mfma_reorder:
-        needed_by = mfma_reorder[needed_by]
-    if not is_lr0:
-        # LR1/3 is reading data for next iteration.
-        needed_by += num_vmfma
+        needed_by = _transform_index_standard(
+            linear_index, is_lr0, use_f32x_emulation, mfma_reorder, num_vmfma
+        )
     
     return needed_by
 
@@ -1028,15 +1107,56 @@ def verify_grs_finish_before_lrs(schedule_info: 'ScheduleInfo', context: dict, c
     return True, ""
 
 
+def index_for_force_unroll_sub_iter(original_idx: int, M: int, N: int) -> int:
+    """
+    Map original column-major index to index scheme used by force unroll sub-iter:
+    Split the tile for each wave into 4 blocks, each indexed in column-major order.
+        -------
+        | 0| 2|
+        |--|--|
+        | 1| 3|
+        -------
+    Then, within each block, index within column-major order.
+    For a 4x4 tile, the index changes as follows:
+        |  0  4  8 12 |  ->  |  0  2  8 10 |
+        |  1  5  9 13 |  ->  |  1  3  9 11 |
+        |  2  6 10 14 |  ->  |  4  6 12 14 |
+        |  3  7 11 15 |  ->  |  5  7 13 15 |
+    
+    Args:
+        original_idx: The original column-major index
+        M: Number of rows in the matrix
+        N: Number of columns in the matrix
+    
+    Returns:
+        The permuted index
+    """
+    # Block dimensions
+    block_rows = M // 2
+    block_cols = N // 2
+    block_size = block_rows * block_cols
+    
+    # Convert linear index to 2D coordinates (column-major)
+    row = original_idx % M
+    col = original_idx // M
+    
+    # Determine which block (0-3) in column-major order
+    block_row = row // block_rows  # 0 or 1
+    block_col = col // block_cols  # 0 or 1
+    block_idx = block_col * 2 + block_row  # Column-major block indexing
+    
+    # Position within the block
+    local_row = row % block_rows
+    local_col = col % block_cols
+    local_idx = local_col * block_rows + local_row
+    
+    return block_idx * block_size + local_idx
+
+
 def verify_lrs_finished_before_vmfma(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
     Ensure that the LocalReads are guaranteed to be complete before the first VMFMA that uses their data.
     """
-    if context.get("kernel", {}).get("UseF32XEmulation", False):
-        message = "LR completion before vmfma validation is disabled for F32X emulation"
-        printWarning(f"{message}")
-        return True, message
-    
     kernel = context["kernel"]
 
     relevant_names = ["LRA0", "LRB0", "LRA1", "LRB1", "SYNC"]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -556,6 +556,7 @@ class TestCustomScheduleTF32:
         })
         kernel.update({
             "UseF32XEmulation": True,
+            "ForceUnrollSubIter": True,
             "MacroTile0": 192, "MacroTile1": 256, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
             "DirectToLds": True,

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -22,10 +22,12 @@
 #
 # SPDX-License-Identifier: MIT
 ################################################################################
+from typing import Any, Optional
 from rocisa.instruction import SWaitCnt
 
-from Tensile.Components.CMSValidator import verify_lrs_finished_before_vmfma
+from Tensile.Components.CMSValidator import verify_lrs_finished_before_vmfma, index_for_force_unroll_sub_iter, lr_needed_by_mfma
 from cms_validation_base import CMSValidationTestBase
+from Tensile.Common import IsaVersion
 
 class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
     def validation_function(self, sched, kernel_dict, codePathIdx):
@@ -339,6 +341,99 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         }
         self.validate(optSchedule, syncCode, 1, None, None, 0, None)
 
+class TestValidateLRsCompleteBeforeVMFMA_tf32(CMSValidationTestBase):
+    """
+    For TF32, each tile produces 3 MFMAs (hi*hi, hi*lo, lo*hi).
+    With MIWaveTileA=2, MIWaveTileB=2, we have 4 tile pairs, producing 12 MFMAs total.
+    
+    MFMA ordering (column-major):
+    - MFMAs 0,1,2: A3*B3 (hi*hi, hi*lo, lo*hi)
+    - MFMAs 3,4,5: A0*B3
+    - MFMAs 6,7,8: A3*B0
+    - MFMAs 9,10,11: A0*B0
+    
+    LRB0 needed at 6
+    LRA0 needed at 3
+    LRB3 needed at 12 (0 of next iter)
+    LRA3 needed at 12 (0 of next iter)
+    """
+    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None):
+        super().setUp({"UseF32XEmulation": True, "ISA": IsaVersion(9,5,0), "DepthU": 32, "ForceUnrollSubIter": True})
+
+    def validation_function(self, sched, kernel_dict, codePathIdx):
+        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
+
+    def test_LR0s_pass(self):
+        """
+        Simple TF32 test case.
+        """
+        assert self.num_vmfma == 12
+        
+        optSchedule = {
+            "SYNC": [[2, 5]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[1, 1]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="LRA0"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LRB0"),
+        ]
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+    
+    def test_LR0s_fail(self):
+        """
+        Same as passing case, but LRA0 guaranteed too late.
+        """
+        assert self.num_vmfma == 12
+        
+        optSchedule = {
+            "SYNC": [[3, 5]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[1, 1]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="LRA0"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LRB0"),
+        ]
+        self.validate(optSchedule, syncCode, 1, None, None, 0, "LRA0 at index 0 is not valid. Needed before index 3, but only guaranteed at index 3.")
+    
+    def test_LR0s_fail2(self):
+        """
+        Same as passing case, but LRB0 guaranteed too late.
+        """
+        assert self.num_vmfma == 12
+        
+        optSchedule = {
+            "SYNC": [[2, 6]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[1, 1]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="LRA0"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LRB0"),
+        ]
+        self.validate(optSchedule, syncCode, 1, None, None, 0, "LRB0 at index 1 is not valid. Needed before index 6, but only guaranteed at index 6.")
+
+    def test_LR3s_pass(self):
+        """
+        Passing case for LRA3s
+        """
+        assert self.num_vmfma == 12
+
+        optSchedule = {
+            "SYNC": [[2, 5, 7]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[1, 1]],
+            "LRA1": [[6, 6]],
+            "LRB1": [[6, 6]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="LRA0"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LRB0"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LRA3 and LRB3"),
+        ]
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+
 class TestValidateLRsCompleteBeforeVMFMA_MfmaReorder(CMSValidationTestBase):
     def validation_function(self, sched, kernel_dict, codePathIdx):
         return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
@@ -395,3 +490,326 @@ class TestValidateLRsCompleteBeforeVMFMA_MfmaReorder(CMSValidationTestBase):
         ]
 
         self.validate(optSchedule, syncCode, 1, None, None, 0, None, nllZeroDscnt=True, mfmaReorder=mfmaReorder)
+
+    def test_tf32(self):
+        """
+        """
+        self.setUp({"UseF32XEmulation": True, "ISA": IsaVersion(9,5,0), "DepthU": 32, "ForceUnrollSubIter": True})
+        assert self.num_vmfma == 12
+        
+        # Row-major reordering: swap middle two groups
+        # Original: [0,1,2, 3,4,5, 6,7,8, 9,10,11] (col-major: A3B3, A0B3, A3B0, A0B0)
+        # Reorder:  [0,1,2, 6,7,8, 3,4,5, 9,10,11] (row-major: A3B3, A3B0, A0B3, A0B0)
+        mfmaReorder = [0, 1, 2, 6, 7, 8, 3, 4, 5, 9, 10, 11]
+        
+        # After reordering, the physical MFMAs are:
+        # 0-2: A0*B0, 3-5: A0*B1, 6-8: A1*B0, 9-11: A1*B1
+        # LR0 loads for 2nd half (originally 6-11, which are tiles A0*B1 and A1*B1)
+        # After reordering, these tiles are at physical indices 3-5 and 9-11
+        optSchedule = {
+            "LRA0": [[0, 0]],  # Load A0 and A1 early
+            "LRB0": [[0, 0]],  # Load B0 and B1 early
+            "LRA1": [[6, 6]],  # Load for next iteration
+            "LRB1": [[7, 7]],  
+            "SYNC": [[2, 10]],  # Wait for LR0s before first use, and LR1s before next iter
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="All LR0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="All LR1s"),
+        ]
+        
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None, mfmaReorder=mfmaReorder)
+
+class TestValidateLRsCompleteBeforeVMFMA_ForceUnrollSubIter(CMSValidationTestBase):
+    """
+    When ForceUnrollSubIter is enabled, the MFMAs are issued in a different order than the default column-major order.
+    Further, each loop iteration only contains MIWaveTileA * MIWaveTileB MFMAs, instead of 2 * MIWaveTileA * MIWaveTileB MFMAs.
+
+    Default is column-major ordering of MFMAs:
+    A v \ B ->
+    | 0 4  8 12 |
+    | 1 5  9 13 |
+    | 2 6 10 14 |
+    | 3 7 11 15 |
+
+    When ForceUnrollSubIter is enabled, the MFMAs are issued in 4 quandrants in column-major order, within each quandrant the MFMAsare issued in row-major order:
+    | 0 2  8 10 |
+    | 1 3  9 11 |
+    | 4 6 12 14 |
+    | 5 7 13 15 |
+
+    LR0s load the second half of tile data, and LR3s load the first half.
+    Thus:
+    - LRA0 must be finished before num_vmfma // 4 - 1
+    - LRB0 must be finished before num_vmfma // 2 - 1
+    - LRA3 must be finished before 0 (of next iteration)
+        - MUST also start after 3 * num_vmfma // 4 (since it's reusing registers used by LRA0)
+    - LRB3 must be finished before 0 (of next iteration)
+        - MUST also start after num_vmfma // 2 (since it's reusing registers used by LRB0)
+
+    NOTE:   These tests do not include the Pack commands which are REQUIRED for a valid kernel.
+            Not including them here in order to test just the LR-VMFMA orderling logic.
+    """
+    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None):
+        super().setUp({"ForceUnrollSubIter": True, "MIWaveTileA": 4, "MIWaveTileB": 4, "DepthU": 32})
+
+    def validation_function(self, sched, kernel_dict, codePathIdx):
+        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
+
+
+    def test_bf16(self):
+        assert self.num_vmfma == 16
+
+        optSchedule = {
+            "SYNC": [[3]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[0, 0]],
+            "LRA3": [[7, 7]],
+            "LRB3": [[7, 7]],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+        ]
+
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+
+
+class TestIndexForForceUnrollSubIter:
+    def test_index_for_force_unroll_sub_iter(self):
+        M, N = 4, 4
+        
+        """
+        Mapping between column-major linear index and the vmfma index when mfmas are done in column-major order.
+        | 0 4  8 12 |
+        | 1 5  9 13 |
+        | 2 6 10 14 |
+        | 3 7 11 15 |
+        """
+        index_col_major = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        """"
+        Mapping between column-major linear index and the vmfma index when mfmas are done in for_unroll_sub_iter order.
+        | 0 2  8 10 |
+        | 1 3  9 11 |
+        | 4 6 12 14 |
+        | 5 7 13 15 |
+        """
+        index_expected  = [0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15]
+
+        index_permuted = [index_for_force_unroll_sub_iter(i, M, N) for i in index_col_major]
+        assert index_permuted == index_expected
+
+class TestLRNeededByMFMA:
+    def test_simple_bf16(self):
+        """
+        Simple test with default (column-major) MFMA ordering.
+        """
+        n_tiles_a, n_tiles_b = 4, 4
+        n_local_reads_a, n_local_reads_b = 4, 4
+        num_vmfma = 2 * n_tiles_a * n_tiles_b
+
+        force_unroll_sub_iter = False
+
+        mfma_reorder = []
+
+        expected_results = {
+            "LRA0": [16, 17, 18, 19],
+            "LRB0": [16, 20, 24, 28],
+            "LRA1": [32, 33, 34, 35],  # 1st half of next iteration
+            "LRB1": [32, 36, 40, 44],  # 1st half of next iteration
+        }
+
+        for lr_name, expected_indices in expected_results.items():
+            actual_indices = [lr_needed_by_mfma(lr_name, lr_idx, num_vmfma, mfma_reorder, n_tiles_a, n_tiles_b, n_local_reads_a, n_local_reads_b, force_unroll_sub_iter, use_f32x_emulation=False) for lr_idx in range(len(expected_indices))]
+            assert actual_indices == expected_indices
+    
+    def test_simple_tf32(self):
+        """
+        TF32 without ForceUnrollSubIter - each tile produces 3 MFMAs.
+        """
+        n_tiles_a, n_tiles_b = 4, 4
+        n_local_reads_a, n_local_reads_b = 4, 4
+        num_vmfma = 2 * n_tiles_a * n_tiles_b * 3  # TF32: 3 MFMAs per tile
+
+        force_unroll_sub_iter = False
+        mfma_reorder = []
+
+        expected_results = {
+            "LRA0": [48, 51, 54, 57],
+            "LRB0": [48, 60, 72, 84],
+            "LRA1": [96, 99, 102, 105],
+            "LRB1": [96, 108, 120, 132],
+        }
+
+        for lr_name, expected_indices in expected_results.items():
+            actual_indices = [lr_needed_by_mfma(lr_name, lr_idx, num_vmfma, mfma_reorder,
+                             n_tiles_a, n_tiles_b, n_local_reads_a, n_local_reads_b,
+                             force_unroll_sub_iter, use_f32x_emulation=True)
+                             for lr_idx in range(len(expected_indices))]
+            assert actual_indices == expected_indices
+    
+    def test_mfma_reorder_bf16(self):
+        """
+        Simple test with MFMAs reordered into row-major order.
+        """
+        n_tiles_a, n_tiles_b = 4, 4
+        n_local_reads_a, n_local_reads_b = 4, 4
+        num_vmfma = 2 * n_tiles_a * n_tiles_b
+
+        force_unroll_sub_iter = False
+        
+        mfma_reorder = [ 0,  4,  8, 12,  1,  5,  9, 13,  2,  6, 10, 14,  3,  7, 11, 15,
+                        16, 20, 24, 28, 17, 21, 25, 29, 18, 22, 26, 30, 19, 23, 27, 31]
+
+        expected_results = {
+            "LRA0": [16, 20, 24, 28],
+            "LRB0": [16, 17, 18, 19],
+            "LRA1": [32, 36, 40, 44],  # 1st half of next iteration
+            "LRB1": [32, 33, 34, 35],  # 1st half of next iteration
+        }
+
+        for lr_name, expected_indices in expected_results.items():
+            actual_indices = [lr_needed_by_mfma(lr_name, lr_idx, num_vmfma, mfma_reorder, n_tiles_a, n_tiles_b, n_local_reads_a, n_local_reads_b, force_unroll_sub_iter, use_f32x_emulation=False) for lr_idx in range(len(expected_indices))]
+            assert actual_indices == expected_indices
+
+    def test_force_unroll_sub_iter_bf16(self):
+        """
+        Simple test case with force_unroll_sub_iter enabled. MFMA order:
+        |  0  2 |  8 10 |
+        |  1  3 |  9 11 |
+        |-------|-------|
+        |  4  6 | 12 14 |
+        |  5  7 | 13 15 |
+        """
+        n_tiles_a, n_tiles_b = 4, 4
+        n_local_reads_a, n_local_reads_b = 4, 4
+        num_vmfma = n_tiles_a * n_tiles_b
+
+        force_unroll_sub_iter = True
+        
+        mfma_reorder = []
+
+        expected_results = {
+            "LRA0": [ 4,  4,  5,  5],
+            "LRB0": [ 8,  8, 10, 10],
+            "LRA3": [16, 16, 17, 17],  # 1st half of next iteration
+            "LRB3": [16, 16, 18, 18],  # 1st half of next iteration
+        }
+
+        for lr_name, expected_indices in expected_results.items():
+            actual_indices = [lr_needed_by_mfma(lr_name, lr_idx, num_vmfma, mfma_reorder, n_tiles_a, n_tiles_b, n_local_reads_a, n_local_reads_b, force_unroll_sub_iter, use_f32x_emulation=False) for lr_idx in range(len(expected_indices))]
+            assert actual_indices == expected_indices
+    
+    def test_mfma_reorder_and_force_unroll_sub_iter_bf16(self):
+        """
+        Test combining force_unroll_sub_iter with an additional mfma_reorder.
+        
+        The reordering process has two steps:
+        1. force_unroll_sub_iter permutation is applied first, splitting the 4x4 tile
+           into quadrants processed in column-major order, column-major within each quadrant:
+           |  0  2 |  8 10 |
+           |  1  3 |  9 11 |
+           |-------|-------|
+           |  4  6 | 12 14 |
+           |  5  7 | 13 15 |
+        
+        2. Then mfma_reorder is applied on top to change to row-major quadrants 
+           with row-major within each quadrant:
+           |  0  1 |  4  5 |
+           |  2  3 |  6  7 |
+           |-------|-------|
+           |  8  9 | 12 13 |
+           | 10 11 | 14 15 |
+        
+        The mfma_reorder maps each force_unroll_sub_iter position to its new
+        execution position in the row-major scheme.
+        """
+        n_tiles_a, n_tiles_b = 4, 4
+        n_local_reads_a, n_local_reads_b = 4, 4
+        num_vmfma = n_tiles_a * n_tiles_b
+
+        force_unroll_sub_iter = True
+        
+        # Row-major quadrants, row-major within each quadrant
+        # Maps force_unroll index -> execution position
+        mfma_reorder = [0, 2, 1, 3, 8, 10, 9, 11, 4, 6, 5, 7, 12, 14, 13, 15]
+
+        expected_results = {
+            # LRA0: second half of rows (rows 2-3)
+            # lr_idx 0,1 -> row 2 -> +offset=2 -> force_unroll(2)=4 -> reorder[4]=8
+            # lr_idx 2,3 -> row 3 -> +offset=3 -> force_unroll(3)=5 -> reorder[5]=10
+            "LRA0": [8, 8, 10, 10],
+            # LRB0: second half of cols (cols 2-3)
+            # lr_idx 0,1 -> col 2 -> +offset=8 -> force_unroll(8)=8 -> reorder[8]=4
+            # lr_idx 2,3 -> col 3 -> +offset=12 -> force_unroll(12)=10 -> reorder[10]=5
+            "LRB0": [4, 4, 5, 5],
+            # LRA3: first half of rows for next iteration
+            # lr_idx 0,1 -> row 0 -> force_unroll(0)=0 -> reorder[0]=0 -> +16=16
+            # lr_idx 2,3 -> row 1 -> force_unroll(1)=1 -> reorder[1]=2 -> +16=18
+            "LRA3": [16, 16, 18, 18],
+            # LRB3: first half of cols for next iteration
+            # lr_idx 0,1 -> col 0 -> force_unroll(0)=0 -> reorder[0]=0 -> +16=16
+            # lr_idx 2,3 -> col 1 -> col-major idx 4 -> force_unroll(4)=2 -> reorder[2]=1 -> +16=17
+            "LRB3": [16, 16, 17, 17],
+        }
+
+        for lr_name, expected_indices in expected_results.items():
+            actual_indices = [lr_needed_by_mfma(lr_name, lr_idx, num_vmfma, mfma_reorder, n_tiles_a, n_tiles_b, n_local_reads_a, n_local_reads_b, force_unroll_sub_iter, use_f32x_emulation=False) for lr_idx in range(len(expected_indices))]
+            assert actual_indices == expected_indices
+
+    def test_force_unroll_sub_iter_tf32(self):
+        """
+        Test TF32 (F32X emulation) combined with ForceUnrollSubIter.
+        
+        This test catches the bug where the *3 multiplication for F32X was applied
+        BEFORE index_for_force_unroll_sub_iter() instead of AFTER. The reordering
+        function operates on tile indices (0 to n_tiles_a * n_tiles_b - 1), so the
+        *3 conversion to MFMA indices must happen after reordering.
+        
+        With ForceUnrollSubIter, each tile produces 3 MFMAs (hi*hi, hi*lo, lo*hi):
+        |  0-2   6-8  | 24-26 30-32 |
+        |  3-5   9-11 | 27-29 33-35 |
+        |-------------|-------------|
+        | 12-14 18-20 | 36-38 42-44 |
+        | 15-17 21-23 | 39-41 45-47 |
+        
+        LR0s load the second half of tile data:
+        - LRA0 loads rows 2-3 (bottom half), needed starting at MFMA 12
+        - LRB0 loads cols 2-3 (right half), needed starting at MFMA 24
+        
+        LR3s load the first half for next iteration.
+        """
+        n_tiles_a, n_tiles_b = 4, 4
+        n_local_reads_a, n_local_reads_b = 4, 4
+        num_vmfma = n_tiles_a * n_tiles_b * 3  # TF32: 3 MFMAs per tile
+
+        force_unroll_sub_iter = True
+        mfma_reorder = []
+
+        expected_results = {
+            # LRA0: second half of rows (rows 2-3)
+            # Tile calculation: lr_idx 0,1 -> tile row 2, lr_idx 2,3 -> tile row 3
+            # After offset (+2) and force_unroll reordering, then *3 for TF32:
+            # lr_idx 0,1: offset=2, force_unroll(2)=4, *3=12
+            # lr_idx 2,3: offset=3, force_unroll(3)=5, *3=15
+            "LRA0": [12, 12, 15, 15],
+            # LRB0: second half of cols (cols 2-3)
+            # lr_idx 0,1: linear=0, offset=8, force_unroll(8)=8, *3=24
+            # lr_idx 2,3: linear=4, offset=12, force_unroll(12)=10, *3=30
+            "LRB0": [24, 24, 30, 30],
+            # LRA3: first half of rows for next iteration
+            # lr_idx 0,1: linear=0, force_unroll(0)=0, *3=0, +48=48
+            # lr_idx 2,3: linear=1, force_unroll(1)=1, *3=3, +48=51
+            "LRA3": [48, 48, 51, 51],
+            # LRB3: first half of cols for next iteration
+            # lr_idx 0,1: linear=0, force_unroll(0)=0, *3=0, +48=48
+            # lr_idx 2,3: linear=4, force_unroll(4)=2, *3=6, +48=54
+            "LRB3": [48, 48, 54, 54],
+        }
+
+        for lr_name, expected_indices in expected_results.items():
+            actual_indices = [lr_needed_by_mfma(lr_name, lr_idx, num_vmfma, mfma_reorder,
+                             n_tiles_a, n_tiles_b, n_local_reads_a, n_local_reads_b,
+                             force_unroll_sub_iter, use_f32x_emulation=True)
+                             for lr_idx in range(len(expected_indices))]
+            assert actual_indices == expected_indices, f"{lr_name}: expected {expected_indices}, got {actual_indices}"


### PR DESCRIPTION
## Motivation

Required to validate LR hazards on TF32 kernels. Also required to validate Pack commands (future PR).

## Technical Details

Depends on #3442.

1. Handles the tiled column-major approach.
2. Handles that 3 MFMA per emulated TF32 MFMA.

## Test Plan

1. Added extra tests.
3. Run existing tests.

## Test Result

Passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
