### PR TITLE
[rocblas/tensile] Support building generic architectures using another arch's logic files

### DIFF
--- a/projects/rocblas/library/src/tensile_host.cpp
+++ b/projects/rocblas/library/src/tensile_host.cpp
@@ -83,20 +83,21 @@ namespace
     // Maps specific architectures to their generic fallback.
     // When exact-match libraries don't exist, try the generic variant.
     // Add new mappings as needed.
+	// Reference: https://llvm.org/docs/AMDGPUUsage.html
     static const std::unordered_map<std::string, std::string> archFallbackMap = {
-        // gfx9 family -> gfx9-generic
+		// Vega and non-CDNA
         {"gfx900", "gfx9-generic"},
         {"gfx902", "gfx9-generic"},
         {"gfx904", "gfx9-generic"},
         {"gfx906", "gfx9-generic"},
-        {"gfx908", "gfx9-generic"},
         {"gfx909", "gfx9-generic"},
-        {"gfx90a", "gfx9-generic"},
         {"gfx90c", "gfx9-generic"},
-        {"gfx940", "gfx9-generic"},
-        {"gfx941", "gfx9-generic"},
-        {"gfx942", "gfx9-generic"},
-        // gfx10 family -> gfx10-3-generic (RDNA2)
+		// RDNA1
+        {"gfx1010", "gfx10-1-generic"},
+        {"gfx1011", "gfx10-1-generic"},
+        {"gfx1012", "gfx10-1-generic"},
+        {"gfx1013", "gfx10-1-generic"},
+        // RDNA2
         {"gfx1030", "gfx10-3-generic"},
         {"gfx1031", "gfx10-3-generic"},
         {"gfx1032", "gfx10-3-generic"},
@@ -104,7 +105,7 @@ namespace
         {"gfx1034", "gfx10-3-generic"},
         {"gfx1035", "gfx10-3-generic"},
         {"gfx1036", "gfx10-3-generic"},
-        // gfx11 family -> gfx11-generic (RDNA3)
+        // RDNA3/3.5
         {"gfx1100", "gfx11-generic"},
         {"gfx1101", "gfx11-generic"},
         {"gfx1102", "gfx11-generic"},
@@ -113,6 +114,12 @@ namespace
         {"gfx1151", "gfx11-generic"},
         {"gfx1152", "gfx11-generic"},
         {"gfx1153", "gfx11-generic"},
+		// RDNA4
+        {"gfx1200", "gfx12-generic"},
+        {"gfx1201", "gfx12-generic"},
+		// MI300[a-zA-Z]
+		{"gfx942", "gfx9-4-generic"},
+		{"gfx950", "gfx9-4-generic"},
     };
 
     static std::string getArchFallback(const std::string& arch)

--- a/projects/rocblas/library/src/tensile_host.cpp
+++ b/projects/rocblas/library/src/tensile_host.cpp
@@ -84,8 +84,35 @@ namespace
     // When exact-match libraries don't exist, try the generic variant.
     // Add new mappings as needed.
     static const std::unordered_map<std::string, std::string> archFallbackMap = {
-        {"gfx1032", "gfx10-3-generic"},
+        // gfx9 family -> gfx9-generic
+        {"gfx900", "gfx9-generic"},
+        {"gfx902", "gfx9-generic"},
+        {"gfx904", "gfx9-generic"},
+        {"gfx906", "gfx9-generic"},
+        {"gfx908", "gfx9-generic"},
+        {"gfx909", "gfx9-generic"},
+        {"gfx90a", "gfx9-generic"},
         {"gfx90c", "gfx9-generic"},
+        {"gfx940", "gfx9-generic"},
+        {"gfx941", "gfx9-generic"},
+        {"gfx942", "gfx9-generic"},
+        // gfx10 family -> gfx10-3-generic (RDNA2)
+        {"gfx1030", "gfx10-3-generic"},
+        {"gfx1031", "gfx10-3-generic"},
+        {"gfx1032", "gfx10-3-generic"},
+        {"gfx1033", "gfx10-3-generic"},
+        {"gfx1034", "gfx10-3-generic"},
+        {"gfx1035", "gfx10-3-generic"},
+        {"gfx1036", "gfx10-3-generic"},
+        // gfx11 family -> gfx11-generic (RDNA3)
+        {"gfx1100", "gfx11-generic"},
+        {"gfx1101", "gfx11-generic"},
+        {"gfx1102", "gfx11-generic"},
+        {"gfx1103", "gfx11-generic"},
+        {"gfx1150", "gfx11-generic"},
+        {"gfx1151", "gfx11-generic"},
+        {"gfx1152", "gfx11-generic"},
+        {"gfx1153", "gfx11-generic"},
     };
 
     static std::string getArchFallback(const std::string& arch)

--- a/projects/rocblas/library/src/tensile_host.cpp
+++ b/projects/rocblas/library/src/tensile_host.cpp
@@ -120,6 +120,15 @@ namespace
         auto it = archFallbackMap.find(arch);
         return (it != archFallbackMap.end()) ? it->second : "";
     }
+
+    static constexpr const char* getTensileLibraryExt()
+    {
+#ifdef TENSILE_YAML
+        return ".yaml";
+#else
+        return ".dat";
+#endif
+    }
 }
 
 // cppcheck-suppress preprocessorErrorDirective
@@ -857,108 +866,91 @@ namespace
                 path += "/" + processor;
 
             // Try to find the Tensile library, with fallback to generic architecture
-            std::string fallbackArch   = getArchFallback(processor);
-            std::string effectiveArch  = processor;
-            bool        usingFallback  = false;
+            std::string fallbackArch  = getArchFallback(processor);
+            std::string effectiveArch = processor;
+            const char* libExt        = getTensileLibraryExt();
 
