### PR TITLE
[rocBLAS] initialization fixes and make reference covert mixed precision

### DIFF
--- a/projects/rocblas/clients/common/cblas_interface.cpp
+++ b/projects/rocblas/clients/common/cblas_interface.cpp
@@ -1122,7 +1122,10 @@ void cast_to_buffer(
         U*       dst    = A_u + offset;
         for(size_t j = 0; j < rowsA; j++)
         {
-            *dst++ = static_cast<U>(*src++);
+            if constexpr(std::is_same_v<T, rocblas_bfloat16> && std::is_same_v<U, float>)
+                *dst++ = float(*src++);
+            else
+                *dst++ = static_cast<U>(*src++);
         }
     }
 }
@@ -1137,7 +1140,12 @@ void cast_from_buffer(int64_t m, int64_t n, int64_t ldc, const host_vector<T>& C
     {
         size_t offset = i * ldc;
         for(size_t j = 0; j < m; j++)
-            C_u[j + offset] = static_cast<U>(C_t[j + offset]);
+        {
+            if constexpr(std::is_same_v<U, rocblas_bfloat16> && std::is_same_v<T, float>)
+                C_u[j + offset] = rocblas_bfloat16(C_t[j + offset]);
+            else
+                C_u[j + offset] = static_cast<U>(C_t[j + offset]);
+        }
     }
 }
 
@@ -2304,7 +2312,7 @@ void ref_syrk_ex(rocblas_fill      uplo,
 
 INSTANTIATE_SYRK_EX_TEMPLATE(rocblas_half, rocblas_half, float)
 INSTANTIATE_SYRK_EX_TEMPLATE(rocblas_half, float, float)
-// for reference bfloat16 we just keep output always higher precision
+INSTANTIATE_SYRK_EX_TEMPLATE(rocblas_bfloat16, rocblas_bfloat16, float)
 INSTANTIATE_SYRK_EX_TEMPLATE(rocblas_bfloat16, float, float)
 INSTANTIATE_SYRK_EX_TEMPLATE(float, float, double)
 INSTANTIATE_SYRK_EX_TEMPLATE(float, double, double)

--- a/projects/rocblas/clients/include/blas3/testing_syrk.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_syrk.hpp
@@ -231,7 +231,7 @@ void testing_syrk(const Arguments& arg)
     rocblas_init_matrix(
         hA, arg, rocblas_client_alpha_sets_nan, rocblas_client_general_matrix, true, true);
     rocblas_init_matrix(
-        hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false, true);
+        hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false);
     hC_gold = hC;
 
     if(arg.unit_check || arg.norm_check)

--- a/projects/rocblas/clients/include/blas3/testing_syrk_batched.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_syrk_batched.hpp
@@ -257,7 +257,7 @@ void testing_syrk_batched(const Arguments& arg)
     rocblas_init_matrix(
         hA, arg, rocblas_client_alpha_sets_nan, rocblas_client_general_matrix, true, true);
     rocblas_init_matrix(
-        hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false, true);
+        hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false);
 
     hC_gold.copy_from(hC);
 

--- a/projects/rocblas/clients/include/blas3/testing_syrk_strided_batched.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_syrk_strided_batched.hpp
@@ -413,7 +413,7 @@ void testing_syrk_strided_batched(const Arguments& arg)
     rocblas_init_matrix(
         hA, arg, rocblas_client_alpha_sets_nan, rocblas_client_general_matrix, true, true);
     rocblas_init_matrix(
-        hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, true, true);
+        hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, true);
 
     hC_gold.copy_from(hC);
 

--- a/projects/rocblas/clients/include/blas_ex/testing_herk_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_herk_ex.hpp
@@ -96,7 +96,7 @@ void testing_herk_ex_bad_arg(const Arguments& arg)
         rocblas_init_matrix(
             hA, arg, rocblas_client_alpha_sets_nan, rocblas_client_general_matrix, true, true);
         rocblas_init_matrix(
-            hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false, true);
+            hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false);
 
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         CHECK_HIP_ERROR(dC.transfer_from(hC));

