### PR TITLE
Replace BOOST_SCOPE_EXIT with std::scope_exit for rocfft-test

### DIFF
--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -240,6 +240,10 @@ endif()
 
 if(HAVE_SCOPE_HEADER OR HAVE_EXPERIMENTAL_SCOPE_HEADER )
   target_compile_definitions(rocfft-test PRIVATE HAVE_SCOPE_EXIT)
+else()
+  find_package( Boost REQUIRED )
+  set( Boost_DEBUG ON )
+  set( Boost_DETAILED_FAILURE_MSG ON )
 endif()
 
 

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -46,6 +46,10 @@ project( rocfft-clients-tests LANGUAGES CXX )
 
 set(CMAKE_CXX_STANDARD 20)
 
+include(CheckIncludeFileCXX)
+check_include_file_cxx("scope" HAVE_SCOPE_HEADER)
+check_include_file_cxx("experimental/scope" HAVE_EXPERIMENTAL_SCOPE_HEADER)
+
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 
@@ -233,6 +237,11 @@ if( BUILD_FFTW OR NOT FFTW_FOUND )
 else()
   include_directories(${FFTW_INCLUDE_DIRS})
 endif()
+
+if(HAVE_SCOPE_HEADER OR HAVE_EXPERIMENTAL_SCOPE_HEADER )
+  target_compile_definitions(rocfft-test PRIVATE HAVE_SCOPE_EXIT)
+endif()
+
 
 set( rocfft-test_include_dirs
   $<BUILD_INTERFACE:${FFTW_INCLUDE_DIRS}>

--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -44,7 +44,8 @@ endif()
 
 project( rocfft-clients-tests LANGUAGES CXX )
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
+
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 
@@ -107,10 +108,6 @@ if (NOT WIN32)
   target_compile_options( rocfft-test PRIVATE -fgpu-rdc )
   target_link_options( rocfft-test PRIVATE -fgpu-rdc )
 endif()
-
-find_package( Boost REQUIRED )
-set( Boost_DEBUG ON )
-set( Boost_DETAILED_FAILURE_MSG ON )
 
 option( BUILD_FFTW "Download and build FFTW" OFF )
 
@@ -238,7 +235,6 @@ else()
 endif()
 
 set( rocfft-test_include_dirs
-  $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
   $<BUILD_INTERFACE:${FFTW_INCLUDE_DIRS}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/include>
   ${ROCM_CLANG_ROOT}/include

--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -27,7 +27,6 @@
 #include "../../shared/precision_type.h"
 #include "../../shared/rocfft_complex.h"
 #include "hip/hip_runtime_api.h"
-#include <boost/scope_exit.hpp>
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
@@ -51,8 +50,17 @@ namespace std
     namespace filesystem = experimental::filesystem;
 }
 #endif
-
 namespace fs = std::filesystem;
+
+#if __has_include(<scope>)
+#include <scope>
+namespace scope = std;
+#else
+#include <experimental/scope>
+namespace scope = std::experimental;
+#endif
+
+
 
 #ifndef WIN32
 // get program_invocation_name
@@ -216,12 +224,13 @@ TEST(rocfft_UnitTest, log_levels)
     }
 
     // clean up environment and temporary file when we exit
-    BOOST_SCOPE_EXIT_ALL(=)
+    scope::scope_exit guard([=]()
     {
         rocfft_cleanup();
         // re-init logs with default logging
         rocfft_setup();
-    };
+        
+    });
     rocfft_cleanup();
 
     // enumerate all known log levels and direct all of the logs to nowhere
@@ -297,13 +306,13 @@ TEST(rocfft_UnitTest, log_multithreading)
     static const char* TRACE_FILE           = "trace.log";
 
     // clean up environment and temporary file when we exit
-    BOOST_SCOPE_EXIT_ALL(=)
+    scope::scope_exit guard([=]()
     {
         rocfft_cleanup();
         remove(TRACE_FILE);
         // re-init logs with default logging
         rocfft_setup();
-    };
+    });
 
     // ask for trace logging, since that's the easiest to trigger
     rocfft_cleanup();
@@ -491,7 +500,7 @@ void rtc_cache_main()
     size_t onekernel_cache_bytes = 0;
 
     // cleanup
-    BOOST_SCOPE_EXIT_ALL(=)
+    scope::scope_exit guard([=]()
     {
         // close log file handles
         rocfft_cleanup();
@@ -503,7 +512,7 @@ void rtc_cache_main()
             rocfft_cache_buffer_free(empty_cache);
         if(onekernel_cache)
             rocfft_cache_buffer_free(onekernel_cache);
-    };
+    });
 
     rocfft_cleanup();
     EnvironmentSetTemp cache_env("ROCFFT_RTC_CACHE_PATH", rtc_cache_path.c_str());
