### PR TITLE
[hipdnn][ALMIOPEN-867] Added BFP8 data types support

### DIFF
--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
@@ -27,11 +27,12 @@ enum class DataType : int8_t {
   INT32 = 6,
   INT8 = 7,
   FP8_E4M3 = 8,
+  FP8_E5M2 = 9,
   MIN = UNSET,
-  MAX = FP8_E4M3
+  MAX = FP8_E5M2
 };
 
-inline const DataType (&EnumValuesDataType())[9] {
+inline const DataType (&EnumValuesDataType())[10] {
   static const DataType values[] = {
     DataType::UNSET,
     DataType::FLOAT,
@@ -41,13 +42,14 @@ inline const DataType (&EnumValuesDataType())[9] {
     DataType::UINT8,
     DataType::INT32,
     DataType::INT8,
-    DataType::FP8_E4M3
+    DataType::FP8_E4M3,
+    DataType::FP8_E5M2
   };
   return values;
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[10] = {
+  static const char * const names[11] = {
     "UNSET",
     "FLOAT",
     "HALF",
@@ -57,13 +59,14 @@ inline const char * const *EnumNamesDataType() {
     "INT32",
     "INT8",
     "FP8_E4M3",
+    "FP8_E5M2",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameDataType(DataType e) {
-  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::FP8_E4M3)) return "";
+  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::FP8_E5M2)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDataType()[index];
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -5,6 +5,7 @@
 
 #include <flatbuffers/flatbuffers.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <stdexcept>
 #include <string>
@@ -93,7 +94,8 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
     case data_objects::DataType::FP8_E5M2:
         if(auto val = tensorAttr.value.AsFloat8Value())
         {
-            return static_cast<TargetType>(val->value());
+            auto bfp8 = hipdnn_data_sdk::utilities::bfp8::uchar_as_bfp8(val->value());
+            return static_cast<TargetType>(static_cast<float>(bfp8));
         }
         break;
     case data_objects::DataType::UNSET:

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -90,6 +90,12 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
             return static_cast<TargetType>(static_cast<float>(fp8));
         }
         break;
+    case data_objects::DataType::FP8_E5M2:
+        if(auto val = tensorAttr.value.AsFloat8Value())
+        {
+            return static_cast<TargetType>(val->value());
+        }
+        break;
     case data_objects::DataType::UNSET:
         throw std::runtime_error(std::string(paramName) + " tensor has UNSET data type");
     default:

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
@@ -7,6 +7,7 @@
 #include <hipdnn_data_sdk/utilities/MigratableMemory.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <iostream>
@@ -590,6 +591,8 @@ inline std::unique_ptr<utilities::ITensor> createTensor(data_objects::DataType d
         return std::make_unique<Tensor<int8_t>>(dims, strides);
     case data_objects::DataType::FP8_E4M3:
         return std::make_unique<Tensor<hip_fp8_e4m3>>(dims, strides);
+    case data_objects::DataType::FP8_E5M2:
+        return std::make_unique<Tensor<hip_fp8_e5m2>>(dims, strides);
     default:
         throw std::runtime_error("Unsupported data type for tensor");
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp16.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp16.hpp
@@ -10,7 +10,8 @@
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <string>
 
-#define HIPDNN_NAN_BF16 ushort_as_bfloat16(static_cast<unsigned short>(0x7FFFU))
+#define HIPDNN_NAN_BF16 \
+    hipdnn_data_sdk::utilities::bfp16::ushort_as_bfloat16(static_cast<unsigned short>(0x7FFFU))
 
 inline __HOST_DEVICE__ hip_bfloat16 operator""_bf(long double value)
 {

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp8.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp8.hpp
@@ -1,0 +1,127 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hip/hip_fp8.h>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <string>
+#include <type_traits>
+
+#define HIPDNN_NAN_BFP8 uchar_as_bfp8(static_cast<unsigned char>(0x7F))
+
+using hip_fp8_e5m2 = __hip_fp8_e5m2;
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 operator""_bfp8(long double val)
+{
+    return {static_cast<float>(val)};
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 operator-(hip_fp8_e5m2 a)
+{
+    hip_fp8_e5m2 val = a;
+    val.__x ^= 0x80;
+    return val;
+}
+
+inline __HOST_DEVICE__ bool operator==(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return float(a) == float(b);
+}
+
+inline __HOST_DEVICE__ bool operator!=(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return float(a) != float(b);
+}
+
+inline __HOST_DEVICE__ bool operator>(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return float(a) > float(b);
+}
+
+inline __HOST_DEVICE__ bool operator>=(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return float(a) >= float(b);
+}
+
+inline __HOST_DEVICE__ bool operator<(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return float(a) < float(b);
+}
+
+inline __HOST_DEVICE__ bool operator<=(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return float(a) <= float(b);
+}
+
+namespace hipdnn_data_sdk::utilities::bfp8
+{
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 uchar_as_bfp8(const unsigned char a)
+{
+    hip_fp8_e5m2 val;
+    val.__x = a;
+    return val;
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 bfp8abs(hip_fp8_e5m2 a)
+{
+    hip_fp8_e5m2 abs = a;
+    abs.__x &= 0x7f;
+    return abs;
+}
+
+inline __HOST_DEVICE__ bool bfp8isnan(hip_fp8_e5m2 a)
+{
+    return (a.__x & 0x7f) > 0x7c;
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 bfp8max(const hip_fp8_e5m2 a, const hip_fp8_e5m2 b)
+{
+    auto aNan = bfp8isnan(a);
+    auto bNan = bfp8isnan(b);
+
+    if(aNan || bNan)
+    {
+        if(aNan && bNan)
+        {
+            return HIPDNN_NAN_BFP8; // return canonical NaN
+        }
+
+        return aNan ? b : a;
+    }
+
+    return a >= b ? a : b;
+}
+
+} // namespace hipdnn_data_sdk::utilities::bfp8
+
+namespace std
+{
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 fabs(hip_fp8_e5m2 num)
+{
+    return hipdnn_data_sdk::utilities::bfp8::bfp8abs(num);
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 abs(hip_fp8_e5m2 num)
+{
+    return hipdnn_data_sdk::utilities::bfp8::bfp8abs(num);
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 max(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return hipdnn_data_sdk::utilities::bfp8::bfp8max(a, b);
+}
+
+} // namespace std
+
+template <>
+struct fmt::formatter<hip_fp8_e5m2> : fmt::formatter<float>
+{
+    template <typename FormatContext>
+    auto format(hip_fp8_e5m2 h, FormatContext& ctx) const
+    {
+        return fmt::formatter<float>::format(static_cast<float>(h), ctx);
+    }
+};

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp8.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp8.hpp
@@ -8,7 +8,8 @@
 #include <string>
 #include <type_traits>
 
-#define HIPDNN_NAN_BFP8 uchar_as_bfp8(static_cast<unsigned char>(0x7F))
+#define HIPDNN_NAN_BFP8 \
+    hipdnn_data_sdk::utilities::bfp8::uchar_as_bfp8(static_cast<unsigned char>(0x7F))
 
 using hip_fp8_e5m2 = __hip_fp8_e5m2;
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
@@ -7,7 +7,8 @@
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <string>
 
-#define HIPDNN_NAN_FP16 ushort_as_half(static_cast<unsigned short>(0x7FFFU))
+#define HIPDNN_NAN_FP16 \
+    hipdnn_data_sdk::utilities::fp16::ushort_as_half(static_cast<unsigned short>(0x7FFFU))
 
 inline __HOST_DEVICE__ half operator""_h(long double value)
 {

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
@@ -8,7 +8,8 @@
 #include <string>
 #include <type_traits>
 
-#define HIPDNN_NAN_FP8 uchar_as_fp8(static_cast<unsigned char>(0x7F))
+#define HIPDNN_NAN_FP8 \
+    hipdnn_data_sdk::utilities::fp8::uchar_as_fp8(static_cast<unsigned char>(0x7F))
 
 using hip_fp8_e4m3 = __hip_fp8_e4m3;
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
@@ -81,6 +81,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType,
                                  {DataType::INT32, "int32"},
                                  {DataType::INT8, "int8"},
                                  {DataType::FP8_E4M3, "fp8_e4m3"},
+                                 {DataType::FP8_E5M2, "fp8_e5m2"},
                              }
 
 )

--- a/projects/hipdnn/data_sdk/schemas/data_types.fbs
+++ b/projects/hipdnn/data_sdk/schemas/data_types.fbs
@@ -13,4 +13,5 @@ enum DataType : byte {
     INT32 = 6,
     INT8 = 7,
     FP8_E4M3 = 8,
+    FP8_E5M2 = 9,
 }

--- a/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 
@@ -105,4 +106,44 @@ TEST(TestUtilsFp8, Max)
     EXPECT_EQ(std::max(a, nan), 1.0_fp8);
     EXPECT_EQ(std::max(nan, b), 2.0_fp8);
     EXPECT_TRUE(hipdnn_data_sdk::utilities::fp8::fp8isnan(std::max(nan, nan)));
+}
+
+TEST(TestUtilsBfp8, BasicUsage)
+{
+    hip_fp8_e5m2 bf = 1.0_bfp8;
+    EXPECT_EQ(bf, 1.0_bfp8);
+}
+
+TEST(TestUtilsBfp8, Negation)
+{
+    hip_fp8_e5m2 bf = 1.0_bfp8;
+    EXPECT_EQ(-bf, static_cast<hip_fp8_e5m2>(-1.0f));
+}
+
+TEST(TestUtilsBfp8, Fabs)
+{
+    EXPECT_EQ(std::fabs(-1.0_bfp8), 1.0_bfp8);
+    EXPECT_EQ(std::fabs(1.0_bfp8), 1.0_bfp8);
+}
+
+TEST(TestUtilsBfp8, Comparison)
+{
+    EXPECT_EQ(1.25_bfp8, 1.25_bfp8);
+    ASSERT_NE(1.0_bfp8, 2.0_bfp8);
+    ASSERT_LT(0.0001_bfp8, 0.0002_bfp8); // 0.00010.00 < 0.00010.01
+    ASSERT_LT(-0.0002_bfp8, 0.0003_bfp8); // 1.00010.00 <= 0.00011.01
+    ASSERT_GT(0.0003_bfp8, 0.0002_bfp8); // 0.00011.01 > 0.00010.01
+    ASSERT_GE(0.0002_bfp8, -0.0002_bfp8); // 0.00010.01 >= 1.00010.01
+}
+
+TEST(TestUtilsBfp8, Max)
+{
+    hip_fp8_e5m2 a = 1.0_bfp8;
+    hip_fp8_e5m2 b = 2.0_bfp8;
+    hip_fp8_e5m2 nan = hipdnn_data_sdk::utilities::bfp8::uchar_as_bfp8(0x7F);
+    EXPECT_EQ(std::max(a, b), 2.0_bfp8);
+    EXPECT_EQ(std::max(b, a), 2.0_bfp8);
+    EXPECT_EQ(std::max(a, nan), 1.0_bfp8);
+    EXPECT_EQ(std::max(nan, b), 2.0_bfp8);
+    EXPECT_TRUE(hipdnn_data_sdk::utilities::bfp8::bfp8isnan(std::max(nan, nan)));
 }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -8,6 +8,7 @@
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_data_sdk/utilities/PointwiseValidation.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 
@@ -90,6 +91,7 @@ enum class DataType
     INT32 = 6,
     INT8 = 7,
     FP8_E4M3 = 8,
+    FP8_E5M2 = 9,
 };
 typedef DataType DataType_t; // NOLINT(readability-identifier-naming)
 
@@ -140,6 +142,10 @@ DataType getDataTypeEnumFromType()
     else if constexpr(std::is_same_v<T, hip_fp8_e4m3>)
     {
         return DataType::FP8_E4M3;
+    }
+    else if constexpr(std::is_same_v<T, hip_fp8_e5m2>)
+    {
+        return DataType::FP8_E5M2;
     }
     else
     {
@@ -194,6 +200,8 @@ inline hipdnn_data_sdk::data_objects::DataType toSdkType(const DataType& type)
         return hipdnn_data_sdk::data_objects::DataType::INT8;
     case DataType::FP8_E4M3:
         return hipdnn_data_sdk::data_objects::DataType::FP8_E4M3;
+    case DataType::FP8_E5M2:
+        return hipdnn_data_sdk::data_objects::DataType::FP8_E5M2;
     default:
         return hipdnn_data_sdk::data_objects::DataType::UNSET;
     }
@@ -219,6 +227,8 @@ inline hipdnn_frontend::DataType fromSdkType(const hipdnn_data_sdk::data_objects
         return hipdnn_frontend::DataType::INT8;
     case hipdnn_data_sdk::data_objects::DataType::FP8_E4M3:
         return hipdnn_frontend::DataType::FP8_E4M3;
+    case hipdnn_data_sdk::data_objects::DataType::FP8_E5M2:
+        return hipdnn_frontend::DataType::FP8_E5M2;
     default:
         return hipdnn_frontend::DataType::NOT_SET;
     }
@@ -463,6 +473,8 @@ inline const char* to_string(const DataType& type)
         return "int8";
     case DataType::FP8_E4M3:
         return "fp8_e4m3";
+    case DataType::FP8_E5M2:
+        return "fp8_e5m2";
     default:
         return "unknown";
     }

--- a/projects/hipdnn/frontend/tests/TestNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestNode.cpp
@@ -43,7 +43,8 @@ TEST(TestNode, PostValidateNodeComputeDataType)
            {DataType::UINT8, ErrorCode::OK},
            {DataType::INT32, ErrorCode::OK},
            {DataType::INT8, ErrorCode::OK},
-           {DataType::FP8_E4M3, ErrorCode::OK}};
+           {DataType::FP8_E4M3, ErrorCode::OK},
+           {DataType::FP8_E5M2, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -207,7 +207,8 @@ TEST(TestTensorAttributes, ValidateDataType)
            {DataType::UINT8, ErrorCode::OK},
            {DataType::INT32, ErrorCode::OK},
            {DataType::INT8, ErrorCode::OK},
-           {DataType::FP8_E4M3, ErrorCode::OK}};
+           {DataType::FP8_E4M3, ErrorCode::OK},
+           {DataType::FP8_E5M2, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTypes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTypes.cpp
@@ -17,6 +17,7 @@ TEST(TestTypes, ToSdkTypeDataTypes)
     EXPECT_EQ(toSdkType(DataType::INT32), hipdnn_data_sdk::data_objects::DataType::INT32);
     EXPECT_EQ(toSdkType(DataType::INT8), hipdnn_data_sdk::data_objects::DataType::INT8);
     EXPECT_EQ(toSdkType(DataType::FP8_E4M3), hipdnn_data_sdk::data_objects::DataType::FP8_E4M3);
+    EXPECT_EQ(toSdkType(DataType::FP8_E5M2), hipdnn_data_sdk::data_objects::DataType::FP8_E5M2);
     EXPECT_EQ(toSdkType(DataType::NOT_SET), hipdnn_data_sdk::data_objects::DataType::UNSET);
 }
 
@@ -32,6 +33,7 @@ TEST(TestTypes, FromSdkTypeDataTypes)
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT32), DataType::INT32);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT8), DataType::INT8);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP8_E4M3), DataType::FP8_E4M3);
+    EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP8_E5M2), DataType::FP8_E5M2);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UNSET), DataType::NOT_SET);
 }
 
