### PR TITLE
[rocBLAS] refactor to simplify syrk/herk_ex workspace code

### DIFF
--- a/projects/rocblas/library/src/blas3/rocblas_syrk_herk.hpp
+++ b/projects/rocblas/library/src/blas3/rocblas_syrk_herk.hpp
@@ -52,7 +52,7 @@ inline bool rocblas_use_only_gemm(rocblas_handle handle, rocblas_int n, rocblas_
                               && n < czsyrk_gfx90a_n_higher_threshold)));
 }
 
-template <typename T, bool FORCE_GEMM = false>
+template <typename T>
 inline size_t rocblas_internal_syrk_herk_workspace(rocblas_handle handle,
                                                    rocblas_int    n,
                                                    rocblas_int    k,
@@ -61,7 +61,7 @@ inline size_t rocblas_internal_syrk_herk_workspace(rocblas_handle handle,
     size_t size = 1;
 
     //Allocating workspace memory when only using gemm
-    if(FORCE_GEMM || rocblas_use_only_gemm<T>(handle, n, k))
+    if(rocblas_use_only_gemm<T>(handle, n, k))
         if(n > 0 && batch_count > 0)
             size = ((int64_t(n) * (n - 1)) / 2) * sizeof(T) * batch_count;
 

--- a/projects/rocblas/library/src/blas_ex/rocblas_herk_ex_imp.hpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_herk_ex_imp.hpp
@@ -27,6 +27,7 @@
 #include "rocblas.h"
 #include "rocblas_block_sizes.h"
 #include "rocblas_gemm_ex.hpp"
+#include "rocblas_syrk_ex.hpp"
 #include "utility.hpp"
 
 namespace
@@ -50,17 +51,17 @@ namespace
         if(!handle)
             return rocblas_status_invalid_handle;
 
+        constexpr bool HERM = true;
+
         //Check if the handle is in the device memory size query, as there are two algorithms one which requires extra workspace memory and one which doesn't
         if(handle->is_device_memory_size_query())
         {
             //If rocblas_use_only_gemm is true then it is required to allocate extra workspace memory
-            static bool constexpr FORCEGEMM = false;
-            if(FORCEGEMM) //rocblas_use_only_gemm<T>(handle, n, k))
+            if(rocblas_internal_syrk_herk_ex_use_gemm<HERM>(compute_type))
             {
                 if(!n)
                     return rocblas_status_size_unchanged;
-                size_t size
-                    = rocblas_internal_syrk_herk_workspace<double, FORCEGEMM>(handle, n, k, 1);
+                size_t size = rocblas_internal_syrk_herk_ex_workspace<HERM>(handle, n, k, 1);
                 return handle->set_optimal_device_memory_size(size);
             }
             else

--- a/projects/rocblas/library/src/blas_ex/rocblas_herk_ex_kernels.cpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_herk_ex_kernels.cpp
@@ -55,12 +55,10 @@ ROCBLAS_INTERNAL_EXPORT_NOINLINE rocblas_status
     constexpr bool BATCHED = false;
     constexpr bool HERM    = true;
 
-    /* if constexpr(sizeof(Tex) < 8)
+    /* TODO if constexpr(rocblas_internal_syrk_herk_ex_use_gemm<Tex>())
     {
-        constexpr bool FORCEDGEMM = true;
-
         size_t size
-            = rocblas_internal_syrk_herk_workspace<T, FORCEDGEMM>(handle, n, k, batch_count);
+            = rocblas_internal_syrk_herk_ex_workspace<HERM>(handle, n, k, batch_count);
 
         //Allocate Workspace memory
         auto w_mem = handle->device_malloc(size);

--- a/projects/rocblas/library/src/blas_ex/rocblas_syrk_ex.hpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_syrk_ex.hpp
@@ -26,7 +26,30 @@
 #include "handle.hpp"
 #include "logging.hpp"
 
-template <typename T>
+template <bool HERM = false>
+inline bool rocblas_internal_syrk_herk_ex_use_gemm(rocblas_datatype compute_type)
+{
+    if(!HERM)
+    {
+        if(compute_type == rocblas_datatype_f32_r)
+            return true;
+        else
+            return false;
+    }
+    else
+        return false;
+}
+
+template <typename Tex, bool HERM = false>
+inline constexpr bool rocblas_internal_syrk_herk_ex_use_gemm()
+{
+    if(!HERM)
+        return (sizeof(Tex) < 8);
+    else
+        return false;
+}
+
+template <bool HERM = false>
 inline size_t rocblas_internal_syrk_herk_ex_workspace(rocblas_handle handle,
                                                       rocblas_int    n,
                                                       rocblas_int    k,
@@ -34,9 +57,12 @@ inline size_t rocblas_internal_syrk_herk_ex_workspace(rocblas_handle handle,
 {
     size_t size = 1;
 
-    //Allocating workspace memory when for high precision compute and result C
-    if(n > 0 && batch_count > 0)
-        size = int64_t(n) * (n) * sizeof(T) * batch_count;
+    if(!HERM)
+    {
+        //Allocating workspace memory for C temp see use_gemm cases for types (type float >= required)
+        if(n > 0 && batch_count > 0)
+            size = int64_t(n) * (n) * sizeof(float) * batch_count; // float as only compute f32_r
+    }
 
     return size;
 }

--- a/projects/rocblas/library/src/blas_ex/rocblas_syrk_ex_imp.hpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_syrk_ex_imp.hpp
@@ -53,14 +53,11 @@ namespace
         //Check if the handle is in the device memory size query, as there are two algorithms one which requires extra workspace memory and one which doesn't
         if(handle->is_device_memory_size_query())
         {
-            //If rocblas_use_only_gemm is true then it is required to allocate extra workspace memory
-            static bool constexpr FORCEGEMM = true;
-            if(FORCEGEMM) //rocblas_use_only_gemm<T>(handle, n, k))
+            if(rocblas_internal_syrk_herk_ex_use_gemm(compute_type))
             {
                 if(!n)
                     return rocblas_status_size_unchanged;
-                size_t size
-                    = rocblas_internal_syrk_herk_workspace<double, FORCEGEMM>(handle, n, k, 1);
+                size_t size = rocblas_internal_syrk_herk_ex_workspace(handle, n, k, 1);
                 return handle->set_optimal_device_memory_size(size);
             }
             else

--- a/projects/rocblas/library/src/blas_ex/rocblas_syrk_ex_kernels.cpp
+++ b/projects/rocblas/library/src/blas_ex/rocblas_syrk_ex_kernels.cpp
@@ -56,12 +56,9 @@ ROCBLAS_INTERNAL_EXPORT_NOINLINE rocblas_status
     constexpr bool BATCHED = false;
     constexpr bool HERM    = false;
 
-    if constexpr(sizeof(Tex) < 8)
+    if constexpr(rocblas_internal_syrk_herk_ex_use_gemm<Tex>())
     {
-        constexpr bool FORCEDGEMM = true;
-
-        size_t size
-            = rocblas_internal_syrk_herk_workspace<T, FORCEDGEMM>(handle, n, k, batch_count);
+        size_t size = rocblas_internal_syrk_herk_ex_workspace<HERM>(handle, n, k, batch_count);
 
         //Allocate Workspace memory
         auto w_mem = handle->device_malloc(size);


### PR DESCRIPTION
## Motivation

Overlap with syrk/herk to be removed as will not follow the same workspace pattern.  Simplify and avoid adding to non _ex functions

## Technical Details

Isolated code for workspace and GEMM algorithms for syrk_ex/herk_ex

## Test Plan

Standard test coverage from math-CI.  
