### PR TITLE
[hipDNN][ALMIOPEN-813] Added INT8 data type support

### DIFF
--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
@@ -25,11 +25,12 @@ enum class DataType : int8_t {
   DOUBLE = 4,
   UINT8 = 5,
   INT32 = 6,
+  INT8 = 7,
   MIN = UNSET,
-  MAX = INT32
+  MAX = INT8
 };
 
-inline const DataType (&EnumValuesDataType())[7] {
+inline const DataType (&EnumValuesDataType())[8] {
   static const DataType values[] = {
     DataType::UNSET,
     DataType::FLOAT,
@@ -37,13 +38,14 @@ inline const DataType (&EnumValuesDataType())[7] {
     DataType::BFLOAT16,
     DataType::DOUBLE,
     DataType::UINT8,
-    DataType::INT32
+    DataType::INT32,
+    DataType::INT8
   };
   return values;
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[8] = {
+  static const char * const names[9] = {
     "UNSET",
     "FLOAT",
     "HALF",
@@ -51,13 +53,14 @@ inline const char * const *EnumNamesDataType() {
     "DOUBLE",
     "UINT8",
     "INT32",
+    "INT8",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameDataType(DataType e) {
-  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT32)) return "";
+  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT8)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDataType()[index];
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -76,6 +76,12 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
             return static_cast<TargetType>(val->value());
         }
         break;
+    case data_objects::DataType::INT8:
+        if(auto val = tensorAttr.value.AsFloat8Value())
+        {
+            return static_cast<TargetType>(val->value());
+        }
+        break;
     case data_objects::DataType::UNSET:
         throw std::runtime_error(std::string(paramName) + " tensor has UNSET data type");
     default:

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
@@ -561,6 +561,8 @@ inline std::unique_ptr<utilities::ITensor> createTensor(data_objects::DataType d
         return std::make_unique<Tensor<uint8_t>>(dims, strides);
     case data_objects::DataType::INT32:
         return std::make_unique<Tensor<int32_t>>(dims, strides);
+    case data_objects::DataType::INT8:
+        return std::make_unique<Tensor<int8_t>>(dims, strides);
     default:
         throw std::runtime_error("Unsupported data type for tensor");
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
@@ -79,6 +79,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType,
                                  {DataType::DOUBLE, "double"},
                                  {DataType::UINT8, "uint8"},
                                  {DataType::INT32, "int32"},
+                                 {DataType::INT8, "int8"},
                              }
 
 )

--- a/projects/hipdnn/data_sdk/schemas/data_types.fbs
+++ b/projects/hipdnn/data_sdk/schemas/data_types.fbs
@@ -10,5 +10,6 @@ enum DataType : byte {
     BFLOAT16 = 3,
     DOUBLE = 4,
     UINT8 = 5,
-    INT32 = 6
+    INT32 = 6,
+    INT8 = 7
 }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -86,6 +86,7 @@ enum class DataType
     DOUBLE = 4,
     UINT8 = 5,
     INT32 = 6,
+    INT8 = 7,
 };
 typedef DataType DataType_t; // NOLINT(readability-identifier-naming)
 
@@ -122,6 +123,10 @@ DataType getDataTypeEnumFromType()
     {
         return DataType::INT32;
     }
+    else if constexpr(std::is_same_v<T, int8_t>)
+    {
+        return DataType::INT8;
+    }
     else
     {
         return DataType::NOT_SET;
@@ -157,6 +162,8 @@ inline hipdnn_data_sdk::data_objects::DataType toSdkType(const DataType& type)
         return hipdnn_data_sdk::data_objects::DataType::UINT8;
     case DataType::INT32:
         return hipdnn_data_sdk::data_objects::DataType::INT32;
+    case DataType::INT8:
+        return hipdnn_data_sdk::data_objects::DataType::INT8;
     default:
         return hipdnn_data_sdk::data_objects::DataType::UNSET;
     }
@@ -178,6 +185,8 @@ inline hipdnn_frontend::DataType fromSdkType(const hipdnn_data_sdk::data_objects
         return hipdnn_frontend::DataType::UINT8;
     case hipdnn_data_sdk::data_objects::DataType::INT32:
         return hipdnn_frontend::DataType::INT32;
+    case hipdnn_data_sdk::data_objects::DataType::INT8:
+        return hipdnn_frontend::DataType::INT8;
     default:
         return hipdnn_frontend::DataType::NOT_SET;
     }
@@ -314,6 +323,8 @@ inline const char* to_string(const DataType& type)
         return "uint8";
     case DataType::INT32:
         return "int32";
+    case DataType::INT8:
+        return "int8";
     default:
         return "unknown";
     }

--- a/projects/hipdnn/frontend/tests/TestNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestNode.cpp
@@ -41,7 +41,8 @@ TEST(TestNode, PostValidateNodeComputeDataType)
            {DataType::BFLOAT16, ErrorCode::OK},
            {DataType::DOUBLE, ErrorCode::OK},
            {DataType::UINT8, ErrorCode::OK},
-           {DataType::INT32, ErrorCode::OK}};
+           {DataType::INT32, ErrorCode::OK},
+           {DataType::INT8, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -205,7 +205,8 @@ TEST(TestTensorAttributes, ValidateDataType)
            {DataType::BFLOAT16, ErrorCode::OK},
            {DataType::DOUBLE, ErrorCode::OK},
            {DataType::UINT8, ErrorCode::OK},
-           {DataType::INT32, ErrorCode::OK}};
+           {DataType::INT32, ErrorCode::OK},
+           {DataType::INT8, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTypes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTypes.cpp
@@ -15,6 +15,7 @@ TEST(TestTypes, ToSdkTypeDataTypes)
     EXPECT_EQ(toSdkType(DataType::DOUBLE), hipdnn_data_sdk::data_objects::DataType::DOUBLE);
     EXPECT_EQ(toSdkType(DataType::UINT8), hipdnn_data_sdk::data_objects::DataType::UINT8);
     EXPECT_EQ(toSdkType(DataType::INT32), hipdnn_data_sdk::data_objects::DataType::INT32);
+    EXPECT_EQ(toSdkType(DataType::INT8), hipdnn_data_sdk::data_objects::DataType::INT8);
     EXPECT_EQ(toSdkType(DataType::NOT_SET), hipdnn_data_sdk::data_objects::DataType::UNSET);
 }
 
