### PR TITLE
New MIOpen BN Fwd Inference APIs taking inverse variance

### DIFF
--- a/projects/miopen/CHANGELOG.md
+++ b/projects/miopen/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 Full documentation for MIOpen is available [here](https://rocm.docs.amd.com/projects/MIOpen/en/latest/)
 ## (Unreleased) MIOpen 3.5.1 for ROCm 7.11.0
+### Added
+* New API entry-points `miopenBatchNormalizationForwardInferenceInvVariance` and
+  `miopenBatchNormForwardInferenceActivationInvVariance` to support hipDNN.
+
 ### Optimized
 * Added `MIOPEN_SEARCH_CUTOFF` option which can reduce tuning times by skipping slow solvers and kernels
 

--- a/projects/miopen/driver/bn_driver.hpp
+++ b/projects/miopen/driver/bn_driver.hpp
@@ -123,6 +123,7 @@ private:
     bool bsaveMeanVar;
     bool keepRunningMeanVar;
     bool estimatedMeanVar;
+    bool useInverseVar;
 
     int forw;
     int back;
@@ -236,10 +237,20 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::GetandSetData()
         estMean.InitHostData(estMean.GetTensor().desc.GetElementSize(),
                              true,
                              uniform_signed_initializer<TAcc>(2e-3 /*scale*/, 1000 /*range*/));
-        // estVaraince has to be +ve number otherwise 1/sqrt(-ve) would
-        // give img number
-        estVariance.GetTensor().generate(
-            uniform_unsigned_initializer<TAcc>(2e-3 /*scale*/, 1000 /*range*/));
+
+        if(!useInverseVar)
+        {
+            // estVaraince has to be +ve number otherwise 1/sqrt(-ve) would
+            // give img number
+            estVariance.GetTensor().generate(
+                uniform_unsigned_initializer<TAcc>(2e-3 /*scale*/, 1000 /*range*/));
+        }
+        else
+        {
+            // Given an epsilon of 1e-5, the max value is 1/sqrt(epsilon) ==> 316.228
+            // Given a max variance of 2, the min value is 1/sqrt(epsilon + 2.0) ==> 0.7
+            estVariance.GetTensor().generate(uniform_unsigned_initializer<TAcc>(0.7, 317));
+        }
     }
     else if(isFwdTrain)
     {
@@ -356,6 +367,11 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::AddCmdLineArgs()
                          '&',
                          "0",
                          "MIOpen tuning policy (Default=0, or no tuning policy set)",
+                         "int");
+    inflags.AddInputFlag("inverse_variance",
+                         'I',
+                         "0",
+                         "Use inverse variance for forward inference (Default=0)",
                          "int");
 
     return miopenStatusSuccess;
@@ -551,6 +567,13 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::SetBNParametersFromCm
 
     activ_mode = static_cast<miopenActivationMode_t>(inflags.GetValueInt("activ_mode"));
 
+    useInverseVar = inflags.GetValueInt("inverse_variance");
+    if(useInverseVar && forw != 2)
+    {
+        printf("Inverse variance can only be used with forward inference\n");
+        exit(EXIT_FAILURE); // NOLINT (concurrency-mt-unsafe)
+    }
+
     return miopenStatusSuccess;
 }
 
@@ -660,43 +683,87 @@ void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runGPUFwdInference(T
 
     if(keepRunningMeanVar)
     { // use precalculated mean and variance
-        miopenBatchNormalizationForwardInference_V2(GetHandle(),
-                                                    bn_mode,
-                                                    &alpha,
-                                                    &beta,
-                                                    &in.GetTensor().desc,
-                                                    in.GetDevicePtr(),
-                                                    &out.GetTensor().desc,
-                                                    out.GetDevicePtr(),
-                                                    &scale.GetTensor().desc,
-                                                    &bias.GetTensor().desc,
-                                                    &estMean.GetTensor().desc,
-                                                    &estVariance.GetTensor().desc,
-                                                    scale.GetDevicePtr(),
-                                                    bias.GetDevicePtr(),
-                                                    estMean.GetDevicePtr(),
-                                                    estVariance.GetDevicePtr(),
-                                                    epsilon);
+        if(!useInverseVar)
+        {
+            miopenBatchNormalizationForwardInference_V2(GetHandle(),
+                                                        bn_mode,
+                                                        &alpha,
+                                                        &beta,
+                                                        &in.GetTensor().desc,
+                                                        in.GetDevicePtr(),
+                                                        &out.GetTensor().desc,
+                                                        out.GetDevicePtr(),
+                                                        &scale.GetTensor().desc,
+                                                        &bias.GetTensor().desc,
+                                                        &estMean.GetTensor().desc,
+                                                        &estVariance.GetTensor().desc,
+                                                        scale.GetDevicePtr(),
+                                                        bias.GetDevicePtr(),
+                                                        estMean.GetDevicePtr(),
+                                                        estVariance.GetDevicePtr(),
+                                                        epsilon);
+        }
+        else
+        {
+            miopenBatchNormalizationForwardInferenceInvVariance(GetHandle(),
+                                                                bn_mode,
+                                                                &alpha,
+                                                                &beta,
+                                                                &in.GetTensor().desc,
+                                                                in.GetDevicePtr(),
+                                                                &out.GetTensor().desc,
+                                                                out.GetDevicePtr(),
+                                                                &scale.GetTensor().desc,
+                                                                &bias.GetTensor().desc,
+                                                                &estMean.GetTensor().desc,
+                                                                &estVariance.GetTensor().desc,
+                                                                scale.GetDevicePtr(),
+                                                                bias.GetDevicePtr(),
+                                                                estMean.GetDevicePtr(),
+                                                                estVariance.GetDevicePtr());
+        }
     }
     else
     { // recalculate mean and variance
-        miopenBatchNormalizationForwardInference_V2(GetHandle(),
-                                                    bn_mode,
-                                                    &alpha,
-                                                    &beta,
-                                                    &in.GetTensor().desc,
-                                                    in.GetDevicePtr(),
-                                                    &out.GetTensor().desc,
-                                                    out.GetDevicePtr(),
-                                                    &scale.GetTensor().desc,
-                                                    &bias.GetTensor().desc,
-                                                    &estMean.GetTensor().desc,
-                                                    &estVariance.GetTensor().desc,
-                                                    scale.GetDevicePtr(),
-                                                    bias.GetDevicePtr(),
-                                                    nullptr,
-                                                    nullptr,
-                                                    epsilon);
+        if(!useInverseVar)
+        {
+            miopenBatchNormalizationForwardInference_V2(GetHandle(),
+                                                        bn_mode,
+                                                        &alpha,
+                                                        &beta,
+                                                        &in.GetTensor().desc,
+                                                        in.GetDevicePtr(),
+                                                        &out.GetTensor().desc,
+                                                        out.GetDevicePtr(),
+                                                        &scale.GetTensor().desc,
+                                                        &bias.GetTensor().desc,
+                                                        &estMean.GetTensor().desc,
+                                                        &estVariance.GetTensor().desc,
+                                                        scale.GetDevicePtr(),
+                                                        bias.GetDevicePtr(),
+                                                        nullptr,
+                                                        nullptr,
+                                                        epsilon);
+        }
+        else
+        {
+            miopenBatchNormalizationForwardInferenceInvVariance(GetHandle(),
+                                                                bn_mode,
+                                                                &alpha,
+                                                                &beta,
+                                                                &in.GetTensor().desc,
+                                                                in.GetDevicePtr(),
+                                                                &out.GetTensor().desc,
+                                                                out.GetDevicePtr(),
+                                                                &scale.GetTensor().desc,
+                                                                &bias.GetTensor().desc,
+                                                                &estMean.GetTensor().desc,
+                                                                &estVariance.GetTensor().desc,
+                                                                scale.GetDevicePtr(),
+                                                                bias.GetDevicePtr(),
+                                                                nullptr,
+                                                                nullptr);
+        }
     }
     return;
 }
