### PR TITLE
[rocWMMA] Use amd-smi instead of rocm-smi

### DIFF
--- a/projects/rocwmma/CMakeLists.txt
+++ b/projects/rocwmma/CMakeLists.txt
@@ -165,19 +165,19 @@ find_package( hiprtc REQUIRED )
 find_package( OpenMP REQUIRED )
 
 if (ROCWMMA_BUILD_BENCHMARK_TESTS)
-    ## Check for ROCM-smi
-    find_package(rocm_smi PATHS ${ROCM_PATH}/lib/cmake/rocm_smi)
-    if (rocm_smi_FOUND)
-      message(STATUS "Found rocm_smi at ${ROCM_SMI_INCLUDE_DIR}")
+    ## Check for AMD-smi
+    find_package(amd_smi PATHS ${ROCM_PATH}/lib/cmake/amd_smi)
+    if (amd_smi_FOUND)
+      message(STATUS "Found amd_smi at ${AMD_SMI_INCLUDE_DIR}")
     else()
-      set(ROCM_SMI_INCLUDE_DIR "${ROCM_PATH}/rocm_smi/include")
-      set(ROCM_SMI_LIB_DIR     "${ROCM_PATH}/rocm_smi/lib")
-      set(ROCM_SMI_LIBRARY   rocm_smi64)
+      set(AMD_SMI_INCLUDE_DIR "${ROCM_PATH}/include")
+      set(AMD_SMI_LIB_DIR     "${ROCM_PATH}/lib")
+      set(AMD_SMI_LIBRARY   amd_smi)
     endif()
 endif()
 
 add_library(rocwmma INTERFACE)
