### PR TITLE
[hipdnn][ALMIOPEN-868] Added FP8 data types support 

### DIFF
--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
@@ -26,11 +26,12 @@ enum class DataType : int8_t {
   UINT8 = 5,
   INT32 = 6,
   INT8 = 7,
+  FP8_E4M3 = 8,
   MIN = UNSET,
-  MAX = INT8
+  MAX = FP8_E4M3
 };
 
-inline const DataType (&EnumValuesDataType())[8] {
+inline const DataType (&EnumValuesDataType())[9] {
   static const DataType values[] = {
     DataType::UNSET,
     DataType::FLOAT,
@@ -39,13 +40,14 @@ inline const DataType (&EnumValuesDataType())[8] {
     DataType::DOUBLE,
     DataType::UINT8,
     DataType::INT32,
-    DataType::INT8
+    DataType::INT8,
+    DataType::FP8_E4M3
   };
   return values;
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[9] = {
+  static const char * const names[10] = {
     "UNSET",
     "FLOAT",
     "HALF",
@@ -54,13 +56,14 @@ inline const char * const *EnumNamesDataType() {
     "UINT8",
     "INT32",
     "INT8",
+    "FP8_E4M3",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameDataType(DataType e) {
-  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT8)) return "";
+  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::FP8_E4M3)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDataType()[index];
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -5,6 +5,7 @@
 
 #include <flatbuffers/flatbuffers.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -85,7 +86,8 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
     case data_objects::DataType::FP8_E4M3:
         if(auto val = tensorAttr.value.AsFloat8Value())
         {
-            return static_cast<TargetType>(val->value());
+            auto fp8 = hipdnn_data_sdk::utilities::fp8::uchar_as_fp8(val->value());
+            return static_cast<TargetType>(static_cast<float>(fp8));
         }
         break;
     case data_objects::DataType::UNSET:

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -82,6 +82,12 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
             return static_cast<TargetType>(val->value());
         }
         break;
+    case data_objects::DataType::FP8_E4M3:
+        if(auto val = tensorAttr.value.AsFloat8Value())
+        {
+            return static_cast<TargetType>(val->value());
+        }
+        break;
     case data_objects::DataType::UNSET:
         throw std::runtime_error(std::string(paramName) + " tensor has UNSET data type");
     default:

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
@@ -8,6 +8,7 @@
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <iostream>
 #include <numeric>
 #include <random>
@@ -587,6 +588,8 @@ inline std::unique_ptr<utilities::ITensor> createTensor(data_objects::DataType d
         return std::make_unique<Tensor<int32_t>>(dims, strides);
     case data_objects::DataType::INT8:
         return std::make_unique<Tensor<int8_t>>(dims, strides);
+    case data_objects::DataType::FP8_E4M3:
+        return std::make_unique<Tensor<hip_fp8_e4m3>>(dims, strides);
     default:
         throw std::runtime_error("Unsupported data type for tensor");
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp16.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp16.hpp
@@ -55,7 +55,7 @@ inline __HOST_DEVICE__ hip_bfloat16 hmax(const hip_bfloat16 a, const hip_bfloat1
         return aNan ? b : a;
     }
 
-    return a.data > b.data ? a : b;
+    return a > b ? a : b;
 }
 
 } // namespace hipdnn_data_sdk::utilities::bfp16

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
@@ -14,6 +14,43 @@ inline __HOST_DEVICE__ half operator""_h(long double value)
     return {static_cast<float>(value)};
 }
 
+inline __HOST_DEVICE__ half operator-(half a)
+{
+    auto r = static_cast<__half_raw>(a);
+    r.x ^= 0x8000u;
+    return r;
+}
+
+inline __HOST_DEVICE__ bool operator==(half a, half b)
+{
+    return static_cast<__half_raw>(a).x == static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator!=(half a, half b)
+{
+    return static_cast<__half_raw>(a).x != static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator<(half a, half b)
+{
+    return static_cast<__half_raw>(a).x < static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator>(half a, half b)
+{
+    return static_cast<__half_raw>(a).x > static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator<=(half a, half b)
+{
+    return static_cast<__half_raw>(a).x <= static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator>=(half a, half b)
+{
+    return static_cast<__half_raw>(a).x >= static_cast<__half_raw>(b).x;
+}
+
 namespace hipdnn_data_sdk::utilities::fp16
 {
 
@@ -33,7 +70,7 @@ inline __HOST_DEVICE__ half habs(half num)
 
 inline __HOST_DEVICE__ bool hisnan(__half x)
 {
-    __half_raw hr = x;
+    auto hr = static_cast<__half_raw>(x);
     return (hr.x & 0x7FFFU) > 0x7C00u;
 }
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
@@ -23,32 +23,34 @@ inline __HOST_DEVICE__ half operator-(half a)
 
 inline __HOST_DEVICE__ bool operator==(half a, half b)
 {
-    return static_cast<__half_raw>(a).x == static_cast<__half_raw>(b).x;
+    return static_cast<float>(a) == static_cast<float>(b);
 }
 
 inline __HOST_DEVICE__ bool operator!=(half a, half b)
 {
-    return static_cast<__half_raw>(a).x != static_cast<__half_raw>(b).x;
+    return static_cast<float>(a) != static_cast<float>(b);
 }
 
 inline __HOST_DEVICE__ bool operator<(half a, half b)
 {
-    return static_cast<__half_raw>(a).x < static_cast<__half_raw>(b).x;
+    return static_cast<float>(a) < static_cast<float>(b);
 }
 
 inline __HOST_DEVICE__ bool operator>(half a, half b)
 {
-    return static_cast<__half_raw>(a).x > static_cast<__half_raw>(b).x;
+    return static_cast<float>(a) > static_cast<float>(b);
 }
 
 inline __HOST_DEVICE__ bool operator<=(half a, half b)
 {
-    return static_cast<__half_raw>(a).x <= static_cast<__half_raw>(b).x;
+    return static_cast<float>(a) <= static_cast<float>(b);
+    ;
 }
 
 inline __HOST_DEVICE__ bool operator>=(half a, half b)
 {
-    return static_cast<__half_raw>(a).x >= static_cast<__half_raw>(b).x;
+    return static_cast<float>(a) >= static_cast<float>(b);
+    ;
 }
 
 namespace hipdnn_data_sdk::utilities::fp16
@@ -76,23 +78,20 @@ inline __HOST_DEVICE__ bool hisnan(__half x)
 
 inline __HOST_DEVICE__ half hmax(const half a, const half b)
 {
-    if(hisnan(a) && !hisnan(b))
+    auto aNan = hisnan(a);
+    auto bNan = hisnan(b);
+
+    if(aNan || bNan)
     {
-        return b;
+        if(aNan && bNan)
+        {
+            return HIPDNN_NAN_FP16; // return canonical NaN
+        }
+
+        return aNan ? b : a;
     }
-    if(!hisnan(a) && hisnan(b))
-    {
-        return a;
-    }
-    if(hisnan(a) && hisnan(b))
-    {
-        return HIPDNN_NAN_FP16;
-    }
-    if(static_cast<__half_raw>(a).x > static_cast<__half_raw>(b).x)
-    {
-        return __half_raw{static_cast<__half_raw>(a).x};
-    }
-    return __half_raw{static_cast<__half_raw>(b).x};
+
+    return a > b ? a : b;
 }
 
 } // namespace hipdnn_data_sdk::utilities::fp16

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
@@ -44,13 +44,11 @@ inline __HOST_DEVICE__ bool operator>(half a, half b)
 inline __HOST_DEVICE__ bool operator<=(half a, half b)
 {
     return static_cast<float>(a) <= static_cast<float>(b);
-    ;
 }
 
 inline __HOST_DEVICE__ bool operator>=(half a, half b)
 {
     return static_cast<float>(a) >= static_cast<float>(b);
-    ;
 }
 
 namespace hipdnn_data_sdk::utilities::fp16

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
@@ -37,7 +37,6 @@ inline __HOST_DEVICE__ bool operator!=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
 inline __HOST_DEVICE__ bool operator>(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
 {
     return float(a) > float(b);
-    ;
 }
 
 inline __HOST_DEVICE__ bool operator>=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
@@ -26,35 +26,36 @@ inline __HOST_DEVICE__ hip_fp8_e4m3 operator-(hip_fp8_e4m3 a)
 
 inline __HOST_DEVICE__ bool operator==(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
 {
-    return a.__x == b.__x;
+    return float(a) == float(b);
 }
 
 inline __HOST_DEVICE__ bool operator!=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
 {
-    return a.__x != b.__x;
+    return float(a) != float(b);
 }
 
 inline __HOST_DEVICE__ bool operator>(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
 {
-    return a.__x > b.__x;
+    return float(a) > float(b);
+    ;
 }
 
 inline __HOST_DEVICE__ bool operator>=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
 {
-    return a.__x >= b.__x;
+    return float(a) >= float(b);
 }
 
 inline __HOST_DEVICE__ bool operator<(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
 {
-    return a.__x < b.__x;
+    return float(a) < float(b);
 }
 
 inline __HOST_DEVICE__ bool operator<=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
 {
-    return a.__x <= b.__x;
+    return float(a) <= float(b);
 }
 
-namespace hipdnn_sdk::utilities::fp8
+namespace hipdnn_data_sdk::utilities::fp8
 {
 inline __HOST_DEVICE__ hip_fp8_e4m3 uchar_as_fp8(const unsigned char a)
 {
@@ -93,24 +94,24 @@ inline __HOST_DEVICE__ hip_fp8_e4m3 fp8max(const hip_fp8_e4m3 a, const hip_fp8_e
     return a >= b ? a : b;
 }
 
-} // namespace hipdnn_sdk::utilities::fp8
+} // namespace hipdnn_data_sdk::utilities::fp8
 
 namespace std
 {
 
 inline __HOST_DEVICE__ hip_fp8_e4m3 fabs(hip_fp8_e4m3 num)
 {
-    return hipdnn_sdk::utilities::fp8::fp8abs(num);
+    return hipdnn_data_sdk::utilities::fp8::fp8abs(num);
 }
 
 inline __HOST_DEVICE__ hip_fp8_e4m3 abs(hip_fp8_e4m3 num)
 {
-    return hipdnn_sdk::utilities::fp8::fp8abs(num);
+    return hipdnn_data_sdk::utilities::fp8::fp8abs(num);
 }
 
 inline __HOST_DEVICE__ hip_fp8_e4m3 max(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
 {
-    return hipdnn_sdk::utilities::fp8::fp8max(a, b);
+    return hipdnn_data_sdk::utilities::fp8::fp8max(a, b);
 }
 
 } // namespace std

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
@@ -1,0 +1,126 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hip/hip_fp8.h>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <string>
+#include <type_traits>
+
+#define HIPDNN_NAN_FP8 uchar_as_fp8(static_cast<unsigned char>(0x7F))
+
+using hip_fp8_e4m3 = __hip_fp8_e4m3;
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 operator""_fp8(long double val)
+{
+    return {static_cast<float>(val)};
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 operator-(hip_fp8_e4m3 a)
+{
+    hip_fp8_e4m3 val = a;
+    val.__x ^= 0x80;
+    return val;
+}
+
+inline __HOST_DEVICE__ bool operator==(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x == b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator!=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x != b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator>(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x > b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator>=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x >= b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator<(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x < b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator<=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x <= b.__x;
+}
+
+namespace hipdnn_sdk::utilities::fp8
+{
+inline __HOST_DEVICE__ hip_fp8_e4m3 uchar_as_fp8(const unsigned char a)
+{
+    hip_fp8_e4m3 val;
+    val.__x = a;
+    return val;
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 fp8abs(hip_fp8_e4m3 a)
+{
+    hip_fp8_e4m3 abs = a;
+    abs.__x &= 0x7f;
+    return abs;
+}
+
+inline __HOST_DEVICE__ bool fp8isnan(hip_fp8_e4m3 x)
+{
+    return (x.__x & 0x7f) == 0x7f;
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 fp8max(const hip_fp8_e4m3 a, const hip_fp8_e4m3 b)
+{
+    auto aNan = fp8isnan(a);
+    auto bNan = fp8isnan(b);
+
+    if(aNan || bNan)
+    {
+        if(aNan && bNan)
+        {
+            return HIPDNN_NAN_FP8; // return canonical NaN
+        }
+
+        return aNan ? b : a;
+    }
+
+    return a >= b ? a : b;
+}
+
+} // namespace hipdnn_sdk::utilities::fp8
+
+namespace std
+{
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 fabs(hip_fp8_e4m3 num)
+{
+    return hipdnn_sdk::utilities::fp8::fp8abs(num);
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 abs(hip_fp8_e4m3 num)
+{
+    return hipdnn_sdk::utilities::fp8::fp8abs(num);
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 max(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return hipdnn_sdk::utilities::fp8::fp8max(a, b);
+}
+
+} // namespace std
+
+template <>
+struct fmt::formatter<hip_fp8_e4m3> : fmt::formatter<float>
+{
+    template <typename FormatContext>
+    auto format(hip_fp8_e4m3 h, FormatContext& ctx) const
+    {
+        return fmt::formatter<float>::format(static_cast<float>(h), ctx);
+    }
+};

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
@@ -80,6 +80,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType,
                                  {DataType::UINT8, "uint8"},
                                  {DataType::INT32, "int32"},
                                  {DataType::INT8, "int8"},
+                                 {DataType::FP8_E4M3, "fp8_e4m3"},
                              }
 
 )

--- a/projects/hipdnn/data_sdk/schemas/data_types.fbs
+++ b/projects/hipdnn/data_sdk/schemas/data_types.fbs
@@ -11,5 +11,6 @@ enum DataType : byte {
     DOUBLE = 4,
     UINT8 = 5,
     INT32 = 6,
-    INT8 = 7
+    INT8 = 7,
+    FP8_E4M3 = 8,
 }

--- a/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
@@ -5,6 +5,7 @@
 
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 
 TEST(TestUtilsFp16, BasicUsage)
 {
@@ -44,4 +45,28 @@ TEST(TestUtilsBfp16, Max)
     hip_bfloat16 b = 2.0_bf;
     EXPECT_EQ(std::max(a, b), 2.0_bf);
     EXPECT_EQ(std::max(b, a), 2.0_bf);
+}
+
+TEST(TestUtilsFp8, BasicUsage)
+{
+    hip_fp8_e4m3 fp8 = 1.0_fp8;
+    EXPECT_EQ(fp8, 1.0_fp8);
+}
+
+TEST(TestUtilsFp8, Fabs)
+{
+    EXPECT_EQ(std::fabs(-1.0_fp8), 1.0_fp8);
+    EXPECT_EQ(std::fabs(1.0_fp8), 1.0_fp8);
+}
+
+TEST(TestUtilsFp8, Max)
+{
+    hip_fp8_e4m3 a = 1.0_fp8;
+    hip_fp8_e4m3 b = 2.0_fp8;
+    hip_fp8_e4m3 nan = hipdnn_sdk::utilities::fp8::uchar_as_fp8(0x7F);
+    EXPECT_EQ(std::max(a, b), 2.0_fp8);
+    EXPECT_EQ(std::max(b, a), 2.0_fp8);
+    EXPECT_EQ(std::max(a, nan), 1.0_fp8);
+    EXPECT_EQ(std::max(nan, b), 2.0_fp8);
+    EXPECT_EQ(std::max(nan, nan), nan);
 }

--- a/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
@@ -19,6 +19,16 @@ TEST(TestUtilsFp16, Fabs)
     EXPECT_EQ(std::fabs(1.0_h), 1.0_h);
 }
 
+TEST(TestUtilsFp16, Comparison)
+{
+    EXPECT_EQ(1.25_h, 1.25_h);
+    ASSERT_NE(1.0_h, 2.0_h);
+    ASSERT_LT(0.0156_h, 0.0176_h);
+    ASSERT_LE(-0.0156_h, 0.0176_h);
+    ASSERT_GT(0.0215_h, 0.0176_h);
+    ASSERT_GE(0.0215_h, -0.0176_h);
+}
+
 TEST(TestUtilsFp16, Max)
 {
     half a = 1.0_h;
@@ -39,6 +49,16 @@ TEST(TestUtilsBfp16, Fabs)
     EXPECT_EQ(std::fabs(1.0_bf), 1.0_bf);
 }
 
+TEST(TestUtilsBfp16, Comparison)
+{
+    EXPECT_EQ(1.25_bf, 1.25_bf);
+    ASSERT_NE(1.0_bf, 2.0_bf);
+    ASSERT_LT(0.017_bf, 0.018_bf);
+    ASSERT_LE(-0.017_bf, 0.018_bf);
+    ASSERT_GT(0.022_bf, 0.018_bf);
+    ASSERT_GE(0.022_bf, -0.018_bf);
+}
+
 TEST(TestUtilsBfp16, Max)
 {
     hip_bfloat16 a = 1.0_bf;
@@ -53,20 +73,36 @@ TEST(TestUtilsFp8, BasicUsage)
     EXPECT_EQ(fp8, 1.0_fp8);
 }
 
+TEST(TestUtilsFp8, Negation)
+{
+    hip_fp8_e4m3 fp8 = 1.0_fp8;
+    EXPECT_EQ(-fp8, static_cast<hip_fp8_e4m3>(-1.0f));
+}
+
 TEST(TestUtilsFp8, Fabs)
 {
     EXPECT_EQ(std::fabs(-1.0_fp8), 1.0_fp8);
     EXPECT_EQ(std::fabs(1.0_fp8), 1.0_fp8);
 }
 
+TEST(TestUtilsFp8, Comparison)
+{
+    EXPECT_EQ(1.25_fp8, 1.25_fp8);
+    ASSERT_NE(1.0_fp8, 2.0_fp8);
+    ASSERT_LT(0.0156_fp8, 0.0176_fp8); // 0.0001.000 < 0.0001.001
+    ASSERT_LE(-0.0156_fp8, 0.0176_fp8); // 1.0001.000 <= 0.0001.001
+    ASSERT_GT(0.0215_fp8, 0.0176_fp8); // 0.0001.011 > 0.0001.001
+    ASSERT_GE(0.0215_fp8, -0.0176_fp8); // 0.0001.011 >= 1.0001.001
+}
+
 TEST(TestUtilsFp8, Max)
 {
     hip_fp8_e4m3 a = 1.0_fp8;
     hip_fp8_e4m3 b = 2.0_fp8;
-    hip_fp8_e4m3 nan = hipdnn_sdk::utilities::fp8::uchar_as_fp8(0x7F);
+    hip_fp8_e4m3 nan = hipdnn_data_sdk::utilities::fp8::uchar_as_fp8(0x7F);
     EXPECT_EQ(std::max(a, b), 2.0_fp8);
     EXPECT_EQ(std::max(b, a), 2.0_fp8);
     EXPECT_EQ(std::max(a, nan), 1.0_fp8);
     EXPECT_EQ(std::max(nan, b), 2.0_fp8);
-    EXPECT_EQ(std::max(nan, nan), nan);
+    EXPECT_TRUE(hipdnn_data_sdk::utilities::fp8::fp8isnan(std::max(nan, nan)));
 }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -9,6 +9,7 @@
 #include <hipdnn_data_sdk/utilities/PointwiseValidation.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 
 #include <bitset>
 #include <set>
@@ -88,6 +89,7 @@ enum class DataType
     UINT8 = 5,
     INT32 = 6,
     INT8 = 7,
+    FP8_E4M3 = 8,
 };
 typedef DataType DataType_t; // NOLINT(readability-identifier-naming)
 
@@ -134,6 +136,10 @@ DataType getDataTypeEnumFromType()
     else if constexpr(std::is_same_v<T, int8_t>)
     {
         return DataType::INT8;
+    }
+    else if constexpr(std::is_same_v<T, hip_fp8_e4m3>)
+    {
+        return DataType::FP8_E4M3;
     }
     else
     {
@@ -186,6 +192,8 @@ inline hipdnn_data_sdk::data_objects::DataType toSdkType(const DataType& type)
         return hipdnn_data_sdk::data_objects::DataType::INT32;
     case DataType::INT8:
         return hipdnn_data_sdk::data_objects::DataType::INT8;
+    case DataType::FP8_E4M3:
+        return hipdnn_data_sdk::data_objects::DataType::FP8_E4M3;
     default:
         return hipdnn_data_sdk::data_objects::DataType::UNSET;
     }
@@ -209,6 +217,8 @@ inline hipdnn_frontend::DataType fromSdkType(const hipdnn_data_sdk::data_objects
         return hipdnn_frontend::DataType::INT32;
     case hipdnn_data_sdk::data_objects::DataType::INT8:
         return hipdnn_frontend::DataType::INT8;
+    case hipdnn_data_sdk::data_objects::DataType::FP8_E4M3:
+        return hipdnn_frontend::DataType::FP8_E4M3;
     default:
         return hipdnn_frontend::DataType::NOT_SET;
     }
@@ -451,6 +461,8 @@ inline const char* to_string(const DataType& type)
         return "int32";
     case DataType::INT8:
         return "int8";
+    case DataType::FP8_E4M3:
+        return "fp8_e4m3";
     default:
         return "unknown";
     }

--- a/projects/hipdnn/frontend/tests/TestNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestNode.cpp
@@ -42,7 +42,8 @@ TEST(TestNode, PostValidateNodeComputeDataType)
            {DataType::DOUBLE, ErrorCode::OK},
            {DataType::UINT8, ErrorCode::OK},
            {DataType::INT32, ErrorCode::OK},
-           {DataType::INT8, ErrorCode::OK}};
+           {DataType::INT8, ErrorCode::OK},
+           {DataType::FP8_E4M3, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -206,7 +206,8 @@ TEST(TestTensorAttributes, ValidateDataType)
            {DataType::DOUBLE, ErrorCode::OK},
            {DataType::UINT8, ErrorCode::OK},
            {DataType::INT32, ErrorCode::OK},
-           {DataType::INT8, ErrorCode::OK}};
+           {DataType::INT8, ErrorCode::OK},
+           {DataType::FP8_E4M3, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorValueAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorValueAttributes.cpp
@@ -109,13 +109,13 @@ TEST(TestTensorValueAttributes, PackUnpackHalfValue)
     EXPECT_EQ(fbTensor->value_type(), TensorValue::Float16Value);
     auto hval = fbTensor->value_as_Float16Value();
     ASSERT_NE(hval, nullptr);
-    EXPECT_EQ(hval->value(), 1.0_h);
+    EXPECT_EQ(half(hval->value()), 1.0_h);
 
     auto unpacked = std::unique_ptr<TensorAttributesT>(fbTensor->UnPack());
     ASSERT_EQ(unpacked->value.type, TensorValue::Float16Value);
     auto* halfVal = unpacked->value.AsFloat16Value();
     ASSERT_NE(halfVal, nullptr);
-    EXPECT_EQ(halfVal->value(), 1.0_h);
+    EXPECT_EQ(half(halfVal->value()), 1.0_h);
 }
 
 TEST(TestTensorValueAttributes, PackUnpackBFloat1Value)

--- a/projects/hipdnn/frontend/tests/TestTypes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTypes.cpp
@@ -16,6 +16,7 @@ TEST(TestTypes, ToSdkTypeDataTypes)
     EXPECT_EQ(toSdkType(DataType::UINT8), hipdnn_data_sdk::data_objects::DataType::UINT8);
     EXPECT_EQ(toSdkType(DataType::INT32), hipdnn_data_sdk::data_objects::DataType::INT32);
     EXPECT_EQ(toSdkType(DataType::INT8), hipdnn_data_sdk::data_objects::DataType::INT8);
+    EXPECT_EQ(toSdkType(DataType::FP8_E4M3), hipdnn_data_sdk::data_objects::DataType::FP8_E4M3);
     EXPECT_EQ(toSdkType(DataType::NOT_SET), hipdnn_data_sdk::data_objects::DataType::UNSET);
 }
 
@@ -30,6 +31,7 @@ TEST(TestTypes, FromSdkTypeDataTypes)
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UINT8), DataType::UINT8);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT32), DataType::INT32);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT8), DataType::INT8);
+    EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP8_E4M3), DataType::FP8_E4M3);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UNSET), DataType::NOT_SET);
 }
 
