### PR TITLE
[hipBLAS] zero init common error and time variables in client

### DIFF
--- a/projects/hipblas/clients/include/blas1/testing_asum.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_asum.hpp
@@ -113,7 +113,7 @@ void testing_asum(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    Tr cpu_result, hipblas_result_host, hipblas_result_device;
+    Tr cpu_result{0}, hipblas_result_host{0}, hipblas_result_device{0};
 
     double gpu_time_used, hipblas_error_host = 0, hipblas_error_device = 0;
 

--- a/projects/hipblas/clients/include/blas1/testing_asum_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_asum_batched.hpp
@@ -114,7 +114,7 @@ void testing_asum_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<T> hx(N, incx, batch_count);

--- a/projects/hipblas/clients/include/blas1/testing_asum_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_asum_strided_batched.hpp
@@ -93,7 +93,7 @@ void testing_asum_strided_batched(const Arguments& arg)
 
     hipblasStride stridex = N * incx * stride_scale;
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double             gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
     hipblasLocalHandle handle(arg);
 
     // check to prevent undefined memory allocation error

--- a/projects/hipblas/clients/include/blas1/testing_axpy.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_axpy.hpp
@@ -142,7 +142,7 @@ void testing_axpy(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy_device.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas1/testing_axpy_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_axpy_batched.hpp
@@ -130,7 +130,7 @@ void testing_axpy_batched(const Arguments& arg)
 
     T alpha = arg.get_alpha<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<T> hy_host(N, incy, batch_count);

--- a/projects/hipblas/clients/include/blas1/testing_axpy_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_axpy_strided_batched.hpp
@@ -160,7 +160,7 @@ void testing_axpy_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas1/testing_dot.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_dot.hpp
@@ -143,7 +143,7 @@ void testing_dot(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true, true);

--- a/projects/hipblas/clients/include/blas1/testing_dot_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_dot_batched.hpp
@@ -134,7 +134,7 @@ void testing_dot_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<T> hx(N, incx, batch_count);

--- a/projects/hipblas/clients/include/blas1/testing_dot_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_dot_strided_batched.hpp
@@ -172,7 +172,7 @@ void testing_dot_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true, true);

--- a/projects/hipblas/clients/include/blas1/testing_iamax_iamin.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_iamax_iamin.hpp
@@ -122,7 +122,7 @@ void testing_iamax_iamin(const Arguments& arg, FUNC func)
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this
     // practice
     host_vector<T> hx(N, incx);
-    R              cpu_result, hipblas_result_host, hipblas_result_device;
+    R              cpu_result{0}, hipblas_result_host{0}, hipblas_result_device{0};
 
     device_vector<T> dx(N, incx);
     device_vector<R> d_hipblas_result(1);
@@ -136,8 +136,8 @@ void testing_iamax_iamin(const Arguments& arg, FUNC func)
     // copy data from CPU to device
     CHECK_HIP_ERROR(dx.transfer_from(hx));
 
-    double gpu_time_used;
-    R      hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0};
+    R      hipblas_error_host{0}, hipblas_error_device{0};
 
     if(arg.unit_check || arg.norm_check)
     {

--- a/projects/hipblas/clients/include/blas1/testing_iamax_iamin_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_iamax_iamin_batched.hpp
@@ -138,7 +138,7 @@ void testing_iamax_iamin_batched(const Arguments& arg, FUNC func)
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);
     CHECK_HIP_ERROR(dx.transfer_from(hx));
 
-    double gpu_time_used;
+    double gpu_time_used{0};
     R      hipblas_error_host = 0, hipblas_error_device = 0;
 
     if(arg.unit_check || arg.norm_check)

--- a/projects/hipblas/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
@@ -153,7 +153,7 @@ void testing_iamax_iamin_strided_batched(const Arguments& arg, FUNC func)
     // copy data from CPU to device
     CHECK_HIP_ERROR(dx.transfer_from(hx));
 
-    double gpu_time_used;
+    double gpu_time_used{0};
     R      hipblas_error_host = 0, hipblas_error_device = 0;
 
     if(arg.unit_check || arg.norm_check)

--- a/projects/hipblas/clients/include/blas1/testing_nrm2.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_nrm2.hpp
@@ -106,7 +106,7 @@ void testing_nrm2(const Arguments& arg)
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(N, incx);
-    Tr             cpu_result, hipblas_result_host, hipblas_result_device;
+    Tr             cpu_result{0}, hipblas_result_host{0}, hipblas_result_device{0};
 
     device_vector<T>  dx(N, incx);
     device_vector<Tr> d_hipblas_result(1);
