### PR TITLE
Add failure exit status to hipDNN samples and integrate with ctest

### DIFF
--- a/projects/hipdnn/samples/CMakeLists.txt
+++ b/projects/hipdnn/samples/CMakeLists.txt
@@ -63,3 +63,26 @@ if(WIN32)
         endif()
     endif()
 endif()
+
+# Enable testing and add sample tests
+enable_testing()
+
+# Helper function to add a hipDNN sample test
+function(add_hipdnn_sample_test TARGET_NAME)
+    add_test(NAME sample_${TARGET_NAME} COMMAND ${TARGET_NAME} --verify-cpu)
+    set_tests_properties(sample_${TARGET_NAME} PROPERTIES LABELS "sample_test")
+endfunction()
+
+# Register convolution samples as tests
+add_hipdnn_sample_test(conv_fprop)
+add_hipdnn_sample_test(conv_dgrad)
+add_hipdnn_sample_test(conv_wgrad)
+add_hipdnn_sample_test(fused_conv_fprop_activ)
+add_hipdnn_sample_test(fused_conv_fprop_bias_activ)
+
+# Register batchnorm samples as tests
+add_hipdnn_sample_test(bn_training)
+add_hipdnn_sample_test(fused_bn_training_activ)
+add_hipdnn_sample_test(bn_backward)
+add_hipdnn_sample_test(fused_bn_inference_drelu_bn_backward)
+# Note: bn_inference is currently disabled per issue #2459

--- a/projects/hipdnn/samples/batchnorm/BnBackward.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnBackward.cpp
@@ -17,7 +17,7 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     auto inputType = getDataTypeEnumFromType<InputType>();
     auto intermediateType = getDataTypeEnumFromType<IntermediateType>();
@@ -102,6 +102,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     auto dscaleHostPtr = dscaleTensor.memory().hostData();
     auto dbiasHostPtr = dbiasTensor.memory().hostData();
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation...\n";
@@ -135,6 +137,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
         std::cout << "  dx: " << (dxValid ? "successful" : "failed") << "\n";
         std::cout << "  dscale: " << (dscaleValid ? "successful" : "failed") << "\n";
         std::cout << "  dbias: " << (dbiasValid ? "successful" : "failed") << "\n";
+
+        validationPassed = dxValid && dscaleValid && dbiasValid;
     }
 
     std::cout << "First 10 dx values: ";
@@ -155,6 +159,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
     std::cout << "\nBatch normalization backward graph execution complete for " << inputType
               << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -167,9 +172,18 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All batch normalization backwards runs completed.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All batch normalization backward runs completed successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "One or more batch normalization backward runs failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/batchnorm/BnInference.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInference.cpp
@@ -20,7 +20,7 @@ using namespace hipdnn_data_sdk;
 // Note: Sample temporarily disabled due to https://github.com/ROCm/rocm-libraries/issues/2459
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     auto inputType = getDataTypeEnumFromType<InputType>();
     auto intermediateType = getDataTypeEnumFromType<IntermediateType>();
@@ -95,6 +95,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     yTensor.memory().markDeviceModified();
     auto yHostPtr = yTensor.memory().hostData();
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation...\n";
@@ -114,6 +116,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
         std::cout << "CPU reference validation:\n";
         std::cout << "  y: " << (yValid ? "successful" : "failed") << "\n";
+
+        validationPassed = yValid;
     }
 
     std::cout << "First 10 y values: ";
@@ -124,6 +128,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
     std::cout << "\nBatch normalization inference graph execution complete for " << inputType
               << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -136,9 +141,18 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All batch normalization inference runs completed.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All batch normalization inference runs completed successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "One or more batch normalization inference runs failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/batchnorm/BnTraining.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnTraining.cpp
@@ -18,7 +18,7 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     auto inputType = getDataTypeEnumFromType<InputType>();
     auto intermediateType = getDataTypeEnumFromType<IntermediateType>();
@@ -175,6 +175,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     auto savedMeanHostPtr = savedMeanTensor.memory().hostData();
     auto savedInvVarHostPtr = savedInvVarTensor.memory().hostData();
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation...\n";
@@ -231,6 +233,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
             std::cout << "  next_running_mean: " << (nextMeanValid ? "successful" : "failed")
                       << "\n";
             std::cout << "  next_running_var: " << (nextVarValid ? "successful" : "failed") << "\n";
+
+            validationPassed = yValid && meanValid && invVarValid && nextMeanValid && nextVarValid;
         }
         else
         {
@@ -272,6 +276,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
             std::cout << "  saved_mean: " << (meanValid ? "successful" : "failed") << "\n";
             std::cout << "  saved_inv_variance: " << (invVarValid ? "successful" : "failed")
                       << "\n";
+
+            validationPassed = yValid && meanValid && invVarValid;
         }
     }
 
@@ -293,6 +299,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
     std::cout << "\nBatch normalization training graph execution complete for " << inputType
               << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -305,9 +312,18 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All batch normalization training runs completed.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All batch normalization training runs completed successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "One or more batch normalization training runs failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/batchnorm/FusedBnInfDReluBnBwd.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInfDReluBnBwd.cpp