@@ -73,6 +75,7 @@ TEST(TestTypes, GetDataTypeEnumFromType)
     EXPECT_EQ(getDataTypeEnumFromType<uint8_t>(), DataType::UINT8);
     EXPECT_EQ(getDataTypeEnumFromType<int32_t>(), DataType::INT32);
     EXPECT_EQ(getDataTypeEnumFromType<int8_t>(), DataType::INT8);
+    EXPECT_EQ(getDataTypeEnumFromType<hip_fp8_e4m3>(), DataType::FP8_E4M3);
 
     EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType::NOT_SET);
     EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType::NOT_SET);
@@ -89,6 +92,7 @@ TEST(TestTypes, DataTypeToString)
     EXPECT_STREQ(to_string(DataType::UINT8), "uint8");
     EXPECT_STREQ(to_string(DataType::INT32), "int32");
     EXPECT_STREQ(to_string(DataType::INT8), "int8");
+    EXPECT_STREQ(to_string(DataType::FP8_E4M3), "fp8_e4m3");
     EXPECT_STREQ(to_string(DataType::NOT_SET), "unknown");
 }
 
@@ -124,6 +128,10 @@ TEST(TestTypes, DataTypeStreamOperator)
 
     oss << DataType::INT8;
     EXPECT_EQ(oss.str(), "int8");