@@ -746,12 +755,12 @@ TEST(rocfft_UnitTest, rtc_test_harness)
 
     rocfft_cleanup();
 
-    BOOST_SCOPE_EXIT_ALL()
+    scope::scope_exit guard([]()
     {
         // reinit rocFFT so caching goes back to normal
         rocfft_cleanup();
         rocfft_setup();
-    };
+    });
 
     // extra scope to control lifetime of env vars
     {

--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -52,12 +52,14 @@ namespace std
 #endif
 namespace fs = std::filesystem;
 
+#ifdef HAVE_SCOPE_EXIT
 #if __has_include(<scope>)
 #include <scope>
 namespace scope = std;
 #else
 #include <experimental/scope>
 namespace scope = std::experimental;
+#endif
 #endif
 
 
@@ -214,6 +216,7 @@ TEST(rocfft_UnitTest, plan_description_reuse)
     ASSERT_EQ(rocfft_plan_description_destroy(desc), rocfft_status_success);
 }
 
+#ifdef HAVE_SCOPE_EXIT
 // run a transform with all log levels enabled
 TEST(rocfft_UnitTest, log_levels)
 {
@@ -291,8 +294,10 @@ TEST(rocfft_UnitTest, log_levels)
         }
     }
 }
+#endif
 
 // Check whether logs can be emitted from multiple threads properly
+#ifdef HAVE_SCOPE_EXIT
 TEST(rocfft_UnitTest, log_multithreading)
 {
     if(hash_prob(random_seed, ::testing::UnitTest::GetInstance()->current_test_info()->name())
@@ -355,6 +360,7 @@ TEST(rocfft_UnitTest, log_multithreading)
         ASSERT_TRUE(res) << "line contains invalid content: " << line;
     }
 }
+#endif
 
 // a function that accepts a plan's requested size on input, and
 // returns the size to actually allocate for the test
@@ -477,6 +483,7 @@ TEST(rocfft_UnitTest, workmem_null)
 
 static const size_t RTC_PROBLEM_SIZE = 2304;
 // runtime compilation cache tests main loop
+#ifdef HAVE_SCOPE_EXIT
 void rtc_cache_main()
 {
     if(hash_prob(random_seed, ::testing::UnitTest::GetInstance()->current_test_info()->name())
@@ -630,6 +637,7 @@ void rtc_cache_main()
     rocfft_cleanup();
     ASSERT_TRUE(fft_kernel_was_compiled());
 }
+#endif
 
 // run the main body of rtc cache tests twice to uncover potential
 // problems with thread reuse between iterations
@@ -733,6 +741,7 @@ TEST(rocfft_UnitTest, rtc_helper_crash)
     plan = nullptr;
 }
 
+#ifdef HAVE_SCOPE_EXIT
 TEST(rocfft_UnitTest, rtc_test_harness)
 {
     if(hash_prob(random_seed, ::testing::UnitTest::GetInstance()->current_test_info()->name())
@@ -885,3 +894,4 @@ TEST(rocfft_UnitTest, rtc_test_harness)
         }
     }
 }
+#endif

--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -64,8 +64,6 @@ namespace scope = std::experimental;
 #include <boost/scope_exit.hpp>
 #endif
 
-
-
 #ifndef WIN32
 // get program_invocation_name
 #include <errno.h>
@@ -218,7 +216,6 @@ TEST(rocfft_UnitTest, plan_description_reuse)
     ASSERT_EQ(rocfft_plan_description_destroy(desc), rocfft_status_success);
 }
 
-
 // run a transform with all log levels enabled
 TEST(rocfft_UnitTest, log_levels)
 {
@@ -234,16 +231,15 @@ TEST(rocfft_UnitTest, log_levels)
 #else
     BOOST_SCOPE_EXIT_ALL(=)
 #endif
-    {
-        rocfft_cleanup();
-        // re-init logs with default logging
-        rocfft_setup();
-        
-    }
+                            {
+                                rocfft_cleanup();
+                                // re-init logs with default logging
+                                rocfft_setup();
+                            }
 #ifdef HAVE_SCOPE_EXIT
-        )
+    )
 #endif
-    ;
+        ;
     rocfft_cleanup();
 
     // enumerate all known log levels and direct all of the logs to nowhere
@@ -251,7 +247,7 @@ TEST(rocfft_UnitTest, log_levels)
 #ifdef WIN32
     static const char* log_output = "NUL";
 #else
