### PR TITLE
[hipblaslt] Refactor api_method handling: use enum and unify argument mapping

### DIFF
--- a/projects/hipblaslt/clients/bench/src/client.cpp
+++ b/projects/hipblaslt/clients/bench/src/client.cpp
@@ -80,6 +80,25 @@ int run_bench_test(Arguments&         arg,
     // Enable information cout
     arg.print_solution_found = true;
 
+    switch(arg.api_method)
+    {
+    case 0:
+        arg.use_ext            = false;
+        arg.use_ext_setproblem = false;
+        break;
+    case 1:
+        arg.use_ext            = true;
+        arg.use_ext_setproblem = false;
+        break;
+    case 2:
+        arg.use_ext            = true;
+        arg.use_ext_setproblem = true;
+        break;
+    default:
+        throw std::invalid_argument("Invalid value for api_method: " + std::to_string(arg.api_method));
+        break;
+    }
+
     // Skip past any testing_ prefix in function
     static constexpr char prefix[] = "testing_";
     const char*           function = arg.function;
@@ -298,7 +317,6 @@ try
     bool        any_stride        = false;
     bool        dump_matrix       = false;
 
-    int         api_method      = 0;
     std::string api_method_str  = "";
     std::string algo_method_str = "";
 
@@ -657,15 +675,15 @@ try
 
     if(api_method_str.compare("c") == 0)
     {
-        api_method = 0;
+        arg.api_method = 0;
     }
     else if(api_method_str.compare("mix") == 0)
     {
-        api_method = 1;
+        arg.api_method = 1;
     }
     else if(api_method_str.compare("cpp") == 0)
     {
-        api_method = 2;
+        arg.api_method = 2;
     }
     else
     {
@@ -708,7 +726,7 @@ try
         arg.gsu_vector[i] = gsu_vector[i];
         max_gsu           = max(max_gsu, arg.gsu_vector[i]);
     }
-    if((max_gsu > 0) && ((api_method == 0) || arg.grouped_gemm))
+    if((max_gsu > 0) && ((arg.api_method == 0) || arg.grouped_gemm))
     {
         hipblaslt_cerr << "Currently split K only supports GEMM + api_method mix or cpp."
                        << std::endl;
@@ -731,7 +749,7 @@ try
         arg.wgm_vector[i] = wgm_vector[i];
         max_wgm           = max(max_wgm, arg.wgm_vector[i]);
     }
-    if((max_wgm > 0) && (api_method == 0))
+    if((max_wgm > 0) && (arg.api_method == 0))
     {
         hipblaslt_cerr << "Currently workgroup mapping only supports api_method mix or cpp."
                        << std::endl;
@@ -1005,25 +1023,6 @@ try
     {
         arg.norm_check     = 1;
         arg.allclose_check = 1;
-    }
-
-    switch(api_method)
-    {
-    case 0:
-        arg.use_ext            = false;
-        arg.use_ext_setproblem = false;
-        break;
-    case 1:
-        arg.use_ext            = true;
-        arg.use_ext_setproblem = false;
-        break;
-    case 2:
-        arg.use_ext            = true;
-        arg.use_ext_setproblem = true;
-        break;
-    default:
-        throw std::invalid_argument("Invalid value for api_method: " + std::to_string(api_method));
-        break;
     }
 
     arg.norm_check_assert = false;

--- a/projects/hipblaslt/clients/bench/src/client.cpp
+++ b/projects/hipblaslt/clients/bench/src/client.cpp
@@ -80,25 +80,6 @@ int run_bench_test(Arguments&         arg,
     // Enable information cout
     arg.print_solution_found = true;
 
-    switch(arg.api_method)
-    {
-    case 0:
-        arg.use_ext            = false;
-        arg.use_ext_setproblem = false;
-        break;
-    case 1:
-        arg.use_ext            = true;
-        arg.use_ext_setproblem = false;
-        break;
-    case 2:
-        arg.use_ext            = true;
-        arg.use_ext_setproblem = true;
-        break;
-    default:
-        throw std::invalid_argument("Invalid value for api_method: " + std::to_string(arg.api_method));
-        break;
-    }
-
     // Skip past any testing_ prefix in function
     static constexpr char prefix[] = "testing_";
     const char*           function = arg.function;
@@ -675,15 +656,15 @@ try
 
     if(api_method_str.compare("c") == 0)
     {
-        arg.api_method = 0;
+        arg.api_method = Arguments::ApiMethod::C_API;
     }
     else if(api_method_str.compare("mix") == 0)
     {
-        arg.api_method = 1;
+        arg.api_method = Arguments::ApiMethod::MIX_API;
     }
     else if(api_method_str.compare("cpp") == 0)
     {
-        arg.api_method = 2;
+        arg.api_method = Arguments::ApiMethod::CPP_API;
     }
     else
     {
@@ -726,7 +707,7 @@ try
         arg.gsu_vector[i] = gsu_vector[i];
         max_gsu           = max(max_gsu, arg.gsu_vector[i]);
     }
-    if((max_gsu > 0) && ((arg.api_method == 0) || arg.grouped_gemm))
+    if((max_gsu > 0) && ((arg.api_method == Arguments::ApiMethod::C_API) || arg.grouped_gemm))
     {
         hipblaslt_cerr << "Currently split K only supports GEMM + api_method mix or cpp."
                        << std::endl;
@@ -749,7 +730,7 @@ try
         arg.wgm_vector[i] = wgm_vector[i];
         max_wgm           = max(max_wgm, arg.wgm_vector[i]);
     }
-    if((max_wgm > 0) && (arg.api_method == 0))
+    if((max_wgm > 0) && (arg.api_method == Arguments::ApiMethod::C_API))
     {
         hipblaslt_cerr << "Currently workgroup mapping only supports api_method mix or cpp."
                        << std::endl;

--- a/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
+++ b/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
@@ -58,6 +58,12 @@ struct Arguments
         Block  = 3
     };
 
+    enum class ApiMethod : int
+    {
+        C_API = 0,
+        MIX_API = 1,
+        CPP_API = 2
+    };
     /*************************************************************************
      *                    Beginning Of Arguments                             *
      *************************************************************************/
@@ -165,14 +171,14 @@ struct Arguments
     uint32_t scaleBBlockColSize;
 
     // API related
-    bool    use_ext;
-    bool    use_ext_setproblem;
-    int     algo_method; // 0 for getheuristic, 1 for get all algos, 2 for algo index
-    int     api_method; // 0 for c, 1 for mix, 2 for cpp
-    bool    use_user_args;
-    int32_t rotating;
-    bool    use_gpu_timer;
-    float   skip_slow_solution_ratio;
+    bool      use_ext;
+    bool      use_ext_setproblem;
+    int       algo_method; // 0 for getheuristic, 1 for get all algos, 2 for algo index
+    ApiMethod api_method;
+    bool      use_user_args;
+    int32_t   rotating;
+    bool      use_gpu_timer;
+    float     skip_slow_solution_ratio;
     // tuning
     int32_t gsu_vector[MAX_SUPPORTED_NUM_PROBLEMS]; // This is for client
     int32_t wgm_vector[MAX_SUPPORTED_NUM_PROBLEMS]; // This is for client

--- a/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
+++ b/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
@@ -171,8 +171,6 @@ struct Arguments
     uint32_t scaleBBlockColSize;
 
     // API related
-    bool      use_ext;
-    bool      use_ext_setproblem;
     int       algo_method; // 0 for getheuristic, 1 for get all algos, 2 for algo index
     ApiMethod api_method;
     bool      use_user_args;
@@ -278,8 +276,6 @@ struct Arguments
     OPER(scaleABlockColSize) SEP     \
     OPER(scaleBBlockRowSize) SEP     \
     OPER(scaleBBlockColSize) SEP     \
-    OPER(use_ext) SEP                \
-    OPER(use_ext_setproblem) SEP     \
     OPER(algo_method) SEP            \
     OPER(api_method) SEP             \
     OPER(use_user_args) SEP          \

--- a/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
+++ b/projects/hipblaslt/clients/common/include/hipblaslt_arguments.hpp
@@ -302,6 +302,9 @@ struct Arguments
     friend hipblaslt_internal_ostream& operator<<(hipblaslt_internal_ostream& str,
                                                   const Arguments&            arg);
 
+    friend hipblaslt_internal_ostream& operator<<(hipblaslt_internal_ostream& str,
+                                                  std::pair<char const *, Arguments::ApiMethod> m);
+
     // Google Tests uses this with std:ostream automatically to dump parameters
     friend std::ostream& operator<<(std::ostream& str, const Arguments& arg);
 

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -1194,6 +1194,13 @@ std::tuple<hipDataType, hipDataType> derive_unset_compute_input_type(const Argum
     return {real_compute_input_typeA, real_compute_input_typeB};
 }
 
+// Derive `use_ext` and `use_ext_setproblem` from a validated api_method; branchless, no-throw.
+void set_ext_from_valid_api_method(const Arguments::ApiMethod& api_method, bool& use_ext, bool& use_ext_setproblem) noexcept
+{
+    use_ext            = (api_method != Arguments::ApiMethod::C_API);
+    use_ext_setproblem = (api_method == Arguments::ApiMethod::CPP_API);
+}
+
 void testing_matmul_with_bias(const Arguments& arg,
                               hipDataType      TiA,
                               hipDataType      TiB,
@@ -1363,8 +1370,15 @@ void testing_matmul_with_bias(const Arguments& arg,
 
     std::vector<void*> alpha_in(gemm_count);
 
-    bool do_swizzle_a = arg.swizzle_a && isSwizzleSupported(TiA);
+    bool do_swizzle_a = arg.swizzle_a && isSwizzleSupported(TiA); 
     bool do_swizzle_b = arg.swizzle_b && isSwizzleSupported(TiB);
+
+    // Set flags based on a validated api_method.
+    // 'use_ext' and 'use_ext_setproblem' are determined exclusively by the given api_method.
+    // The helper ensures the mapping follows the predefined rules for valid API modes.
+    bool use_ext = false;
+    bool use_ext_setproblem = false;
+    set_ext_from_valid_api_method(arg.api_method, use_ext, use_ext_setproblem);
 
     // Need to split into two for loop to calculate the rotating buffer
     int64_t totalRotatingSizeNeeded = 0;
@@ -2460,7 +2474,7 @@ void testing_matmul_with_bias(const Arguments& arg,
 
     std::vector<hipblaslt_ext::GemmEpilogue> extepilogue;
     hipblaslt_ext::GemmProblemType           extproblemtype;
-    if(arg.use_ext_setproblem)
+    if(use_ext_setproblem)
     {
         extinputs.resize(block_count, std::vector<hipblaslt_ext::GemmInputs>(gemm_count));
         extepilogue.resize(gemm_count);
@@ -2594,7 +2608,7 @@ void testing_matmul_with_bias(const Arguments& arg,
     remove_duplicate = std::set<uint32_t>(wgm_vector.begin(), wgm_vector.end());
     wgm_vector.assign(remove_duplicate.begin(), remove_duplicate.end());
     std::vector<hipblaslt_ext::GemmTuning> tuningVec;
-    if(arg.use_ext)
+    if(use_ext)
     {
         for(size_t wgm = 0; wgm < wgm_vector.size(); wgm++)
             for(size_t gsu = 0; gsu < gsu_vector.size(); gsu++)
@@ -2648,9 +2662,9 @@ void testing_matmul_with_bias(const Arguments& arg,
 
             if(!do_grouped_gemm)
             {
-                if(arg.use_ext)
+                if(use_ext)
                 {
-                    if(arg.use_ext_setproblem)
+                    if(use_ext_setproblem)
                     {
                         for(int32_t b = 0; b < block_count; b++)
                             CHECK_HIPBLASLT_ERROR(gemmVec[b].setProblem(M[0],
@@ -2743,7 +2757,7 @@ void testing_matmul_with_bias(const Arguments& arg,
             }
             else
             {
-                if(arg.use_ext_setproblem)
+                if(use_ext_setproblem)
                 {
                     auto num_batches_64
                         = std::vector<int64_t>{num_batches.begin(), num_batches.end()};
@@ -2841,9 +2855,9 @@ void testing_matmul_with_bias(const Arguments& arg,
         int requestCount = 0;
         if(!do_grouped_gemm)
         {
-            if(arg.use_ext)
+            if(use_ext)
             {
-                if(arg.use_ext_setproblem)
+                if(use_ext_setproblem)
                 {
                     for(int32_t b = 0; b < block_count; b++)
                         CHECK_HIPBLASLT_ERROR(gemmVec[b].setProblem(M[0],
@@ -2946,7 +2960,7 @@ void testing_matmul_with_bias(const Arguments& arg,
         }
         else
         {
-            if(arg.use_ext_setproblem)
+            if(use_ext_setproblem)
             {
                 auto num_batches_64 = std::vector<int64_t>{num_batches.begin(), num_batches.end()};
                 for(int32_t b = 0; b < block_count; b++)
@@ -3023,9 +3037,9 @@ void testing_matmul_with_bias(const Arguments& arg,
 
         if(!do_grouped_gemm)
         {
-            if(arg.use_ext)
+            if(use_ext)
             {
-                if(arg.use_ext_setproblem)
+                if(use_ext_setproblem)
                 {
                     for(int32_t b = 0; b < block_count; b++)
                         CHECK_HIPBLASLT_ERROR(gemmVec[b].setProblem(M[0],
@@ -3113,7 +3127,7 @@ void testing_matmul_with_bias(const Arguments& arg,
         }
         else
         {
-            if(arg.use_ext_setproblem)
+            if(use_ext_setproblem)
             {
                 auto num_batches_64 = std::vector<int64_t>{num_batches.begin(), num_batches.end()};
                 for(int32_t b = 0; b < block_count; b++)
@@ -3509,7 +3523,7 @@ void testing_matmul_with_bias(const Arguments& arg,
             }
             if(!do_grouped_gemm)
             {
-                if(arg.use_ext)
+                if(use_ext)
                 {
                     gemmVec[0].setMaxWorkspaceBytes(workspace_size);
                     CHECK_HIPBLASLT_ERROR(
@@ -3682,7 +3696,7 @@ void testing_matmul_with_bias(const Arguments& arg,
             if(!do_grouped_gemm)
             {
                 EfficiencyMonitor& perf_monitor = getEfficiencyMonitor();
-                if(arg.use_ext)
+                if(use_ext)
                 {
                     for(int32_t b = 0; b < block_count; b++)
                     {
@@ -4063,7 +4077,7 @@ void testing_matmul_with_bias(const Arguments& arg,
             {
                 if(arg.print_kernel_info)
                 {
-                    if(arg.use_ext)
+                    if(use_ext)
                     {
                         if(!do_grouped_gemm)
                         {

--- a/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
+++ b/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
@@ -71,7 +71,7 @@ void Arguments::init()
     algo                   = 0;
     solution_index         = -1;
     requested_solution_num = 1;
-    api_method = 0;
+    api_method = Arguments::ApiMethod::C_API;
 
     a_type              = HIP_R_16F;
     b_type              = HIP_R_16F;

--- a/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
+++ b/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
@@ -170,6 +170,19 @@ hipblaslt_internal_ostream& operator<<(hipblaslt_internal_ostream& os, const Arg
     return os << " }\n";
 }
 
+hipblaslt_internal_ostream& operator<<(hipblaslt_internal_ostream& os, std::pair<char const *, Arguments::ApiMethod> m)
+{
+    const char* s;
+    switch(m.second)
+    {
+    case Arguments::ApiMethod::C_API:   s = "c";   break;
+    case Arguments::ApiMethod::MIX_API: s = "mix"; break;
+    case Arguments::ApiMethod::CPP_API: s = "cpp"; break;
+    default: s = "c"; break;
+    }
+    return os << m.first << ": " << s;
+}
+
 // Google Tests uses this automatically with std::ostream to dump parameters
 std::ostream& operator<<(std::ostream& os, const Arguments& arg)
 {

--- a/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
+++ b/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
@@ -71,6 +71,7 @@ void Arguments::init()
     algo                   = 0;
     solution_index         = -1;
     requested_solution_num = 1;
+    api_method = 0;
 
     a_type              = HIP_R_16F;
     b_type              = HIP_R_16F;

--- a/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
+++ b/projects/hipblaslt/clients/common/src/hipblaslt_arguments.cpp
@@ -127,8 +127,6 @@ void Arguments::init()
     scaleBBlockRowSize = 0;
     scaleBBlockColSize = 0;
 
-    use_ext                  = false;
-    use_ext_setproblem       = false;
     algo_method              = 0;
     use_user_args            = false;
     rotating                 = 0;

--- a/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
+++ b/projects/hipblaslt/clients/tests/data/hipblaslt_common.yaml
@@ -575,8 +575,6 @@ Arguments:
   - scaleABlockColSize: c_uint32
   - scaleBBlockRowSize: c_uint32
   - scaleBBlockColSize: c_uint32
-  - use_ext: c_bool
-  - use_ext_setproblem: c_bool
   - algo_method: c_int32
   - api_method: c_int32
   - use_user_args: c_bool

--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -971,8 +971,7 @@ Tests:
   batch_count: [1, 5]
   transA: T
   transB: N
-  use_ext: [1]
-  use_ext_setproblem: [0, 1]
+  api_method: [1, 2]
   alpha: 1
   beta: [ 0.0, 2.0 ]
   bias_vector: [0, 1]
@@ -1009,8 +1008,7 @@ Tests:
   batch_count: [1, 5]
   transA: T
   transB: N
-  use_ext: [1]
-  use_ext_setproblem: [0, 1]
+  api_method: [1, 2]
   alpha: 1
   beta: [ 0.0, 2.0 ]
   bias_vector: [0, 1]
@@ -1445,7 +1443,7 @@ Tests:
   K: [127, 129]
   transA_transB: *transA_transB_range
   grouped_gemm: [2]
-  use_ext_setproblem: [0, 1]
+  api_method: [0, 1, 2]
   algo_method: [2]
   alpha: 1
   beta: [ 0.0, 2.0 ]
@@ -1461,7 +1459,7 @@ Tests:
   K: [127, 129]
   transA_transB: *transA_transB_range
   grouped_gemm: [2]
-  use_ext_setproblem: [1]
+  api_method: 2
   algo_method: [2]
   use_user_args: 1
   alpha: 1
@@ -1827,8 +1825,7 @@ Tests:
   N: [127, 129]
   K: [127, 129]
   transA_transB: *transA_transB_range
-  use_ext: [1]
-  use_ext_setproblem: [0, 1]
+  api_method: [1, 2]
   algo_method: [0, 1, 2]
   alpha: 1
   beta: [ 0.0, 2.0 ]
@@ -1991,8 +1988,7 @@ Tests:
   transA_transB: *transA_transB_range
   alpha: 1
   beta: [ 0, 2 ]
-  use_ext: [1]
-  use_ext_setproblem: [0, 1]
+  api_method: [1, 2]
   bias_vector: 1
   bias_type: [f32_r]
   unit_check: 1
@@ -2028,8 +2024,7 @@ Tests:
   transA_transB: *transA_transB_range
   alpha: 1
   beta: [ 0, 2 ]
-  use_ext: [1]
-  use_ext_setproblem: [1]
+  api_method: 2
   bias_vector: 1
   bias_type: [f32_r]
   unit_check: 1
@@ -2049,8 +2044,7 @@ Tests:
   scaleB: [0,1]
   scaleC: [0,1]
   scaleD: [0,1]
-  use_ext: [1]
-  use_ext_setproblem: [1]
+  api_method: 2
   bias_vector: 1
   bias_type: [f32_r]
   unit_check: 1
@@ -2070,8 +2064,7 @@ Tests:
   scaleB: [0,1]
   amaxScaleA: [0, 1]
   amaxScaleB: [0, 1]
-  use_ext: [1]
-  use_ext_setproblem: [1]
+  api_method: 2
   bias_vector: 1
   bias_type: [f32_r]
   unit_check: 1
@@ -2085,8 +2078,7 @@ Tests:
     - { M:  128,   N:  128,    K:  65536 }
   transA_transB: *transA_transB_range
   algo_method: [2]
-  use_ext: [1]
-  use_ext_setproblem: [0]
+  api_method: 1
   gsu_vector: [[0], [1], [4], [7], [38]]
   alpha: 1
   beta: 2.0
@@ -2101,8 +2093,7 @@ Tests:
     - { M:  1024, N:  1024, K:  80 }
   transA_transB: *transA_transB_range
   algo_method: [2]
-  use_ext: [1]
-  use_ext_setproblem: [0]
+  api_method: 1
   grouped_gemm: [0]
   wgm_vector: [[0], [4], [9], [16]]
   alpha: 1
@@ -2118,8 +2109,7 @@ Tests:
     - { M:  1024, N:  1024, K:  80 }
   transA_transB: *transA_transB_range
   algo_method: [2]
-  use_ext: [1]
-  use_ext_setproblem: [0]
+  api_method: 1
   grouped_gemm: [2]
   wgm_vector: [[0], [4], [9], [16]]
   alpha: 1

--- a/projects/hipblaslt/clients/tests/src/matmul_gtest.cpp
+++ b/projects/hipblaslt/clients/tests/src/matmul_gtest.cpp
@@ -172,12 +172,6 @@ namespace
                     name << "_APIAlgoIndex";
                 else if(arg.algo_method == 1)
                     name << "_APIFindAllAlgo";
-                if(arg.api_method == Arguments::ApiMethod::MIX_API)
-                    name << "_MixAPI";
-                else if(arg.api_method == Arguments::ApiMethod::CPP_API)
-                    name << "_CppAPI";
-                else
-                    name << "_CAPI";
                 if(arg.use_user_args)
                     name << "_UserArgs";
                 if(arg.gsu_vector[0])

--- a/projects/hipblaslt/clients/tests/src/matmul_gtest.cpp
+++ b/projects/hipblaslt/clients/tests/src/matmul_gtest.cpp
@@ -164,10 +164,8 @@ namespace
                 if(arg.c_equal_d)
                     name << "_C_EQUAL_D";
                 // grouped gemm only supports ext
-                if(arg.use_ext || arg.grouped_gemm > 0)
+                if(arg.grouped_gemm > 0)
                     name << "_APIExt";
-                if(arg.use_ext_setproblem)
-                    name << "_APIExtSet";
                 if(arg.algo_method == 2)
                     name << "_APIAlgoIndex";
                 else if(arg.algo_method == 1)

--- a/projects/hipblaslt/clients/tests/src/matmul_gtest.cpp
+++ b/projects/hipblaslt/clients/tests/src/matmul_gtest.cpp
@@ -172,6 +172,12 @@ namespace
                     name << "_APIAlgoIndex";
                 else if(arg.algo_method == 1)
                     name << "_APIFindAllAlgo";
+                if(arg.api_method == Arguments::ApiMethod::MIX_API)
+                    name << "_MixAPI";
+                else if(arg.api_method == Arguments::ApiMethod::CPP_API)
+                    name << "_CppAPI";
+                else
+                    name << "_CAPI";
                 if(arg.use_user_args)
                     name << "_UserArgs";
                 if(arg.gsu_vector[0])


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR addresses inconsistencies in how api_method influences argument settings within hipblaslt-bench and hipblaslt-test. Previously, use_ext and use_ext_setproblem were not consistently updated based on api_method, causing mismatches between direct argument input, YAML-based configuration parsing and generated arguments of test cases for hipblaslt-test. The goal is to ensure uniform behavior and predictable execution regardless of input source.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Replaced magic numbers (0, 1, 2) with enum class ApiMethod for better readability and type safety.
- Moved logic for setting use_ext and use_ext_setproblem based on api_method from client.cpp to testing_matmul.hpp.
- Unified argument handling for api_method across:
  - Direct command-line input
  - YAML configuration parsing
  - hipblaslt-test
- Refactored related code paths to reduce duplication and improve maintainability.
- Verified that changes do not impact other benchmark modes or APIs.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Ran regression tests on existing benchmarks to confirm no unintended side effects.
- Verified consistent behavior for:
  - Direct input arguments
  - YAML-based configuration
  - hipblaslt-test

## Test Result

<!-- Briefly summarize test outcomes. -->
Regression tests showed no failures.
`[----------] Global test environment tear-down
[==========] 40777 tests from 11 test suites ran. (4125597 ms total)
[  PASSED  ] 40777 tests.
hipBLASLt version: 100200
hipBLASLt git version: 
command line: ./build/release/clients/hipblaslt-test `
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