@@ -714,45 +781,91 @@ void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runGPUFwdInferenceAc
                                   static_cast<double>(0.0));
     if(keepRunningMeanVar)
     { // use precalculated mean and variance
-        miopenBatchNormForwardInferenceActivation(GetHandle(),
-                                                  bn_mode,
-                                                  &alpha,
-                                                  &beta,
-                                                  &in.GetTensor().desc,
-                                                  in.GetDevicePtr(),
-                                                  &out.GetTensor().desc,
-                                                  out.GetDevicePtr(),
-                                                  &scale.GetTensor().desc,
-                                                  &bias.GetTensor().desc,
-                                                  &estMean.GetTensor().desc,
-                                                  &estVariance.GetTensor().desc,
-                                                  scale.GetDevicePtr(),
-                                                  bias.GetDevicePtr(),
-                                                  estMean.GetDevicePtr(),
-                                                  estVariance.GetDevicePtr(),
-                                                  epsilon,
-                                                  activ_desc);
+        if(!useInverseVar)
+        {
+            miopenBatchNormForwardInferenceActivation(GetHandle(),
+                                                      bn_mode,
+                                                      &alpha,
+                                                      &beta,
+                                                      &in.GetTensor().desc,
+                                                      in.GetDevicePtr(),
+                                                      &out.GetTensor().desc,
+                                                      out.GetDevicePtr(),
+                                                      &scale.GetTensor().desc,
+                                                      &bias.GetTensor().desc,
+                                                      &estMean.GetTensor().desc,
+                                                      &estVariance.GetTensor().desc,
+                                                      scale.GetDevicePtr(),
+                                                      bias.GetDevicePtr(),
+                                                      estMean.GetDevicePtr(),
+                                                      estVariance.GetDevicePtr(),
+                                                      epsilon,
+                                                      activ_desc);
+        }
+        else
+        {
+            miopenBatchNormForwardInferenceActivationInvVariance(GetHandle(),
+                                                                 bn_mode,
+                                                                 &alpha,
+                                                                 &beta,
+                                                                 &in.GetTensor().desc,
+                                                                 in.GetDevicePtr(),
+                                                                 &out.GetTensor().desc,
+                                                                 out.GetDevicePtr(),
+                                                                 &scale.GetTensor().desc,
+                                                                 &bias.GetTensor().desc,
+                                                                 &estMean.GetTensor().desc,
+                                                                 &estVariance.GetTensor().desc,
+                                                                 scale.GetDevicePtr(),
+                                                                 bias.GetDevicePtr(),
+                                                                 estMean.GetDevicePtr(),
+                                                                 estVariance.GetDevicePtr(),
+                                                                 activ_desc);
+        }
     }
     else
     { // recalculate mean and variance
-        miopenBatchNormForwardInferenceActivation(GetHandle(),
-                                                  bn_mode,
-                                                  &alpha,
-                                                  &beta,
-                                                  &in.GetTensor().desc,
-                                                  in.GetDevicePtr(),
-                                                  &out.GetTensor().desc,
-                                                  out.GetDevicePtr(),
-                                                  &scale.GetTensor().desc,
-                                                  &bias.GetTensor().desc,
-                                                  &estMean.GetTensor().desc,
-                                                  &estVariance.GetTensor().desc,
-                                                  scale.GetDevicePtr(),
-                                                  bias.GetDevicePtr(),
-                                                  nullptr,
-                                                  nullptr,
-                                                  epsilon,
-                                                  activ_desc);
+        if(!useInverseVar)
+        {
+            miopenBatchNormForwardInferenceActivation(GetHandle(),
+                                                      bn_mode,
+                                                      &alpha,
+                                                      &beta,
+                                                      &in.GetTensor().desc,
+                                                      in.GetDevicePtr(),
+                                                      &out.GetTensor().desc,
+                                                      out.GetDevicePtr(),
+                                                      &scale.GetTensor().desc,
+                                                      &bias.GetTensor().desc,
+                                                      &estMean.GetTensor().desc,
+                                                      &estVariance.GetTensor().desc,
+                                                      scale.GetDevicePtr(),
+                                                      bias.GetDevicePtr(),
+                                                      nullptr,
+                                                      nullptr,
+                                                      epsilon,
+                                                      activ_desc);
+        }
+        else
+        {
+            miopenBatchNormForwardInferenceActivationInvVariance(GetHandle(),
+                                                                 bn_mode,
+                                                                 &alpha,
+                                                                 &beta,
+                                                                 &in.GetTensor().desc,
+                                                                 in.GetDevicePtr(),
+                                                                 &out.GetTensor().desc,
+                                                                 out.GetDevicePtr(),
+                                                                 &scale.GetTensor().desc,
+                                                                 &bias.GetTensor().desc,
+                                                                 &estMean.GetTensor().desc,
+                                                                 &estVariance.GetTensor().desc,
+                                                                 scale.GetDevicePtr(),
+                                                                 bias.GetDevicePtr(),
+                                                                 nullptr,
+                                                                 nullptr,
+                                                                 activ_desc);
+        }
     }
     miopenDestroyActivationDescriptor(activ_desc);
     return;
@@ -1157,7 +1270,8 @@ void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runCPUFwdInference(T
                                        bias.GetTensor(),
                                        epsilon,
                                        estMean.GetTensor(),
-                                       estVariance.GetTensor());
+                                       estVariance.GetTensor(),
+                                       useInverseVar);
     }
     else if(bn_mode == miopenBNSpatial)
     { // 1xCx1x1
@@ -1168,7 +1282,8 @@ void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runCPUFwdInference(T
                                       bias.GetTensor(),
                                       epsilon,
                                       estMean.GetTensor(),
-                                      estVariance.GetTensor());
+                                      estVariance.GetTensor(),
+                                      useInverseVar);
         if(activ_mode > 0)
         {
             activationHostInfer(activ_mode,

--- a/projects/miopen/driver/driver.hpp
+++ b/projects/miopen/driver/driver.hpp
@@ -382,16 +382,17 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
 [[noreturn]] inline void Usage(int e)
 {
     printf("Usage: ./driver *base_arg* *other_args*\n");
-    printf("Supported Base Arguments: conv[fp16|int8|bfp16], CBAInfer[fp16|bfp16], "
-           "CAInfer[fp16|bfp16], pool[fp16], lrn[fp16], "
-           "activ[fp16], softmax[fp16], bnorm[fp16], rnn[fp16], gemm[fp16], ctc, dropout[fp16], "
-           "tensorop, reduce[fp16|fp64], layernorm[bfp16|fp16], "
-           "groupnorm[bfp16|fp16], cat[bfp16|fp16], addlayernorm[bfp16|fp16], "
-           "t5layernorm[bfp16|fp16], adam[fp16], ampadam, reduceextreme[bfp16|fp16], "
-           "adamw[fp16], ampadamw, transformersadamw[fp16], transformersampadamw, "
-           "getitem[bfp16|fp16], reducecalculation[bfp16|fp16], rope[bfp16|fp16], "
-           "prelu[bfp16|fp16], kthvalue[bfp16|fp16], glu[bfp16|fp16], softmarginloss[bfp16|fp16], "
-           "multimarginloss[bfp16|fp16]\n");
+    printf(
+        "Supported Base Arguments: conv[fp16|int8|bfp16], CBAInfer[fp16|bfp16], "
+        "CAInfer[fp16|bfp16], pool[fp16], lrn[fp16], "
+        "activ[fp16], softmax[fp16], bnorm[fp16|bfp16], rnn[fp16], gemm[fp16], ctc, dropout[fp16], "
+        "tensorop, reduce[fp16|fp64], layernorm[bfp16|fp16], "
+        "groupnorm[bfp16|fp16], cat[bfp16|fp16], addlayernorm[bfp16|fp16], "
+        "t5layernorm[bfp16|fp16], adam[fp16], ampadam, reduceextreme[bfp16|fp16], "
+        "adamw[fp16], ampadamw, transformersadamw[fp16], transformersampadamw, "
+        "getitem[bfp16|fp16], reducecalculation[bfp16|fp16], rope[bfp16|fp16], "
+        "prelu[bfp16|fp16], kthvalue[bfp16|fp16], glu[bfp16|fp16], softmarginloss[bfp16|fp16], "
+        "multimarginloss[bfp16|fp16]\n");
     exit(e); // NOLINT (concurrency-mt-unsafe)
 }
 

--- a/projects/miopen/include/miopen/miopen.h
+++ b/projects/miopen/include/miopen/miopen.h
@@ -3086,6 +3086,101 @@ miopenBatchNormalizationForwardInference_V2(miopenHandle_t handle,
                                             void* estimatedVariance,
                                             double epsilon);
 
+/*! @brief Execute forward inference layer for batch normalization using inverse variance
+ *
+ * Batch normalization pass for forward inference pass.
+ * Takes in batch normalization mode bn_mode and input tensor x, output tensor y, bnBias and bnScale
+ * with their descriptor.
+ *
+ * If either estimatedMean, or estimatedInvVariance are null pointers then the values for the mean
+ * and inverse variance will be calculated from input data using an epsilon of 1e-5, and this
+ * calculated mean and inverse variance will be used to update input values.
+ *
+ * @param handle                    MIOpen handle (input)
+ * @param bn_mode                   Batch normalization mode (input)
+ * @param alpha                     Floating point scaling factor, allocated on the host (input)
+ * @param beta                      Floating point shift factor, allocated on the host (input)
+ * @param xDesc                     Tensor descriptor for data input tensor x (input)
+ * @param x                         Data tensor x (input)
+ * @param yDesc                     Tensor descriptor for output data tensor y (input)
+ * @param y                         Data tensor y (output)
+ * @param ScaleDesc                 Tensor descriptor for BN scaling
+ * @param biasVarDesc               Tensor descriptor for BN bias
+ * @param estMeanDesc               Tensor descriptor for BN estimated Mean
+ * @param estInvVarianceDesc        Tensor descriptor for BN estimated inverse variance
+ * @param bnScale                   Batch norm scaling, gamma, tensor (input)
+ * @param bnBias                    Batch norm bias, beta, tensor (input)
+ * @param estimatedMean             Running average saved during forward training (input)
+ * @param estimatedInvVariance      Running inverse variance saved during forward training (input)
+ * @return                          miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenBatchNormalizationForwardInferenceInvVariance(
+    miopenHandle_t handle,
+    miopenBatchNormMode_t bn_mode,
+    void* alpha,
+    void* beta,
+    const miopenTensorDescriptor_t xDesc,
+    const void* x,
+    const miopenTensorDescriptor_t yDesc,
+    void* y,
+    const miopenTensorDescriptor_t scaleDesc,
+    const miopenTensorDescriptor_t biasDesc,
+    const miopenTensorDescriptor_t estMeanDesc,
+    const miopenTensorDescriptor_t estInvVarianceDesc,
+    void* bnScale,
+    void* bnBias,
+    void* estimatedMean,
+    void* estimatedInvVariance);
+
+/*! @brief Execute forward inference layer for batch normalization with fused activation using
+ * inverse variance
+ *
+ * Batch normalization pass for forward inference pass.
+ * Takes in batch normalization mode bn_mode and input tensor x, output tensor y, bnBias and bnScale
+ * with their descriptor.
+ *
+ * If either estimatedMean, or estimatedInvVariance are null pointers then the values for the mean
+ * and inverse variance will be calculated from input data using an epsilon of 1e-5 and this
+ * calculated mean and inverse variance will be used to update input values.
+ *
+ * @param handle                    MIOpen handle (input)
+ * @param bn_mode                   Batch normalization mode (input)
+ * @param alpha                     Floating point scaling factor, allocated on the host (input)
+ * @param beta                      Floating point shift factor, allocated on the host (input)
+ * @param xDesc                     Tensor descriptor for data input tensor x (input)
+ * @param x                         Data tensor x (input)
+ * @param yDesc                     Tensor descriptor for output data tensor y (input)
+ * @param y                         Data tensor y (output)
+ * @param ScaleDesc                 Tensor descriptor for BN scaling
+ * @param biasVarDesc               Tensor descriptor for BN bias
+ * @param estMeanDesc               Tensor descriptor for BN estimated Mean
+ * @param estInvVarianceDesc        Tensor descriptor for BN estimated inverse variance
+ * @param bnScale                   Batch norm scaling, gamma, tensor (input)
+ * @param bnBias                    Batch norm bias, beta, tensor (input)
+ * @param estimatedMean             Running average saved during forward training (input)
+ * @param estimatedInvVariance      Running inverse variance saved during forward training (input)
+ * @param activDesc                 Activation descriptor
+ * @return                          miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenBatchNormForwardInferenceActivationInvVariance(
+    miopenHandle_t handle,
+    miopenBatchNormMode_t bn_mode,
+    void* alpha,
+    void* beta,
+    const miopenTensorDescriptor_t xDesc,
+    const void* x,
+    const miopenTensorDescriptor_t yDesc,
+    void* y,
+    const miopenTensorDescriptor_t scaleDesc,
+    const miopenTensorDescriptor_t biasDesc,
+    const miopenTensorDescriptor_t estMeanDesc,
+    const miopenTensorDescriptor_t estInvVarianceDesc,
+    void* bnScale,
+    void* bnBias,
+    void* estimatedMean,
+    void* estimatedInvVariance,
+    const miopenActivationDescriptor_t activDesc);
+
 /*! @brief Execute forward inference layer for batch normalization with fused activation
  *
  * Batch normalization pass for forward inference pass.

--- a/projects/miopen/src/batch_norm_api.cpp
+++ b/projects/miopen/src/batch_norm_api.cpp
@@ -62,7 +62,8 @@ void LogCmdBNorm(const miopenTensorDescriptor_t xDesc,
                  const void* resultSaveMean,
                  const void* resultSaveInvVariance,
                  const BatchNormDirection_t dir,
-                 const miopenActivationDescriptor_t activDesc)
+                 const miopenActivationDescriptor_t activDesc,
+                 const bool useInverseVariance = false)
 {
     if(miopen::IsLoggingCmd())
     {
@@ -77,7 +78,8 @@ void LogCmdBNorm(const miopenTensorDescriptor_t xDesc,
                                                           resultSaveMean,
                                                           resultSaveInvVariance,
                                                           dir,
-                                                          activDesc);
+                                                          activDesc,
+                                                          useInverseVariance);
         MIOPEN_LOG_DRIVER_CMD(str);
     }
 }
@@ -295,6 +297,43 @@ miopenBatchNormalizationForwardInference_V2(miopenHandle_t handle,
                                                      nullptr);
 }
 
+extern "C" miopenStatus_t miopenBatchNormalizationForwardInferenceInvVariance(
+    miopenHandle_t handle,
+    miopenBatchNormMode_t bn_mode,
+    void* alpha,
+    void* beta,
+    const miopenTensorDescriptor_t xDesc,
+    const void* x,
+    const miopenTensorDescriptor_t yDesc,
+    void* y,
+    const miopenTensorDescriptor_t scaleDesc,
+    const miopenTensorDescriptor_t biasDesc,
+    const miopenTensorDescriptor_t estMeanDesc,
+    const miopenTensorDescriptor_t estInvVarianceDesc,
+    void* bnScale,
+    void* bnBias,
+    void* estimatedMean,
+    void* estimatedInvVariance)
+{
+    return miopenBatchNormForwardInferenceActivationInvVariance(handle,
+                                                                bn_mode,
+                                                                alpha,
+                                                                beta,
+                                                                xDesc,
+                                                                x,
+                                                                yDesc,
+                                                                y,
+                                                                scaleDesc,
+                                                                biasDesc,
+                                                                estMeanDesc,
+                                                                estInvVarianceDesc,
+                                                                bnScale,
+                                                                bnBias,
+                                                                estimatedMean,
+                                                                estimatedInvVariance,
+                                                                nullptr);
+}
+
 extern "C" miopenStatus_t
 miopenBatchNormForwardInferenceActivation(miopenHandle_t handle,
                                           miopenBatchNormMode_t bn_mode,
@@ -402,6 +441,91 @@ miopenBatchNormForwardInferenceActivation(miopenHandle_t handle,
                                               actDesc);
         });
     }
+}
+
+extern "C" miopenStatus_t miopenBatchNormForwardInferenceActivationInvVariance(
+    miopenHandle_t handle,
+    miopenBatchNormMode_t bn_mode,
+    void* alpha,
+    void* beta,
+    const miopenTensorDescriptor_t xDesc,
+    const void* x,
+    const miopenTensorDescriptor_t yDesc,
+    void* y,
+    const miopenTensorDescriptor_t scaleDesc,
+    const miopenTensorDescriptor_t biasDesc,
+    const miopenTensorDescriptor_t estMeanDesc,
+    const miopenTensorDescriptor_t estInvVarianceDesc,
+    void* bnScale,
+    void* bnBias,
+    void* estimatedMean,
+    void* estimatedInvVariance,
+    const miopenActivationDescriptor_t activDesc)
+{
+    MIOPEN_LOG_FUNCTION(handle,
+                        bn_mode,
+                        alpha,
+                        beta,
+                        xDesc,
+                        x,
+                        yDesc,
+                        y,
+                        scaleDesc,
+                        biasDesc,
+                        estMeanDesc,
+                        estInvVarianceDesc,
+                        bnScale,
+                        bnBias,
+                        estimatedMean,
+                        estimatedInvVariance,
+                        activDesc);
+
+    miopen::debug::LogCmdBNorm(xDesc,
+                               yDesc,
+                               scaleDesc,
+                               biasDesc,
+                               estMeanDesc,
+                               bn_mode,
+                               nullptr,
+                               nullptr,
+                               estMeanDesc,
+                               estimatedInvVariance,
+                               miopen::debug::BatchNormDirection_t::ForwardInference,
+                               activDesc,
+                               true);
+
+    int size{0};
+    miopenGetTensorDescriptorSize(xDesc, &size);
+    // In case of NxCxDxHxW
+    auto ReshapeIfNeeded = [size](const auto desc) {
+        return (size == 5) ? miopen::BuildReshaped4DTensorDescriptor(miopen::deref(desc))
+                           : miopen::deref(desc);
+    };
+
+    miopen::ActivationDescriptor actDesc =
+        (activDesc != nullptr)
+            ? miopen::deref(activDesc)
+            : miopen::ActivationDescriptor(miopenActivationPASTHRU, 0.0f, 0.0f, 0.0f);
+    return miopen::try_([&] {
+        miopen::BatchNormForwardInference(miopen::deref(handle),
+                                          bn_mode,
+                                          alpha,
+                                          beta,
+                                          ReshapeIfNeeded(xDesc),
+                                          DataCast(x),
+                                          ReshapeIfNeeded(yDesc),
+                                          DataCast(y),
+                                          ReshapeIfNeeded(scaleDesc),
+                                          ReshapeIfNeeded(biasDesc),
+                                          ReshapeIfNeeded(estMeanDesc),
+                                          ReshapeIfNeeded(estInvVarianceDesc),
+                                          DataCast(bnScale),
+                                          DataCast(bnBias),
+                                          DataCast(estimatedMean),
+                                          DataCast(estimatedInvVariance),
+                                          {} /* No epilson value for inverse variance */,
+                                          actDesc);
+    });
 }
 
 extern "C" miopenStatus_t