+    oss.str("");
+
+    oss << DataType::FP8_E4M3;
+    EXPECT_EQ(oss.str(), "fp8_e4m3");
     oss.str("");
 
     oss << DataType::NOT_SET;

--- a/projects/hipdnn/python/src/types_bindings.cpp
+++ b/projects/hipdnn/python/src/types_bindings.cpp
@@ -19,7 +19,8 @@ void types_bindings(nb::module_& m)
         .value("DOUBLE", DataType::DOUBLE)
         .value("UINT8", DataType::UINT8)
         .value("INT32", DataType::INT32)
-        .value("INT8", DataType::INT8);
+        .value("INT8", DataType::INT8)
+        .value("FP8_E4M3", DataType::FP8_E4M3);
 
     // Bind ConvolutionMode enum
     nb::enum_<ConvolutionMode>(m, "ConvolutionMode")

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -298,13 +298,13 @@ struct TypeTriplet
     using Third = T3;
 };
 
-using TypesBackwardNchw
-    = ::testing::Types<TypeTriplet<float, float, float>,
-                       TypeTriplet<hip_bfloat16, float, float>,
-                       TypeTriplet<half, float, float>,
-                       TypeTriplet<int8_t, float, float>,
-                       TypePair<hip_fp8_e4m3, float, float> TypeTriplet<half, hip_bfloat16, float>,
-                       TypeTriplet<double, double, double>>;
+using TypesBackwardNchw = ::testing::Types<TypeTriplet<float, float, float>,
+                                           TypeTriplet<hip_bfloat16, float, float>,
+                                           TypeTriplet<half, float, float>,
+                                           TypeTriplet<int8_t, float, float>,
+                                           TypeTriplet<hip_fp8_e4m3, float, float>,
+                                           TypeTriplet<half, hip_bfloat16, float>,
+                                           TypeTriplet<double, double, double>>;
 
 template <typename T>
 class CpuFpReferenceBatchnormBackwardNchw : public ::testing::Test

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -7,6 +7,7 @@
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/FileUtilities.hpp>
@@ -107,7 +108,8 @@ using TypesFwdInferenceNchw = ::testing::Types<TypePair<float, float>,
                                                TypePair<half, float>,
                                                TypePair<hip_bfloat16, float>,
                                                TypePair<double, double>,