--- a/projects/rocblas/clients/include/blas_ex/testing_herk_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_herk_ex.hpp
@@ -31,15 +31,15 @@ void testing_herk_ex_bad_arg(const Arguments& arg)
 {
     using Tab_ex = real_t<Tex>;
 
+    auto rocblas_herk_ex_fn = arg.api & c_API_FORTRAN ? rocblas_herk_ex_fortran : rocblas_herk_ex;
+    auto rocblas_herk_ex_fn_64
+        = arg.api & c_API_FORTRAN ? rocblas_herk_ex_fortran : rocblas_herk_ex;
+    // TODO
+    //auto rocblas_herk_ex_fn_64
+    //    = arg.api & c_API_FORTRAN ? rocblas_herk_ex_64_fortran : rocblas_herk_ex_64;
+
     for(auto pointer_mode : {rocblas_pointer_mode_host, rocblas_pointer_mode_device})
     {
-        auto rocblas_herk_ex_fn
-            = arg.api & c_API_FORTRAN ? rocblas_herk_ex : rocblas_herk_ex_fortran;
-        auto rocblas_herk_ex_fn_64 = arg.api & c_API_FORTRAN ? rocblas_herk_ex : rocblas_herk_ex;
-        // TODO
-        //auto rocblas_herk_ex_fn_64
-        //    = arg.api & c_API_FORTRAN ? rocblas_herk_ex_64_fortran : rocblas_herk_ex_64;
-
         const rocblas_fill      uplo   = rocblas_fill_upper;
         const rocblas_operation transA = rocblas_operation_none;
         const int64_t           N      = 100;
@@ -165,8 +165,9 @@ nullptr, a_type, lda, one, nullptr, c_type, ldc, compute_type));
 template <typename Ti, typename To, typename Tex>
 void testing_herk_ex(const Arguments& arg)
 {
-    auto rocblas_herk_ex_fn = arg.api & c_API_FORTRAN ? rocblas_herk_ex : rocblas_herk_ex_fortran;
-    auto rocblas_herk_ex_fn_64 = arg.api & c_API_FORTRAN ? rocblas_herk_ex : rocblas_herk_ex;
+    auto rocblas_herk_ex_fn = arg.api & c_API_FORTRAN ? rocblas_herk_ex_fortran : rocblas_herk_ex;
+    auto rocblas_herk_ex_fn_64
+        = arg.api & c_API_FORTRAN ? rocblas_herk_ex_fortran : rocblas_herk_ex;
     // TODO
     //auto rocblas_herk_ex_fn_64
     //    = arg.api & c_API_FORTRAN ? rocblas_herk_ex_64_fortran : rocblas_herk_ex_64;
@@ -200,8 +201,6 @@ void testing_herk_ex(const Arguments& arg)
     rocblas_datatype c_type       = arg.c_type;
     rocblas_datatype compute_type = arg.compute_type;
 
-    using To_hpa = std::conditional_t<std::is_same_v<To, rocblas_bfloat16>, float, To>;
-
     // check for invalid sizes
     bool invalid_size = N < 0 || K < 0 || lda < A_row || ldc < N;
     if(invalid_size)
@@ -223,7 +222,6 @@ void testing_herk_ex(const Arguments& arg)
     // Allocate host memory
     HOST_MEMCHECK(host_matrix<Ti>, hA, (A_row, A_col, lda));
     HOST_MEMCHECK(host_matrix<To>, hC, (N, N, ldc));
-    HOST_MEMCHECK(host_matrix<To_hpa>, hC_gold, (N, N, ldc));
 
     if(arg.unit_check || arg.norm_check)
     {
@@ -237,11 +235,13 @@ void testing_herk_ex(const Arguments& arg)
         rocblas_init_matrix(
             hA, arg, rocblas_client_alpha_sets_nan, rocblas_client_general_matrix, true, true);
         rocblas_init_matrix(
-            hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false, true);
+            hC, arg, rocblas_client_beta_sets_nan, rocblas_client_hermitian_matrix, false);
 
         HOST_MEMCHECK(host_matrix<To>, hC_copy, (N, N, ldc));
         HOST_MEMCHECK(host_matrix<To>, hC_orig, (N, N, ldc));
+        HOST_MEMCHECK(host_matrix<To>, hC_gold, (N, N, ldc));
         hC_orig = hC;
+        hC_gold = hC;
 
         // copy data from CPU to device
         CHECK_HIP_ERROR(dA.transfer_from(hA));
@@ -361,7 +361,7 @@ void testing_herk_ex(const Arguments& arg)
         // CPU BLAS
         cpu_time_used = get_time_us_no_sync();
 
-        ref_herk_ex<Ti, To_hpa, Tab_ex>(
+        ref_herk_ex<Ti, To, Tab_ex>(
             uplo, transA, N, K, h_alpha_Tc, hA, lda, h_beta_Tc, hC_gold, ldc);
 
         cpu_time_used = get_time_us_no_sync() - cpu_time_used;
@@ -380,19 +380,18 @@ void testing_herk_ex(const Arguments& arg)
                                      ? sum_error_tolerance_for_gfx11<Tex, Ti, To>
                                      : 4 * sum_error_tolerance<Ti>;
                     tol = tol * K + 2 * sum_error_tolerance<To>; // add To conversion rounding error
-                    near_check_general<To, To_hpa>(N, N, ldc, hC_gold, hC, tol);
+                    near_check_general<To>(N, N, ldc, hC_gold, hC, tol);
                 }
                 else
                 {
-                    unit_check_general<To, To_hpa>(N, N, ldc, hC_gold, hC);
+                    unit_check_general<To>(N, N, ldc, hC_gold, hC);
                 }
             }
 
             double error = 0;
             if(arg.norm_check)
             {
-                error_host
-                    = std::abs(norm_check_general<To>('F', N, N, ldc, (To_hpa*)hC_gold, (To*)hC));
+                error = std::abs(norm_check_general<To>('F', N, N, ldc, (To*)hC_gold, (To*)hC));
             }
             return error;
         };