--- a/projects/miopen/src/batchnorm/problem_description.cpp
+++ b/projects/miopen/src/batchnorm/problem_description.cpp
@@ -193,13 +193,17 @@ NetworkConfig ProblemDescription::MakeNetworkConfig() const
 
     // direction
     ss << "x" << GetDirectionStr();
-    // save and running
-    if(direction == Direction::ForwardTraining)
+    // per-direction configs
+    if(direction == Direction::ForwardInference)
+    {
+        ss << "x" << (useInverseVariance ? "InvVar" : "Var");
+    }
+    else if(direction == Direction::ForwardTraining)
     {
         ss << "x" << resultsave;
         ss << "x" << resultrunning;
     }
-    if(direction == Direction::Backward)
+    else if(direction == Direction::Backward)
     {
         ss << "x" << useSaved;
     }

--- a/projects/miopen/src/driver_arguments.cpp
+++ b/projects/miopen/src/driver_arguments.cpp
@@ -301,6 +301,7 @@ std::string BnormArgsForMIOpenDriver(const miopenTensorDescriptor_t xDesc,
                                      const void* resultSaveInvVariance,
                                      const BatchNormDirection_t& dir,
                                      const miopenActivationDescriptor_t activDesc,
+                                     bool useInverseVariance,
                                      bool print_for_bn_driver)
 {
     int size = {0};
@@ -317,27 +318,29 @@ std::string BnormArgsForMIOpenDriver(const miopenTensorDescriptor_t xDesc,
                    dir);
     }
 
