### PR TITLE
[hipsparse] Fix file loading to look for new .csr extension

### DIFF
--- a/projects/hipsparse/clients/common/hipsparse_gentest.py
+++ b/projects/hipsparse/clients/common/hipsparse_gentest.py
@@ -406,7 +406,7 @@ def generate(test, function):
                     #
                     if ((not os.path.isdir(filename_arg))
                         and (not glob.glob(filename_arg))
-                        and (not glob.glob(filename_arg + ".csr"))):
+                        and (not glob.glob(filename_arg + ".bin"))):
                         print("skip unrecognized filename, directory or filename glob expression: '" + test[key] + "'")
                     else:
                         cleanlist.append(test[key])
@@ -439,7 +439,7 @@ def generate(test, function):
                         #
                         names = glob.glob(filename_arg)
                         if not names:
-                            names = glob.glob(filename_arg + ".csr")
+                            names = glob.glob(filename_arg + ".bin")
                             generate(test,function)
 
                         else:

--- a/projects/hipsparse/clients/include/hipsparse_arguments.hpp
+++ b/projects/hipsparse/clients/include/hipsparse_arguments.hpp
@@ -119,7 +119,7 @@ struct Arguments
     int timing;
     int iters;
 
-    char filename[192]; // nos2.bin, bmwcra_1.bin, etc
+    char filename[192]; // nos2.csr, bmwcra_1.csr, etc
     char function[64]; // axpby, spmv_csr, etc
     char category[32]; // quick, pre_checkin, etc
 

--- a/projects/hipsparse/clients/include/hipsparse_arguments.hpp
+++ b/projects/hipsparse/clients/include/hipsparse_arguments.hpp
@@ -119,7 +119,7 @@ struct Arguments
     int timing;
     int iters;
 
-    char filename[192]; // nos2.csr, bmwcra_1.csr, etc
+    char filename[192]; // nos2.bin, bmwcra_1.bin, etc
     char function[64]; // axpby, spmv_csr, etc
     char category[32]; // quick, pre_checkin, etc
 

--- a/projects/hipsparse/clients/include/testing_csrcolor.hpp
+++ b/projects/hipsparse/clients/include/testing_csrcolor.hpp
@@ -260,6 +260,8 @@ void testing_csrcolor(const Arguments& argus)
         return;
     }
 
+    std::cout << "AAAA m: " << m << " k: " << k << " nnz: " << nnz << std::endl;
+
     hipsparseColorInfo_t colorInfo;
     CHECK_HIPSPARSE_ERROR(hipsparseCreateColorInfo(&colorInfo));
 
@@ -276,11 +278,14 @@ void testing_csrcolor(const Arguments& argus)
     int* dcoloring   = (int*)dcoloring_managed.get();
     int* dreordering = (int*)dreordering_managed.get();
 
+    std::cout << "BBBB" << std::endl;
     // copy data from CPU to device
     CHECK_HIP_ERROR(
         hipMemcpy(drow_ptr, hrow_ptr.data(), sizeof(int) * (m + 1), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dcol_ind, hcol_ind.data(), sizeof(int) * nnz, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dval, hval.data(), sizeof(T) * nnz, hipMemcpyHostToDevice));
+
+    std::cout << "CCCC" << std::endl;
 
     int ncolors;
 
@@ -298,6 +303,8 @@ void testing_csrcolor(const Arguments& argus)
                                              colorInfo));
     CHECK_HIP_ERROR(hipDeviceSynchronize());
 
+    std::cout << "ncolors: " << ncolors << std::endl;
+
     if(argus.unit_check)
     {
         std::vector<int> hcoloring(m);
@@ -307,6 +314,7 @@ void testing_csrcolor(const Arguments& argus)
         CHECK_HIP_ERROR(
             hipMemcpy(hreordering.data(), dreordering, sizeof(int) * m, hipMemcpyDeviceToHost));
 
+        std::cout << "DDDD" << std::endl;
         // Check that two adjacent nodes do not have the same color
         for(int row = 0; row < m; ++row)
         {
@@ -329,6 +337,8 @@ void testing_csrcolor(const Arguments& argus)
             }
         }
 
+        std::cout << "EEEE" << std::endl;
+
         // Check if colors are contiguous
         int max_value = 0;
         for(size_t i = 0; i < hcoloring.size(); ++i)
@@ -347,6 +357,8 @@ void testing_csrcolor(const Arguments& argus)
         }
         ++max_value;
 
+        std::cout << "max_value: " << max_value << std::endl;
+
 #ifdef __HIP_PLATFORM_AMD__
         std::vector<bool> marker(max_value, false);
         for(size_t i = 0; i < hcoloring.size(); ++i)
@@ -361,6 +373,8 @@ void testing_csrcolor(const Arguments& argus)
                                     HIPSPARSE_STATUS_SUCCESS);
         }
 #endif
+
+        std::cout << "FFFF" << std::endl;
     }
 
     CHECK_HIPSPARSE_ERROR(hipsparseDestroyColorInfo(colorInfo));

--- a/projects/hipsparse/clients/include/testing_csrcolor.hpp
+++ b/projects/hipsparse/clients/include/testing_csrcolor.hpp
@@ -260,8 +260,6 @@ void testing_csrcolor(const Arguments& argus)
         return;
     }
 
-    std::cout << "AAAA m: " << m << " k: " << k << " nnz: " << nnz << std::endl;
-
     hipsparseColorInfo_t colorInfo;
     CHECK_HIPSPARSE_ERROR(hipsparseCreateColorInfo(&colorInfo));
 
@@ -278,14 +276,11 @@ void testing_csrcolor(const Arguments& argus)
     int* dcoloring   = (int*)dcoloring_managed.get();
     int* dreordering = (int*)dreordering_managed.get();
 
-    std::cout << "BBBB" << std::endl;
     // copy data from CPU to device
     CHECK_HIP_ERROR(
         hipMemcpy(drow_ptr, hrow_ptr.data(), sizeof(int) * (m + 1), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dcol_ind, hcol_ind.data(), sizeof(int) * nnz, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dval, hval.data(), sizeof(T) * nnz, hipMemcpyHostToDevice));
-
-    std::cout << "CCCC" << std::endl;
 
     int ncolors;
 
