### PR TITLE
[hipblasLT] [origami] SK use Tree reduction if < 2 split develop

### DIFF
--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -2608,6 +2608,11 @@ namespace TensileLite
                     sk.grid = tiles;
                 }
             }
+
+            if(sk.reduction == ReductionType::Parallel && sk.grid / tiles < 2)
+            {
+                throw std::runtime_error("hipblasLT Error: Cannot use Parallel reduction with StreamK kernel with splitting factor < 2\n");
+            }
         }
 
         if(debug)

--- a/shared/origami/src/origami/streamk.cpp
+++ b/shared/origami/src/origami/streamk.cpp
@@ -298,7 +298,7 @@ namespace origami
                     // For problems with large k and low number of tiles, use parallel reduction
                     // TODO Benchmark to check if limits are correct
                     constexpr int MinItersForParallel = 64;
-                    constexpr int MaxTilesForParallel = 64;
+                    const int MaxTilesForParallel = cu_count / 4;
                     if (iters_per_tile >= MinItersForParallel && tiles <= MaxTilesForParallel)
                         reductionStrat = reduction_type::Parallel;
                 }


### PR DESCRIPTION
## Motivation

See https://github.com/ROCm/rocm-libraries/pull/3403

If origami gives us Parallel reduction and sk.grid/tiles==1 then we will launch post kernel call, this PR sets reduction strategy to Tree reduction in this case.

## Technical Details

After calling getSKReduction, this does a check to see if sk.grid/tiles < 2, if so we ensure the reduction type is Tree reduction. Small change to origami intended to keep select_grid behaviour the same.

## Test Plan

CI testing, local run of hipblaslt-test with CPX.

## Test Result

TBA

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