-    ss << " -n " << miopen::deref(xDesc).GetLengths()[0] // clang-format off
-            << " -c " << miopen::deref(xDesc).GetLengths()[1];
-        if(size == 5)
-        {
-            ss << " -D " << miopen::deref(xDesc).GetLengths()[2]
-            << " -H " << miopen::deref(xDesc).GetLengths()[3]
-            << " -W " << miopen::deref(xDesc).GetLengths()[4];
-        }
-        else
-        {
-            ss << " -H " << miopen::deref(xDesc).GetLengths()[2]
-            << " -W " << miopen::deref(xDesc).GetLengths()[3];
-        }
-        if (activDesc != nullptr && miopen::deref(activDesc).GetMode() != miopenActivationPASTHRU)
-	{
-            ss << " -f " << miopen::deref(activDesc).GetMode()
-	    << " -x " << miopen::deref(activDesc).GetAlpha()
-	    << " -y " << miopen::deref(activDesc).GetBeta()
-	    << " -z " << miopen::deref(activDesc).GetGamma();
-	}
-            ss << " -m " << bn_mode; // clang-format on
+    ss << " -n " << miopen::deref(xDesc).GetLengths()[0];
+    ss << " -c " << miopen::deref(xDesc).GetLengths()[1];
+    if(size == 5)
+    {
+        ss << " -D " << miopen::deref(xDesc).GetLengths()[2];
+        ss << " -H " << miopen::deref(xDesc).GetLengths()[3];
+        ss << " -W " << miopen::deref(xDesc).GetLengths()[4];
+    }
+    else
+    {
+        ss << " -H " << miopen::deref(xDesc).GetLengths()[2];
+        ss << " -W " << miopen::deref(xDesc).GetLengths()[3];
+    }
+
+    if(activDesc != nullptr && miopen::deref(activDesc).GetMode() != miopenActivationPASTHRU)
+    {
+        ss << " -f " << miopen::deref(activDesc).GetMode();
+        ss << " -x " << miopen::deref(activDesc).GetAlpha();
+        ss << " -y " << miopen::deref(activDesc).GetBeta();
+        ss << " -z " << miopen::deref(activDesc).GetGamma();
+    }
+    ss << " -m " << bn_mode;
+    ss << " -I " << (useInverseVariance ? '1' : '0');
     if(print_for_bn_driver)
     {
         BnDriverInfo(ss,

--- a/projects/miopen/src/fusion.cpp
+++ b/projects/miopen/src/fusion.cpp
@@ -412,6 +412,7 @@ std::string LogCmdBnormFusion(const miopenFusionPlanDescriptor_t fusePlanDesc, i
                                         nullptr,
                                         miopen::debug::BatchNormDirection_t::ForwardInference,
                                         nullptr,
+                                        false,
                                         false); // having false allows safe handling of nullptrs
     }
     else

--- a/projects/miopen/src/include/miopen/batch_norm.hpp
+++ b/projects/miopen/src/include/miopen/batch_norm.hpp
@@ -29,6 +29,7 @@
 #include <miopen/common.hpp>
 #include <miopen/miopen.h>
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -180,7 +181,7 @@ MIOPEN_INTERNALS_EXPORT void BatchNormForwardInference(const Handle& handle,
                                                        ConstData_t bnBias,
                                                        ConstData_t estimatedMean,
                                                        ConstData_t estimatedVariance,
-                                                       double epsilon,
+                                                       std::optional<double> epsilonOpt,
                                                        const ActivationDescriptor& activDesc);
 
 MIOPEN_INTERNALS_EXPORT void BatchNormForwardTraining(const Handle& handle,

--- a/projects/miopen/src/include/miopen/batchnorm/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/batchnorm/problem_description.hpp
@@ -33,6 +33,7 @@
 
 #include <cassert>
 #include <string>
+#include <optional>
 
 namespace miopen {
 
@@ -149,7 +150,7 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
         out_layout = ComputeOutLayout();
     }
 
-    // Forward Inference with activation
+    // Forward Inference with activation, epsilon_ doesn't have a value if using inverse variance.
     ProblemDescription(miopenBatchNormMode_t bn_mode_,
                        const TensorDescriptor& xDesc_,
                        const TensorDescriptor& yDesc_,
@@ -157,7 +158,7 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
                        const TensorDescriptor& biasDesc_,
                        const TensorDescriptor& sMeanDesc_,
                        const TensorDescriptor& sVarianceDesc_,
-                       double epsilon_,
+                       std::optional<double> epsilon_,
                        const ActivationDescriptor& activDesc_)
         : direction(Direction::ForwardInference),
           bn_mode(bn_mode_),
@@ -167,34 +168,16 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
           biasDesc(biasDesc_),
           sMeanDesc(sMeanDesc_),
           sVarianceDesc(sVarianceDesc_),
-          epsilon(epsilon_),
           activDesc(activDesc_)
     {
-        SetSpatialDims();
-        in_layout  = ComputeInLayout();
-        out_layout = ComputeOutLayout();
-    }
-
-    // Forward Inference with activation using inverse variance
-    ProblemDescription(miopenBatchNormMode_t bn_mode_,
-                       const TensorDescriptor& xDesc_,
-                       const TensorDescriptor& yDesc_,
-                       const TensorDescriptor& scaleDesc_,
-                       const TensorDescriptor& biasDesc_,
-                       const TensorDescriptor& sMeanDesc_,
-                       const TensorDescriptor& sVarianceDesc_,
-                       const ActivationDescriptor& activDesc_)
-        : direction(Direction::ForwardInference),
-          bn_mode(bn_mode_),
-          xDesc(xDesc_),
-          yOrDyDesc(yDesc_),
-          scaleDesc(scaleDesc_),
-          biasDesc(biasDesc_),
-          sMeanDesc(sMeanDesc_),
-          sVarianceDesc(sVarianceDesc_),
-          useInverseVariance(true),
-          activDesc(activDesc_)
-    {
+        if(epsilon_.has_value())
+        {
+            epsilon = epsilon_.value();
+        }
+        else
+        {
+            useInverseVariance = true;
+        }
         SetSpatialDims();
         in_layout  = ComputeInLayout();
         out_layout = ComputeOutLayout();

--- a/projects/miopen/src/include/miopen/batchnorm/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/batchnorm/problem_description.hpp
@@ -175,6 +175,31 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
         out_layout = ComputeOutLayout();
     }
 
+    // Forward Inference with activation using inverse variance
+    ProblemDescription(miopenBatchNormMode_t bn_mode_,
+                       const TensorDescriptor& xDesc_,
+                       const TensorDescriptor& yDesc_,
+                       const TensorDescriptor& scaleDesc_,
+                       const TensorDescriptor& biasDesc_,
+                       const TensorDescriptor& sMeanDesc_,
+                       const TensorDescriptor& sVarianceDesc_,
+                       const ActivationDescriptor& activDesc_)
+        : direction(Direction::ForwardInference),
+          bn_mode(bn_mode_),
+          xDesc(xDesc_),
+          yOrDyDesc(yDesc_),
+          scaleDesc(scaleDesc_),
+          biasDesc(biasDesc_),
+          sMeanDesc(sMeanDesc_),
+          sVarianceDesc(sVarianceDesc_),
+          useInverseVariance(true),
+          activDesc(activDesc_)
+    {
+        SetSpatialDims();
+        in_layout  = ComputeInLayout();
+        out_layout = ComputeOutLayout();
+    }
+
     // Backward without activation
     ProblemDescription(miopenBatchNormMode_t bn_mode_,
                        const TensorDescriptor& xDesc_,
@@ -334,6 +359,7 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
 
     bool Is2D() const { return xDesc.GetLengths().size() == 4; }
     bool Is3D() const { return xDesc.GetLengths().size() == 5; }
+    bool isInverseVariance() const { return useInverseVariance; }
 
     bool IsFp64() const { return xDesc.GetType() == miopenDouble; }
     bool IsFp32() const { return xDesc.GetType() == miopenFloat; }
@@ -412,6 +438,7 @@ private:
     bool resultsave            = false;
     bool resultrunning         = false;
     bool useSaved              = false;
+    bool useInverseVariance    = false;
     std::string in_layout      = "NCHW";
     std::string out_layout     = "NCHW";
     std::string din_layout     = "NCHW";

--- a/projects/miopen/src/include/miopen/driver_arguments.hpp
+++ b/projects/miopen/src/include/miopen/driver_arguments.hpp
@@ -85,6 +85,7 @@ std::string BnormArgsForMIOpenDriver(miopenTensorDescriptor_t xDesc,
                                      const void* resultSaveInvVariance,
                                      const BatchNormDirection_t& dir,
                                      miopenActivationDescriptor_t activDesc,
+                                     bool useInverseVariance  = false,
                                      bool print_for_bn_driver = true);
 } // namespace debug
 } // namespace miopen

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdInferPerActHIP.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdInferPerActHIP.cpp
@@ -38,6 +38,42 @@ using FLOAT_VEC_TYPE = typename miopen::mapped_vector_type<FLOAT, MIO_BN_VEC_SIZ
 using FLOAT_ACCUM_VEC_TYPE =
     typename miopen::mapped_vector_type<FLOAT_ACCUM, MIO_BN_VEC_SIZE>::type;
 
+__device__ __forceinline__ void BNFwdInferPerActivationImpl(unsigned int adjIndex,
+                                                            const FLOAT* in,
+                                                            FLOAT* out,
+                                                            const FLOAT_ACCUM* mean,
+                                                            const FLOAT_ACCUM* invVariance,
+                                                            const FLOAT_ACCUM* scale,
+                                                            const FLOAT_ACCUM* bias,
+                                                            unsigned int batchSize,
+                                                            unsigned int batchStride)
+{
+    FLOAT_ACCUM inhat[MIO_BN_VEC_SIZE];
+    FLOAT value[MIO_BN_VEC_SIZE];
+
+    // loop over the batches
+    for(unsigned int n = 0; n < batchSize; ++n)
+    {
+        // load input value
+        const unsigned int batchIndex = (n * batchStride) + adjIndex;
+        *(reinterpret_cast<FLOAT_VEC_TYPE*>(value)) =
+            *(reinterpret_cast<const FLOAT_VEC_TYPE*>(in + batchIndex));
+
+        // perform batchnorm operation
+#pragma unroll
+        for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+        {
+            inhat[i] = (CVT_FLOAT2ACCUM(value[i]) - mean[i]) * invVariance[i];
+            inhat[i] = scale[i] * inhat[i] + bias[i];
+            value[i] = CVT_ACCUM2FLOAT(inhat[i]);
+        }
+
+        // write output value
+        *(reinterpret_cast<FLOAT_VEC_TYPE*>(out + batchIndex)) =
+            *(reinterpret_cast<const FLOAT_VEC_TYPE*>(value));
+    }
+}
+
 extern "C" __global__ void __launch_bounds__(blockSize)
     MIOpenBatchNormFwdInferPerActivationEst(const FLOAT* __restrict in,
                                             FLOAT* __restrict out,
@@ -88,28 +124,57 @@ extern "C" __global__ void __launch_bounds__(blockSize)
     {
         invVariance[i] = rsqrt(fabs(variance[i] + static_cast<FLOAT_ACCUM>(epsilon)));
     }
-    FLOAT_ACCUM inhat[MIO_BN_VEC_SIZE];
-    FLOAT value[MIO_BN_VEC_SIZE];
+    BNFwdInferPerActivationImpl(
+        adjIndex, in, out, mean, invVariance, pscale, pbias, batchSize, batchStride);
+}
 
-    // loop over the batches
-    for(unsigned int n = 0; n < batchSize; ++n)
+// Uses estimated inverse variance rather than inverse variance, which avoids need for an
+// epsilon parameter and rsqrt() operations.
+extern "C" __global__ void __launch_bounds__(blockSize)
+    MIOpenBatchNormFwdInferPerActivationEstInvVar(
+        const FLOAT* __restrict in,
+        FLOAT* __restrict out,
+        const FLOAT_ACCUM* __restrict estimatedMean,
+        const FLOAT_ACCUM* __restrict estimatedInvVariance,
+        const FLOAT_ACCUM* __restrict scale,
+        const FLOAT_ACCUM* __restrict bias,
+        unsigned int c,
+        unsigned int hw,
+        unsigned int batchSize,
+        unsigned int cStride,
+        unsigned int hwStride,
+        unsigned int batchStride)
+{
+    unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
+    unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+
+    // decide vector sizes based on problem layout
+    constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
+    constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
+
+    // skip execution for out-of-bound threads
+    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw)
     {
-        // load input value
-        const unsigned int batchIndex = (n * batchStride) + adjIndex;
-        *(reinterpret_cast<FLOAT_VEC_TYPE*>(value)) =
-            *(reinterpret_cast<const FLOAT_VEC_TYPE*>(in + batchIndex));
-
-        // perform batchnorm operation
-#pragma unroll
-        for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
-        {
-            inhat[i] = (CVT_FLOAT2ACCUM(value[i]) - mean[i]) * invVariance[i];
-            inhat[i] = pscale[i] * inhat[i] + pbias[i];
-            value[i] = CVT_ACCUM2FLOAT(inhat[i]);
-        }
-
-        // write output value
-        *(reinterpret_cast<FLOAT_VEC_TYPE*>(out + batchIndex)) =
-            *(reinterpret_cast<const FLOAT_VEC_TYPE*>(value));
+        return;
     }
+
+    // indices for current thread
+    unsigned int adjIndex = (tidx * cStride * vecSizeX) + (tidy * hwStride * vecSizeY);
+
+    // batch parameters and values for current thread
+    FLOAT_ACCUM mean[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM pscale[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM pbias[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM invVariance[MIO_BN_VEC_SIZE];
+    *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(mean)) =
+        *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedMean + adjIndex));
+    *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(invVariance)) =
+        *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedInvVariance + adjIndex));
+    *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pscale)) =
+        *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(scale + adjIndex));
+    *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pbias)) =
+        *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(bias + adjIndex));
+
+    BNFwdInferPerActivationImpl(
+        adjIndex, in, out, mean, invVariance, pscale, pbias, batchSize, batchStride);
 }

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdInferSpatialHIP.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdInferSpatialHIP.cpp
@@ -39,6 +39,52 @@ using FLOAT_VEC_TYPE = typename miopen::mapped_vector_type<FLOAT, MIO_BN_VEC_SIZ
 using FLOAT_ACCUM_VEC_TYPE =
     typename miopen::mapped_vector_type<FLOAT_ACCUM, MIO_BN_VEC_SIZE>::type;
 