@@ -28,6 +29,7 @@ TEST(TestTypes, FromSdkTypeDataTypes)
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::DOUBLE), DataType::DOUBLE);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UINT8), DataType::UINT8);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT32), DataType::INT32);
+    EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT8), DataType::INT8);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UNSET), DataType::NOT_SET);
 }
 
@@ -70,6 +72,7 @@ TEST(TestTypes, GetDataTypeEnumFromType)
     EXPECT_EQ(getDataTypeEnumFromType<double>(), DataType::DOUBLE);
     EXPECT_EQ(getDataTypeEnumFromType<uint8_t>(), DataType::UINT8);
     EXPECT_EQ(getDataTypeEnumFromType<int32_t>(), DataType::INT32);
+    EXPECT_EQ(getDataTypeEnumFromType<int8_t>(), DataType::INT8);
 
     EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType::NOT_SET);
     EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType::NOT_SET);
@@ -85,6 +88,7 @@ TEST(TestTypes, DataTypeToString)
     EXPECT_STREQ(to_string(DataType::DOUBLE), "fp64");
     EXPECT_STREQ(to_string(DataType::UINT8), "uint8");
     EXPECT_STREQ(to_string(DataType::INT32), "int32");
+    EXPECT_STREQ(to_string(DataType::INT8), "int8");
     EXPECT_STREQ(to_string(DataType::NOT_SET), "unknown");
 }
 
@@ -116,6 +120,10 @@ TEST(TestTypes, DataTypeStreamOperator)
 
     oss << DataType::INT32;
     EXPECT_EQ(oss.str(), "int32");
+    oss.str("");
+
+    oss << DataType::INT8;
+    EXPECT_EQ(oss.str(), "int8");
     oss.str("");
 
     oss << DataType::NOT_SET;

--- a/projects/hipdnn/python/src/memory_bindings.cpp
+++ b/projects/hipdnn/python/src/memory_bindings.cpp
@@ -175,6 +175,8 @@ void memory_bindings(nb::module_& m)
                 return sizeof(int32_t);
             else if(dtype_str == "<u1" || dtype_str == "uint8")
                 return sizeof(uint8_t);
+            else if(dtype_str == "<i1" || dtype_str == "int8")
+                return sizeof(int8_t);
             else
                 throw std::runtime_error("Unsupported dtype: " + dtype_str);
         },

--- a/projects/hipdnn/python/src/types_bindings.cpp
+++ b/projects/hipdnn/python/src/types_bindings.cpp
@@ -18,7 +18,8 @@ void types_bindings(nb::module_& m)
         .value("BFLOAT16", DataType::BFLOAT16)
         .value("DOUBLE", DataType::DOUBLE)
         .value("UINT8", DataType::UINT8)
-        .value("INT32", DataType::INT32);
+        .value("INT32", DataType::INT32)
+        .value("INT8", DataType::INT8);
 
     // Bind ConvolutionMode enum
     nb::enum_<ConvolutionMode>(m, "ConvolutionMode")

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
@@ -49,9 +49,8 @@ public:
             T refValue = refView.getHostValue(indices);
             T implValue = implView.getHostValue(indices);
 
-            T absDiff = static_cast<T>(std::fabs(implValue - refValue));
-            T threshold
-                = _absoluteTolerance + _relativeTolerance * static_cast<T>(std::fabs(refValue));
+            T absDiff = std::fabs(implValue - refValue);
+            T threshold = _absoluteTolerance + _relativeTolerance * std::fabs(refValue);
 
             if(absDiff > threshold)
             {
@@ -84,6 +83,58 @@ private:
     T _relativeTolerance;
 };
 
