### PR TITLE
[rocThrust] Add global memory check to benchmarks to prevent OutOfMemory Errors

### DIFF
--- a/projects/rocthrust/benchmark/bench/adjacent_difference/basic.cu
+++ b/projects/rocthrust/benchmark/bench/adjacent_difference/basic.cu
@@ -93,31 +93,33 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                           \
-  benchmark::RegisterBenchmark(                                                                 \
-    bench_utils::bench_naming::format_name(                                                     \
-      "{algo:adjacent_difference,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                                 \
-    run_benchmark<Benchmark, T>,                                                                \
-    Elements,                                                                                   \
+#define CREATE_BENCHMARK(T, Elements)                                                                      \
+  benchmark::RegisterBenchmark(                                                                            \
+    bench_utils::bench_naming::format_name("{algo:adjacent_difference,subalgo:" + name + ",input_type:" #T \
+                                           + ",elements:" + bench_utils::format_pow2(Elements))           \
+      .c_str(),                                                                                            \
+    run_benchmark<Benchmark, T>,                                                                           \
+    Elements,                                                                                              \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)};
-
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/adjacent_difference/custom.cu
+++ b/projects/rocthrust/benchmark/bench/adjacent_difference/custom.cu
@@ -111,30 +111,33 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                           \
-  benchmark::RegisterBenchmark(                                                                 \
-    bench_utils::bench_naming::format_name(                                                     \
-      "{algo:adjacent_difference,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                                 \
-    run_benchmark<Benchmark<Val>, T>,                                                           \
-    Elements,                                                                                   \
+#define CREATE_BENCHMARK(T, Elements)                                                                      \
+  benchmark::RegisterBenchmark(                                                                            \
+    bench_utils::bench_naming::format_name("{algo:adjacent_difference,subalgo:" + name + ",input_type:" #T \
+                                           + ",elements:" + bench_utils::format_pow2(Elements))            \
+      .c_str(),                                                                                            \
+    run_benchmark<Benchmark<Val>, T>,                                                                      \
+    Elements,                                                                                              \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <template <int> class Benchmark, int Val = 42 /*magic number in Thrust's benchmark*/>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)};
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/adjacent_difference/in_place.cu
+++ b/projects/rocthrust/benchmark/bench/adjacent_difference/in_place.cu
@@ -90,30 +90,33 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                           \
-  benchmark::RegisterBenchmark(                                                                 \
-    bench_utils::bench_naming::format_name(                                                     \
-      "{algo:adjacent_difference,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                                 \
-    run_benchmark<Benchmark, T>,                                                                \
-    Elements,                                                                                   \
+#define CREATE_BENCHMARK(T, Elements)                                                                      \
+  benchmark::RegisterBenchmark(                                                                            \
+    bench_utils::bench_naming::format_name("{algo:adjacent_difference,subalgo:" + name + ",input_type:" #T \
+                                           + ",elements:" + bench_utils::format_pow2(Elements))            \
+      .c_str(),                                                                                            \
+    run_benchmark<Benchmark, T>,                                                                           \
+    Elements,                                                                                              \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)};
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/copy/basic.cu
+++ b/projects/rocthrust/benchmark/bench/copy/basic.cu
@@ -97,17 +97,21 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                                                 \
-  benchmark::RegisterBenchmark(                                                                                       \
-    bench_utils::bench_naming::format_name("{algo:copy,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                                                       \
-    run_benchmark<Benchmark, T>,                                                                                      \
-    Elements,                                                                                                         \
+#define CREATE_BENCHMARK(T, Elements)                                                                       \
+  benchmark::RegisterBenchmark(                                                                             \
+    bench_utils::bench_naming::format_name(                                                                 \
+      "{algo:copy,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                             \
+    run_benchmark<Benchmark, T>,                                                                            \
+    Elements,                                                                                               \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 // Non-trivially-copyable/relocatable type which is not allowed to be copied using std::memcpy or cudaMemcpy
 struct non_trivial
@@ -138,18 +142,18 @@ template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(uint8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(uint16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(uint32_t),
-    BENCHMARK_TYPE(int64_t),
-    BENCHMARK_TYPE(uint64_t),
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t),
-    BENCHMARK_TYPE(non_trivial)};
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(uint8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(uint16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(uint32_t)
+  BENCHMARK_TYPE(int64_t)
+  BENCHMARK_TYPE(uint64_t)
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
+  BENCHMARK_TYPE(non_trivial)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/copy/if.cu
+++ b/projects/rocthrust/benchmark/bench/copy/if.cu
@@ -131,39 +131,43 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, EntropyReduction)                                      \
-  benchmark::RegisterBenchmark(                                                              \
-    bench_utils::bench_naming::format_name(                                                  \
-      "{algo:copy,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements              \
-      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction))) \
-      .c_str(),                                                                              \
-    run_benchmark<Benchmark, T>,                                                             \
-    Elements,                                                                                \
-    seed_type,                                                                               \
+#define CREATE_BENCHMARK(T, Elements, EntropyReduction)                                                    \
+  benchmark::RegisterBenchmark(                                                                            \
+    bench_utils::bench_naming::format_name(                                                                \
+      "{algo:copy,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements) \
+      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction)))               \
+      .c_str(),                                                                                            \
+    run_benchmark<Benchmark, T>,                                                                           \
+    Elements,                                                                                              \
+    seed_type,                                                                                             \
     EntropyReduction)
 
-#define BENCHMARK_TYPE_ENTROPY(type, entropy)                                         \
-  CREATE_BENCHMARK(type, 1 << 16, entropy), CREATE_BENCHMARK(type, 1 << 20, entropy), \
-    CREATE_BENCHMARK(type, 1 << 24, entropy), CREATE_BENCHMARK(type, 1 << 28, entropy)
+#define BENCHMARK_TYPE_ENTROPY(type, entropies)                              \
+  for (size_t size : bench_utils::sizes)                                     \
+  {                                                                          \
+    for (int entropy : entropies)                                            \
+    {                                                                        \
+      if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+        bs.push_back(CREATE_BENCHMARK(type, size, entropy));                 \
+    }                                                                        \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
   constexpr int entropy_reductions[] = {0, 2, 4200}; // 1.000, 0.544, 0.000;
+  std::vector<benchmark::internal::Benchmark*> bs;
 
-  for (int entropy_reduction : entropy_reductions)
-  {
-    std::vector<benchmark::internal::Benchmark*> bs = {
-      BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(float, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(double, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(bench_utils::large_data, entropy_reduction)}; // rocThrust issue #565
-    benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
-  }
+  BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reductions)
+  BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reductions)
+  BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reductions)
+  BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reductions)
+  BENCHMARK_TYPE_ENTROPY(float, entropy_reductions)
+  BENCHMARK_TYPE_ENTROPY(double, entropy_reductions)
+  BENCHMARK_TYPE_ENTROPY(bench_utils::large_data, entropy_reductions)
+
+  benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 
 int main(int argc, char* argv[])

--- a/projects/rocthrust/benchmark/bench/equal/basic.cu
+++ b/projects/rocthrust/benchmark/bench/equal/basic.cu
@@ -76,34 +76,40 @@ void run_benchmark(benchmark::State& state,
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, CommonPrefixRatio)                                                              \
-  benchmark::RegisterBenchmark(                                                                                       \
-    bench_utils::bench_naming::format_name("{algo:equal,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements \
-                                           + ", common_prefix_ratio:" #CommonPrefixRatio)                             \
-      .c_str(),                                                                                                       \
-    run_benchmark<Benchmark, T>,                                                                                      \
-    Elements,                                                                                                         \
-    seed_type,                                                                                                        \
+#define CREATE_BENCHMARK(T, Elements, CommonPrefixRatio)                                                    \
+  benchmark::RegisterBenchmark(                                                                             \
+    bench_utils::bench_naming::format_name(                                                                 \
+      "{algo:equal,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements) \
+      + ", common_prefix_ratio:" #CommonPrefixRatio)                                                        \
+      .c_str(),                                                                                             \
+    run_benchmark<Benchmark, T>,                                                                            \
+    Elements,                                                                                               \
+    seed_type,                                                                                              \
     CommonPrefixRatio)
 
-#define BENCHMARK_ELEMENTS(type, elements) \
-  CREATE_BENCHMARK(type, elements, 1.0), CREATE_BENCHMARK(type, elements, 0.5), CREATE_BENCHMARK(type, elements, 0.0)
+#define BENCHMARK_ELEMENTS(type, elements)             \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 1.0)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 0.5)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 0.0));
 
-#define BENCHMARK_TYPE(type)                                                                               \
-  BENCHMARK_ELEMENTS(type, 1 << 16), BENCHMARK_ELEMENTS(type, 1 << 20), BENCHMARK_ELEMENTS(type, 1 << 24), \
-    BENCHMARK_ELEMENTS(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      BENCHMARK_ELEMENTS(type, size)                                       \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(uint32_t),
-    BENCHMARK_TYPE(int64_t),
-    BENCHMARK_TYPE(uint64_t)};
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(uint32_t)
+  BENCHMARK_TYPE(int64_t)
+  BENCHMARK_TYPE(uint64_t)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/fill/basic.cu
+++ b/projects/rocthrust/benchmark/bench/fill/basic.cu
@@ -90,33 +90,36 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                                                 \
-  benchmark::RegisterBenchmark(                                                                                       \
-    bench_utils::bench_naming::format_name("{algo:fill,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                                                       \
-    run_benchmark<Benchmark<Val>, T>,                                                                                 \
-    Elements,                                                                                                         \
+#define CREATE_BENCHMARK(T, Elements)                                                                       \
+  benchmark::RegisterBenchmark(                                                                             \
+    bench_utils::bench_naming::format_name(                                                                 \
+      "{algo:fill,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                             \
+    run_benchmark<Benchmark<Val>, T>,                                                                       \
+    Elements,                                                                                               \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <template <int> class Benchmark, int Val = 42 /*magic number in Thrust's benchmark*/>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/for_each/basic.cu
+++ b/projects/rocthrust/benchmark/bench/for_each/basic.cu
@@ -100,34 +100,36 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                \
-  benchmark::RegisterBenchmark(                                                      \
-    bench_utils::bench_naming::format_name(                                          \
-      "{algo:for_each,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                      \
-    run_benchmark<Benchmark, T>,                                                     \
-    Elements,                                                                        \
+#define CREATE_BENCHMARK(T, Elements)                                                                           \
+  benchmark::RegisterBenchmark(                                                                                 \
+    bench_utils::bench_naming::format_name(                                                                     \
+      "{algo:for_each,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                                 \
+    run_benchmark<Benchmark, T>,                                                                                \
+    Elements,                                                                                                   \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/inner_product/basic.cu
+++ b/projects/rocthrust/benchmark/bench/inner_product/basic.cu
@@ -92,34 +92,36 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                     \
-  benchmark::RegisterBenchmark(                                                           \
-    bench_utils::bench_naming::format_name(                                               \
-      "{algo:inner_product,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                           \
-    run_benchmark<Benchmark, T>,                                                          \
-    Elements,                                                                             \
+#define CREATE_BENCHMARK(T, Elements)                                                                                \
+  benchmark::RegisterBenchmark(                                                                                      \
+    bench_utils::bench_naming::format_name(                                                                          \
+      "{algo:inner_product,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                                      \
+    run_benchmark<Benchmark, T>,                                                                                     \
+    Elements,                                                                                                        \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/merge/basic.cu
+++ b/projects/rocthrust/benchmark/bench/merge/basic.cu
@@ -107,26 +107,30 @@ void run_benchmark(benchmark::State& state,
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, EntropyReduction, InputSizeRatio)                                               \
-  benchmark::RegisterBenchmark(                                                                                       \
-    bench_utils::bench_naming::format_name(                                                                           \
-      "{algo:merge,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements + ",entropy:"                        \
-      + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction)) + ",input_size_ratio:" #InputSizeRatio) \
-      .c_str(),                                                                                                       \
-    run_benchmark<Benchmark, T>,                                                                                      \
-    Elements,                                                                                                         \
-    seed_type,                                                                                                        \
-    EntropyReduction,                                                                                                 \
+#define CREATE_BENCHMARK(T, Elements, EntropyReduction, InputSizeRatio)                                     \
+  benchmark::RegisterBenchmark(                                                                             \
+    bench_utils::bench_naming::format_name(                                                                 \
+      "{algo:merge,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements) \
+      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction))                 \
+      + ",input_size_ratio:" #InputSizeRatio)                                                               \
+      .c_str(),                                                                                             \
+    run_benchmark<Benchmark, T>,                                                                            \
+    Elements,                                                                                               \
+    seed_type,                                                                                              \
+    EntropyReduction,                                                                                       \
     InputSizeRatio)
 
-#define BENCHMARK_ELEMENTS(type, elements, entropy)                                             \
-  CREATE_BENCHMARK(type, elements, entropy, 25), CREATE_BENCHMARK(type, elements, entropy, 50), \
-    CREATE_BENCHMARK(type, elements, entropy, 75)
+#define BENCHMARK_ELEMENTS(type, elements, entropy)            \
+  bs.push_back(CREATE_BENCHMARK(type, elements, entropy, 25)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, entropy, 50)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, entropy, 75));
 
-#define BENCHMARK_TYPE_ENTROPY(type, entropy)                                             \
-  BENCHMARK_ELEMENTS(type, 1 << 16, entropy), BENCHMARK_ELEMENTS(type, 1 << 20, entropy), \
-    BENCHMARK_ELEMENTS(type, 1 << 24, entropy), BENCHMARK_ELEMENTS(type, 1 << 28, entropy)
-
+#define BENCHMARK_TYPE_ENTROPY(type, entropy)                              \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      BENCHMARK_ELEMENTS(type, size, entropy);                             \
+  }
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
@@ -135,17 +139,16 @@ void add_benchmarks(
 
   for (int entropy_reduction : entropy_reductions)
   {
-    std::vector<benchmark::internal::Benchmark*> bs = {
-      BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction),
+    std::vector<benchmark::internal::Benchmark*> bs;
+    BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-      BENCHMARK_TYPE_ENTROPY(int128_t, entropy_reduction),
+    BENCHMARK_TYPE_ENTROPY(int128_t, entropy_reduction)
 #endif
-      BENCHMARK_TYPE_ENTROPY(float, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(double, entropy_reduction)
-    };
+    BENCHMARK_TYPE_ENTROPY(float, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(double, entropy_reduction)
     benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
   }
 }

--- a/projects/rocthrust/benchmark/bench/partition/basic.cu
+++ b/projects/rocthrust/benchmark/bench/partition/basic.cu
@@ -126,20 +126,23 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, EntropyReduction)                                      \
-  benchmark::RegisterBenchmark(                                                              \
-    bench_utils::bench_naming::format_name(                                                  \
-      "{algo:partition,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements         \
-      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction))) \
-      .c_str(),                                                                              \
-    run_benchmark<Benchmark, T>,                                                             \
-    Elements,                                                                                \
-    seed_type,                                                                               \
+#define CREATE_BENCHMARK(T, Elements, EntropyReduction)                                                         \
+  benchmark::RegisterBenchmark(                                                                                 \
+    bench_utils::bench_naming::format_name(                                                                     \
+      "{algo:partition,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements) \
+      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction)))                    \
+      .c_str(),                                                                                                 \
+    run_benchmark<Benchmark, T>,                                                                                \
+    Elements,                                                                                                   \
+    seed_type,                                                                                                  \
     EntropyReduction)
 
-#define BENCHMARK_TYPE_ENTROPY(type, entropy)                                         \
-  CREATE_BENCHMARK(type, 1 << 16, entropy), CREATE_BENCHMARK(type, 1 << 20, entropy), \
-    CREATE_BENCHMARK(type, 1 << 24, entropy), CREATE_BENCHMARK(type, 1 << 28, entropy)
+#define BENCHMARK_TYPE_ENTROPY(type, entropy)                              \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size, entropy));                 \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
@@ -149,17 +152,16 @@ void add_benchmarks(
 
   for (int entropy_reduction : entropy_reductions)
   {
-    std::vector<benchmark::internal::Benchmark*> bs = {
-      BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction),
+    std::vector<benchmark::internal::Benchmark*> bs;
+    BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-      BENCHMARK_TYPE_ENTROPY(int128_t, entropy_reduction),
+    BENCHMARK_TYPE_ENTROPY(int128_t, entropy_reduction)
 #endif
-      BENCHMARK_TYPE_ENTROPY(float, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(double, entropy_reduction)
-    };
+    BENCHMARK_TYPE_ENTROPY(float, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(double, entropy_reduction)
     benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
   }
 }

--- a/projects/rocthrust/benchmark/bench/reduce/basic.cu
+++ b/projects/rocthrust/benchmark/bench/reduce/basic.cu
@@ -90,33 +90,36 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                                                   \
-  benchmark::RegisterBenchmark(                                                                                         \
-    bench_utils::bench_naming::format_name("{algo:reduce,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                                                         \
-    run_benchmark<Benchmark, T>,                                                                                        \
-    Elements,                                                                                                           \
+#define CREATE_BENCHMARK(T, Elements)                                                                         \
+  benchmark::RegisterBenchmark(                                                                               \
+    bench_utils::bench_naming::format_name(                                                                   \
+      "{algo:reduce,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                               \
+    run_benchmark<Benchmark, T>,                                                                              \
+    Elements,                                                                                                 \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/reduce/by_key.cu
+++ b/projects/rocthrust/benchmark/bench/reduce/by_key.cu
@@ -124,53 +124,62 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(KeyT, ValueT, Elements, MaxSegmentSize)                                            \
-  benchmark::RegisterBenchmark(                                                                             \
-    bench_utils::bench_naming::format_name(                                                                 \
-      "{algo:reduce,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT + ",elements:" #Elements \
-      + ",max_segment_size:" #MaxSegmentSize)                                                               \
-      .c_str(),                                                                                             \
-    run_benchmark<Benchmark, KeyT, ValueT>,                                                                 \
-    Elements,                                                                                               \
-    seed_type,                                                                                              \
+#define CREATE_BENCHMARK(KeyT, ValueT, Elements, MaxSegmentSize)                                  \
+  benchmark::RegisterBenchmark(                                                                   \
+    bench_utils::bench_naming::format_name(                                                       \
+      "{algo:reduce,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT                \
+      + ",elements:" + bench_utils::format_pow2(Elements) + ",max_segment_size:" #MaxSegmentSize) \
+      .c_str(),                                                                                   \
+    run_benchmark<Benchmark, KeyT, ValueT>,                                                       \
+    Elements,                                                                                     \
+    seed_type,                                                                                    \
     MaxSegmentSize)
 
-#define BENCHMARK_ELEMENTS(key_type, value_type, elements)                                                  \
-  CREATE_BENCHMARK(key_type, value_type, elements, 1), CREATE_BENCHMARK(key_type, value_type, elements, 4), \
-    CREATE_BENCHMARK(key_type, value_type, elements, 8)
+#define BENCHMARK_ELEMENTS(key_type, value_type, elements)           \
+  bs.push_back(CREATE_BENCHMARK(key_type, value_type, elements, 1)); \
+  bs.push_back(CREATE_BENCHMARK(key_type, value_type, elements, 4)); \
+  bs.push_back(CREATE_BENCHMARK(key_type, value_type, elements, 8));
 
-#define BENCHMARK_VALUE_TYPE(key_type, value_type)                                                      \
-  BENCHMARK_ELEMENTS(key_type, value_type, 1 << 16), BENCHMARK_ELEMENTS(key_type, value_type, 1 << 20), \
-    BENCHMARK_ELEMENTS(key_type, value_type, 1 << 24), BENCHMARK_ELEMENTS(key_type, value_type, 1 << 28)
+#define BENCHMARK_VALUE_TYPE(key_type, value_type)                                                           \
+  for (size_t size : bench_utils::sizes)                                                                     \
+  {                                                                                                          \
+    if ((sizeof(key_type) * size + sizeof(value_type) * size) <= bench_utils::system.devProp.totalGlobalMem) \
+      BENCHMARK_ELEMENTS(key_type, value_type, size)                                                         \
+  }
 
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-#  define BENCHMARK_KEY_TYPE(key_type)                                                  \
-    BENCHMARK_VALUE_TYPE(key_type, int8_t), BENCHMARK_VALUE_TYPE(key_type, int16_t),    \
-      BENCHMARK_VALUE_TYPE(key_type, int32_t), BENCHMARK_VALUE_TYPE(key_type, int64_t), \
-      BENCHMARK_VALUE_TYPE(key_type, int128_t), BENCHMARK_VALUE_TYPE(key_type, float),  \
-      BENCHMARK_VALUE_TYPE(key_type, double)
+#  define BENCHMARK_KEY_TYPE(key_type)       \
+    BENCHMARK_VALUE_TYPE(key_type, int8_t)   \
+    BENCHMARK_VALUE_TYPE(key_type, int16_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int32_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int64_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int128_t) \
+    BENCHMARK_VALUE_TYPE(key_type, float)    \
+    BENCHMARK_VALUE_TYPE(key_type, double)
 #else
-#  define BENCHMARK_KEY_TYPE(key_type)                                                  \
-    BENCHMARK_VALUE_TYPE(key_type, int8_t), BENCHMARK_VALUE_TYPE(key_type, int16_t),    \
-      BENCHMARK_VALUE_TYPE(key_type, int32_t), BENCHMARK_VALUE_TYPE(key_type, int64_t), \
-      BENCHMARK_VALUE_TYPE(key_type, float), BENCHMARK_VALUE_TYPE(key_type, double)
+#  define BENCHMARK_KEY_TYPE(key_type)      \
+    BENCHMARK_VALUE_TYPE(key_type, int8_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int16_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int32_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int64_t) \
+    BENCHMARK_VALUE_TYPE(key_type, float)   \
+    BENCHMARK_VALUE_TYPE(key_type, double)
 #endif
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_KEY_TYPE(int8_t),
-    BENCHMARK_KEY_TYPE(int16_t),
-    BENCHMARK_KEY_TYPE(int32_t),
-    BENCHMARK_KEY_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_KEY_TYPE(int8_t)
+  BENCHMARK_KEY_TYPE(int16_t)
+  BENCHMARK_KEY_TYPE(int32_t)
+  BENCHMARK_KEY_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_KEY_TYPE(int128_t),
+  BENCHMARK_KEY_TYPE(int128_t)
 #endif
-    BENCHMARK_KEY_TYPE(float32_t),
-    BENCHMARK_KEY_TYPE(float64_t)
-  };
+  BENCHMARK_KEY_TYPE(float32_t)
+  BENCHMARK_KEY_TYPE(float64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/scan/exclusive/by_key.cu
+++ b/projects/rocthrust/benchmark/bench/scan/exclusive/by_key.cu
@@ -98,45 +98,52 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(KeyT, ValueT, Elements)                                                                     \
-  benchmark::RegisterBenchmark(                                                                                      \
-    bench_utils::bench_naming::format_name(                                                                          \
-      "{algo:exclusive_scan,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT + ",elements:" #Elements) \
-      .c_str(),                                                                                                      \
-    run_benchmark<Benchmark, KeyT, ValueT>,                                                                          \
-    Elements,                                                                                                        \
+#define CREATE_BENCHMARK(KeyT, ValueT, Elements)                                           \
+  benchmark::RegisterBenchmark(                                                            \
+    bench_utils::bench_naming::format_name(                                                \
+      "{algo:exclusive_scan,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT \
+      + ",elements:" + bench_utils::format_pow2(Elements))                                 \
+      .c_str(),                                                                            \
+    run_benchmark<Benchmark, KeyT, ValueT>,                                                \
+    Elements,                                                                              \
     seed_type)
 
-#define BENCHMARK_VALUE_TYPE(key_type, value_type)                                                  \
-  CREATE_BENCHMARK(key_type, value_type, 1 << 16), CREATE_BENCHMARK(key_type, value_type, 1 << 20), \
-    CREATE_BENCHMARK(key_type, value_type, 1 << 24), CREATE_BENCHMARK(key_type, value_type, 1 << 28)
+#define BENCHMARK_VALUE_TYPE(key_type, value_type)                                                           \
+  for (size_t size : bench_utils::sizes)                                                                     \
+  {                                                                                                          \
+    if ((sizeof(key_type) * size + sizeof(value_type) * size) <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(key_type, value_type, size));                                            \
+  }
 
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-#  define BENCHMARK_KEY_TYPE(key_type)                                                  \
-    BENCHMARK_VALUE_TYPE(key_type, int8_t), BENCHMARK_VALUE_TYPE(key_type, int16_t),    \
-      BENCHMARK_VALUE_TYPE(key_type, int32_t), BENCHMARK_VALUE_TYPE(key_type, int64_t), \
-      BENCHMARK_VALUE_TYPE(key_type, int128_t)
+#  define BENCHMARK_KEY_TYPE(key_type)      \
+    BENCHMARK_VALUE_TYPE(key_type, int8_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int16_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int32_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int64_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int128_t)
 #else
-#  define BENCHMARK_KEY_TYPE(key_type)                                               \
-    BENCHMARK_VALUE_TYPE(key_type, int8_t), BENCHMARK_VALUE_TYPE(key_type, int16_t), \
-      BENCHMARK_VALUE_TYPE(key_type, int32_t), BENCHMARK_VALUE_TYPE(key_type, int64_t)
+#  define BENCHMARK_KEY_TYPE(key_type)      \
+    BENCHMARK_VALUE_TYPE(key_type, int8_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int16_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int32_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int64_t)
 #endif
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_KEY_TYPE(int8_t),
-    BENCHMARK_KEY_TYPE(int16_t),
-    BENCHMARK_KEY_TYPE(int32_t),
-    BENCHMARK_KEY_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_KEY_TYPE(int8_t)
+  BENCHMARK_KEY_TYPE(int16_t)
+  BENCHMARK_KEY_TYPE(int32_t)
+  BENCHMARK_KEY_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_KEY_TYPE(int128_t),
+  BENCHMARK_KEY_TYPE(int128_t)
 #endif
-    BENCHMARK_KEY_TYPE(float32_t),
-    BENCHMARK_KEY_TYPE(float64_t)
-  };
+  BENCHMARK_KEY_TYPE(float32_t)
+  BENCHMARK_KEY_TYPE(float64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/scan/exclusive/max.cu
+++ b/projects/rocthrust/benchmark/bench/scan/exclusive/max.cu
@@ -93,34 +93,36 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                      \
-  benchmark::RegisterBenchmark(                                                            \
-    bench_utils::bench_naming::format_name(                                                \
-      "{algo:exclusive_scan,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                            \
-    run_benchmark<Benchmark, T>,                                                           \
-    Elements,                                                                              \
+#define CREATE_BENCHMARK(T, Elements)                                                                                 \
+  benchmark::RegisterBenchmark(                                                                                       \
+    bench_utils::bench_naming::format_name(                                                                           \
+      "{algo:exclusive_scan,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                                       \
+    run_benchmark<Benchmark, T>,                                                                                      \
+    Elements,                                                                                                         \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/scan/exclusive/sum.cu
+++ b/projects/rocthrust/benchmark/bench/scan/exclusive/sum.cu
@@ -93,34 +93,37 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                      \
-  benchmark::RegisterBenchmark(                                                            \
-    bench_utils::bench_naming::format_name(                                                \
-      "{algo:exclusive_scan,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                            \
-    run_benchmark<Benchmark, T>,                                                           \
-    Elements,                                                                              \
+#define CREATE_BENCHMARK(T, Elements)                                                                                 \
+  benchmark::RegisterBenchmark(                                                                                       \
+    bench_utils::bench_naming::format_name(                                                                           \
+      "{algo:exclusive_scan,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                                       \
+    run_benchmark<Benchmark, T>,                                                                                      \
+    Elements,                                                                                                         \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
+
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/scan/inclusive/by_key.cu
+++ b/projects/rocthrust/benchmark/bench/scan/inclusive/by_key.cu
@@ -98,45 +98,51 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(KeyT, ValueT, Elements)                                                                     \
-  benchmark::RegisterBenchmark(                                                                                      \
-    bench_utils::bench_naming::format_name(                                                                          \
-      "{algo:inclusive_scan,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT + ",elements:" #Elements) \
-      .c_str(),                                                                                                      \
-    run_benchmark<Benchmark, KeyT, ValueT>,                                                                          \
-    Elements,                                                                                                        \
+#define CREATE_BENCHMARK(KeyT, ValueT, Elements)                                           \
+  benchmark::RegisterBenchmark(                                                            \
+    bench_utils::bench_naming::format_name(                                                \
+      "{algo:inclusive_scan,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT \
+      + ",elements:" + bench_utils::format_pow2(Elements))                                 \
+      .c_str(),                                                                            \
+    run_benchmark<Benchmark, KeyT, ValueT>,                                                \
+    Elements,                                                                              \
     seed_type)
 
-#define BENCHMARK_VALUE_TYPE(key_type, value_type)                                                  \
-  CREATE_BENCHMARK(key_type, value_type, 1 << 16), CREATE_BENCHMARK(key_type, value_type, 1 << 20), \
-    CREATE_BENCHMARK(key_type, value_type, 1 << 24), CREATE_BENCHMARK(key_type, value_type, 1 << 28)
-
+#define BENCHMARK_VALUE_TYPE(key_type, value_type)                                                           \
+  for (size_t size : bench_utils::sizes)                                                                     \
+  {                                                                                                          \
+    if ((sizeof(key_type) * size + sizeof(value_type) * size) <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(key_type, value_type, size));                                            \
+  }
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-#  define BENCHMARK_KEY_TYPE(key_type)                                                  \
-    BENCHMARK_VALUE_TYPE(key_type, int8_t), BENCHMARK_VALUE_TYPE(key_type, int16_t),    \
-      BENCHMARK_VALUE_TYPE(key_type, int32_t), BENCHMARK_VALUE_TYPE(key_type, int64_t), \
-      BENCHMARK_VALUE_TYPE(key_type, int128_t)
+#  define BENCHMARK_KEY_TYPE(key_type)      \
+    BENCHMARK_VALUE_TYPE(key_type, int8_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int16_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int32_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int64_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int128_t)
 #else
-#  define BENCHMARK_KEY_TYPE(key_type)                                               \
-    BENCHMARK_VALUE_TYPE(key_type, int8_t), BENCHMARK_VALUE_TYPE(key_type, int16_t), \
-      BENCHMARK_VALUE_TYPE(key_type, int32_t), BENCHMARK_VALUE_TYPE(key_type, int64_t)
+#  define BENCHMARK_KEY_TYPE(key_type)      \
+    BENCHMARK_VALUE_TYPE(key_type, int8_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int16_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int32_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int64_t)
 #endif
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_KEY_TYPE(int8_t),
-    BENCHMARK_KEY_TYPE(int16_t),
-    BENCHMARK_KEY_TYPE(int32_t),
-    BENCHMARK_KEY_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_KEY_TYPE(int8_t)
+  BENCHMARK_KEY_TYPE(int16_t)
+  BENCHMARK_KEY_TYPE(int32_t)
+  BENCHMARK_KEY_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_KEY_TYPE(int128_t),
+  BENCHMARK_KEY_TYPE(int128_t)
 #endif
-    BENCHMARK_KEY_TYPE(float32_t),
-    BENCHMARK_KEY_TYPE(float64_t)
-  };
+  BENCHMARK_KEY_TYPE(float32_t)
+  BENCHMARK_KEY_TYPE(float64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/scan/inclusive/max.cu
+++ b/projects/rocthrust/benchmark/bench/scan/inclusive/max.cu
@@ -94,34 +94,37 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                      \
-  benchmark::RegisterBenchmark(                                                            \
-    bench_utils::bench_naming::format_name(                                                \
-      "{algo:inclusive_scan,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                            \
-    run_benchmark<Benchmark, T>,                                                           \
-    Elements,                                                                              \
+#define CREATE_BENCHMARK(T, Elements)                                                                                 \
+  benchmark::RegisterBenchmark(                                                                                       \
+    bench_utils::bench_naming::format_name(                                                                           \
+      "{algo:inclusive_scan,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                                       \
+    run_benchmark<Benchmark, T>,                                                                                      \
+    Elements,                                                                                                         \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
+
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/scan/inclusive/sum.cu
+++ b/projects/rocthrust/benchmark/bench/scan/inclusive/sum.cu
@@ -93,34 +93,37 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                      \
-  benchmark::RegisterBenchmark(                                                            \
-    bench_utils::bench_naming::format_name(                                                \
-      "{algo:inclusive_scan,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                            \
-    run_benchmark<Benchmark, T>,                                                           \
-    Elements,                                                                              \
+#define CREATE_BENCHMARK(T, Elements)                                                                                 \
+  benchmark::RegisterBenchmark(                                                                                       \
+    bench_utils::bench_naming::format_name(                                                                           \
+      "{algo:inclusive_scan,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                                       \
+    run_benchmark<Benchmark, T>,                                                                                      \
+    Elements,                                                                                                         \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
+
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/set_operations/base.hpp
+++ b/projects/rocthrust/benchmark/bench/set_operations/base.hpp
@@ -125,8 +125,9 @@ void run_benchmark(benchmark::State& state,
 #define CREATE_BENCHMARK(T, Elements, EntropyReduction, InputSizeRatio)                                               \
   benchmark::RegisterBenchmark(                                                                                       \
     bench_utils::bench_naming::format_name(                                                                           \
-      "{algo:" + algo_name + ",subalgo:basic" + ",input_type:" #T + ",elements:" #Elements + ",entropy:"              \
-      + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction)) + ",input_size_ratio:" #InputSizeRatio) \
+      "{algo:" + algo_name + ",subalgo:basic" + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements) \
+      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction))                           \
+      + ",input_size_ratio:" #InputSizeRatio)                                                                         \
       .c_str(),                                                                                                       \
     run_benchmark<T, OpT>,                                                                                            \
     Elements,                                                                                                         \
@@ -134,13 +135,17 @@ void run_benchmark(benchmark::State& state,
     EntropyReduction,                                                                                                 \
     InputSizeRatio)
 
-#define BENCHMARK_ELEMENTS(type, elements, entropy)                                             \
-  CREATE_BENCHMARK(type, elements, entropy, 25), CREATE_BENCHMARK(type, elements, entropy, 50), \
-    CREATE_BENCHMARK(type, elements, entropy, 75)
+#define BENCHMARK_ELEMENTS(type, elements, entropy)            \
+  bs.push_back(CREATE_BENCHMARK(type, elements, entropy, 25)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, entropy, 50)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, entropy, 75));
 
-#define BENCHMARK_TYPE_ENTROPY(type, entropy)                                             \
-  BENCHMARK_ELEMENTS(type, 1 << 16, entropy), BENCHMARK_ELEMENTS(type, 1 << 20, entropy), \
-    BENCHMARK_ELEMENTS(type, 1 << 24, entropy), BENCHMARK_ELEMENTS(type, 1 << 28, entropy)
+#define BENCHMARK_TYPE_ENTROPY(type, entropy)                              \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      BENCHMARK_ELEMENTS(type, size, entropy)                              \
+  }
 
 template <class OpT>
 void add_benchmarks(
@@ -150,11 +155,11 @@ void add_benchmarks(
 
   for (int entropy_reduction : entropy_reductions)
   {
-    std::vector<benchmark::internal::Benchmark*> bs = {
-      BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction)};
+    std::vector<benchmark::internal::Benchmark*> bs;
+    BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction)
 
     benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
   }

--- a/projects/rocthrust/benchmark/bench/set_operations/by_key.hpp
+++ b/projects/rocthrust/benchmark/bench/set_operations/by_key.hpp
@@ -140,9 +140,9 @@ void run_benchmark(benchmark::State& state,
 #define CREATE_BENCHMARK(KeyT, ValueT, Elements, EntropyReduction, InputSizeRatio)                                    \
   benchmark::RegisterBenchmark(                                                                                       \
     bench_utils::bench_naming::format_name(                                                                           \
-      "{algo:" + algo_name + ",subalgo:by_key" + ",key_type:" #KeyT + ",value_type:" #ValueT + ",elements:" #Elements \
-      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction))                           \
-      + ",input_size_ratio:" #InputSizeRatio)                                                                         \
+      "{algo:" + algo_name + ",subalgo:by_key" + ",key_type:" #KeyT + ",value_type:" #ValueT                          \
+      + ",elements:" + bench_utils::format_pow2(Elements) + ",entropy:"                                               \
+      + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction)) + ",input_size_ratio:" #InputSizeRatio) \
       .c_str(),                                                                                                       \
     run_benchmark<KeyT, ValueT, OpT>,                                                                                 \
     Elements,                                                                                                         \
@@ -150,19 +150,21 @@ void run_benchmark(benchmark::State& state,
     EntropyReduction,                                                                                                 \
     InputSizeRatio)
 
-#define BENCHMARK_ELEMENTS(key_type, value_type, elements, entropy) \
-  CREATE_BENCHMARK(key_type, value_type, elements, entropy, 25),    \
-    CREATE_BENCHMARK(key_type, value_type, elements, entropy, 50),  \
-    CREATE_BENCHMARK(key_type, value_type, elements, entropy, 75)
+#define BENCHMARK_ELEMENTS(key_type, value_type, elements, entropy)            \
+  bs.push_back(CREATE_BENCHMARK(key_type, value_type, elements, entropy, 25)); \
+  bs.push_back(CREATE_BENCHMARK(key_type, value_type, elements, entropy, 50)); \
+  bs.push_back(CREATE_BENCHMARK(key_type, value_type, elements, entropy, 75));
 
-#define BENCHMARK_VALUE_TYPE(key_type, value_type, entropy)     \
-  BENCHMARK_ELEMENTS(key_type, value_type, 1 << 16, entropy),   \
-    BENCHMARK_ELEMENTS(key_type, value_type, 1 << 20, entropy), \
-    BENCHMARK_ELEMENTS(key_type, value_type, 1 << 24, entropy), \
-    BENCHMARK_ELEMENTS(key_type, value_type, 1 << 28, entropy)
+#define BENCHMARK_VALUE_TYPE(key_type, value_type, entropy)                                                  \
+  for (size_t size : bench_utils::sizes)                                                                     \
+  {                                                                                                          \
+    if ((sizeof(key_type) * size + sizeof(value_type) * size) <= bench_utils::system.devProp.totalGlobalMem) \
+      BENCHMARK_ELEMENTS(key_type, value_type, size, entropy)                                                \
+  }
 
 #define BENCHMARK_KEY_TYPE_ENTROPY(key_type, entropy) \
-  BENCHMARK_VALUE_TYPE(key_type, int8_t, entropy), BENCHMARK_VALUE_TYPE(key_type, int64_t, entropy)
+  BENCHMARK_VALUE_TYPE(key_type, int8_t, entropy)     \
+  BENCHMARK_VALUE_TYPE(key_type, int64_t, entropy)
 
 template <class OpT>
 void add_benchmarks(
@@ -172,11 +174,11 @@ void add_benchmarks(
 
   for (int entropy_reduction : entropy_reductions)
   {
-    std::vector<benchmark::internal::Benchmark*> bs = {
-      BENCHMARK_KEY_TYPE_ENTROPY(int8_t, entropy_reduction),
-      BENCHMARK_KEY_TYPE_ENTROPY(int16_t, entropy_reduction),
-      BENCHMARK_KEY_TYPE_ENTROPY(int32_t, entropy_reduction),
-      BENCHMARK_KEY_TYPE_ENTROPY(int64_t, entropy_reduction)};
+    std::vector<benchmark::internal::Benchmark*> bs;
+    BENCHMARK_KEY_TYPE_ENTROPY(int8_t, entropy_reduction)
+    BENCHMARK_KEY_TYPE_ENTROPY(int16_t, entropy_reduction)
+    BENCHMARK_KEY_TYPE_ENTROPY(int32_t, entropy_reduction)
+    BENCHMARK_KEY_TYPE_ENTROPY(int64_t, entropy_reduction)
 
     benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
   }

--- a/projects/rocthrust/benchmark/bench/shuffle/basic.cu
+++ b/projects/rocthrust/benchmark/bench/shuffle/basic.cu
@@ -121,38 +121,42 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, RngEngine, Elements)                                                                \
-  benchmark::RegisterBenchmark(                                                                                 \
-    bench_utils::bench_naming::format_name(                                                                     \
-      "{algo:shuffle,subalgo:" + name + ",input_type:" #T + ",rng_engine:" #RngEngine + ",elements:" #Elements) \
-      .c_str(),                                                                                                 \
-    run_benchmark<Benchmark, T>,                                                                                \
-    Elements,                                                                                                   \
-    seed_type,                                                                                                  \
+#define CREATE_BENCHMARK(T, RngEngine, Elements)                                      \
+  benchmark::RegisterBenchmark(                                                       \
+    bench_utils::bench_naming::format_name(                                           \
+      "{algo:shuffle,subalgo:" + name + ",input_type:" #T + ",rng_engine:" #RngEngine \
+      + ",elements:" + bench_utils::format_pow2(Elements))                            \
+      .c_str(),                                                                       \
+    run_benchmark<Benchmark, T>,                                                      \
+    Elements,                                                                         \
+    seed_type,                                                                        \
     RngEngine)
 
-#define BENCHMARK_RNG_ENGINE(type, rng_engine)                                              \
-  CREATE_BENCHMARK(type, rng_engine, 1 << 16), CREATE_BENCHMARK(type, rng_engine, 1 << 20), \
-    CREATE_BENCHMARK(type, rng_engine, 1 << 24), CREATE_BENCHMARK(type, rng_engine, 1 << 28)
+#define BENCHMARK_RNG_ENGINE(type, rng_engine)                             \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, rng_engine, size));              \
+  }
 
-#define BENCHMARK_TYPE(type)                                                    \
-  BENCHMARK_RNG_ENGINE(type, "minstd"), BENCHMARK_RNG_ENGINE(type, "ranlux24"), \
-    BENCHMARK_RNG_ENGINE(type, "ranlux48"), BENCHMARK_RNG_ENGINE(type, "taus88")
+#define BENCHMARK_TYPE(type)             \
+  BENCHMARK_RNG_ENGINE(type, "minstd")   \
+  BENCHMARK_RNG_ENGINE(type, "ranlux24") \
+  BENCHMARK_RNG_ENGINE(type, "ranlux48") \
+  BENCHMARK_RNG_ENGINE(type, "taus88")
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t)
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-      ,
-    BENCHMARK_TYPE(int128_t)
+  BENCHMARK_TYPE(int128_t)
 #endif
-  };
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/sort/keys.cu
+++ b/projects/rocthrust/benchmark/bench/sort/keys.cu
@@ -95,21 +95,23 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, EntropyReduction)                                      \
-  benchmark::RegisterBenchmark(                                                              \
-    bench_utils::bench_naming::format_name(                                                  \
-      "{algo:sort,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements              \
-      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction))) \
-      .c_str(),                                                                              \
-    run_benchmark<Benchmark, T>,                                                             \
-    Elements,                                                                                \
-    seed_type,                                                                               \
+#define CREATE_BENCHMARK(T, Elements, EntropyReduction)                                                    \
+  benchmark::RegisterBenchmark(                                                                            \
+    bench_utils::bench_naming::format_name(                                                                \
+      "{algo:sort,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements) \
+      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction)))               \
+      .c_str(),                                                                                            \
+    run_benchmark<Benchmark, T>,                                                                           \
+    Elements,                                                                                              \
+    seed_type,                                                                                             \
     EntropyReduction)
 
-#define BENCHMARK_TYPE_ENTROPY(type, entropy)                                         \
-  CREATE_BENCHMARK(type, 1 << 16, entropy), CREATE_BENCHMARK(type, 1 << 20, entropy), \
-    CREATE_BENCHMARK(type, 1 << 24, entropy), CREATE_BENCHMARK(type, 1 << 28, entropy)
-
+#define BENCHMARK_TYPE_ENTROPY(type, entropy)                              \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size, entropy));                 \
+  }
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
@@ -118,17 +120,16 @@ void add_benchmarks(
 
   for (int entropy_reduction : entropy_reductions)
   {
-    std::vector<benchmark::internal::Benchmark*> bs = {
-      BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction),
+    std::vector<benchmark::internal::Benchmark*> bs;
+    BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-      BENCHMARK_TYPE_ENTROPY(int128_t, entropy_reduction),
+    BENCHMARK_TYPE_ENTROPY(int128_t, entropy_reduction)
 #endif
-      BENCHMARK_TYPE_ENTROPY(float, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(double, entropy_reduction)
-    };
+    BENCHMARK_TYPE_ENTROPY(float, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(double, entropy_reduction)
     benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
   }
 }

--- a/projects/rocthrust/benchmark/bench/sort/keys_custom.cu
+++ b/projects/rocthrust/benchmark/bench/sort/keys_custom.cu
@@ -95,21 +95,24 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, EntropyReduction)                                      \
-  benchmark::RegisterBenchmark(                                                              \
-    bench_utils::bench_naming::format_name(                                                  \
-      "{algo:sort,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements              \
-      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction))) \
-      .c_str(),                                                                              \
-    run_benchmark<Benchmark, T>,                                                             \
-    Elements,                                                                                \
-    seed_type,                                                                               \
+#define CREATE_BENCHMARK(T, Elements, EntropyReduction)                                                    \
+  benchmark::RegisterBenchmark(                                                                            \
+    bench_utils::bench_naming::format_name(                                                                \
+      "{algo:sort,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements) \
+      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction)))               \
+      .c_str(),                                                                                            \
+    run_benchmark<Benchmark, T>,                                                                           \
+    Elements,                                                                                              \
+    seed_type,                                                                                             \
     EntropyReduction)
 
-#define BENCHMARK_TYPE_ENTROPY(type, entropy)                                         \
-  CREATE_BENCHMARK(type, 1 << 16, entropy), CREATE_BENCHMARK(type, 1 << 20, entropy), \
-    CREATE_BENCHMARK(type, 1 << 24, entropy), CREATE_BENCHMARK(type, 1 << 28, entropy)
-
+#define BENCHMARK_TYPE_ENTROPY(type, entropy)                              \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size, entropy));                 \
+  }
+  
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
@@ -118,17 +121,16 @@ void add_benchmarks(
 
   for (int entropy_reduction : entropy_reductions)
   {
-    std::vector<benchmark::internal::Benchmark*> bs = {
-      BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction),
+    std::vector<benchmark::internal::Benchmark*> bs;
+    BENCHMARK_TYPE_ENTROPY(int8_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int16_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int32_t, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(int64_t, entropy_reduction)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-      BENCHMARK_TYPE_ENTROPY(int128_t, entropy_reduction),
+    BENCHMARK_TYPE_ENTROPY(int128_t, entropy_reduction)
 #endif
-      BENCHMARK_TYPE_ENTROPY(float, entropy_reduction),
-      BENCHMARK_TYPE_ENTROPY(double, entropy_reduction)
-    };
+    BENCHMARK_TYPE_ENTROPY(float, entropy_reduction)
+    BENCHMARK_TYPE_ENTROPY(double, entropy_reduction)
     benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
   }
 }

--- a/projects/rocthrust/benchmark/bench/sort/pairs.cu
+++ b/projects/rocthrust/benchmark/bench/sort/pairs.cu
@@ -74,7 +74,7 @@ void run_benchmark(
   std::vector<double> gpu_times;
 
   // Generate input
-  const auto entropy                 = bench_utils::get_entropy_percentage(entropy_reduction) / 100.0f;
+  const auto entropy                    = bench_utils::get_entropy_percentage(entropy_reduction) / 100.0f;
   thrust::device_vector<KeyT> in_keys   = bench_utils::generate(elements, seed_type, entropy);
   thrust::device_vector<ValueT> in_vals = bench_utils::generate(elements, seed_type);
 
@@ -97,24 +97,29 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(KeyT, ValueT, Elements, EntropyReduction)                                        \
-  benchmark::RegisterBenchmark(                                                                           \
-    bench_utils::bench_naming::format_name(                                                               \
-      "{algo:sort,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT + ",elements:" #Elements \
-      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction)))              \
-      .c_str(),                                                                                           \
-    run_benchmark<Benchmark, KeyT, ValueT>,                                                               \
-    Elements,                                                                                             \
-    seed_type,                                                                                            \
+#define CREATE_BENCHMARK(KeyT, ValueT, Elements, EntropyReduction)                           \
+  benchmark::RegisterBenchmark(                                                              \
+    bench_utils::bench_naming::format_name(                                                  \
+      "{algo:sort,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT             \
+      + ",elements:" + bench_utils::format_pow2(Elements)                                    \
+      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction))) \
+      .c_str(),                                                                              \
+    run_benchmark<Benchmark, KeyT, ValueT>,                                                  \
+    Elements,                                                                                \
+    seed_type,                                                                               \
     EntropyReduction)
 
-#define BENCHMARK_VALUE_TYPE(key_type, value_type, entropy)                                                           \
-  CREATE_BENCHMARK(key_type, value_type, 1 << 16, entropy), CREATE_BENCHMARK(key_type, value_type, 1 << 20, entropy), \
-    CREATE_BENCHMARK(key_type, value_type, 1 << 24, entropy), CREATE_BENCHMARK(key_type, value_type, 1 << 28, entropy)
-
-#define BENCHMARK_KEY_TYPE_ENTROPY(key_type, entropy)                                                \
-  BENCHMARK_VALUE_TYPE(key_type, int8_t, entropy), BENCHMARK_VALUE_TYPE(key_type, int16_t, entropy), \
-    BENCHMARK_VALUE_TYPE(key_type, int32_t, entropy), BENCHMARK_VALUE_TYPE(key_type, int64_t, entropy)
+#define BENCHMARK_VALUE_TYPE(key_type, value_type, entropy)                                                  \
+  for (size_t size : bench_utils::sizes)                                                                     \
+  {                                                                                                          \
+    if ((sizeof(key_type) * size + sizeof(value_type) * size) <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(key_type, value_type, size, entropy));                                   \
+  }
+#define BENCHMARK_KEY_TYPE_ENTROPY(key_type, entropy) \
+  BENCHMARK_VALUE_TYPE(key_type, int8_t, entropy)     \
+  BENCHMARK_VALUE_TYPE(key_type, int16_t, entropy)    \
+  BENCHMARK_VALUE_TYPE(key_type, int32_t, entropy)    \
+  BENCHMARK_VALUE_TYPE(key_type, int64_t, entropy)
 
 template <class Benchmark>
 void add_benchmarks(
@@ -124,11 +129,11 @@ void add_benchmarks(
 
   for (int entropy_reduction : entropy_reductions)
   {
-    std::vector<benchmark::internal::Benchmark*> bs = {
-      BENCHMARK_KEY_TYPE_ENTROPY(int8_t, entropy_reduction),
-      BENCHMARK_KEY_TYPE_ENTROPY(int16_t, entropy_reduction),
-      BENCHMARK_KEY_TYPE_ENTROPY(int32_t, entropy_reduction),
-      BENCHMARK_KEY_TYPE_ENTROPY(int64_t, entropy_reduction)};
+    std::vector<benchmark::internal::Benchmark*> bs;
+    BENCHMARK_KEY_TYPE_ENTROPY(int8_t, entropy_reduction)
+    BENCHMARK_KEY_TYPE_ENTROPY(int16_t, entropy_reduction)
+    BENCHMARK_KEY_TYPE_ENTROPY(int32_t, entropy_reduction)
+    BENCHMARK_KEY_TYPE_ENTROPY(int64_t, entropy_reduction)
     benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
   }
 }

--- a/projects/rocthrust/benchmark/bench/sort/pairs_custom.cu
+++ b/projects/rocthrust/benchmark/bench/sort/pairs_custom.cu
@@ -75,7 +75,7 @@ void run_benchmark(
   std::vector<double> gpu_times;
 
   // Generate input
-  const auto entropy                 = bench_utils::get_entropy_percentage(entropy_reduction) / 100.0f;
+  const auto entropy                    = bench_utils::get_entropy_percentage(entropy_reduction) / 100.0f;
   thrust::device_vector<KeyT> in_keys   = bench_utils::generate(elements, seed_type, entropy);
   thrust::device_vector<ValueT> in_vals = bench_utils::generate(elements, seed_type);
 
@@ -98,24 +98,29 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(KeyT, ValueT, Elements, EntropyReduction)                                        \
-  benchmark::RegisterBenchmark(                                                                           \
-    bench_utils::bench_naming::format_name(                                                               \
-      "{algo:sort,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT + ",elements:" #Elements \
-      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction)))              \
-      .c_str(),                                                                                           \
-    run_benchmark<Benchmark, KeyT, ValueT>,                                                               \
-    Elements,                                                                                             \
-    seed_type,                                                                                            \
+#define CREATE_BENCHMARK(KeyT, ValueT, Elements, EntropyReduction)                           \
+  benchmark::RegisterBenchmark(                                                              \
+    bench_utils::bench_naming::format_name(                                                  \
+      "{algo:sort,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT             \
+      + ",elements:" + bench_utils::format_pow2(Elements)                                    \
+      + ",entropy:" + std::to_string(bench_utils::get_entropy_percentage(EntropyReduction))) \
+      .c_str(),                                                                              \
+    run_benchmark<Benchmark, KeyT, ValueT>,                                                  \
+    Elements,                                                                                \
+    seed_type,                                                                               \
     EntropyReduction)
 
-#define BENCHMARK_VALUE_TYPE(key_type, value_type, entropy)                                                           \
-  CREATE_BENCHMARK(key_type, value_type, 1 << 16, entropy), CREATE_BENCHMARK(key_type, value_type, 1 << 20, entropy), \
-    CREATE_BENCHMARK(key_type, value_type, 1 << 24, entropy), CREATE_BENCHMARK(key_type, value_type, 1 << 28, entropy)
-
-#define BENCHMARK_KEY_TYPE_ENTROPY(key_type, entropy)                                                \
-  BENCHMARK_VALUE_TYPE(key_type, int8_t, entropy), BENCHMARK_VALUE_TYPE(key_type, int16_t, entropy), \
-    BENCHMARK_VALUE_TYPE(key_type, int32_t, entropy), BENCHMARK_VALUE_TYPE(key_type, int64_t, entropy)
+#define BENCHMARK_VALUE_TYPE(key_type, value_type, entropy)                                                  \
+  for (size_t size : bench_utils::sizes)                                                                     \
+  {                                                                                                          \
+    if ((sizeof(key_type) * size + sizeof(value_type) * size) <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(key_type, value_type, size, entropy));                                   \
+  }
+#define BENCHMARK_KEY_TYPE_ENTROPY(key_type, entropy) \
+  BENCHMARK_VALUE_TYPE(key_type, int8_t, entropy)     \
+  BENCHMARK_VALUE_TYPE(key_type, int16_t, entropy)    \
+  BENCHMARK_VALUE_TYPE(key_type, int32_t, entropy)    \
+  BENCHMARK_VALUE_TYPE(key_type, int64_t, entropy)
 
 template <class Benchmark>
 void add_benchmarks(
@@ -125,11 +130,11 @@ void add_benchmarks(
 
   for (int entropy_reduction : entropy_reductions)
   {
-    std::vector<benchmark::internal::Benchmark*> bs = {
-      BENCHMARK_KEY_TYPE_ENTROPY(int8_t, entropy_reduction),
-      BENCHMARK_KEY_TYPE_ENTROPY(int16_t, entropy_reduction),
-      BENCHMARK_KEY_TYPE_ENTROPY(int32_t, entropy_reduction),
-      BENCHMARK_KEY_TYPE_ENTROPY(int64_t, entropy_reduction)};
+    std::vector<benchmark::internal::Benchmark*> bs;
+    BENCHMARK_KEY_TYPE_ENTROPY(int8_t, entropy_reduction)
+    BENCHMARK_KEY_TYPE_ENTROPY(int16_t, entropy_reduction)
+    BENCHMARK_KEY_TYPE_ENTROPY(int32_t, entropy_reduction)
+    BENCHMARK_KEY_TYPE_ENTROPY(int64_t, entropy_reduction)
     benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
   }
 }

--- a/projects/rocthrust/benchmark/bench/tabulate/basic.cu
+++ b/projects/rocthrust/benchmark/bench/tabulate/basic.cu
@@ -107,24 +107,29 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                \
-  benchmark::RegisterBenchmark(                                                      \
-    bench_utils::bench_naming::format_name(                                          \
-      "{algo:tabulate,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                      \
-    run_benchmark<Benchmark, T>,                                                     \
-    Elements,                                                                        \
+#define CREATE_BENCHMARK(T, Elements)                                                                           \
+  benchmark::RegisterBenchmark(                                                                                 \
+    bench_utils::bench_naming::format_name(                                                                     \
+      "{algo:tabulate,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                                 \
+    run_benchmark<Benchmark, T>,                                                                                \
+    Elements,                                                                                                   \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {BENCHMARK_TYPE(uint32_t), BENCHMARK_TYPE(uint64_t)};
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(uint32_t)
+  BENCHMARK_TYPE(uint64_t)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/transform/basic.cu
+++ b/projects/rocthrust/benchmark/bench/transform/basic.cu
@@ -140,29 +140,29 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                 \
-  benchmark::RegisterBenchmark(                                                       \
-    bench_utils::bench_naming::format_name(                                           \
-      "{algo:transform,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                       \
-    run_benchmark<Benchmark, T>,                                                      \
-    Elements,                                                                         \
+#define CREATE_BENCHMARK(T, Elements)                                                                            \
+  benchmark::RegisterBenchmark(                                                                                  \
+    bench_utils::bench_naming::format_name(                                                                      \
+      "{algo:transform,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
+      .c_str(),                                                                                                  \
+    run_benchmark<Benchmark, T>,                                                                                 \
+    Elements,                                                                                                    \
     seed_type)
 
-// clang-format off
-#define BENCHMARK_TYPE(type)       \
-  CREATE_BENCHMARK(type, 1 << 16), \
-  CREATE_BENCHMARK(type, 1 << 20), \
-  CREATE_BENCHMARK(type, 1 << 24), \
-  CREATE_BENCHMARK(type, 1 << 28)
-// clang-format on
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {BENCHMARK_TYPE(uint32_t), BENCHMARK_TYPE(uint64_t)};
-
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(uint32_t)
+  BENCHMARK_TYPE(uint64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 
@@ -299,7 +299,7 @@ void run_babelstream(benchmark::State& state, const std::size_t n)
     {
       duration = Benchmark::template run<T>(a, b, c);
     }
-    catch(const ::thrust::system::detail::bad_alloc& e)
+    catch (const ::thrust::system::detail::bad_alloc& e)
     {
       (void) hipGetLastError();
       state.SkipWithError(("thrust::system::detail::bad_alloc: " + std::string(e.what())).c_str());
@@ -319,40 +319,41 @@ void run_babelstream(benchmark::State& state, const std::size_t n)
 #define CREATE_BABELSTREAM_BENCHMARK(T, Elements, Benchmark)                                             \
   benchmark::RegisterBenchmark(                                                                          \
     bench_utils::bench_naming::format_name(                                                              \
-      "{algo:transform,subalgo:" + name + "." + #Benchmark + ",input_type:" #T + ",elements:" #Elements) \
+      "{algo:transform,subalgo:" + name + "." + #Benchmark + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements)) \
       .c_str(),                                                                                          \
     run_babelstream<Benchmark, T>,                                                                       \
     Elements)
 
-// clang-format off
 // Different benchmarks use a different number of buffers. H200/B200 can fit 2^31 elements for all benchmarks and types.
 // Upstream BabelStream uses 2^25. Allocation failure just skips the benchmark
-#define BENCHMARK_BABELSTREAM_TYPE(type)              \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, mul),   \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, mul),   \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, add),   \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, add),   \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, triad), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, triad), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, nstream), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, nstream), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 25, nstream_stable), \
-  CREATE_BABELSTREAM_BENCHMARK(type, 1u << 31, nstream_stable)
-// clang-format on
+#define BENCHMARK_BABELSTREAM_TYPE(type)                                          \
+  if (sizeof(type) * (1u << 25) <= bench_utils::system.devProp.totalGlobalMem)    \
+  {                                                                               \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 25), mul));            \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 25), add));            \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 25), triad));          \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 25), nstream));        \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 25), nstream_stable)); \
+  }                                                                               \
+  if (sizeof(type) * (1u << 31) <= bench_utils::system.devProp.totalGlobalMem)    \
+  {                                                                               \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 31), mul));            \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 31), add));            \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 31), triad));          \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 31), nstream));        \
+    bs.push_back(CREATE_BABELSTREAM_BENCHMARK(type, (1u << 31), nstream_stable)); \
+  }
 
 void add_benchmarks(const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_BABELSTREAM_TYPE(int8_t),
-    BENCHMARK_BABELSTREAM_TYPE(int16_t),
-    BENCHMARK_BABELSTREAM_TYPE(float),
-    BENCHMARK_BABELSTREAM_TYPE(double)
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_BABELSTREAM_TYPE(int8_t)
+  BENCHMARK_BABELSTREAM_TYPE(int16_t)
+  BENCHMARK_BABELSTREAM_TYPE(float)
+  BENCHMARK_BABELSTREAM_TYPE(double)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-      ,
-    BENCHMARK_BABELSTREAM_TYPE(int128_t)
+  BENCHMARK_BABELSTREAM_TYPE(int128_t)
 #endif
-  };
-
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 #undef CREATE_BABELSTREAM_BENCHMARK

--- a/projects/rocthrust/benchmark/bench/transform_reduce/sum.cu
+++ b/projects/rocthrust/benchmark/bench/transform_reduce/sum.cu
@@ -101,34 +101,36 @@ void run_benchmark(benchmark::State& state, const std::size_t elements, const st
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements)                                                        \
-  benchmark::RegisterBenchmark(                                                              \
-    bench_utils::bench_naming::format_name(                                                  \
-      "{algo:transform_reduce,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements) \
-      .c_str(),                                                                              \
-    run_benchmark<Benchmark, T>,                                                             \
-    Elements,                                                                                \
+#define CREATE_BENCHMARK(T, Elements)                                                                   \
+  benchmark::RegisterBenchmark(                                                                         \
+    bench_utils::bench_naming::format_name("{algo:transform_reduce,subalgo:" + name + ",input_type:" #T \
+                                           + ",elements:" + bench_utils::format_pow2(Elements))         \
+      .c_str(),                                                                                         \
+    run_benchmark<Benchmark, T>,                                                                        \
+    Elements,                                                                                           \
     seed_type)
 
-#define BENCHMARK_TYPE(type)                                                                         \
-  CREATE_BENCHMARK(type, 1 << 16), CREATE_BENCHMARK(type, 1 << 20), CREATE_BENCHMARK(type, 1 << 24), \
-    CREATE_BENCHMARK(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      bs.push_back(CREATE_BENCHMARK(type, size));                          \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
 
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }

--- a/projects/rocthrust/benchmark/bench/unique/basic.cu
+++ b/projects/rocthrust/benchmark/bench/unique/basic.cu
@@ -97,38 +97,43 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, MaxSegmentSize)                                                                  \
-  benchmark::RegisterBenchmark(                                                                                        \
-    bench_utils::bench_naming::format_name("{algo:unique,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements \
-                                           + ",max_segment_size:" #MaxSegmentSize)                                     \
-      .c_str(),                                                                                                        \
-    run_benchmark<Benchmark, T>,                                                                                       \
-    Elements,                                                                                                          \
-    seed_type,                                                                                                         \
+#define CREATE_BENCHMARK(T, Elements, MaxSegmentSize)                                                        \
+  benchmark::RegisterBenchmark(                                                                              \
+    bench_utils::bench_naming::format_name(                                                                  \
+      "{algo:unique,subalgo:" + name + ",input_type:" #T + ",elements:" + bench_utils::format_pow2(Elements) \
+      + ",max_segment_size:" #MaxSegmentSize)                                                                \
+      .c_str(),                                                                                              \
+    run_benchmark<Benchmark, T>,                                                                             \
+    Elements,                                                                                                \
+    seed_type,                                                                                               \
     MaxSegmentSize)
 
-#define BENCHMARK_ELEMENTS(type, elements) \
-  CREATE_BENCHMARK(type, elements, 1), CREATE_BENCHMARK(type, elements, 4), CREATE_BENCHMARK(type, elements, 8)
+#define BENCHMARK_ELEMENTS(type, elements)           \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 1)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 4)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 8));
 
-#define BENCHMARK_TYPE(type)                                                                               \
-  BENCHMARK_ELEMENTS(type, 1 << 16), BENCHMARK_ELEMENTS(type, 1 << 20), BENCHMARK_ELEMENTS(type, 1 << 24), \
-    BENCHMARK_ELEMENTS(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+      BENCHMARK_ELEMENTS(type, size);                                      \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t),
-    BENCHMARK_TYPE(int16_t),
-    BENCHMARK_TYPE(int32_t),
-    BENCHMARK_TYPE(int64_t),
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-    BENCHMARK_TYPE(int128_t),
+  BENCHMARK_TYPE(int128_t)
 #endif
-    BENCHMARK_TYPE(float32_t),
-    BENCHMARK_TYPE(float64_t)
-  };
+  BENCHMARK_TYPE(float32_t)
+  BENCHMARK_TYPE(float64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/unique/by_key.cu
+++ b/projects/rocthrust/benchmark/bench/unique/by_key.cu
@@ -116,55 +116,68 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(KeyT, ValueT, Elements, MaxSegmentSize)                                            \
-  benchmark::RegisterBenchmark(                                                                             \
-    bench_utils::bench_naming::format_name(                                                                 \
-      "{algo:unique,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT + ",elements:" #Elements \
-      + ",max_segment_size:" #MaxSegmentSize)                                                               \
-      .c_str(),                                                                                             \
-    run_benchmark<Benchmark, KeyT, ValueT>,                                                                 \
-    Elements,                                                                                               \
-    seed_type,                                                                                              \
+#define CREATE_BENCHMARK(KeyT, ValueT, Elements, MaxSegmentSize)                                  \
+  benchmark::RegisterBenchmark(                                                                   \
+    bench_utils::bench_naming::format_name(                                                       \
+      "{algo:unique,subalgo:" + name + ",key_type:" #KeyT + ",value_type:" #ValueT                \
+      + ",elements:" + bench_utils::format_pow2(Elements) + ",max_segment_size:" #MaxSegmentSize) \
+      .c_str(),                                                                                   \
+    run_benchmark<Benchmark, KeyT, ValueT>,                                                       \
+    Elements,                                                                                     \
+    seed_type,                                                                                    \
     MaxSegmentSize)
 
-#define BENCHMARK_ELEMENTS(key_type, value_type, elements) \
-  CREATE_BENCHMARK(key_type, value_type, elements, 1), CREATE_BENCHMARK(key_type, value_type, elements, 8)
+#define BENCHMARK_ELEMENTS(key_type, value_type, elements)           \
+  bs.push_back(CREATE_BENCHMARK(key_type, value_type, elements, 1)); \
+  bs.push_back(CREATE_BENCHMARK(key_type, value_type, elements, 8));
 
-#define BENCHMARK_VALUE_TYPE(key_type, value_type)                                                      \
-  BENCHMARK_ELEMENTS(key_type, value_type, 1 << 16), BENCHMARK_ELEMENTS(key_type, value_type, 1 << 20), \
-    BENCHMARK_ELEMENTS(key_type, value_type, 1 << 24), BENCHMARK_ELEMENTS(key_type, value_type, 1 << 28)
+#define BENCHMARK_VALUE_TYPE(key_type, value_type)                                                           \
+  for (size_t size : bench_utils::sizes)                                                                     \
+  {                                                                                                          \
+    if ((sizeof(key_type) * size + sizeof(value_type) * size) <= bench_utils::system.devProp.totalGlobalMem) \
+      BENCHMARK_ELEMENTS(key_type, value_type, size);                                                        \
+  }
 
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-#  define BENCHMARK_KEY_TYPE(key_type)                                                     \
-    BENCHMARK_VALUE_TYPE(key_type, int8_t), BENCHMARK_VALUE_TYPE(key_type, uint8_t),       \
-      BENCHMARK_VALUE_TYPE(key_type, int16_t), BENCHMARK_VALUE_TYPE(key_type, uint16_t),   \
-      BENCHMARK_VALUE_TYPE(key_type, int32_t), BENCHMARK_VALUE_TYPE(key_type, uint32_t),   \
-      BENCHMARK_VALUE_TYPE(key_type, int64_t), BENCHMARK_VALUE_TYPE(key_type, uint64_t),   \
-      BENCHMARK_VALUE_TYPE(key_type, int128_t), BENCHMARK_VALUE_TYPE(key_type, uint128_t), \
-      BENCHMARK_VALUE_TYPE(key_type, float), BENCHMARK_VALUE_TYPE(key_type, double)
+#  define BENCHMARK_KEY_TYPE(key_type)        \
+    BENCHMARK_VALUE_TYPE(key_type, int8_t)    \
+    BENCHMARK_VALUE_TYPE(key_type, uint8_t)   \
+    BENCHMARK_VALUE_TYPE(key_type, int16_t)   \
+    BENCHMARK_VALUE_TYPE(key_type, uint16_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int32_t)   \
+    BENCHMARK_VALUE_TYPE(key_type, uint32_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int64_t)   \
+    BENCHMARK_VALUE_TYPE(key_type, uint64_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int128_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, uint128_t) \
+    BENCHMARK_VALUE_TYPE(key_type, float)     \
+    BENCHMARK_VALUE_TYPE(key_type, double)
 #else
-#  define BENCHMARK_KEY_TYPE(key_type)                                                   \
-    BENCHMARK_VALUE_TYPE(key_type, int8_t), BENCHMARK_VALUE_TYPE(key_type, uint8_t),     \
-      BENCHMARK_VALUE_TYPE(key_type, int16_t), BENCHMARK_VALUE_TYPE(key_type, uint16_t), \
-      BENCHMARK_VALUE_TYPE(key_type, int32_t), BENCHMARK_VALUE_TYPE(key_type, uint32_t), \
-      BENCHMARK_VALUE_TYPE(key_type, int64_t), BENCHMARK_VALUE_TYPE(key_type, uint64_t), \
-      BENCHMARK_VALUE_TYPE(key_type, float), BENCHMARK_VALUE_TYPE(key_type, double)
+#  define BENCHMARK_KEY_TYPE(key_type)       \
+    BENCHMARK_VALUE_TYPE(key_type, int8_t)   \
+    BENCHMARK_VALUE_TYPE(key_type, uint8_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, int16_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, uint16_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int32_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, uint32_t) \
+    BENCHMARK_VALUE_TYPE(key_type, int64_t)  \
+    BENCHMARK_VALUE_TYPE(key_type, uint64_t) \
+    BENCHMARK_VALUE_TYPE(key_type, float)    \
+    BENCHMARK_VALUE_TYPE(key_type, double)
 #endif
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_KEY_TYPE(int8_t),
-    BENCHMARK_KEY_TYPE(int16_t),
-    BENCHMARK_KEY_TYPE(int32_t),
-    BENCHMARK_KEY_TYPE(int64_t)
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_KEY_TYPE(int8_t)
+  BENCHMARK_KEY_TYPE(int16_t)
+  BENCHMARK_KEY_TYPE(int32_t)
+  BENCHMARK_KEY_TYPE(int64_t)
 #if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
-      ,
-    BENCHMARK_KEY_TYPE(int128_t)
+  BENCHMARK_KEY_TYPE(int128_t)
 #endif
-  };
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/vectorized_search/basic.cu
+++ b/projects/rocthrust/benchmark/bench/vectorized_search/basic.cu
@@ -97,29 +97,40 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, NeedlesRatio)                                                      \
-  benchmark::RegisterBenchmark(                                                                          \
-    bench_utils::bench_naming::format_name("{algo:vectorized_search,subalgo:" + name + ",input_type:" #T \
-                                           + ",elements:" #Elements + ",needles_ratio:" #NeedlesRatio)   \
-      .c_str(),                                                                                          \
-    run_benchmark<Benchmark, T>,                                                                         \
-    Elements,                                                                                            \
-    seed_type,                                                                                           \
+#define CREATE_BENCHMARK(T, Elements, NeedlesRatio)                                          \
+  benchmark::RegisterBenchmark(                                                              \
+    bench_utils::bench_naming::format_name(                                                  \
+      "{algo:vectorized_search,subalgo:" + name + ",input_type:" #T                          \
+      + ",elements:" + bench_utils::format_pow2(Elements) + ",needles_ratio:" #NeedlesRatio) \
+      .c_str(),                                                                              \
+    run_benchmark<Benchmark, T>,                                                             \
+    Elements,                                                                                \
+    seed_type,                                                                               \
     NeedlesRatio)
 
-#define BENCHMARK_ELEMENTS(type, elements) \
-  CREATE_BENCHMARK(type, elements, 1), CREATE_BENCHMARK(type, elements, 25), CREATE_BENCHMARK(type, elements, 50)
+#define BENCHMARK_ELEMENTS(type, elements)            \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 1));  \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 25)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 50));
 
-#define BENCHMARK_TYPE(type)                                                                               \
-  BENCHMARK_ELEMENTS(type, 1 << 16), BENCHMARK_ELEMENTS(type, 1 << 20), BENCHMARK_ELEMENTS(type, 1 << 24), \
-    BENCHMARK_ELEMENTS(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+    {                                                                      \
+      BENCHMARK_ELEMENTS(type, size)                                       \
+    }                                                                      \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t), BENCHMARK_TYPE(int16_t), BENCHMARK_TYPE(int32_t), BENCHMARK_TYPE(int64_t)};
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/vectorized_search/lower_bound.cu
+++ b/projects/rocthrust/benchmark/bench/vectorized_search/lower_bound.cu
@@ -97,29 +97,40 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, NeedlesRatio)                                                      \
-  benchmark::RegisterBenchmark(                                                                          \
-    bench_utils::bench_naming::format_name("{algo:vectorized_search,subalgo:" + name + ",input_type:" #T \
-                                           + ",elements:" #Elements + ",needles_ratio:" #NeedlesRatio)   \
-      .c_str(),                                                                                          \
-    run_benchmark<Benchmark, T>,                                                                         \
-    Elements,                                                                                            \
-    seed_type,                                                                                           \
+#define CREATE_BENCHMARK(T, Elements, NeedlesRatio)                                          \
+  benchmark::RegisterBenchmark(                                                              \
+    bench_utils::bench_naming::format_name(                                                  \
+      "{algo:vectorized_search,subalgo:" + name + ",input_type:" #T                          \
+      + ",elements:" + bench_utils::format_pow2(Elements) + ",needles_ratio:" #NeedlesRatio) \
+      .c_str(),                                                                              \
+    run_benchmark<Benchmark, T>,                                                             \
+    Elements,                                                                                \
+    seed_type,                                                                               \
     NeedlesRatio)
 
-#define BENCHMARK_ELEMENTS(type, elements) \
-  CREATE_BENCHMARK(type, elements, 1), CREATE_BENCHMARK(type, elements, 25), CREATE_BENCHMARK(type, elements, 50)
+#define BENCHMARK_ELEMENTS(type, elements)            \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 1));  \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 25)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 50));
 
-#define BENCHMARK_TYPE(type)                                                                               \
-  BENCHMARK_ELEMENTS(type, 1 << 16), BENCHMARK_ELEMENTS(type, 1 << 20), BENCHMARK_ELEMENTS(type, 1 << 24), \
-    BENCHMARK_ELEMENTS(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+    {                                                                      \
+      BENCHMARK_ELEMENTS(type, size)                                       \
+    }                                                                      \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t), BENCHMARK_TYPE(int16_t), BENCHMARK_TYPE(int32_t), BENCHMARK_TYPE(int64_t)};
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench/vectorized_search/upper_bound.cu
+++ b/projects/rocthrust/benchmark/bench/vectorized_search/upper_bound.cu
@@ -97,29 +97,39 @@ void run_benchmark(
   state.counters["gpu_noise"] = gpu_cv;
 }
 
-#define CREATE_BENCHMARK(T, Elements, NeedlesRatio)                                                                 \
-  benchmark::RegisterBenchmark(                                                                                     \
-    bench_utils::bench_naming::format_name(                                                                         \
-      "{algo:merge,subalgo:" + name + ",input_type:" #T + ",elements:" #Elements + ",needles_ratio:" #NeedlesRatio) \
-      .c_str(),                                                                                                     \
-    run_benchmark<Benchmark, T>,                                                                                    \
-    Elements,                                                                                                       \
-    seed_type,                                                                                                      \
+#define CREATE_BENCHMARK(T, Elements, NeedlesRatio)                                                                \
+  benchmark::RegisterBenchmark(                                                                                    \
+    bench_utils::bench_naming::format_name("{algo:merge,subalgo:" + name + ",input_type:" #T + ",elements:"        \
+                                           + bench_utils::format_pow2(Elements) + ",needles_ratio:" #NeedlesRatio) \
+      .c_str(),                                                                                                    \
+    run_benchmark<Benchmark, T>,                                                                                   \
+    Elements,                                                                                                      \
+    seed_type,                                                                                                     \
     NeedlesRatio)
 
-#define BENCHMARK_ELEMENTS(type, elements) \
-  CREATE_BENCHMARK(type, elements, 1), CREATE_BENCHMARK(type, elements, 25), CREATE_BENCHMARK(type, elements, 50)
+#define BENCHMARK_ELEMENTS(type, elements)            \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 1));  \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 25)); \
+  bs.push_back(CREATE_BENCHMARK(type, elements, 50));
 
-#define BENCHMARK_TYPE(type)                                                                               \
-  BENCHMARK_ELEMENTS(type, 1 << 16), BENCHMARK_ELEMENTS(type, 1 << 20), BENCHMARK_ELEMENTS(type, 1 << 24), \
-    BENCHMARK_ELEMENTS(type, 1 << 28)
+#define BENCHMARK_TYPE(type)                                               \
+  for (size_t size : bench_utils::sizes)                                   \
+  {                                                                        \
+    if (sizeof(type) * size <= bench_utils::system.devProp.totalGlobalMem) \
+    {                                                                      \
+      BENCHMARK_ELEMENTS(type, size)                                       \
+    }                                                                      \
+  }
 
 template <class Benchmark>
 void add_benchmarks(
   const std::string& name, std::vector<benchmark::internal::Benchmark*>& benchmarks, const std::string seed_type)
 {
-  std::vector<benchmark::internal::Benchmark*> bs = {
-    BENCHMARK_TYPE(int8_t), BENCHMARK_TYPE(int16_t), BENCHMARK_TYPE(int32_t), BENCHMARK_TYPE(int64_t)};
+  std::vector<benchmark::internal::Benchmark*> bs;
+  BENCHMARK_TYPE(int8_t)
+  BENCHMARK_TYPE(int16_t)
+  BENCHMARK_TYPE(int32_t)
+  BENCHMARK_TYPE(int64_t)
   benchmarks.insert(benchmarks.end(), bs.begin(), bs.end());
 }
 

--- a/projects/rocthrust/benchmark/bench_utils/bench_utils.hpp
+++ b/projects/rocthrust/benchmark/bench_utils/bench_utils.hpp
@@ -704,6 +704,31 @@ private:
   }
 };
 
+inline std::string format_pow2(size_t n)
+{
+  unsigned int k = 0;
+  while (!(n & 1))
+  {
+    k++;
+    n >>= 1;
+  }
+  return "1 << " + std::to_string(k);
+}
+
+struct sys_info
+{
+  hipDeviceProp_t devProp;
+  sys_info()
+  {
+    int device_id = 0;
+    HIP_CHECK(hipGetDevice(&device_id));
+    HIP_CHECK(hipGetDeviceProperties(&devProp, device_id));
+  }
+};
+
+inline sys_info system;
+inline constexpr size_t sizes[] = {1u << 16, 1u << 20, 1u << 24, 1u << 28};
+
 } // namespace bench_utils
 
 #endif // ROCTHRUST_BENCHMARKS_BENCH_UTILS_BENCH_UTILS_HPP_


### PR DESCRIPTION
## Motivation

QA reported out of memory errors while running rocthrust benchmarks. This PR aims to fix this issue.

## Technical Details

Before creating the benchmarks, we double check if we have enough global memory for this type of data with this size. If we do not have enough memory we do not create the test.

## Test Plan

Run local benchmarks to see if there are any errors and Basic CI.

## Test Result

Local benchmark produces no errors. Pending CI checks