-#ifdef TENSILE_YAML
-            tensileLibraryPath = path + "/TensileLibrary_lazy_" + processor + ".yaml";
-#else
-            tensileLibraryPath = path + "/TensileLibrary_lazy_" + processor + ".dat";
-#endif
-            if(!TestPath(tensileLibraryPath))
-            {
-                // Try fallback architecture for lazy library
-                if(!fallbackArch.empty())
+            // Lambda to try finding a library, returns true if found
+            auto tryLibrary = [&](const std::string& tryPath,
+                                  const std::string& arch,
+                                  bool               lazy) -> bool {
+                std::string prefix  = lazy ? "TensileLibrary_lazy_" : "TensileLibrary_";
+                std::string libPath = tryPath + "/" + prefix + arch + libExt;
+                if(TestPath(libPath))
                 {
-                    std::string fallbackPath = base_path;
-                    if(TestPath(fallbackPath + "/" + fallbackArch))
-                        fallbackPath += "/" + fallbackArch;
-#ifdef TENSILE_YAML
-                    std::string fallbackLibPath = fallbackPath + "/TensileLibrary_lazy_" + fallbackArch + ".yaml";
-#else
-                    std::string fallbackLibPath = fallbackPath + "/TensileLibrary_lazy_" + fallbackArch + ".dat";
-#endif
-                    if(TestPath(fallbackLibPath))
-                    {
-                        tensileLibraryPath = fallbackLibPath;
-                        path               = fallbackPath;
-                        effectiveArch      = fallbackArch;
-                        usingFallback      = true;
-                    }
+                    tensileLibraryPath        = libPath;
+                    path                      = tryPath;
+                    effectiveArch             = arch;
+                    tensile_lazy_load_enabled = lazy;
+                    return true;
+                }
+                return false;
+            };
+
+            // Helper to get arch-specific path
+            auto getArchPath = [&](const std::string& arch) -> std::string {
+                std::string archPath = base_path;
+                if(TestPath(base_path + "/" + arch))
+                    archPath = base_path + "/" + arch;
+                return archPath;
+            };
+
+            // Search in order of preference:
+            // 1. Lazy library with exact architecture
+            // 2. Lazy library with fallback architecture
+            // 3. Non-lazy library with exact architecture
+            // 4. Non-lazy library with fallback architecture
+            // 5. Generic TensileLibrary (no arch suffix)
+
+            bool found = tryLibrary(path, processor, true);
+
+            if(!found && !fallbackArch.empty())
+                found = tryLibrary(getArchPath(fallbackArch), fallbackArch, true);
+
+            if(!found)
+                found = tryLibrary(path, effectiveArch, false);
+
+            if(!found && !fallbackArch.empty())
+                found = tryLibrary(getArchPath(fallbackArch), fallbackArch, false);
+
+            if(!found)
+            {
+                // Try generic library (no arch suffix)
+                std::string genericPath = path + "/TensileLibrary" + libExt;
+                if(TestPath(genericPath))
+                {
+                    tensileLibraryPath        = genericPath;
+                    tensile_lazy_load_enabled = false;
+                    found                     = true;
                 }
             }
 
-            if(!TestPath(tensileLibraryPath))
+            if(!found)
             {
-#ifdef TENSILE_YAML
-                tensileLibraryPath = path + "/TensileLibrary_" + effectiveArch + ".yaml";
-#else
-                tensileLibraryPath = path + "/TensileLibrary_" + effectiveArch + ".dat";
-#endif
-                if(!TestPath(tensileLibraryPath))
-                {
-                    // Try fallback for non-lazy library if not already using fallback
-                    if(!usingFallback && !fallbackArch.empty())
-                    {
-                        std::string fallbackPath = base_path;
-                        if(TestPath(fallbackPath + "/" + fallbackArch))
-                            fallbackPath += "/" + fallbackArch;
-#ifdef TENSILE_YAML
-                        std::string fallbackLibPath = fallbackPath + "/TensileLibrary_" + fallbackArch + ".yaml";
-#else
-                        std::string fallbackLibPath = fallbackPath + "/TensileLibrary_" + fallbackArch + ".dat";
-#endif
-                        if(TestPath(fallbackLibPath))
-                        {
-                            tensileLibraryPath = fallbackLibPath;
-                            path               = fallbackPath;
-                            effectiveArch      = fallbackArch;
-                            usingFallback      = true;
-                        }
-                    }
-                }
-            }
-
-            if(!TestPath(tensileLibraryPath))
-            {
-#ifdef TENSILE_YAML
-                    tensileLibraryPath = path + "/TensileLibrary.yaml";
-#else
-                    tensileLibraryPath = path + "/TensileLibrary.dat";
-#endif
-                    if(!TestPath(tensileLibraryPath))
-                    {
 #if ROCBLAS_TENSILE_SEPARATE_ARCH
-                        rocblas_cerr << "\nrocBLAS error: Cannot read " << tensileLibraryPath
-                                     << ": " << strerror(errno) << " for GPU arch : " << processor
-                                     << std::endl;
+                rocblas_cerr << "\nrocBLAS error: Cannot read " << tensileLibraryPath
+                             << ": " << strerror(errno) << " for GPU arch : " << processor
+                             << std::endl;
 #if ROCBLAS_TENSILE_LAZY_LOAD
-                        std::regex fileMatcher(path + "/TensileLibrary_lazy.*");
+                std::regex fileMatcher(path + "/TensileLibrary_lazy.*");
 #else
-                        std::regex fileMatcher(path + "/TensileLibrary_gfx\\d+.dat");
+                std::regex fileMatcher(path + "/TensileLibrary_gfx\\d+.dat");
 #endif
-                        rocblas_cerr << " List of available TensileLibrary Files : " << std::endl;
-                        for(auto& file_name : fs::directory_iterator(path))
-                        {
-                            if(std::regex_match(file_name.path().string(), fileMatcher))
-                            {
-                                rocblas_cerr << file_name << std::endl;
-                            }
-                        }
+                rocblas_cerr << " List of available TensileLibrary Files : " << std::endl;
+                for(auto& file_name : fs::directory_iterator(path))
+                {
+                    if(std::regex_match(file_name.path().string(), fileMatcher))
+                        rocblas_cerr << file_name << std::endl;
+                }
 #else
-                        rocblas_cerr << "\nrocBLAS error: Cannot read " << tensileLibraryPath
-                                     << ": " << strerror(errno) << std::endl;
+                rocblas_cerr << "\nrocBLAS error: Cannot read " << tensileLibraryPath
+                             << ": " << strerror(errno) << std::endl;
 #endif
-                        rocblas_abort();
-                    }
+                rocblas_abort();
             }
-
-            if(tensileLibraryPath.find("_lazy_") != std::string::npos && TestPath(tensileLibraryPath))
-                tensile_lazy_load_enabled = true;
 
             // Update processor to effectiveArch for code object loading
-            if(usingFallback)
+            if(effectiveArch != processor)
                 processor = effectiveArch;
 
             //Supports multi architecture configuration in lazy library loading mode

--- a/projects/rocblas/library/src/tensile_host.cpp
+++ b/projects/rocblas/library/src/tensile_host.cpp
@@ -76,6 +76,25 @@
 #define ROCBLAS_LIB_PATH "/opt/rocm/lib"
 #endif
 
+#include <unordered_map>
+
+namespace
+{
+    // Maps specific architectures to their generic fallback.
+    // When exact-match libraries don't exist, try the generic variant.
+    // Add new mappings as needed.
+    static const std::unordered_map<std::string, std::string> archFallbackMap = {
+        {"gfx1032", "gfx10-3-generic"},
+        {"gfx90c", "gfx9-generic"},
+    };
+
+    static std::string getArchFallback(const std::string& arch)
+    {
+        auto it = archFallbackMap.find(arch);
+        return (it != archFallbackMap.end()) ? it->second : "";
+    }
+}
+
 // cppcheck-suppress preprocessorErrorDirective
 #if __has_include(<filesystem>)
 #include <filesystem>
@@ -810,6 +829,11 @@ namespace
             if(TestPath(path + "/" + processor))
                 path += "/" + processor;
 
+            // Try to find the Tensile library, with fallback to generic architecture
+            std::string fallbackArch   = getArchFallback(processor);
+            std::string effectiveArch  = processor;
+            bool        usingFallback  = false;
+
 #ifdef TENSILE_YAML
             tensileLibraryPath = path + "/TensileLibrary_lazy_" + processor + ".yaml";
 #else
@@ -817,14 +841,60 @@ namespace
 #endif
             if(!TestPath(tensileLibraryPath))
             {
-
+                // Try fallback architecture for lazy library
+                if(!fallbackArch.empty())
+                {
+                    std::string fallbackPath = base_path;
+                    if(TestPath(fallbackPath + "/" + fallbackArch))
+                        fallbackPath += "/" + fallbackArch;
 #ifdef TENSILE_YAML
-                tensileLibraryPath = path + "/TensileLibrary_" + processor + ".yaml";
+                    std::string fallbackLibPath = fallbackPath + "/TensileLibrary_lazy_" + fallbackArch + ".yaml";
 #else
-                tensileLibraryPath = path + "/TensileLibrary_" + processor + ".dat";
+                    std::string fallbackLibPath = fallbackPath + "/TensileLibrary_lazy_" + fallbackArch + ".dat";
+#endif
+                    if(TestPath(fallbackLibPath))
+                    {
+                        tensileLibraryPath = fallbackLibPath;
+                        path               = fallbackPath;
+                        effectiveArch      = fallbackArch;
+                        usingFallback      = true;
+                    }
+                }
+            }
+
+            if(!TestPath(tensileLibraryPath))
+            {
+#ifdef TENSILE_YAML
+                tensileLibraryPath = path + "/TensileLibrary_" + effectiveArch + ".yaml";
+#else
+                tensileLibraryPath = path + "/TensileLibrary_" + effectiveArch + ".dat";
 #endif
                 if(!TestPath(tensileLibraryPath))
                 {
+                    // Try fallback for non-lazy library if not already using fallback
+                    if(!usingFallback && !fallbackArch.empty())
+                    {
+                        std::string fallbackPath = base_path;
+                        if(TestPath(fallbackPath + "/" + fallbackArch))
+                            fallbackPath += "/" + fallbackArch;
+#ifdef TENSILE_YAML
+                        std::string fallbackLibPath = fallbackPath + "/TensileLibrary_" + fallbackArch + ".yaml";
+#else
+                        std::string fallbackLibPath = fallbackPath + "/TensileLibrary_" + fallbackArch + ".dat";
+#endif
+                        if(TestPath(fallbackLibPath))
+                        {
+                            tensileLibraryPath = fallbackLibPath;
+                            path               = fallbackPath;
+                            effectiveArch      = fallbackArch;
+                            usingFallback      = true;
+                        }
+                    }
+                }
+            }
+
+            if(!TestPath(tensileLibraryPath))
+            {
 #ifdef TENSILE_YAML
                     tensileLibraryPath = path + "/TensileLibrary.yaml";
 #else
@@ -855,10 +925,14 @@ namespace
 #endif
                         rocblas_abort();
                     }
-                }
             }
