### PR TITLE
[hipDNN] Fix async logging hangs on Windows

### DIFF
--- a/projects/hipdnn/backend/tests/main.cpp
+++ b/projects/hipdnn/backend/tests/main.cpp
@@ -3,10 +3,13 @@ Copyright © Advanced Micro Devices, Inc., or its affiliates.
 SPDX-License-Identifier: MIT
 */
 
-#include "logging/Logging.hpp"
+#include <spdlog/spdlog.h>
+
 #include <gtest/gtest.h>
 #include <hipdnn_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
+
+#include "logging/Logging.hpp"
 
 int main(int argc, char** argv)
 {
@@ -18,5 +21,7 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }

--- a/projects/hipdnn/data_sdk/tests/main.cpp
+++ b/projects/hipdnn/data_sdk/tests/main.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
 #include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
@@ -17,5 +19,7 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }

--- a/projects/hipdnn/docs/HowTo.md
+++ b/projects/hipdnn/docs/HowTo.md
@@ -92,6 +92,12 @@ target_link_libraries(your_target hip::host hip::device)
 
 hipDNN uses the spdlog header-only library for logging. See the [Environment docs](./Environment.md#logging-configuration) for further details.
 
+> [!CAUTION]
+> There is a known issue on Windows where logging must be explicitly shut down before the application exits to ensure all log messages are flushed and resources are released. See [spdlog Windows Issues](https://github.com/gabime/spdlog/wiki/Asynchronous-logging#windows-issues) for more information.
+> ```cpp
+> spdlog::shutdown();
+> ```
+
 ### Working with Schemas
 
 hipDNN uses FlatBuffers for schema-based data objects to describe graphs and operations.

--- a/projects/hipdnn/frontend/tests/main.cpp
+++ b/projects/hipdnn/frontend/tests/main.cpp
@@ -4,6 +4,8 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
 
@@ -13,5 +15,7 @@ int main(int argc, char** argv)
 
     hipdnn_frontend::initializeFrontendLogging();
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }

--- a/projects/hipdnn/plugin_sdk/tests/main.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/main.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
 
@@ -12,5 +14,7 @@ int main(int argc, char** argv)
     hipdnn::logging::initializeCallbackLogging(COMPONENT_NAME,
                                                hipdnn_test_sdk::utilities::testLoggingCallback);
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/main.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/integration_tests/main.cpp
@@ -4,6 +4,8 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
 
@@ -17,5 +19,7 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }

--- a/projects/hipdnn/plugins/miopen_legacy_plugin/tests/main.cpp
+++ b/projects/hipdnn/plugins/miopen_legacy_plugin/tests/main.cpp
@@ -4,6 +4,7 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
 
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
@@ -19,5 +20,7 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }

--- a/projects/hipdnn/sdk/tests/main.cpp
+++ b/projects/hipdnn/sdk/tests/main.cpp
@@ -4,6 +4,8 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
 
@@ -14,5 +16,7 @@ int main(int argc, char** argv)
     hipdnn::logging::initializeCallbackLogging(COMPONENT_NAME,
                                                hipdnn_test_sdk::utilities::testLoggingCallback);
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }

--- a/projects/hipdnn/test_sdk/tests/main.cpp
+++ b/projects/hipdnn/test_sdk/tests/main.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
 #include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
@@ -17,5 +19,7 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }

--- a/projects/hipdnn/tests/backend/main.cpp
+++ b/projects/hipdnn/tests/backend/main.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
 
 // Custom main() to register HipErrorHandler event listener.
@@ -15,5 +17,7 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }

--- a/projects/hipdnn/tests/frontend/main.cpp
+++ b/projects/hipdnn/tests/frontend/main.cpp
@@ -4,6 +4,8 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_sdk/logging/Logger.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
@@ -19,5 +21,7 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    return RUN_ALL_TESTS();
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
 }


### PR DESCRIPTION
## Motivation

There is an spdlog [issue](https://github.com/gabime/spdlog/wiki/Asynchronous-logging#windows-issues) on Windows where asynchronous loggers aren't properly cleaned up, leaving zombie threads.

## Technical Details

Add `spdlog::shutdown()` to test  `main.cpp`s & update `HowTo.md`.

## Test Plan

Identify whether hung testing processes still exist on Windows.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