+template <unsigned int vecSizeX, unsigned int vecSizeY>
+__device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
+                                                      unsigned int tidy,
+                                                      const FLOAT* in,
+                                                      FLOAT* out,
+                                                      const FLOAT_ACCUM* mean,
+                                                      const FLOAT_ACCUM* invVariance,
+                                                      const FLOAT_ACCUM* scale,
+                                                      const FLOAT_ACCUM* bias,
+                                                      unsigned int batchSize,
+                                                      unsigned int cStride,
+                                                      unsigned int hwStride,
+                                                      unsigned int batchStride,
+                                                      FLOAT_ACCUM alpha,
+                                                      FLOAT_ACCUM beta)
+{
+    FLOAT_ACCUM inhat[MIO_BN_VEC_SIZE];
+    FLOAT value[MIO_BN_VEC_SIZE];
+
+    // loop over the batches
+    for(unsigned int n = 0; n < batchSize; ++n)
+    {
+        // load input value
+        const unsigned int batchIndex =
+            (n * batchStride) + (tidx * cStride * vecSizeX) + (tidy * hwStride * vecSizeY);
+        *(reinterpret_cast<FLOAT_VEC_TYPE*>(value)) =
+            *(reinterpret_cast<const FLOAT_VEC_TYPE*>(in + batchIndex));
+
+        // perform batchnorm and activation
+#pragma unroll
+        for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+        {
+            inhat[i] = (CVT_FLOAT2ACCUM(value[i]) - mean[i]) * invVariance[i];
+            inhat[i] = scale[i] * inhat[i] + bias[i];
+            inhat[i] = miopen::batchnorm::activation_op<FLOAT_ACCUM,
+                                                        miopen::neuron_op_type{MIOPEN_NRN_OP_ID}>(
+                inhat[i], alpha, beta);
+            value[i] = CVT_ACCUM2FLOAT(inhat[i]);
+        }
+
+        // write output value
+        *(reinterpret_cast<FLOAT_VEC_TYPE*>(out + batchIndex)) =
+            *(reinterpret_cast<const FLOAT_VEC_TYPE*>(value));
+    }
+}
+
 extern "C" __global__ void __launch_bounds__(blockSize)
     MIOpenBatchNormFwdInferSpatialEst(const FLOAT* __restrict in,
                                       FLOAT* __restrict out,
@@ -53,8 +99,8 @@ extern "C" __global__ void __launch_bounds__(blockSize)
                                       unsigned int cStride,
                                       unsigned int hwStride,
                                       unsigned int batchStride,
-                                      FLOAT_ACCUM _alpha,
-                                      FLOAT_ACCUM _beta)
+                                      FLOAT_ACCUM alpha,
+                                      FLOAT_ACCUM beta)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
@@ -109,32 +155,101 @@ extern "C" __global__ void __launch_bounds__(blockSize)
     {
         invVariance[i] = rsqrt(fabs(variance[i] + static_cast<FLOAT_ACCUM>(epsilon)));
     }
-    FLOAT_ACCUM inhat[MIO_BN_VEC_SIZE];
-    FLOAT value[MIO_BN_VEC_SIZE];
 
-    // loop over the batches
-    for(unsigned int n = 0; n < batchSize; ++n)
+    BNFwdInferSpatialImpl<vecSizeX, vecSizeY>(tidx,
+                                              tidy,
+                                              in,
+                                              out,
+                                              mean,
+                                              invVariance,
+                                              pscale,
+                                              pbias,
+                                              batchSize,
+                                              cStride,
+                                              hwStride,
+                                              batchStride,
+                                              alpha,
+                                              beta);
+}
+
+// Uses estimated inverse variance rather than inverse variance, which avoids need for an
+// epsilon parameter and rsqrt() operations.
+extern "C" __global__ void __launch_bounds__(blockSize)
+    MIOpenBatchNormFwdInferSpatialEstInvVar(const FLOAT* __restrict in,
+                                            FLOAT* __restrict out,
+                                            const FLOAT_ACCUM* __restrict estimatedMean,
+                                            const FLOAT_ACCUM* __restrict estimatedInvVariance,
+                                            const FLOAT_ACCUM* __restrict scale,
+                                            const FLOAT_ACCUM* __restrict bias,
+                                            unsigned int c,
+                                            unsigned int hw,
+                                            unsigned int batchSize,
+                                            unsigned int cStride,
+                                            unsigned int hwStride,
+                                            unsigned int batchStride,
+                                            FLOAT_ACCUM alpha,
+                                            FLOAT_ACCUM beta)
+{
+    unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
+    unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+
+    // decide vector sizes based on problem layout
+    constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
+    constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
+
+    // skip execution for out-of-bound threads
+    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw)
     {
-        // load input value
-        const unsigned int batchIndex =
-            (n * batchStride) + (tidx * cStride * vecSizeX) + (tidy * hwStride * vecSizeY);
-        *(reinterpret_cast<FLOAT_VEC_TYPE*>(value)) =
-            *(reinterpret_cast<const FLOAT_VEC_TYPE*>(in + batchIndex));
+        return;
+    }
 
-        // perform batchnorm and activation
+    // indices for current thread
+    unsigned int adjIndex = tidx * vecSizeX;
+
+    // batch parameters and values for current thread
+    FLOAT_ACCUM mean[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM pscale[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM pbias[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM invVariance[MIO_BN_VEC_SIZE];
+    if constexpr(MIO_LAYOUT_NHWC)
+    {
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(mean)) =
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedMean + adjIndex));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(invVariance)) =
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedInvVariance + adjIndex));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pscale)) =
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(scale + adjIndex));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pbias)) =
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(bias + adjIndex));
+    }
+    else // NCHW layout
+    {
+        const auto mean_val        = estimatedMean[adjIndex];
+        const auto invVariance_val = estimatedInvVariance[adjIndex];
+        const auto pscale_val      = scale[adjIndex];
+        const auto pbias_val       = bias[adjIndex];
 #pragma unroll
         for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
         {
-            inhat[i] = (CVT_FLOAT2ACCUM(value[i]) - mean[i]) * invVariance[i];
-            inhat[i] = pscale[i] * inhat[i] + pbias[i];
-            inhat[i] = miopen::batchnorm::activation_op<FLOAT_ACCUM,
-                                                        miopen::neuron_op_type{MIOPEN_NRN_OP_ID}>(
-                inhat[i], _alpha, _beta);
-            value[i] = CVT_ACCUM2FLOAT(inhat[i]);
+            mean[i]        = mean_val;
+            invVariance[i] = invVariance_val;
+            pscale[i]      = pscale_val;
+            pbias[i]       = pbias_val;
         }
-
-        // write output value
-        *(reinterpret_cast<FLOAT_VEC_TYPE*>(out + batchIndex)) =
-            *(reinterpret_cast<const FLOAT_VEC_TYPE*>(value));
     }
+
+    BNFwdInferSpatialImpl<vecSizeX, vecSizeY>(tidx,
+                                              tidy,
+                                              in,
+                                              out,
+                                              mean,
+                                              invVariance,
+                                              pscale,
+                                              pbias,
+                                              batchSize,
+                                              cStride,
+                                              hwStride,
+                                              batchStride,
+                                              alpha,
+                                              beta);
 }