+template <class T>
+class CpuIntReferenceValidation : public IReferenceValidation
+{
+public:
+    CpuIntReferenceValidation() = default;
+    ~CpuIntReferenceValidation() override = default;
+
+    bool allClose(hipdnn_data_sdk::utilities::ITensor& reference,
+                  hipdnn_data_sdk::utilities::ITensor& implementation) const override
+    {
+        if(reference.elementCount() != implementation.elementCount()
+           || reference.dims() != implementation.dims())
+        {
+            return false;
+        }
+
+        hipdnn_data_sdk::utilities::TensorView<T> refView(reference);
+        hipdnn_data_sdk::utilities::TensorView<T> implView(implementation);
+
+        std::atomic<bool> result(true);
+
+        auto validateFunc = [&](const std::vector<int64_t>& indices) {
+            T refValue = refView.getHostValue(indices);
+            T implValue = implView.getHostValue(indices);
+
+            T absDiff = static_cast<T>(std::abs(implValue - refValue));
+
+            // Integer values ​​must be equal
+            if(absDiff > 0)
+            {
+                // Log error and mark as failed
+                HIPDNN_LOG_ERROR("Validation failed for integer values at indices {}: ",
+                                 "reference value = {}, "
+                                 "implementation value = {}, "
+                                 "absolute difference = {}",
+                                 indices,
+                                 refValue,
+                                 implValue,
+                                 absDiff);
+                result.store(false, std::memory_order_relaxed);
+            }
+            return result.load(std::memory_order_relaxed);
+        };
+
+        // Create and execute parallel functor
+        auto parallelFunc = makeParallelTensorFunctor(validateFunc, reference.dims());
+        parallelFunc(std::thread::hardware_concurrency());
+
+        return result.load();
+    }
+};
+
 inline std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>
     createAllCloseValidator(hipdnn_data_sdk::data_objects::DataType dataType,
                             float absoluteTolerance = std::numeric_limits<float>::epsilon(),
@@ -104,8 +155,29 @@ inline std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>
     case hipdnn_data_sdk::data_objects::DataType::DOUBLE:
         return std::make_unique<CpuFpReferenceValidation<double>>(
             static_cast<double>(absoluteTolerance), static_cast<double>(relativeTolerance));
+    case hipdnn_data_sdk::data_objects::DataType::INT8:
+        return std::make_unique<CpuIntReferenceValidation<int8_t>>();
+    case hipdnn_data_sdk::data_objects::DataType::UINT8:
+        return std::make_unique<CpuIntReferenceValidation<uint8_t>>();
+    case hipdnn_data_sdk::data_objects::DataType::INT32:
+        return std::make_unique<CpuIntReferenceValidation<int32_t>>();
     default:
         throw std::runtime_error("Unsupported data type for allClose validator");
+    }
+}
+
+template <typename T>
+inline std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>
+    createAllCloseValidator(T absoluteTolerance = std::numeric_limits<T>::epsilon(),
+                            T relativeTolerance = std::numeric_limits<T>::epsilon())
+{
+    if constexpr(std::is_integral_v<T>)
+    {
+        return std::make_unique<CpuIntReferenceValidation<T>>();
+    }
+    else
+    {
+        return std::make_unique<CpuFpReferenceValidation<T>>(absoluteTolerance, relativeTolerance);
     }
 }
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
@@ -49,8 +49,9 @@ public:
             T refValue = refView.getHostValue(indices);
             T implValue = implView.getHostValue(indices);
 
-            T absDiff = std::fabs(implValue - refValue);
-            T threshold = _absoluteTolerance + _relativeTolerance * std::fabs(refValue);
+            T absDiff = static_cast<T>(std::fabs(implValue - refValue));
+            T threshold
+                = _absoluteTolerance + _relativeTolerance * static_cast<T>(std::fabs(refValue));
 
             if(absDiff > threshold)
             {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
@@ -221,6 +221,10 @@ constexpr T getTolerance()
     {
         return 1e-2_bf;
     }
+    else if constexpr(std::is_same_v<T, int8_t>)
+    {
+        return 0;
+    }
     else
     {
         static_assert(false, "Type not supported");

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/UnaryOperationFunctors.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/UnaryOperationFunctors.hpp
@@ -92,7 +92,7 @@ struct Negation
     template <typename X>
     auto operator()(const X& x) const -> X
     {
-        return -x;
+        return static_cast<X>(-x);
     }
 };
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -148,6 +148,19 @@ TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdInferenceNchw)
         inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor);
 }
 
+TEST(TestCpuFpReferenceBatchnormInt8, BatchnormFwdInferenceNchw)
+{
+    Tensor<int8_t> inputTensor({1, 3, 224, 224});
+    Tensor<int8_t> outputTensor({1, 3, 224, 224});
+    Tensor<float> biasTensor({1, 3});
+    Tensor<float> scaleTensor({1, 3});
+    Tensor<float> meanTensor({1, 3});
+    Tensor<float> varianceTensor({1, 3});
+
+    CpuFpReferenceBatchnorm::fwdInference(
+        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor);
+}
+
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInferenceNhwc)
 {
     Tensor<float> inputTensor({6, 3, 32, 32}, TensorLayout::NHWC);
@@ -357,6 +370,27 @@ TEST(TestCpuFpReferenceBatchnormFp16, BatchnormBackwardNchw)
     Tensor<half> xTensor({6, 3, 32, 32});
     Tensor<half> dyTensor({6, 3, 32, 32});
     Tensor<half> dxTensor({6, 3, 32, 32});
+    Tensor<float> scaleTensor({1, 3});
+    Tensor<float> meanTensor({1, 3});
+    Tensor<float> invVarianceTensor({1, 3});
+    Tensor<float> dscaleTensor({1, 3});
+    Tensor<float> dbiasTensor({1, 3});
+
+    CpuFpReferenceBatchnorm::backward(dyTensor,
+                                      xTensor,
+                                      meanTensor,
+                                      invVarianceTensor,
+                                      scaleTensor,
+                                      dxTensor,
+                                      dscaleTensor,
+                                      dbiasTensor);
+}
+
+TEST(TestCpuFpReferenceBatchnormInt8, BatchnormBackwardNchw)
+{
+    Tensor<int8_t> xTensor({6, 3, 32, 32});
+    Tensor<int8_t> dyTensor({6, 3, 32, 32});
+    Tensor<int8_t> dxTensor({6, 3, 32, 32});
     Tensor<float> scaleTensor({1, 3});
     Tensor<float> meanTensor({1, 3});
     Tensor<float> invVarianceTensor({1, 3});
@@ -1098,6 +1132,32 @@ TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdTrainingNchw)
     Tensor<double> savedInvVariance({1, 3});
 
     inputTensor.fillWithValue(1.0);
