### PR TITLE
[origami] Prediction modes + target.

### DIFF
--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -181,6 +181,32 @@ enum class reduction_t : std::uint32_t {
 };
 
 /**
+ * @brief Prediction mode types for latency estimation.
+ *
+ * Different approaches for predicting kernel performance.
+ */
+enum class prediction_modes_t : std::uint32_t {
+  estimation  = 0,    ///< Fast analytical estimation-based prediction (typically faster)
+  simulation  = 1,    ///< Slow simulation-like prediction (typically more accurate)
+  count,              ///< Count of prediction modes
+  none = 0xFFFFFFFFu  ///< Explicitly invalid
+};
+
+/**
+ * @brief Target backend types for kernel execution.
+ *
+ * Different backends that kernels can target.
+ */
+enum class target_t : std::uint32_t {
+  generic          = 0,  ///< Generic backend (backend agnostic, not supported yet)
+  hipblaslt        = 1,  ///< hipBLASLt backend
+  triton           = 2,  ///< Triton backend
+  composable_kernel = 3, ///< Composable Kernel backend (Not supported yet)
+  count,                 ///< Count of target types
+  none = 0xFFFFFFFFu     ///< Explicitly invalid
+};
+
+/**
  * @brief Convert integer to reduction_t enum.
  *
  * @param rt Integer value to convert
@@ -324,16 +350,25 @@ struct config_t {
   /// Reduction strategy.
   reduction_t reduction_strategy = reduction_t::none;
 
+  /// Prediction mode for latency estimation.
+  prediction_modes_t prediction_mode = prediction_modes_t::estimation;
+
+  /// Target backend for kernel execution.
+  target_t target = target_t::hipblaslt;
+
   constexpr bool operator==(const config_t& o) const noexcept {
     return mt == o.mt && mi == o.mi && cache_hints_a == o.cache_hints_a &&
-           cache_hints_b == o.cache_hints_b && workgroup_mapping == o.workgroup_mapping;
+           cache_hints_b == o.cache_hints_b && workgroup_mapping == o.workgroup_mapping &&
+           prediction_mode == o.prediction_mode && target == o.target;
   }
 
   std::size_t hash() const {
     return std::hash<size_t>()(mt.m) ^ std::hash<size_t>()(mt.n) ^ std::hash<size_t>()(mt.k) ^
            std::hash<size_t>()(mi.m) ^ std::hash<size_t>()(mi.n) ^ std::hash<size_t>()(mi.k) ^
            std::hash<int>()(cache_hints_a) ^ std::hash<int>()(cache_hints_b) ^
-           std::hash<int>()(workgroup_mapping);
+           std::hash<int>()(workgroup_mapping) ^
+           std::hash<std::uint32_t>()(static_cast<std::uint32_t>(prediction_mode)) ^
+           std::hash<std::uint32_t>()(static_cast<std::uint32_t>(target));
   }
 
   void validate() const {


### PR DESCRIPTION
## Motivation

- Add API support for prediction modes (slow but more accurate, and fast but more estimation based) for Origami solution selection.
- Add targets so triton can make different choices than hipblaslt in the selection backend.

## Technical Details

Introduces two new enums and exposes them through user-defined configs.

## Test Plan

Run through Azure CI (deprecated), TheRock CI.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