-            else
+
+            if(tensileLibraryPath.find("_lazy_") != std::string::npos && TestPath(tensileLibraryPath))
                 tensile_lazy_load_enabled = true;
+
+            // Update processor to effectiveArch for code object loading
+            if(usingFallback)
+                processor = effectiveArch;
 
             //Supports multi architecture configuration in lazy library loading mode
             static int initialize_once = [&] {

--- a/shared/tensile/Tensile/BuildCommands/AssemblyCommands.py
+++ b/shared/tensile/Tensile/BuildCommands/AssemblyCommands.py
@@ -103,13 +103,15 @@ def buildAssemblyCodeObjectFiles(
     if len(assemblyKernels) == 0:
         return []
 
+    # Group kernels by requested architecture name (or computed gfx name if not set)
+    # This preserves alias names like gfx11-generic instead of converting to gfx1100
     archKernelMap = collections.defaultdict(list)
     for k in assemblyKernels:
-        archKernelMap[tuple(k["ISA"])].append(k)
+        archName = k.get("RequestedArchName", gfxName(tuple(k["ISA"])))
+        archKernelMap[archName].append(k)
 
     coFiles = []
-    for arch, archKernels in archKernelMap.items():
-        gfx = gfxName(arch)
+    for gfx, archKernels in archKernelMap.items():
         objectFiles = [
             str(asmDir / (writer.getKernelFileBase(k) + extObj))
             for k in archKernels

--- a/shared/tensile/Tensile/Common.py
+++ b/shared/tensile/Tensile/Common.py
@@ -328,8 +328,36 @@ architectureMap = {
   'gfx1100':'navi31', 'gfx1101':'navi32', 'gfx1102':'navi33', 'gfx1103':'gfx1103',
   'gfx1150':'strixpoint', 'gfx1151':'strixhalo', 'gfx1152':'gfx1152', 'gfx1153':'gfx1153',
   'gfx1200':'gfx1200',
-  'gfx1201':'gfx1201'
+  'gfx1201':'gfx1201',
+  # Aliases for generic architectures
+  'gfx10-3-generic':'navi21', 'gfx9-generic':'vega10',
+  'gfx11-generic': 'navi31',
 }
+
+# Architecture aliases: maps alias names to base architecture for configuration lookup.
+# The alias name is used for --offload-arch, the base arch for capabilities/logic files.
+# Add new aliases here as needed.
+archAliases = {
+    'gfx10-3-generic': 'gfx1030',
+    'gfx9-generic': 'gfx900',
+    'gfx11-generic': 'gfx1100',
+}
+
+def resolveArchAlias(archName: str) -> str:
+    """Resolve alias to base architecture for configuration lookup.
+
+    Preserves xnack/other suffixes (e.g., 'gfx10-3-generic:xnack+' -> 'gfx1030:xnack+').
+
+    Args:
+        archName: Architecture name, possibly an alias with optional suffix.
+
+    Returns:
+        The resolved base architecture name with suffix preserved.
+    """
+    baseName = archName.split(':')[0]
+    suffix = archName[len(baseName):]
+    resolved = archAliases.get(baseName, baseName)
+    return resolved + suffix
 
 def getArchitectureName(gfxName: str) -> Optional[str]:
   """Maps the provided Gfx architecture to its common name using the **architectureMap**.
@@ -2192,6 +2220,8 @@ def tryAssembler(isaVersion, asmString, debug=False, *options):
 
 def gfxArch(name: str) -> Optional[IsaVersion]:
     import re
+    # Resolve alias to base arch for capability lookup
+    name = resolveArchAlias(name)
     match = re.search(r'gfx([0-9a-fA-F]{3,})', name)
     if not match: return None
 

--- a/shared/tensile/Tensile/LibraryIO.py
+++ b/shared/tensile/Tensile/LibraryIO.py
@@ -168,16 +168,36 @@ class LibraryLogic(NamedTuple):
     library: SolutionLibrary.MasterSolutionLibrary
 
 
-def parseLibraryLogicFile(filename, outputArchName=None):
+def parseLibraryLogicFile(filename, scheduleToArchs=None):
     """Wrapper function to read and parse a library logic file.
 
     Args:
         filename: Path to the library logic file.
-        outputArchName: Optional override for output architecture name. If provided,
-            this name will be used for all output file naming (lazy libraries, code objects)
-            while the original ArchitectureName is still used for ISA capabilities.
+        scheduleToArchs: Optional dict mapping schedule names to list of output arch names.
+            When a schedule has multiple archs, this function returns multiple results.
+
+    Returns:
+        List of LibraryLogic tuples (always a list for consistent handling).
     """
-    return parseLibraryLogicData(readYAML(filename), filename, outputArchName)
+    data = readYAML(filename)
+
+    # Get schedule name from data
+    if isinstance(data, list):
+        scheduleName = data[1] if len(data) > 1 else None
+    else:
+        scheduleName = data.get("ScheduleName")
+
+    # Get list of output archs for this schedule
+    outputArchs = None
+    if scheduleToArchs and scheduleName:
+        outputArchs = scheduleToArchs.get(scheduleName)
+
+    if outputArchs:
+        # Return one result per requested arch
+        return [parseLibraryLogicData(data, filename, arch) for arch in outputArchs]
+    else:
+        # No override - use original arch name, still return as list
+        return [parseLibraryLogicData(data, filename, None)]
 
 
 def parseLibraryLogicData(data, srcFile="?", outputArchName=None):

--- a/shared/tensile/Tensile/LibraryIO.py
+++ b/shared/tensile/Tensile/LibraryIO.py
@@ -168,13 +168,28 @@ class LibraryLogic(NamedTuple):
     library: SolutionLibrary.MasterSolutionLibrary
 
 
-def parseLibraryLogicFile(filename):
-    """Wrapper function to read and parse a library logic file."""
-    return parseLibraryLogicData(readYAML(filename), filename)
+def parseLibraryLogicFile(filename, outputArchName=None):
+    """Wrapper function to read and parse a library logic file.
+
+    Args:
+        filename: Path to the library logic file.
+        outputArchName: Optional override for output architecture name. If provided,
+            this name will be used for all output file naming (lazy libraries, code objects)
+            while the original ArchitectureName is still used for ISA capabilities.
+    """
+    return parseLibraryLogicData(readYAML(filename), filename, outputArchName)
 
 
-def parseLibraryLogicData(data, srcFile="?"):
-    """Parses the data of a library logic file."""
+def parseLibraryLogicData(data, srcFile="?", outputArchName=None):
+    """Parses the data of a library logic file.
+
+    Args:
+        data: Parsed YAML data from the library logic file.
+        srcFile: Path to the source file (for error messages).
+        outputArchName: Optional override for output architecture name. If provided,
+            this name will be used for all output file naming (lazy libraries, code objects)
+            while the original ArchitectureName is still used for ISA capabilities.
+    """
     if type(data) is list:
         data = parseLibraryLogicList(data, srcFile)
 
@@ -196,6 +211,13 @@ def parseLibraryLogicData(data, srcFile="?"):
     elif data["ArchitectureName"] not in architectureMap:
         raise ValueError(f"{data['ArchitectureName']} is not a supported architecture." \
             f" Review the library logic file {srcFile}.")
+
+    # Set output architecture name for file naming
+    # Use provided override if given, otherwise fall back to logic file's arch
+    if outputArchName:
+        data["OutputArchName"] = outputArchName
+    else:
+        data["OutputArchName"] = data["ArchitectureName"]
 
     if not versionIsCompatible(data["MinimumRequiredVersion"]):
         printWarning("Version = {} in library logic file {} does not match Tensile version = {}" \
@@ -225,7 +247,10 @@ def parseLibraryLogicData(data, srcFile="?"):
 
     newLibrary = SolutionLibrary.MasterSolutionLibrary.FromOriginalState(data, solutions)
 
-    return LibraryLogic(data["ScheduleName"], data["ArchitectureName"], problemType, solutions, \
+    # Return with OUTPUT arch name as the architecture identifier
+    # This ensures masterLibraries is keyed by the requested arch (e.g., gfx11-generic)
+    # rather than the logic file's arch (e.g., gfx1100)
+    return LibraryLogic(data["ScheduleName"], data["OutputArchName"], problemType, solutions, \
             data.get("ExactLogic"), newLibrary)
 
 

--- a/shared/tensile/Tensile/SolutionLibrary.py
+++ b/shared/tensile/Tensile/SolutionLibrary.py
@@ -306,15 +306,18 @@ class MasterSolutionLibrary:
 
         # functions for creating each "level" of the library
         def hardware(d, problemType, solutions, library, placeholderName):
-            devicePart = d["ArchitectureName"]
+            # Use original ArchitectureName for ISA/capability lookup
+            archName = d["ArchitectureName"]
+            # Use OutputArchName for file naming (supports alias architectures like gfx11-generic)
+            outputArchName = d.get("OutputArchName", archName)
             cuCount = d["CUCount"]
             isAPU = d["IsAPU"]
 
             newLib = PredicateLibrary(tag="Hardware")
-            if devicePart == "fallback":
+            if archName == "fallback":
                 pred = Hardware.HardwarePredicate("TruePred")
             else:
-                pred = Hardware.HardwarePredicate.FromHardware(Common.gfxArch(devicePart), cuCount, isAPU)
+                pred = Hardware.HardwarePredicate.FromHardware(Common.gfxArch(archName), cuCount, isAPU)
 
             newLib.rows.append({"predicate": pred, "library": library})
 
@@ -323,7 +326,7 @@ class MasterSolutionLibrary:
                     placeholderName += "_CU" + str(cuCount)
                 if isAPU is not None:
                     placeholderName += "_APU" if isAPU == 1 else "_XPU"
-                placeholderName += "_" + str(devicePart)
+                placeholderName += "_" + str(outputArchName)
 
             return newLib, placeholderName
 

--- a/shared/tensile/Tensile/SolutionLibrary.py
+++ b/shared/tensile/Tensile/SolutionLibrary.py
@@ -247,7 +247,7 @@ class PredicateLibrary:
 
 
 class MasterSolutionLibrary:
-    StateKeys = ["solutions", "library"]
+    StateKeys = ["solutions", "library", "requestedArchName"]
     ArchitectureSet = set()
 
     @classmethod
@@ -482,11 +482,12 @@ class MasterSolutionLibrary:
 
         return cls(solutionMap, library)
 
-    def __init__(self, solutions, library, version=None):
+    def __init__(self, solutions, library, version=None, requestedArchName=None):
         self.lazyLibraries = {}
         self.solutions = solutions
         self.library = library
         self.version = version
+        self.requestedArchName = requestedArchName
 
     def state(self):
         rv = {
@@ -496,6 +497,8 @@ class MasterSolutionLibrary:
 
         if self.version is not None:
             rv["version"] = self.version
+        if self.requestedArchName is not None:
+            rv["requestedArchName"] = self.requestedArchName
         return rv
 
     def applyNaming(self, naming=None):

--- a/shared/tensile/Tensile/Source/cmake/TensileSupportedArchitectures.cmake
+++ b/shared/tensile/Tensile/Source/cmake/TensileSupportedArchitectures.cmake
@@ -56,7 +56,9 @@ if(NOT BUILD_ADDRESS_SANITIZER)
         "gfx1152"
         "gfx1153"
         "gfx1200"
-        "gfx1201")
+        "gfx1201"
+        "gfx10-3-generic"
+        "gfx11-generic")
 
     set(SUPPORTED_ARCHITECTURES ${BASE_ARCHITECTURES})
     list(APPEND SUPPORTED_ARCHITECTURES

--- a/shared/tensile/Tensile/Source/lib/source/hip/HipHardware.cpp
+++ b/shared/tensile/Tensile/Source/lib/source/hip/HipHardware.cpp
@@ -71,7 +71,6 @@ namespace Tensile
                                           deviceId));
             }
 #endif
-
             return GetDevice(prop);
         }
 

--- a/shared/tensile/Tensile/TensileCreateLibrary.py
+++ b/shared/tensile/Tensile/TensileCreateLibrary.py
@@ -55,6 +55,7 @@ from .Common import (
     globalParameters,
     printExit,
     printWarning,
+    resolveArchAlias,
     splitArchs,
     tPrint,
 )
@@ -1386,7 +1387,8 @@ def TensileCreateLibrary():
     ]
 
     _, requestedArchs = splitArchs()
-    if all(a.split(":")[0] not in supportedArchs for a in requestedArchs):
+    # Resolve aliases before checking if architecture is supported
+    if all(resolveArchAlias(a).split(":")[0] not in supportedArchs for a in requestedArchs):
         printExit(
             f"No requested architecture is supported by ROCm {globalParameters['HipClangVersion']}\n  Requested {', '.join(requestedArchs)}\n  Supported {', '.join(supportedArchs)}"
         )

--- a/shared/tensile/Tensile/TensileCreateLibrary.py
+++ b/shared/tensile/Tensile/TensileCreateLibrary.py
@@ -1483,6 +1483,8 @@ def TensileCreateLibrary():
     # Build mapping from schedule name to list of requested arch names
     # This handles cases like gfx1100;gfx11-generic where both map to navi31
     # Each logic file will produce one output per requested arch for its schedule
+    # Note: xnack variants (gfx90a:xnack-, gfx90a:xnack+) are normalized to base name
+    # since xnack handling is done at kernel compile level, not library level
     scheduleToArchs = None
     if args["SeparateArchitectures"]:
         requestedArchs = splitDelimitedString(args["Architecture"], {";", "_"})
@@ -1490,7 +1492,10 @@ def TensileCreateLibrary():
         for reqArch in requestedArchs:
             scheduleName = getArchitectureName(reqArch)
             if scheduleName:
-                scheduleToArchs[scheduleName].append(reqArch)
+                # Normalize: strip xnack suffix to avoid duplicate library entries
+                baseName = reqArch.split(':')[0]
+                if baseName not in scheduleToArchs[scheduleName]:
+                    scheduleToArchs[scheduleName].append(baseName)
         # Convert to regular dict, or None if empty
         scheduleToArchs = dict(scheduleToArchs) if scheduleToArchs else None
 

--- a/shared/tensile/Tensile/TensileCreateLibrary.py
+++ b/shared/tensile/Tensile/TensileCreateLibrary.py
@@ -50,7 +50,6 @@ from .Common import (
     CHeader,
     CMakeHeader,
     archAliases,
-    architectureMap,
     assignGlobalParameters,
     ensurePath,
     getArchitectureName,
@@ -968,10 +967,17 @@ def addFallback(masterLibraries: Dict[str, MasterSolutionLibrary]) -> None:
             value.insert(masterLibraries["fallback"])
 
     for archName in archs:
-        archName = archName.split("-", 1)[0]
-        if archName not in masterLibraries:
-            tPrint(1, "Using fallback for arch: " + archName)
-            masterLibraries[archName] = masterLibraries["fallback"]
+        lookupName = archName
+        # Don't truncate generic architecture names (e.g., gfx11-generic)
+        # TODO: Review with maintainers - what was the original intent of splitting
+        # on '-' for architectures like gfx90a-xnack+? The split adds the base name
+        # (gfx90a) to masterLibraries, but this seems incorrect if the user requested
+        # gfx90a-xnack+ specifically.
+        if "generic" not in archName:
+            lookupName = archName.split("-", 1)[0]
+        if lookupName not in masterLibraries:
+            tPrint(1, "Using fallback for arch: " + lookupName)
+            masterLibraries[lookupName] = masterLibraries["fallback"]
 
     masterLibraries.pop("fallback")
 
@@ -1030,26 +1036,66 @@ def makeSolutions(
     return itertools.chain(gen1, gen2)
 
 
-def parseLibraryLogicFiles(logicFiles: List[str]) -> List[LibraryIO.LibraryLogic]:
+def parseLibraryLogicFiles(
+    logicFiles: List[str],
+    scheduleToRequestedArchs: Optional[Dict[str, List[str]]] = None
+) -> List[LibraryIO.LibraryLogic]:
     """Load and parse logic (yaml) files.
 
     Given a list of paths to yaml files containing library logic, load the files
-    into memory and parse the data into a named tuple (i.e. LibraryLogic). This
-    operation is parallelized over N processes.
+    into memory and parse the data into a named tuple (i.e. LibraryLogic).
+
+    If scheduleToRequestedArchs maps a schedule to multiple archs (e.g., navi31 -> [gfx1100, gfx11-generic]),
+    the logic file is parsed multiple times, once per arch, producing separate libraries.
+    This supports cases like --architecture=gfx1100;gfx11-generic where both outputs are needed.
 
     Args:
         logicFiles: List of paths to logic files.
+        scheduleToRequestedArchs: Optional mapping from schedule name to list of requested arch names.
 
     Returns:
         List of library logic tuples.
     """
-    return Common.ParallelMap(
-        LibraryIO.parseLibraryLogicFile, logicFiles, "Reading logic files", multiArg=False
-    )
+    if not scheduleToRequestedArchs:
+        # No override - use original parallel parsing
+        return Common.ParallelMap(
+            LibraryIO.parseLibraryLogicFile, logicFiles, "Reading logic files", multiArg=False
+        )
+
+    # When we have arch overrides, parse each file once per requested arch
+    results = []
+    for path in logicFiles:
+        # Load YAML once
+        rawData = LibraryIO.readYAML(path)
+
+        # Get schedule name from raw data
+        if isinstance(rawData, list):
+            scheduleName = rawData[1] if len(rawData) > 1 else None
+        else:
+            scheduleName = rawData.get("ScheduleName")
+
+        # Get list of requested archs for this schedule
+        requestedArchs = scheduleToRequestedArchs.get(scheduleName) if scheduleName else None
+
+        if not requestedArchs:
+            # No override - parse with original arch name
+            result = LibraryIO.parseLibraryLogicData(rawData, path, outputArchName=None)
+            results.append(result)
+        else:
+            # Parse once per requested arch
+            for reqArch in requestedArchs:
+                result = LibraryIO.parseLibraryLogicData(rawData, path, outputArchName=reqArch)
+                results.append(result)
+
+    return results
 
 
 def generateLogicData(
-    logicFiles: List[str], version: str, printLevel: int, separate: bool
+    logicFiles: List[str],
+    version: str,
+    printLevel: int,
+    separate: bool,
+    scheduleToRequestedArchs: Optional[Dict[str, List[str]]] = None
 ) -> Dict[str, MasterSolutionLibrary]:
     """Generates a dictionary of master solution libraries.
 
@@ -1058,13 +1104,16 @@ def generateLogicData(
         version: User provided version for the library.
         printLevel: Level of debug printing requested.
         separate: Separate libraries by architecture.
+        scheduleToRequestedArchs: Optional mapping from schedule name to list of requested arch names.
+            When provided, logic files are parsed once per requested arch, producing separate libraries
+            with the correct output names (e.g., gfx11-generic instead of gfx1100).
 
     Returns:
         For separate architectures, a dictionary of architecture
         separated master solution libraries; otherwise, a single
         master solution library for all architectures.
     """
-    libraries = parseLibraryLogicFiles(logicFiles)
+    libraries = parseLibraryLogicFiles(logicFiles, scheduleToRequestedArchs)
     logicList = libraries if not printLevel else Utils.tqdm(libraries, desc="Processing logic data")
     masterLibraries = makeMasterLibraries(logicList, separate)
     if separate and "fallback" in masterLibraries:
@@ -1402,7 +1451,6 @@ def TensileCreateLibrary():
     for alias, base in archAliases.items():
         if base in supportedArchs:
             supportedArchs.append(alias)
-    print(f"DEBUG supportedArchs: {supportedArchs}")
 
     _, requestedArchs = splitArchs()
     # Resolve aliases before checking if architecture is supported
@@ -1452,74 +1500,22 @@ def TensileCreateLibrary():
     tPrint(1, "#      set --verbose=2 to view all files")
     tPrint(2, "#   " + "\n#   ".join(logicFiles))
 
-    masterLibraries = generateLogicData(
-        logicFiles, args["Version"], args["PrintLevel"], args["SeparateArchitectures"]
-    )
-
-    def renameLazyLibraryKeys(lib, requestedArchName):
-        """Rename lazy library keys to use requestedArchName instead of original arch.
-
-        Lazy library names end with architecture (e.g., TensileLibrary_Type_..._gfx1100).
-        This function renames them to use the requested arch (e.g., gfx11-generic).
-        Also updates the codeObjectFile on each solution to match the new name.
-        """
-        if not requestedArchName or not lib.lazyLibraries:
-            return
-
-        # Get all known architecture names to check for suffix replacement
-        knownArchs = set(architectureMap.keys())
-
-        newLazyLibraries = {}
-        for name, lazyLib in lib.lazyLibraries.items():
-            newName = name
-            # Check if name ends with any known architecture
-            for arch in knownArchs:
-                if name.endswith("_" + arch):
-                    newName = name[:-len(arch)] + requestedArchName
-                    break
-            # Update codeObjectFile on solutions to match new name
-            for sol in lazyLib.solutions.values():
-                sol.originalSolution["codeObjectFile"] = newName
-            newLazyLibraries[newName] = lazyLib
-        lib.lazyLibraries = newLazyLibraries
-
-    # Rename masterLibraries keys from logic file arch names to requested arch names
-    # This is needed for alias architectures (e.g., gfx11-generic -> navi31 -> gfx11-generic)
-    # Also handles multiple requested names for same base arch (e.g., gfx1100;gfx11-generic)
+    # Build mapping from schedule name to list of requested arch names
+    # This supports cases like --architecture=gfx1100;gfx11-generic where both outputs are needed
+    # For each logic file (keyed by schedule), we parse once per requested arch
+    scheduleToRequestedArchs = None
     if args["SeparateArchitectures"]:
         requestedArchs = splitDelimitedString(args["Architecture"], {";", "_"})
-        # Build mapping: common name -> list of requested arch names
-        commonToRequested = collections.defaultdict(list)
+        scheduleToRequestedArchs = collections.defaultdict(list)
         for reqArch in requestedArchs:
-            commonName = getArchitectureName(reqArch)
-            if commonName:
-                commonToRequested[commonName].append(reqArch)
+            scheduleName = getArchitectureName(reqArch)
+            if scheduleName:
+                scheduleToRequestedArchs[scheduleName].append(reqArch)
 
-        # Create library entries for each requested arch name
-        renamedLibraries = {}
-        for archName, lib in masterLibraries.items():
-            # Convert archName to common name for lookup (e.g., gfx1100 -> navi31)
-            # This is needed because masterLibraries keys may be gfx names (gfx1100)
-            # while commonToRequested is keyed by common names (navi31)
-            archCommonName = getArchitectureName(archName)
-            if archCommonName:
-                requestedNames = commonToRequested.get(archCommonName, [archName])
-            else:
-                requestedNames = [archName]
-            for reqName in requestedNames:
-                # Deep copy if multiple names map to same base arch OR if we'll merge
-                # (merging requires a copy to avoid "dict changed size during iteration")
-                needsCopy = len(requestedNames) > 1 or reqName in renamedLibraries
-                newLib = copy.deepcopy(lib) if needsCopy else lib
-                newLib.requestedArchName = reqName
-                renameLazyLibraryKeys(newLib, reqName)
-                if reqName in renamedLibraries:
-                    # Merge with existing library instead of overwriting
-                    renamedLibraries[reqName].merge(newLib)
-                else:
-                    renamedLibraries[reqName] = newLib
-        masterLibraries = renamedLibraries
-    print(f"DEBUG masterLibraries keys: {list(masterLibraries.keys())}")
+    masterLibraries = generateLogicData(
+        logicFiles, args["Version"], args["PrintLevel"], args["SeparateArchitectures"],
+        scheduleToRequestedArchs
+    )
 
     solutions = generateSolutions(masterLibraries, args["SeparateArchitectures"])
     if lazyLoading and args["WriteMasterSolutionIndex"]:
@@ -1592,7 +1588,6 @@ def TensileCreateLibrary():
     newLibraryDir.mkdir(exist_ok=True)
 
     masterFileList = generateMasterFileList(masterLibraries, supportedArchs, lazyLoading)
-    print(f"DEBUG masterFileList: {[name for name, lib in masterFileList]}")
 
     tPrint(1, f"# Writing {len(masterFileList)} solution selection catalog(s)")
     for name, lib in masterFileList:

--- a/shared/tensile/Tensile/TensileCreateLibrary.py
+++ b/shared/tensile/Tensile/TensileCreateLibrary.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
     exit(1)
 
 import collections
+import copy
 import itertools
 import os
 import re
@@ -48,6 +49,8 @@ from .Common import (
     HR,
     CHeader,
     CMakeHeader,
+    archAliases,
+    architectureMap,
     assignGlobalParameters,
     ensurePath,
     getArchitectureName,
@@ -629,9 +632,11 @@ def buildObjectFileNames(
     sourceArchs, _ = splitArchs()
 
     # Asm based kernels target the configured ISA
+    # Use RequestedArchName if set (for alias architectures), otherwise compute from ISA
     asmArchs = collections.defaultdict(list)
     for kernelName, kernel in zip(asmKernelNames, asmKernels):
-        asmArchs[kernelName].append(gfxName(kernel["ISA"]))
+        outputArch = kernel.get("RequestedArchName", gfxName(kernel["ISA"]))
+        asmArchs[kernelName].append(outputArch)
 
     # Build a list of source files
     if not globalParameters["MergeFiles"]:
@@ -997,19 +1002,27 @@ def makeSolutions(
     in the master solution libraries. If using separate architectures
     but not using lazy loading, lazyLibraries should be an empty dict.
 
+    Also propagates the library's requestedArchName to each solution.
+
     Args:
         masterLibraries: A dictionary containing the master solution libraries.
 
     Returns:
         Generator representing a sequence of library logic tuples.
     """
+    def tagSolution(sol, requestedArchName):
+        """Tag solution with the requested architecture name for output file naming."""
+        if requestedArchName is not None:
+            sol.originalSolution["RequestedArchName"] = requestedArchName
+        return sol.originalSolution
+
     gen1 = (
-        sol.originalSolution
+        tagSolution(sol, masterLibrary.requestedArchName)
         for masterLibrary in masterLibraries.values()
         for sol in masterLibrary.solutions.values()
     )
     gen2 = (
-        sol.originalSolution
+        tagSolution(sol, masterLibrary.requestedArchName)
         for masterLibrary in masterLibraries.values()
         for lib in masterLibrary.lazyLibraries.values()
         for sol in lib.solutions.values()
@@ -1385,6 +1398,11 @@ def TensileCreateLibrary():
         for arch in globalParameters["SupportedISA"]
         if globalParameters["AsmCaps"][arch]["SupportedISA"]
     ]
+    # Add alias names that resolve to supported architectures
+    for alias, base in archAliases.items():
+        if base in supportedArchs:
+            supportedArchs.append(alias)
+    print(f"DEBUG supportedArchs: {supportedArchs}")
 
     _, requestedArchs = splitArchs()
     # Resolve aliases before checking if architecture is supported
@@ -1437,6 +1455,72 @@ def TensileCreateLibrary():
     masterLibraries = generateLogicData(
         logicFiles, args["Version"], args["PrintLevel"], args["SeparateArchitectures"]
     )
+
+    def renameLazyLibraryKeys(lib, requestedArchName):
+        """Rename lazy library keys to use requestedArchName instead of original arch.
+
+        Lazy library names end with architecture (e.g., TensileLibrary_Type_..._gfx1100).
+        This function renames them to use the requested arch (e.g., gfx11-generic).
+        Also updates the codeObjectFile on each solution to match the new name.
+        """
+        if not requestedArchName or not lib.lazyLibraries:
+            return
+
+        # Get all known architecture names to check for suffix replacement
+        knownArchs = set(architectureMap.keys())
+
+        newLazyLibraries = {}
+        for name, lazyLib in lib.lazyLibraries.items():
+            newName = name
+            # Check if name ends with any known architecture
+            for arch in knownArchs:
+                if name.endswith("_" + arch):
+                    newName = name[:-len(arch)] + requestedArchName
+                    break
+            # Update codeObjectFile on solutions to match new name
+            for sol in lazyLib.solutions.values():
+                sol.originalSolution["codeObjectFile"] = newName
+            newLazyLibraries[newName] = lazyLib
+        lib.lazyLibraries = newLazyLibraries
+
+    # Rename masterLibraries keys from logic file arch names to requested arch names
+    # This is needed for alias architectures (e.g., gfx11-generic -> navi31 -> gfx11-generic)
+    # Also handles multiple requested names for same base arch (e.g., gfx1100;gfx11-generic)
+    if args["SeparateArchitectures"]:
+        requestedArchs = splitDelimitedString(args["Architecture"], {";", "_"})
+        # Build mapping: common name -> list of requested arch names
+        commonToRequested = collections.defaultdict(list)
+        for reqArch in requestedArchs:
+            commonName = getArchitectureName(reqArch)
+            if commonName:
+                commonToRequested[commonName].append(reqArch)
+
+        # Create library entries for each requested arch name
+        renamedLibraries = {}
+        for archName, lib in masterLibraries.items():
+            # Convert archName to common name for lookup (e.g., gfx1100 -> navi31)
+            # This is needed because masterLibraries keys may be gfx names (gfx1100)
+            # while commonToRequested is keyed by common names (navi31)
+            archCommonName = getArchitectureName(archName)
+            if archCommonName:
+                requestedNames = commonToRequested.get(archCommonName, [archName])
+            else:
+                requestedNames = [archName]
+            for reqName in requestedNames:
+                # Deep copy if multiple names map to same base arch OR if we'll merge
+                # (merging requires a copy to avoid "dict changed size during iteration")
+                needsCopy = len(requestedNames) > 1 or reqName in renamedLibraries
+                newLib = copy.deepcopy(lib) if needsCopy else lib
+                newLib.requestedArchName = reqName
+                renameLazyLibraryKeys(newLib, reqName)
+                if reqName in renamedLibraries:
+                    # Merge with existing library instead of overwriting
+                    renamedLibraries[reqName].merge(newLib)
+                else:
+                    renamedLibraries[reqName] = newLib
+        masterLibraries = renamedLibraries
+    print(f"DEBUG masterLibraries keys: {list(masterLibraries.keys())}")
+
     solutions = generateSolutions(masterLibraries, args["SeparateArchitectures"])
     if lazyLoading and args["WriteMasterSolutionIndex"]:
         writeMasterSolutionIndexCSV(outputPath, masterLibraries)
@@ -1508,6 +1592,7 @@ def TensileCreateLibrary():
     newLibraryDir.mkdir(exist_ok=True)
 
     masterFileList = generateMasterFileList(masterLibraries, supportedArchs, lazyLoading)
+    print(f"DEBUG masterFileList: {[name for name, lib in masterFileList]}")
 
     tPrint(1, f"# Writing {len(masterFileList)} solution selection catalog(s)")
     for name, lib in masterFileList:

--- a/shared/tensile/Tensile/TensileCreateLibrary.py
+++ b/shared/tensile/Tensile/TensileCreateLibrary.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
 
 import collections
 import copy
+import functools
 import itertools
 import os
 import re
@@ -1038,56 +1039,35 @@ def makeSolutions(
 
 def parseLibraryLogicFiles(
     logicFiles: List[str],
-    scheduleToRequestedArchs: Optional[Dict[str, List[str]]] = None
+    scheduleToArchs: Optional[Dict[str, List[str]]] = None
 ) -> List[LibraryIO.LibraryLogic]:
     """Load and parse logic (yaml) files.
 
     Given a list of paths to yaml files containing library logic, load the files
     into memory and parse the data into a named tuple (i.e. LibraryLogic).
 
-    If scheduleToRequestedArchs maps a schedule to multiple archs (e.g., navi31 -> [gfx1100, gfx11-generic]),
-    the logic file is parsed multiple times, once per arch, producing separate libraries.
-    This supports cases like --architecture=gfx1100;gfx11-generic where both outputs are needed.
-
     Args:
         logicFiles: List of paths to logic files.
-        scheduleToRequestedArchs: Optional mapping from schedule name to list of requested arch names.
+        scheduleToArchs: Optional mapping from schedule name to list of output arch names.
+            When a schedule has multiple archs (e.g., gfx1100 and gfx11-generic both
+            mapping to navi31), the logic file is parsed once but produces multiple outputs.
 
     Returns:
         List of library logic tuples.
     """
-    if not scheduleToRequestedArchs:
-        # No override - use original parallel parsing
+    if scheduleToArchs:
+        parseFunc = functools.partial(
+            LibraryIO.parseLibraryLogicFile,
+            scheduleToArchs=scheduleToArchs
+        )
+        results = Common.ParallelMap(parseFunc, logicFiles, "Reading logic files", multiArg=False)
+        # flatten to 1D list since each result is a list from
+        # `parseLibraryLogicFile` is a list
+        return itertools.chain.from_iterable(results)
+    else:
         return Common.ParallelMap(
             LibraryIO.parseLibraryLogicFile, logicFiles, "Reading logic files", multiArg=False
         )
-
-    # When we have arch overrides, parse each file once per requested arch
-    results = []
-    for path in logicFiles:
-        # Load YAML once
-        rawData = LibraryIO.readYAML(path)
-
-        # Get schedule name from raw data
-        if isinstance(rawData, list):
-            scheduleName = rawData[1] if len(rawData) > 1 else None
-        else:
-            scheduleName = rawData.get("ScheduleName")
-
-        # Get list of requested archs for this schedule
-        requestedArchs = scheduleToRequestedArchs.get(scheduleName) if scheduleName else None
-
-        if not requestedArchs:
-            # No override - parse with original arch name
-            result = LibraryIO.parseLibraryLogicData(rawData, path, outputArchName=None)
-            results.append(result)
-        else:
-            # Parse once per requested arch
-            for reqArch in requestedArchs:
-                result = LibraryIO.parseLibraryLogicData(rawData, path, outputArchName=reqArch)
-                results.append(result)
-
-    return results
 
 
 def generateLogicData(
@@ -1095,7 +1075,7 @@ def generateLogicData(
     version: str,
     printLevel: int,
     separate: bool,
-    scheduleToRequestedArchs: Optional[Dict[str, List[str]]] = None
+    scheduleToArchs: Optional[Dict[str, List[str]]] = None
 ) -> Dict[str, MasterSolutionLibrary]:
     """Generates a dictionary of master solution libraries.
 
@@ -1104,16 +1084,16 @@ def generateLogicData(
         version: User provided version for the library.
         printLevel: Level of debug printing requested.
         separate: Separate libraries by architecture.
-        scheduleToRequestedArchs: Optional mapping from schedule name to list of requested arch names.
-            When provided, logic files are parsed once per requested arch, producing separate libraries
-            with the correct output names (e.g., gfx11-generic instead of gfx1100).
+        scheduleToArchs: Optional mapping from schedule name to list of output arch names.
+            When a schedule has multiple archs (e.g., gfx1100 and gfx11-generic both
+            mapping to navi31), the logic file produces multiple outputs.
 
     Returns:
         For separate architectures, a dictionary of architecture
         separated master solution libraries; otherwise, a single
         master solution library for all architectures.
     """
-    libraries = parseLibraryLogicFiles(logicFiles, scheduleToRequestedArchs)
+    libraries = parseLibraryLogicFiles(logicFiles, scheduleToArchs)
     logicList = libraries if not printLevel else Utils.tqdm(libraries, desc="Processing logic data")
     masterLibraries = makeMasterLibraries(logicList, separate)
     if separate and "fallback" in masterLibraries:
@@ -1501,20 +1481,22 @@ def TensileCreateLibrary():
     tPrint(2, "#   " + "\n#   ".join(logicFiles))
 
     # Build mapping from schedule name to list of requested arch names
-    # This supports cases like --architecture=gfx1100;gfx11-generic where both outputs are needed
-    # For each logic file (keyed by schedule), we parse once per requested arch
-    scheduleToRequestedArchs = None
+    # This handles cases like gfx1100;gfx11-generic where both map to navi31
+    # Each logic file will produce one output per requested arch for its schedule
+    scheduleToArchs = None
     if args["SeparateArchitectures"]:
         requestedArchs = splitDelimitedString(args["Architecture"], {";", "_"})
-        scheduleToRequestedArchs = collections.defaultdict(list)
+        scheduleToArchs = collections.defaultdict(list)
         for reqArch in requestedArchs:
             scheduleName = getArchitectureName(reqArch)
             if scheduleName:
-                scheduleToRequestedArchs[scheduleName].append(reqArch)
+                scheduleToArchs[scheduleName].append(reqArch)
+        # Convert to regular dict, or None if empty
+        scheduleToArchs = dict(scheduleToArchs) if scheduleToArchs else None
 
     masterLibraries = generateLogicData(
         logicFiles, args["Version"], args["PrintLevel"], args["SeparateArchitectures"],
-        scheduleToRequestedArchs
+        scheduleToArchs
     )
 
     solutions = generateSolutions(masterLibraries, args["SeparateArchitectures"])


### PR DESCRIPTION
## Motivation

Enables building rocBLAS with generic architectures like `-DGPU_TARGET="gfx10-3-generic"`. This is the first step to (unofficial) support almost all, if not all, AMD GPUs since 2017, namely all Vega and RDNA1/2/3/3.5/4 GPUs.

Once this PR is verified to be working, by adjusting the default `GPU_TARGET` list for building release binaries:
- Replace `gfx900` with `gfx9-generic`
- Replace `gfx1030` with `gfx10-3-generic`
- Add `gfx11-generic`.
- Optionally add `gfx12-generic` once the `gfx12**` family gets large enough.

the rocBLAS binaries distributed by AMD should be able to run on all Vega and RDNA1/2/3/3.5/4 GPUs. This list should be comprehensive enough that almost every AMD GPU user can get rocBLAS running out-of-the-box.

The performance might not be amazing due to lack of tuning and inability to utilize all available optimizations in generic architectures, but it's much better than straight up not being able to run at all.

## Technical Details

The core idea is to reuse the library files for existing architectures. For example, `gfx10-3-generic` can use the library files for `gfx1030` to generate the kernels. The difficult part is to ensure that the naming and the argument to `offload-arch` use the correct architecture. I call this "aliasing", that is `gfx10-3-generic` is an alias for `gfx1030`. This relation is stored in a top-level dict in Tensile:
```python
  # Maps arch name -> schedule name (for finding logic files)
  architectureMap = {
      ...
      'gfx11-generic': 'navi31',
      'gfx10-3-generic': 'navi21',
      'gfx9-generic': 'vega10',
  }

  # Maps alias -> base arch (for ISA capabilities lookup)
  archAliases = {
      'gfx11-generic': 'gfx1100',
      'gfx10-3-generic': 'gfx1030',
      'gfx9-generic': 'gfx900',
  }
```

On a high-level, the changes to Tensile are:
1. Try to resolve the `outputArch` (e.g. `gfx10-3-generic`) to a `baseArch` (e.g. `gfx1030`)
2. Modify `parseLibraryLogicData()` to accept `outputArchName` parameter. This ensures all internal naming of a `MasterSolutionLibrary` uses the correct architecture from the start, so the value of flags like `--offload-arch` is correct by construction. Similarly, use `outputArchName` for `PlaceholderLibrary.filenamePrefix`.
3. Add a map `scheduleToArchs: schedule_name -> [list of requested_arch_names]` that maps the schedule name (e.g. `navi21`) to a list of architectures that it should compile to (e.g. `gfx1030` and `gfx10-3-generic`). This allows us to read each logic file once but produce multiple outputs - one per target architecture. Note that xnack variants like `gfx90a:xnack-` and `gfx90a:xnack+` are normalized to `gfx90a` since xnack handling is done at kernel compile level, not library level.
```python
  scheduleToArchs = collections.defaultdict(list)
  for reqArch in requestedArchs:
      scheduleName = getArchitectureName(reqArch)
      if scheduleName:
          # Normalize: strip xnack suffix to avoid duplicate library entries
          baseName = reqArch.split(':')[0]
          if baseName not in scheduleToArchs[scheduleName]:
              scheduleToArchs[scheduleName].append(baseName)
```
4. Pass `scheduleToArchs` to the parallel file parsing via `functools.partial`. Each parallel worker reads the YAML once and returns a list of results (one per target arch). The results are then flattened.
```python
  def parseLibraryLogicFile(filename, scheduleToArchs=None):
      """Always returns a list of LibraryLogic tuples for consistent handling."""
      data = readYAML(filename)
      scheduleName = data.get("ScheduleName")
      outputArchs = scheduleToArchs.get(scheduleName) if scheduleToArchs else None

      if outputArchs:
          # Return one result per requested arch
          return [parseLibraryLogicData(data, filename, arch) for arch in outputArchs]
      else:
          # No override - use original arch name
          return [parseLibraryLogicData(data, filename, None)]

  # In parseLibraryLogicFiles():
  parseFunc = functools.partial(parseLibraryLogicFile, scheduleToArchs=scheduleToArchs)
  results = Common.ParallelMap(parseFunc, logicFiles, "Reading logic files")
  # Flatten: each parallel result is a list
  return itertools.chain.from_iterable(results)
```

The dataflow looks like:
```
    Input flag: --architecture=gfx11-generic
             ↓
    getArchitectureName("gfx11-generic") → "navi31"
             ↓
    Build scheduleToArchs = {"navi31": ["gfx11-generic"]}
             ↓
    findLogicFiles(logicArchs={"navi31"}) → navi31_*.yaml
             ↓
    ParallelMap with parseLibraryLogicFile(scheduleToArchs=...)
             ↓
    parseLibraryLogicData(outputArchName="gfx11-generic")
             ↓
    data["OutputArchName"] = "gfx11-generic"
             ↓
    FromOriginalState() uses OutputArchName for all naming
             ↓
    Output: TensileLibrary_lazy_gfx11-generic.dat
            *_gfx11-generic.{hsaco,co,dat} (compiled with --offload-arch=gfx11-generic)
```

For multi-architecture builds like `--architecture="gfx1030;gfx10-3-generic;gfx1151"`:
```
    Input: "gfx1030;gfx10-3-generic;gfx1151"
             ↓
    getArchitectureName for each:
      gfx1030        → "navi21"
      gfx10-3-generic → "navi21"
      gfx1151        → "navi33"
             ↓
    scheduleToArchs = {
        "navi21": ["gfx1030", "gfx10-3-generic"],
        "navi33": ["gfx1151"]
    }
             ↓
    findLogicFiles(logicArchs={"navi21", "navi33"})
      → navi21_*.yaml + navi33_*.yaml
             ↓
    ParallelMap reads all files concurrently:
      - Each navi21_*.yaml → 2 outputs (gfx1030 + gfx10-3-generic)
      - Each navi33_*.yaml → 1 output (gfx1151)
             ↓
    Flatten results
             ↓
    Output:
      TensileLibrary_lazy_gfx1030.dat
      TensileLibrary_lazy_gfx10-3-generic.dat
      TensileLibrary_lazy_gfx1151.dat
      *_gfx1030.{hsaco,co,dat}
      *_gfx10-3-generic.{hsaco,co,dat}
      *_gfx1151.{hsaco,co,dat}
```

At runtime, rocBLAS loads exact-match libraries first, then falls back to generic libraries. A little bit of refactoring is done for the loading library logic to make the process easier to understand (see the diff and comments in `tensile_host.cpp`).

Ideally we should tune on these generic architectures as well, but for now this is the easiest way to add support without massive changes. If someone wants to tune it in the future, they can just remove the generic architectures from Tensile's alias mapping and Tensile would treat generic architectures just as any other regular architectures.

## Test Plan

All rocBLAS test suite pass (modulo out-of-vram errors) with:
- [x] `GPU_TARGET="gfx11-generic` on `gfx1151` (Radeon 8060S from AMD Ryzen AI Max+ 395)
- [x] `GPU_TARGET="gfx1100;gfx11-generic` on `gfx1151` (Radeon 8060S from AMD Ryzen AI Max+ 395)
- [x] `GPU_TARGET="gfx1100;gfx1151;gfx11-generic` on `gfx1151` (Radeon 8060S from AMD Ryzen AI Max+ 395)
- [ ] `GPU_TARGET="gfx10-3-generic` on `gfx1032` (Radeon 6600M)
- [ ] `GPU_TARGET="gfx1030;gfx10-3-generic` on `gfx1032` (Radeon 6600M)
- [ ] `GPU_TARGET="gfx9-generic` on `gfx90c` (iGPU from Ryzen 7 5800H)
- [ ] `GPU_TARGET="gfx900;gfx9-generic` on `gfx90c` (iGPU from Ryzen 7 5800H)
- [x] `GPU_TARGET="gfx90a"` (builds and `TensileManifest.txt` is unchanged`)
- [x] `GPU_TARGET="gfx90a:xnack+"` (builds and `TensileManifest.txt` is unchanged`)

## Test Result

See above. No failures so far but I also need to test a lot more.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