@@ -303,8 +298,6 @@ void testing_csrcolor(const Arguments& argus)
                                              colorInfo));
     CHECK_HIP_ERROR(hipDeviceSynchronize());
 
-    std::cout << "ncolors: " << ncolors << std::endl;
-
     if(argus.unit_check)
     {
         std::vector<int> hcoloring(m);
@@ -314,7 +307,6 @@ void testing_csrcolor(const Arguments& argus)
         CHECK_HIP_ERROR(
             hipMemcpy(hreordering.data(), dreordering, sizeof(int) * m, hipMemcpyDeviceToHost));
 
-        std::cout << "DDDD" << std::endl;
         // Check that two adjacent nodes do not have the same color
         for(int row = 0; row < m; ++row)
         {
@@ -337,8 +329,6 @@ void testing_csrcolor(const Arguments& argus)
             }
         }
 
-        std::cout << "EEEE" << std::endl;
-
         // Check if colors are contiguous
         int max_value = 0;
         for(size_t i = 0; i < hcoloring.size(); ++i)
@@ -357,8 +347,6 @@ void testing_csrcolor(const Arguments& argus)
         }
         ++max_value;
 
-        std::cout << "max_value: " << max_value << std::endl;
-
 #ifdef __HIP_PLATFORM_AMD__
         std::vector<bool> marker(max_value, false);
         for(size_t i = 0; i < hcoloring.size(); ++i)
@@ -373,8 +361,6 @@ void testing_csrcolor(const Arguments& argus)
                                     HIPSPARSE_STATUS_SUCCESS);
         }
 #endif
-
-        std::cout << "FFFF" << std::endl;
     }
 
     CHECK_HIPSPARSE_ERROR(hipsparseDestroyColorInfo(colorInfo));