@@ -76,6 +78,7 @@ TEST(TestTypes, GetDataTypeEnumFromType)
     EXPECT_EQ(getDataTypeEnumFromType<int32_t>(), DataType::INT32);
     EXPECT_EQ(getDataTypeEnumFromType<int8_t>(), DataType::INT8);
     EXPECT_EQ(getDataTypeEnumFromType<hip_fp8_e4m3>(), DataType::FP8_E4M3);
+    EXPECT_EQ(getDataTypeEnumFromType<hip_fp8_e5m2>(), DataType::FP8_E5M2);
 
     EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType::NOT_SET);
     EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType::NOT_SET);
@@ -93,6 +96,7 @@ TEST(TestTypes, DataTypeToString)
     EXPECT_STREQ(to_string(DataType::INT32), "int32");
     EXPECT_STREQ(to_string(DataType::INT8), "int8");
     EXPECT_STREQ(to_string(DataType::FP8_E4M3), "fp8_e4m3");
+    EXPECT_STREQ(to_string(DataType::FP8_E5M2), "fp8_e5m2");
     EXPECT_STREQ(to_string(DataType::NOT_SET), "unknown");
 }
 
@@ -132,6 +136,10 @@ TEST(TestTypes, DataTypeStreamOperator)
 
     oss << DataType::FP8_E4M3;
     EXPECT_EQ(oss.str(), "fp8_e4m3");
