### PR TITLE
[ci] Adding temporary resolution to forked repos for retrieving runner data

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -86,7 +86,10 @@ jobs:
           AMDGPU_FAMILIES: "gfx94X, gfx950"
           # Variable comes from ROCm organization variable 'ROCM_THEROCK_TEST_RUNNERS'
           ROCM_THEROCK_TEST_RUNNERS: ${{ vars.ROCM_THEROCK_TEST_RUNNERS }}
-          LOAD_TEST_RUNNERS_FROM_VAR: true
+          # TODO(#2656): Migrate the organization variable to S3 file. Below code is a temporary resolution
+          # If it is a forked repo, we cannot access organization variables (so load in the file)
+          # Otherwise, we use the organization variable directly
+          LOAD_TEST_RUNNERS_FROM_VAR: ${{ github.event.pull_request.head.repo.full_name == 'ROCm/rocm-libraries' }}
         id: configure_linux
         run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
 
@@ -97,7 +100,10 @@ jobs:
           AMDGPU_FAMILIES: "gfx1151"
           # Variable comes from ROCm organization variable 'ROCM_THEROCK_TEST_RUNNERS'
           ROCM_THEROCK_TEST_RUNNERS: ${{ vars.ROCM_THEROCK_TEST_RUNNERS }}
-          LOAD_TEST_RUNNERS_FROM_VAR: true
+          # TODO(#2656): Migrate the organization variable to S3 file. Below code is a temporary resolution
+          # If it is a forked repo, we cannot access organization variables (so load in the file)
+          # Otherwise, we use the organization variable directly
+          LOAD_TEST_RUNNERS_FROM_VAR: ${{ github.event.pull_request.head.repo.full_name == 'ROCm/rocm-libraries' }}
         id: configure_windows
         run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
 


### PR DESCRIPTION
## Motivation

Currently, forked repos cannot access the org variable, causing failures. For now, this is a temporary resolution to fix, then in a future PR, I will implement https://github.com/ROCm/TheRock/issues/2656 to resolve this in a better manner

## Technical Details

for forks, we get the data from amdgpu_family_matrix directly.

## Test Plan

workflow_dispatch test to make sure pick up is correct
CI will also test

## Test Result

workflow dispatch setup step gets data correctly: https://github.com/ROCm/rocm-libraries/actions/runs/20380407353/job/58569222418

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