--- a/projects/miopen/src/ocl/batchnormocl.cpp
+++ b/projects/miopen/src/ocl/batchnormocl.cpp
@@ -287,24 +287,15 @@ void BatchNormForwardInference(const Handle& handle,
         // variance don't require and epsilon paramter. If epsilonOpt doesn't have a value then
         // treat the estimatedVariance parameter as inverse variance rather than variance.
         const bool useInverseVariance = !epsilonOpt.has_value();
-
-        const auto problem = useInverseVariance ? batchnorm::ProblemDescription{bn_mode,
-                                                                                xDesc,
-                                                                                yDesc,
-                                                                                scaleDesc,
-                                                                                biasDesc,
-                                                                                estMeanDesc,
-                                                                                estVarianceDesc,
-                                                                                activDesc}
-                                                : batchnorm::ProblemDescription{bn_mode,
-                                                                                xDesc,
-                                                                                yDesc,
-                                                                                scaleDesc,
-                                                                                biasDesc,
-                                                                                estMeanDesc,
-                                                                                estVarianceDesc,
-                                                                                epsilonOpt.value(),
-                                                                                activDesc};
+        const auto problem            = batchnorm::ProblemDescription{bn_mode,
+                                                           xDesc,
+                                                           yDesc,
+                                                           scaleDesc,
+                                                           biasDesc,
+                                                           estMeanDesc,
+                                                           estVarianceDesc,
+                                                           epsilonOpt,
+                                                           activDesc};
 
         const auto invoke_params = [&]() {
             auto tmp              = batchnorm::InfInvokeParams{};

--- a/projects/miopen/src/ocl/batchnormocl.cpp
+++ b/projects/miopen/src/ocl/batchnormocl.cpp
@@ -241,7 +241,7 @@ void BatchNormForwardInference(const Handle& handle,
                                ConstData_t bnBias,
                                ConstData_t estimatedMean,
                                ConstData_t estimatedVariance,
-                               double epsilon,
+                               std::optional<double> epsilonOpt,
                                const ActivationDescriptor& activDesc)
 {
 
@@ -283,15 +283,28 @@ void BatchNormForwardInference(const Handle& handle,
             MIOPEN_THROW(miopenStatusBadParm);
         }
 
-        const auto problem = batchnorm::ProblemDescription{bn_mode,
-                                                           xDesc,
-                                                           yDesc,
-                                                           scaleDesc,
-                                                           biasDesc,
-                                                           estMeanDesc,
-                                                           estVarianceDesc,
-                                                           epsilon,
-                                                           activDesc};
+        // The BN forward inference APIs taking an estimated inverse variance rather than a
+        // variance don't require and epsilon paramter. If epsilonOpt doesn't have a value then
+        // treat the estimatedVariance parameter as inverse variance rather than variance.
+        const bool useInverseVariance = !epsilonOpt.has_value();
+
+        const auto problem = useInverseVariance ? batchnorm::ProblemDescription{bn_mode,
+                                                                                xDesc,
+                                                                                yDesc,
+                                                                                scaleDesc,
+                                                                                biasDesc,
+                                                                                estMeanDesc,
+                                                                                estVarianceDesc,
+                                                                                activDesc}
+                                                : batchnorm::ProblemDescription{bn_mode,
+                                                                                xDesc,
+                                                                                yDesc,
+                                                                                scaleDesc,
+                                                                                biasDesc,
+                                                                                estMeanDesc,
+                                                                                estVarianceDesc,
+                                                                                epsilonOpt.value(),
+                                                                                activDesc};
 
         const auto invoke_params = [&]() {
             auto tmp              = batchnorm::InfInvokeParams{};
@@ -303,11 +316,16 @@ void BatchNormForwardInference(const Handle& handle,
             tmp.bnBias            = bnBias;
             tmp.estimatedMean     = estimatedMean;
             tmp.estimatedVariance = estimatedVariance;
-            tmp.epsilon           = epsilon;
+            if(!useInverseVariance)
+            {
+                tmp.epsilon = epsilonOpt.value();
+            }
             return tmp;
         }();
 
-        const auto algo    = AlgorithmName{"miopenBatchNormalizationForwardInference"};
+        const auto algo    = useInverseVariance
+                                 ? AlgorithmName{"miopenBatchNormalizationForwardInferenceInvVariance"}
+                                 : AlgorithmName{"miopenBatchNormalizationForwardInference"};
         const auto solvers = solver::SolverContainer<solver::batchnorm::BnFwdInference>{};
 
         solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
@@ -332,7 +350,7 @@ void BatchNormForwardInference(const Handle& handle,
                                  0,
                                  nullptr,
                                  nullptr,
-                                 epsilon,
+                                 epsilonOpt.value_or(1e-5),
                                  nullptr,
                                  nullptr,
                                  activDesc);

--- a/projects/miopen/src/solver/batchnorm/forward_inference.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_inference.cpp
@@ -124,11 +124,19 @@ ConvSolution BnFwdInference::GetSolution(const ExecutionContext& context,
         { // SPATIAL kernels
             kernel.kernel_file += "SpatialHIP.cpp";
             kernel.kernel_name += "SpatialEst";
+            if(problem.isInverseVariance())
+            {
+                kernel.kernel_name += "InvVar";
+            }
         }
         else
         { // PER ACTIVATION
             kernel.kernel_file += "PerActHIP.cpp";
             kernel.kernel_name += "PerActivationEst";
+            if(problem.isInverseVariance())
+            {
+                kernel.kernel_name += "InvVar";
+            }
         }
 
         const auto build_params = KernelBuildParameters{
@@ -176,39 +184,79 @@ ConvSolution BnFwdInference::GetSolution(const ExecutionContext& context,
 
             if(params.xDesc->GetLayout_t() == miopenTensorNHWC)
             {
-                kernel(params.x,
-                       params.y,
-                       params.estimatedMean,
-                       params.estimatedVariance,
-                       params.bnScale,
-                       params.bnBias,
-                       params.epsilon,
-                       c_,
-                       h_ * w_,
-                       n_,
-                       1,           // cStride
-                       c_,          // hwStride
-                       in_nstride_, // batchStride
-                       alpha_activ,
-                       beta_activ);
+                if(problem.isInverseVariance())
+                {
+                    kernel(params.x,
+                           params.y,
+                           params.estimatedMean,
+                           params.estimatedVariance,
+                           params.bnScale,
+                           params.bnBias,
+                           c_,
+                           h_ * w_,
+                           n_,
+                           1,           // cStride
+                           c_,          // hwStride
+                           in_nstride_, // batchStride
+                           alpha_activ,
+                           beta_activ);
+                }
+                else
+                {
+                    kernel(params.x,
+                           params.y,
+                           params.estimatedMean,
+                           params.estimatedVariance,
+                           params.bnScale,
+                           params.bnBias,
+                           params.epsilon,
+                           c_,
+                           h_ * w_,
+                           n_,
+                           1,           // cStride
+                           c_,          // hwStride
+                           in_nstride_, // batchStride
+                           alpha_activ,
+                           beta_activ);
+                }
             }
             else
             {
-                kernel(params.x,
-                       params.y,
-                       params.estimatedMean,
-                       params.estimatedVariance,
-                       params.bnScale,
-                       params.bnBias,
-                       params.epsilon,
-                       c_,
-                       h_ * w_,
-                       n_,
-                       h_ * w_,     // cStride
-                       1,           // hwStride
-                       in_nstride_, // batchStride
-                       alpha_activ,
-                       beta_activ);
+                if(problem.isInverseVariance())
+                {
+                    kernel(params.x,
+                           params.y,
+                           params.estimatedMean,
+                           params.estimatedVariance,
+                           params.bnScale,
+                           params.bnBias,
+                           c_,
+                           h_ * w_,
+                           n_,
+                           h_ * w_,     // cStride
+                           1,           // hwStride
+                           in_nstride_, // batchStride
+                           alpha_activ,
+                           beta_activ);
+                }
+                else
+                {
+                    kernel(params.x,
+                           params.y,
+                           params.estimatedMean,
+                           params.estimatedVariance,
+                           params.bnScale,
+                           params.bnBias,
+                           params.epsilon,
+                           c_,
+                           h_ * w_,
+                           n_,
+                           h_ * w_,     // cStride
+                           1,           // hwStride
+                           in_nstride_, // batchStride
+                           alpha_activ,
+                           beta_activ);
+                }
             }
         };
     };

--- a/projects/miopen/test/fusionHost.hpp
+++ b/projects/miopen/test/fusionHost.hpp
@@ -140,15 +140,17 @@ void batchNormSpatialHostInference(const tensor<T>& input,
                                    const tensor<U>& bias,
                                    double epsilon,
                                    const tensor<V>& estimatedMean,
-                                   const tensor<V>& estimatedVariance)
+                                   const tensor<V>& estimatedVariance,
+                                   bool useInverseVariance = false)
 {
 
     int n_batches, channels, height, width;
     std::tie(n_batches, channels, height, width) = miopen::tien<4>(input.desc.GetLengths());
     miopen::par_for(channels, 1, [&](int cidx) { // via channel
-        V mean           = estimatedMean(0, cidx, 0, 0);
-        V variance       = estimatedVariance(0, cidx, 0, 0);
-        double invertVar = 1.0 / sqrt(variance + epsilon);
+        V mean     = estimatedMean(0, cidx, 0, 0);
+        V variance = estimatedVariance(0, cidx, 0, 0);
+        double invertVar =
+            useInverseVariance ? static_cast<double>(variance) : 1.0 / sqrt(variance + epsilon);
         // process the batch per channel
         for(int row = 0; row < height; row++)
         { // via rows
@@ -174,7 +176,8 @@ void batchNormPerActivHostInference(const tensor<T>& input,
                                     const tensor<U>& bias,
                                     double epsilon,
                                     const tensor<V>& estimatedMean,
-                                    const tensor<V>& estimatedVariance)
+                                    const tensor<V>& estimatedVariance,
+                                    bool useInverseVariance = false)
 {
     int n_batches, channels, height, width;
     std::tie(n_batches, channels, height, width) = miopen::tien<4>(input.desc.GetLengths());
@@ -186,7 +189,7 @@ void batchNormPerActivHostInference(const tensor<T>& input,
                 // apply down the n_batch dimension
                 double mean       = estimatedMean(0, cidx, row, column);
                 double variance   = estimatedVariance(0, cidx, row, column);
-                double elemInvVar = 1.0 / sqrt(variance + epsilon);
+                double elemInvVar = useInverseVariance ? variance : 1.0 / sqrt(variance + epsilon);
                 for(int bidx = 0; bidx < n_batches; bidx++)
                 { // via mini_batch
                     // per (x-dims) channel load a block of data into LDS

--- a/projects/miopen/test/gtest/bn.hpp
+++ b/projects/miopen/test/gtest/bn.hpp
@@ -39,6 +39,7 @@ enum BNApiType
 {
     testBNAPIV1,
     testBNAPIV2,
+    testBNAPIInvVar,
 };
 
 // Assuming miopenTensorLayout_t and testAPI_t are the types of your enums
@@ -60,6 +61,7 @@ static std::string ApiVerisonToString(int api_version)
     {
     case testBNAPIV1: return "testBNAPIV1";
     case testBNAPIV2: return "testBNAPIV2";
+    case testBNAPIInvVar: return "testBNAPIInvVar";
     default: return "UnknownAPIVersion";
     }
 }
@@ -157,7 +159,8 @@ protected:
     {
         std::tie(bn_config, tensor_layout, bn_mode, api_type, bn_infer_test_data.activ_mode) =
             this->GetParam();
-        bn_infer_test_data.SetUpImpl(bn_config, bn_mode, tensor_layout);
+        bn_infer_test_data.SetUpImpl(
+            bn_config, bn_mode, tensor_layout, (api_type == BNApiType::testBNAPIInvVar));
 
         bn_infer_test_data.activ_alpha = 0.1;
         bn_infer_test_data.activ_beta  = 0.3;
@@ -173,29 +176,60 @@ protected:
                                           bn_infer_test_data.activ_alpha,
                                           bn_infer_test_data.activ_beta,
                                           0.0);
+
             if(tuning_policy == miopenTuningPolicy_t::miopenTuningPolicySearch)
             {
                 miopenSetTuningPolicy(&handle, tuning_policy); // set tuning
             }
-            res =
-                miopenBatchNormForwardInferenceActivation(&handle,
-                                                          bn_mode,
-                                                          &bn_infer_test_data.alpha,
-                                                          &bn_infer_test_data.beta,
-                                                          &bn_infer_test_data.input.desc,
-                                                          bn_infer_test_data.in_dev.get(),
-                                                          &bn_infer_test_data.output.desc,
-                                                          bn_infer_test_data.out_dev.get(),
-                                                          &bn_infer_test_data.scale.desc,
-                                                          &bn_infer_test_data.shift.desc,
-                                                          &bn_infer_test_data.estMean.desc,
-                                                          &bn_infer_test_data.estVariance.desc,
-                                                          bn_infer_test_data.scale_dev.get(),
-                                                          bn_infer_test_data.shift_dev.get(),
-                                                          bn_infer_test_data.estMean_dev.get(),
-                                                          bn_infer_test_data.estVariance_dev.get(),
-                                                          bn_infer_test_data.epsilon,
-                                                          activ_desc);
+
+            if(api_type == BNApiType::testBNAPIV1)
+            {
+                res = miopenBatchNormForwardInferenceActivation(
+                    &handle,
+                    bn_mode,
+                    &bn_infer_test_data.alpha,
+                    &bn_infer_test_data.beta,
+                    &bn_infer_test_data.input.desc,
+                    bn_infer_test_data.in_dev.get(),
+                    &bn_infer_test_data.output.desc,
+                    bn_infer_test_data.out_dev.get(),
+                    &bn_infer_test_data.scale.desc,
+                    &bn_infer_test_data.shift.desc,
+                    &bn_infer_test_data.estMean.desc,
+                    &bn_infer_test_data.estVariance.desc,
+                    bn_infer_test_data.scale_dev.get(),
+                    bn_infer_test_data.shift_dev.get(),
+                    bn_infer_test_data.estMean_dev.get(),
+                    bn_infer_test_data.estVariance_dev.get(),
+                    bn_infer_test_data.epsilon,
+                    activ_desc);
+            }
+            else if(api_type == BNApiType::testBNAPIInvVar)
+            {
+                res = miopenBatchNormForwardInferenceActivationInvVariance(
+                    &handle,
+                    bn_mode,
+                    &bn_infer_test_data.alpha,
+                    &bn_infer_test_data.beta,
+                    &bn_infer_test_data.input.desc,
+                    bn_infer_test_data.in_dev.get(),
+                    &bn_infer_test_data.output.desc,
+                    bn_infer_test_data.out_dev.get(),
+                    &bn_infer_test_data.scale.desc,
+                    &bn_infer_test_data.shift.desc,
+                    &bn_infer_test_data.estMean.desc,
+                    &bn_infer_test_data.estVariance.desc,
+                    bn_infer_test_data.scale_dev.get(),
+                    bn_infer_test_data.shift_dev.get(),
+                    bn_infer_test_data.estMean_dev.get(),
+                    bn_infer_test_data.estVariance_dev.get(),
+                    activ_desc);
+            }
+            else
+            {
+                GTEST_FAIL() << "ERROR: unknown bn api type!!";
+            }
+
             if(tuning_policy == miopenTuningPolicy_t::miopenTuningPolicySearch)
             {
                 miopenSetTuningPolicy(&handle,
@@ -205,12 +239,12 @@ protected:
         }
         else
         {
+            if(tuning_policy == miopenTuningPolicy_t::miopenTuningPolicySearch)
+            {
+                miopenSetTuningPolicy(&handle, tuning_policy); // set tuning
+            }
             if(api_type == BNApiType::testBNAPIV1)
             {
-                if(tuning_policy == miopenTuningPolicy_t::miopenTuningPolicySearch)
-                {
-                    miopenSetTuningPolicy(&handle, tuning_policy); // set tuning
-                }
                 res = miopenBatchNormalizationForwardInference(
                     &handle,
                     bn_mode,
@@ -226,18 +260,9 @@ protected:
                     bn_infer_test_data.estMean_dev.get(),
                     bn_infer_test_data.estVariance_dev.get(),
                     bn_infer_test_data.epsilon);
-                if(tuning_policy == miopenTuningPolicy_t::miopenTuningPolicySearch)
-                {
-                    miopenSetTuningPolicy(
-                        &handle, miopenTuningPolicy_t::miopenTuningPolicyNone); // unset tuning
-                }
             }
             else if(api_type == BNApiType::testBNAPIV2)
             {
-                if(tuning_policy == miopenTuningPolicy_t::miopenTuningPolicySearch)
-                {
-                    miopenSetTuningPolicy(&handle, tuning_policy); // set tuning
-                }
                 res = miopenBatchNormalizationForwardInference_V2(
                     &handle,
                     bn_mode,
@@ -256,14 +281,37 @@ protected:
                     bn_infer_test_data.estMean_dev.get(),
                     bn_infer_test_data.estVariance_dev.get(),
                     bn_infer_test_data.epsilon);
-                if(tuning_policy == miopenTuningPolicy_t::miopenTuningPolicySearch)
-                {
-                    miopenSetTuningPolicy(
-                        &handle, miopenTuningPolicy_t::miopenTuningPolicyNone); // unset tuning
-                }
+            }
+            else if(api_type == BNApiType::testBNAPIInvVar)
+            {
+                res = miopenBatchNormalizationForwardInferenceInvVariance(
+                    &handle,
+                    bn_mode,
+                    &bn_infer_test_data.alpha,
+                    &bn_infer_test_data.beta,
+                    &bn_infer_test_data.input.desc,
+                    bn_infer_test_data.in_dev.get(),
+                    &bn_infer_test_data.output.desc,
+                    bn_infer_test_data.out_dev.get(),
+                    &bn_infer_test_data.scale.desc,
+                    &bn_infer_test_data.shift.desc,
+                    &bn_infer_test_data.estMean.desc,
+                    &bn_infer_test_data.estVariance.desc,
+                    bn_infer_test_data.scale_dev.get(),
+                    bn_infer_test_data.shift_dev.get(),
+                    bn_infer_test_data.estMean_dev.get(),
+                    bn_infer_test_data.estVariance_dev.get());
             }
             else
+            {
                 GTEST_FAIL() << "ERROR: unknown bn api type!!";
+            }
+
+            if(tuning_policy == miopenTuningPolicy_t::miopenTuningPolicySearch)
+            {
+                miopenSetTuningPolicy(&handle,
+                                      miopenTuningPolicy_t::miopenTuningPolicyNone); // unset tuning
+            }
         }
         if(res != miopenStatusSuccess)
         {

--- a/projects/miopen/test/gtest/bn_infer.cpp
+++ b/projects/miopen/test/gtest/bn_infer.cpp
@@ -126,29 +126,29 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
                                           testing::ValuesIn({miopenBNSpatial,
                                                              miopenBNPerActivation}),
-                                          testing::ValuesIn({testBNAPIV2}),
+                                          testing::ValuesIn({testBNAPIV2, testBNAPIInvVar}),
                                           testing::ValuesIn({miopenActivationPASTHRU})),
                          TestNameGenerator<BN2DTestCase>());
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_BNOCLInferLarge2D_FP16,
-                         testing::Combine(testing::ValuesIn(Network2DLarge<BN2DTestCase>()),
-                                          testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
-                                          testing::ValuesIn({miopenBNSpatial,
-                                                             miopenBNPerActivation}),
-                                          testing::ValuesIn({testBNAPIV1, testBNAPIV2}),
-                                          testing::ValuesIn({miopenActivationPASTHRU})),
-                         TestNameGenerator<BN2DTestCase>());
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_BNOCLInferLarge2D_FP16,
+    testing::Combine(testing::ValuesIn(Network2DLarge<BN2DTestCase>()),
+                     testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
+                     testing::ValuesIn({miopenBNSpatial, miopenBNPerActivation}),
+                     testing::ValuesIn({testBNAPIV1, testBNAPIV2, testBNAPIInvVar}),
+                     testing::ValuesIn({miopenActivationPASTHRU})),
+    TestNameGenerator<BN2DTestCase>());
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_BNOCLInferLarge3D_FP16,
-                         testing::Combine(testing::ValuesIn(Network3DBN<BN3DTestCase>()),
-                                          testing::ValuesIn({miopenTensorNCDHW, miopenTensorNDHWC}),
-                                          testing::ValuesIn({miopenBNSpatial,
-                                                             miopenBNPerActivation}),
-                                          testing::ValuesIn({testBNAPIV1, testBNAPIV2}),
-                                          testing::ValuesIn({miopenActivationPASTHRU})),
-                         TestNameGenerator<BN3DTestCase>());
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_BNOCLInferLarge3D_FP16,
+    testing::Combine(testing::ValuesIn(Network3DBN<BN3DTestCase>()),
+                     testing::ValuesIn({miopenTensorNCDHW, miopenTensorNDHWC}),
+                     testing::ValuesIn({miopenBNSpatial, miopenBNPerActivation}),
+                     testing::ValuesIn({testBNAPIV1, testBNAPIV2, testBNAPIInvVar}),
+                     testing::ValuesIn({miopenActivationPASTHRU})),
+    TestNameGenerator<BN3DTestCase>());
 // bfp16
 INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_BNCKInferLarge2D_BFP16,
@@ -156,29 +156,29 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
                                           testing::ValuesIn({miopenBNSpatial,
                                                              miopenBNPerActivation}),
-                                          testing::ValuesIn({testBNAPIV2}),
+                                          testing::ValuesIn({testBNAPIV2, testBNAPIInvVar}),
                                           testing::ValuesIn({miopenActivationPASTHRU})),
                          TestNameGenerator<BN2DTestCase>());
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_BNOCLInferLarge2D_BFP16,
-                         testing::Combine(testing::ValuesIn(Network2DLarge<BN2DTestCase>()),
-                                          testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
-                                          testing::ValuesIn({miopenBNSpatial,
-                                                             miopenBNPerActivation}),
-                                          testing::ValuesIn({testBNAPIV1, testBNAPIV2}),
-                                          testing::ValuesIn({miopenActivationPASTHRU})),
-                         TestNameGenerator<BN2DTestCase>());
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_BNOCLInferLarge2D_BFP16,
+    testing::Combine(testing::ValuesIn(Network2DLarge<BN2DTestCase>()),
+                     testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
+                     testing::ValuesIn({miopenBNSpatial, miopenBNPerActivation}),
+                     testing::ValuesIn({testBNAPIV1, testBNAPIV2, testBNAPIInvVar}),
+                     testing::ValuesIn({miopenActivationPASTHRU})),
+    TestNameGenerator<BN2DTestCase>());
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_BNOCLInferLarge3D_BFP16,
-                         testing::Combine(testing::ValuesIn(Network3DBN<BN3DTestCase>()),
-                                          testing::ValuesIn({miopenTensorNCDHW, miopenTensorNDHWC}),
-                                          testing::ValuesIn({miopenBNSpatial,
-                                                             miopenBNPerActivation}),
-                                          testing::ValuesIn({testBNAPIV1, testBNAPIV2}),
-                                          testing::ValuesIn({miopenActivationPASTHRU})),
-                         TestNameGenerator<BN3DTestCase>());
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_BNOCLInferLarge3D_BFP16,
+    testing::Combine(testing::ValuesIn(Network3DBN<BN3DTestCase>()),
+                     testing::ValuesIn({miopenTensorNCDHW, miopenTensorNDHWC}),
+                     testing::ValuesIn({miopenBNSpatial, miopenBNPerActivation}),
+                     testing::ValuesIn({testBNAPIV1, testBNAPIV2, testBNAPIInvVar}),
+                     testing::ValuesIn({miopenActivationPASTHRU})),
+    TestNameGenerator<BN3DTestCase>());
 
 // fp32
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -197,7 +197,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
                                           testing::ValuesIn({miopenBNSpatial,
                                                              miopenBNPerActivation}),