+    oss.str("");
+
+    oss << DataType::FP8_E5M2;
+    EXPECT_EQ(oss.str(), "fp8_e5m2");
     oss.str("");
 
     oss << DataType::NOT_SET;

--- a/projects/hipdnn/python/src/types_bindings.cpp
+++ b/projects/hipdnn/python/src/types_bindings.cpp
@@ -20,7 +20,8 @@ void types_bindings(nb::module_& m)
         .value("UINT8", DataType::UINT8)
         .value("INT32", DataType::INT32)
         .value("INT8", DataType::INT8)
-        .value("FP8_E4M3", DataType::FP8_E4M3);
+        .value("FP8_E4M3", DataType::FP8_E4M3)
+        .value("FP8_E5M2", DataType::FP8_E5M2);
 
     // Bind ConvolutionMode enum
     nb::enum_<ConvolutionMode>(m, "ConvolutionMode")

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -6,6 +6,7 @@
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
@@ -109,7 +110,8 @@ using TypesFwdInferenceNchw = ::testing::Types<TypePair<float, float>,
                                                TypePair<hip_bfloat16, float>,
                                                TypePair<double, double>,
                                                TypePair<int8_t, float>,
-                                               TypePair<hip_fp8_e4m3, float>>;
+                                               TypePair<hip_fp8_e4m3, float>,
+                                               TypePair<hip_fp8_e5m2, float>>;
 
 template <class T>
 class CpuFpReferenceBatchnormFwdInferenceNchw : public ::testing::Test
