### PR TITLE
[Testing][Ex CI] Add a variable to pass the head_sha to fix the race condition

### DIFF
--- a/.azuredevops/templates/report-summary-check.yml
+++ b/.azuredevops/templates/report-summary-check.yml
@@ -63,7 +63,17 @@ jobs:
           "https://api.github.com/app/installations/$APP_INSTALLATION_ID/access_tokens" | jq -r .token)
 
         PR_NUMBER=$(echo "$(Build.SourceBranch)" | sed 's|refs/pull/\([0-9]*\)/.*|\1|')
-        PR_HEAD_SHA=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/pulls/$PR_NUMBER" | jq -r '.head.sha')
+        
+        # Use the HEAD SHA passed from the dispatcher to avoid race conditions
+        # when new commits are pushed while the build is running
+        if [[ -n "$(prHeadSha)" && "$(prHeadSha)" != "\$(prHeadSha)" ]]; then
+          PR_HEAD_SHA="$(prHeadSha)"
+          echo "Using HEAD SHA from pipeline variable: $PR_HEAD_SHA"
+        else
+          # Fallback for non-dispatcher triggered builds (e.g., direct PR triggers)
+          PR_HEAD_SHA=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/pulls/$PR_NUMBER" | jq -r '.head.sha')
+          echo "Using HEAD SHA from GitHub API (fallback): $PR_HEAD_SHA"
+        fi
         CHECK=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/commits/$PR_HEAD_SHA/check-runs" | jq -r '.check_runs[] | select(.name == "Azure CI Summary")')
         CHECK_ID=$(echo "$CHECK" | jq -r '.id')
         CHECK_SUMMARY=$(echo "$CHECK" | jq -r '.output.summary')

--- a/.azuredevops/templates/report-summary-check.yml
+++ b/.azuredevops/templates/report-summary-check.yml
@@ -62,52 +62,17 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           "https://api.github.com/app/installations/$APP_INSTALLATION_ID/access_tokens" | jq -r .token)
 
-        # Get PR number and build ID
         PR_NUMBER=$(echo "$(Build.SourceBranch)" | sed 's|refs/pull/\([0-9]*\)/.*|\1|')
-        BUILD_ID="$(Build.BuildId)"
-        echo "PR Number: $PR_NUMBER, Build ID: $BUILD_ID"
-        
-        # Get the current HEAD SHA
         PR_HEAD_SHA=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/pulls/$PR_NUMBER" | jq -r '.head.sha')
-        echo "Current HEAD SHA: $PR_HEAD_SHA"
-        
-        # Find the Azure CI Summary check-run on current HEAD (paginate to handle many check-runs)
-        PAGE=1
-        CHECK=""
-        while true; do
-          RESPONSE=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/commits/$PR_HEAD_SHA/check-runs?per_page=100&page=$PAGE")
-          CHECK=$(echo "$RESPONSE" | jq -r '.check_runs[] | select(.name == "Azure CI Summary")')
-          
-          # Found it or no more results
-          if [[ -n "$CHECK" ]] || [[ $(echo "$RESPONSE" | jq '.check_runs | length') -eq 0 ]]; then
-            break
-          fi
-          
-          PAGE=$((PAGE + 1))
-          # Safety limit to prevent infinite loops
-          if [[ $PAGE -gt 10 ]]; then
-            echo "Warning: Reached page limit (1000 check-runs) without finding Azure CI Summary"
-            break
-          fi
-        done
-        
+        CHECK=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/commits/$PR_HEAD_SHA/check-runs" | jq -r '.check_runs[] | select(.name == "Azure CI Summary")')
         CHECK_ID=$(echo "$CHECK" | jq -r '.id')
         CHECK_SUMMARY=$(echo "$CHECK" | jq -r '.output.summary')
         CHECK_TEXT=$(echo "$CHECK" | jq -r '.output.text')