--- a/projects/rocblas/clients/include/blas_ex/testing_syrk_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_syrk_ex.hpp
@@ -95,7 +95,7 @@ void testing_syrk_ex_bad_arg(const Arguments& arg)
         rocblas_init_matrix(
             hA, arg, rocblas_client_alpha_sets_nan, rocblas_client_general_matrix, true, true);
         rocblas_init_matrix(
-            hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false, true);
+            hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false);
 
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         CHECK_HIP_ERROR(dC.transfer_from(hC));

--- a/projects/rocblas/clients/include/blas_ex/testing_syrk_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_syrk_ex.hpp
@@ -29,15 +29,16 @@
 template <typename Ti, typename To, typename Tex>
 void testing_syrk_ex_bad_arg(const Arguments& arg)
 {
+    auto rocblas_syrk_ex_fn = arg.api & c_API_FORTRAN ? rocblas_syrk_ex_fortran : rocblas_syrk_ex;
+    auto rocblas_syrk_ex_fn_64
+        = arg.api & c_API_FORTRAN ? rocblas_syrk_ex_fortran : rocblas_syrk_ex;
+
+    // TODO
+    //auto rocblas_syrk_ex_fn_64
+    //    = arg.api & c_API_FORTRAN ? rocblas_syrk_ex_64_fortran : rocblas_syrk_ex_64;
+
     for(auto pointer_mode : {rocblas_pointer_mode_host, rocblas_pointer_mode_device})
     {
-        auto rocblas_syrk_ex_fn
-            = arg.api & c_API_FORTRAN ? rocblas_syrk_ex : rocblas_syrk_ex_fortran;
-        auto rocblas_syrk_ex_fn_64 = arg.api & c_API_FORTRAN ? rocblas_syrk_ex : rocblas_syrk_ex;
-        // TODO
-        //auto rocblas_syrk_ex_fn_64
-        //    = arg.api & c_API_FORTRAN ? rocblas_syrk_ex_64_fortran : rocblas_syrk_ex_64;
-
         const rocblas_fill      uplo   = rocblas_fill_upper;
         const rocblas_operation transA = rocblas_operation_none;
         const int64_t           N      = 100;
@@ -163,8 +164,9 @@ nullptr, a_type, lda, one, nullptr, c_type, ldc, compute_type));
 template <typename Ti, typename To, typename Tex>
 void testing_syrk_ex(const Arguments& arg)
 {
-    auto rocblas_syrk_ex_fn = arg.api & c_API_FORTRAN ? rocblas_syrk_ex : rocblas_syrk_ex_fortran;
-    auto rocblas_syrk_ex_fn_64 = arg.api & c_API_FORTRAN ? rocblas_syrk_ex : rocblas_syrk_ex;
+    auto rocblas_syrk_ex_fn = arg.api & c_API_FORTRAN ? rocblas_syrk_ex_fortran : rocblas_syrk_ex;
+    auto rocblas_syrk_ex_fn_64
+        = arg.api & c_API_FORTRAN ? rocblas_syrk_ex_fortran : rocblas_syrk_ex;
     // TODO
     //auto rocblas_syrk_ex_fn_64
     //    = arg.api & c_API_FORTRAN ? rocblas_syrk_ex_64_fortran : rocblas_syrk_ex_64;
@@ -196,8 +198,6 @@ void testing_syrk_ex(const Arguments& arg)
     rocblas_datatype c_type       = arg.c_type;
     rocblas_datatype compute_type = arg.compute_type;
 
-    using To_hpa = std::conditional_t<std::is_same_v<To, rocblas_bfloat16>, float, To>;
-
     // check for invalid sizes
     bool invalid_size = N < 0 || K < 0 || lda < A_row || ldc < N;
     if(invalid_size)
@@ -219,7 +219,6 @@ void testing_syrk_ex(const Arguments& arg)
     // Allocate host memory
     HOST_MEMCHECK(host_matrix<Ti>, hA, (A_row, A_col, lda));
     HOST_MEMCHECK(host_matrix<To>, hC, (N, N, ldc));
-    HOST_MEMCHECK(host_matrix<To_hpa>, hC_gold, (N, N, ldc));
 
     if(arg.unit_check || arg.norm_check)
     {
@@ -233,11 +232,14 @@ void testing_syrk_ex(const Arguments& arg)
         rocblas_init_matrix(
             hA, arg, rocblas_client_alpha_sets_nan, rocblas_client_general_matrix, true, true);
         rocblas_init_matrix(
-            hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false, true);
+            hC, arg, rocblas_client_beta_sets_nan, rocblas_client_symmetric_matrix, false);
 
         HOST_MEMCHECK(host_matrix<To>, hC_copy, (N, N, ldc));
         HOST_MEMCHECK(host_matrix<To>, hC_orig, (N, N, ldc));
+        HOST_MEMCHECK(host_matrix<To>, hC_gold, (N, N, ldc));
+
         hC_orig = hC;
+        hC_gold = hC;
 
         // copy data from CPU to device
         CHECK_HIP_ERROR(dA.transfer_from(hA));
@@ -355,8 +357,7 @@ void testing_syrk_ex(const Arguments& arg)
         // CPU BLAS
         cpu_time_used = get_time_us_no_sync();
 
-        ref_syrk_ex<Ti, To_hpa, Tex>(
-            uplo, transA, N, K, h_alpha_Tc, hA, lda, h_beta_Tc, hC_gold, ldc);
+        ref_syrk_ex<Ti, To, Tex>(uplo, transA, N, K, h_alpha_Tc, hA, lda, h_beta_Tc, hC_gold, ldc);
 
         cpu_time_used = get_time_us_no_sync() - cpu_time_used;
 
@@ -374,19 +375,18 @@ void testing_syrk_ex(const Arguments& arg)
                                      ? sum_error_tolerance_for_gfx11<Tex, Ti, To>
                                      : 4 * sum_error_tolerance<Ti>;
                     tol = tol * K + 2 * sum_error_tolerance<To>; // add To conversion rounding error
-                    near_check_general<To, To_hpa>(N, N, ldc, hC_gold, hC, tol);
+                    near_check_general<To>(N, N, ldc, hC_gold, hC, tol);
                 }
                 else
                 {
-                    unit_check_general<To, To_hpa>(N, N, ldc, hC_gold, hC);
+                    unit_check_general<To>(N, N, ldc, hC_gold, hC);
                 }
             }
 
             double error = 0;
             if(arg.norm_check)
             {
-                error_host
-                    = std::abs(norm_check_general<To>('F', N, N, ldc, (To_hpa*)hC_gold, (To*)hC));
+                error = std::abs(norm_check_general<To>('F', N, N, ldc, (To*)hC_gold, (To*)hC));
             }
             return error;
         };