@@ -114,7 +114,7 @@ void testing_nrm2(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas1/testing_nrm2_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_nrm2_batched.hpp
@@ -116,7 +116,7 @@ void testing_nrm2_batched(const Arguments& arg)
 
     int64_t sizeX = N * incx;
 
-    double gpu_time_used;
+    double gpu_time_used{0};
     double hipblas_error_host = 0, hipblas_error_device = 0;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice

--- a/projects/hipblas/clients/include/blas1/testing_nrm2_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_nrm2_strided_batched.hpp
@@ -133,7 +133,7 @@ void testing_nrm2_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    double gpu_time_used;
+    double gpu_time_used{0};
     double hipblas_error_host = 0, hipblas_error_device = 0;
 
     // Initial Data on CPU

--- a/projects/hipblas/clients/include/blas1/testing_rot.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rot.hpp
@@ -98,7 +98,7 @@ void testing_rot(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     int64_t abs_incx = incx >= 0 ? incx : -incx;
     int64_t abs_incy = incy >= 0 ? incy : -incy;

--- a/projects/hipblas/clients/include/blas1/testing_rot_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rot_batched.hpp
@@ -104,7 +104,7 @@ void testing_rot_batched(const Arguments& arg)
     int64_t abs_incx = incx >= 0 ? incx : -incx;
     int64_t abs_incy = incy >= 0 ? incy : -incy;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);

--- a/projects/hipblas/clients/include/blas1/testing_rot_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rot_strided_batched.hpp
@@ -128,7 +128,7 @@ void testing_rot_strided_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     host_strided_batch_vector<T> hx(N, incx, stride_x, batch_count);

--- a/projects/hipblas/clients/include/blas1/testing_rotg.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rotg.hpp
@@ -72,7 +72,7 @@ void testing_rotg(const Arguments& arg)
     auto hipblasRotgFn_64
         = arg.api == FORTRAN_64 ? hipblasRotg_64<T, U, true> : hipblasRotg_64<T, U, false>;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     hipblasLocalHandle handle(arg);
 

--- a/projects/hipblas/clients/include/blas1/testing_rotg_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rotg_batched.hpp
@@ -90,7 +90,7 @@ void testing_rotg_batched(const Arguments& arg)
     if(batch_count <= 0)
         return;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     hipblasLocalHandle handle(arg);
 

--- a/projects/hipblas/clients/include/blas1/testing_rotg_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rotg_strided_batched.hpp
@@ -101,7 +101,7 @@ void testing_rotg_strided_batched(const Arguments& arg)
     if(batch_count <= 0)
         return;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     hipblasLocalHandle handle(arg);
 

--- a/projects/hipblas/clients/include/blas1/testing_rotm.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rotm.hpp
@@ -111,7 +111,7 @@ void testing_rotm(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     int64_t abs_incx = incx >= 0 ? incx : -incx;
     int64_t abs_incy = incy >= 0 ? incy : -incy;

--- a/projects/hipblas/clients/include/blas1/testing_rotm_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rotm_batched.hpp
@@ -107,7 +107,7 @@ void testing_rotm_batched(const Arguments& arg)
     int64_t abs_incx = incx >= 0 ? incx : -incx;
     int64_t abs_incy = incy >= 0 ? incy : -incy;
 
-    double gpu_time_used, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_device{0};
 
     host_batch_vector<T> hx(N, incx, batch_count);
     host_batch_vector<T> hy(N, incy, batch_count);

--- a/projects/hipblas/clients/include/blas1/testing_rotm_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rotm_strided_batched.hpp
@@ -155,7 +155,7 @@ void testing_rotm_strided_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     host_strided_batch_vector<T> hx(N, incx, stride_x, batch_count);

--- a/projects/hipblas/clients/include/blas1/testing_rotmg.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rotmg.hpp
@@ -77,7 +77,7 @@ void testing_rotmg(const Arguments& arg)
     auto hipblasRotmgFn_64
         = arg.api == FORTRAN_64 ? hipblasRotmg_64<T, true> : hipblasRotmg_64<T, false>;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     hipblasLocalHandle handle(arg);
 

--- a/projects/hipblas/clients/include/blas1/testing_rotmg_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rotmg_batched.hpp
@@ -92,7 +92,7 @@ void testing_rotmg_batched(const Arguments& arg)
     if(batch_count <= 0)
         return;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     hipblasLocalHandle handle(arg);
 

--- a/projects/hipblas/clients/include/blas1/testing_rotmg_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas1/testing_rotmg_strided_batched.hpp
@@ -171,7 +171,7 @@ void testing_rotmg_strided_batched(const Arguments& arg)
     if(batch_count <= 0)
         return;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     hipblasLocalHandle handle(arg);
 

--- a/projects/hipblas/clients/include/blas2/testing_gbmv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_gbmv.hpp
@@ -312,7 +312,7 @@ void testing_gbmv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -400,7 +400,7 @@ void testing_gbmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_gbmv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_gbmv_batched.hpp
@@ -411,7 +411,7 @@ void testing_gbmv_batched(const Arguments& arg)
     size_t abs_incx = incx >= 0 ? incx : -incx;
     size_t abs_incy = incy >= 0 ? incy : -incy;
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -525,7 +525,7 @@ void testing_gbmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_gbmv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_gbmv_strided_batched.hpp
@@ -488,7 +488,7 @@ void testing_gbmv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -588,7 +588,7 @@ void testing_gbmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_gemv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_gemv.hpp
@@ -254,7 +254,7 @@ void testing_gemv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -329,7 +329,7 @@ void testing_gemv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/projects/hipblas/clients/include/blas2/testing_gemv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_gemv_batched.hpp
@@ -381,7 +381,7 @@ void testing_gemv_batched(const Arguments& arg)
 
     int abs_incy = incy >= 0 ? incy : -incy;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -492,7 +492,7 @@ void testing_gemv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;

--- a/projects/hipblas/clients/include/blas2/testing_gemv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_gemv_strided_batched.hpp
@@ -459,7 +459,7 @@ void testing_gemv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -554,7 +554,7 @@ void testing_gemv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
         hipStream_t stream;

--- a/projects/hipblas/clients/include/blas2/testing_ger.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_ger.hpp
@@ -185,7 +185,7 @@ void testing_ger(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
 
@@ -243,7 +243,7 @@ void testing_ger(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_ger_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_ger_batched.hpp
@@ -211,7 +211,7 @@ void testing_ger_batched(const Arguments& arg)
 
     size_t A_size = lda * N;
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
 
@@ -327,7 +327,7 @@ void testing_ger_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_ger_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_ger_strided_batched.hpp
@@ -317,7 +317,7 @@ void testing_ger_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
 
@@ -406,7 +406,7 @@ void testing_ger_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hbmv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hbmv.hpp
@@ -209,7 +209,7 @@ void testing_hbmv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -283,7 +283,7 @@ void testing_hbmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hbmv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hbmv_batched.hpp
@@ -330,7 +330,7 @@ void testing_hbmv_batched(const Arguments& arg)
         return;
     }
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -441,7 +441,7 @@ void testing_hbmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hbmv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hbmv_strided_batched.hpp
@@ -414,7 +414,7 @@ void testing_hbmv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -510,7 +510,7 @@ void testing_hbmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hemv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hemv.hpp
@@ -193,7 +193,7 @@ void testing_hemv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -261,7 +261,7 @@ void testing_hemv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hemv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hemv_batched.hpp
@@ -300,7 +300,7 @@ void testing_hemv_batched(const Arguments& arg)
         return;
     }
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -408,7 +408,7 @@ void testing_hemv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hemv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hemv_strided_batched.hpp
@@ -400,7 +400,7 @@ void testing_hemv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -493,7 +493,7 @@ void testing_hemv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_her.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_her.hpp
@@ -157,7 +157,7 @@ void testing_her(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     U h_alpha = arg.get_alpha<U>();
 
@@ -215,7 +215,7 @@ void testing_her(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_her2.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_her2.hpp
@@ -172,7 +172,7 @@ void testing_her2(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
 
@@ -233,7 +233,7 @@ void testing_her2(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_her2_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_her2_batched.hpp
@@ -216,7 +216,7 @@ void testing_her2_batched(const Arguments& arg)
     size_t            A_size = lda * N;
     hipblasFillMode_t uplo   = char2hipblas_fill(arg.uplo);
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
 
@@ -331,7 +331,7 @@ void testing_her2_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_her2_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_her2_strided_batched.hpp
@@ -332,7 +332,7 @@ void testing_her2_strided_batched(const Arguments& arg)
     device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
     device_vector<T>               d_alpha(1);
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
 
@@ -421,7 +421,7 @@ void testing_her2_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_her_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_her_batched.hpp
@@ -169,7 +169,7 @@ void testing_her_batched(const Arguments& arg)
 
     size_t A_size = lda * N;
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     U h_alpha = arg.get_alpha<U>();
 
@@ -271,7 +271,7 @@ void testing_her_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_her_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_her_strided_batched.hpp
@@ -219,7 +219,7 @@ void testing_her_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     U h_alpha = arg.get_alpha<U>();
 
@@ -281,7 +281,7 @@ void testing_her_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hpmv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hpmv.hpp
@@ -213,7 +213,7 @@ void testing_hpmv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -284,7 +284,7 @@ void testing_hpmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hpmv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hpmv_batched.hpp
@@ -302,7 +302,7 @@ void testing_hpmv_batched(const Arguments& arg)
         return;
     }
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -413,7 +413,7 @@ void testing_hpmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hpmv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hpmv_strided_batched.hpp
@@ -403,7 +403,7 @@ void testing_hpmv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
@@ -497,7 +497,7 @@ void testing_hpmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dy.transfer_from(hy));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hpr.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hpr.hpp
@@ -169,7 +169,7 @@ void testing_hpr(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     U h_alpha = arg.get_alpha<U>();
 
@@ -225,7 +225,7 @@ void testing_hpr(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hpr2.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hpr2.hpp
@@ -185,7 +185,7 @@ void testing_hpr2(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
 
@@ -246,7 +246,7 @@ void testing_hpr2(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hpr2_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hpr2_batched.hpp
@@ -231,7 +231,7 @@ void testing_hpr2_batched(const Arguments& arg)
     size_t            size_A = hipblas_packed_matrix_size(N);
     hipblasFillMode_t uplo   = char2hipblas_fill(arg.uplo);
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
 
@@ -347,7 +347,7 @@ void testing_hpr2_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hpr2_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hpr2_strided_batched.hpp
@@ -348,7 +348,7 @@ void testing_hpr2_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
 
@@ -439,7 +439,7 @@ void testing_hpr2_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hpr_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hpr_batched.hpp
@@ -158,7 +158,7 @@ void testing_hpr_batched(const Arguments& arg)
 
     int64_t size_A = hipblas_packed_matrix_size(N);
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     U h_alpha = arg.get_alpha<U>();
 
@@ -259,7 +259,7 @@ void testing_hpr_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_hpr_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_hpr_strided_batched.hpp
@@ -216,7 +216,7 @@ void testing_hpr_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double hipblas_error_host, hipblas_error_device;
+    double hipblas_error_host{0}, hipblas_error_device{0};
 
     U h_alpha = arg.get_alpha<U>();
 
@@ -281,7 +281,7 @@ void testing_hpr_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_sbmv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_sbmv.hpp
@@ -222,7 +222,7 @@ void testing_sbmv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas2/testing_sbmv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_sbmv_batched.hpp
@@ -342,7 +342,7 @@ void testing_sbmv_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();

--- a/projects/hipblas/clients/include/blas2/testing_sbmv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_sbmv_strided_batched.hpp
@@ -429,7 +429,7 @@ void testing_sbmv_strided_batched(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas2/testing_spmv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_spmv.hpp
@@ -210,7 +210,7 @@ void testing_spmv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas2/testing_spmv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_spmv_batched.hpp
@@ -292,7 +292,7 @@ void testing_spmv_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();

--- a/projects/hipblas/clients/include/blas2/testing_spmv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_spmv_strided_batched.hpp
@@ -405,7 +405,7 @@ void testing_spmv_strided_batched(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas2/testing_spr.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_spr.hpp
@@ -164,7 +164,7 @@ void testing_spr(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas2/testing_spr2.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_spr2.hpp
@@ -171,7 +171,7 @@ void testing_spr2(const Arguments& arg)
 
     T h_alpha = arg.get_alpha<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas2/testing_spr2_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_spr2_batched.hpp
@@ -232,7 +232,7 @@ void testing_spr2_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hAp), `d` is in GPU (device) memory (eg dAp).
     host_batch_matrix<T> hA(N, N, N, batch_count);

--- a/projects/hipblas/clients/include/blas2/testing_spr2_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_spr2_strided_batched.hpp
@@ -347,7 +347,7 @@ void testing_spr2_strided_batched(const Arguments& arg)
 
     T h_alpha = arg.get_alpha<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas2/testing_spr_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_spr_batched.hpp
@@ -169,7 +169,7 @@ void testing_spr_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hAp), `d` is in GPU (device) memory (eg dAp).
     // Allocate host memory

--- a/projects/hipblas/clients/include/blas2/testing_spr_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_spr_strided_batched.hpp
@@ -214,7 +214,7 @@ void testing_spr_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas2/testing_symv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_symv.hpp
@@ -202,7 +202,7 @@ void testing_symv(const Arguments& arg)
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas2/testing_symv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_symv_batched.hpp
@@ -305,7 +305,7 @@ void testing_symv_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();

--- a/projects/hipblas/clients/include/blas2/testing_symv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_symv_strided_batched.hpp
@@ -420,7 +420,7 @@ void testing_symv_strided_batched(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas2/testing_syr.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_syr.hpp
@@ -161,7 +161,7 @@ void testing_syr(const Arguments& arg)
 
     T h_alpha = arg.get_alpha<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas2/testing_syr2.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_syr2.hpp
@@ -185,7 +185,7 @@ void testing_syr2(const Arguments& arg)
 
     T h_alpha = arg.get_alpha<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas2/testing_syr2_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_syr2_batched.hpp
@@ -242,7 +242,7 @@ void testing_syr2_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hA), `d` is in GPU (device) memory (eg dA).
     // Allocate host memory

--- a/projects/hipblas/clients/include/blas2/testing_syr2_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_syr2_strided_batched.hpp
@@ -363,7 +363,7 @@ void testing_syr2_strided_batched(const Arguments& arg)
 
     T h_alpha = arg.get_alpha<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas2/testing_syr_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_syr_batched.hpp
@@ -193,7 +193,7 @@ void testing_syr_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hA), `d` is in GPU (device) memory (eg dA).
     // Allocate host memory

--- a/projects/hipblas/clients/include/blas2/testing_syr_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_syr_strided_batched.hpp
@@ -239,7 +239,7 @@ void testing_syr_strided_batched(const Arguments& arg)
 
     T h_alpha = arg.get_alpha<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas2/testing_tbmv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tbmv.hpp
@@ -165,7 +165,7 @@ void testing_tbmv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAb.memcheck());
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(
@@ -209,7 +209,7 @@ void testing_tbmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dx.transfer_from(hx));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));

--- a/projects/hipblas/clients/include/blas2/testing_tbmv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tbmv_batched.hpp
@@ -208,7 +208,7 @@ void testing_tbmv_batched(const Arguments& arg)
         return;
     }
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Naming: `h` is in CPU (host) memory(eg hAb), `d` is in GPU (device) memory (eg dAb).
     // Allocate host memory
@@ -285,7 +285,7 @@ void testing_tbmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dx.transfer_from(hx));
 
         hipStream_t stream;

--- a/projects/hipblas/clients/include/blas2/testing_tbmv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tbmv_strided_batched.hpp
@@ -283,7 +283,7 @@ void testing_tbmv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAb.memcheck());
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(
@@ -343,7 +343,7 @@ void testing_tbmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double gpu_time_used;
+        double gpu_time_used{0};
         CHECK_HIP_ERROR(dx.transfer_from(hx));
 
         hipStream_t stream;

--- a/projects/hipblas/clients/include/blas2/testing_tbsv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tbsv.hpp
@@ -166,7 +166,7 @@ void testing_tbsv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAb.memcheck());
     CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA,
@@ -218,7 +218,7 @@ void testing_tbsv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_tbsv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tbsv_batched.hpp
@@ -231,7 +231,7 @@ void testing_tbsv_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAb.memcheck());
     CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
-    double hipblas_error, cumulative_hipblas_error = 0;
+    double hipblas_error{0}, cumulative_hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA,
@@ -302,7 +302,7 @@ void testing_tbsv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_tbsv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tbsv_strided_batched.hpp
@@ -296,7 +296,7 @@ void testing_tbsv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAb.memcheck());
     CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