-        
-        # Verify this check-run contains our build ID (prevents updating wrong check-run)
-        if [[ -z "$CHECK_ID" || "$CHECK_ID" == "null" ]]; then
+
+        if [[ -z "$CHECK_ID" ]]; then
           echo "No Azure CI Summary check found for commit $PR_HEAD_SHA"
           exit 0
         fi
-        
-        if [[ "$CHECK_TEXT" != *"$BUILD_ID="* ]]; then
-          echo "Check-run does not contain this build ID ($BUILD_ID)."
-          echo "This build was likely superseded by a newer commit. Exiting gracefully."
-          exit 0
-        fi
-        
-        echo "Found check-run ID $CHECK_ID with our build ID"
         if [[ "$CHECK_SUMMARY" == *"$(Build.BuildId)"* ]]; then
           CHECK_SUMMARY=$(echo "$CHECK_SUMMARY" | sed "s/buildId=$(Build.BuildId)[^|]*|[^|]*|/buildId=$(Build.BuildId)) | ${{ parameters.checkConclusion }} |/")
         fi

--- a/.azuredevops/templates/report-summary-check.yml
+++ b/.azuredevops/templates/report-summary-check.yml
@@ -71,9 +71,26 @@ jobs:
         PR_HEAD_SHA=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/pulls/$PR_NUMBER" | jq -r '.head.sha')
         echo "Current HEAD SHA: $PR_HEAD_SHA"
         
-        # Find the Azure CI Summary check-run on current HEAD
-        CHECK=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/commits/$PR_HEAD_SHA/check-runs" \
-          | jq -r '.check_runs[] | select(.name == "Azure CI Summary")')
+        # Find the Azure CI Summary check-run on current HEAD (paginate to handle many check-runs)
+        PAGE=1
+        CHECK=""
+        while true; do
+          RESPONSE=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/commits/$PR_HEAD_SHA/check-runs?per_page=100&page=$PAGE")
+          CHECK=$(echo "$RESPONSE" | jq -r '.check_runs[] | select(.name == "Azure CI Summary")')
+          
+          # Found it or no more results
+          if [[ -n "$CHECK" ]] || [[ $(echo "$RESPONSE" | jq '.check_runs | length') -eq 0 ]]; then
+            break
+          fi
+          
+          PAGE=$((PAGE + 1))
+          # Safety limit to prevent infinite loops
+          if [[ $PAGE -gt 10 ]]; then
+            echo "Warning: Reached page limit (1000 check-runs) without finding Azure CI Summary"
+            break
+          fi
+        done
+        
         CHECK_ID=$(echo "$CHECK" | jq -r '.id')
         CHECK_SUMMARY=$(echo "$CHECK" | jq -r '.output.summary')
         CHECK_TEXT=$(echo "$CHECK" | jq -r '.output.text')

--- a/.azuredevops/templates/report-summary-check.yml
+++ b/.azuredevops/templates/report-summary-check.yml
@@ -38,6 +38,7 @@ jobs:
       APP_ID: $(APP_ID)
       APP_INSTALLATION_ID: $(APP_INSTALLATION_ID)
       APP_PRIVATE_KEY: $(APP_PRIVATE_KEY)
+      PR_HEAD_SHA_VAR: $(prHeadSha)
     inputs:
       targetType: 'inline'
       script: |
@@ -66,8 +67,8 @@ jobs:
         
         # Use the HEAD SHA passed from the dispatcher to avoid race conditions
         # when new commits are pushed while the build is running
-        if [[ -n "$(prHeadSha)" && "$(prHeadSha)" != "\$(prHeadSha)" ]]; then
-          PR_HEAD_SHA="$(prHeadSha)"
+        if [[ -n "$PR_HEAD_SHA_VAR" && "$PR_HEAD_SHA_VAR" != "\$(prHeadSha)" ]]; then
+          PR_HEAD_SHA="$PR_HEAD_SHA_VAR"
           echo "Using HEAD SHA from pipeline variable: $PR_HEAD_SHA"
         else
           # Fallback for non-dispatcher triggered builds (e.g., direct PR triggers)

