### PR TITLE
[MIOpen] Temporary disable wmma kernel for CK grouped conv

### DIFF
--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -256,6 +256,10 @@ struct CKArgs
     template <typename ConvPtr>
     bool IsSupportedBy(const ConvPtr& conv_ptr) const
     {
+        // TODO: Remove this limitation for CK Wmma instances
+        if(conv_ptr->GetTypeString().find("Wmma") != -1) {
+            return false;
+        }
         auto arg_ptr        = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, 1);
         auto workspace_size = conv_ptr->GetWorkSpaceSize(arg_ptr.get());
         if(workspace_size != 0)
@@ -266,6 +270,10 @@ struct CKArgs
     template <typename ConvPtr>
     bool IsSupportedBySplitK(const ConvPtr& conv_ptr, int split_k) const
     {
+        // TODO: Remove this limitation for CK Wmma instances
+        if(conv_ptr->GetTypeString().find("Wmma") != -1) {
+            return false;
+        }
         auto arg_ptr        = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, split_k);
         auto workspace_size = conv_ptr->GetWorkSpaceSize(arg_ptr.get());
         if(workspace_size != 0)

--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -165,6 +165,10 @@ struct CKArgs
     template <typename ConvPtr>
     bool IsSupportedBy(const ConvPtr& conv_ptr) const
     {
+        // TODO: Remove this limitation for CK Wmma instances
+        if(conv_ptr->GetTypeString().find("Wmma") != -1) {
+            return false;
+        }
         auto arg_ptr        = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, 1);
         auto workspace_size = conv_ptr->GetWorkSpaceSize(arg_ptr.get());
         if(workspace_size != 0)
@@ -175,6 +179,10 @@ struct CKArgs
     template <typename ConvPtr>
     bool IsSupportedBySplitK(const ConvPtr& conv_ptr, int split_k) const
     {
+        // TODO: Remove this limitation for CK Wmma instances
+        if(conv_ptr->GetTypeString().find("Wmma") != -1) {
+            return false;
+        }
         auto arg_ptr        = MakeArgPtr(conv_ptr, nullptr, nullptr, nullptr, 1.0f, 0.0f, split_k);
         auto workspace_size = conv_ptr->GetWorkSpaceSize(arg_ptr.get());
         if(workspace_size != 0)


### PR DESCRIPTION
## Motivation

Temporary disable wmma kernels for CK grouped Convolution in miopen to resolve runtime problems.

## Technical Details

New wmma kernels resulted with problems for gfx9

## Test Plan

test_group_conv2d_wrw can reproduce it

## Test Result

At now pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