-    double hipblas_error, cumulative_hipblas_error = 0;
+    double hipblas_error{0}, cumulative_hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA,
@@ -370,7 +370,7 @@ void testing_tbsv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_tpmv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tpmv.hpp
@@ -142,7 +142,7 @@ void testing_tpmv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAp.memcheck());
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(
@@ -186,7 +186,7 @@ void testing_tpmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_tpmv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tpmv_batched.hpp
@@ -175,7 +175,7 @@ void testing_tpmv_batched(const Arguments& arg)
         return;
     }
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Naming: `h` is in CPU (host) memory(eg hAp), `d` is in GPU (device) memory (eg dAp).
     // Allocate host memory
@@ -250,7 +250,7 @@ void testing_tpmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_tpmv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tpmv_strided_batched.hpp
@@ -225,7 +225,7 @@ void testing_tpmv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAp.memcheck());
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(
@@ -274,7 +274,7 @@ void testing_tpmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_tpsv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tpsv.hpp
@@ -147,7 +147,7 @@ void testing_tpsv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAp.memcheck());
     CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
-    double gpu_time_used, hipblas_error;
+    double gpu_time_used{0}, hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA,
@@ -199,7 +199,7 @@ void testing_tpsv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));

--- a/projects/hipblas/clients/include/blas2/testing_tpsv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tpsv_batched.hpp
@@ -201,7 +201,7 @@ void testing_tpsv_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAp.memcheck());
     CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