--- a/.azuredevops/templates/report-summary-check.yml
+++ b/.azuredevops/templates/report-summary-check.yml
@@ -63,8 +63,35 @@ jobs:
           "https://api.github.com/app/installations/$APP_INSTALLATION_ID/access_tokens" | jq -r .token)
 
         PR_NUMBER=$(echo "$(Build.SourceBranch)" | sed 's|refs/pull/\([0-9]*\)/.*|\1|')
-        PR_HEAD_SHA=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/pulls/$PR_NUMBER" | jq -r '.head.sha')
-        CHECK=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/commits/$PR_HEAD_SHA/check-runs" | jq -r '.check_runs[] | select(.name == "Azure CI Summary")')
+        BUILD_ID="$(Build.BuildId)"
+        echo "PR Number: $PR_NUMBER, Build ID: $BUILD_ID"
+        
+        # Get the current HEAD SHA
+        PR_HEAD_SHA=$(curl -s -H "Authorization: token $GH_TOKEN" \
+          "https://api.github.com/repos/ROCm/rocm-libraries/pulls/$PR_NUMBER" | jq -r '.head.sha')
+        echo "Current HEAD SHA: $PR_HEAD_SHA"
+        
+        # Find the Azure CI Summary check-run on current HEAD
+        # GitHub API returns max 30 check-runs per page, so we paginate for PRs with many checks
+        PAGE=1
+        CHECK=""
+        while true; do
+          echo "Searching for Azure CI Summary (page $PAGE)..."
+          RESPONSE=$(curl -s -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/ROCm/rocm-libraries/commits/$PR_HEAD_SHA/check-runs?per_page=100&page=$PAGE")
+          CHECK=$(echo "$RESPONSE" | jq -r '.check_runs[] | select(.name == "Azure CI Summary")')
+          PAGE_COUNT=$(echo "$RESPONSE" | jq '.check_runs | length')
+          
+          if [[ -n "$CHECK" ]] || [[ $PAGE_COUNT -eq 0 ]]; then
+            break
+          fi
+          PAGE=$((PAGE + 1))
+          if [[ $PAGE -gt 10 ]]; then
+            echo "Warning: Exceeded 1000 check-runs without finding Azure CI Summary"
+            break
+          fi
+        done
+        
         CHECK_ID=$(echo "$CHECK" | jq -r '.id')
         CHECK_SUMMARY=$(echo "$CHECK" | jq -r '.output.summary')
         CHECK_TEXT=$(echo "$CHECK" | jq -r '.output.text')
@@ -73,12 +100,20 @@ jobs:
           echo "No Azure CI Summary check found for commit $PR_HEAD_SHA"
           exit 0
         fi
-        if [[ "$CHECK_SUMMARY" == *"$(Build.BuildId)"* ]]; then
-          CHECK_SUMMARY=$(echo "$CHECK_SUMMARY" | sed "s/buildId=$(Build.BuildId)[^|]*|[^|]*|/buildId=$(Build.BuildId)) | ${{ parameters.checkConclusion }} |/")
+        
+        # Verify this check-run contains our build ID (prevents updating wrong check-run)
+        # This handles the case where a build was cancelled due to a newer commit
+        if [[ "$CHECK_TEXT" != *"$BUILD_ID="* ]]; then
+          echo "Check-run does not contain this build ID ($BUILD_ID)."
+          echo "This build was likely superseded by a newer commit. Exiting gracefully."
+          exit 0
         fi
-        if [[ "$CHECK_TEXT" == *"$(Build.BuildId)="* ]]; then
-          CHECK_TEXT=$(echo "$CHECK_TEXT" | sed "s/$(Build.BuildId)=[^;]*;/$(Build.BuildId)=${{ parameters.checkConclusion }};/")
-        fi
+        
+        echo "Found check-run ID $CHECK_ID with build ID $BUILD_ID"
+        
+        # Update summary and text with this build's status
+        CHECK_SUMMARY=$(echo "$CHECK_SUMMARY" | sed "s/buildId=$BUILD_ID[^|]*|[^|]*|/buildId=$BUILD_ID) | ${{ parameters.checkConclusion }} |/")
+        CHECK_TEXT=$(echo "$CHECK_TEXT" | sed "s/$BUILD_ID=[^;]*;/$BUILD_ID=${{ parameters.checkConclusion }};/")
 
         CHECK_STATUS=$(echo "$CHECK_TEXT" | grep -q "pending" && echo "in_progress" || echo "completed")
         CHECK_CONCLUSION=$(echo "$CHECK_TEXT" | grep -q -e "cancelled" -e "failure" && echo "failure" || echo "success")

--- a/.azuredevops/templates/report-summary-check.yml
+++ b/.azuredevops/templates/report-summary-check.yml
@@ -38,7 +38,6 @@ jobs:
       APP_ID: $(APP_ID)
       APP_INSTALLATION_ID: $(APP_INSTALLATION_ID)
       APP_PRIVATE_KEY: $(APP_PRIVATE_KEY)
-      PR_HEAD_SHA_VAR: $(prHeadSha)
     inputs:
       targetType: 'inline'
       script: |
@@ -63,27 +62,35 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           "https://api.github.com/app/installations/$APP_INSTALLATION_ID/access_tokens" | jq -r .token)
 
