### PR TITLE
for each staggerUMapping option, use s_cbranch_scc0 instead of s_cbra…

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4494,9 +4494,9 @@ class KernelWriterAssembly(KernelWriter):
         label = Label("StaggerUMapping_%d"%(i + 1), comment="")
         module.add(SCmpEQU32(src0=sgpr(staggerUMapping), src1=hex(i << 13)))
         if i != 4:
-          module.add(SCBranchSCC1(labelName=label.getLabelName()))
+          module.add(SCBranchSCC0(labelName=label.getLabelName()))
         else:
-          module.add(SCBranchSCC1(labelName=staggerLabel.getLabelName()))
+          module.add(SCBranchSCC0(labelName=staggerLabel.getLabelName()))
         if i == 0:
           module.add(SMovB32(dst=sgpr(staggerInput), src=sgpr("WorkGroup0")))
         elif i == 1:


### PR DESCRIPTION
…nch_scc1 for correct branching.

## Motivation

Found a code logic error while handling staggerUMapping options.

## Technical Details

in declareStaggerParms() in rocm-libraries/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py for each staggerUMapping option, it would jump to the label when the option matches.
refer to doc in ValidParameters.py shows:
    # How the tile assignment (wg0, wg1, wg2) controls the initial StaggerU offset:
    # 0: Use wg0
    # 1: Use wg1
    # 2: Use wg2
    # 3: Use wgSerial, wgSerial = wg0 + wg1 * nwg0 + wg2 * (nwg0 * nwg1)
    # 4: Debug mode, offset each tile max allowed StaggerU.  This just moves hotspot
    #    to a different bank since all workgroups still start at same point.
    "StaggerUMapping": [0, 1, 2, 3, 4],


The original code would produce the following assembly snippet, s19 contains the unshifted staggerUMapping, 
when it is 0, it should not branch to label_StaggerUMapping_1, but takes wg0 as argument and stores in s16 and then goto end.
other options are likewise.
So, we should change the **_s_cbranch_scc1_** to **_s_cbranch_scc0_**

```
s_cmp_eq_u32 s19, 0x0
**s_cbranch_scc1** label_StaggerUMapping_1
s_mov_b32 s16, s[sgprWorkGroup0]
s_branch label_staggerInputEnd
label_StaggerUMapping_1:
s_cmp_eq_u32 s19, 0x2000
**s_cbranch_scc1** label_StaggerUMapping_2
s_mov_b32 s16, s[sgprWorkGroup1]
s_branch label_staggerInputEnd
label_StaggerUMapping_2:
s_cmp_eq_u32 s19, 0x4000
**s_cbranch_scc1** label_StaggerUMapping_3
s_mov_b32 s16, -0x1
s_branch label_staggerInputEnd
label_StaggerUMapping_3:
s_cmp_eq_u32 s19, 0x6000
**s_cbranch_scc1** label_StaggerUMapping_4
s_mul_i32 s17, s[sgprNumWorkGroups0], s[sgprWorkGroup1]
s_add_u32 s16, s16, s17
s_add_u32 s16, s16, s[sgprWorkGroup0]
s_branch label_staggerInputEnd
label_StaggerUMapping_4:
s_cmp_eq_u32 s19, 0x8000
**s_cbranch_scc1** label_staggerInputEnd
s_mov_b32 s16, -0x1
s_branch label_staggerInputEnd
label_staggerInputEnd:
```


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