-    static const char* log_output   = "/dev/null";
+    static const char* log_output = "/dev/null";
 #endif
     EnvironmentSetTemp log_trace_path("ROCFFT_LOG_TRACE_PATH", log_output);
     EnvironmentSetTemp log_bench_path("ROCFFT_LOG_BENCH_PATH", log_output);
@@ -325,16 +321,16 @@ TEST(rocfft_UnitTest, log_multithreading)
     BOOST_SCOPE_EXIT_ALL(=)
 #endif
 
-    {
-        rocfft_cleanup();
-        remove(TRACE_FILE);
-        // re-init logs with default logging
-        rocfft_setup();
-    }
+                            {
+                                rocfft_cleanup();
+                                remove(TRACE_FILE);
+                                // re-init logs with default logging
+                                rocfft_setup();
+                            }
 #ifdef HAVE_SCOPE_EXIT
-        )
+    )
 #endif
-    ;
+        ;
 
     // ask for trace logging, since that's the easiest to trigger
     rocfft_cleanup();
@@ -528,22 +524,22 @@ void rtc_cache_main()
 #else
     BOOST_SCOPE_EXIT_ALL(=)
 #endif
-    {
-        // close log file handles
-        rocfft_cleanup();
-        remove(rtc_cache_path.c_str());
-        remove(rtc_log_path.c_str());
-        // re-init lib now that the env vars are gone
-        rocfft_setup();
-        if(empty_cache)
-            rocfft_cache_buffer_free(empty_cache);
-        if(onekernel_cache)
-            rocfft_cache_buffer_free(onekernel_cache);
-    }
+                            {
+                                // close log file handles
+                                rocfft_cleanup();
+                                remove(rtc_cache_path.c_str());
+                                remove(rtc_log_path.c_str());
+                                // re-init lib now that the env vars are gone
+                                rocfft_setup();
+                                if(empty_cache)
+                                    rocfft_cache_buffer_free(empty_cache);
+                                if(onekernel_cache)
+                                    rocfft_cache_buffer_free(onekernel_cache);
+                            }
 #ifdef HAVE_SCOPE_EXIT
-        )
+    )
 #endif
-    ;
+        ;
 
     rocfft_cleanup();
     EnvironmentSetTemp cache_env("ROCFFT_RTC_CACHE_PATH", rtc_cache_path.c_str());
@@ -789,16 +785,16 @@ TEST(rocfft_UnitTest, rtc_test_harness)
     scope::scope_exit guard([]()
 #else
     BOOST_SCOPE_EXIT_ALL()
-#endif        
-    {
-        // reinit rocFFT so caching goes back to normal
-        rocfft_cleanup();
-        rocfft_setup();
-    }
-#ifdef HAVE_SCOPE_EXIT
-        )
 #endif
-    ;
+                            {
+                                // reinit rocFFT so caching goes back to normal
+                                rocfft_cleanup();
+                                rocfft_setup();
+                            }
+#ifdef HAVE_SCOPE_EXIT
+    )
+#endif
+        ;
 
     // extra scope to control lifetime of env vars
     {

--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -373,7 +373,6 @@ TEST(rocfft_UnitTest, log_multithreading)
         ASSERT_TRUE(res) << "line contains invalid content: " << line;
     }
 }
-#endif
 
 // a function that accepts a plan's requested size on input, and
 // returns the size to actually allocate for the test
@@ -919,4 +918,3 @@ TEST(rocfft_UnitTest, rtc_test_harness)
         }
     }
 }
-#endif

--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -637,8 +637,6 @@ void rtc_cache_main()
     rocfft_cleanup();
     ASSERT_TRUE(fft_kernel_was_compiled());
 }
-#endif
-
 // run the main body of rtc cache tests twice to uncover potential
 // problems with thread reuse between iterations
 TEST(rocfft_UnitTest, rtc_cache_iter_1)
@@ -650,6 +648,7 @@ TEST(rocfft_UnitTest, rtc_cache_iter_2)
 {
     rtc_cache_main();
 }
+#ifdef HAVE_SCOPE_EXIT
 
 // make sure cache API functions tolerate null pointers without crashing
 TEST(rocfft_UnitTest, rtc_cache_null)

--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -60,6 +60,8 @@ namespace scope = std;
 #include <experimental/scope>
 namespace scope = std::experimental;
 #endif
+#else
+#include <boost/scope_exit.hpp>
 #endif
 
 
@@ -216,7 +218,7 @@ TEST(rocfft_UnitTest, plan_description_reuse)
     ASSERT_EQ(rocfft_plan_description_destroy(desc), rocfft_status_success);
 }
 
-#ifdef HAVE_SCOPE_EXIT
+
 // run a transform with all log levels enabled
 TEST(rocfft_UnitTest, log_levels)
 {
@@ -227,13 +229,21 @@ TEST(rocfft_UnitTest, log_levels)
     }
 
     // clean up environment and temporary file when we exit