-                                               TypePair<int8_t, float>>;
+                                               TypePair<int8_t, float>,
+                                               TypePair<hip_fp8_e4m3, float>>;
 
 template <class T>
 class CpuFpReferenceBatchnormFwdInferenceNchw : public ::testing::Test
@@ -296,12 +298,13 @@ struct TypeTriplet
     using Third = T3;
 };
 
-using TypesBackwardNchw = ::testing::Types<TypeTriplet<float, float, float>,
-                                           TypeTriplet<hip_bfloat16, float, float>,
-                                           TypeTriplet<half, float, float>,
-                                           TypeTriplet<int8_t, float, float>,
-                                           TypeTriplet<half, hip_bfloat16, float>,
-                                           TypeTriplet<double, double, double>>;
+using TypesBackwardNchw
+    = ::testing::Types<TypeTriplet<float, float, float>,
+                       TypeTriplet<hip_bfloat16, float, float>,
+                       TypeTriplet<half, float, float>,
+                       TypeTriplet<int8_t, float, float>,
+                       TypePair<hip_fp8_e4m3, float, float> TypeTriplet<half, hip_bfloat16, float>,
+                       TypeTriplet<double, double, double>>;
 
 template <typename T>
 class CpuFpReferenceBatchnormBackwardNchw : public ::testing::Test
