### PR TITLE
[rocPRIM] removed deprecated functions from api reference

### DIFF
--- a/projects/rocprim/docs/reference/intrinsics.rst
+++ b/projects/rocprim/docs/reference/intrinsics.rst
@@ -21,10 +21,8 @@ Bitwise
 Warp size
 ===========
 
-.. doxygenfunction:: rocprim::warp_size()
 .. doxygenfunction:: rocprim::host_warp_size(const int device_id, unsigned int& warp_size)
 .. doxygenfunction:: rocprim::host_warp_size(const hipStream_t stream, unsigned int& warp_size)
-.. doxygenfunction:: rocprim::device_warp_size()
 
 Lane and Warp ID
 =================


### PR DESCRIPTION
## Motivation

 `rocprim::device_warp_size()` and `rocprim::warp_size()` have been removed from the api and as such need to be removed from the doc.
.