+    for(int i = 0; i < 3; i++)
+    {
+        scaleTensor.setHostValue(1.0, 0, i);
+        biasTensor.setHostValue(0.0, 0, i);
+    }
+
+    CpuFpReferenceBatchnorm::fwdTraining(inputTensor,
+                                         scaleTensor,
+                                         biasTensor,
+                                         outputTensor,
+                                         BATCHNORM_DEFAULT_EPSILON,
+                                         0.1,
+                                         &savedMean,
+                                         &savedInvVariance);
+}
+
+TEST(TestCpuFpReferenceBatchnormInt8, BatchnormFwdTrainingNchw)
+{
+    Tensor<int8_t> inputTensor({2, 3, 4, 4});
+    Tensor<int8_t> outputTensor({2, 3, 4, 4});
+    Tensor<double> scaleTensor({1, 3});
+    Tensor<double> biasTensor({1, 3});
+    Tensor<double> savedMean({1, 3});
+    Tensor<double> savedInvVariance({1, 3});
+
+    inputTensor.fillWithValue(1);
     for(int i = 0; i < 3; i++)
     {
         scaleTensor.setHostValue(1.0, 0, i);

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
@@ -239,6 +239,38 @@ TEST(TestCpuFpReferenceConvolutionFp64, ConvolutionFwdInferenceBasic)
     EXPECT_DOUBLE_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99.0);
 }
 
+TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionFwdInferenceBasic)
+{
+    Tensor<int8_t> inputTensor({1, 1, 4, 4});
+    Tensor<int8_t> weightTensor({1, 1, 3, 3});
+    Tensor<int8_t> outputTensor({1, 1, 2, 2});
+
+    // Fill input with sequential values
+    for(int i = 0; i < 16; ++i)
+    {
+        inputTensor.memory().hostData()[i] = static_cast<int8_t>(i + 1);
+    }
+
+    // Fill weights with 1s
+    for(int i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = 1.0;
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::fprop<int8_t, int8_t, int8_t, int32_t>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+
+    // Same expected values as fp32 test
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 0), 54);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99);
+}
+
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionFwdInferenceWithDilation)
 {
     // Test with dilation = 2
@@ -1072,6 +1104,33 @@ TEST(TestCpuFpReferenceConvolutionFp64, ConvolutionBwdDataBasic)
         inputTensor, weightTensor, outputTensor, strides, dilations, padding);
 }
 
+TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionBwdDataBasic)
+{
+    // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
+    Tensor<int8_t> inputTensor({1, 1, 4, 4});
+    Tensor<int8_t> weightTensor({1, 1, 3, 3});
+    Tensor<int8_t> outputTensor({1, 1, 2, 2});
+
+    // gradOutput values: simple pattern
+    outputTensor.setHostValue(1, 0, 0, 0, 0);
+    outputTensor.setHostValue(2, 0, 0, 0, 1);
+    outputTensor.setHostValue(3, 0, 0, 1, 0);
+    outputTensor.setHostValue(4, 0, 0, 1, 1);
+
+    // Weight values: simple 3x3 kernel
+    for(size_t i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = static_cast<int8_t>(i + 1);
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::dgrad<int8_t, int8_t, int8_t, int32_t>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+}
+
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionBwdDataSimple)
 {
     // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
@@ -1879,6 +1938,42 @@ TEST(TestCpuFpReferenceConvolutionFp64, ConvolutionWrwBasic)
 
     // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 0.5 = 5.0
     EXPECT_FLOAT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 5.0);
+}
+
+TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionWrwBasic)
+{
+    // Minimal sanity test for wgrad using smallest possible tensor sizes
+    // Input: 1x1x2x2 (1 batch, 1 input channel, 2x2 spatial)
+    // Weight: 1x1x1x1 (1 output channel, 1 input channel, 1x1 kernel)
+    // GradOutput: 1x1x2x2 (1 batch, 1 output channel, 2x2 spatial)
+    Tensor<int8_t> inputTensor({1, 1, 2, 2});
+    Tensor<int8_t> gradWeightTensor({1, 1, 1, 1});
+    Tensor<int8_t> gradOutputTensor({1, 1, 2, 2});
+
+    // Set input values: [1, 2; 3, 4]
+    inputTensor.setHostValue(1, 0, 0, 0, 0);
+    inputTensor.setHostValue(2, 0, 0, 0, 1);
+    inputTensor.setHostValue(3, 0, 0, 1, 0);
+    inputTensor.setHostValue(4, 0, 0, 1, 1);
+
+    // Set gradient output values: [1, 1; 1, 1]
+    gradOutputTensor.setHostValue(1, 0, 0, 0, 0);
+    gradOutputTensor.setHostValue(1, 0, 0, 0, 1);
+    gradOutputTensor.setHostValue(1, 0, 0, 1, 0);
+    gradOutputTensor.setHostValue(1, 0, 0, 1, 1);
+
+    // Initialize weight to zero
+    gradWeightTensor.setHostValue(0, 0, 0, 0, 0);
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::wgrad<int8_t, int8_t, int8_t, int32_t>(
+        inputTensor, gradWeightTensor, gradOutputTensor, strides, dilations, padding);
+
+    // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 1 = 10
+    EXPECT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 10);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvBwdWeightMultiBatch)

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceValidation.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceValidation.cpp
@@ -22,6 +22,8 @@ void makeTensorsEqual(T& tensor1, T& tensor2)
     });
 }
 
+/* ======== CpuFpReferenceValidation tests ======== */
+
 TEST(TestCpuFpReferenceValidation, NegativeToleranceThrows)
 {
     EXPECT_THROW(CpuFpReferenceValidation<float> refValidation(-1e-5f), std::invalid_argument);
@@ -339,3 +341,232 @@ TEST(TestCpuFpReferenceValidation, TensorSameElementCountDifferentDims)
     // even though element counts are the same
     EXPECT_FALSE(refValidation.allClose(tensor1, tensor2));
 }