+        # Get PR number and build ID
         PR_NUMBER=$(echo "$(Build.SourceBranch)" | sed 's|refs/pull/\([0-9]*\)/.*|\1|')
+        BUILD_ID="$(Build.BuildId)"
+        echo "PR Number: $PR_NUMBER, Build ID: $BUILD_ID"
         
-        # Use the HEAD SHA passed from the dispatcher to avoid race conditions
-        # when new commits are pushed while the build is running
-        if [[ -n "$PR_HEAD_SHA_VAR" && "$PR_HEAD_SHA_VAR" != "\$(prHeadSha)" ]]; then
-          PR_HEAD_SHA="$PR_HEAD_SHA_VAR"
-          echo "Using HEAD SHA from pipeline variable: $PR_HEAD_SHA"
-        else
-          # Fallback for non-dispatcher triggered builds (e.g., direct PR triggers)
-          PR_HEAD_SHA=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/pulls/$PR_NUMBER" | jq -r '.head.sha')
-          echo "Using HEAD SHA from GitHub API (fallback): $PR_HEAD_SHA"
-        fi
-        CHECK=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/commits/$PR_HEAD_SHA/check-runs" | jq -r '.check_runs[] | select(.name == "Azure CI Summary")')
+        # Get the current HEAD SHA
+        PR_HEAD_SHA=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/pulls/$PR_NUMBER" | jq -r '.head.sha')
+        echo "Current HEAD SHA: $PR_HEAD_SHA"
+        
+        # Find the Azure CI Summary check-run on current HEAD
+        CHECK=$(curl -s "https://api.github.com/repos/ROCm/rocm-libraries/commits/$PR_HEAD_SHA/check-runs" \
+          | jq -r '.check_runs[] | select(.name == "Azure CI Summary")')
         CHECK_ID=$(echo "$CHECK" | jq -r '.id')
         CHECK_SUMMARY=$(echo "$CHECK" | jq -r '.output.summary')
         CHECK_TEXT=$(echo "$CHECK" | jq -r '.output.text')
-
-        if [[ -z "$CHECK_ID" ]]; then
+        
+        # Verify this check-run contains our build ID (prevents updating wrong check-run)
+        if [[ -z "$CHECK_ID" || "$CHECK_ID" == "null" ]]; then
           echo "No Azure CI Summary check found for commit $PR_HEAD_SHA"
           exit 0
         fi
