### PR TITLE
[rocfft-test] Remove unnecessary include in buffer_hash_test.cpp

### DIFF
--- a/projects/rocfft/clients/tests/buffer_hash_test.cpp
+++ b/projects/rocfft/clients/tests/buffer_hash_test.cpp
@@ -22,7 +22,6 @@
 #include "../../shared/params_gen.h"
 #include "../../shared/rocfft_params.h"
 #include <algorithm>
-#include <chrono>
 #include <gtest/gtest.h>
 #include <memory>
 #include <random>


### PR DESCRIPTION
## Motivation

The removed include is unnecessary and may trigger a build failure with C++20 standard on some systems, due to a [known bug](https://github.com/llvm/llvm-project/issues/92586).

## Technical Details

Self-explanatory.

## Test Plan

N/A.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