+
+/* ================================================= */
+
+/* ======== CpuIntReferenceValidation tests ======== */
+
+TEST(TestCpuIntReferenceValidationInt32, BasicTensorUsage)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+    std::vector<int64_t> dims = {10, 10};
+
+    Tensor<int32_t> tensor1(dims);
+    tensor1.fillTensorWithRandomValues(-25, 25);
+    Tensor<int32_t> tensor2(dims);
+    makeTensorsEqual<Tensor<int32_t>>(tensor1, tensor2);
+
+    EXPECT_TRUE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidationInt8, BasicTensorUsage)
+{
+    CpuIntReferenceValidation<int8_t> refValidation;
+    std::vector<int64_t> dims = {10, 10};
+
+    Tensor<int8_t> tensor1(dims);
+    tensor1.fillTensorWithRandomValues(-128, 127);
+    Tensor<int8_t> tensor2(dims);
+    makeTensorsEqual<Tensor<int8_t>>(tensor1, tensor2);
+
+    EXPECT_TRUE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidationUint8, BasicTensorUsage)
+{
+    CpuIntReferenceValidation<uint8_t> refValidation;
+    std::vector<int64_t> dims = {10, 10};
+
+    Tensor<uint8_t> tensor1(dims);
+    tensor1.fillTensorWithRandomValues(0, 256);
+    Tensor<uint8_t> tensor2(dims);
+    makeTensorsEqual<Tensor<uint8_t>>(tensor1, tensor2);
+
+    EXPECT_TRUE(refValidation.allClose(tensor1, tensor2));
+}
+
+// TensorNotComparable tests
+TEST(TestCpuIntReferenceValidationInt32, TensorNotComparable)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+    std::vector<int64_t> dims = {10, 10};
+
+    Tensor<int32_t> tensor1(dims);
+    Tensor<int32_t> tensor2(dims);
+    tensor1.fillTensorWithValue(-10);
+    tensor2.fillTensorWithValue(10);
+
+    EXPECT_FALSE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidationInt8, TensorNotComparable)
+{
+    CpuIntReferenceValidation<int8_t> refValidation;
+    std::vector<int64_t> dims = {10, 10};
+
+    Tensor<int8_t> tensor1(dims);
+    Tensor<int8_t> tensor2(dims);
+    tensor1.fillTensorWithValue(-10);
+    tensor2.fillTensorWithValue(10);
+
+    EXPECT_FALSE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidationUint8, TensorNotComparable)
+{
+    CpuIntReferenceValidation<uint8_t> refValidation;
+    std::vector<int64_t> dims = {10, 10};
+
+    Tensor<uint8_t> tensor1(dims);
+    Tensor<uint8_t> tensor2(dims);
+    tensor1.fillTensorWithValue(-10);
+    tensor2.fillTensorWithValue(10);
+
+    EXPECT_FALSE(refValidation.allClose(tensor1, tensor2));
+}
+
+// Edge case: different element counts
+TEST(TestCpuIntReferenceValidation, TensorDifferentElementCounts)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+
+    Tensor<int32_t> tensor1({10, 10});
+    Tensor<int32_t> tensor2({5, 5});
+    tensor1.fillTensorWithValue(1);
+    tensor2.fillTensorWithValue(1);
+
+    EXPECT_FALSE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidationStrided, StridedTensorEqual)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+    std::vector<int64_t> dims = {2, 2, 2, 2};
+    std::vector<int64_t> strides = {2, 4, 8, 16};
+
+    Tensor<int32_t> tensor1(dims, strides);
+    Tensor<int32_t> tensor2(dims, strides);
+
+    // Fill with same values
+    iterateAlongDimensions(dims, [&](const std::vector<int64_t>& indices) {
+        auto value = static_cast<int32_t>((indices[0] * 1000) + (indices[1] * 100)
+                                          + (indices[2] * 10) + indices[3]);
+        tensor1.setHostValue(value, indices);
+        tensor2.setHostValue(value, indices);
+    });
+
+    EXPECT_TRUE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidation, StridedTensorNotEqual)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+    std::vector<int64_t> dims = {2, 2, 2, 2};
+    std::vector<int64_t> strides = {2, 4, 8, 16};
+
+    Tensor<int32_t> tensor1(dims, strides);
+    Tensor<int32_t> tensor2(dims, strides);
+
+    // Fill tensor1
+    iterateAlongDimensions(dims, [&](const std::vector<int64_t>& indices) {
+        auto value = static_cast<int32_t>((indices[0] * 1000) + (indices[1] * 100)
+                                          + (indices[2] * 10) + indices[3]);
+        tensor1.setHostValue(value, indices);
+        tensor2.setHostValue(value, indices);
+    });
+
+    // Change one element in tensor2
+    std::vector<int64_t> indices = {1, 1, 1, 1};
+    tensor2.setHostValue(9999.0f, indices);
+
+    EXPECT_FALSE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidation, StridedTensorAllZeros)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+    std::vector<int64_t> dims = {2, 2, 2, 2};
+    std::vector<int64_t> strides = {2, 4, 8, 16};
+
+    Tensor<int32_t> tensor1(dims, strides);
+    Tensor<int32_t> tensor2(dims, strides);
+
+    tensor1.fillTensorWithValue(0);
+    tensor2.fillTensorWithValue(0);
+
+    EXPECT_TRUE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidation, StridedTensorDifferentStrides)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+    std::vector<int64_t> dims = {2, 2, 2, 2};
+    std::vector<int64_t> strides1 = {2, 4, 8, 16};
+    std::vector<int64_t> strides2 = {8, 4, 2, 1}; // Different stride order
+
+    Tensor<int32_t> tensor1(dims, strides1);
+    Tensor<int32_t> tensor2(dims, strides2);
+
+    // Set same logical values despite different memory layouts
+    iterateAlongDimensions(dims, [&](const std::vector<int64_t>& indices) {
+        auto value = static_cast<int32_t>(indices[0] + indices[1] + indices[2] + indices[3]);
+        tensor1.setHostValue(value, indices);
+        tensor2.setHostValue(value, indices);
+    });
+
+    EXPECT_TRUE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidation, StridedTensorFirstElementDiffers)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+    std::vector<int64_t> dims = {2, 2, 2, 2};
+    std::vector<int64_t> strides = {2, 4, 8, 16};
+
+    Tensor<int32_t> tensor1(dims, strides);
+    Tensor<int32_t> tensor2(dims, strides);
+
+    tensor1.fillTensorWithValue(1);
+    tensor2.fillTensorWithValue(1);
+
+    // Change first element
+    std::vector<int64_t> indices = {0, 0, 0, 0};
+    tensor2.setHostValue(2, indices);
+
+    EXPECT_FALSE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidation, StridedTensorLastElementDiffers)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+    std::vector<int64_t> dims = {2, 2, 2, 2};
+    std::vector<int64_t> strides = {2, 4, 8, 16};
+
+    Tensor<int32_t> tensor1(dims, strides);
+    Tensor<int32_t> tensor2(dims, strides);
+
+    tensor1.fillTensorWithValue(1);
+    tensor2.fillTensorWithValue(1);
+
+    // Change last element
+    std::vector<int64_t> indices = {1, 1, 1, 1};
+    tensor2.setHostValue(2, indices);
+
+    EXPECT_FALSE(refValidation.allClose(tensor1, tensor2));
+}
+
+TEST(TestCpuIntReferenceValidation, TensorSameElementCountDifferentDims)
+{
+    CpuIntReferenceValidation<int32_t> refValidation;
+
+    Tensor<int32_t> tensor1({2, 50}); // 100 elements
+    Tensor<int32_t> tensor2({10, 10}); // 100 elements
+    tensor1.fillTensorWithValue(1);
+    tensor2.fillTensorWithValue(1);
+
+    // Should return false because dimensions don't match
+    // even though element counts are the same
+    EXPECT_FALSE(refValidation.allClose(tensor1, tensor2));
+}
+
+/* ================================================= */

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
@@ -79,8 +79,8 @@ protected:
         expected.fillWithValue(static_cast<OutputType>(TEST_VALUE_3));
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinarySubtractOperation()
@@ -99,8 +99,8 @@ protected:
         expected.fillWithValue(static_cast<OutputType>(TEST_VALUE_3));
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinaryAddOperationSanityValidation()
@@ -159,8 +159,8 @@ protected:
             PointwiseMode::ADD, output, input1, input2);
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinarySubtractOperationSanityValidation()
@@ -224,8 +224,8 @@ protected:
             PointwiseMode::SUB, output, input1, input2);
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinaryAddOperation3D()
@@ -244,8 +244,8 @@ protected:
         expected.fillWithValue(static_cast<OutputType>(TEST_VALUE_4));
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinarySingleElementTensors()
@@ -276,8 +276,8 @@ protected:
             PointwiseMode::SUB, output, input1, input2);
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinaryNumericalPrecision()
@@ -297,8 +297,8 @@ protected:
             static_cast<OutputType>(PRECISION_TEST_A + PRECISION_TEST_B), 0, 0, 0, 0);
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testElementwise1D()
@@ -325,8 +325,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(static_cast<float>(13)), 4);
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBroadcast2Dx1D()
@@ -367,8 +367,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBroadcast3D()
@@ -402,8 +402,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBroadcast3DImplicitLeading()
@@ -438,8 +438,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     // Test case: 4D × 4D: [N,C,H,W] + [1,C,1,1] → broadcast to [N,C,H,W]
@@ -489,8 +489,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     // Test case: Complex N-D broadcasting: [2,1,3,1] + [1,2,1,4] → [2,2,3,4]
@@ -543,8 +543,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBroadcast5D()
@@ -607,8 +607,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     // ======================= UNARY OPERATIONS =======================
@@ -653,8 +653,8 @@ protected:
             static_cast<OutputType>(TEST_VALUE_1_5), 0, 2, 1, 1); // max(0, 1.5) = 1.5
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testReluBackwardOperation()
@@ -730,8 +730,8 @@ protected:
                               1); // dy=3.0, x=1.5>0: dx=3.0*1=3.0
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testParameterizedReluForwardOperation()
@@ -785,8 +785,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(TEST_VALUE_1), 0, 1, 1, 1); // 1.0 (in range)
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testParameterizedReluBackwardOperation()
@@ -869,8 +869,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testSigmoidForwardOperation()
@@ -935,8 +935,8 @@ protected:
                               1); // sigmoid(1.5)
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testSigmoidBackwardOperation()
@@ -993,8 +993,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testTanhForwardOperation()
@@ -1034,8 +1034,8 @@ protected:
             static_cast<OutputType>(std::tanh(TEST_VALUE_1_5)), 0, 1, 1, 1); // tanh(1.5)
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testTanhBackwardOperation()
@@ -1090,8 +1090,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testAbsoluteValueOperation()
@@ -1131,8 +1131,8 @@ protected:
             static_cast<OutputType>(std::abs(-TEST_VALUE_4)), 0, 1, 1, 1); // |-4| = 4
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testNegationOperation()
@@ -1165,8 +1165,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(TEST_VALUE_4), 0, 1, 1, 1); // -(-4) = 4
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testUnary1DOperation()
@@ -1193,8 +1193,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(2.0f), 4); // max(0, 2) = 2
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testUnary2DOperation()
@@ -1227,8 +1227,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testUnary3DOperation()
@@ -1246,8 +1246,8 @@ protected:
         expected.fillWithValue(static_cast<OutputType>(TEST_VALUE_2_5));
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testUnarySingleElementTensor()
@@ -1265,8 +1265,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(std::tanh(E)), 0, 0, 0, 0);
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testIdentityOperation()
@@ -1299,8 +1299,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(SQRT_2), 0, 1, 1, 1); // √2
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 };
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
@@ -109,28 +109,54 @@ protected:
         Tensor<Input2Type> input2({1, 1, 2, 2});
         Tensor<OutputType> output({1, 1, 2, 2});
 