-                                          testing::ValuesIn({testBNAPIV2}),
+                                          testing::ValuesIn({testBNAPIV2, testBNAPIInvVar}),
                                           testing::ValuesIn({miopenActivationPASTHRU})),
                          TestNameGenerator<BN2DTestCase>());
 
@@ -207,7 +207,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn({miopenTensorNCDHW, miopenTensorNDHWC}),
                                           testing::ValuesIn({miopenBNSpatial,
                                                              miopenBNPerActivation}),
-                                          testing::ValuesIn({testBNAPIV2}),
+                                          testing::ValuesIn({testBNAPIV2, testBNAPIInvVar}),
                                           testing::ValuesIn({miopenActivationPASTHRU})),
                          TestNameGenerator<BN3DTestCase>());
 // fp64
@@ -227,6 +227,6 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
                                           testing::ValuesIn({miopenBNSpatial,
                                                              miopenBNPerActivation}),
-                                          testing::ValuesIn({testBNAPIV2}),
+                                          testing::ValuesIn({testBNAPIV2, testBNAPIInvVar}),
                                           testing::ValuesIn({miopenActivationPASTHRU})),
                          TestNameGenerator<BN2DTestCase>());

--- a/projects/miopen/test/gtest/bn_infer_activation.cpp
+++ b/projects/miopen/test/gtest/bn_infer_activation.cpp
@@ -48,7 +48,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          testing::Combine(testing::ValuesIn(Network2DLarge<BN2DTestCase>()),
                                           testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
                                           testing::ValuesIn({miopenBNSpatial}),
-                                          testing::ValuesIn({testBNAPIV1}),
+                                          testing::ValuesIn({testBNAPIV1, testBNAPIInvVar}),
                                           testing::ValuesIn({miopenActivationCLAMP})),
                          TestNameGenerator<BN2DTestCase>());
 