+        
+        if [[ "$CHECK_TEXT" != *"$BUILD_ID="* ]]; then
+          echo "Check-run does not contain this build ID ($BUILD_ID)."
+          echo "This build was likely superseded by a newer commit. Exiting gracefully."
+          exit 0
+        fi
+        
+        echo "Found check-run ID $CHECK_ID with our build ID"
         if [[ "$CHECK_SUMMARY" == *"$(Build.BuildId)"* ]]; then
           CHECK_SUMMARY=$(echo "$CHECK_SUMMARY" | sed "s/buildId=$(Build.BuildId)[^|]*|[^|]*|/buildId=$(Build.BuildId)) | ${{ parameters.checkConclusion }} |/")
         fi

--- a/.github/workflows/azure-ci-dispatcher.yml
+++ b/.github/workflows/azure-ci-dispatcher.yml
@@ -256,6 +256,11 @@ jobs:
                       "refName": "refs/pull/${{ github.event.pull_request.number }}/merge"
                     }
                   }
+                },
+                "variables": {
+                  "prHeadSha": {
+                    "value": "${{ github.event.pull_request.head.sha }}"
+                  }
                 }
               }')
 

--- a/.github/workflows/azure-ci-dispatcher.yml
+++ b/.github/workflows/azure-ci-dispatcher.yml
@@ -256,11 +256,6 @@ jobs:
                       "refName": "refs/pull/${{ github.event.pull_request.number }}/merge"
                     }
                   }
-                },
-                "variables": {
-                  "prHeadSha": {
-                    "value": "${{ github.event.pull_request.head.sha }}"
-                  }
                 }
               }')
 

--- a/projects/composablekernel/README.md
+++ b/projects/composablekernel/README.md
@@ -245,3 +245,4 @@ script/uninstall_precommit.sh
 
 If you need to temporarily disable pre-commit hooks, you can add the `--no-verify` option to the
 `git commit` command.
+

--- a/projects/hipblas-common/README.md
+++ b/projects/hipblas-common/README.md
@@ -46,3 +46,4 @@ python3 ./rmake.py --install
 hipBLAS-common generates the following targets for consumption in internal and external projects.
 
 * `roc::hipblas-common`
+

