### PR TITLE
[TheRock CI] Updating TheRock CI Linux build container hash

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:4443d9d710b9471e8ef658d509358bd92602498e67161b9280474bce0bb0decd
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:583d473f263a289222c48d4b493e2956b2354a45796f09dee6f2c8ecd4504ab6
       options: -v /runner/config:/home/awsconfig/
     strategy:
       fail-fast: true


### PR DESCRIPTION
## Motivation

Noticing that `therock-gmp` is failing as specific tools are missing. Failed here: https://github.com/ROCm/rocm-libraries/actions/runs/20437918799/job/58723710808

## Technical Details

Updating TheRock CI Linux build container hash

## Test Plan

Testing with CI runs locally (https://github.com/ROCm/rocm-libraries/actions/runs/20442604580/job/58738943103)

## Test Result

Works here: (https://github.com/ROCm/rocm-libraries/actions/runs/20442604580/job/58738943103

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