@@ -58,6 +58,6 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          testing::Combine(testing::ValuesIn(Network2DLarge<BN2DTestCase>()),
                                           testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC}),
                                           testing::ValuesIn({miopenBNSpatial}),
-                                          testing::ValuesIn({testBNAPIV1}),
+                                          testing::ValuesIn({testBNAPIV1, testBNAPIInvVar}),
                                           testing::ValuesIn({miopenActivationCLAMP})),
                          TestNameGenerator<BN2DTestCase>());

--- a/projects/miopen/test/gtest/bn_test_data.hpp
+++ b/projects/miopen/test/gtest/bn_test_data.hpp
@@ -284,11 +284,14 @@ template <typename XDataType,
           typename TConfig>
 struct BNInferTestData : public BNTestData<XDataType, YDataType, AccDataType, TConfig>
 {
-    void
-    SetUpImpl(const TConfig& config, miopenBatchNormMode_t t_bnmode, miopenTensorLayout_t t_layout)
+    void SetUpImpl(const TConfig& config,
+                   miopenBatchNormMode_t t_bnmode,
+                   miopenTensorLayout_t t_layout,
+                   bool useInverseVariance_)
     {
         BNTestData<XDataType, YDataType, AccDataType, TConfig>::SetUpImpl(
             config, t_bnmode, t_layout);
+        useInverseVariance = useInverseVariance_;
         CreateTensors();
         InitTensorsWithRandValue();
         WriteToGPU();
@@ -308,6 +311,7 @@ struct BNInferTestData : public BNTestData<XDataType, YDataType, AccDataType, TC
     double activ_alpha;
     double activ_beta;
     miopenActivationMode_t activ_mode;
+    bool useInverseVariance = false;
 
 private:
     void CreateTensors()
@@ -338,10 +342,19 @@ private:
         shift.generate(uniform_signed_initializer<BiasDataType>(2e-3 /*scale*/, 1000 /*range*/));
         estMean.generate(
             uniform_signed_initializer<MeanVarDataType>(2e-3 /*scale*/, 1000 /*range*/));
-        // estVaraince has to be +ve number otherwise 1/sqrt(-ve) would
-        // give img number
-        estVariance.generate(
-            uniform_unsigned_initializer<MeanVarDataType>(2e-3 /*scale*/, 1000 /*range*/));
+        if(useInverseVariance)
+        {
+            // Given an epsilon of 1e-5, the max value is 1/sqrt(epsilon) ==> 316.228
+            // Given a max variance of 2, the min value is 1/sqrt(epsilon + 2.0) ==> 0.7
+            estVariance.generate(uniform_unsigned_initializer<MeanVarDataType>(0.7, 317));
+        }
+        else
+        {
+            // estVaraince has to be +ve number otherwise 1/sqrt(-ve) would
+            // give img number
+            estVariance.generate(
+                uniform_unsigned_initializer<MeanVarDataType>(2e-3 /*scale*/, 1000 /*range*/));
+        }
     }
     void WriteToGPU()
     {

--- a/projects/miopen/test/gtest/test_operations.hpp
+++ b/projects/miopen/test/gtest/test_operations.hpp
@@ -53,7 +53,8 @@ void ComputeCPUBNInference(DLModule& dl_module)
                                       dl_module.shift,
                                       dl_module.epsilon,
                                       dl_module.estMean,
-                                      dl_module.estVariance);
+                                      dl_module.estVariance,
+                                      dl_module.useInverseVariance);
     }
     else if(dl_module.bn_mode == miopenBNPerActivation)
     {
@@ -63,7 +64,8 @@ void ComputeCPUBNInference(DLModule& dl_module)
                                        dl_module.shift,
                                        dl_module.epsilon,
                                        dl_module.estMean,
-                                       dl_module.estVariance);
+                                       dl_module.estVariance,
+                                       dl_module.useInverseVariance);
     }
     else
     {


### PR DESCRIPTION
## Motivation

Introduces two new MIOpen APIs for Batch Norm forward inference:
* `miopenBatchNormalizationForwardInferenceInvVariance`
* `miopenBatchNormForwardInferenceActivationInvVariance`

They both take the estimated inverse variance as a parameter, rather than estimated variance, and as a result don't need the epsilon parameter.

These will be used by hipDNN graph API for BatchnormFwdInference which use inverse variance rather than variance as the input tensor. See https://github.com/ROCm/rocm-libraries/issues/2459

## Technical Details

Reuses the existing `BnFwdInference` solver but in the BN problem description object a new member variable is added to track whether it was inverse variance used in the problem. A different kernel is called by the solver if this is the case, which can omit the `rsqrt()` operations the variant with regular variance is required to perform.

MIOpenDriver is also updated to use the new APIs when running forward inference when the `-I`/`--inverse_variance` option is non-zero, where zero is the default. This makes it explicit when the new APIs are being used rather than change from behavior from underneath users feet. There is also a modification to the driver help message because it should be `bnorm[fp16|bfp16]` rather than just `bnorm[fp16]` as `bfp16` is available to use.

## Test Plan

Extends the `test_bn_infer` and `test_bn_infer_activation` tests to cover the new APIs.

Follow on PR to hipDNN using this API also works as expected - https://github.com/ROCm/rocm-libraries/pull/3619

## Test Result

New tests pass on gfx90a & gfx942

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