--- a/projects/rocblas/clients/include/norm.hpp
+++ b/projects/rocblas/clients/include/norm.hpp
@@ -127,8 +127,8 @@ double norm_check_general(char norm_type, int64_t M, int64_t N, int64_t lda, VEC
         for(int64_t j = 0; j < M; j++)
         {
             size_t idx       = j + i * (size_t)lda;
-            hCPU_double[idx] = hCPU[idx];
-            hGPU_double[idx] = hGPU[idx];
+            hCPU_double[idx] = float(hCPU[idx]);
+            hGPU_double[idx] = float(hGPU[idx]);
         }
     }
 

--- a/projects/rocblas/clients/include/rocblas_init.hpp
+++ b/projects/rocblas/clients/include/rocblas_init.hpp
@@ -97,6 +97,11 @@ void rocblas_init_matrix_alternating_sign(rocblas_check_matrix_type matrix_type,
                     A[i + j * lda + b * stride] = (i ^ j) & 1 ? T(value) : T(negate(value));
                 }
     }
+    else
+    {
+        throw std::invalid_argument(
+            "Invalid matrix_type for rocblas_init_matrix_alternating_sign function!");
+    }
 }
 
 template <typename U, typename T>
@@ -136,6 +141,11 @@ void rocblas_init_matrix_alternating_sign(rocblas_check_matrix_type matrix_type,
                         = uplo == 'U' ? (j >= i ? rand_gen() : T(0)) : (j <= i ? rand_gen() : T(0));
                     A[i + j * lda] = (i ^ j) & 1 ? T(value) : T(negate(value));
                 }