-    double gpu_time_used, hipblas_error, cumulative_hipblas_error = 0;
+    double gpu_time_used{0}, hipblas_error{0}, cumulative_hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA,
@@ -270,7 +270,7 @@ void testing_tpsv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));

--- a/projects/hipblas/clients/include/blas2/testing_tpsv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_tpsv_strided_batched.hpp
@@ -230,7 +230,7 @@ void testing_tpsv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dAp.memcheck());
     CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
-    double hipblas_error, cumulative_hipblas_error = 0;
+    double hipblas_error{0}, cumulative_hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA,
@@ -293,7 +293,7 @@ void testing_tpsv_strided_batched(const Arguments& arg)
     }
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_trmv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_trmv.hpp
@@ -150,7 +150,7 @@ void testing_trmv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(
@@ -193,7 +193,7 @@ void testing_trmv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_trmv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_trmv_batched.hpp
@@ -182,7 +182,7 @@ void testing_trmv_batched(const Arguments& arg)
         return;
     }
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Naming: `h` is in CPU (host) memory(eg hA), `d` is in GPU (device) memory (eg dA).
     // Allocate host memory
@@ -255,7 +255,7 @@ void testing_trmv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_trmv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_trmv_strided_batched.hpp
@@ -257,7 +257,7 @@ void testing_trmv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(
@@ -304,7 +304,7 @@ void testing_trmv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/projects/hipblas/clients/include/blas2/testing_trsv.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_trsv.hpp
@@ -151,7 +151,7 @@ void testing_trsv(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
-    double hipblas_error;
+    double hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA,
@@ -201,7 +201,7 @@ void testing_trsv(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));

--- a/projects/hipblas/clients/include/blas2/testing_trsv_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_trsv_batched.hpp
@@ -202,7 +202,7 @@ void testing_trsv_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
-    double hipblas_error, cumulative_hipblas_error;
+    double hipblas_error{0}, cumulative_hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA,
@@ -268,7 +268,7 @@ void testing_trsv_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));

