### PR TITLE
Revert "Replace BOOST_SCOPE_EXIT with std::scope_exit for rocfft-test"

### DIFF
--- a/projects/rocfft/clients/tests/CMakeLists.txt
+++ b/projects/rocfft/clients/tests/CMakeLists.txt
@@ -44,12 +44,7 @@ endif()
 
 project( rocfft-clients-tests LANGUAGES CXX )
 
-set(CMAKE_CXX_STANDARD 20)
-
-include(CheckIncludeFileCXX)
-check_include_file_cxx("scope" HAVE_SCOPE_HEADER)
-check_include_file_cxx("experimental/scope" HAVE_EXPERIMENTAL_SCOPE_HEADER)
-
+set(CMAKE_CXX_STANDARD 17)
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 
@@ -112,6 +107,10 @@ if (NOT WIN32)
   target_compile_options( rocfft-test PRIVATE -fgpu-rdc )
   target_link_options( rocfft-test PRIVATE -fgpu-rdc )
 endif()
+
+find_package( Boost REQUIRED )
+set( Boost_DEBUG ON )
+set( Boost_DETAILED_FAILURE_MSG ON )
 
 option( BUILD_FFTW "Download and build FFTW" OFF )
 
@@ -238,16 +237,8 @@ else()
   include_directories(${FFTW_INCLUDE_DIRS})
 endif()
 
-if(HAVE_SCOPE_HEADER OR HAVE_EXPERIMENTAL_SCOPE_HEADER )
-  target_compile_definitions(rocfft-test PRIVATE HAVE_SCOPE_EXIT)
-else()
-  find_package( Boost REQUIRED )
-  set( Boost_DEBUG ON )
-  set( Boost_DETAILED_FAILURE_MSG ON )
-endif()
-
-
 set( rocfft-test_include_dirs
+  $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
   $<BUILD_INTERFACE:${FFTW_INCLUDE_DIRS}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../library/src/include>
   ${ROCM_CLANG_ROOT}/include

--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -27,6 +27,7 @@
 #include "../../shared/precision_type.h"
 #include "../../shared/rocfft_complex.h"
 #include "hip/hip_runtime_api.h"
+#include <boost/scope_exit.hpp>
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
@@ -50,19 +51,8 @@ namespace std
     namespace filesystem = experimental::filesystem;
 }
 #endif
-namespace fs = std::filesystem;
 
-#ifdef HAVE_SCOPE_EXIT
-#if __has_include(<scope>)
-#include <scope>
-namespace scope = std;
-#else
-#include <experimental/scope>
-namespace scope = std::experimental;
-#endif
-#else
-#include <boost/scope_exit.hpp>
-#endif
+namespace fs = std::filesystem;
 
 #ifndef WIN32
 // get program_invocation_name
@@ -226,20 +216,12 @@ TEST(rocfft_UnitTest, log_levels)
     }
 
     // clean up environment and temporary file when we exit
-#ifdef HAVE_SCOPE_EXIT
-    scope::scope_exit guard([=]()
-#else
     BOOST_SCOPE_EXIT_ALL(=)
-#endif
-                            {
-                                rocfft_cleanup();
-                                // re-init logs with default logging
-                                rocfft_setup();
-                            }
-#ifdef HAVE_SCOPE_EXIT
-    )
-#endif
-        ;
+    {
+        rocfft_cleanup();
+        // re-init logs with default logging
+        rocfft_setup();
+    };
     rocfft_cleanup();
 
     // enumerate all known log levels and direct all of the logs to nowhere
@@ -247,7 +229,7 @@ TEST(rocfft_UnitTest, log_levels)
 #ifdef WIN32
     static const char* log_output = "NUL";
 #else
-    static const char* log_output = "/dev/null";
+    static const char* log_output   = "/dev/null";
 #endif
     EnvironmentSetTemp log_trace_path("ROCFFT_LOG_TRACE_PATH", log_output);
     EnvironmentSetTemp log_bench_path("ROCFFT_LOG_BENCH_PATH", log_output);
