### PR TITLE
Enable CK describe with MIOpen info logs for

### DIFF
--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -939,6 +939,10 @@ if(BUILD_TESTING)
     target_compile_definitions(MIOpen PUBLIC $<BUILD_INTERFACE:MIOPEN_BUILD_TESTING>)
 endif()
 
+if(MIOPEN_CK_BUILDER_EXPERIMENTAL)
+    target_compile_definitions(MIOpen PRIVATE CK_EXPERIMENTAL_BUILDER)
+endif()
+
 if(MIOPEN_ENABLE_AI_KERNEL_TUNING OR MIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK)
     target_link_libraries(MIOpen PRIVATE frugally-deep::fdeep Eigen3::Eigen)
     if(NOT TARGET nlohmann_json)

--- a/projects/miopen/src/include/miopen/conv_solution.hpp
+++ b/projects/miopen/src/include/miopen/conv_solution.hpp
@@ -66,10 +66,6 @@ struct ConvSolution
     int n_in_data_tiles; // # of blocks of different inputs in LDS
     int n_stacks;        // # of diff stacks (part of batch).
 
-#ifdef CK_EXPERIMENTAL_BUILDER
-    std::string ck_kernel_desc; // ck builder kernel description
-#endif
-
     ConvSolution(miopenStatus_t status_ = miopenStatusSuccess)
         : status(status_),
           solver_id("<unknown>"),

--- a/projects/miopen/src/include/miopen/conv_solution.hpp
+++ b/projects/miopen/src/include/miopen/conv_solution.hpp
@@ -66,6 +66,10 @@ struct ConvSolution
     int n_in_data_tiles; // # of blocks of different inputs in LDS
     int n_stacks;        // # of diff stacks (part of batch).
 
+#ifdef CK_EXPERIMENTAL_BUILDER
+    std::string ck_kernel_desc; // ck builder kernel description
+#endif
+
     ConvSolution(miopenStatus_t status_ = miopenStatusSuccess)
         : status(status_),
           solver_id("<unknown>"),