@@ -956,6 +959,7 @@ using TypesFwdTrainingNhwc = ::testing::Types<TypeTriplet<hip_bfloat16, float, f
                                               TypeTriplet<half, float, float>,
                                               TypeTriplet<double, double, double>,
                                               TypeTriplet<int8_t, double, double>,
+                                              TypeTriplet<hip_fp8_e4m3, float, float>,
                                               TypeTriplet<half, hip_bfloat16, float>>;
 
 template <typename T>

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
@@ -5,6 +5,7 @@
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 
@@ -269,6 +270,38 @@ TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionFwdInferenceBasic)
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63);
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90);
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99);
+}
+
+TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionFwdInferenceBasic)
+{
+    Tensor<hip_fp8_e4m3> inputTensor({1, 1, 4, 4});
+    Tensor<hip_fp8_e4m3> weightTensor({1, 1, 3, 3});
+    Tensor<hip_fp8_e4m3> outputTensor({1, 1, 2, 2});
+
+    // Fill input with sequential values
+    for(int i = 0; i < 16; ++i)
+    {
+        inputTensor.memory().hostData()[i] = static_cast<hip_fp8_e4m3>(i + 1);
+    }
+
+    // Fill weights with 1s
+    for(int i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = 1.0_fp8;
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::fprop<hip_fp8_e4m3, hip_fp8_e4m3, hip_fp8_e4m3, float>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+
+    // Same expected values as fp32 test
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 0), 54.0_fp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63.0_fp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90.0_fp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99.0_fp8);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionFwdInferenceWithDilation)
@@ -1067,6 +1100,33 @@ TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionBwdDataBasic)
         inputTensor, weightTensor, outputTensor, strides, dilations, padding);
 }
 
+TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionBwdDataBasic)
+{
+    // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
+    Tensor<hip_fp8_e4m3> inputTensor({1, 1, 4, 4});
+    Tensor<hip_fp8_e4m3> weightTensor({1, 1, 3, 3});
+    Tensor<hip_fp8_e4m3> outputTensor({1, 1, 2, 2});
+
+    // gradOutput values: simple pattern
+    outputTensor.setHostValue(1.0_fp8, 0, 0, 0, 0);
+    outputTensor.setHostValue(2.0_fp8, 0, 0, 0, 1);
+    outputTensor.setHostValue(3.0_fp8, 0, 0, 1, 0);
+    outputTensor.setHostValue(4.0_fp8, 0, 0, 1, 1);
+
+    // Weight values: simple 3x3 kernel
+    for(size_t i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = static_cast<hip_fp8_e4m3>(i + 1);
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::dgrad<hip_fp8_e4m3, hip_fp8_e4m3, hip_fp8_e4m3, float>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+}
+
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionBwdDataSimple)
 {
     // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
@@ -1790,6 +1850,42 @@ TYPED_TEST(CpuFpReferenceConvolutionWrwBasic, TypesConvolutionWrwBasic)
     {
         EXPECT_FLOAT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), static_cast<TypeParam>(10.0));
     }