-        input1.setHostValue(static_cast<Input1Type>(PI), 0, 0, 0, 0); // π
-        input1.setHostValue(static_cast<Input1Type>(E), 0, 0, 0, 1); // e
-        input1.setHostValue(static_cast<Input1Type>(SQRT_2), 0, 0, 1, 0); // √2
-        input1.setHostValue(static_cast<Input1Type>(GOLDEN_RATIO), 0, 0, 1, 1); // φ (golden ratio)
+        // Create expected tensor with computed results
+        Tensor<OutputType> expected({1, 1, 2, 2});
 
-        input2.setHostValue(static_cast<Input2Type>(LN_2), 0, 0, 0, 0); // ln(2)
-        input2.setHostValue(static_cast<Input2Type>(std::sin(1.0f)), 0, 0, 0, 1);
-        input2.setHostValue(static_cast<Input2Type>(std::cos(1.0f)), 0, 0, 1, 0);
-        input2.setHostValue(static_cast<Input2Type>(std::tan(1.0f)), 0, 0, 1, 1);
+        if constexpr(std::is_integral_v<Input1Type> || std::is_integral_v<Input2Type>)
+        {
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_1), 0, 0, 0, 0);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 0, 1);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_3), 0, 0, 1, 0);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_4), 0, 0, 1, 1);
+
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_4), 0, 0, 0, 0);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_3), 0, 0, 0, 1);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_2), 0, 0, 1, 0);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_1), 0, 0, 1, 1);
+
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_1 + (-TEST_VALUE_4)), 0, 0, 0, 0);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_2 + (-TEST_VALUE_3)), 0, 0, 0, 1);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_3 + (-TEST_VALUE_2)), 0, 0, 1, 0);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_4 + (-TEST_VALUE_1)), 0, 0, 1, 1);
+        }
+        else
+        {
+            input1.setHostValue(static_cast<Input1Type>(PI), 0, 0, 0, 0); // π
+            input1.setHostValue(static_cast<Input1Type>(E), 0, 0, 0, 1); // e
+            input1.setHostValue(static_cast<Input1Type>(SQRT_2), 0, 0, 1, 0); // √2
+            input1.setHostValue(
+                static_cast<Input1Type>(GOLDEN_RATIO), 0, 0, 1, 1); // φ (golden ratio)
+
+            input2.setHostValue(static_cast<Input2Type>(LN_2), 0, 0, 0, 0); // ln(2)
+            input2.setHostValue(static_cast<Input2Type>(std::sin(1.0f)), 0, 0, 0, 1);
+            input2.setHostValue(static_cast<Input2Type>(std::cos(1.0f)), 0, 0, 1, 0);
+            input2.setHostValue(static_cast<Input2Type>(std::tan(1.0f)), 0, 0, 1, 1);
+
+            expected.setHostValue(static_cast<OutputType>(PI + LN_2), 0, 0, 0, 0); // π + ln(2)
+            expected.setHostValue(
+                static_cast<OutputType>(E + std::sin(1.0f)), 0, 0, 0, 1); // e + sin(1)
+            expected.setHostValue(
+                static_cast<OutputType>(SQRT_2 + std::cos(1.0f)), 0, 0, 1, 0); // √2 + cos(1)
+            expected.setHostValue(
+                static_cast<OutputType>(GOLDEN_RATIO + std::tan(1.0f)), 0, 0, 1, 1); // φ + tan(1)
+        }
 
         CpuReferencePointwiseImpl<OutputType, Input1Type, Input2Type>::pointwiseCompute(
             PointwiseMode::ADD, output, input1, input2);