@@ -303,6 +305,7 @@ using TypesBackwardNchw = ::testing::Types<TypeTriplet<float, float, float>,
                                            TypeTriplet<half, float, float>,
                                            TypeTriplet<int8_t, float, float>,
                                            TypeTriplet<hip_fp8_e4m3, float, float>,
+                                           TypeTriplet<hip_fp8_e5m2, float, float>,
                                            TypeTriplet<half, hip_bfloat16, float>,
                                            TypeTriplet<double, double, double>>;
 
@@ -960,6 +963,7 @@ using TypesFwdTrainingNhwc = ::testing::Types<TypeTriplet<hip_bfloat16, float, f
                                               TypeTriplet<double, double, double>,
                                               TypeTriplet<int8_t, double, double>,
                                               TypeTriplet<hip_fp8_e4m3, float, float>,
+                                              TypeTriplet<hip_fp8_e5m2, float, float>,
                                               TypeTriplet<half, hip_bfloat16, float>>;
 
 template <typename T>

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
@@ -1174,7 +1174,7 @@ TEST(TestCpuFpReferenceConvolutionBfp8, ConvolutionBwdDataBasic)
     outputTensor.setHostValue(4.0_bfp8, 0, 0, 1, 1);
 
     // Weight values: simple 3x3 kernel