--- a/projects/miopen/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/projects/miopen/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -384,7 +384,6 @@ ConvSolution InitAnyInvokerFactory(const ProblemDescriptionType& problem,
     ConvSolution result;
 #ifdef CK_EXPERIMENTAL_BUILDER
     std::string description = (*ptr_iter)->describe()->detailed();
-    result.ck_kernel_desc   = description;
 
     if(!description.empty())
     {
@@ -1151,7 +1150,6 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
 
 #ifdef CK_EXPERIMENTAL_BUILDER
     std::string description = (*ptr_iter)->describe()->detailed();
-    result.ck_kernel_desc   = description;
 
     if(!description.empty())
     {
@@ -1310,7 +1308,6 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
     ConvSolution result;
 #ifdef CK_EXPERIMENTAL_BUILDER
     std::string description = (*ptr_iter)->describe()->detailed();
-    result.ck_kernel_desc   = description;
 
     if(!description.empty())
     {

--- a/projects/miopen/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/projects/miopen/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -382,6 +382,16 @@ ConvSolution InitAnyInvokerFactory(const ProblemDescriptionType& problem,
         return {miopenStatusInvalidValue};
 
     ConvSolution result;
+#ifdef CK_EXPERIMENTAL_BUILDER
+    std::string description = (*ptr_iter)->describe()->detailed();
+    result.ck_kernel_desc   = description;
+
+    if(!description.empty())
+    {
+        MIOPEN_LOG_I(description);
+    }
+#endif
+
     result.invoker_factory =
         [ck_args     = CKArgsType{problem},
          sh_conv_ptr = std::shared_ptr{std::move(*ptr_iter)}](const std::vector<Kernel>&) mutable {
@@ -1139,6 +1149,16 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
         return {miopenStatusInvalidValue};
     }
 
+#ifdef CK_EXPERIMENTAL_BUILDER
+    std::string description = (*ptr_iter)->describe()->detailed();
+    result.ck_kernel_desc   = description;
+
+    if(!description.empty())
+    {
+        MIOPEN_LOG_I(description);
+    }
+#endif
+
     if constexpr(std::is_same_v<CastType, miopen::conv::WrWInvokeParams>)
     {
         auto ck_ws_size = ck_args.GetCKSplitkWorkspaceSize(*ptr_iter, split_k.value_or(1));
@@ -1287,9 +1307,18 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
         return {miopenStatusInvalidValue};
     }
 
+    ConvSolution result;
+#ifdef CK_EXPERIMENTAL_BUILDER
+    std::string description = (*ptr_iter)->describe()->detailed();
+    result.ck_kernel_desc   = description;
+
+    if(!description.empty())
+    {
+        MIOPEN_LOG_I(description);
+    }
+#endif
     if constexpr(std::is_same_v<CastType, miopen::conv::WrWInvokeParams>)
     {
-        ConvSolution result;
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
         miopenAlphaBetaCase_t alpha_beta_case = problem.GetAlphaBetaCase();
         auto ck_args                          = CKArgsType{problem};
@@ -1361,7 +1390,6 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
     }
     else
     {
-        ConvSolution result;
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
         result.invoker_factory = [kernel_id   = kernel_id,
                                   split_k     = split_k,


### PR DESCRIPTION
## Motivation

MIOpenDriver currently uses internal MIOpen solver IDs: miopen::solver::Id(s.solution_id).ToString(),has no visibility into CK kernel details. Only knows high-level algorithm type from MIOpen.

```
$ ./bin/MIOpenDriver conv  -W 128 -H 128 -c 64 -k 64 -w 1 --time 1 -S 137 -F 1
MIOpenDriver conv -W 128 -H 128 -c 64 -k 64 -w 1 --time 1 -S 137 -F 1
PRNG seed: 12345678
Timestamp: 2025-12-15 20:02:17 UTC; Host Name: ctr-cx71-mi300x-02.amd.com; Operating System: Linux 6.8.0-31-generic; ROCm: 7.1.25424; MIOpen Driver: 3.5.1; CPU Vendor: AMD; CPU Model: 2 x EPYC 9654; RAM Size: 1511 GB; GPU Model: 1 x ; AMDGPU Driver: 6.14.15
Forward Conv solutions available: 6
- id: 84 algo: 3, time: 1.37072 ms, ws: 0, name: ConvBinWinogradRxSf2x3g1
- id: 37 algo: 3, time: 2.31212 ms, ws: 0, name: ConvBinWinogradRxSf3x2
- id: 137 algo: 5, time: 2.50101 ms, ws: 826003456, name: ConvHipImplicitGemmGroupFwdXdlops
- id: 107 algo: 5, time: 3.62681 ms, ws: 826003456, name: ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC
- id: 91 algo: 0, time: 6.34463 ms, ws: 36578304, name: GemmFwdRest
- id: 85 algo: 1, time: 36.7472 ms, ws: 0, name: ConvDirectNaiveConvFwd
Wall-clock Time Forward Conv. Elapsed: 2.55719 ms, Auxiliary API calls: 329.808 ms (GWSS: 0.0308838)
MIOpen Forward Conv. Algorithm: 5, Solution: 137/ConvHipImplicitGemmGroupFwdXdlops
GPU Kernel Time Forward Conv. Elapsed: 2.443352 ms (average)
stats: name, n, c, ho, wo, y, x, k, flopCnt, bytesRead, bytesWritten, GFLOPs, GB/s, timeMs
stats: fwd-conv3x3u1, 100, 64, 126, 126, 3, 3, 64, 117050572800, 419577856, 406425600, 47906, 338, 2.443352

```

[[CK_BUILDER] Add describe() method to device ops for runtime introspection by shumway](https://github.com/ROCm/composable_kernel/pull/3375) enables runtime introspection of kernel configurations. 

For now we have scoped this to only work with experimental CK Builder kernels.

## Technical Details

Enables Composable Kernel (CK) kernel description logging within MIOpen when the `MIOPEN_CK_BUILDER_EXPERIMENTAL` flag is enabled. It adds infrastructure to capture and log detailed CK kernel information for debugging and analysis purposes.

- Adds new optional field to `ConvSolution`
- Stores detailed kernel description string from CK's describe API
- Conditionally compiled to maintain ABI compatibility

## Test Plan

Locally tested with CK Builder commit [CK_BUILDER] CK Tile header installation for builder, algorithm concept improvements (#3419)

```
# Enable kernel description logging
export MIOPEN_LOG_LEVEL=5  # Info level or higher

# Run MIOpenDriver to see CK kernel details
 ./bin/MIOpenDriver conv  -W 128 -H 128 -c 64 -k 64 -w 1 --time 1 -S 137 -F 1
 MIOpenDriver conv -W 128 -H 128 -c 64 -k 64 -w 1 --time 1 -S 137 -F 1
MIOpen(HIP): Info [get_device_name] Raw device name: gfx942:sramecc+:xnack-
MIOpen(HIP): Info [Handle] stream: 0x35d99a0, device_id: 0
MIOpen(HIP): Info [] MIOPEN_FIND_MODE = DYNAMIC_HYBRID(5)
PRNG seed: 12345678
Timestamp: 2025-12-23 07:11:13 UTC; Host Name: ctr-cx63-mi300x-21.amd.com; Operating System: Linux 6.8.0-31-generic; ROCm: 7.1.25424; MIOpen Driver: 3.5.1; CPU Vendor: AMD; CPU Model: 2 x EPYC 9654; RAM Size: 1511 GB; GPU Model: 1 x ; AMDGPU Driver: 6.12.12
MIOpen(HIP): Info [AmdRocmMetadataVersionDetect] ROCm MD version AMDHSA_COv3, HIP version 7.1.25424, MIOpen version 3.5.1.decfa6a173
MIOpen(HIP): Info [GetSolutionCount] 
MIOpen(HIP): Info [IsNetworkedFilesystem] Filesystem type at '"/home/AMD/anarao/.config"' is: 0x6969 'NFS_SUPER_MAGIC'
MIOpen(HIP): Info [Measure] ReadonlyRamDb::Prefetch time: 5e-05 ms
MIOpen(HIP): Info [Prefetch] File is unreadable: "/home/AMD/anarao/.cache/dvc-tmp/gfx942_38.HIP.3_5_1_b3811300ed-dirty.ufdb.txt"
MIOpen(HIP): Info [Measure] RamDb::Prefetch time: 0.29015 ms
MIOpen(HIP): Info [GetSolutions] 
Forward Conv solutions available: 6
- id: 84 algo: 3, time: 10 ms, ws: 0, name: ConvBinWinogradRxSf2x3g1
- id: 37 algo: 3, time: 20 ms, ws: 0, name: ConvBinWinogradRxSf3x2
- id: 137 algo: 5, time: 30 ms, ws: 826003456, name: ConvHipImplicitGemmGroupFwdXdlops
- id: 107 algo: 5, time: 40 ms, ws: 826003456, name: ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC
- id: 91 algo: 0, time: 50 ms, ws: 36578304, name: GemmFwdRest
- id: 85 algo: 1, time: 60 ms, ws: 0, name: ConvDirectNaiveConvFwd
MIOpen(HIP): Info [GetForwardSolutionWorkspaceSize] solver_id = ConvHipImplicitGemmGroupFwdXdlops
MIOpen(HIP): Info [CompileSolution] solver_id = ConvHipImplicitGemmGroupFwdXdlops
MIOpen(HIP): Info [FindSolutionImpl] ConvHipImplicitGemmGroupFwdXdlops
MIOpen(HIP): Info [Prefetch] File is unreadable: "/home/AMD/anarao/.cache/dvc-tmp/gfx942_38.HIP.3_5_1_b3811300ed-dirty.udb.txt"
MIOpen(HIP): Info [Measure] RamDb::Prefetch time: 0.291372 ms
MIOpen(HIP): Info [FindSolutionImpl] Perf Db: record not found for: ConvHipImplicitGemmGroupFwdXdlops
MIOpen(HIP): Info [RunParameterPredictionModel] Params set by AI: DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle<256, 128, 64, 16, Default, 32, 32, 2, 1, 4, 4, 4, 1, 1, 1>
MIOpen(HIP): Info [InitInvokerFactoryNCHW] 2D Forward Convolution Kernel
├─ Signature
│  ├─ Tensor Type: FP32
│  ├─ Input Layout: NHWGC
│  ├─ Weight Layout: GKYXC
│  ├─ Output Layout: NHWGK
│  ├─ Input elementwise operation: PASS_THROUGH
│  ├─ Weights elementwise operation: PASS_THROUGH
│  └─ Output elementwise operation: PASS_THROUGH
└─ Algorithm
   ├─ Thread block size: 256
   ├─ Data tile size: 128×64×16
   ├─ Gemm padding: MNK_PADDING
   ├─ Convolution specialization: DEFAULT
   ├─ Pipeline version: V1
   ├─ Pipeline scheduler: DEFAULT
   ├─ Warp Gemm parameters: 
   │  ├─ subtile size: 32×32
   │  └─ Number of warp gemm iterations: 2×1
   └─ Memory access:
      ├─ A Tile transfer: 
      │  ├─ Tile dimensions: 4×128×4×
      │  ├─ The innermost K subdimension size: 4
      │  ├─ Spatial thread distribution over the data tile: 1×0×2
      │  ├─ The order of accessing data tile axes: 1×0×2
      │  ├─ Vectorized memory access axis index (with contiguous memory): 2
      │  ├─ Vector access (GMEM read) instruction size: 4
      │  ├─ Vector access (LDS write) instruction size: 4
      │  └─ LDS data layout padding (to prevent bank conflicts): 4
      ├─ B Tile transfer: 
      │  ├─ Tile dimensions: 4×64×4×
      │  ├─ The innermost K subdimension size: 4
      │  ├─ Spatial thread distribution over the data tile: 1×0×2
      │  ├─ The order of accessing data tile axes: 1×0×2
      │  ├─ Vectorized memory access axis index (with contiguous memory): 2
      │  ├─ Vector access (GMEM read) instruction size: 4
      │  ├─ Vector access (LDS write) instruction size: 4
      │  └─ LDS data layout padding (to prevent bank conflicts): 4
      └─ C Tile transfer: 
         ├─ Data shuffle (number of gemm instructions per iteration): 1×1
         ├─ Spatial thread distribution used to store data: 1×16×1×16
         └─ Vector access (GMEM write) instruction size: 4
MIOpen(HIP): Info [IsNetworkedFilesystem] Filesystem type at '"/home/AMD/anarao/.cache"' is: 0x6969 'NFS_SUPER_MAGIC'
MIOpen(HIP): Info [KernDb] database not present
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
MIOpen(HIP): Info [ConvolutionForwardImmediate] solver_id = ConvHipImplicitGemmGroupFwdXdlops, workspace = 826003456
Wall-clock Time Forward Conv. Elapsed: 10.4843 ms, Auxiliary API calls: 92.2719 ms (GWSS: 0.0294189)
MIOpen Forward Conv. Algorithm: 5, Solution: 137/ConvHipImplicitGemmGroupFwdXdlops
GPU Kernel Time Forward Conv. Elapsed: 10.383998 ms (average)
stats: name, n, c, ho, wo, y, x, k, flopCnt, bytesRead, bytesWritten, GFLOPs, GB/s, timeMs
stats: fwd-conv3x3u1, 100, 64, 126, 126, 3, 3, 64, 117050572800, 419577856, 406425600, 11272, 80, 10.383998
Forward Convolution Verifies OK on GPU reference (8.94522e-08 < 1.5e-05) 
```

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