--- a/projects/hipblas/clients/include/blas2/testing_trsv_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas2/testing_trsv_strided_batched.hpp
@@ -261,7 +261,7 @@ void testing_trsv_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dx_or_b.memcheck());
 
-    double hipblas_error, cumulative_hipblas_error;
+    double hipblas_error{0}, cumulative_hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA,
@@ -331,7 +331,7 @@ void testing_trsv_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        double      gpu_time_used;
+        double      gpu_time_used{0};
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));

--- a/projects/hipblas/clients/include/blas3/testing_dgmm.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_dgmm.hpp
@@ -163,7 +163,7 @@ void testing_dgmm(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(dC.memcheck());
 
-    double gpu_time_used, hipblas_error;
+    double gpu_time_used{0}, hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_dgmm_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_dgmm_batched.hpp
@@ -226,7 +226,7 @@ void testing_dgmm_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(dC.memcheck());
 
-    double gpu_time_used, hipblas_error;
+    double gpu_time_used{0}, hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_dgmm_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_dgmm_strided_batched.hpp
@@ -321,7 +321,7 @@ void testing_dgmm_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(dC.memcheck());
 
-    double gpu_time_used, hipblas_error;
+    double gpu_time_used{0}, hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_geam.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_geam.hpp
@@ -254,7 +254,7 @@ void testing_geam(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double             gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
     hipblasLocalHandle handle(arg);
 
     int64_t A_row = transA == HIPBLAS_OP_N ? M : N;

--- a/projects/hipblas/clients/include/blas3/testing_geam_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_geam_batched.hpp
@@ -444,7 +444,7 @@ void testing_geam_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hA), `d` is in GPU (device) memory (eg dA).
     // Allocate host memory

--- a/projects/hipblas/clients/include/blas3/testing_geam_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_geam_strided_batched.hpp
@@ -510,7 +510,7 @@ void testing_geam_strided_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hA), `d` is in GPU (device) memory (eg dA).
     // Allocate host memory

--- a/projects/hipblas/clients/include/blas3/testing_gemm.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_gemm.hpp
@@ -319,7 +319,7 @@ void testing_gemm(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hA), `d` is in GPU (device) memory (eg dA).
     // Allocate host memory

--- a/projects/hipblas/clients/include/blas3/testing_gemm_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_gemm_batched.hpp
@@ -440,7 +440,7 @@ void testing_gemm_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hA), `d` is in GPU (device) memory (eg dA).
     // Allocate host memory