-
-        // Create expected tensor with computed results
-        Tensor<OutputType> expected({1, 1, 2, 2});
-        expected.setHostValue(static_cast<OutputType>(PI + LN_2), 0, 0, 0, 0); // π + ln(2)
-        expected.setHostValue(
-            static_cast<OutputType>(E + std::sin(1.0f)), 0, 0, 0, 1); // e + sin(1)
-        expected.setHostValue(
-            static_cast<OutputType>(SQRT_2 + std::cos(1.0f)), 0, 0, 1, 0); // √2 + cos(1)
-        expected.setHostValue(
-            static_cast<OutputType>(GOLDEN_RATIO + std::tan(1.0f)), 0, 0, 1, 1); // φ + tan(1)
 
         auto tolerance = getMixedTypeTolerance();
         CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
@@ -143,31 +169,59 @@ protected:
         Tensor<Input2Type> input2({1, 1, 2, 2});
         Tensor<OutputType> output({1, 1, 2, 2});
 
-        input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2 * PI), 0, 0, 0, 0); // 2π
-        input1.setHostValue(static_cast<Input1Type>(E * E), 0, 0, 0, 1); // e²
-        input1.setHostValue(static_cast<Input1Type>(SQRT_5), 0, 0, 1, 0); // √5
-        input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 1, 1); // Simple test value
+        // Create expected tensor with computed results
+        Tensor<OutputType> expected({1, 1, 2, 2});
 