+}
+
+TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionWrwBasic)
+{
+    // Minimal sanity test for wgrad using smallest possible tensor sizes
+    // Input: 1x1x2x2 (1 batch, 1 input channel, 2x2 spatial)
+    // Weight: 1x1x1x1 (1 output channel, 1 input channel, 1x1 kernel)
+    // GradOutput: 1x1x2x2 (1 batch, 1 output channel, 2x2 spatial)
+    Tensor<hip_fp8_e4m3> inputTensor({1, 1, 2, 2});
+    Tensor<hip_fp8_e4m3> gradWeightTensor({1, 1, 1, 1});
+    Tensor<hip_fp8_e4m3> gradOutputTensor({1, 1, 2, 2});
+
+    // Set input values: [1, 2; 3, 4]
+    inputTensor.setHostValue(1.0_fp8, 0, 0, 0, 0);
+    inputTensor.setHostValue(2.0_fp8, 0, 0, 0, 1);
+    inputTensor.setHostValue(3.0_fp8, 0, 0, 1, 0);
+    inputTensor.setHostValue(4.0_fp8, 0, 0, 1, 1);
+
+    // Set gradient output values: [1, 1; 1, 1]
+    gradOutputTensor.setHostValue(1.0_fp8, 0, 0, 0, 0);
+    gradOutputTensor.setHostValue(1.0_fp8, 0, 0, 0, 1);
+    gradOutputTensor.setHostValue(1.0_fp8, 0, 0, 1, 0);
+    gradOutputTensor.setHostValue(1.0_fp8, 0, 0, 1, 1);
+
+    // Initialize weight to zero
+    gradWeightTensor.setHostValue(0.0_fp8, 0, 0, 0, 0);
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::wgrad<hip_fp8_e4m3, hip_fp8_e4m3, hip_fp8_e4m3, float>(
+        inputTensor, gradWeightTensor, gradOutputTensor, strides, dilations, padding);
+
+    // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 1 = 10
+    EXPECT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 10.0_fp8);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvBwdWeightMultiBatch)

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
@@ -1114,7 +1114,7 @@ TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionBwdDataBasic)
     outputTensor.setHostValue(4.0_fp8, 0, 0, 1, 1);
 
     // Weight values: simple 3x3 kernel
-    for(size_t i = 0; i < 9; ++i)
+    for(int i = 0; i < 9; ++i)
     {
         weightTensor.memory().hostData()[i] = static_cast<hip_fp8_e4m3>(i + 1);
     }


### PR DESCRIPTION
## Motivation

Updated `hipdnn` to have fp8 operation support within the ticket ALMIOPEN-868.

## Technical Details

The PR implements support of FP8 data type (`fp8_e4m3`) to hipDNN frontend, data sdk, test sdk using `__hip_fp8_e4_m3` classes from HIP. Implemented the files `UtilsFp8.hpp` for work with these data types in hipDNN. The changes are based on https://github.com/ROCm/rocm-libraries/pull/3510.

Also the PR adds missed overrided comparison function for `half` data type. Without these changes, if there is comparison of half values, now the build failed because the compiler now finds ambiguous overloads (there are multiple options: to be converted to float or new fp8).

Depends on the fix: https://github.com/ROCm/rocm-systems/pull/2448

## Test Plan

Added utility FP8 tests, convolution and batchnorm tests with FP8. As far as I understand, we cannot add Pointwise tests with such data types due to unimplemented operators +,-,etc for this data type in HIP.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