@@ -20,7 +20,7 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     auto inputType = getDataTypeEnumFromType<InputType>();
     auto intermediateType = getDataTypeEnumFromType<IntermediateType>();
@@ -148,6 +148,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     auto dscaleHostPtr = dscaleTensor.memory().hostData();
     auto dbiasHostPtr = dbiasTensor.memory().hostData();
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation using CpuReferenceGraphExecutor...\n";
@@ -193,6 +195,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
         std::cout << "  dx: " << (dxValid ? "successful" : "failed") << "\n";
         std::cout << "  dscale: " << (dscaleValid ? "successful" : "failed") << "\n";
         std::cout << "  dbias: " << (dbiasValid ? "successful" : "failed") << "\n";
+
+        validationPassed = dxValid && dscaleValid && dbiasValid;
     }
 
     std::cout << "First 10 dx values: ";
@@ -213,6 +217,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
     std::cout << "\nFused BN Inference + Activation Backward + BN Backward graph execution "
               << "complete for " << inputType << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -225,9 +230,20 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All fused BN Inference + Activation Backward + BN Backward runs completed.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All fused BN Inference + Activation Backward + BN Backward runs completed "
+                  << "successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "One or more fused BN Inference + Activation Backward + BN Backward runs "
+                  << "failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/batchnorm/FusedBnTrainingActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnTrainingActiv.cpp
@@ -19,7 +19,7 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     auto inputType = getDataTypeEnumFromType<InputType>();
     auto intermediateType = getDataTypeEnumFromType<IntermediateType>();
@@ -198,6 +198,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     auto savedMeanHostPtr = savedMeanTensor.memory().hostData();
     auto savedInvVarHostPtr = savedInvVarTensor.memory().hostData();
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation using CpuReferenceGraphExecutor...\n";
@@ -245,8 +247,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
         bool meanValid = statsValidator.allClose(savedMeanRefTensor, savedMeanTensor);
         bool invVarValid = statsValidator.allClose(savedInvVarRefTensor, savedInvVarTensor);
 
-        bool nextMeanValid = false;
-        bool nextVarValid = false;
+        bool nextMeanValid = true;
+        bool nextVarValid = true;
         if(config.useRunningStats)
         {
             nextMeanValid = statsValidator.allClose(nextMeanRefTensor, nextMeanTensor);
@@ -265,6 +267,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
             std::cout << "  next_running_variance: " << (nextVarValid ? "successful" : "failed")
                       << "\n";
         }
+
+        validationPassed = yValid && meanValid && invVarValid && nextMeanValid && nextVarValid;
     }
 
     std::cout << "First 10 activated_y values: ";
@@ -285,6 +289,7 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
     std::cout << "\nBatch normalization training + activation graph execution complete for "
               << inputType << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -297,9 +302,19 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All batch normalization training + activation runs completed.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All batch normalization training + activation runs completed successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout
+            << "One or more batch normalization training + activation runs failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/convolution/ConvDgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvDgrad.cpp
@@ -18,7 +18,7 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     const auto inputType = getDataTypeEnumFromType<InputType>();
 
@@ -108,6 +108,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     }
     std::cout << '\n';
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation...\n";
@@ -126,9 +128,12 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
         std::cout << "CPU reference validation:\n";
         std::cout << "  dx: " << (dxValid ? "successful" : "failed") << "\n";
+
+        validationPassed = dxValid;
     }
 
     std::cout << "Convolution backward data graph execution complete for " << inputType << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -141,9 +146,18 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All convolution backward data runs completed.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All convolution backward data runs completed successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "One or more convolution backward data runs failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/convolution/ConvFprop.cpp
+++ b/projects/hipdnn/samples/convolution/ConvFprop.cpp
@@ -18,7 +18,7 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     const auto inputType = getDataTypeEnumFromType<InputType>();
 
@@ -103,6 +103,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     }
     std::cout << '\n';
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation...\n";
@@ -121,9 +123,12 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
         std::cout << "CPU reference validation:\n";
         std::cout << "  y: " << (yValid ? "successful" : "failed") << "\n";
+
+        validationPassed = yValid;
     }
 
     std::cout << "Convolution fprop graph execution complete for " << inputType << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -136,9 +141,18 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All convolution fprop runs completed.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All convolution fprop runs completed successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "One or more convolution fprop runs failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/convolution/ConvWgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvWgrad.cpp
@@ -18,7 +18,7 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     const auto inputType = getDataTypeEnumFromType<InputType>();
 
@@ -108,6 +108,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     }
     std::cout << '\n';
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation...\n";
@@ -126,10 +128,13 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
         std::cout << "CPU reference validation:\n";
         std::cout << "  dw: " << (dwValid ? "successful" : "failed") << "\n";
+
+        validationPassed = dwValid;
     }
 
     std::cout << "Convolution backward weights graph execution complete for " << inputType
               << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -142,9 +147,18 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All convolution backward weights runs completed.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All convolution backward weights runs completed successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "One or more convolution backward weights runs failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/convolution/FusedConvFpropActiv.cpp