--- a/projects/hipblas/README.md
+++ b/projects/hipblas/README.md
@@ -109,3 +109,4 @@ hipblasSgemmStridedBatched( hipblasHandle_t handle,
 
 hipBLAS assumes matrix A and vectors x, y are allocated in GPU memory space filled with data. You
 are responsible for copying data to and from the host and device memory.
+

--- a/projects/hipblaslt/README.md
+++ b/projects/hipblaslt/README.md
@@ -222,3 +222,4 @@ If you want to submit an issue, you can do so on
 [GitHub](https://github.com/ROCm/rocm-libraries/issues).
 
 To contribute to our repository, you can create a GitHub pull request.
+

--- a/projects/hipblaslt/README.md
+++ b/projects/hipblaslt/README.md
@@ -223,3 +223,4 @@ If you want to submit an issue, you can do so on
 
 To contribute to our repository, you can create a GitHub pull request.
 
+

--- a/projects/hipcub/README.md
+++ b/projects/hipcub/README.md
@@ -276,3 +276,4 @@ or follow [this link](https://github.com/ROCm/rocm-libraries/issues?q=is%3Aissue
 ## Contributing
 
 Contributions are most welcome! Learn more at [CONTRIBUTING](./CONTRIBUTING.md).
+

--- a/projects/hipdnn/README.md
+++ b/projects/hipdnn/README.md
@@ -71,3 +71,4 @@ See [Docker README](./dockerfiles/README.md) for containerized development envir
 ## Contributing
 
 For information about contributing to the hipDNN project, please see the [Contributing Guide](./CONTRIBUTING.md).
+

--- a/projects/hipfft/README.md
+++ b/projects/hipfft/README.md
@@ -90,3 +90,4 @@ You can report bugs and feature requests through the rocm-libraries GitHub
 ## Contribute
 
 If you want to contribute to hipFFT, you must follow our [contribution guidelines](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipfft/.github/CONTRIBUTING.md).
+

--- a/projects/hiprand/README.md
+++ b/projects/hiprand/README.md
@@ -129,3 +129,4 @@ python3 -m sphinx -T -E -b html -d docs/_build/doctrees -D language=en docs docs
 ```
 
 You can then open `docs/_build/html/index.html` in your browser to view the documentation.
+

--- a/projects/hipsolver/README.md
+++ b/projects/hipsolver/README.md
@@ -95,3 +95,4 @@ hipsolverSgeqrf(hipsolverHandle_t handle,
 ## Supported Functionality
 
 For a complete listing of all supported functions, see the [hipSOLVER user guide](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/howto/usage.html) and/or [API documentation](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/reference/index.html).
+

--- a/projects/hipsparse/README.md
+++ b/projects/hipsparse/README.md
@@ -87,3 +87,4 @@ hipsparseScsrmv(hipsparseHandle_t handle,
 
 hipSPARSE assumes matrix A and vectors x, y are allocated in GPU memory space filled with data. Users
 are responsible for copying data to and from the host and device memory.
+

--- a/projects/hipsparselt/README.md
+++ b/projects/hipsparselt/README.md
@@ -294,3 +294,4 @@ cd build/release
 # Run benchmark, e.g.
 ./clients/staging/hipsparselt-bench -f spmm -i 200 -m 256 -n 256 -k 256
 ```
+

--- a/projects/hiptensor/README.md
+++ b/projects/hiptensor/README.md
@@ -73,3 +73,4 @@ The latest official documentation for hipTensor is available at:
 ## Contributing to the hipTensor Library
 
 Community collaboration is encouraged! If you are considering contributing, please follow the [hipTensor Contribution Guide](https://rocm.docs.amd.com/projects/hipTensor/en/latest/contribution/contributors-guide.html) to get started.
+

--- a/projects/miopen/README.md
+++ b/projects/miopen/README.md
@@ -367,3 +367,4 @@ You can find prebuilt Docker images on
 Our
 [porting guide](https://rocm.docs.amd.com/projects/MIOpen/en/latest/MIOpen_Porting_Guide.html)
 highlights the key differences between cuDNN and MIOpen APIs.
+

--- a/projects/rocblas/README.md
+++ b/projects/rocblas/README.md
@@ -15,3 +15,4 @@ ROCm installation and required platform dependencies, refer to the
 
 > [!NOTE]
 > The published rocBLAS documentation is available at [rocBLAS](https://rocm.docs.amd.com/projects/rocBLAS/en/latest/index.html) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the rocBLAS/docs folder of this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
+

--- a/projects/rocfft/README.md
+++ b/projects/rocfft/README.md
@@ -104,3 +104,4 @@ You can report bugs and feature requests through the rocm-libraries GitHub
 ## Contribute
 
 If you want to contribute to rocFFT, you must follow the [contribution guidelines](https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocfft/.github/CONTRIBUTING.md).
+

--- a/projects/rocprim/README.md
+++ b/projects/rocprim/README.md
@@ -373,3 +373,4 @@ Licensing information is in [LICENSE](./LICENSE.txt).
 # Test commit 1766092859
 # Test 1766094029
 # Test 1766098775
+

--- a/projects/rocprim/README.md
+++ b/projects/rocprim/README.md
@@ -374,3 +374,4 @@ Licensing information is in [LICENSE](./LICENSE.txt).
 # Test 1766094029
 # Test 1766098775
 
+

--- a/projects/rocprim/README.md
+++ b/projects/rocprim/README.md
@@ -369,3 +369,4 @@ Contributions of any kind are most welcome! Contribution instructions are in
 [CONTRIBUTING](./CONTRIBUTING.md).
 
 Licensing information is in [LICENSE](./LICENSE.txt).
+

--- a/projects/rocprim/README.md
+++ b/projects/rocprim/README.md
@@ -372,3 +372,4 @@ Licensing information is in [LICENSE](./LICENSE.txt).
 
 # Test commit 1766092859
 # Test 1766094029
+# Test 1766098775

--- a/projects/rocprim/README.md
+++ b/projects/rocprim/README.md
@@ -371,3 +371,4 @@ Contributions of any kind are most welcome! Contribution instructions are in
 Licensing information is in [LICENSE](./LICENSE.txt).
 
 # Test commit 1766092859
+# Test 1766094029

--- a/projects/rocprim/README.md
+++ b/projects/rocprim/README.md
@@ -370,3 +370,4 @@ Contributions of any kind are most welcome! Contribution instructions are in
 
 Licensing information is in [LICENSE](./LICENSE.txt).
 
+# Test commit 1766092859

--- a/projects/rocrand/README.md
+++ b/projects/rocrand/README.md
@@ -273,3 +273,4 @@ Contributions of any kind are most welcome! You can find more information at
 [CONTRIBUTING](./CONTRIBUTING.md).
 
 Licensing information is located at [LICENSE](./LICENSE.txt).
+

--- a/projects/rocsolver/README.md
+++ b/projects/rocsolver/README.md
@@ -137,3 +137,4 @@ system environment, but here is a typical example:
 [5]: clients/samples/
 [6]: https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/lapack.html#rocsolver-type-geqrf
 [7]: CONTRIBUTING.md
+

--- a/projects/rocsparse/README.md
+++ b/projects/rocsparse/README.md
@@ -139,3 +139,4 @@ To submit an issue, a bug, or a feature request, use the rocm-libraries GitHub
 
 The [license file](https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocsparse/LICENSE.md) is located in the main
 repository.
+

--- a/projects/rocthrust/README.md
+++ b/projects/rocthrust/README.md
@@ -401,3 +401,4 @@ or follow [this link](https://github.com/ROCm/rocm-libraries/issues?q=is%3Aissue
 ## License
 
 rocThrust is distributed under the [Apache 2.0 LICENSE](./LICENSE).
+

--- a/projects/rocwmma/README.md
+++ b/projects/rocwmma/README.md
@@ -119,3 +119,4 @@ The latest official documentation for rocWMMA is available at:
 ## Contributing to the rocWMMA Library
 
 Community collaboration is encouraged! If you are considering contributing, please follow the [rocWMMA Contribution Guide](https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocwmma/CONTRIBUTING.md) to get started.
+


### PR DESCRIPTION
## Motivation
The issue was not a race condition but a GitHub API pagination problem.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
### How Check-Runs Work
Check-runs are associated with a specific commit SHA, not a PR. Each GitHub Actions job, Azure pipeline, and third-party integration creates its own check-run on the commit. PRs that trigger many workflows (e.g., TheRock CI with sharded tests) can have 30+ check-runs per commit

### The Bug
The GitHub API endpoint /commits/{sha}/check-runs returns a maximum of 30 results by default. When a commit has many check-runs:

- The "Azure CI Summary" check-run could be at position 31+
- The API call would not return it
- Azure pipeline would log: No Azure CI Summary check found for commit {sha}
- Example: PR #3409 had 43 check-runs, with "Azure CI Summary" at position 32 - beyond the default page size of 30.

### The Fix
Added per_page=100 and pagination logic to fetch all check-runs
Added build ID verification to prevent updating wrong check-run (edge case protection)

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
1. Create this PR and wait for Azure CI to trigger
2. Push a second commit while Azure builds are running to simulate the race condition
3. Verify in Azure build logs that "Using HEAD SHA from pipeline variable" message appears
4. Confirm the Azure CI Summary check-run updates correctly on the original commit

No need for a review from rocprim, just using the doc as a way to trigger the azure workflow.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
