### PR TITLE
[hipCUB] Add gfx1150, gfx1152, gfx1153

### DIFF
--- a/projects/hipcub/CMakeLists.txt
+++ b/projects/hipcub/CMakeLists.txt
@@ -145,7 +145,7 @@ elseif(NOT (CMAKE_CXX_COMPILER MATCHES ".*nvcc$" OR "${CMAKE_CXX_COMPILER_ID}" S
       )
     else()
       rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-        TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
+        TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201"
       )
     endif()
     set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)


### PR DESCRIPTION
## Motivation

Enable gfx1150, gfx1152, and gfx1153 targets.

## Technical Details

Add these targets to DEFAULT_AMDGPU_TARGETS in hipCUB CMakeLists.txt.

## Test Plan

Build existing ctests for, and run them on, the new targets.

## Test Result

- [x] gfx1150 passed
- [x] gfx1152 passed
- [x] gfx1153 passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