-        input2.setHostValue(static_cast<Input2Type>(PI / TEST_VALUE_2), 0, 0, 0, 0); // π/2
-        input2.setHostValue(static_cast<Input2Type>(E), 0, 0, 0, 1); // e
-        input2.setHostValue(static_cast<Input2Type>(SQRT_3), 0, 0, 1, 0); // √3
-        input2.setHostValue(static_cast<Input2Type>(TEST_VALUE_1), 0, 0, 1, 1); // Simple test value
+        if constexpr(std::is_integral_v<Input1Type> || std::is_integral_v<Input2Type>)
+        {
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_1), 0, 0, 0, 0);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 0, 1);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_3), 0, 0, 1, 0);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_4), 0, 0, 1, 1);
+
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_4), 0, 0, 0, 0);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_3), 0, 0, 0, 1);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_2), 0, 0, 1, 0);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_1), 0, 0, 1, 1);
+
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_1 - (-TEST_VALUE_4)), 0, 0, 0, 0);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_2 - (-TEST_VALUE_3)), 0, 0, 0, 1);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_3 - (-TEST_VALUE_2)), 0, 0, 1, 0);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_4 - (-TEST_VALUE_1)), 0, 0, 1, 1);
+        }
+        else
+        {
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2 * PI), 0, 0, 0, 0); // 2π
+            input1.setHostValue(static_cast<Input1Type>(E * E), 0, 0, 0, 1); // e²
+            input1.setHostValue(static_cast<Input1Type>(SQRT_5), 0, 0, 1, 0); // √5
+            input1.setHostValue(
+                static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 1, 1); // Simple test value
+
+            input2.setHostValue(static_cast<Input2Type>(PI / TEST_VALUE_2), 0, 0, 0, 0); // π/2
+            input2.setHostValue(static_cast<Input2Type>(E), 0, 0, 0, 1); // e
+            input2.setHostValue(static_cast<Input2Type>(SQRT_3), 0, 0, 1, 0); // √3
+            input2.setHostValue(
+                static_cast<Input2Type>(TEST_VALUE_1), 0, 0, 1, 1); // Simple test value
+
+            expected.setHostValue(
+                static_cast<OutputType>((TEST_VALUE_2 * PI) - (PI / TEST_VALUE_2)),
+                0,
+                0,
+                0,
+                0); // 2π - π/2 = 3π/2
+            expected.setHostValue(static_cast<OutputType>((E * E) - E), 0, 0, 0,
+                                  1); // e² - e
+            expected.setHostValue(static_cast<OutputType>(SQRT_5 - SQRT_3), 0, 0, 1, 0); // √5 - √3
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_2 - TEST_VALUE_1), 0, 0, 1, 1); // 2 - 1
+        }
 
         CpuReferencePointwiseImpl<OutputType, Input1Type, Input2Type>::pointwiseCompute(
             PointwiseMode::SUB, output, input1, input2);
-
-        // Create expected tensor with computed results
-        Tensor<OutputType> expected({1, 1, 2, 2});
-        expected.setHostValue(static_cast<OutputType>((TEST_VALUE_2 * PI) - (PI / TEST_VALUE_2)),
-                              0,
-                              0,
-                              0,
-                              0); // 2π - π/2 = 3π/2
-        expected.setHostValue(static_cast<OutputType>((E * E) - E), 0, 0, 0,
-                              1); // e² - e
-        expected.setHostValue(static_cast<OutputType>(SQRT_5 - SQRT_3), 0, 0, 1, 0); // √5 - √3
-        expected.setHostValue(
-            static_cast<OutputType>(TEST_VALUE_2 - TEST_VALUE_1), 0, 0, 1, 1); // 2 - 1
 
         auto tolerance = getMixedTypeTolerance();
         CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
@@ -200,15 +254,26 @@ protected:
         Tensor<Input2Type> input2({1, 1, 1, 1});
         Tensor<OutputType> output({1, 1, 1, 1});
 
-        input1.setHostValue(static_cast<Input1Type>(E * E), 0, 0, 0, 0); // e²
-        input2.setHostValue(static_cast<Input2Type>(E), 0, 0, 0, 0); // e
+        Tensor<OutputType> expected({1, 1, 1, 1});
+
+        if constexpr(std::is_integral_v<Input1Type> || std::is_integral_v<Input2Type>)
+        {
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 0, 0);
+            input2.setHostValue(static_cast<Input2Type>(TEST_VALUE_5), 0, 0, 0, 0);
+
+            expected.setHostValue(static_cast<OutputType>(TEST_VALUE_2 - TEST_VALUE_5), 0, 0, 0, 0);
+        }
+        else
+        {
+            input1.setHostValue(static_cast<Input1Type>(E * E), 0, 0, 0, 0); // e²
+            input2.setHostValue(static_cast<Input2Type>(E), 0, 0, 0, 0); // e
+
+            expected.setHostValue(static_cast<OutputType>((E * E) - E), 0, 0, 0,
+                                  0); // e² - e
+        }
 
         CpuReferencePointwiseImpl<OutputType, Input1Type, Input2Type>::pointwiseCompute(
             PointwiseMode::SUB, output, input1, input2);
-
-        Tensor<OutputType> expected({1, 1, 1, 1});
-        expected.setHostValue(static_cast<OutputType>((E * E) - E), 0, 0, 0,
-                              0); // e² - e
 
         auto tolerance = getMixedTypeTolerance();
         CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
@@ -1239,7 +1304,7 @@ protected:
     }
 };
 
-using TestTypes = ::testing::Types<float, half, hip_bfloat16, double>;
+using TestTypes = ::testing::Types<float, half, hip_bfloat16, double, int8_t>;
 // Empty third argument required for C++17 compatibility with TYPED_TEST_SUITE macro
 TYPED_TEST_SUITE(CpuReferencePointwiseFixture, TestTypes, );
 
@@ -1271,6 +1336,12 @@ TYPED_TEST(CpuReferencePointwiseFixture, BinarySingleElementTensors)
 
 TYPED_TEST(CpuReferencePointwiseFixture, BinaryNumericalPrecision)
 {
+    // This test uses fractional precision test values,
+    // which don't make sense for integer types since they'd be truncated to 0.
+    if constexpr(std::is_integral_v<TypeParam>)
+    {
+        GTEST_SKIP() << "Skipping numerical precision test for integer types";
+    }
     this->testBinaryNumericalPrecision();
 }
 


### PR DESCRIPTION
### Details
- Added `INT8` data support to frontend, data_sdk and test_sdk.
- Added simple test with INT8 convolution fprop, dgrad, wgrad.

### Issue
- ALMIOPEN-813