--- a/projects/hipsparse/clients/include/testing_spmv_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_csr.hpp
@@ -43,7 +43,7 @@ template <typename I, typename J, typename T>
 void testing_spmv_csr_bad_arg(const Arguments& argus)
 {
 #if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -60,7 +60,7 @@ void testing_spmv_csr_bad_arg(const Arguments& argus)
 #else
 #if(CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_ALG_DEFAULT;
-#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -176,7 +176,7 @@ template <typename I, typename J, typename T>
 void testing_spmv_csr(Arguments argus)
 {
 #if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     J                    m        = argus.M;
     J                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_spmv_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_csr.hpp
@@ -22,8 +22,8 @@
  * ************************************************************************ */
 
 #pragma once
-#ifndef TESTING_SPMV_SELL_HPP
-#define TESTING_SPMV_SELL_HPP
+#ifndef TESTING_SPMV_CSR_HPP
+#define TESTING_SPMV_CSR_HPP
 
 #include "display.hpp"
 #include "flops.hpp"
@@ -43,7 +43,7 @@ template <typename I, typename J, typename T>
 void testing_spmv_csr_bad_arg(const Arguments& argus)
 {
 #if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -60,7 +60,7 @@ void testing_spmv_csr_bad_arg(const Arguments& argus)
 #else
 #if(CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_ALG_DEFAULT;
-#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -176,7 +176,7 @@ template <typename I, typename J, typename T>
 void testing_spmv_csr(Arguments argus)
 {
 #if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     J                    m        = argus.M;
     J                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/utility.hpp
+++ b/projects/hipsparse/clients/include/utility.hpp
@@ -161,8 +161,8 @@ inline std::string get_filename(const std::string& matrix_filename)
 // BSR indexing macros
 #define BSR_IND(j, bi, bj, dir) \
     ((dir == HIPSPARSE_DIRECTION_ROW) ? BSR_IND_R(j, bi, bj) : BSR_IND_C(j, bi, bj))
-#define BSR_IND_R(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) * bsr_dim + (bj))
-#define BSR_IND_C(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) + (bj) * bsr_dim)
+#define BSR_IND_R(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi)*bsr_dim + (bj))
+#define BSR_IND_C(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) + (bj)*bsr_dim)
 
 #if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 11003))
 inline const char* hipsparseStatusToString(hipsparseStatus_t status)

--- a/projects/hipsparse/clients/include/utility.hpp
+++ b/projects/hipsparse/clients/include/utility.hpp
@@ -1119,7 +1119,43 @@ int read_bin_matrix(const char*          filename,
 
     int err;
 
-    int nrowf, ncolf, nnzf;
+    // Read rocALUTION header string
+    const char expected_header[] = "#rocALUTION binary csr file";
+    char       header[sizeof(expected_header)];
+    err = fread(header, sizeof(char), sizeof(expected_header) - 1, f);
+    if(!err)
+    {
+        fclose(f);
+        return -1;
+    }
+    header[sizeof(expected_header) - 1] = '\0';
+    if(strcmp(header, expected_header) != 0)
+    {
+        fclose(f);
+        return -1;
+    }
+
+    // Skip newline character written by std::endl
+    char newline;
+    err = fread(&newline, sizeof(char), 1, f);
+    if(!err)
+    {
+        fclose(f);
+        return -1;
+    }
+
+    // Read version number
+    int version;
+    err = fread(&version, sizeof(int), 1, f);
+    if(!err)
+    {
+        fclose(f);
+        return -1;
+    }
+
+    int nrowf = 0;
+    int ncolf = 0;
+    int nnzf = 0;
 
     err = fread(&nrowf, sizeof(int), 1, f);
     err |= fread(&ncolf, sizeof(int), 1, f);

--- a/projects/hipsparse/clients/include/utility.hpp
+++ b/projects/hipsparse/clients/include/utility.hpp
@@ -1229,7 +1229,7 @@ bool generate_csr_matrix(const std::string    filename,
         std::string full_filename_path = get_filename(filename);
         std::string extension = full_filename_path.substr(full_filename_path.find_last_of(".") + 1);
 
-        if(extension == "bin")
+        if(extension == "csr")
         {
             if(read_bin_matrix(full_filename_path.c_str(),
                                nrow,
@@ -1314,7 +1314,7 @@ bool generate_coo_matrix(const std::string    filename,
         std::string full_filename_path = get_filename(filename);
         std::string extension = full_filename_path.substr(full_filename_path.find_last_of(".") + 1);
 
-        if(extension == "bin")
+        if(extension == "csr")
         {
             std::vector<I> csr_row_ptr;
             if(read_bin_matrix(full_filename_path.c_str(),

--- a/projects/hipsparse/clients/include/utility.hpp
+++ b/projects/hipsparse/clients/include/utility.hpp
@@ -1155,7 +1155,7 @@ int read_bin_matrix(const char*          filename,
 
     int nrowf = 0;
     int ncolf = 0;
-    int nnzf = 0;
+    int nnzf  = 0;
 
     err = fread(&nrowf, sizeof(int), 1, f);
     err |= fread(&ncolf, sizeof(int), 1, f);

--- a/projects/hipsparse/clients/include/utility.hpp
+++ b/projects/hipsparse/clients/include/utility.hpp
@@ -99,7 +99,7 @@ inline std::string get_filename(const std::string& matrix_filename)
     size_t last_dot_pos = matrix_filename_with_ext.find_last_of('.');
     if(last_dot_pos == std::string::npos || last_dot_pos == 0)
     {
-        matrix_filename_with_ext += ".csr";
+        matrix_filename_with_ext += ".bin";
     }
 
     const char* matrices_dir = get_hipsparse_clients_matrices_dir();
@@ -161,8 +161,8 @@ inline std::string get_filename(const std::string& matrix_filename)
 // BSR indexing macros
 #define BSR_IND(j, bi, bj, dir) \
     ((dir == HIPSPARSE_DIRECTION_ROW) ? BSR_IND_R(j, bi, bj) : BSR_IND_C(j, bi, bj))
-#define BSR_IND_R(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi)*bsr_dim + (bj))
-#define BSR_IND_C(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) + (bj)*bsr_dim)
+#define BSR_IND_R(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) * bsr_dim + (bj))
+#define BSR_IND_C(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) + (bj) * bsr_dim)
 
 #if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 11003))
 inline const char* hipsparseStatusToString(hipsparseStatus_t status)
@@ -1119,40 +1119,6 @@ int read_bin_matrix(const char*          filename,
 
     int err;
 
-    // Read rocALUTION header string
-    const char expected_header[] = "#rocALUTION binary csr file";
-    char       header[sizeof(expected_header)];
-    err = fread(header, sizeof(char), sizeof(expected_header) - 1, f);
-    if(!err)
-    {
-        fclose(f);
-        return -1;
-    }
-    header[sizeof(expected_header) - 1] = '\0';
-    if(strcmp(header, expected_header) != 0)
-    {
-        fclose(f);
-        return -1;
-    }
-
-    // Skip newline character written by std::endl
-    char newline;
-    err = fread(&newline, sizeof(char), 1, f);
-    if(!err)
-    {
-        fclose(f);
-        return -1;
-    }
-
-    // Read version number
-    int version;
-    err = fread(&version, sizeof(int), 1, f);
-    if(!err)
-    {
-        fclose(f);
-        return -1;
-    }
-
     int nrowf = 0;
     int ncolf = 0;
     int nnzf  = 0;
@@ -1265,7 +1231,7 @@ bool generate_csr_matrix(const std::string    filename,
         std::string full_filename_path = get_filename(filename);
         std::string extension = full_filename_path.substr(full_filename_path.find_last_of(".") + 1);
 
-        if(extension == "csr")
+        if(extension == "bin")
         {
             if(read_bin_matrix(full_filename_path.c_str(),
                                nrow,
@@ -1350,7 +1316,7 @@ bool generate_coo_matrix(const std::string    filename,
         std::string full_filename_path = get_filename(filename);
         std::string extension = full_filename_path.substr(full_filename_path.find_last_of(".") + 1);
 
-        if(extension == "csr")
+        if(extension == "bin")
         {
             std::vector<I> csr_row_ptr;
             if(read_bin_matrix(full_filename_path.c_str(),

--- a/projects/hipsparse/clients/tests/CMakeLists.txt
+++ b/projects/hipsparse/clients/tests/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
     file(COPY ${CMAKE_MATRICES_DIR}/ DESTINATION ${PROJECT_BINARY_DIR}/matrices)
   
     if(STATUS AND NOT STATUS EQUAL 0)
-      message(FATAL_ERROR "Failed to copy matrix .csr files, aborting.")
+      message(FATAL_ERROR "Failed to copy matrix .bin files, aborting.")
     endif()
   endif()
 

--- a/projects/hipsparse/clients/tests/CMakeLists.txt
+++ b/projects/hipsparse/clients/tests/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
     file(COPY ${CMAKE_MATRICES_DIR}/ DESTINATION ${PROJECT_BINARY_DIR}/matrices)
   
     if(STATUS AND NOT STATUS EQUAL 0)
-      message(FATAL_ERROR "Failed to copy matrix .bin files, aborting.")
+      message(FATAL_ERROR "Failed to copy matrix .csr files, aborting.")
     endif()
   endif()
 

--- a/projects/hipsparse/clients/tests/rocm/CMakeLists.txt
+++ b/projects/hipsparse/clients/tests/rocm/CMakeLists.txt
@@ -28,15 +28,20 @@ set(HIPSPARSE_TEST_SOURCES
     test_gthrz.cpp
     test_roti.cpp
     test_sctr.cpp
+    test_doti.cpp
+    test_dotci.cpp
     # Level 2
     test_bsrmv.cpp
     test_bsrsv2.cpp
     test_bsrxmv.cpp
     test_csrsv2.cpp
+    test_csrmv.cpp
     test_gemvi.cpp
+    test_hybmv.cpp
     # Level 3
     test_bsrmm.cpp
     test_bsrsm2.cpp
+    test_csrmm.cpp
     test_csrsm2.cpp
     test_gemmi.cpp
     # Precond 
@@ -65,9 +70,12 @@ set(HIPSPARSE_TEST_SOURCES
     test_cscsort.cpp
     test_csr2bsr.cpp
     test_csr2coo.cpp
+    test_csr2csc.cpp
+    test_csr2csc_ex2.cpp
     test_csr2csr_compress.cpp
     test_csr2dense.cpp
     test_csr2gebsr.cpp
+    test_csr2hyb.cpp
     test_csrilusv.cpp
     test_csrsort.cpp
     test_csru2csr.cpp
@@ -76,6 +84,7 @@ set(HIPSPARSE_TEST_SOURCES
     test_gebsr2csr.cpp
     test_gebsr2gebsc.cpp
     test_gebsr2gebsr.cpp
+    test_hyb2csr.cpp
     test_identity.cpp
     test_nnz.cpp
     test_prune_csr2csr.cpp

--- a/projects/hipsparse/clients/tests/test_csrilusv.cpp
+++ b/projects/hipsparse/clients/tests/test_csrilusv.cpp
@@ -34,13 +34,13 @@ typedef std::tuple<base, std::string> csrilusv_bin_tuple;
 
 base csrilusv_idxbase_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 
-std::string csrilusv_bin[] = {"scircuit.csr",
+std::string csrilusv_bin[] = {"scircuit.bin",
 #if defined(__HIP_PLATFORM_AMD__)
                               //                              "bmwcra_1.csr",
-                              "nos1.csr",
+                              "nos1.bin",
 #endif
-                              "nos6.csr",
-                              "amazon0312.csr"};
+                              "nos6.bin",
+                              "amazon0312.bin"};
 
 class parameterized_csrilusv_bin : public testing::TestWithParam<csrilusv_bin_tuple>
 {

--- a/projects/hipsparse/cmake/ClientMatrices.cmake
+++ b/projects/hipsparse/cmake/ClientMatrices.cmake
@@ -105,7 +105,7 @@ foreach(i RANGE 0 ${len1})
   list(GET sep_m 1 mat)
 
   # Download test matrices if not already downloaded
-  if(NOT EXISTS "${CMAKE_MATRICES_DIR}/${mat}.csr")
+  if(NOT EXISTS "${CMAKE_MATRICES_DIR}/${mat}.bin")
     if(NOT HIPSPARSE_MTX_DIR)
       # First try user specified mirror, if available
       if(DEFINED ENV{HIPSPARSE_TEST_MIRROR} AND NOT $ENV{HIPSPARSE_TEST_MIRROR} STREQUAL "")
@@ -164,7 +164,7 @@ foreach(i RANGE 0 ${len1})
     else()
       file(RENAME ${HIPSPARSE_MTX_DIR}/${mat}/${mat}.mtx ${CMAKE_MATRICES_DIR}/${mat}.mtx)
     endif()
-    execute_process(COMMAND ${PROJECT_BINARY_DIR}/mtx2csr.exe ${mat}.mtx ${mat}.csr
+    execute_process(COMMAND ${PROJECT_BINARY_DIR}/mtx2csr.exe ${mat}.mtx ${mat}.bin
       RESULT_VARIABLE STATUS
       WORKING_DIRECTORY ${CMAKE_MATRICES_DIR})
     if(STATUS AND NOT STATUS EQUAL 0)

--- a/projects/hipsparse/cmake/hipsparse_clientmatrices.cmake
+++ b/projects/hipsparse/cmake/hipsparse_clientmatrices.cmake
@@ -92,7 +92,7 @@ foreach(i RANGE 0 ${len1})
   list(GET sep_m 1 mat)
 
   # Download test matrices if not already downloaded
-  if(NOT EXISTS "${CMAKE_MATRICES_DIR}/${mat}.csr")
+  if(NOT EXISTS "${CMAKE_MATRICES_DIR}/${mat}.bin")
     if(NOT HIPSPARSE_MTX_DIR)
       # First try user specified mirror, if available
       if(DEFINED ENV{HIPSPARSE_TEST_MIRROR} AND NOT $ENV{HIPSPARSE_TEST_MIRROR} STREQUAL "")
@@ -151,7 +151,7 @@ foreach(i RANGE 0 ${len1})
     else()
       file(RENAME ${HIPSPARSE_MTX_DIR}/${mat}/${mat}.mtx ${CMAKE_MATRICES_DIR}/${mat}.mtx)
     endif()
-    execute_process(COMMAND ${HIPSPARSE_MTX2CSR} ${mat}.mtx ${mat}.csr
+    execute_process(COMMAND ${HIPSPARSE_MTX2CSR} ${mat}.mtx ${mat}.bin
       RESULT_VARIABLE STATUS
       WORKING_DIRECTORY ${CMAKE_MATRICES_DIR})
     if(STATUS AND NOT STATUS EQUAL 0)

--- a/projects/hipsparse/deps/convert.cpp
+++ b/projects/hipsparse/deps/convert.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2019 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,91 +20,93 @@
  * THE SOFTWARE.
  *
  * ************************************************************************ */
-
 #include <algorithm>
-#include <math.h>
+#include <cmath>
+#include <complex>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
 #include <sstream>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <vector>
 
-int read_mtx_matrix(const char*          filename,
-                    int&                 nrow,
-                    int&                 ncol,
-                    int&                 nnz,
-                    std::vector<int>&    row,
-                    std::vector<int>&    col,
-                    std::vector<double>& val)
+struct mtx_header
 {
-    FILE* f = fopen(filename, "r");
-    if(!f)
-    {
-        return -1;
-    }
-
-    char line[1024];
-
-    // Check for banner
-    if(!fgets(line, 1024, f))
-    {
-        return -1;
-    }
-
     char banner[16];
     char array[16];
     char coord[16];
     char data[16];
     char type[16];
+    int  symmetric;
+};
+
+bool read_mtx_header(FILE* f, int& nrow, int& ncol, int& nnz, mtx_header& header)
+{
+    char line[1024];
+
+    // Check for banner
+    if(!fgets(line, 1024, f))
+    {
+        return false;
+    }
 
     // Extract banner
-    if(sscanf(line, "%s %s %s %s %s", banner, array, coord, data, type) != 5)
+    if(sscanf(line,
+              "%s %s %s %s %s",
+              header.banner,
+              header.array,
+              header.coord,
+              header.data,
+              header.type)
+       != 5)
     {
-        return -1;
+        return false;
     }
 
     // Convert to lower case
-    for(char* p = array; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = header.array; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char* p = coord; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = header.coord; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char* p = data; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = header.data; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char* p = type; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = header.type; *p != '\0'; *p = tolower(*p), p++)
         ;
 
     // Check banner
-    if(strncmp(line, "%%MatrixMarket", 14) != 0)
+    if(strncmp(line, "%%MatrixMarket", 14))
     {
-        return -1;
+        return false;
     }
 
     // Check array type
-    if(strcmp(array, "matrix") != 0)
+    if(strcmp(header.array, "matrix"))
     {
-        return -1;
+        return false;
     }
 
     // Check coord
-    if(strcmp(coord, "coordinate") != 0)
+    if(strcmp(header.coord, "coordinate"))
     {
-        return -1;
+        return false;
     }
 
     // Check data
-    if(strcmp(data, "real") != 0 && strcmp(data, "integer") != 0 && strcmp(data, "pattern") != 0)
+    if(strcmp(header.data, "real") && strcmp(header.data, "complex")
+       && strcmp(header.data, "integer") && strcmp(header.data, "pattern"))
     {
-        return -1;
+        return false;
     }
 
     // Check type
-    if(strcmp(type, "general") != 0 && strcmp(type, "symmetric") != 0)
+    if(strcmp(header.type, "general") && strcmp(header.type, "symmetric")
+       && strcmp(header.type, "hermitian"))
     {
-        return -1;
+        return false;
     }
 
     // Symmetric flag
-    int symm = !strcmp(type, "symmetric");
+    header.symmetric = !strcmp(header.type, "symmetric") || !strcmp(header.type, "hermitian");
 
     // Skip comments
     while(fgets(line, 1024, f))
@@ -116,68 +118,95 @@ int read_mtx_matrix(const char*          filename,
     }
 
     // Read dimensions
-    int snnz;
+    sscanf(line, "%d %d %d", &nrow, &ncol, &nnz);
 
-    sscanf(line, "%d %d %d", &nrow, &ncol, &snnz);
-    nnz = symm ? (snnz - nrow) * 2 + nrow : snnz;
+    return true;
+}
 
-    std::vector<int>    unsorted_row(nnz);
-    std::vector<int>    unsorted_col(nnz);
-    std::vector<double> unsorted_val(nnz);
+void set_value(double& dst, double rsrc, double isrc)
+{
+    dst = rsrc;
+}
+
+void set_value(std::complex<double>& dst, double rsrc, double isrc)
+{
+    dst = std::complex<double>(rsrc, isrc);
+}
+
+template <typename T>
+bool read_mtx_matrix(FILE*             f,
+                     const mtx_header& header,
+                     int               nrow,
+                     int               ncol,
+                     int&              nnz,
+                     std::vector<int>& row_ind,
+                     std::vector<int>& col_ind,
+                     std::vector<T>&   val)
+{
+    // Cache for line
+    char line[1024];
+
+    // Read unsorted data
+    std::vector<int> unsorted_row(header.symmetric ? 2 * nnz : nnz);
+    std::vector<int> unsorted_col(header.symmetric ? 2 * nnz : nnz);
+    std::vector<T>   unsorted_val(header.symmetric ? 2 * nnz : nnz);
 
     // Read entries
     int idx = 0;
     while(fgets(line, 1024, f))
     {
-        if(idx >= nnz)
+        if(idx >= (header.symmetric ? 2 * nnz : nnz))
         {
-            return -1;
+            return false;
         }
 
         int    irow;
         int    icol;
+        double rval;
         double ival;
 
-        if(!strcmp(data, "pattern"))
+        if(!strcmp(header.data, "pattern"))
         {
             sscanf(line, "%d %d", &irow, &icol);
-            ival = 1.0;
+            rval = 1.0;
         }
         else
         {
-            sscanf(line, "%d %d %lg", &irow, &icol, &ival);
+            if(!strcmp(header.data, "complex"))
+            {
+                sscanf(line, "%d %d %lg %lg", &irow, &icol, &rval, &ival);
+            }
+            else
+            {
+                sscanf(line, "%d %d %lg", &irow, &icol, &rval);
+            }
         }
 
         --irow;
         --icol;
 
-        // Take absolute matrix value to avoid rounding issues when testing
-        ival = std::abs(ival);
-
         unsorted_row[idx] = irow;
         unsorted_col[idx] = icol;
-        unsorted_val[idx] = ival;
+        set_value(unsorted_val[idx], rval, ival);
 
         ++idx;
 
-        if(symm && irow != icol)
+        if(header.symmetric && irow != icol)
         {
-            if(idx >= nnz)
+            if(idx >= (header.symmetric ? 2 * nnz : nnz))
             {
-                return -1;
+                return false;
             }
 
             unsorted_row[idx] = icol;
             unsorted_col[idx] = irow;
-            unsorted_val[idx] = ival;
+            set_value(unsorted_val[idx], rval, ival);
             ++idx;
         }
     }
-    fclose(f);
 
-    row.resize(nnz);
-    col.resize(nnz);
-    val.resize(nnz);
+    // Store "real" number of non-zero entries
+    nnz = idx;
 
     // Sort by row and column index
     std::vector<int> perm(nnz);
@@ -201,39 +230,53 @@ int read_mtx_matrix(const char*          filename,
         }
     });
 
+    // Resize arrays
+    row_ind.resize(nnz);
+    col_ind.resize(nnz);
+    val.resize(nnz);
+
     for(int i = 0; i < nnz; ++i)
     {
-        row[i] = unsorted_row[perm[i]];
-        col[i] = unsorted_col[perm[i]];
-        val[i] = unsorted_val[perm[i]];
+        row_ind[i] = unsorted_row[perm[i]];
+        col_ind[i] = unsorted_col[perm[i]];
+        val[i]     = unsorted_val[perm[i]];
     }
 
-    return 0;
+    return true;
 }
 
-int write_bin_matrix(
-    const char* filename, int m, int n, int nnz, const int* ptr, const int* col, const double* val)
+template <typename T>
+bool write_bin_matrix(
+    const char* filename, int m, int n, int nnz, const int* ptr, const int* col, const T* val)
 {
-    FILE* f = fopen(filename, "wb");
-    if(!f)
+    std::ofstream out(filename, std::ios::out | std::ios::binary);
+
+    if(!out.is_open())
     {
-        return -1;
+        return false;
     }
 
-    int err;
-    err = fwrite(&m, sizeof(int), 1, f);
-    err |= fwrite(&n, sizeof(int), 1, f);
-    err |= fwrite(&nnz, sizeof(int), 1, f);
-    err |= fwrite(ptr, sizeof(int), m + 1, f);
-    err |= fwrite(col, sizeof(int), nnz, f);
-    err |= fwrite(val, sizeof(double), nnz, f);
+    // Header
+    out << "#rocALUTION binary csr file" << std::endl;
 
-    fclose(f);
+    // rocALUTION version
+    int version = 10602;
+    out.write((char*)&version, sizeof(int));
 
-    return 0;
+    // Data
+    out.write((char*)&m, sizeof(int));
+    out.write((char*)&n, sizeof(int));
+    out.write((char*)&nnz, sizeof(int));
+    out.write((char*)ptr, (m + 1) * sizeof(int));
+    out.write((char*)col, nnz * sizeof(int));
+    out.write((char*)val, nnz * sizeof(T));
+
+    out.close();
+
+    return true;
 }
 
-int coo_to_csr(int m, int nnz, const int* src_row, std::vector<int>& dst_ptr)
+bool coo_to_csr(int m, int nnz, const int* src_row, std::vector<int>& dst_ptr)
 {
     dst_ptr.resize(m + 1, 0);
 
@@ -249,37 +292,85 @@ int coo_to_csr(int m, int nnz, const int* src_row, std::vector<int>& dst_ptr)
         dst_ptr[i + 1] += dst_ptr[i];
     }
 
-    return 0;
+    return true;
 }
 
 int main(int argc, char* argv[])
 {
+    if(argc < 3)
+    {
+        std::cerr << argv[0] << " <matrix.mtx> <matrix.csr>" << std::endl;
+        return -1;
+    }
+
+    // Matrix dimensions
     int m;
     int n;
     int nnz;
 
-    std::vector<int>    ptr;
-    std::vector<int>    row;
-    std::vector<int>    col;
-    std::vector<double> val;
+    // Matrix mtx header
+    mtx_header header;
 
-    if(read_mtx_matrix(argv[1], m, n, nnz, row, col, val) != 0)
+    // Open file for reading
+    FILE* f = fopen(argv[1], "r");
+    if(!f)
     {
-        fprintf(stderr, "Cannot open [read] %s.\n", argv[1]);
+        std::cerr << "Cannot open [read] .mtx file " << argv[1] << std::endl;
         return -1;
     }
 
-    if(coo_to_csr(m, nnz, row.data(), ptr) != 0)
+    if(!read_mtx_header(f, m, n, nnz, header))
     {
-        fprintf(stderr, "Cannot convert %s from COO to CSR.\n", argv[1]);
+        std::cerr << "Cannot read .mtx header from " << argv[1] << std::endl;
         return -1;
     }
 
-    if(write_bin_matrix(argv[2], m, n, nnz, ptr.data(), col.data(), val.data()) != 0)
+    std::vector<int>                  row_ptr;
+    std::vector<int>                  row_ind;
+    std::vector<int>                  col_ind;
+    std::vector<double>               rval;
+    std::vector<std::complex<double>> cval;
+
+    bool status;
+    if(!strcmp(header.data, "complex"))
     {
-        fprintf(stderr, "Cannot open [write] %s.\n", argv[2]);
+        status = read_mtx_matrix(f, header, m, n, nnz, row_ind, col_ind, cval);
+    }
+    else
+    {
+        status = read_mtx_matrix(f, header, m, n, nnz, row_ind, col_ind, rval);
+    }
+
+    if(!status)
+    {
+        std::cerr << "Cannot read .mtx data from " << argv[1] << std::endl;
+        return -1;
+    }
+
+    // Close file
+    fclose(f);
+
+    if(!coo_to_csr(m, nnz, row_ind.data(), row_ptr))
+    {
+        std::cerr << "Cannot convert " << argv[1] << " from COO to CSR." << std::endl;
+        return -1;
+    }
+
+    if(!strcmp(header.data, "complex"))
+    {
+        status = write_bin_matrix(argv[2], m, n, nnz, row_ptr.data(), col_ind.data(), cval.data());
+    }
+    else
+    {
+        status = write_bin_matrix(argv[2], m, n, nnz, row_ptr.data(), col_ind.data(), rval.data());
+    }
+
+    if(!status)
+    {
+        std::cerr << "Cannot open [write] " << argv[2] << std::endl;
         return -1;
     }
 
     return 0;
 }
+

--- a/projects/hipsparse/deps/convert.cpp
+++ b/projects/hipsparse/deps/convert.cpp
@@ -373,4 +373,3 @@ int main(int argc, char* argv[])
 
     return 0;
 }
-

--- a/projects/hipsparse/deps/convert.cpp
+++ b/projects/hipsparse/deps/convert.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2019 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,92 +21,89 @@
  *
  * ************************************************************************ */
 #include <algorithm>
-#include <cmath>
-#include <complex>
-#include <cstdlib>
-#include <cstring>
-#include <fstream>
-#include <iostream>
+#include <math.h>
 #include <sstream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <vector>
 
-struct mtx_header
+int read_mtx_matrix(const char*          filename,
+                    int&                 nrow,
+                    int&                 ncol,
+                    int&                 nnz,
+                    std::vector<int>&    row,
+                    std::vector<int>&    col,
+                    std::vector<double>& val)
 {
-    char banner[16];
-    char array[16];
-    char coord[16];
-    char data[16];
-    char type[16];
-    int  symmetric;
-};
+    FILE* f = fopen(filename, "r");
+    if(!f)
+    {
+        return -1;
+    }
 
-bool read_mtx_header(FILE* f, int& nrow, int& ncol, int& nnz, mtx_header& header)
-{
     char line[1024];
 
     // Check for banner
     if(!fgets(line, 1024, f))
     {
-        return false;
+        return -1;
     }
 
+    char banner[16];
+    char array[16];
+    char coord[16];
+    char data[16];
+    char type[16];
+
     // Extract banner
-    if(sscanf(line,
-              "%s %s %s %s %s",
-              header.banner,
-              header.array,
-              header.coord,
-              header.data,
-              header.type)
-       != 5)
+    if(sscanf(line, "%s %s %s %s %s", banner, array, coord, data, type) != 5)
     {
-        return false;
+        return -1;
     }
 
     // Convert to lower case
-    for(char* p = header.array; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = array; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char* p = header.coord; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = coord; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char* p = header.data; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = data; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char* p = header.type; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = type; *p != '\0'; *p = tolower(*p), p++)
         ;
 
     // Check banner
-    if(strncmp(line, "%%MatrixMarket", 14))
+    if(strncmp(line, "%%MatrixMarket", 14) != 0)
     {
-        return false;
+        return -1;
     }
 
     // Check array type
-    if(strcmp(header.array, "matrix"))
+    if(strcmp(array, "matrix") != 0)
     {
-        return false;
+        return -1;
     }
 
     // Check coord
-    if(strcmp(header.coord, "coordinate"))
+    if(strcmp(coord, "coordinate") != 0)
     {
-        return false;
+        return -1;
     }
 
     // Check data
-    if(strcmp(header.data, "real") && strcmp(header.data, "complex")
-       && strcmp(header.data, "integer") && strcmp(header.data, "pattern"))
+    if(strcmp(data, "real") != 0 && strcmp(data, "integer") != 0 && strcmp(data, "pattern") != 0)
     {
-        return false;
+        return -1;
     }
 
     // Check type
-    if(strcmp(header.type, "general") && strcmp(header.type, "symmetric")
-       && strcmp(header.type, "hermitian"))
+    if(strcmp(type, "general") != 0 && strcmp(type, "symmetric") != 0)
     {
-        return false;
+        return -1;
     }
 
     // Symmetric flag
-    header.symmetric = !strcmp(header.type, "symmetric") || !strcmp(header.type, "hermitian");
+    int symm = !strcmp(type, "symmetric");
 
     // Skip comments
     while(fgets(line, 1024, f))
@@ -118,95 +115,68 @@ bool read_mtx_header(FILE* f, int& nrow, int& ncol, int& nnz, mtx_header& header
     }
 
     // Read dimensions
-    sscanf(line, "%d %d %d", &nrow, &ncol, &nnz);
+    int snnz;
 
-    return true;
-}
+    sscanf(line, "%d %d %d", &nrow, &ncol, &snnz);
+    nnz = symm ? (snnz - nrow) * 2 + nrow : snnz;
 
-void set_value(double& dst, double rsrc, double isrc)
-{
-    dst = rsrc;
-}
-
-void set_value(std::complex<double>& dst, double rsrc, double isrc)
-{
-    dst = std::complex<double>(rsrc, isrc);
-}
-
-template <typename T>
-bool read_mtx_matrix(FILE*             f,
-                     const mtx_header& header,
-                     int               nrow,
-                     int               ncol,
-                     int&              nnz,
-                     std::vector<int>& row_ind,
-                     std::vector<int>& col_ind,
-                     std::vector<T>&   val)
-{
-    // Cache for line
-    char line[1024];
-
-    // Read unsorted data
-    std::vector<int> unsorted_row(header.symmetric ? 2 * nnz : nnz);
-    std::vector<int> unsorted_col(header.symmetric ? 2 * nnz : nnz);
-    std::vector<T>   unsorted_val(header.symmetric ? 2 * nnz : nnz);
+    std::vector<int>    unsorted_row(nnz);
+    std::vector<int>    unsorted_col(nnz);
+    std::vector<double> unsorted_val(nnz);
 
     // Read entries
     int idx = 0;
     while(fgets(line, 1024, f))
     {
-        if(idx >= (header.symmetric ? 2 * nnz : nnz))
+        if(idx >= nnz)
         {
-            return false;
+            return -1;
         }
 
         int    irow;
         int    icol;
-        double rval;
         double ival;
 
-        if(!strcmp(header.data, "pattern"))
+        if(!strcmp(data, "pattern"))
         {
             sscanf(line, "%d %d", &irow, &icol);
-            rval = 1.0;
+            ival = 1.0;
         }
         else
         {
-            if(!strcmp(header.data, "complex"))
-            {
-                sscanf(line, "%d %d %lg %lg", &irow, &icol, &rval, &ival);
-            }
-            else
-            {
-                sscanf(line, "%d %d %lg", &irow, &icol, &rval);
-            }
+            sscanf(line, "%d %d %lg", &irow, &icol, &ival);
         }
 
         --irow;
         --icol;
 
+        // Take absolute matrix value to avoid rounding issues when testing
+        ival = std::abs(ival);
+
         unsorted_row[idx] = irow;
         unsorted_col[idx] = icol;
-        set_value(unsorted_val[idx], rval, ival);
+        unsorted_val[idx] = ival;
 
         ++idx;
 
-        if(header.symmetric && irow != icol)
+        if(symm && irow != icol)
         {
-            if(idx >= (header.symmetric ? 2 * nnz : nnz))
+            if(idx >= nnz)
             {
-                return false;
+                return -1;
             }
 
             unsorted_row[idx] = icol;
             unsorted_col[idx] = irow;
-            set_value(unsorted_val[idx], rval, ival);
+            unsorted_val[idx] = ival;
             ++idx;
         }
     }
+    fclose(f);
 
-    // Store "real" number of non-zero entries
-    nnz = idx;
+    row.resize(nnz);
+    col.resize(nnz);
+    val.resize(nnz);
 
     // Sort by row and column index
     std::vector<int> perm(nnz);
@@ -214,7 +184,6 @@ bool read_mtx_matrix(FILE*             f,
     {
         perm[i] = i;
     }
-
     std::sort(perm.begin(), perm.end(), [&](const int& a, const int& b) {
         if(unsorted_row[a] < unsorted_row[b])
         {
@@ -230,53 +199,39 @@ bool read_mtx_matrix(FILE*             f,
         }
     });
 
-    // Resize arrays
-    row_ind.resize(nnz);
-    col_ind.resize(nnz);
-    val.resize(nnz);
-
     for(int i = 0; i < nnz; ++i)
     {
-        row_ind[i] = unsorted_row[perm[i]];
-        col_ind[i] = unsorted_col[perm[i]];
-        val[i]     = unsorted_val[perm[i]];
+        row[i] = unsorted_row[perm[i]];
+        col[i] = unsorted_col[perm[i]];
+        val[i] = unsorted_val[perm[i]];
     }
 
-    return true;
+    return 0;
 }
 
-template <typename T>
-bool write_bin_matrix(
-    const char* filename, int m, int n, int nnz, const int* ptr, const int* col, const T* val)
+int write_bin_matrix(
+    const char* filename, int m, int n, int nnz, const int* ptr, const int* col, const double* val)
 {
-    std::ofstream out(filename, std::ios::out | std::ios::binary);
-
-    if(!out.is_open())
+    FILE* f = fopen(filename, "wb");
+    if(!f)
     {
-        return false;
+        return -1;
     }
 
-    // Header
-    out << "#rocALUTION binary csr file" << std::endl;
+    int err;
+    err = fwrite(&m, sizeof(int), 1, f);
+    err |= fwrite(&n, sizeof(int), 1, f);
+    err |= fwrite(&nnz, sizeof(int), 1, f);
+    err |= fwrite(ptr, sizeof(int), m + 1, f);
+    err |= fwrite(col, sizeof(int), nnz, f);
+    err |= fwrite(val, sizeof(double), nnz, f);
 
-    // rocALUTION version
-    int version = 10602;
-    out.write((char*)&version, sizeof(int));
+    fclose(f);
 
-    // Data
-    out.write((char*)&m, sizeof(int));
-    out.write((char*)&n, sizeof(int));
-    out.write((char*)&nnz, sizeof(int));
-    out.write((char*)ptr, (m + 1) * sizeof(int));
-    out.write((char*)col, nnz * sizeof(int));
-    out.write((char*)val, nnz * sizeof(T));
-
-    out.close();
-
-    return true;
+    return 0;
 }
 
-bool coo_to_csr(int m, int nnz, const int* src_row, std::vector<int>& dst_ptr)
+int coo_to_csr(int m, int nnz, const int* src_row, std::vector<int>& dst_ptr)
 {
     dst_ptr.resize(m + 1, 0);
 
@@ -285,89 +240,41 @@ bool coo_to_csr(int m, int nnz, const int* src_row, std::vector<int>& dst_ptr)
     {
         ++dst_ptr[src_row[i] + 1];
     }
-
     // Exclusive scan
     for(int i = 0; i < m; ++i)
     {
         dst_ptr[i + 1] += dst_ptr[i];
     }
 
-    return true;
+    return 0;
 }
 
 int main(int argc, char* argv[])
 {
-    if(argc < 3)
-    {
-        std::cerr << argv[0] << " <matrix.mtx> <matrix.csr>" << std::endl;
-        return -1;
-    }
-
-    // Matrix dimensions
     int m;
     int n;
     int nnz;
 
-    // Matrix mtx header
-    mtx_header header;
+    std::vector<int>    ptr;
+    std::vector<int>    row;
+    std::vector<int>    col;
+    std::vector<double> val;
 
-    // Open file for reading
-    FILE* f = fopen(argv[1], "r");
-    if(!f)
+    if(read_mtx_matrix(argv[1], m, n, nnz, row, col, val) != 0)
     {
-        std::cerr << "Cannot open [read] .mtx file " << argv[1] << std::endl;
+        fprintf(stderr, "Cannot open [read] %s.\n", argv[1]);
         return -1;
     }
 
-    if(!read_mtx_header(f, m, n, nnz, header))
+    if(coo_to_csr(m, nnz, row.data(), ptr) != 0)
     {
-        std::cerr << "Cannot read .mtx header from " << argv[1] << std::endl;
+        fprintf(stderr, "Cannot convert %s from COO to CSR.\n", argv[1]);
         return -1;
     }
 
-    std::vector<int>                  row_ptr;
-    std::vector<int>                  row_ind;
-    std::vector<int>                  col_ind;
-    std::vector<double>               rval;
-    std::vector<std::complex<double>> cval;
-
-    bool status;
-    if(!strcmp(header.data, "complex"))
+    if(write_bin_matrix(argv[2], m, n, nnz, ptr.data(), col.data(), val.data()) != 0)
     {
-        status = read_mtx_matrix(f, header, m, n, nnz, row_ind, col_ind, cval);
-    }
-    else
-    {
-        status = read_mtx_matrix(f, header, m, n, nnz, row_ind, col_ind, rval);
-    }
-
-    if(!status)
-    {
-        std::cerr << "Cannot read .mtx data from " << argv[1] << std::endl;
-        return -1;
-    }
-
-    // Close file
-    fclose(f);
-
-    if(!coo_to_csr(m, nnz, row_ind.data(), row_ptr))
-    {
-        std::cerr << "Cannot convert " << argv[1] << " from COO to CSR." << std::endl;
-        return -1;
-    }
-
-    if(!strcmp(header.data, "complex"))
-    {
-        status = write_bin_matrix(argv[2], m, n, nnz, row_ptr.data(), col_ind.data(), cval.data());
-    }
-    else
-    {
-        status = write_bin_matrix(argv[2], m, n, nnz, row_ptr.data(), col_ind.data(), rval.data());
-    }
-
-    if(!status)
-    {
-        std::cerr << "Cannot open [write] " << argv[2] << std::endl;
+        fprintf(stderr, "Cannot open [write] %s.\n", argv[2]);
         return -1;
     }
 

--- a/projects/hipsparse/deps/convert.cpp
+++ b/projects/hipsparse/deps/convert.cpp
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  *
  * ************************************************************************ */
+
 #include <algorithm>
 #include <math.h>
 #include <sstream>
@@ -184,6 +185,7 @@ int read_mtx_matrix(const char*          filename,
     {
         perm[i] = i;
     }
+
     std::sort(perm.begin(), perm.end(), [&](const int& a, const int& b) {
         if(unsorted_row[a] < unsorted_row[b])
         {
@@ -240,6 +242,7 @@ int coo_to_csr(int m, int nnz, const int* src_row, std::vector<int>& dst_ptr)
     {
         ++dst_ptr[src_row[i] + 1];
     }
+
     // Exclusive scan
     for(int i = 0; i < m; ++i)
     {


### PR DESCRIPTION
## Motivation

We recently changed the matrix file extension from .bin to .csr. There were still some spots where we were looking for the old .bin extension. There were also small discrepencies in the .csr files generated by rocsparse and the .bin files generated by hipsparse. This meant that simply changing the extension was not enough, we need to also make sure the matrix binary files are exactly the same. This PR undoes the changing of the matrix files extension from .bin to .csr.

There were also some tests that were accidentally disabled when using the ROCm backend. This PR re-enables them.
