### PR TITLE
[hipDNN] Fixed up some tests using the wrong plugin

### DIFF
--- a/projects/hipdnn/tests/backend/IntegrationBackendDescriptor.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationBackendDescriptor.cpp
@@ -6,11 +6,27 @@
 #include <hipdnn_sdk/data_objects/graph_generated.h>
 #include <hipdnn_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+#include <test_plugins/TestPluginConstants.hpp>
 #include <vector>
 
 namespace fs = std::filesystem;
 
-TEST(IntegrationBackendDescriptor, CreateAndDestroy)
+class IntegrationBackendDescriptor : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        const std::array<const char*, 1> paths
+            = {hipdnn_tests::plugin_constants::testGoodPluginPath().c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+    }
+
+    void TearDown() override {}
+};
+
+TEST_F(IntegrationBackendDescriptor, CreateAndDestroy)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
 
@@ -22,7 +38,7 @@ TEST(IntegrationBackendDescriptor, CreateAndDestroy)
     EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(IntegrationBackendDescriptor, CreateWithNullptr)
+TEST_F(IntegrationBackendDescriptor, CreateWithNullptr)
 {
     hipdnnStatus_t status
         = hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINE_DESCRIPTOR, nullptr);
@@ -30,7 +46,7 @@ TEST(IntegrationBackendDescriptor, CreateWithNullptr)
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(IntegrationBackendDescriptor, WillNotCreateDescriptorIfTypeNotSupported)
+TEST_F(IntegrationBackendDescriptor, WillNotCreateDescriptorIfTypeNotSupported)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
 
@@ -39,7 +55,7 @@ TEST(IntegrationBackendDescriptor, WillNotCreateDescriptorIfTypeNotSupported)
     EXPECT_EQ(status, HIPDNN_STATUS_NOT_SUPPORTED);
 }
 
-TEST(IntegrationBackendDescriptor, WontDestroyDescriptorIfNull)
+TEST_F(IntegrationBackendDescriptor, WontDestroyDescriptorIfNull)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
 
@@ -48,7 +64,7 @@ TEST(IntegrationBackendDescriptor, WontDestroyDescriptorIfNull)
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(IntegrationBackendDescriptor, Finalize)
+TEST_F(IntegrationBackendDescriptor, Finalize)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
 
@@ -57,7 +73,7 @@ TEST(IntegrationBackendDescriptor, Finalize)
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(IntegrationBackendDescriptor, GetAttributeWithNullDescriptor)
+TEST_F(IntegrationBackendDescriptor, GetAttributeWithNullDescriptor)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
     hipdnnBackendAttributeName_t attributeName = HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH;
@@ -76,7 +92,7 @@ TEST(IntegrationBackendDescriptor, GetAttributeWithNullDescriptor)
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(IntegrationBackendDescriptor, SetAttributeWithNullDescriptor)
+TEST_F(IntegrationBackendDescriptor, SetAttributeWithNullDescriptor)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
     hipdnnBackendAttributeName_t attributeName = HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH;
@@ -90,7 +106,7 @@ TEST(IntegrationBackendDescriptor, SetAttributeWithNullDescriptor)
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(IntegrationBackendDescriptor, CreateAndDeserializeGraphExtWithNullGraph)
+TEST_F(IntegrationBackendDescriptor, CreateAndDeserializeGraphExtWithNullGraph)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
 
@@ -100,7 +116,7 @@ TEST(IntegrationBackendDescriptor, CreateAndDeserializeGraphExtWithNullGraph)
     EXPECT_EQ(descriptor, nullptr);
 }
 
-TEST(IntegrationBackendDescriptor, SetOperationGraph)
+TEST_F(IntegrationBackendDescriptor, SetOperationGraph)
 {
     SKIP_IF_NO_DEVICES();
     flatbuffers::FlatBufferBuilder builder;
@@ -139,7 +155,7 @@ TEST(IntegrationBackendDescriptor, SetOperationGraph)
     EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(IntegrationBackendDescriptor, FinalizeInvalidOperationGraph)
+TEST_F(IntegrationBackendDescriptor, FinalizeInvalidOperationGraph)
 {
     hipdnnBackendDescriptor_t descriptor = nullptr;
     auto status

--- a/projects/hipdnn/tests/backend/IntegrationHandleApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationHandleApi.cpp
@@ -4,6 +4,22 @@
 #include "hipdnn_backend.h"
 #include <gtest/gtest.h>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+#include <test_plugins/TestPluginConstants.hpp>
+
+class IntegrationHandleApi : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        const std::array<const char*, 1> paths
+            = {hipdnn_tests::plugin_constants::testGoodPluginPath().c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+    }
+
+    void TearDown() override {}
+};
 
 TEST(IntegrationHandleApi, CreateAndDestroy)
 {

--- a/projects/hipdnn/tests/backend/IntegrationHandleApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationHandleApi.cpp
@@ -21,7 +21,22 @@ protected:
     void TearDown() override {}
 };
 
-TEST(IntegrationHandleApi, CreateAndDestroy)
+class IntegrationGpuHandleApi : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        const std::array<const char*, 1> paths
+            = {hipdnn_tests::plugin_constants::testGoodPluginPath().c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+    }
+
+    void TearDown() override {}
+};
+
+TEST_F(IntegrationHandleApi, CreateAndDestroy)
 {
     hipdnnHandle_t handle = nullptr;
 
@@ -33,28 +48,28 @@ TEST(IntegrationHandleApi, CreateAndDestroy)
     ASSERT_EQ(destroyStatus, HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(IntegrationHandleApi, CreateWithNullptr)
+TEST_F(IntegrationHandleApi, CreateWithNullptr)
 {
     hipdnnStatus_t status = hipdnnCreate(nullptr);
 
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(IntegrationHandleApi, SetStreamNullptrHandle)
+TEST_F(IntegrationHandleApi, SetStreamNullptrHandle)
 {
     hipStream_t testStream = nullptr;
     auto setStreamStatus = hipdnnSetStream(nullptr, testStream);
     ASSERT_EQ(setStreamStatus, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(IntegrationHandleApi, GetStreamNullptrHandle)
+TEST_F(IntegrationHandleApi, GetStreamNullptrHandle)
 {
     hipStream_t retrievedStream = nullptr;
     auto getStreamStatus = hipdnnGetStream(nullptr, &retrievedStream);
     ASSERT_EQ(getStreamStatus, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
-TEST(IntegrationHandleApi, GetStreamNullptrStreamPointer)
+TEST_F(IntegrationHandleApi, GetStreamNullptrStreamPointer)
 {
     hipdnnHandle_t handle = nullptr;
 
@@ -71,7 +86,7 @@ TEST(IntegrationHandleApi, GetStreamNullptrStreamPointer)
     ASSERT_EQ(destroyStatus, HIPDNN_STATUS_SUCCESS);
 }
 
-TEST(IntegrationGpuHandleApi, GetStreamPointer)
+TEST_F(IntegrationGpuHandleApi, GetStreamPointer)
 {
     SKIP_IF_NO_DEVICES();
 


### PR DESCRIPTION
## Motivation
During an investigation into a potential hang during testing, noticed that a few of the tests were being run against the MIOpen plugin, rather than the test plugin.

## Technical Details
- Forced the tests to use the test plugin

## Test Plan
- Unit / Integration Tests run
- CI/CD passes

## Test Result
- [x] Integration tests pass

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
