### PR TITLE
[Hipblaslt][CMS] Disable UsePLRPack for BF16 192x256x64 NT CMS Schedule

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -707,9 +707,6 @@ def _get_schedule_192x256x64_16bit(kernel, useLDSTr, TLDS):
         syncCode = syncTable[1::2]
         nglshift = nllshift = 14 # vmcnt shift for ngl and nll
     elif isNT(kernel) and not useLDSTr and TLDS == 0:
-
-        kernel["UsePLRPack"] = True
-
         optSchedule = {
             'SYNC'  : [[-1, 25, 25, 46, 46, 55, 55, 72, 72]],
             'GRIncA': [[0, 0, 0, 1, 1, 1, 2, 2, 2]],


### PR DESCRIPTION
## Motivation
This PR is a fix for https://github.com/ROCm/rocm-libraries/issues/3563. 

## Technical Details
Tensile tuning validation failed (i.e. gemm operation generated the wrong output) when setting ```kernel["UsePLRPack"] = True```. Thus, disable ```UsePLRPack``` for now. Will enable ```UsePLRPack``` back if enabling ```UsePLRPack``` with some rescheduling could actually benefit the performance after some further investigation.

## Test Result
With ```kernel["UsePLRPack"] = False```, CMS kernel for BF16 192x256x64 NT still generates the correct output according to the Tensile result.
 
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