--- a/projects/hipblas/clients/include/blas3/testing_gemm_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_gemm_strided_batched.hpp
@@ -546,7 +546,7 @@ void testing_gemm_strided_batched(const Arguments& arg)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     /* =====================================================================
          HIPBLAS

--- a/projects/hipblas/clients/include/blas3/testing_hemm.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_hemm.hpp
@@ -252,7 +252,7 @@ void testing_hemm(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_hermitian_matrix, true);
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas3/testing_hemm_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_hemm_batched.hpp
@@ -403,7 +403,7 @@ void testing_hemm_batched(const Arguments& arg)
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();

--- a/projects/hipblas/clients/include/blas3/testing_hemm_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_hemm_strided_batched.hpp
@@ -490,7 +490,7 @@ void testing_hemm_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();

--- a/projects/hipblas/clients/include/blas3/testing_her2k.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_her2k.hpp
@@ -282,7 +282,7 @@ void testing_her2k(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     U h_beta  = arg.get_beta<U>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_her2k_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_her2k_batched.hpp
@@ -412,7 +412,7 @@ void testing_her2k_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     size_t rows = (transA != HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);
     size_t cols = (transA == HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);

--- a/projects/hipblas/clients/include/blas3/testing_her2k_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_her2k_strided_batched.hpp
@@ -506,7 +506,7 @@ void testing_her2k_strided_batched(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     U h_beta  = arg.get_beta<U>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_herk.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_herk.hpp
@@ -224,7 +224,7 @@ void testing_herk(const Arguments& arg)
     U h_alpha = arg.get_alpha<U>();
     U h_beta  = arg.get_beta<U>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_herk_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_herk_batched.hpp
@@ -324,7 +324,7 @@ void testing_herk_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     size_t rows = (transA != HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);
     size_t cols = (transA == HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);

--- a/projects/hipblas/clients/include/blas3/testing_herk_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_herk_strided_batched.hpp
@@ -423,7 +423,7 @@ void testing_herk_strided_batched(const Arguments& arg)
     U h_alpha = arg.get_alpha<U>();
     U h_beta  = arg.get_beta<U>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_herkx.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_herkx.hpp
@@ -283,7 +283,7 @@ void testing_herkx(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     U h_beta  = arg.get_beta<U>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_herkx_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_herkx_batched.hpp
@@ -411,7 +411,7 @@ void testing_herkx_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     size_t rows = (transA != HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);
     size_t cols = (transA == HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);

--- a/projects/hipblas/clients/include/blas3/testing_herkx_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_herkx_strided_batched.hpp
@@ -506,7 +506,7 @@ void testing_herkx_strided_batched(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     U h_beta  = arg.get_beta<U>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_symm.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_symm.hpp
@@ -253,7 +253,7 @@ void testing_symm(const Arguments& arg)
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_symm_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_symm_batched.hpp
@@ -406,7 +406,7 @@ void testing_symm_batched(const Arguments& arg)
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hA), `d` is in GPU (device) memory (eg dA).
     // Allocate host memory

--- a/projects/hipblas/clients/include/blas3/testing_symm_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_symm_strided_batched.hpp
@@ -495,7 +495,7 @@ void testing_symm_strided_batched(const Arguments& arg)
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_symmetric_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_syr2k.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_syr2k.hpp
@@ -275,7 +275,7 @@ void testing_syr2k(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_syr2k_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_syr2k_batched.hpp
@@ -392,7 +392,7 @@ void testing_syr2k_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     size_t rows = (transA != HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);
     size_t cols = (transA == HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);

--- a/projects/hipblas/clients/include/blas3/testing_syr2k_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_syr2k_strided_batched.hpp
@@ -481,7 +481,7 @@ void testing_syr2k_strided_batched(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_syrk.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_syrk.hpp
@@ -220,7 +220,7 @@ void testing_syrk(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_syrk_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_syrk_batched.hpp
@@ -311,7 +311,7 @@ void testing_syrk_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     size_t rows = (transA != HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);
     size_t cols = (transA == HIPBLAS_OP_N ? std::max(K, int64_t(1)) : N);

--- a/projects/hipblas/clients/include/blas3/testing_syrk_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_syrk_strided_batched.hpp
@@ -407,7 +407,7 @@ void testing_syrk_strided_batched(const Arguments& arg)
     T h_alpha = arg.get_alpha<T>();
     T h_beta  = arg.get_beta<T>();
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_syrkx.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_syrkx.hpp
@@ -273,7 +273,7 @@ void testing_syrkx(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_syrkx_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_syrkx_batched.hpp
@@ -416,7 +416,7 @@ void testing_syrkx_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_syrkx_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_syrkx_strided_batched.hpp
@@ -480,7 +480,7 @@ void testing_syrkx_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_trmm.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_trmm.hpp
@@ -402,7 +402,7 @@ void testing_trmm(const Arguments& arg)
 
     device_matrix<T>* dOut = inplace ? &dB : &dC;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_triangular_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_trmm_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_trmm_batched.hpp
@@ -463,7 +463,7 @@ void testing_trmm_batched(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Naming: `h` is in CPU (host) memory(eg hA), `d` is in GPU (device) memory (eg dA).
     // Allocate host memory

--- a/projects/hipblas/clients/include/blas3/testing_trmm_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_trmm_strided_batched.hpp
@@ -559,7 +559,7 @@ void testing_trmm_strided_batched(const Arguments& arg)
 
     device_strided_batch_matrix<T>* dOut = inplace ? &dB : &dC;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_triangular_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_trsm.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_trsm.hpp
@@ -250,7 +250,7 @@ void testing_trsm(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dB.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial data on CPU
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas3/testing_trsm_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_trsm_batched.hpp
@@ -386,7 +386,7 @@ void testing_trsm_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dB.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial data on CPU
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas3/testing_trsm_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_trsm_strided_batched.hpp
@@ -437,7 +437,7 @@ void testing_trsm_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dB.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial data on CPU
     hipblas_init_matrix(

--- a/projects/hipblas/clients/include/blas3/testing_trtri.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_trtri.hpp
@@ -113,7 +113,7 @@ void testing_trtri(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial Data on CPU

--- a/projects/hipblas/clients/include/blas3/testing_trtri_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_trtri_batched.hpp
@@ -164,7 +164,7 @@ void testing_trtri_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
 
-    double gpu_time_used, hipblas_error;
+    double gpu_time_used{0}, hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_triangular_matrix, true);

--- a/projects/hipblas/clients/include/blas3/testing_trtri_strided_batched.hpp
+++ b/projects/hipblas/clients/include/blas3/testing_trtri_strided_batched.hpp
@@ -185,7 +185,7 @@ void testing_trtri_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
 
-    double gpu_time_used, hipblas_error;
+    double gpu_time_used{0}, hipblas_error{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_never_set_nan, hipblas_triangular_matrix, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_axpy_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_axpy_batched_ex.hpp
@@ -269,7 +269,7 @@ void testing_axpy_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_axpy_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_axpy_ex.hpp
@@ -220,7 +220,7 @@ void testing_axpy_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_axpy_strided_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_axpy_strided_batched_ex.hpp
@@ -297,7 +297,7 @@ void testing_axpy_strided_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_dot_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_dot_batched_ex.hpp
@@ -244,7 +244,7 @@ void testing_dot_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true, false);

--- a/projects/hipblas/clients/include/blas_ex/testing_dot_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_dot_ex.hpp
@@ -202,9 +202,7 @@ void testing_dot_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    Tr cpu_result, hipblas_result_host, hipblas_result_device;
-
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true, false);
@@ -216,6 +214,8 @@ void testing_dot_ex(const Arguments& arg)
 
     if(arg.unit_check || arg.norm_check)
     {
+        Tr cpu_result, hipblas_result_host, hipblas_result_device;
+
         /* =====================================================================
             HIPBLAS
         =================================================================== */