-    for(size_t i = 0; i < 9; ++i)
+    for(int i = 0; i < 9; ++i)
     {
         weightTensor.memory().hostData()[i] = static_cast<hip_fp8_e5m2>(i + 1);
     }

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -302,6 +303,38 @@ TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionFwdInferenceBasic)
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63.0_fp8);
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90.0_fp8);
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99.0_fp8);
+}
+
+TEST(TestCpuFpReferenceConvolutionBfp8, ConvolutionFwdInferenceBasic)
+{
+    Tensor<hip_fp8_e5m2> inputTensor({1, 1, 4, 4});
+    Tensor<hip_fp8_e5m2> weightTensor({1, 1, 3, 3});
+    Tensor<hip_fp8_e5m2> outputTensor({1, 1, 2, 2});
+
+    // Fill input with sequential values
+    for(int i = 0; i < 16; ++i)
+    {
+        inputTensor.memory().hostData()[i] = static_cast<hip_fp8_e5m2>(i + 1);
+    }
+
+    // Fill weights with 1s
+    for(int i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = 1.0_bfp8;
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::fprop<hip_fp8_e5m2, hip_fp8_e5m2, hip_fp8_e5m2, float>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+
+    // Same expected values as fp32 test
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 0), 54.0_bfp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63.0_bfp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90.0_bfp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99.0_bfp8);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionFwdInferenceWithDilation)
@@ -1127,6 +1160,33 @@ TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionBwdDataBasic)
         inputTensor, weightTensor, outputTensor, strides, dilations, padding);
 }
 
