### PR TITLE
[MIOpen] Switch logging call to MIOpen logger

### DIFF
--- a/projects/miopen/src/comgr.cpp
+++ b/projects/miopen/src/comgr.cpp
@@ -962,8 +962,7 @@ void BuildHip(const std::string& name,
         {
             auto rocm_include_arg = "-I" + rocm_path + "/include";
             opts.push_back(rocm_include_arg);
-            std::cout << "HIPRTC compile ROCm include path argument: " << rocm_include_arg
-                      << std::endl;
+            MIOPEN_LOG_T("HIPRTC compile ROCm include path argument: " << rocm_include_arg);
         }
 
         HiprtcProgram prog(name, text);


### PR DESCRIPTION
## Motivation

A change I made in #2898 accidentally snuck in a std::cout logging statement that should have been using MIOPEN_LOG_T, as this is what the previous code was doing.

## Technical Details

Switch to MIOPEN_LOG_T

## Test Plan

* Full test run

## Test Result

* Waiting for results

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
