### PR TITLE
[rocfft-test] Remove dependency on boost tokenizer

### DIFF
--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -125,7 +125,7 @@ fft_params::fft_mp_lib mp_lib = fft_params::fft_mp_lib_none;
 // Number of multi-process ranks to launch
 int mp_ranks = 1;
 // Multi-process launch command (e.g. mpirun --np 4 /path/to/rocfft_mpi_worker)
-std::vector<std::string> mp_launch_argv;
+std::vector<std::string> mp_launch_words;
 
 void init_gtest_flags()
 {
@@ -420,10 +420,13 @@ int main(int argc, char* argv[])
         ->default_val(1)
         ->check(CLI::NonNegativeNumber);
     app.add_option("--mp_launch",
-                   mp_launch_argv,
-                   "Command line prefix to launch multi-process transforms, e.g. \"mpirun --np 4 "
-                   "/path/to/rocfft_mpi_worker\"")
-        ->default_val(decltype(mp_launch_argv)()) /* empty command by default */
+                   mp_launch_words,
+                   "Command line prefix to launch multi-process transforms, e.g. \n"
+                   "\"mpirun --np 4 /path/to/rocfft_mpi_worker\"\n"
+                   "NOTE: embedded quotes must be used for all command arguments that contain "
+                   "space character(s). For instance,\n"
+                   "\"mpirun --np 4 \\\"/path with spaces/to/rocfft_mpi_worker\\\"\"")
+        ->default_val(decltype(mp_launch_words)()) /* empty command by default */
         ->delimiter(' ') /* splits the command into its words */
         ->each([&](const std::string&) {
             if(mp_lib == fft_params::fft_mp_lib_none)

--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -125,7 +125,7 @@ fft_params::fft_mp_lib mp_lib = fft_params::fft_mp_lib_none;
 // Number of multi-process ranks to launch
 int mp_ranks = 1;
 // Multi-process launch command (e.g. mpirun --np 4 /path/to/rocfft_mpi_worker)
-std::string mp_launch;
+std::vector<std::string> mp_launch_argv;
 
 void init_gtest_flags()
 {
@@ -420,10 +420,11 @@ int main(int argc, char* argv[])
         ->default_val(1)
         ->check(CLI::NonNegativeNumber);
     app.add_option("--mp_launch",
-                   mp_launch,
+                   mp_launch_argv,
                    "Command line prefix to launch multi-process transforms, e.g. \"mpirun --np 4 "
                    "/path/to/rocfft_mpi_worker\"")
-        ->default_val("")
+        ->default_val(decltype(mp_launch_argv)()) /* empty command by default */
+        ->delimiter(' ') /* splits the command into its words */
         ->each([&](const std::string&) {
             if(mp_lib == fft_params::fft_mp_lib_none)
             {

--- a/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
+++ b/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
@@ -34,7 +34,7 @@
 #include "../../shared/subprocess.h"
 #include "rocfft/rocfft.h"
 
-extern std::string mp_launch;
+extern std::vector<std::string> mp_launch_argv;
 
 extern last_cpu_fft_cache last_cpu_fft_data;
 
@@ -107,23 +107,12 @@ TEST_P(accuracy_test, vs_fftw)
     }
     case fft_params::fft_mp_lib_mpi:
     {
-        // Multi-proc FFT.
-        // Split launcher into tokens since the first one is the exe
-        // and the remainder is the start of its argv
-        boost::escaped_list_separator<char>                   sep('\\', ' ', '\"');
-        boost::tokenizer<boost::escaped_list_separator<char>> tokenizer(mp_launch, sep);
-        std::string                                           exe;
-        std::vector<std::string>                              argv;
-        for(auto t : tokenizer)
-        {
-            if(t.empty())
-                continue;
+        if(mp_launch_argv.empty())
+            GTEST_FAIL() << "Required multi-process launch command was omitted";
 
-            if(exe.empty())
-                exe = t;
-            else
-                argv.push_back(t);
-        }
+        // Multi-proc FFT.
+        std::string              exe = mp_launch_argv.front();
+        std::vector<std::string> argv(mp_launch_argv.begin() + 1, mp_launch_argv.end());
         // append test token and ask for accuracy test
         argv.push_back("--token");
         argv.push_back(testcase_token);

--- a/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
+++ b/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
@@ -34,7 +34,38 @@
 #include "../../shared/subprocess.h"
 #include "rocfft/rocfft.h"
 
-extern std::vector<std::string> mp_launch_argv;
+extern std::vector<std::string> mp_launch_words;
+struct user_mp_launch_command
+{
+    std::string              exe;
+    std::vector<std::string> user_mp_argv;
+};
+static user_mp_launch_command get_mp_launch_command()
+{
+    auto combine_quoted_args_from = [&](size_t& start_idx) {
+        std::string    ret;
+        constexpr char quote = '"';
+        while(start_idx < mp_launch_words.size()
+              && (ret.empty() || (ret.front() == quote && ret.back() != quote)))
+        {
+            if(!ret.empty())
+                ret += " ";
+            ret += mp_launch_words[start_idx++];
+        }
+        if(!ret.empty() && ret.front() == quote)
+            ret.erase(ret.begin());
+        if(!ret.empty() && ret.back() == quote)
+            ret.erase(ret.begin() + ret.size() - 1);
+        return ret;
+    };
+
+    size_t                 running_idx = 0;
+    user_mp_launch_command ret;
+    ret.exe = combine_quoted_args_from(running_idx);
+    while(running_idx < mp_launch_words.size())
+        ret.user_mp_argv.push_back(combine_quoted_args_from(running_idx));
+    return ret;
+}
 
 extern last_cpu_fft_cache last_cpu_fft_data;
 
@@ -107,12 +138,13 @@ TEST_P(accuracy_test, vs_fftw)
     }
     case fft_params::fft_mp_lib_mpi:
     {
-        if(mp_launch_argv.empty())
-            GTEST_FAIL() << "Required multi-process launch command was omitted";
-
         // Multi-proc FFT.
-        std::string              exe = mp_launch_argv.front();
-        std::vector<std::string> argv(mp_launch_argv.begin() + 1, mp_launch_argv.end());
+        static const auto mp_launch_command = get_mp_launch_command();
+
+        if(mp_launch_command.exe.empty())
+            GTEST_FAIL() << "Required multi-process executable to launch was omitted "
+                            "(\"--mp_launch\" option)";
+        auto argv = mp_launch_command.user_mp_argv;
         // append test token and ask for accuracy test
         argv.push_back("--token");
         argv.push_back(testcase_token);
@@ -120,7 +152,7 @@ TEST_P(accuracy_test, vs_fftw)
 
         // throws an exception if launch fails or if subprocess
         // returns nonzero exit code
-        execute_subprocess(exe, argv, {});
+        execute_subprocess(mp_launch_command.exe, argv, {});
         break;
     }
     default:


### PR DESCRIPTION
## Motivation

This would help lift dependencies on boost for `rocfft-test`.

## Technical Details

Splitting a user-provided mpi launch command into its words can be handled by CLI11.

## Test Plan

TBD.

## Test Result

TBD.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