+        }
+        else
+        {
+            throw std::invalid_argument(
+                "Invalid matrix_type for rocblas_init_matrix_alternating_sign function!");
         }
     }
 }
@@ -324,6 +334,10 @@ void rocblas_init_matrix(rocblas_check_matrix_type matrix_type,
             }
         }
     }
+    else
+    {
+        throw std::invalid_argument("Invalid matrix_type for rocblas_init_matrix function!");
+    }
 }
 
 template <typename U, typename T>
@@ -485,6 +499,10 @@ void rocblas_init_matrix(rocblas_check_matrix_type matrix_type,
                 }
             }
         }
+        else
+        {
+            throw std::invalid_argument("Invalid matrix_type for rocblas_init_matrix function!");
+        }
     }
 }
 
@@ -609,6 +627,10 @@ void rocblas_init_matrix_trig(rocblas_check_matrix_type matrix_type,
                     A[i + j * lda + b * stride] = value;
                 }
     }
+    else
+    {
+        throw std::invalid_argument("Invalid matrix_type for rocblas_init_matrix_trig function!");
+    }
 }
 
 template <typename T, typename U>
@@ -704,6 +726,11 @@ void rocblas_init_matrix_trig(rocblas_check_matrix_type matrix_type,
                               : (j <= i ? T(seedReset ? cos(i + j * M) : sin(i + j * M)) : T(0));
                     A[i + j * lda] = value;
                 }
+        }
+        else
+        {
+            throw std::invalid_argument(
+                "Invalid matrix_type for rocblas_init_matrix_trig function!");
         }
     }
 }


### PR DESCRIPTION
## Motivation

Reference function to convert to expected mixed precision output to match hipBLAS.  
Simpler and closer match to device functions.
Adds exceptions for invalid initializations to catch test harness errors

## Test Plan

Run pre_checkin and extended tests in math-CI.  

