### PR TITLE
switched every usage of std::is_integral to rocprim::is_integral

### DIFF
--- a/projects/rocprim/benchmark/benchmark_device_histogram.cpp
+++ b/projects/rocprim/benchmark/benchmark_device_histogram.cpp
@@ -66,8 +66,8 @@ void run_even_benchmark(benchmark_utils::state&& state,
     size_t size = bytes / sizeof(T);
 
     using counter_type = unsigned int;
-    using level_type =
-        typename std::conditional_t<std::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
+    using level_type   = typename std::
+        conditional_t<rocprim::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
 
     const level_type lower_level = 0;
     const level_type upper_level = bins * scale;
@@ -124,8 +124,8 @@ void run_multi_even_benchmark(benchmark_utils::state&& state,
     size_t size = bytes / sizeof(T);
 
     using counter_type = unsigned int;
-    using level_type =
-        typename std::conditional_t<std::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
+    using level_type   = typename std::
+        conditional_t<rocprim::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
 
     unsigned int num_levels[ActiveChannels];
     level_type   lower_level[ActiveChannels];
@@ -198,8 +198,8 @@ void run_range_benchmark(benchmark_utils::state&& state, size_t bins)
     size_t size = bytes / sizeof(T);
 
     using counter_type = unsigned int;
-    using level_type =
-        typename std::conditional_t<std::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
+    using level_type   = typename std::
+        conditional_t<rocprim::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
 
     // Generate data
     const auto     random_range = limit_random_range<T>(0, bins);
@@ -258,8 +258,8 @@ void run_multi_range_benchmark(benchmark_utils::state&& state, size_t bins)
     size_t size = bytes / sizeof(T);
 
     using counter_type = unsigned int;
-    using level_type =
-        typename std::conditional_t<std::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
+    using level_type   = typename std::
+        conditional_t<rocprim::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
 
     const int               num_levels_channel = bins + 1;
     unsigned int            num_levels[ActiveChannels];

--- a/projects/rocprim/benchmark/benchmark_device_histogram.parallel.hpp
+++ b/projects/rocprim/benchmark/benchmark_device_histogram.parallel.hpp
@@ -202,7 +202,7 @@ struct device_histogram_benchmark : public benchmark_utils::autotune_interface
 
         using counter_type = unsigned int;
         using level_type   = typename std::
-            conditional_t<std::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
+            conditional_t<rocprim::is_integral<T>::value && sizeof(T) < sizeof(int), int, T>;
 
         struct case_data
         {

--- a/projects/rocprim/example/example_utils.hpp
+++ b/projects/rocprim/example/example_utils.hpp
@@ -47,8 +47,8 @@
     }
 
 template<class T>
-inline auto get_random_data(size_t size, T min, T max)
-    -> typename std::enable_if<std::is_integral<T>::value, std::vector<T>>::type
+inline auto get_random_data(size_t size, T min, T max) ->
+    typename std::enable_if<rocprim::is_integral<T>::value, std::vector<T>>::type
 {
     std::random_device rd;
     std::default_random_engine gen(rd());

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp
@@ -107,7 +107,7 @@ struct sample_to_bin_even
 template<class Level>
 struct sample_to_bin_even<
     Level,
-    typename std::enable_if<std::is_integral<Level>::value && (sizeof(Level) <= 4)>::type>
+    typename std::enable_if<rocprim::is_integral<Level>::value && (sizeof(Level) <= 4)>::type>
 {
     size_t        bins;
     Level         lower_level;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -53,14 +53,14 @@ struct ordered_block_id
     //   my_kernel<<<x, y>>>(ordered_bid);
     //
     // On the kernel side it should be:
-    //   __globbal__ my_kernel(ordered_block_id<> ordered_bid)
+    //   __global__ my_kernel(ordered_block_id<> ordered_bid)
     //   {
     //     __shared__ ordered_block_id<>::storage ordered_bid_storage;
     //
     //     auto tid      = threadIdx.x;
     //     auto block_id = ordered_bid.get(tid, ordered_bid_storage);
     //   }
-    static_assert(std::is_integral<T>::value, "T must be integer");
+    static_assert(rocprim::is_integral<T>::value, "T must be integer");
     using id_type = T;
 
     /// Pointer to global memory that contains the atomic counter for block id.

--- a/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -785,7 +785,7 @@ hipError_t radix_sort_keys(void*              temporary_storage,
                            hipStream_t        stream            = 0,
                            bool               debug_synchronous = false)
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        ignored;
     return detail::radix_sort_impl<Config, false>(temporary_storage,
@@ -902,7 +902,7 @@ hipError_t radix_sort_keys(void*               temporary_storage,
                            hipStream_t         stream            = 0,
                            bool                debug_synchronous = false)
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        is_result_in_output;
     hipError_t  error = detail::radix_sort_impl<Config, false>(temporary_storage,
@@ -1052,7 +1052,7 @@ auto radix_sort_keys(void*              temporary_storage,
                      bool               debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        ignored;
     return detail::radix_sort_impl<Config, false>(temporary_storage,
@@ -1184,7 +1184,7 @@ auto radix_sort_keys(void*              temporary_storage,
                      bool               debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        ignored;
     return detail::radix_sort_impl<Config, false>(
@@ -1327,7 +1327,7 @@ auto radix_sort_keys(void*               temporary_storage,
                      bool                debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        is_result_in_output;
     hipError_t  error = detail::radix_sort_impl<Config, false>(temporary_storage,
@@ -1461,7 +1461,7 @@ auto radix_sort_keys(void*               temporary_storage,
                      bool                debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        is_result_in_output;
     hipError_t  error = detail::radix_sort_impl<Config, false>(
@@ -1586,7 +1586,7 @@ hipError_t radix_sort_keys_desc(void*              temporary_storage,
                                 hipStream_t        stream            = 0,
                                 bool               debug_synchronous = false)
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        ignored;
     return detail::radix_sort_impl<Config, true>(temporary_storage,
@@ -1703,7 +1703,7 @@ hipError_t radix_sort_keys_desc(void*               temporary_storage,
                                 hipStream_t         stream            = 0,
                                 bool                debug_synchronous = false)
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        is_result_in_output;
     hipError_t  error = detail::radix_sort_impl<Config, true>(temporary_storage,
@@ -1853,7 +1853,7 @@ auto radix_sort_keys_desc(void*              temporary_storage,
                           bool               debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        ignored;
     return detail::radix_sort_impl<Config, true>(temporary_storage,
@@ -1985,7 +1985,7 @@ auto radix_sort_keys_desc(void*              temporary_storage,
                           bool               debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        ignored;
     return detail::radix_sort_impl<Config, true>(
@@ -2128,7 +2128,7 @@ auto radix_sort_keys_desc(void*               temporary_storage,
                           bool                debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        is_result_in_output;
     hipError_t  error = detail::radix_sort_impl<Config, true>(temporary_storage,
@@ -2262,7 +2262,7 @@ auto radix_sort_keys_desc(void*               temporary_storage,
                           bool                debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     empty_type* values = nullptr;
     bool        is_result_in_output;
     hipError_t  error
@@ -2406,7 +2406,7 @@ hipError_t radix_sort_pairs(void*                temporary_storage,
                             hipStream_t          stream            = 0,
                             bool                 debug_synchronous = false)
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool ignored;
     return detail::radix_sort_impl<Config, false>(temporary_storage,
                                                   storage_size,
@@ -2536,7 +2536,7 @@ hipError_t radix_sort_pairs(void*                 temporary_storage,
                             hipStream_t           stream            = 0,
                             bool                  debug_synchronous = false)
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool       is_result_in_output;
     hipError_t error = detail::radix_sort_impl<Config, false>(temporary_storage,
                                                               storage_size,
@@ -2705,7 +2705,7 @@ auto radix_sort_pairs(void*                temporary_storage,
                       bool                 debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool ignored;
     return detail::radix_sort_impl<Config, false>(temporary_storage,
                                                   storage_size,
@@ -2851,7 +2851,7 @@ auto radix_sort_pairs(void*                temporary_storage,
                       bool                 debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool ignored;
     return detail::radix_sort_impl<Config, false>(
         temporary_storage,
@@ -3005,7 +3005,7 @@ auto radix_sort_pairs(void*                 temporary_storage,
                       bool                  debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool       is_result_in_output;
     hipError_t error = detail::radix_sort_impl<Config, false>(temporary_storage,
                                                               storage_size,
@@ -3147,7 +3147,7 @@ auto radix_sort_pairs(void*                 temporary_storage,
                       bool                  debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool       is_result_in_output;
     hipError_t error = detail::radix_sort_impl<Config, false>(
         temporary_storage,
@@ -3287,7 +3287,7 @@ hipError_t radix_sort_pairs_desc(void*                temporary_storage,
                                  hipStream_t          stream            = 0,
                                  bool                 debug_synchronous = false)
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool ignored;
     return detail::radix_sort_impl<Config, true>(temporary_storage,
                                                  storage_size,
@@ -3411,7 +3411,7 @@ hipError_t radix_sort_pairs_desc(void*                 temporary_storage,
                                  hipStream_t           stream            = 0,
                                  bool                  debug_synchronous = false)
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool       is_result_in_output;
     hipError_t error = detail::radix_sort_impl<Config, true>(temporary_storage,
                                                              storage_size,
@@ -3580,7 +3580,7 @@ auto radix_sort_pairs_desc(void*                temporary_storage,
                            bool                 debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool ignored;
     return detail::radix_sort_impl<Config, true>(temporary_storage,
                                                  storage_size,
@@ -3726,7 +3726,7 @@ auto radix_sort_pairs_desc(void*                temporary_storage,
                            bool                 debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool ignored;
     return detail::radix_sort_impl<Config, true>(
         temporary_storage,
@@ -3880,7 +3880,7 @@ auto radix_sort_pairs_desc(void*                 temporary_storage,
                            bool                  debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool       is_result_in_output;
     hipError_t error = detail::radix_sort_impl<Config, true>(temporary_storage,
                                                              storage_size,
@@ -4022,7 +4022,7 @@ auto radix_sort_pairs_desc(void*                 temporary_storage,
                            bool                  debug_synchronous = false)
     -> std::enable_if_t<!std::is_convertible<Decomposer, unsigned int>::value, hipError_t>
 {
-    static_assert(std::is_integral<Size>::value, "Size must be an integral type.");
+    static_assert(rocprim::is_integral<Size>::value, "Size must be an integral type.");
     bool       is_result_in_output;
     hipError_t error
         = detail::radix_sort_impl<Config, true>(temporary_storage,

--- a/projects/rocprim/rocprim/include/rocprim/iterator/counting_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/counting_iterator.hpp
@@ -65,7 +65,7 @@ public:
     /// The category of the iterator.
     using iterator_category = std::random_access_iterator_tag;
 
-    static_assert(std::is_integral<value_type>::value, "Incrementable must be integral type");
+    static_assert(rocprim::is_integral<value_type>::value, "Incrementable must be integral type");
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     using self_type = counting_iterator;

--- a/projects/rocprim/test/rocprim/test_device_merge_inplace.cpp
+++ b/projects/rocprim/test/rocprim/test_device_merge_inplace.cpp
@@ -174,12 +174,12 @@ struct random_data_generator
 
         // not all integral types are valid for int distribution
         using dist_value_type
-            = std::conditional_t<std::is_integral<T>::value
+            = std::conditional_t<rocprim::is_integral<T>::value
                                      && !common::is_valid_for_int_distribution<value_type>::value,
                                  int,
                                  value_type>;
 
-        using val_dist_type = std::conditional_t<std::is_integral<T>::value,
+        using val_dist_type = std::conditional_t<rocprim::is_integral<T>::value,
                                                  common::uniform_int_distribution<dist_value_type>,
                                                  std::uniform_real_distribution<dist_value_type>>;
         using dup_dist_type = common::uniform_int_distribution<int>;

--- a/projects/rocprim/test/rocprim/test_utils_assertions.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_assertions.hpp
@@ -300,7 +300,7 @@ auto assert_near(const std::vector<common::custom_type<T, T, true>>& result,
 template<class T>
 auto assert_near(const std::vector<common::custom_type<T, T, true>>& result,
                  const std::vector<common::custom_type<T, T, true>>& expected,
-                 const float) -> typename std::enable_if<std::is_integral<T>::value>::type
+                 const float) -> typename std::enable_if<rocprim::is_integral<T>::value>::type
 {
     ASSERT_EQ(result.size(), expected.size());
     for(size_t i = 0; i < result.size(); i++)
@@ -342,8 +342,8 @@ auto assert_near(const T& result, const T& expected, const float percent)
 }
 
 template<class T>
-auto assert_near(const T& result, const T& expected, const float)
-    -> typename std::enable_if<std::is_integral<T>::value>::type
+auto assert_near(const T& result, const T& expected, const float) ->
+    typename std::enable_if<rocprim::is_integral<T>::value>::type
 {
     ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result, expected));
 }
@@ -372,7 +372,7 @@ auto assert_near(const common::custom_type<T, T, true>& result,
 template<class T>
 auto assert_near(const common::custom_type<T, T, true>& result,
                  const common::custom_type<T, T, true>& expected,
-                 const float) -> typename std::enable_if<std::is_integral<T>::value>::type
+                 const float) -> typename std::enable_if<rocprim::is_integral<T>::value>::type
 {
     ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result.x, expected.x));
     ASSERT_NO_FATAL_FAILURE(protected_assert_eq(result.y, expected.y));
@@ -380,7 +380,7 @@ auto assert_near(const common::custom_type<T, T, true>& result,
 
 template<class T>
 auto assert_near(const T& result, const T& expected, const float /*percent*/) ->
-    typename std::enable_if<!std::is_integral<T>::value && !std::is_floating_point<T>::value
+    typename std::enable_if<!rocprim::is_integral<T>::value && !std::is_floating_point<T>::value
                             && !(std::is_same<T, rocprim::bfloat16>::value
                                  || std::is_same<T, rocprim::half>::value)>::type
 {

--- a/projects/rocprim/test/rocprim/test_utils_data_generation.hpp
+++ b/projects/rocprim/test/rocprim/test_utils_data_generation.hpp
@@ -211,7 +211,7 @@ private:
 public:
     static std::vector<T> vector()
     {
-        if(std::is_integral<T>::value)
+        if(rocprim::is_integral<T>::value)
         {
             return std::vector<T>();
         }
@@ -439,7 +439,7 @@ inline auto generate_random_data_n(OutputIter                                   
                                    Generator&&                                         gen)
     -> std::enable_if_t<
         is_custom_test_array_type<common::it_value_t<OutputIter>>::value
-            && std::is_integral<typename common::it_value_t<OutputIter>::value_type>::value,
+            && rocprim::is_integral<typename common::it_value_t<OutputIter>::value_type>::value,
         OutputIter>
 {
     using T = typename std::iterator_traits<OutputIter>::value_type;


### PR DESCRIPTION
## Motivation

Current `rocprim::is_integral` and `std::is_integral` are used interchangeably throughout the codebase.
They are mostly identical, with the exception that  `std::is_integral` does not recognize 128bit integers as integral. 

By standardizing to the `rocprim::is_integral` implementation, we avoid edge cases where a 128 bit integer is unexpectedly not detected and inconsistencies.

## Technical Details

For each change we need to ensure no regressions are introduced.

### `projects/rocprim/benchmark/benchmark_device_histogram.cpp`

Only usage:  
https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/benchmark/benchmark_device_histogram.cpp#L70

No regression. `std::is_integral` and `sizeof` are used to ensure that only integers smaller than 16 bytes are used. Replacing this with `rocprim::is_integral` would have no effect, since the `sizeof` check would still fail for larger integer types.

---

### `projects/rocprim/benchmark/benchmark_device_histogram.parallel.hpp`

No regression. Same situation as `benchmark_device_histogram.cpp`:  
https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/benchmark/benchmark_device_histogram.parallel.hpp#L205

---

### `projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp`

Only usage:  
https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/rocprim/include/rocprim/device/detail/device_histogram.hpp#L110

No regression. Similar to the previous two cases, but with a 64-byte size limit.

---

### `projects/rocprim/example/example_utils.hpp`

This is example code and does not appear to be used for generated binaries.  
It still makes sense to update it so that users who implement code by example use the correct trait.

---

### `projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp`

Used multiple times to ensure that the size variable is integral. Example:  
https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/rocprim/include/rocprim/device/device_radix_sort.hpp#L788

Related usage in tests:  
https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/test/rocprim/test_utils_assertions.hpp#L383

This effectively limits the size type to a 64-bit integer. With the minimum element size of 1 byte, this limits sortable data to about 9.2 exabytes. It seems unlikely that supporting more than this would be required.

There does not appear to be any regression caused by supporting 128-bit integers here.

---

### `projects/rocprim/test/rocprim/test_utils_assertions.hpp`

Relevant usage:  
https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/test/rocprim/test_utils_assertions.hpp#L375

This appears to be an oversight. The check is used to select which `assert_near` implementation is used. All other integer types use  
`ASSERT_NO_FATAL_FAILURE(protected_assert_eq(...))`,  
while `uint128_t` ends up using `ASSERT_EQ`.

https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/test/rocprim/test_utils_assertions.hpp#L81

An `operator<<` for `int128` is also already implemented here.  
Supporting 128-bit integers would improve consistency across integer types.

---

### [`projects/rocprim/test/rocprim/test_device_merge_inplace.cpp`](https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/test/rocprim/test_device_merge_inplace.cpp)

[This](https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/test/rocprim/test_device_merge_inplace.cpp#L177) ensures that the integer type is valid for the integer distribution. Since `int128` is already included in `is_valid_for_int_distribution`, the additional `is_integral` check is redundant. `is_valid_for_int_distribution` already performs the necessary validation.

Note: the hipCUB definition of `is_valid_for_int_distribution` does *not* support `int128`:  
https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipcub/test/hipcub/test_utils_data_generation.hpp#L335  

Another problematic line:  
https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/test/rocprim/test_device_merge_inplace.cpp#L182

Here, `std::uniform_real_distribution` is used for `int128`, which it does not support.  
`std::uniform_int_distribution` *does* support `int128`, so this should be switched.  
No regressions are expected from this change.

---

### `projects/rocprim/test/rocprim/test_utils_data_generation.hpp`

This file is used to generate vectors with “special values” such as NaN or infinity. This makes sense for floating-point types, but not for integers.

For integer types, an empty vector is returned. However, since `int128` is not correctly handled, the code attempts to create `int128::infinity` and `int128::quiet_NaN`, neither of which exist. This should result in a compile error.

This issue likely has not been caught yet because the affected path is not currently exercised.  
No regressions are expected.

---

### `projects/rocprim/rocprim/include/rocprim/iterator/counting_iterator.hpp`

Ensures that the value type is an integer:  
https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocprim/rocprim/include/rocprim/iterator/counting_iterator.hpp#L68

This iterator is only used in two places:

- `rocprim/include/rocprim/device/device_segmented_radix_sort.hpp` (with `unsigned int`)
- `rocprim/include/rocprim/device/device_adjacent_find.hpp` (with `std::size_t`)

It currently cannot be instantiated with `int128`, but all operations would be compatible. No regressions are expected from switching the check.

---

### `rocprim/include/rocprim/device/detail/ordered_block_id.hpp`

Used to ensure that an integer type is used for grid IDs.  
All functionality would work with `int128`. No regressions are expected from switching to `rocprim::is_integral`.

---

## Test Plan

Run tests for all modified primitives.

## Test Result

All tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