--- a/projects/hipblas/clients/include/blas_ex/testing_dot_strided_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_dot_strided_batched_ex.hpp
@@ -268,7 +268,7 @@ void testing_dot_strided_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dy.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true, false);

--- a/projects/hipblas/clients/include/blas_ex/testing_gemm_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_gemm_batched_ex.hpp
@@ -415,7 +415,7 @@ void testing_gemm_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
     CHECK_DEVICE_ALLOCATION(d_beta.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -383,7 +383,7 @@ void testing_gemm_ex(const Arguments& arg)
     device_vector<Tex> d_alpha(1);
     device_vector<Tex> d_beta(1);
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
@@ -440,7 +440,7 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_nrm2_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_nrm2_batched_ex.hpp
@@ -160,7 +160,7 @@ void testing_nrm2_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_nrm2_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_nrm2_ex.hpp
@@ -136,9 +136,7 @@ void testing_nrm2_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    Tr cpu_result, hipblas_result_host, hipblas_result_device;
-
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);
@@ -148,6 +146,8 @@ void testing_nrm2_ex(const Arguments& arg)
 
     if(arg.unit_check || arg.norm_check)
     {
+        Tr cpu_result, hipblas_result_host, hipblas_result_device;
+
         // hipblasNrm2 accept both dev/host pointer for the scalar
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         DAPI_CHECK(hipblasNrm2ExFn,

--- a/projects/hipblas/clients/include/blas_ex/testing_nrm2_strided_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_nrm2_strided_batched_ex.hpp
@@ -186,7 +186,7 @@ void testing_nrm2_strided_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_hipblas_result.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_rot_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_rot_batched_ex.hpp
@@ -201,7 +201,7 @@ void testing_rot_batched_ex(const Arguments& arg)
     int64_t abs_incx = incx >= 0 ? incx : -incx;
     int64_t abs_incy = incy >= 0 ? incy : -incy;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     host_batch_vector<Tx> hx_host(N, incx, batch_count);
     host_batch_vector<Ty> hy_host(N, incy, batch_count);

--- a/projects/hipblas/clients/include/blas_ex/testing_rot_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_rot_ex.hpp
@@ -138,7 +138,7 @@ void testing_rot_ex(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     int64_t abs_incx = incx >= 0 ? incx : -incx;
     int64_t abs_incy = incy >= 0 ? incy : -incy;

--- a/projects/hipblas/clients/include/blas_ex/testing_rot_strided_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_rot_strided_batched_ex.hpp
@@ -242,7 +242,7 @@ void testing_rot_strided_batched_ex(const Arguments& arg)
         return;
     }
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     device_strided_batch_vector<Tx> dx(N, incx, stridex, batch_count);
     device_strided_batch_vector<Ty> dy(N, incy, stridey, batch_count);

--- a/projects/hipblas/clients/include/blas_ex/testing_scal_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_scal_batched_ex.hpp
@@ -165,7 +165,7 @@ void testing_scal_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx_host, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_scal_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_scal_ex.hpp
@@ -140,7 +140,7 @@ void testing_scal_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx_host, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_scal_strided_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_scal_strided_batched_ex.hpp
@@ -191,7 +191,7 @@ void testing_scal_strided_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dx.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_vector(hx_host, arg, hipblas_client_alpha_sets_nan, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_syrk_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_syrk_ex.hpp
@@ -271,7 +271,7 @@ void testing_syrk_ex(const Arguments& arg)
     device_vector<Tex> d_alpha(1);
     device_vector<Tex> d_beta(1);
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
 
     // Initial Data on CPU
     hipblas_init_matrix(hA, arg, hipblas_client_alpha_sets_nan, hipblas_general_matrix, true);

--- a/projects/hipblas/clients/include/blas_ex/testing_trsm_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_trsm_batched_ex.hpp
@@ -400,7 +400,7 @@ void testing_trsm_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double             gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
     hipblasLocalHandle handle(arg);
 
     // Initial data on CPU

--- a/projects/hipblas/clients/include/blas_ex/testing_trsm_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_trsm_ex.hpp
@@ -351,7 +351,7 @@ void testing_trsm_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double             gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
     hipblasLocalHandle handle(arg);
 
     // Initial data on CPU

--- a/projects/hipblas/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
+++ b/projects/hipblas/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
@@ -460,7 +460,7 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dinvA.memcheck());
     CHECK_DEVICE_ALLOCATION(d_alpha.memcheck());
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double             gpu_time_used{0}, hipblas_error_host{0}, hipblas_error_device{0};
     hipblasLocalHandle handle(arg);
 
     // Initial data on CPU

--- a/projects/hipblas/clients/include/solver/testing_gels.hpp
+++ b/projects/hipblas/clients/include/solver/testing_gels.hpp
@@ -192,7 +192,7 @@ void testing_gels(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dB.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA, hB, hX on CPU

--- a/projects/hipblas/clients/include/solver/testing_gels_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_gels_batched.hpp
@@ -266,7 +266,7 @@ void testing_gels_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dB.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA, hB, hX on CPU

--- a/projects/hipblas/clients/include/solver/testing_gels_strided_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_gels_strided_batched.hpp
@@ -403,7 +403,7 @@ void testing_gels_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dB.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA, hB, hX on CPU

--- a/projects/hipblas/clients/include/solver/testing_geqrf.hpp
+++ b/projects/hipblas/clients/include/solver/testing_geqrf.hpp
@@ -168,7 +168,7 @@ void testing_geqrf(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
 
-    double gpu_time_used, hipblas_error;
+    double gpu_time_used{0}, hipblas_error{0};
 
     setup_geqrf_testing(arg, hA, dA, dIpiv, M, N, lda);
 

--- a/projects/hipblas/clients/include/solver/testing_geqrf_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_geqrf_batched.hpp
@@ -198,7 +198,7 @@ void testing_geqrf_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
 
-    double gpu_time_used, hipblas_error;
+    double gpu_time_used{0}, hipblas_error{0};
 
     setup_geqrf_batched_testing(arg, hA, hIpiv, dA, dIpiv, M, N, lda, batch_count);
 

--- a/projects/hipblas/clients/include/solver/testing_geqrf_strided_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_geqrf_strided_batched.hpp
@@ -231,7 +231,7 @@ void testing_geqrf_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
 
-    double gpu_time_used, hipblas_error;
+    double gpu_time_used{0}, hipblas_error{0};
 
     setup_geqrf_strided_batched_testing(
         arg, hA, dA, dIpiv, M, N, lda, strideA, strideP, batch_count);

--- a/projects/hipblas/clients/include/solver/testing_getrf.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getrf.hpp
@@ -112,7 +112,7 @@ void testing_getrf(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA on CPU

--- a/projects/hipblas/clients/include/solver/testing_getrf_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getrf_batched.hpp
@@ -136,7 +136,7 @@ void testing_getrf_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA on CPU

--- a/projects/hipblas/clients/include/solver/testing_getrf_npvt.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getrf_npvt.hpp
@@ -102,7 +102,7 @@ void testing_getrf_npvt(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA on CPU

--- a/projects/hipblas/clients/include/solver/testing_getrf_npvt_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getrf_npvt_batched.hpp
@@ -127,7 +127,7 @@ void testing_getrf_npvt_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA on CPU

--- a/projects/hipblas/clients/include/solver/testing_getrf_npvt_strided_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getrf_npvt_strided_batched.hpp
@@ -128,7 +128,7 @@ void testing_getrf_npvt_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dA.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA on CPU

--- a/projects/hipblas/clients/include/solver/testing_getrf_strided_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getrf_strided_batched.hpp
@@ -138,7 +138,7 @@ void testing_getrf_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA on CPU

--- a/projects/hipblas/clients/include/solver/testing_getri_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getri_batched.hpp
@@ -184,7 +184,7 @@ void testing_getri_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA on CPU

--- a/projects/hipblas/clients/include/solver/testing_getri_npvt_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getri_npvt_batched.hpp
@@ -176,7 +176,7 @@ void testing_getri_npvt_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dC.memcheck());
     CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
 
     // Initial hA on CPU

--- a/projects/hipblas/clients/include/solver/testing_getrs.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getrs.hpp
@@ -210,7 +210,7 @@ void testing_getrs(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dB.memcheck());
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
     hipblasOperation_t op = HIPBLAS_OP_N;
 

--- a/projects/hipblas/clients/include/solver/testing_getrs_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getrs_batched.hpp
@@ -262,7 +262,7 @@ void testing_getrs_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dB.memcheck());
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
     hipblasOperation_t op = HIPBLAS_OP_N;
 

--- a/projects/hipblas/clients/include/solver/testing_getrs_strided_batched.hpp
+++ b/projects/hipblas/clients/include/solver/testing_getrs_strided_batched.hpp
@@ -393,7 +393,7 @@ void testing_getrs_strided_batched(const Arguments& arg)
     CHECK_DEVICE_ALLOCATION(dB.memcheck());
     CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
 
-    double             gpu_time_used, hipblas_error;
+    double             gpu_time_used{0}, hipblas_error{0};
     hipblasLocalHandle handle(arg);
     hipblasOperation_t op = HIPBLAS_OP_N;
 

--- a/projects/hipblas/clients/samples/example_bfdot_hip_bfloat16.cpp
+++ b/projects/hipblas/clients/samples/example_bfdot_hip_bfloat16.cpp
@@ -111,7 +111,7 @@ int main()
     size_t                    x_size = N * size_t(incx);
     size_t                    y_size = N * size_t(incy);
 
-    double gpu_time_used;
+    double gpu_time_used = 0.0;
 
     hipblasHandle_t handle;
     hipblasCreate(&handle);

--- a/projects/hipblas/clients/samples/example_c.c
+++ b/projects/hipblas/clients/samples/example_c.c
@@ -41,7 +41,7 @@ int main()
     float* hz = (float*)calloc(N, sizeof(*hz));
     float* dx;
 
-    double gpu_time_used;
+    double gpu_time_used = 0.0;
 
     hipblasHandle_t handle;
     hipblasCreate(&handle);

--- a/projects/hipblas/clients/samples/example_scal_ex.cpp
+++ b/projects/hipblas/clients/samples/example_scal_ex.cpp
@@ -83,9 +83,9 @@ int main()
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     std::vector<hipblasHalf> hx(N);
-    hipblasHalf*             dx;
+    hipblasHalf*             dx = nullptr;
 
-    double gpu_time_used;
+    double gpu_time_used = 0.0;
 
     hipblasHandle_t handle;
     hipblasCreate(&handle);

--- a/projects/hipblas/clients/samples/example_sscal.cpp
+++ b/projects/hipblas/clients/samples/example_sscal.cpp
@@ -82,9 +82,9 @@ int main()
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     std::vector<float> hx(N);
-    float*             dx;
+    float*             dx = nullptr;
 
-    double gpu_time_used;
+    double gpu_time_used = 0.0;
 
     hipblasHandle_t handle;
     hipblasCreate(&handle);


### PR DESCRIPTION
## Motivation

Fix uninitialized client variable use for time and error reporting

## Technical Details

Most changes are for logging only but some cumulative error fixes could rectify false failures

## Test Plan

Standard test runs.  Valgrind run locally.