-target_link_libraries(rocwmma INTERFACE hip::device hip::host OpenMP::OpenMP_CXX ${ROCM_SMI_LIBRARY})
+target_link_libraries(rocwmma INTERFACE hip::device hip::host OpenMP::OpenMP_CXX ${AMD_SMI_LIBRARY})
 
 rocm_install_targets(
   TARGETS rocwmma

--- a/projects/rocwmma/test/common.hpp
+++ b/projects/rocwmma/test/common.hpp
@@ -58,14 +58,14 @@
 #endif
 
 #if ROCWMMA_BENCHMARK_TESTS
-#ifndef CHECK_RSMI_ERROR
-#define CHECK_RSMI_ERROR(expression, smiErrorFlag)                                               \
-    if(auto status = (expression); status != RSMI_STATUS_SUCCESS)                                \
-    {                                                                                            \
-        const char* errName = nullptr;                                                           \
-        rsmi_status_string(status, &errName);                                                    \
-        fprintf(stderr, "rsmi error: '%s'(%d) at %s:%d\n", errName, status, __FILE__, __LINE__); \
-        smiErrorFlag = true;                                                                     \
+#ifndef CHECK_AMDSMI_ERROR
+#define CHECK_AMDSMI_ERROR(expression, smiErrorFlag)                                                 \
+    if(auto status = (expression); status != AMDSMI_STATUS_SUCCESS)                                  \
+    {                                                                                                \
+        const char* errName;                                                                         \
+        amdsmi_status_code_to_string(status, &errName);                                              \
+        fprintf(stderr, "amdsmi error: '%s'(%d) at %s:%d\n", errName, status, __FILE__, __LINE__);   \
+        smiErrorFlag = true;                                                                         \
     }
 #endif
 #endif // ROCWMMA_BENCHMARK_TESTS

--- a/projects/rocwmma/test/hip_device.cpp
+++ b/projects/rocwmma/test/hip_device.cpp
@@ -24,6 +24,8 @@
  *
  *******************************************************************************/
 
+#include <vector>
+
 #include "hip_device.hpp"
 #include "common.hpp"
 
@@ -113,7 +115,7 @@ namespace rocwmma
 
 #if ROCWMMA_BENCHMARK_TESTS
         bool smiErrorFlag = false;
-        CHECK_RSMI_ERROR(rsmi_init(0), smiErrorFlag);
+        CHECK_AMDSMI_ERROR(amdsmi_init(AMDSMI_INIT_AMD_GPUS), smiErrorFlag);
         if(!smiErrorFlag)
         {
             uint64_t hipPCIID = 0;
@@ -121,35 +123,64 @@ namespace rocwmma
             hipPCIID |= ((mProps.pciBusID & 0xFF) << 8);
             hipPCIID |= (mProps.pciDomainID) << 16;
 
-            uint32_t smiCount = 0;
-            CHECK_RSMI_ERROR(rsmi_num_monitor_devices(&smiCount), smiErrorFlag);
-            if(!smiErrorFlag)
+            // Get processor handles for all sockets
+            uint32_t socket_count = 0;
+            CHECK_AMDSMI_ERROR(amdsmi_get_socket_handles(&socket_count, nullptr), smiErrorFlag);
+            if(!smiErrorFlag && socket_count > 0)
             {
-                uint32_t smiDeviceIndex = std::numeric_limits<uint32_t>::max();
-                for(uint32_t smiIndex = 0; smiIndex < smiCount; smiIndex++)
+                std::vector<amdsmi_socket_handle> sockets(socket_count);
+                CHECK_AMDSMI_ERROR(amdsmi_get_socket_handles(&socket_count, sockets.data()), smiErrorFlag);
+                
+                if(!smiErrorFlag)
                 {
-                    uint64_t rsmiPCIID = 0;
-                    CHECK_RSMI_ERROR(rsmi_dev_pci_id_get(smiIndex, &rsmiPCIID), smiErrorFlag);
-                    if(smiErrorFlag)
+                    amdsmi_processor_handle smiDeviceHandle = nullptr;
+                    bool deviceFound = false;
+                    
+                    // Iterate through all sockets to find matching device
+                    for(uint32_t socket_idx = 0; socket_idx < socket_count && !deviceFound; socket_idx++)
                     {
-                        break;
+                        uint32_t processor_count = 0;
+                        CHECK_AMDSMI_ERROR(amdsmi_get_processor_handles(sockets[socket_idx], &processor_count, nullptr), smiErrorFlag);
+                        if(smiErrorFlag || processor_count == 0)
+                            continue;
+                        
+                        std::vector<amdsmi_processor_handle> processors(processor_count);
+                        CHECK_AMDSMI_ERROR(amdsmi_get_processor_handles(sockets[socket_idx], &processor_count, processors.data()), smiErrorFlag);
+                        if(smiErrorFlag)
+                            continue;
+                        
+                        // Check each processor for PCI ID match
+                        for(uint32_t proc_idx = 0; proc_idx < processor_count; proc_idx++)
+                        {
+                            amdsmi_bdf_t bdf;
+                            CHECK_AMDSMI_ERROR(amdsmi_get_gpu_device_bdf(processors[proc_idx], &bdf), smiErrorFlag);
+                            if(smiErrorFlag)
+                                continue;
+                            
+                            // Construct PCI ID from BDF info
+                            uint64_t amdsmiPCIID = 0;
+                            amdsmiPCIID |= bdf.device_number & 0xFF;
+                            amdsmiPCIID |= ((bdf.bus_number & 0xFF) << 8);
+                            amdsmiPCIID |= (bdf.domain_number) << 16;
+                            
+                            if(hipPCIID == amdsmiPCIID)
+                            {
+                                smiDeviceHandle = processors[proc_idx];
+                                deviceFound = true;
+                                break;
+                            }
+                        }
                     }
-                    else if(hipPCIID == rsmiPCIID)
+                    if(!smiErrorFlag && deviceFound)
                     {
-                        smiDeviceIndex = smiIndex;
-                        break;
-                    }
-                }
-
-                if(!smiErrorFlag && (smiDeviceIndex != std::numeric_limits<uint32_t>::max()))
-                {
-                    rsmi_frequencies_t freq;
-                    CHECK_RSMI_ERROR(
-                        rsmi_dev_gpu_clk_freq_get(smiDeviceIndex, RSMI_CLK_TYPE_SYS, &freq),
-                        smiErrorFlag);
-                    if(!smiErrorFlag)
-                    {
-                        mCurFreqMhz = freq.frequency[freq.current] / 1000000;
+                        amdsmi_frequencies_t freq;
+                        CHECK_AMDSMI_ERROR(
+                            amdsmi_get_clk_freq(smiDeviceHandle, AMDSMI_CLK_TYPE_SYS, &freq),
+                            smiErrorFlag);
+                        if(!smiErrorFlag)
+                        {
+                            mCurFreqMhz = freq.frequency[freq.current] / 1000000;
+                        }
                     }
                 }
             }
@@ -206,7 +237,7 @@ namespace rocwmma
     {
 #if ROCWMMA_BENCHMARK_TESTS
         bool smiErrorFlag = false;
-        CHECK_RSMI_ERROR(rsmi_shut_down(), smiErrorFlag);
+        CHECK_AMDSMI_ERROR(amdsmi_shut_down(), smiErrorFlag);
 #endif // ROCWMMA_BENCHMARK_TESTS
     }
 

--- a/projects/rocwmma/test/hip_device.hpp
+++ b/projects/rocwmma/test/hip_device.hpp
@@ -30,7 +30,7 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 #if ROCWMMA_BENCHMARK_TESTS
-#include <rocm_smi/rocm_smi.h>
+#include <amd_smi/amdsmi.h>
 #endif // ROCWMMA_BENCHMARK_TESTS
 #include <rocwmma/internal/constants.hpp>
 


### PR DESCRIPTION
## Motivation

The rocm-smi library used in rocWMMA is being phased out.  This PR moves to using the amd-smi library and associated APIs instead.

## Technical Details

Use amd-smi APIs instead of old rocm-smi APIs.

## Test Plan

Ensure compile, and benchmarking work properly.

## Test Result

I added some print-outs to the code and it seems to be working properly.  Specifically, we are able to update the `mCurFreqMhz` variable.  Tested on gfx90a.

```
LD_PRELOAD=/opt/rocm/llvm/lib/libomp.so build/test/gemm/gemm_PGR0_LB0_MP0_MB_NC_ad_hoc-bench
Attempting to get freq
About to look at all 1 sockets
  Socket 0
Found device and error flag clean
Updating mCurFreqMhz to 800
Note: Google Test filter = -*Emulation*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Gemm_PGR0_LB0_MP0_MB_NC/AdHocTest
[ RUN      ] Gemm_PGR0_LB0_MP0_MB_NC/AdHocTest.RunKernelWithoutWarmup/0
BlocksX, BlocksY, TBlkX, TBlkY, BlkM, BlkN, BlkK, MatM, MatN, MatK, alpha, lda, ldb, beta, ldc, ldd, LytA_LytB_LytC_LytD, Ti_To_Tc, elapsedMs, Problem Size(GFlops), TFlops/s, Efficiency(%), Result
2, 2, 128, 2, 16, 16, 16, 64, 64, 64, 2, 64, 64, 2, 64, 64, N_T_T_T, f16_f32_f32, 0.1248, 0.000524288, 0.0210051, 0, BENCH
[       OK ] Gemm_PGR0_LB0_MP0_MB_NC/AdHocTest.RunKernelWithoutWarmup/0 (877 ms)
[----------] 1 test from Gemm_PGR0_LB0_MP0_MB_NC/AdHocTest (877 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (877 ms total)
[  PASSED  ] 1 test.
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