+#ifdef HAVE_SCOPE_EXIT
     scope::scope_exit guard([=]()
+#else
+    BOOST_SCOPE_EXIT_ALL(=)
+#endif
     {
         rocfft_cleanup();
         // re-init logs with default logging
         rocfft_setup();
         
-    });
+    }
+#ifdef HAVE_SCOPE_EXIT
+        )
+#endif
+    ;
     rocfft_cleanup();
 
     // enumerate all known log levels and direct all of the logs to nowhere
@@ -294,10 +304,8 @@ TEST(rocfft_UnitTest, log_levels)
         }
     }
 }
-#endif
 
 // Check whether logs can be emitted from multiple threads properly
-#ifdef HAVE_SCOPE_EXIT
 TEST(rocfft_UnitTest, log_multithreading)
 {
     if(hash_prob(random_seed, ::testing::UnitTest::GetInstance()->current_test_info()->name())
@@ -311,13 +319,22 @@ TEST(rocfft_UnitTest, log_multithreading)
     static const char* TRACE_FILE           = "trace.log";
 
     // clean up environment and temporary file when we exit
+#ifdef HAVE_SCOPE_EXIT
     scope::scope_exit guard([=]()
+#else
+    BOOST_SCOPE_EXIT_ALL(=)
+#endif
+
     {
         rocfft_cleanup();
         remove(TRACE_FILE);
         // re-init logs with default logging
         rocfft_setup();
-    });
+    }
+#ifdef HAVE_SCOPE_EXIT
+        )
+#endif
+    ;
 
     // ask for trace logging, since that's the easiest to trigger
     rocfft_cleanup();
@@ -483,7 +500,6 @@ TEST(rocfft_UnitTest, workmem_null)
 
 static const size_t RTC_PROBLEM_SIZE = 2304;
 // runtime compilation cache tests main loop
-#ifdef HAVE_SCOPE_EXIT
 void rtc_cache_main()
 {
     if(hash_prob(random_seed, ::testing::UnitTest::GetInstance()->current_test_info()->name())
@@ -507,7 +523,11 @@ void rtc_cache_main()
     size_t onekernel_cache_bytes = 0;
 
     // cleanup
+#ifdef HAVE_SCOPE_EXIT
     scope::scope_exit guard([=]()
+#else
+    BOOST_SCOPE_EXIT_ALL(=)
+#endif
     {
         // close log file handles
         rocfft_cleanup();
@@ -519,7 +539,11 @@ void rtc_cache_main()
             rocfft_cache_buffer_free(empty_cache);
         if(onekernel_cache)
             rocfft_cache_buffer_free(onekernel_cache);
-    });
+    }
+#ifdef HAVE_SCOPE_EXIT
+        )
+#endif
+    ;
 
     rocfft_cleanup();
     EnvironmentSetTemp cache_env("ROCFFT_RTC_CACHE_PATH", rtc_cache_path.c_str());
@@ -648,7 +672,6 @@ TEST(rocfft_UnitTest, rtc_cache_iter_2)
 {
     rtc_cache_main();
 }
-#ifdef HAVE_SCOPE_EXIT
 
 // make sure cache API functions tolerate null pointers without crashing
 TEST(rocfft_UnitTest, rtc_cache_null)
@@ -740,7 +763,6 @@ TEST(rocfft_UnitTest, rtc_helper_crash)
     plan = nullptr;
 }
 
-#ifdef HAVE_SCOPE_EXIT
 TEST(rocfft_UnitTest, rtc_test_harness)
 {
     if(hash_prob(random_seed, ::testing::UnitTest::GetInstance()->current_test_info()->name())
@@ -763,12 +785,20 @@ TEST(rocfft_UnitTest, rtc_test_harness)
 
     rocfft_cleanup();
 
+#ifdef HAVE_SCOPE_EXIT
     scope::scope_exit guard([]()
+#else
+    BOOST_SCOPE_EXIT_ALL()
+#endif        
     {
         // reinit rocFFT so caching goes back to normal
         rocfft_cleanup();
         rocfft_setup();
-    });
+    }
+#ifdef HAVE_SCOPE_EXIT
+        )
+#endif
+    ;
 
     // extra scope to control lifetime of env vars
     {


### PR DESCRIPTION
## Motivation

This removes a boost dependency in rocFFT's test suite.

In particular, VS26 is having issue with boost.

## Technical Details

C++23 has scope_exit in the STL, which we can use to replace  BOOST_SCOPE_EXIT.  However, this isn't always available, so we allow fall-back to std::experimental.

## Test Plan

Changes covered by normal PR tests.