### PR TITLE
[hipsparselt] Fix smart destroyer in hipsparselt example_prune_strip

### DIFF
--- a/projects/hipsparselt/clients/samples/example_prune_strip.cpp
+++ b/projects/hipsparselt/clients/samples/example_prune_strip.cpp
@@ -544,7 +544,7 @@ void run(int64_t              m,
             hipsparseLtDenseDescriptorInit(&handle, &matA, n, m, n, 16, type, HIPSPARSE_ORDER_COL));
     }
     SMART_DESTROYER<const hipsparseLtMatDescriptor_t, hipsparseStatus_t> smA(
-        &matC, hipsparseLtMatDescriptorDestroy);
+        &matA, hipsparseLtMatDescriptorDestroy);
 
     if(!sparse_b)
     {
@@ -565,7 +565,7 @@ void run(int64_t              m,
                                                 HIPSPARSELT_SPARSITY_50_PERCENT));
     }
     SMART_DESTROYER<const hipsparseLtMatDescriptor_t, hipsparseStatus_t> smB(
-        &matC, hipsparseLtMatDescriptorDestroy);
+        &matB, hipsparseLtMatDescriptorDestroy);
 
     auto tmp_m = (!sparse_b) ? m : n;
 
@@ -577,7 +577,7 @@ void run(int64_t              m,
     CHECK_HIPSPARSELT_ERROR(hipsparseLtDenseDescriptorInit(
         &handle, &matD, tmp_m, tmp_m, tmp_m, 16, type, HIPSPARSE_ORDER_COL));
     SMART_DESTROYER<const hipsparseLtMatDescriptor_t, hipsparseStatus_t> smD(
-        &matC, hipsparseLtMatDescriptorDestroy);
+        &matD, hipsparseLtMatDescriptorDestroy);
 
     CHECK_HIPSPARSELT_ERROR(hipsparseLtMatDescSetAttribute(
         &handle, &matA, HIPSPARSELT_MAT_NUM_BATCHES, &batch_count, sizeof(batch_count)));


### PR DESCRIPTION
## Motivation

Currently multiple smart destroyers are created to freeing up `matC` multiple times. Initialize the destroyers correctly by passing in the right matrix handles.

## Technical Details

The majority part of the `example_prune_strip` code works fine, except the final errors reported for multiple destroy calls:

```
type,trans,M,N,ld,stride,batch_count,result,error
H, N, 128, 128, 128, 16384, 10
prune strip test PASSED
expected passed, prune check PASSED
expected falied, prune check PASSED
matDescr=0x7ffd7017a000 did not initialized or already destroyed
matDescr=0x7ffd7017a000 did not initialized or already destroyed
matDescr=0x7ffd7017a000 did not initialized or already destroyed
```

## Test Plan

Ran the binary after applying the fix to make sure the result is correct.

## Test Result

```
type,trans,M,N,ld,stride,batch_count,result,error
H, N, 128, 128, 128, 16384, 10
prune strip test PASSED
expected passed, prune check PASSED
expected falied, prune check PASSED
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