+TEST(TestCpuFpReferenceConvolutionBfp8, ConvolutionBwdDataBasic)
+{
+    // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
+    Tensor<hip_fp8_e5m2> inputTensor({1, 1, 4, 4});
+    Tensor<hip_fp8_e5m2> weightTensor({1, 1, 3, 3});
+    Tensor<hip_fp8_e5m2> outputTensor({1, 1, 2, 2});
+
+    // gradOutput values: simple pattern
+    outputTensor.setHostValue(1.0_bfp8, 0, 0, 0, 0);
+    outputTensor.setHostValue(2.0_bfp8, 0, 0, 0, 1);
+    outputTensor.setHostValue(3.0_bfp8, 0, 0, 1, 0);
+    outputTensor.setHostValue(4.0_bfp8, 0, 0, 1, 1);
+
+    // Weight values: simple 3x3 kernel
+    for(size_t i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = static_cast<hip_fp8_e5m2>(i + 1);
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::dgrad<hip_fp8_e5m2, hip_fp8_e5m2, hip_fp8_e5m2, float>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+}
+
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionBwdDataSimple)
 {
     // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
@@ -1886,6 +1946,42 @@ TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionWrwBasic)
 
     // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 1 = 10
     EXPECT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 10.0_fp8);
+}
+
+TEST(TestCpuFpReferenceConvolutionBfp8, ConvolutionWrwBasic)
+{
+    // Minimal sanity test for wgrad using smallest possible tensor sizes
+    // Input: 1x1x2x2 (1 batch, 1 input channel, 2x2 spatial)
+    // Weight: 1x1x1x1 (1 output channel, 1 input channel, 1x1 kernel)
+    // GradOutput: 1x1x2x2 (1 batch, 1 output channel, 2x2 spatial)
+    Tensor<hip_fp8_e5m2> inputTensor({1, 1, 2, 2});
+    Tensor<hip_fp8_e5m2> gradWeightTensor({1, 1, 1, 1});
+    Tensor<hip_fp8_e5m2> gradOutputTensor({1, 1, 2, 2});
+
+    // Set input values: [1, 2; 3, 4]
+    inputTensor.setHostValue(1.0_bfp8, 0, 0, 0, 0);
+    inputTensor.setHostValue(2.0_bfp8, 0, 0, 0, 1);
+    inputTensor.setHostValue(3.0_bfp8, 0, 0, 1, 0);
+    inputTensor.setHostValue(4.0_bfp8, 0, 0, 1, 1);
+
+    // Set gradient output values: [1, 1; 1, 1]
+    gradOutputTensor.setHostValue(1.0_bfp8, 0, 0, 0, 0);
+    gradOutputTensor.setHostValue(1.0_bfp8, 0, 0, 0, 1);
+    gradOutputTensor.setHostValue(1.0_bfp8, 0, 0, 1, 0);
+    gradOutputTensor.setHostValue(1.0_bfp8, 0, 0, 1, 1);
+
+    // Initialize weight to zero
+    gradWeightTensor.setHostValue(0.0_bfp8, 0, 0, 0, 0);
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::wgrad<hip_fp8_e5m2, hip_fp8_e5m2, hip_fp8_e5m2, float>(
+        inputTensor, gradWeightTensor, gradOutputTensor, strides, dilations, padding);
+
+    // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 1 = 10
+    EXPECT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 10.0_bfp8);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvBwdWeightMultiBatch)


### PR DESCRIPTION
## Motivation

Updated `hipdnn` to have bfp8 operation support within the ticket ALMIOPEN-867.

## Technical Details

The PR implements support of BFP8 data type (`fp8_e5m2`) to hipDNN frontend, data sdk, test sdk using `__hip_fp8_e5_m2` class from HIP. Implemented the files `UtilsBfp8.hpp` for work with these data types in hipDNN. The changes are based on https://github.com/ROCm/rocm-libraries/pull/3525.

## Test Plan

Added utility BFP8 tests, convolution and batchnorm tests with BFP8. As far as I understand, we cannot add Pointwise tests with such data types due to unimplemented operators +,-,etc for this data type in HIP.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