+++ b/projects/hipdnn/samples/convolution/FusedConvFpropActiv.cpp
@@ -20,7 +20,7 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     const auto inputType = getDataTypeEnumFromType<InputType>();
 
@@ -115,6 +115,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     }
     std::cout << '\n';
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation...\n";
@@ -142,10 +144,13 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
         std::cout << "CPU reference validation:\n";
         std::cout << "  pointwise out: " << (outValid ? "successful" : "failed") << "\n";
+
+        validationPassed = outValid;
     }
 
     std::cout << "Fused Convolution fprop + Activ graph execution complete for " << inputType
               << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -158,9 +163,18 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All fused Conv fwd + Activation samples completed successfully.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All fused Conv fwd + Activation runs completed successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "One or more fused Conv fwd + Activation runs failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/convolution/FusedConvFpropBiasActiv.cpp
+++ b/projects/hipdnn/samples/convolution/FusedConvFpropBiasActiv.cpp
@@ -21,7 +21,7 @@ using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
 template <typename InputType, typename IntermediateType>
-void SampleRunner::operator()(const TensorLayout& layout)
+bool SampleRunner::operator()(const TensorLayout& layout)
 {
     const auto inputType = getDataTypeEnumFromType<InputType>();
 
@@ -136,6 +136,8 @@ void SampleRunner::operator()(const TensorLayout& layout)
     }
     std::cout << '\n';
 
+    bool validationPassed = true;
+
     if(config.cpuValidation)
     {
         std::cout << "Running CPU reference validation...\n";
@@ -167,10 +169,13 @@ void SampleRunner::operator()(const TensorLayout& layout)
 
         std::cout << "CPU reference validation:\n";
         std::cout << "  output: " << (outValid ? "successful" : "failed") << "\n";
+
+        validationPassed = outValid;
     }
 
     std::cout << "Fused Convolution fprop + Bias + Activ graph execution complete for " << inputType
               << ".\n\n";
+    return validationPassed;
 }
 
 int main(int argc, char* argv[])
@@ -183,9 +188,18 @@ int main(int argc, char* argv[])
     hipdnnHandle_t handle;
     HIPDNN_CHECK(backend->create(&handle));
 
-    run(SampleRunner{handle, config});
+    bool allPassed = run(SampleRunner{handle, config});
 
     HIPDNN_CHECK(backend->destroy(handle));
-    std::cout << "All fused Conv fwd + Bias + Activation samples completed successfully.\n";
-    return 0;
+
+    if(allPassed)
+    {
+        std::cout << "All fused Conv fwd + Bias + Activation runs completed successfully.\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "One or more fused Conv fwd + Bias + Activation runs failed validation.\n";
+        return 1;
+    }
 }

--- a/projects/hipdnn/samples/utils/Helpers.hpp
+++ b/projects/hipdnn/samples/utils/Helpers.hpp
@@ -107,14 +107,16 @@ inline Config parseCommandLineArgs(int argc, char* argv[])
 }
 
 template <typename F>
-void run(F&& f)
+bool run(F&& f)
 {
-    f.template operator()<float, float>(TensorLayout::NCHW);
-    f.template operator()<half, float>(TensorLayout::NCHW);
-    f.template operator()<hip_bfloat16, float>(TensorLayout::NCHW);
-    f.template operator()<float, float>(TensorLayout::NHWC);
-    f.template operator()<half, float>(TensorLayout::NHWC);
-    f.template operator()<hip_bfloat16, float>(TensorLayout::NHWC);
+    bool allPassed = true;
+    allPassed &= f.template operator()<float, float>(TensorLayout::NCHW);
+    allPassed &= f.template operator()<half, float>(TensorLayout::NCHW);
+    allPassed &= f.template operator()<hip_bfloat16, float>(TensorLayout::NCHW);
+    allPassed &= f.template operator()<float, float>(TensorLayout::NHWC);
+    allPassed &= f.template operator()<half, float>(TensorLayout::NHWC);
+    allPassed &= f.template operator()<hip_bfloat16, float>(TensorLayout::NHWC);
+    return allPassed;
 }
 
 inline std::shared_ptr<hipdnn_frontend::graph::Tensor_attributes>
@@ -146,5 +148,5 @@ struct SampleRunner
     Config config;
 
     template <typename InputType, typename IntermediateType>
-    void operator()(const TensorLayout& layout);
+    bool operator()(const TensorLayout& layout);
 };


### PR DESCRIPTION
## Motivation

hipDNN samples currently always return exit code 0 even when CPU validation fails. This makes them unusable as CI tests since failures go undetected.

Fixes #3539

## Technical Details

Changed `run()` in Helpers.hpp to return a bool that aggregates results from all 6 type/layout configurations using `&=`. Each sample operator() now returns its validation status, and main() uses this to return the appropriate exit code.

Added ctest integration so samples can be run as tests with `ctest -L sample_test`. Each test runs with `--verify-cpu` to enable validation.

Note: bn_inference is excluded from tests since it is disabled per #2459.

## Test Plan

Build and run individual samples to verify exit codes, then run `ctest -L sample_test -V` to confirm all tests are registered and execute correctly.