@@ -315,22 +297,13 @@ TEST(rocfft_UnitTest, log_multithreading)
     static const char* TRACE_FILE           = "trace.log";
 
     // clean up environment and temporary file when we exit
-#ifdef HAVE_SCOPE_EXIT
-    scope::scope_exit guard([=]()
-#else
     BOOST_SCOPE_EXIT_ALL(=)
-#endif
-
-                            {
-                                rocfft_cleanup();
-                                remove(TRACE_FILE);
-                                // re-init logs with default logging
-                                rocfft_setup();
-                            }
-#ifdef HAVE_SCOPE_EXIT
-    )
-#endif
-        ;
+    {
+        rocfft_cleanup();
+        remove(TRACE_FILE);
+        // re-init logs with default logging
+        rocfft_setup();
+    };
 
     // ask for trace logging, since that's the easiest to trigger
     rocfft_cleanup();
@@ -518,27 +491,19 @@ void rtc_cache_main()
     size_t onekernel_cache_bytes = 0;
 
     // cleanup
-#ifdef HAVE_SCOPE_EXIT
-    scope::scope_exit guard([=]()
-#else
     BOOST_SCOPE_EXIT_ALL(=)
-#endif
-                            {
-                                // close log file handles
-                                rocfft_cleanup();
-                                remove(rtc_cache_path.c_str());
-                                remove(rtc_log_path.c_str());
-                                // re-init lib now that the env vars are gone
-                                rocfft_setup();
-                                if(empty_cache)
-                                    rocfft_cache_buffer_free(empty_cache);
-                                if(onekernel_cache)
-                                    rocfft_cache_buffer_free(onekernel_cache);
-                            }
-#ifdef HAVE_SCOPE_EXIT
-    )
-#endif
-        ;
+    {
+        // close log file handles
+        rocfft_cleanup();
+        remove(rtc_cache_path.c_str());
+        remove(rtc_log_path.c_str());
+        // re-init lib now that the env vars are gone
+        rocfft_setup();
+        if(empty_cache)
+            rocfft_cache_buffer_free(empty_cache);
+        if(onekernel_cache)
+            rocfft_cache_buffer_free(onekernel_cache);
+    };
 
     rocfft_cleanup();
     EnvironmentSetTemp cache_env("ROCFFT_RTC_CACHE_PATH", rtc_cache_path.c_str());
@@ -656,6 +621,7 @@ void rtc_cache_main()
     rocfft_cleanup();
     ASSERT_TRUE(fft_kernel_was_compiled());
 }
+
 // run the main body of rtc cache tests twice to uncover potential
 // problems with thread reuse between iterations
 TEST(rocfft_UnitTest, rtc_cache_iter_1)
@@ -780,20 +746,12 @@ TEST(rocfft_UnitTest, rtc_test_harness)
 
     rocfft_cleanup();
 
-#ifdef HAVE_SCOPE_EXIT
-    scope::scope_exit guard([]()
-#else
     BOOST_SCOPE_EXIT_ALL()
-#endif
-                            {
-                                // reinit rocFFT so caching goes back to normal
-                                rocfft_cleanup();
-                                rocfft_setup();
-                            }
-#ifdef HAVE_SCOPE_EXIT
-    )
-#endif
-        ;
+    {
+        // reinit rocFFT so caching goes back to normal
+        rocfft_cleanup();
+        rocfft_setup();
+    };
 
     // extra scope to control lifetime of env vars
     {


### PR DESCRIPTION
- Reverts ROCm/rocm-libraries#3548
- #3548 caused TheRock builds to fail, but the CI was being skipped for rocfft changes. See #3567 
- #3566 requires further work, so to unblock other PRs in the super-repo... proposing a revert.
- TheRock build failure logs linked in ROCm/TheRock#2712