### PR TITLE
[hipblaslt] [CMS] Fix type hint compatibility for python 3.9

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 from collections import defaultdict
 from copy import deepcopy
 from math import floor
+from typing import Optional, Union
 
 from rocisa.instruction import SWaitCnt, SBarrier
 from Tensile.Common.Utilities import printWarning
@@ -310,18 +311,18 @@ class ValidatorInstruction(ABC):
     issued_at: float
 
     @abstractmethod
-    def validate(self) -> str | None:
+    def validate(self) -> Optional[str]:
         ...
 
 @dataclass
 class LocalRead(ValidatorInstruction):
     name: str
     num_vmfma: int
-    issued_at: int | float
-    needed_by: int | float = float('inf')
-    guaranteed_by: int | float = float('inf')
+    issued_at: Union[int, float]
+    needed_by: Union[int, float] = float('inf')
+    guaranteed_by: Union[int, float] = float('inf')
 
-    def validate(self) -> str | None:
+    def validate(self) -> Optional[str]:
         # For when local reads are not being guaranteed by a particular pass.
         if self.needed_by == float('inf'):
             return None
@@ -357,13 +358,13 @@ class LocalRead(ValidatorInstruction):
 class GlobalRead(ValidatorInstruction):
     name: str
     num_vmfma: int
-    issued_at: int | float
+    issued_at: Union[int, float]
     swap_global_read_order: bool
     needed_by: float = float('inf')
-    guaranteed_by: int | float = float('inf')
-    barriered_at: list[int | float] = field(default_factory=list)
+    guaranteed_by: Union[int, float] = float('inf')
+    barriered_at: list[Union[int, float]] = field(default_factory=list)
 
-    def validate(self) -> str | None:
+    def validate(self) -> Optional[str]:
         if self.issued_at < self.guaranteed_by < self.needed_by:
             if any(self.guaranteed_by < barriered_at < self.needed_by for barriered_at in self.barriered_at):
                     return None
@@ -409,7 +410,7 @@ class GlobalRead(ValidatorInstruction):
 
 @dataclass
 class SWait(ValidatorInstruction):
-    issued_at: int | float
+    issued_at: Union[int, float]
     dscnt: int
     vlcnt: int
     vscnt: int
@@ -419,18 +420,18 @@ class SWait(ValidatorInstruction):
     def _is_valid(self) -> bool:
         return self.dscnt >= -1 and self.vlcnt >= -1 and self.vscnt >= -1 and self.issued_at >= -1
 
-    def validate(self) -> str | None:
+    def validate(self) -> Optional[str]:
         if self._is_valid():
             return None
         return f"SWait at index {floor(self.issued_at)} is invalid: dscnt={self.dscnt}, vlcnt={self.vlcnt}, vscnt={self.vscnt}, issued_at={floor(self.issued_at)}."
 
 @dataclass
 class Barrier(ValidatorInstruction):
-    issued_at: int | float
+    issued_at: Union[int, float]
     comment: str
     name: str = "SBarrier"
 
-    def validate(self) -> str | None:
+    def validate(self) -> Optional[str]:
         return f"Barrier at index {floor(self.issued_at)} is not valid. Must be >= -1." if self.issued_at < -1 else None
 
 MAIN_LOOP_PREV = "ML-1"
@@ -795,7 +796,7 @@ def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) 
                 gr.needed_by = LR_target.issued_at
 
 
-def validate_timeline(timeline: Timeline) -> str | None:
+def validate_timeline(timeline: Timeline) -> Optional[str]:
     """
     Validate the timeline by calling the validate method of each instruction.
     

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1017,7 +1017,7 @@ def verify_scc_overlap(scheduleInfo, context: dict, code_path: int) -> tuple[boo
 
     # Checks value is in [interval[0],interval[1]].
     # if lhsGt : ]interval[0],interval[1]] else  [interval[0],interval[1][
-    def inInterval(value : int, interval : list[int], lhsGt : bool):
+    def inInterval(value: int, interval: list[int], lhsGt: bool):
         if lhsGt:
             return value>interval[0] and value<=interval[1]
         else:
@@ -1032,7 +1032,7 @@ def verify_scc_overlap(scheduleInfo, context: dict, code_path: int) -> tuple[boo
     if DTL:
         names += ["GRA", "GRB"]
 
-    def verifyIndices(grIncData : GRIncData, name : str, indices : list[int]) -> str | None:
+    def verifyIndices(grIncData: GRIncData, name: str, indices: list[int]) -> Optional[str]:
         dclIndex = getDeclarationIndex(name)
         dclIndexGrInc = getDeclarationIndex(grIncData.name)
         for v in indices:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -40,7 +40,7 @@ from Tensile.Utilities.Decorators.Shared import CallableGuard
 
 from copy import deepcopy
 from typing import Callable
-from enum import Enum, auto
+from enum import Enum, auto, Union
 import Tensile.Components.CMSValidator as cmsv
 
 # Enum to distinguish between different schedule matching outcomes
@@ -54,9 +54,9 @@ _SCHEDULE_REGISTRY = []
 
 @dataclass
 class SyncSchedule:
-    schedule : list[tuple[int, SWaitCnt | SBarrier]] = field(default_factory=list)
+    schedule : list[tuple[int, Union[SWaitCnt, SBarrier]]] = field(default_factory=list)
 
-    def add(self, idx:int, dscnt:int=-1, vlcnt:int=-1, vscnt:int=-1, comment:str="", barrier:bool=False, barrier_idx:int|None=None, barrier_comment:str=""):
+    def add(self, idx:int, dscnt:int=-1, vlcnt:int=-1, vscnt:int=-1, comment:str="", barrier:bool=False, barrier_idx:Union[int, None]=None, barrier_comment:str=""):
         """ Add a SWaitCnt (and optionally a SBarrier) to the schedule at the given index.
 
         Args:
@@ -113,7 +113,7 @@ def duplicate_list_items(input_list: list, repeat_count: int, step:int=0) -> lis
     """
     return [item + step * j for item in input_list for j in range(repeat_count)]
 
-def count_items(input_list: list[int], sv:int|None = None, ev:int|None = None):
+def count_items(input_list: list[int], sv:Union[int, None] = None, ev:Union[int, None] = None):
     """
     Count how many items in the list are between start value `sv` (inclusive) and end value `ev` (exclusive)
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -39,8 +39,8 @@ from Tensile.Common import IsaVersion
 from Tensile.Utilities.Decorators.Shared import CallableGuard
 
 from copy import deepcopy
-from typing import Callable
-from enum import Enum, auto, Union
+from typing import Callable, Optional, Union
+from enum import Enum, auto
 import Tensile.Components.CMSValidator as cmsv
 
 # Enum to distinguish between different schedule matching outcomes
@@ -54,9 +54,9 @@ _SCHEDULE_REGISTRY = []
 
 @dataclass
 class SyncSchedule:
-    schedule : list[tuple[int, Union[SWaitCnt, SBarrier]]] = field(default_factory=list)
+    schedule: list[tuple[int, Union[SWaitCnt, SBarrier]]] = field(default_factory=list)
 
-    def add(self, idx:int, dscnt:int=-1, vlcnt:int=-1, vscnt:int=-1, comment:str="", barrier:bool=False, barrier_idx:Union[int, None]=None, barrier_comment:str=""):
+    def add(self, idx: int, dscnt: int = -1, vlcnt: int = -1, vscnt: int = -1, comment: str = "", barrier: bool = False, barrier_idx: Optional[int] = None, barrier_comment: str = ""):
         """ Add a SWaitCnt (and optionally a SBarrier) to the schedule at the given index.
 
         Args:
@@ -103,7 +103,7 @@ def create_range(min_val: int, num: int, max_val: int, step: int = 1, repeat: in
     """
     return [min(val, max_val) for val in range(min_val, min_val + num, step) for _ in range(repeat)]
 
-def duplicate_list_items(input_list: list, repeat_count: int, step:int=0) -> list:
+def duplicate_list_items(input_list: list, repeat_count: int, step: int = 0) -> list:
     """
     Duplicate each item in input_list repeat_count times. Optionally duplicate with a step
 
@@ -113,7 +113,7 @@ def duplicate_list_items(input_list: list, repeat_count: int, step:int=0) -> lis
     """
     return [item + step * j for item in input_list for j in range(repeat_count)]
 
-def count_items(input_list: list[int], sv:Union[int, None] = None, ev:Union[int, None] = None):
+def count_items(input_list: list[int], sv: Optional[int] = None, ev: Optional[int] = None):
     """
     Count how many items in the list are between start value `sv` (inclusive) and end value `ev` (exclusive)
 
@@ -144,8 +144,8 @@ class ScheduleInfo:
         syncCode,
         nglshift,
         nllshift,
-        nllZeroDscnt=False,
-        mfmaReorder=[],
+        nllZeroDscnt = False,
+        mfmaReorder = [],
         snopCode = [],
     ):
         self.numCodePaths = numCodePaths
@@ -508,7 +508,7 @@ class RegisterSchedule:
     
     def __call__(self, func: Callable) -> Callable:
         """Wrap the function with matching logic and register it."""
-        def wrapped_func(kernel: dict, useLDSTr: bool, TLDS: int) -> tuple[ScheduleMatchStatus, ScheduleInfo | None]:
+        def wrapped_func(kernel: dict, useLDSTr: bool, TLDS: int) -> tuple[ScheduleMatchStatus, Optional[ScheduleInfo]]:
             # TODO: Currently ULSGRO not checked for in CMS, disabled for now
             if kernel["UnrollLoopSwapGlobalReadOrder"]:
                 return ScheduleMatchStatus.NO_MATCH, None

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
@@ -23,7 +23,7 @@
 # SPDX-License-Identifier: MIT
 ################################################################################
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Optional
 import unittest
 
 from test_CustomSchedule import create_base_kernel, ScheduleInfo
@@ -50,7 +50,7 @@ class CMSValidationTestBase(unittest.TestCase):
         """
         raise NotImplementedError("Subclasses must implement validation_function")
     
-    def setUp(self, kernel_updates: dict[str, Any] | None = None):
+    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None):
         """Initialize kernel and compute number of VMFMAs."""
         self.kernel = create_base_kernel()
         if kernel_updates:
@@ -69,7 +69,7 @@ class CMSValidationTestBase(unittest.TestCase):
         nglshift: int,
         nllshift: int,
         codePathIdx: int,
-        expected_message: str | None,
+        expected_message: Optional[str] = None,
         nllZeroDscnt: bool = False,
         mfmaReorder: list[int] = None,
         snopCode: list[Any] = None,


### PR DESCRIPTION
## Motivation

Type hints using "|" don't work with python 3.9.

## Technical Details

Replace with imports from typing.

Depends on #3444.

## Test Plan

Run existing tests, should have no functional changes.

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
