### PR TITLE
[MIOpen] Implement tuning support for pooling solvers

### DIFF
--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -312,6 +312,7 @@ set( MIOpen_Source
     solver/pooling/backward2d.cpp
     solver/pooling/backwardNd.cpp
     solver/pooling/performanceConfig2d.cpp
+    solver/pooling/performanceConfigNd.cpp
     solver/prelu/backward_prelu_multi_weights.cpp
     solver/prelu/backward_prelu_single_weight.cpp
     solver/prelu/utils.cpp

--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -311,6 +311,7 @@ set( MIOpen_Source
     solver/pooling/forwardNd.cpp
     solver/pooling/backward2d.cpp
     solver/pooling/backwardNd.cpp
+    solver/pooling/performanceConfig2d.cpp
     solver/prelu/backward_prelu_multi_weights.cpp
     solver/prelu/backward_prelu_single_weight.cpp
     solver/prelu/utils.cpp

--- a/projects/miopen/src/include/miopen/pooling/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/pooling/problem_description.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/projects/miopen/src/include/miopen/pooling/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/pooling/problem_description.hpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/projects/miopen/src/include/miopen/pooling/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/pooling/problem_description.hpp
@@ -29,6 +29,7 @@
 #include <miopen/problem_description_base.hpp>
 #include <miopen/tensor.hpp>
 #include <miopen/pooling.hpp>
+#include <miopen/mlo_internal.hpp>
 
 #include <cassert>
 #include <string>
@@ -45,7 +46,16 @@ enum class Direction
     Backward,
 };
 
-struct ProblemDescription
+struct ProblemDescriptionTag
+{
+};
+
+struct ProblemDescription : ProblemDescriptionBase,
+                            ProblemDescriptionTag
+#if MIOPEN_ENABLE_SQLITE
+    ,
+                            SQLiteSerializable<ProblemDescription>
+#endif
 {
     // Forward
     ProblemDescription(const PoolingDescriptor& pooling_,
@@ -100,7 +110,61 @@ struct ProblemDescription
         return save_index;
     }
 
-    NetworkConfig MakeNetworkConfig() const;
+    NetworkConfig MakeNetworkConfig() const override;
+
+    template <class Self>
+    static void Visit(Self&& self, std::function<void(int64_t, std::string)> f)
+    {
+        // The column names match the driver command line argument names
+        f(static_cast<uint64_t>(self.direction), "direction");
+        f(static_cast<uint64_t>(self.pooling.GetPaddingMode()), "pad_mode");
+        f(self.pooling.GetStrides().size() > 2 ? self.pooling.GetStrides()[0] : 0, "pool_stride_d");
+        f(self.pooling.GetStrides().size() > 2 ? self.pooling.GetStrides()[1]
+                                               : self.pooling.GetStrides()[0],
+          "pool_stride_h");
+        f(self.pooling.GetStrides().size() > 2 ? self.pooling.GetStrides()[2]
+                                               : self.pooling.GetStrides()[1],
+          "pool_stride_w");
+        f(self.pooling.GetPads().size() > 2 ? self.pooling.GetPads()[0] : 0, "pad_d");
+        f(self.pooling.GetPads().size() > 2 ? self.pooling.GetPads()[1] : self.pooling.GetPads()[0],
+          "pad_h");
+        f(self.pooling.GetPads().size() > 2 ? self.pooling.GetPads()[2] : self.pooling.GetPads()[1],
+          "pad_w");
+        f(self.pooling.GetLengths().size() > 2 ? self.pooling.GetLengths()[0] : 0, "win_d");
+        f(self.pooling.GetLengths().size() > 2 ? self.pooling.GetLengths()[1]
+                                               : self.pooling.GetLengths()[0],
+          "win_h");
+        f(self.pooling.GetLengths().size() > 2 ? self.pooling.GetLengths()[2]
+                                               : self.pooling.GetLengths()[1],
+          "win_w");
+    }
+
+    template <class Self>
+    static void Visit(Self&& self, std::function<void(std::string, std::string)> f)
+    {
+        f(self.GetInShape(), "in_shape");
+        f(self.GetOutShape(), "out_shape");
+        f(self.xDesc.GetLayout_str(), "layout");
+        f(self.GetDirectionStr(), "direction");
+        f(GetDataTypeName(self.xDesc.GetType()), "data_type");
+        f(self.GetModeStr(), "mode");
+    }
+
+    template <class Self, class Visitor>
+    static void VisitAll(Self&& self, const Visitor& f)
+    {
+        Visit(std::forward<Self>(self), [&](int64_t value, std::string name) { f(value, name); });
+        Visit(std::forward<Self>(self),
+              [&](std::string value, std::string name) { f(value, name); });
+    }
+
+    void Serialize(std::ostream& stream) const { stream << MakeNetworkConfig().ToString(); }
+
+    // This declaration marks pooling as a primitive with tuning enabled.
+    // Any tunable solver would be able pick it and fetch a db instance in ExecutePrimitive.
+    // It has to be discoverable via ADL from problem description.
+    friend auto GetDb(const ExecutionContext& context, const ProblemDescriptionTag&)
+        -> PerformanceDb;
 
 private:
     Direction direction;
@@ -110,6 +174,59 @@ private:
     TensorDescriptor dxDesc;
     TensorDescriptor dyDesc;
     bool save_index = false;
+    std::size_t GetInBatchSize() const { return xDesc.GetLengths()[0]; }
+    std::size_t GetInChannel() const { return xDesc.GetLengths()[1]; }
+    std::size_t GetInDepth() const { return xDesc.GetNumDims() > 4 ? xDesc.GetLengths()[2] : 0; }
+    std::size_t GetInHeight() const { return xDesc.GetLengths()[xDesc.GetNumDims() - 2]; }
+    std::size_t GetInWidth() const { return xDesc.GetLengths()[xDesc.GetNumDims() - 1]; }
+    std::size_t GetOutBatchSize() const { return yDesc.GetLengths()[0]; }
+    std::size_t GetOutChannel() const { return yDesc.GetLengths()[1]; }
+    std::size_t GetOutDepth() const { return yDesc.GetNumDims() > 4 ? yDesc.GetLengths()[2] : 0; }
+    std::size_t GetOutHeight() const { return yDesc.GetLengths()[yDesc.GetNumDims() - 2]; }
+    std::size_t GetOutWidth() const { return yDesc.GetLengths()[yDesc.GetNumDims() - 1]; }
+    std::string GetInShape() const
+    {
+        std::string shape = std::to_string(GetInBatchSize());
+        shape += "x" + std::to_string(GetInChannel());
+        if(GetInDepth() != 0)
+            shape += "x" + std::to_string(GetInDepth());
+        shape += "x" + std::to_string(GetInHeight());
+        shape += "x" + std::to_string(GetInWidth());
+        return shape;
+    }
+    std::string GetOutShape() const
+    {
+        std::string shape = std::to_string(GetOutBatchSize());
+        shape += "x" + std::to_string(GetOutChannel());
+        if(GetOutDepth() != 0)
+            shape += "x" + std::to_string(GetOutDepth());
+        shape += "x" + std::to_string(GetOutHeight());
+        shape += "x" + std::to_string(GetOutWidth());
+        return shape;
+    }
+    std::string GetDirectionStr() const
+    {
+        std::string s;
+
+        switch(direction)
+        {
+        case Direction::Forward: return "Fwd";
+        case Direction::Backward: return "Bwd";
+        default: MIOPEN_THROW(miopenStatusInvalidValue, "Wrong pooling direction provided");
+        }
+
+        return s;
+    }
+    std::string GetModeStr() const
+    {
+        switch(pooling.GetMode())
+        {
+        case miopenPoolingMax: return "max";
+        case miopenPoolingAverage: return "avg";
+        case miopenPoolingAverageInclusive: return "avg_in";
+        default: MIOPEN_THROW(miopenStatusInvalidValue, "Wrong pooling mode provided");
+        }
+    }
 };
 
 } // namespace pooling

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -31,6 +31,9 @@
 #include <miopen/pooling/invoke_params.hpp>
 #include <miopen/pooling/problem_description.hpp>
 #include <miopen/utility/transposing_solver.hpp>
+#include <miopen/performance_config.hpp>
+#include <miopen/execution_context.hpp>
+#include <miopen/generic_search.hpp>
 
 #include <utility>
 
@@ -40,18 +43,119 @@ namespace solver {
 
 namespace pooling {
 
-using PoolingSolver = NonTunableSolverBase<ExecutionContext, miopen::pooling::ProblemDescription>;
+enum class OperationType
+{
+    Forward,
+    Backward
+};
 
-struct PoolingForward2d final : PoolingSolver
+using PoolingSolver = NonTunableSolverBase<ExecutionContext, miopen::pooling::ProblemDescription>;
+template <class PerformanceConfig>
+using PoolingTunableSolver =
+    SolverBaseTunable<ExecutionContext, miopen::pooling::ProblemDescription, PerformanceConfig>;
+
+template <OperationType OpType>
+struct PerformanceConfigPooling2d : PerfConfigBase<PerformanceConfigPooling2d<OpType>>
+{
+    static_assert(OpType == OperationType::Forward || OpType == OperationType::Backward,
+                  "OperationType must be either Forward or Backward");
+
+    int out_pix_tile0;
+    int out_pix_tile1;
+    int local_size0;
+    int local_size1;
+    static constexpr int min_out_pix_tile0 = 1;
+    static constexpr int max_out_pix_tile0 = (OpType == OperationType::Forward) ? 1 : 4;
+    static constexpr int min_out_pix_tile1 = 1;
+    static constexpr int max_out_pix_tile1 = (OpType == OperationType::Forward) ? 16 : 8;
+    static constexpr int min_local_size0   = (OpType == OperationType::Forward) ? 8 : 4;
+    static constexpr int max_local_size0   = 32;
+    static constexpr int min_local_size1   = (OpType == OperationType::Forward) ? 8 : 4;
+    static constexpr int max_local_size1   = (OpType == OperationType::Forward) ? 128 : 16;
+
+    PerformanceConfigPooling2d(int out_pix_tile0_,
+                               int out_pix_tile1_,
+                               int local_size0_,
+                               int local_size1_)
+        : out_pix_tile0(out_pix_tile0_),
+          out_pix_tile1(out_pix_tile1_),
+          local_size0(local_size0_),
+          local_size1(local_size1_)
+    {
+    }
+    PerformanceConfigPooling2d()
+        : PerformanceConfigPooling2d(
+              min_out_pix_tile0, min_out_pix_tile1, min_local_size0, min_local_size1)
+    {
+    }
+    PerformanceConfigPooling2d(bool)
+        : PerformanceConfigPooling2d(
+              min_out_pix_tile0, min_out_pix_tile1, min_local_size0, min_local_size1)
+    {
+    }
+
+    void HeuristicInit(const miopen::pooling::ProblemDescription&);
+    bool SetNextValue(const miopen::pooling::ProblemDescription&);
+    bool IsValidValue() const;
+    bool IsValid(const ExecutionContext&, const miopen::pooling::ProblemDescription&) const;
+    bool operator==(const PerformanceConfigPooling2d& other) const;
+
+    template <class Self, class F>
+    static void Visit(Self&& self, F f)
+    {
+        f(self.out_pix_tile0, "out_pix_tile0");
+        f(self.out_pix_tile1, "out_pix_tile1");
+        f(self.local_size0, "local_size0");
+        f(self.local_size1, "local_size1");
+    }
+
+private:
+    void Init(const miopen::pooling::ProblemDescription&);
+};
+
+extern template struct PerformanceConfigPooling2d<OperationType::Forward>;
+extern template struct PerformanceConfigPooling2d<OperationType::Backward>;
+
+struct PoolingForward2d final
+    : PoolingTunableSolver<PerformanceConfigPooling2d<OperationType::Forward>>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
+    ConvSolution GetSolutionImpl(
+        const ExecutionContext& context,
+        const miopen::pooling::ProblemDescription& problem,
+        const std::optional<PerformanceConfigPooling2d<OperationType::Forward>>& config) const;
+    // This method is added to maintain compatibility with TransposedPoolingFwd2d solver
     ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const override;
+                             const miopen::pooling::ProblemDescription& problem) const
+    {
+        return GetSolutionImpl(context, problem, std::nullopt);
+    }
+    ConvSolution
+    GetSolution(const ExecutionContext& context,
+                const miopen::pooling::ProblemDescription& problem,
+                const PerformanceConfigPooling2d<OperationType::Forward>& config) const override
+    {
+        return GetSolutionImpl(context, problem, config);
+    }
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
+    PerformanceConfigPooling2d<OperationType::Forward>
+    GetDefaultPerformanceConfig(const ExecutionContext&,
+                                const miopen::pooling::ProblemDescription&) const override;
+    bool IsValidPerformanceConfig(
+        const ExecutionContext&,
+        const miopen::pooling::ProblemDescription&,
+        const PerformanceConfigPooling2d<OperationType::Forward>&) const override;
+    PerformanceConfigPooling2d<OperationType::Forward>
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
+    {
+        return GenericSearch(*this, context, problem, invoke_context);
+    }
 };
 
 struct PoolingForwardNd final : PoolingSolver
@@ -133,16 +237,46 @@ struct TransposedPoolingFwdNd final : PoolingFwdNCHWTransposingSolver<PoolingFor
     }
 };
 
-struct PoolingBackward2d final : PoolingSolver
+struct PoolingBackward2d final
+    : PoolingTunableSolver<PerformanceConfigPooling2d<OperationType::Backward>>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingBackward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
+    ConvSolution GetSolutionImpl(
+        const ExecutionContext& context,
+        const miopen::pooling::ProblemDescription& problem,
+        const std::optional<PerformanceConfigPooling2d<OperationType::Backward>>& config) const;
+    // This method is added to maintain compatibility with TransposedPoolingBwd2d solver
     ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const override;
+                             const miopen::pooling::ProblemDescription& problem) const
+    {
+        return GetSolutionImpl(context, problem, std::nullopt);
+    }
+    ConvSolution
+    GetSolution(const ExecutionContext& context,
+                const miopen::pooling::ProblemDescription& problem,
+                const PerformanceConfigPooling2d<OperationType::Backward>& config) const override
+    {
+        return GetSolutionImpl(context, problem, config);
+    }
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
+    PerformanceConfigPooling2d<OperationType::Backward>
+    GetDefaultPerformanceConfig(const ExecutionContext&,
+                                const miopen::pooling::ProblemDescription&) const override;
+    bool IsValidPerformanceConfig(
+        const ExecutionContext&,
+        const miopen::pooling::ProblemDescription&,
+        const PerformanceConfigPooling2d<OperationType::Backward>&) const override;
+    PerformanceConfigPooling2d<OperationType::Backward>
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
+    {
+        return GenericSearch(*this, context, problem, invoke_context);
+    }
 };
 
 struct PoolingBackwardNd final : PoolingSolver

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -97,7 +97,9 @@ struct PerformanceConfigPooling2d : PerfConfigBase<PerformanceConfigPooling2d<Op
     bool SetNextValue(const miopen::pooling::ProblemDescription&);
     virtual bool IsValidValue(const miopen::pooling::ProblemDescription&) const
     {
-        throw std::runtime_error("IsValidValue is not implemented for the base struct");
+        throw std::runtime_error(
+            "IsValidValue of PerformanceConfigPooling2d<OpType> is called, but it is not "
+            "implemented.");
     }
     bool IsValid(const ExecutionContext&, const miopen::pooling::ProblemDescription&) const;
     bool operator==(const PerformanceConfigPooling2d& other) const;
@@ -117,6 +119,22 @@ private:
 
 extern template struct PerformanceConfigPooling2d<OperationType::Forward>;
 extern template struct PerformanceConfigPooling2d<OperationType::Backward>;
+
+struct PerformanceConfigPooling2dForward final
+    : public PerformanceConfigPooling2d<OperationType::Forward>
+{
+    using PerformanceConfigPooling2d<OperationType::Forward>::PerformanceConfigPooling2d;
+
+    bool IsValidValue(const miopen::pooling::ProblemDescription&) const override;
+};
+
+struct PerformanceConfigPooling2dBackward final
+    : public PerformanceConfigPooling2d<OperationType::Backward>
+{
+    using PerformanceConfigPooling2d<OperationType::Backward>::PerformanceConfigPooling2d;
+
+    bool IsValidValue(const miopen::pooling::ProblemDescription&) const override;
+};
 
 template <OperationType OpType>
 struct PerformanceConfigPoolingNd : PerfConfigBase<PerformanceConfigPoolingNd<OpType>>
@@ -178,19 +196,17 @@ private:
 extern template struct PerformanceConfigPoolingNd<OperationType::Forward>;
 extern template struct PerformanceConfigPoolingNd<OperationType::Backward>;
 
-struct PoolingForward2d final
-    : PoolingTunableSolver<PerformanceConfigPooling2d<OperationType::Forward>>
+struct PoolingForward2d final : PoolingTunableSolver<PerformanceConfigPooling2dForward>
 {
-    using PerformanceConfigType = PerformanceConfigPooling2d<OperationType::Forward>;
+    using PerformanceConfigType = PerformanceConfigPooling2dForward;
 
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
-    ConvSolution
-    GetSolution(const ExecutionContext& context,
-                const miopen::pooling::ProblemDescription& problem,
-                const PerformanceConfigPooling2d<OperationType::Forward>& config) const override;
+    ConvSolution GetSolution(const ExecutionContext& context,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PerformanceConfigPooling2dForward& config) const override;
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
     PerformanceConfigPooling2dForward
@@ -230,14 +246,12 @@ struct PoolingForwardNd final : PoolingTunableSolver<PerformanceConfigPoolingNdF
     PerformanceConfigPoolingNdForward
     GetDefaultPerformanceConfig(const ExecutionContext&,
                                 const miopen::pooling::ProblemDescription&) const override;
-    bool IsValidPerformanceConfig(
-        const ExecutionContext&,
-        const miopen::pooling::ProblemDescription&,
-        const PerformanceConfigPoolingNdForward&) const override;
-    PerformanceConfigPoolingNdForward
-    Search(const ExecutionContext& context,
-           const miopen::pooling::ProblemDescription& problem,
-           const AnyInvokeParams& invoke_context) const override
+    bool IsValidPerformanceConfig(const ExecutionContext&,
+                                  const miopen::pooling::ProblemDescription&,
+                                  const PerformanceConfigPoolingNdForward&) const override;
+    PerformanceConfigPoolingNdForward Search(const ExecutionContext& context,
+                                             const miopen::pooling::ProblemDescription& problem,
+                                             const AnyInvokeParams& invoke_context) const override
     {
         return GenericSearch(*this, context, problem, invoke_context);
     }
@@ -354,10 +368,10 @@ struct TransposedPoolingFwd2d final : PoolingFwdNCHWTransposingSolver<PoolingFor
     {
         return PoolingForward2d{}.GetDefaultPerformanceConfig(ctx, problem);
     }
-    bool IsValidPerformanceConfig(
-        const ExecutionContext& ctx,
-        const miopen::pooling::ProblemDescription& problem,
-        const PoolingForward2d::PerformanceConfigType& config) const override
+    bool
+    IsValidPerformanceConfig(const ExecutionContext& ctx,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PoolingForward2d::PerformanceConfigType& config) const override
     {
         return PoolingForward2d{}.IsValidPerformanceConfig(ctx, problem, config);
     }
@@ -382,10 +396,10 @@ struct TransposedPoolingFwdNd final : PoolingFwdNCHWTransposingSolver<PoolingFor
     {
         return PoolingForwardNd{}.GetDefaultPerformanceConfig(ctx, problem);
     }
-    bool IsValidPerformanceConfig(
-        const ExecutionContext& ctx,
-        const miopen::pooling::ProblemDescription& problem,
-        const PoolingForwardNd::PerformanceConfigType& config) const override
+    bool
+    IsValidPerformanceConfig(const ExecutionContext& ctx,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PoolingForwardNd::PerformanceConfigType& config) const override
     {
         return PoolingForwardNd{}.IsValidPerformanceConfig(ctx, problem, config);
     }
@@ -400,16 +414,15 @@ struct TransposedPoolingFwdNd final : PoolingFwdNCHWTransposingSolver<PoolingFor
 
 struct PoolingBackward2d final : PoolingTunableSolver<PerformanceConfigPooling2dBackward>
 {
-    using PerformanceConfigType = PerformanceConfigPooling2d<OperationType::Backward>;
+    using PerformanceConfigType = PerformanceConfigPooling2dBackward;
 
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingBackward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
-    ConvSolution
-    GetSolution(const ExecutionContext& context,
-                const miopen::pooling::ProblemDescription& problem,
-                const PerformanceConfigPooling2d<OperationType::Backward>& config) const override;
+    ConvSolution GetSolution(const ExecutionContext& context,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PerformanceConfigPooling2dBackward& config) const override;
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
     PerformanceConfigPooling2dBackward
@@ -426,7 +439,8 @@ struct PoolingBackward2d final : PoolingTunableSolver<PerformanceConfigPooling2d
     }
 };
 
-struct PerformanceConfigPoolingNdBackward final : PerformanceConfigPoolingNd<OperationType::Backward>
+struct PerformanceConfigPoolingNdBackward final
+    : PerformanceConfigPoolingNd<OperationType::Backward>
 {
     using PerformanceConfigPoolingNd::PerformanceConfigPoolingNd;
 
@@ -449,25 +463,24 @@ struct PoolingBackwardNd final : PoolingTunableSolver<PerformanceConfigPoolingNd
     PerformanceConfigPoolingNdBackward
     GetDefaultPerformanceConfig(const ExecutionContext&,
                                 const miopen::pooling::ProblemDescription&) const override;
-    bool IsValidPerformanceConfig(
-        const ExecutionContext&,
-        const miopen::pooling::ProblemDescription&,
-        const PerformanceConfigPoolingNdBackward&) const override;
-    PerformanceConfigPoolingNdBackward
-    Search(const ExecutionContext& context,
-           const miopen::pooling::ProblemDescription& problem,
-           const AnyInvokeParams& invoke_context) const override
+    bool IsValidPerformanceConfig(const ExecutionContext&,
+                                  const miopen::pooling::ProblemDescription&,
+                                  const PerformanceConfigPoolingNdBackward&) const override;
+    PerformanceConfigPoolingNdBackward Search(const ExecutionContext& context,
+                                              const miopen::pooling::ProblemDescription& problem,
+                                              const AnyInvokeParams& invoke_context) const override
     {
         return GenericSearch(*this, context, problem, invoke_context);
     }
 };
 
 template <class Inner>
-struct PoolingBwdNCHWTransposingSolver : TransposingSolver<PoolingBwdNCHWTransposingSolver<Inner>,
-                                                           PoolingTunableSolver<typename Inner::PerformanceConfigType>,
-                                                           miopen::pooling::ProblemDescription,
-                                                           miopen::pooling::BwdInvokeParams,
-                                                           Inner>
+struct PoolingBwdNCHWTransposingSolver
+    : TransposingSolver<PoolingBwdNCHWTransposingSolver<Inner>,
+                        PoolingTunableSolver<typename Inner::PerformanceConfigType>,
+                        miopen::pooling::ProblemDescription,
+                        miopen::pooling::BwdInvokeParams,
+                        Inner>
 {
     using Problem      = miopen::pooling::ProblemDescription;
     using InvokeParams = miopen::pooling::BwdInvokeParams;
@@ -512,10 +525,10 @@ struct TransposedPoolingBwd2d final : PoolingBwdNCHWTransposingSolver<PoolingBac
     {
         return PoolingBackward2d{}.GetDefaultPerformanceConfig(ctx, problem);
     }
-    bool IsValidPerformanceConfig(
-        const ExecutionContext& ctx,
-        const miopen::pooling::ProblemDescription& problem,
-        const PoolingBackward2d::PerformanceConfigType& config) const override
+    bool
+    IsValidPerformanceConfig(const ExecutionContext& ctx,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PoolingBackward2d::PerformanceConfigType& config) const override
     {
         return PoolingBackward2d{}.IsValidPerformanceConfig(ctx, problem, config);
     }
@@ -540,10 +553,10 @@ struct TransposedPoolingBwdNd final : PoolingBwdNCHWTransposingSolver<PoolingBac
     {
         return PoolingBackwardNd{}.GetDefaultPerformanceConfig(ctx, problem);
     }
-    bool IsValidPerformanceConfig(
-        const ExecutionContext& ctx,
-        const miopen::pooling::ProblemDescription& problem,
-        const PoolingBackwardNd::PerformanceConfigType& config) const override
+    bool
+    IsValidPerformanceConfig(const ExecutionContext& ctx,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PoolingBackwardNd::PerformanceConfigType& config) const override
     {
         return PoolingBackwardNd{}.IsValidPerformanceConfig(ctx, problem, config);
     }

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -67,7 +67,7 @@ struct PerformanceConfigPooling2d : PerfConfigBase<PerformanceConfigPooling2d<Op
     static constexpr int min_out_pix_tile0 = 1;
     static constexpr int max_out_pix_tile0 = (OpType == OperationType::Forward) ? 1 : 4;
     static constexpr int min_out_pix_tile1 = 1;
-    static constexpr int max_out_pix_tile1 = (OpType == OperationType::Forward) ? 16 : 4;
+    static constexpr int max_out_pix_tile1 = (OpType == OperationType::Forward) ? 16 : 8;
     static constexpr int min_local_size0   = (OpType == OperationType::Forward) ? 8 : 4;
     static constexpr int max_local_size0   = 32;
     static constexpr int min_local_size1   = (OpType == OperationType::Forward) ? 8 : 4;
@@ -96,7 +96,10 @@ struct PerformanceConfigPooling2d : PerfConfigBase<PerformanceConfigPooling2d<Op
 
     void HeuristicInit(const miopen::pooling::ProblemDescription&);
     bool SetNextValue(const miopen::pooling::ProblemDescription&);
-    bool IsValidValue() const;
+    virtual bool IsValidValue(const miopen::pooling::ProblemDescription&) const
+    {
+        throw std::runtime_error("IsValidValue is not implemented for the base struct");
+    }
     bool IsValid(const ExecutionContext&, const miopen::pooling::ProblemDescription&) const;
     bool operator==(const PerformanceConfigPooling2d& other) const;
 
@@ -116,43 +119,55 @@ private:
 extern template struct PerformanceConfigPooling2d<OperationType::Forward>;
 extern template struct PerformanceConfigPooling2d<OperationType::Backward>;
 
-struct PoolingForward2d final
-    : PoolingTunableSolver<PerformanceConfigPooling2d<OperationType::Forward>>
+struct PerformanceConfigPooling2dForward final
+    : public PerformanceConfigPooling2d<OperationType::Forward>
+{
+    using PerformanceConfigPooling2d<OperationType::Forward>::PerformanceConfigPooling2d;
+
+    bool IsValidValue(const miopen::pooling::ProblemDescription&) const override;
+};
+
+struct PerformanceConfigPooling2dBackward final
+    : public PerformanceConfigPooling2d<OperationType::Backward>
+{
+    using PerformanceConfigPooling2d<OperationType::Backward>::PerformanceConfigPooling2d;
+
+    bool IsValidValue(const miopen::pooling::ProblemDescription&) const override;
+};
+
+struct PoolingForward2d final : PoolingTunableSolver<PerformanceConfigPooling2dForward>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
-    ConvSolution GetSolutionImpl(
-        const ExecutionContext& context,
-        const miopen::pooling::ProblemDescription& problem,
-        const std::optional<PerformanceConfigPooling2d<OperationType::Forward>>& config) const;
+    ConvSolution
+    GetSolutionImpl(const ExecutionContext& context,
+                    const miopen::pooling::ProblemDescription& problem,
+                    const std::optional<PerformanceConfigPooling2dForward>& config) const;
     // This method is added to maintain compatibility with TransposedPoolingFwd2d solver
     ConvSolution GetSolution(const ExecutionContext& context,
                              const miopen::pooling::ProblemDescription& problem) const
     {
         return GetSolutionImpl(context, problem, std::nullopt);
     }
-    ConvSolution
-    GetSolution(const ExecutionContext& context,
-                const miopen::pooling::ProblemDescription& problem,
-                const PerformanceConfigPooling2d<OperationType::Forward>& config) const override
+    ConvSolution GetSolution(const ExecutionContext& context,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PerformanceConfigPooling2dForward& config) const override
     {
         return GetSolutionImpl(context, problem, config);
     }
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
-    PerformanceConfigPooling2d<OperationType::Forward>
+    PerformanceConfigPooling2dForward
     GetDefaultPerformanceConfig(const ExecutionContext&,
                                 const miopen::pooling::ProblemDescription&) const override;
-    bool IsValidPerformanceConfig(
-        const ExecutionContext&,
-        const miopen::pooling::ProblemDescription&,
-        const PerformanceConfigPooling2d<OperationType::Forward>&) const override;
-    PerformanceConfigPooling2d<OperationType::Forward>
-    Search(const ExecutionContext& context,
-           const miopen::pooling::ProblemDescription& problem,
-           const AnyInvokeParams& invoke_context) const override
+    bool IsValidPerformanceConfig(const ExecutionContext&,
+                                  const miopen::pooling::ProblemDescription&,
+                                  const PerformanceConfigPooling2dForward&) const override;
+    PerformanceConfigPooling2dForward Search(const ExecutionContext& context,
+                                             const miopen::pooling::ProblemDescription& problem,
+                                             const AnyInvokeParams& invoke_context) const override
     {
         return GenericSearch(*this, context, problem, invoke_context);
     }
@@ -237,43 +252,39 @@ struct TransposedPoolingFwdNd final : PoolingFwdNCHWTransposingSolver<PoolingFor
     }
 };
 
-struct PoolingBackward2d final
-    : PoolingTunableSolver<PerformanceConfigPooling2d<OperationType::Backward>>
+struct PoolingBackward2d final : PoolingTunableSolver<PerformanceConfigPooling2dBackward>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingBackward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
-    ConvSolution GetSolutionImpl(
-        const ExecutionContext& context,
-        const miopen::pooling::ProblemDescription& problem,
-        const std::optional<PerformanceConfigPooling2d<OperationType::Backward>>& config) const;
+    ConvSolution
+    GetSolutionImpl(const ExecutionContext& context,
+                    const miopen::pooling::ProblemDescription& problem,
+                    const std::optional<PerformanceConfigPooling2dBackward>& config) const;
     // This method is added to maintain compatibility with TransposedPoolingBwd2d solver
     ConvSolution GetSolution(const ExecutionContext& context,
                              const miopen::pooling::ProblemDescription& problem) const
     {
         return GetSolutionImpl(context, problem, std::nullopt);
     }
-    ConvSolution
-    GetSolution(const ExecutionContext& context,
-                const miopen::pooling::ProblemDescription& problem,
-                const PerformanceConfigPooling2d<OperationType::Backward>& config) const override
+    ConvSolution GetSolution(const ExecutionContext& context,
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PerformanceConfigPooling2dBackward& config) const override
     {
         return GetSolutionImpl(context, problem, config);
     }
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
-    PerformanceConfigPooling2d<OperationType::Backward>
+    PerformanceConfigPooling2dBackward
     GetDefaultPerformanceConfig(const ExecutionContext&,
                                 const miopen::pooling::ProblemDescription&) const override;
-    bool IsValidPerformanceConfig(
-        const ExecutionContext&,
-        const miopen::pooling::ProblemDescription&,
-        const PerformanceConfigPooling2d<OperationType::Backward>&) const override;
-    PerformanceConfigPooling2d<OperationType::Backward>
-    Search(const ExecutionContext& context,
-           const miopen::pooling::ProblemDescription& problem,
-           const AnyInvokeParams& invoke_context) const override
+    bool IsValidPerformanceConfig(const ExecutionContext&,
+                                  const miopen::pooling::ProblemDescription&,
+                                  const PerformanceConfigPooling2dBackward&) const override;
+    PerformanceConfigPooling2dBackward Search(const ExecutionContext& context,
+                                              const miopen::pooling::ProblemDescription& problem,
+                                              const AnyInvokeParams& invoke_context) const override
     {
         return GenericSearch(*this, context, problem, invoke_context);
     }

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -49,7 +49,6 @@ enum class OperationType
     Backward
 };
 
-using PoolingSolver = NonTunableSolverBase<ExecutionContext, miopen::pooling::ProblemDescription>;
 template <class PerformanceConfig>
 using PoolingTunableSolver =
     SolverBaseTunable<ExecutionContext, miopen::pooling::ProblemDescription, PerformanceConfig>;
@@ -119,44 +118,79 @@ private:
 extern template struct PerformanceConfigPooling2d<OperationType::Forward>;
 extern template struct PerformanceConfigPooling2d<OperationType::Backward>;
 
-struct PerformanceConfigPooling2dForward final
-    : public PerformanceConfigPooling2d<OperationType::Forward>
+template <OperationType OpType>
+struct PerformanceConfigPoolingNd : PerfConfigBase<PerformanceConfigPoolingNd<OpType>>
 {
-    using PerformanceConfigPooling2d<OperationType::Forward>::PerformanceConfigPooling2d;
+    static_assert(OpType == OperationType::Forward || OpType == OperationType::Backward,
+                  "OperationType must be either Forward or Backward");
 
-    bool IsValidValue(const miopen::pooling::ProblemDescription&) const override;
+    int pix_w_per_work;
+    int pix_h_per_work;
+    int pix_d_per_work;
+    int local_size;
+    static constexpr int min_pix_per_work = 1;
+    static constexpr int max_pix_per_work = 4;
+
+    PerformanceConfigPoolingNd(int pix_w_per_work_,
+                               int pix_h_per_work_,
+                               int pix_d_per_work_,
+                               int local_size_)
+        : pix_w_per_work(pix_w_per_work_),
+          pix_h_per_work(pix_h_per_work_),
+          pix_d_per_work(pix_d_per_work_),
+          local_size(local_size_)
+    {
+    }
+
+    PerformanceConfigPoolingNd() : PerformanceConfigPoolingNd(1, 1, 1, 1) {}
+
+    PerformanceConfigPoolingNd(bool) : PerformanceConfigPoolingNd(1, 1, 1, 1) {}
+
+    void HeuristicInit(const miopen::pooling::ProblemDescription&);
+    virtual bool SetNextValue(const miopen::pooling::ProblemDescription&)
+    {
+        throw std::runtime_error(
+            "SetNextValue of PerformanceConfigPoolingNd<OpType> is called, but it is not "
+            "implemented.");
+    }
+    virtual bool IsValidValue() const
+    {
+        throw std::runtime_error(
+            "IsValidValue of PerformanceConfigPoolingNd<OpType> is called, but it is not "
+            "implemented.");
+    }
+    bool IsValid(const ExecutionContext&, const miopen::pooling::ProblemDescription&) const;
+    bool operator==(const PerformanceConfigPoolingNd& other) const;
+
+    template <class Self, class F>
+    static void Visit(Self&& self, F f)
+    {
+        f(self.pix_w_per_work, "pix_w_per_work");
+        f(self.pix_h_per_work, "pix_h_per_work");
+        f(self.pix_d_per_work, "pix_d_per_work");
+        f(self.local_size, "local_size");
+    }
+
+private:
+    void Init(const miopen::pooling::ProblemDescription&);
 };
 
-struct PerformanceConfigPooling2dBackward final
-    : public PerformanceConfigPooling2d<OperationType::Backward>
-{
-    using PerformanceConfigPooling2d<OperationType::Backward>::PerformanceConfigPooling2d;
+extern template struct PerformanceConfigPoolingNd<OperationType::Forward>;
+extern template struct PerformanceConfigPoolingNd<OperationType::Backward>;
 
-    bool IsValidValue(const miopen::pooling::ProblemDescription&) const override;
-};
-
-struct PoolingForward2d final : PoolingTunableSolver<PerformanceConfigPooling2dForward>
+struct PoolingForward2d final
+    : PoolingTunableSolver<PerformanceConfigPooling2d<OperationType::Forward>>
 {
+    using PerformanceConfigType = PerformanceConfigPooling2d<OperationType::Forward>;
+
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
     ConvSolution
-    GetSolutionImpl(const ExecutionContext& context,
-                    const miopen::pooling::ProblemDescription& problem,
-                    const std::optional<PerformanceConfigPooling2dForward>& config) const;
-    // This method is added to maintain compatibility with TransposedPoolingFwd2d solver
-    ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const
-    {
-        return GetSolutionImpl(context, problem, std::nullopt);
-    }
-    ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem,
-                             const PerformanceConfigPooling2dForward& config) const override
-    {
-        return GetSolutionImpl(context, problem, config);
-    }
+    GetSolution(const ExecutionContext& context,
+                const miopen::pooling::ProblemDescription& problem,
+                const PerformanceConfigPooling2d<OperationType::Forward>& config) const override;
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
     PerformanceConfigPooling2dForward
@@ -173,19 +207,76 @@ struct PoolingForward2d final : PoolingTunableSolver<PerformanceConfigPooling2dF
     }
 };
 
-struct PoolingForwardNd final : PoolingSolver
+struct PerformanceConfigPoolingNdForward final : PerformanceConfigPoolingNd<OperationType::Forward>
 {
-    const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForwardNd>(); }
+    using PerformanceConfigPoolingNd::PerformanceConfigPoolingNd;
 
+    bool SetNextValue(const miopen::pooling::ProblemDescription&) override;
+    bool IsValidValue() const override;
+};
+
+struct PoolingForwardNd final : PoolingTunableSolver<PerformanceConfigPoolingNdForward>
+{
+    using PerformanceConfigType = PerformanceConfigPoolingNdForward;
+
+    const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForwardNd>(); }
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
     ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const override;
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PerformanceConfigPoolingNdForward& config) const override;
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
+    PerformanceConfigPoolingNdForward
+    GetDefaultPerformanceConfig(const ExecutionContext&,
+                                const miopen::pooling::ProblemDescription&) const override;
+    bool IsValidPerformanceConfig(
+        const ExecutionContext&,
+        const miopen::pooling::ProblemDescription&,
+        const PerformanceConfigPoolingNdForward&) const override;
+    PerformanceConfigPoolingNdForward
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
+    {
+        return GenericSearch(*this, context, problem, invoke_context);
+    }
 };
 
-struct PoolingForwardNaive final : PoolingSolver
+struct PerformanceConfigPoolingForwardNaive : PerfConfigBase<PerformanceConfigPoolingForwardNaive>
+{
+    int local_size0;
+    int local_size1;
+    int local_size2;
+
+    PerformanceConfigPoolingForwardNaive(int local_size0_, int local_size1_, int local_size2_)
+        : local_size0(local_size0_), local_size1(local_size1_), local_size2(local_size2_)
+    {
+    }
+
+    PerformanceConfigPoolingForwardNaive() : PerformanceConfigPoolingForwardNaive(1, 1, 1) {}
+
+    PerformanceConfigPoolingForwardNaive(bool) : PerformanceConfigPoolingForwardNaive(1, 1, 1) {}
+
+    void HeuristicInit(const miopen::pooling::ProblemDescription&);
+    bool SetNextValue(const miopen::pooling::ProblemDescription&);
+    bool IsValidValue() const;
+    bool IsValid(const ExecutionContext&, const miopen::pooling::ProblemDescription&) const;
+    bool operator==(const PerformanceConfigPoolingForwardNaive& other) const;
+
+    template <class Self, class F>
+    static void Visit(Self&& self, F f)
+    {
+        f(self.local_size0, "local_size0");
+        f(self.local_size1, "local_size1");
+        f(self.local_size2, "local_size2");
+    }
+
+private:
+    void Init(const miopen::pooling::ProblemDescription&);
+};
+
+struct PoolingForwardNaive final : PoolingTunableSolver<PerformanceConfigPoolingForwardNaive>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForwardNaive>(); }
     bool IsDynamic() const override { return true; }
@@ -193,17 +284,32 @@ struct PoolingForwardNaive final : PoolingSolver
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
     ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const override;
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PerformanceConfigPoolingForwardNaive& config) const override;
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
+    PerformanceConfigPoolingForwardNaive
+    GetDefaultPerformanceConfig(const ExecutionContext&,
+                                const miopen::pooling::ProblemDescription&) const override;
+    bool IsValidPerformanceConfig(const ExecutionContext&,
+                                  const miopen::pooling::ProblemDescription&,
+                                  const PerformanceConfigPoolingForwardNaive&) const override;
+    PerformanceConfigPoolingForwardNaive
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
+    {
+        return GenericSearch(*this, context, problem, invoke_context);
+    }
 };
 
 template <class Inner>
-struct PoolingFwdNCHWTransposingSolver : TransposingSolver<PoolingFwdNCHWTransposingSolver<Inner>,
-                                                           PoolingSolver,
-                                                           miopen::pooling::ProblemDescription,
-                                                           miopen::pooling::FwdInvokeParams,
-                                                           Inner>
+struct PoolingFwdNCHWTransposingSolver
+    : TransposingSolver<PoolingFwdNCHWTransposingSolver<Inner>,
+                        PoolingTunableSolver<typename Inner::PerformanceConfigType>,
+                        miopen::pooling::ProblemDescription,
+                        miopen::pooling::FwdInvokeParams,
+                        Inner>
 {
     using Problem      = miopen::pooling::ProblemDescription;
     using InvokeParams = miopen::pooling::FwdInvokeParams;
@@ -242,6 +348,26 @@ struct TransposedPoolingFwd2d final : PoolingFwdNCHWTransposingSolver<PoolingFor
     {
         return GetSolverDbId<TransposedPoolingFwd2d>();
     }
+    PoolingForward2d::PerformanceConfigType
+    GetDefaultPerformanceConfig(const ExecutionContext& ctx,
+                                const miopen::pooling::ProblemDescription& problem) const override
+    {
+        return PoolingForward2d{}.GetDefaultPerformanceConfig(ctx, problem);
+    }
+    bool IsValidPerformanceConfig(
+        const ExecutionContext& ctx,
+        const miopen::pooling::ProblemDescription& problem,
+        const PoolingForward2d::PerformanceConfigType& config) const override
+    {
+        return PoolingForward2d{}.IsValidPerformanceConfig(ctx, problem, config);
+    }
+    PoolingForward2d::PerformanceConfigType
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
+    {
+        return PoolingForward2d{}.Search(context, problem, invoke_context);
+    }
 };
 
 struct TransposedPoolingFwdNd final : PoolingFwdNCHWTransposingSolver<PoolingForwardNd>
@@ -250,30 +376,40 @@ struct TransposedPoolingFwdNd final : PoolingFwdNCHWTransposingSolver<PoolingFor
     {
         return GetSolverDbId<TransposedPoolingFwdNd>();
     }
+    PoolingForwardNd::PerformanceConfigType
+    GetDefaultPerformanceConfig(const ExecutionContext& ctx,
+                                const miopen::pooling::ProblemDescription& problem) const override
+    {
+        return PoolingForwardNd{}.GetDefaultPerformanceConfig(ctx, problem);
+    }
+    bool IsValidPerformanceConfig(
+        const ExecutionContext& ctx,
+        const miopen::pooling::ProblemDescription& problem,
+        const PoolingForwardNd::PerformanceConfigType& config) const override
+    {
+        return PoolingForwardNd{}.IsValidPerformanceConfig(ctx, problem, config);
+    }
+    PoolingForwardNd::PerformanceConfigType
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
+    {
+        return PoolingForwardNd{}.Search(context, problem, invoke_context);
+    }
 };
 
 struct PoolingBackward2d final : PoolingTunableSolver<PerformanceConfigPooling2dBackward>
 {
+    using PerformanceConfigType = PerformanceConfigPooling2d<OperationType::Backward>;
+
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingBackward2d>(); }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
     ConvSolution
-    GetSolutionImpl(const ExecutionContext& context,
-                    const miopen::pooling::ProblemDescription& problem,
-                    const std::optional<PerformanceConfigPooling2dBackward>& config) const;
-    // This method is added to maintain compatibility with TransposedPoolingBwd2d solver
-    ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const
-    {
-        return GetSolutionImpl(context, problem, std::nullopt);
-    }
-    ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem,
-                             const PerformanceConfigPooling2dBackward& config) const override
-    {
-        return GetSolutionImpl(context, problem, config);
-    }
+    GetSolution(const ExecutionContext& context,
+                const miopen::pooling::ProblemDescription& problem,
+                const PerformanceConfigPooling2d<OperationType::Backward>& config) const override;
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
     PerformanceConfigPooling2dBackward
@@ -290,21 +426,45 @@ struct PoolingBackward2d final : PoolingTunableSolver<PerformanceConfigPooling2d
     }
 };
 
-struct PoolingBackwardNd final : PoolingSolver
+struct PerformanceConfigPoolingNdBackward final : PerformanceConfigPoolingNd<OperationType::Backward>
 {
-    const std::string& SolverDbId() const override { return GetSolverDbId<PoolingBackwardNd>(); }
+    using PerformanceConfigPoolingNd::PerformanceConfigPoolingNd;
 
+    bool SetNextValue(const miopen::pooling::ProblemDescription&) override;
+    bool IsValidValue() const override;
+};
+
+struct PoolingBackwardNd final : PoolingTunableSolver<PerformanceConfigPoolingNdBackward>
+{
+    using PerformanceConfigType = PerformanceConfigPoolingNdBackward;
+
+    const std::string& SolverDbId() const override { return GetSolverDbId<PoolingBackwardNd>(); }
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::pooling::ProblemDescription& problem) const override;
     ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const override;
+                             const miopen::pooling::ProblemDescription& problem,
+                             const PerformanceConfigPoolingNdBackward& config) const override;
     std::size_t GetWorkspaceSize(const ExecutionContext& context,
                                  const miopen::pooling::ProblemDescription& problem) const override;
+    PerformanceConfigPoolingNdBackward
+    GetDefaultPerformanceConfig(const ExecutionContext&,
+                                const miopen::pooling::ProblemDescription&) const override;
+    bool IsValidPerformanceConfig(
+        const ExecutionContext&,
+        const miopen::pooling::ProblemDescription&,
+        const PerformanceConfigPoolingNdBackward&) const override;
+    PerformanceConfigPoolingNdBackward
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
+    {
+        return GenericSearch(*this, context, problem, invoke_context);
+    }
 };
 
 template <class Inner>
 struct PoolingBwdNCHWTransposingSolver : TransposingSolver<PoolingBwdNCHWTransposingSolver<Inner>,
-                                                           PoolingSolver,
+                                                           PoolingTunableSolver<typename Inner::PerformanceConfigType>,
                                                            miopen::pooling::ProblemDescription,
                                                            miopen::pooling::BwdInvokeParams,
                                                            Inner>
@@ -346,6 +506,26 @@ struct TransposedPoolingBwd2d final : PoolingBwdNCHWTransposingSolver<PoolingBac
     {
         return GetSolverDbId<TransposedPoolingBwd2d>();
     }
+    PoolingBackward2d::PerformanceConfigType
+    GetDefaultPerformanceConfig(const ExecutionContext& ctx,
+                                const miopen::pooling::ProblemDescription& problem) const override
+    {
+        return PoolingBackward2d{}.GetDefaultPerformanceConfig(ctx, problem);
+    }
+    bool IsValidPerformanceConfig(
+        const ExecutionContext& ctx,
+        const miopen::pooling::ProblemDescription& problem,
+        const PoolingBackward2d::PerformanceConfigType& config) const override
+    {
+        return PoolingBackward2d{}.IsValidPerformanceConfig(ctx, problem, config);
+    }
+    PoolingBackward2d::PerformanceConfigType
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
+    {
+        return PoolingBackward2d{}.Search(context, problem, invoke_context);
+    }
 };
 
 struct TransposedPoolingBwdNd final : PoolingBwdNCHWTransposingSolver<PoolingBackwardNd>
@@ -353,6 +533,26 @@ struct TransposedPoolingBwdNd final : PoolingBwdNCHWTransposingSolver<PoolingBac
     const std::string& SolverDbId() const override
     {
         return GetSolverDbId<TransposedPoolingBwdNd>();
+    }
+    PoolingBackwardNd::PerformanceConfigType
+    GetDefaultPerformanceConfig(const ExecutionContext& ctx,
+                                const miopen::pooling::ProblemDescription& problem) const override
+    {
+        return PoolingBackwardNd{}.GetDefaultPerformanceConfig(ctx, problem);
+    }
+    bool IsValidPerformanceConfig(
+        const ExecutionContext& ctx,
+        const miopen::pooling::ProblemDescription& problem,
+        const PoolingBackwardNd::PerformanceConfigType& config) const override
+    {
+        return PoolingBackwardNd{}.IsValidPerformanceConfig(ctx, problem, config);
+    }
+    PoolingBackwardNd::PerformanceConfigType
+    Search(const ExecutionContext& context,
+           const miopen::pooling::ProblemDescription& problem,
+           const AnyInvokeParams& invoke_context) const override
+    {
+        return PoolingBackwardNd{}.Search(context, problem, invoke_context);
     }
 };
 

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -67,7 +67,7 @@ struct PerformanceConfigPooling2d : PerfConfigBase<PerformanceConfigPooling2d<Op
     static constexpr int min_out_pix_tile0 = 1;
     static constexpr int max_out_pix_tile0 = (OpType == OperationType::Forward) ? 1 : 4;
     static constexpr int min_out_pix_tile1 = 1;
-    static constexpr int max_out_pix_tile1 = (OpType == OperationType::Forward) ? 16 : 8;
+    static constexpr int max_out_pix_tile1 = (OpType == OperationType::Forward) ? 16 : 4;
     static constexpr int min_local_size0   = (OpType == OperationType::Forward) ? 8 : 4;
     static constexpr int max_local_size0   = 32;
     static constexpr int min_local_size1   = (OpType == OperationType::Forward) ? 8 : 4;

--- a/projects/miopen/src/include/miopen/utility/transposing_solver.hpp
+++ b/projects/miopen/src/include/miopen/utility/transposing_solver.hpp
@@ -454,10 +454,12 @@ struct TransposingSolver : Base
         return ws_size;
     }
 
-    ConvSolution GetSolution(const ExecutionContext& ctx, const Problem& problem) const override
+    ConvSolution GetSolution(const ExecutionContext& ctx,
+                             const Problem& problem,
+                             const typename Inner::PerformanceConfigType& config) const override
     {
         auto transposed_problem = Transpose(problem);
-        ConvSolution sln        = Inner{}.GetSolution(ctx, transposed_problem);
+        ConvSolution sln        = Inner{}.GetSolution(ctx, transposed_problem, config);
         // NOLINTNEXTLINE (bugprone-unchecked-optional-access)
         auto old_factory             = sln.invoker_factory.value();
         const auto old_kernels_end   = sln.construction_params.size();

--- a/projects/miopen/src/pooling.cpp
+++ b/projects/miopen/src/pooling.cpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2017-2025 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 #include <miopen/pooling.hpp>
 #include <miopen/check_numerics.hpp>
 #include <miopen/datatype.hpp>

--- a/projects/miopen/src/pooling.cpp
+++ b/projects/miopen/src/pooling.cpp
@@ -36,11 +36,23 @@
 #include <miopen/subbuffers.hpp>
 #include <miopen/tensor.hpp>
 #include <miopen/tensor_layout.hpp>
+#include "miopen/pooling/problem_description.hpp"
 
 #include <cassert>
 #include <cmath>
 
 namespace miopen {
+
+namespace pooling {
+
+miopen::PerformanceDb GetDb(const miopen::ExecutionContext& context,
+                            const miopen::pooling::ProblemDescriptionTag&)
+{
+    return {
+        DbKinds::PerfDb, context.GetPerfDbPath("pooling"), context.GetUserPerfDbPath("pooling")};
+}
+
+} // namespace pooling
 
 template <class T, class U>
 T iciel_div(T x, U y)

--- a/projects/miopen/src/solver/pooling/backward2d.cpp
+++ b/projects/miopen/src/solver/pooling/backward2d.cpp
@@ -80,35 +80,11 @@ struct kernel_params
         }
         else
         {
-            out_pix_tile0 = 1;
-            out_pix_tile1 = 1;
-            if(pd.GetMode() == miopenPoolingMax)
-            {
-                out_pix_tile0 = in_width > 8 && in_width <= 24 ? 4 : 1;
-                out_pix_tile1 = in_width <= 24 ? 1 : (in_width > 64 && in_width <= 96 ? 4 : 8);
-            }
-
-            grp_tile0 = 8;
-            grp_tile1 = 8;
-            if(pd.GetMode() == miopenPoolingMax)
-            {
-                grp_tile0 = in_width <= 8     ? 8  //
-                            : in_width <= 16  ? 4  //
-                            : in_width <= 24  ? 8  //
-                            : in_width <= 32  ? 32 //
-                            : in_width <= 64  ? 8  //
-                            : in_width <= 96  ? 16 //
-                            : in_width <= 128 ? 16
-                                              : 32;
-                grp_tile1 = in_width <= 8     ? 8  //
-                            : in_width <= 16  ? 16 //
-                            : in_width <= 24  ? 8  //
-                            : in_width <= 32  ? 4  //
-                            : in_width <= 64  ? 8  //
-                            : in_width <= 96  ? 4  //
-                            : in_width <= 128 ? 16
-                                              : 4;
-            }
+            // set to max values for safer memory estimations
+            out_pix_tile0 = PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile0;
+            out_pix_tile1 = PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile1;
+            grp_tile0     = PerformanceConfigPooling2d<OperationType::Backward>::max_local_size0;
+            grp_tile1     = PerformanceConfigPooling2d<OperationType::Backward>::max_local_size1;
         }
     }
 };
@@ -137,25 +113,14 @@ std::size_t sizeof_local_memory(const miopen::pooling::ProblemDescription& probl
     const kernel_params kp(problem);
 
     // aliases to ease programming
-    const auto& MLO_POOLING_KERNEL_SZ0 = kp.kernel_size_w;
-    const auto& MLO_POOLING_KERNEL_SZ1 = kp.kernel_size_h;
-    const auto& MLO_POOLING_STRIDE0    = kp.kernel_stride_w;
-    const auto& MLO_POOLING_STRIDE1    = kp.kernel_stride_h;
-    // safer estimates of memory with max values of tunable parameters
-    assert(kp.out_pix_tile0 <=
-           PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile0);
-    const auto& MLO_POOLBWD_N_HORIZ_OUT_PIX =
-        PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile0;
-    assert(kp.out_pix_tile1 <=
-           PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile1);
-    const auto& MLO_POOLBWD_N_VERT_OUT_PIX =
-        PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile1;
-    assert(kp.grp_tile0 <= PerformanceConfigPooling2d<OperationType::Backward>::max_local_size0);
-    const auto& MLO_POOLBWD_GROUP_SZ0 =
-        PerformanceConfigPooling2d<OperationType::Backward>::max_local_size0;
-    assert(kp.grp_tile1 <= PerformanceConfigPooling2d<OperationType::Backward>::max_local_size1);
-    const auto& MLO_POOLBWD_GROUP_SZ1 =
-        PerformanceConfigPooling2d<OperationType::Backward>::max_local_size1;
+    const auto& MLO_POOLING_KERNEL_SZ0      = kp.kernel_size_w;
+    const auto& MLO_POOLING_KERNEL_SZ1      = kp.kernel_size_h;
+    const auto& MLO_POOLBWD_N_HORIZ_OUT_PIX = kp.out_pix_tile0;
+    const auto& MLO_POOLBWD_N_VERT_OUT_PIX  = kp.out_pix_tile1;
+    const auto& MLO_POOLING_STRIDE0         = kp.kernel_stride_w;
+    const auto& MLO_POOLING_STRIDE1         = kp.kernel_stride_h;
+    const auto& MLO_POOLBWD_GROUP_SZ0       = kp.grp_tile0;
+    const auto& MLO_POOLBWD_GROUP_SZ1       = kp.grp_tile1;
 
     const auto MLO_POOLBWD_LCL_DATA_WIDTH =
         (static_cast<std::size_t>(MLO_POOLBWD_GROUP_SZ0) * MLO_POOLBWD_N_HORIZ_OUT_PIX +

--- a/projects/miopen/src/solver/pooling/backward2d.cpp
+++ b/projects/miopen/src/solver/pooling/backward2d.cpp
@@ -58,8 +58,7 @@ struct kernel_params
     std::size_t grp_tile1;
 
     kernel_params(const miopen::pooling::ProblemDescription& problem,
-                  const std::optional<PerformanceConfigPooling2d<OperationType::Backward>>& config =
-                      std::nullopt)
+                  const std::optional<PerformanceConfigPooling2dBackward>& config = std::nullopt)
     {
         const auto& pd = problem.GetPooling();
 
@@ -80,11 +79,35 @@ struct kernel_params
         }
         else
         {
-            // set to max values for safer memory estimations
-            out_pix_tile0 = PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile0;
-            out_pix_tile1 = PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile1;
-            grp_tile0     = PerformanceConfigPooling2d<OperationType::Backward>::max_local_size0;
-            grp_tile1     = PerformanceConfigPooling2d<OperationType::Backward>::max_local_size1;
+            out_pix_tile0 = 1;
+            out_pix_tile1 = 1;
+            if(pd.GetMode() == miopenPoolingMax)
+            {
+                out_pix_tile0 = in_width > 8 && in_width <= 24 ? 4 : 1;
+                out_pix_tile1 = in_width <= 24 ? 1 : (in_width > 64 && in_width <= 96 ? 4 : 8);
+            }
+
+            grp_tile0 = 8;
+            grp_tile1 = 8;
+            if(pd.GetMode() == miopenPoolingMax)
+            {
+                grp_tile0 = in_width <= 8     ? 8  //
+                            : in_width <= 16  ? 4  //
+                            : in_width <= 24  ? 8  //
+                            : in_width <= 32  ? 32 //
+                            : in_width <= 64  ? 8  //
+                            : in_width <= 96  ? 16 //
+                            : in_width <= 128 ? 16
+                                              : 32;
+                grp_tile1 = in_width <= 8     ? 8  //
+                            : in_width <= 16  ? 16 //
+                            : in_width <= 24  ? 8  //
+                            : in_width <= 32  ? 4  //
+                            : in_width <= 64  ? 8  //
+                            : in_width <= 96  ? 4  //
+                            : in_width <= 128 ? 16
+                                              : 4;
+            }
         }
     }
 };
@@ -108,9 +131,11 @@ inline std::size_t RoundUpToMultiple(std::size_t v, std::size_t m)
 
 // Compute amount of local memory required for holding the arrays defined
 // in the "mloPoolingAveBwd" and "mloPoolingMaxBwd" kernels.
-std::size_t sizeof_local_memory(const miopen::pooling::ProblemDescription& problem)
+std::size_t
+sizeof_local_memory(const miopen::pooling::ProblemDescription& problem,
+                    const std::optional<PerformanceConfigPooling2dBackward>& config = std::nullopt)
 {
-    const kernel_params kp(problem);
+    const kernel_params kp(problem, config);
 
     // aliases to ease programming
     const auto& MLO_POOLING_KERNEL_SZ0      = kp.kernel_size_w;
@@ -172,15 +197,21 @@ bool PoolingBackward2d::IsApplicable(const ExecutionContext&,
             problem.GetXDesc().GetType() == miopenHalf ||
             problem.GetXDesc().GetType() == miopenBFloat16) &&
            problem.GetXDesc().IsPossibleLayout4D5D("NCHW", strict) &&
-           problem.GetYDesc().IsPossibleLayout4D5D("NCHW", strict) &&
-           sizeof_local_memory(problem) <= TargetProperties::GetMaxLocalMemorySize();
+           problem.GetYDesc().IsPossibleLayout4D5D("NCHW", strict);
 }
 
 ConvSolution PoolingBackward2d::GetSolutionImpl(
     const ExecutionContext&,
     const miopen::pooling::ProblemDescription& problem,
-    const std::optional<PerformanceConfigPooling2d<OperationType::Backward>>& config) const
+    const std::optional<PerformanceConfigPooling2dBackward>& config) const
 {
+    // check local memory requirement
+    if(sizeof_local_memory(problem, config) > TargetProperties::GetMaxLocalMemorySize())
+    {
+        MIOPEN_THROW(
+            "The local memory requirement in PoolingBackward2d solver exceeds the device limit.");
+    }
+
     auto result = ConvSolution{miopenStatusSuccess};
 
     const kernel_params kp(problem, config);
@@ -288,6 +319,23 @@ ConvSolution PoolingBackward2d::GetSolutionImpl(
     return result;
 }
 
+bool PerformanceConfigPooling2dBackward::IsValidValue(
+    const miopen::pooling::ProblemDescription& problem) const
+{
+    if(!IsTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
+        return false;
+    if(!IsTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+        return false;
+    if(!IsTwoPower<min_local_size0, max_local_size0>(local_size0))
+        return false;
+    if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
+        return false;
+    // this constraint is enforced to avoid exceedance of local memory limit
+    if(sizeof_local_memory(problem, *this) > TargetProperties::GetMaxLocalMemorySize())
+        return false;
+    return true;
+}
+
 std::size_t
 PoolingBackward2d::GetWorkspaceSize(const ExecutionContext&,
                                     const miopen::pooling::ProblemDescription& problem) const
@@ -300,15 +348,15 @@ PoolingBackward2d::GetWorkspaceSize(const ExecutionContext&,
 bool PoolingBackward2d::IsValidPerformanceConfig(
     const ExecutionContext& context,
     const miopen::pooling::ProblemDescription& problem,
-    const PerformanceConfigPooling2d<OperationType::Backward>& config) const
+    const PerformanceConfigPooling2dBackward& config) const
 {
     return config.IsValid(context, problem);
 }
 
-PerformanceConfigPooling2d<OperationType::Backward> PoolingBackward2d::GetDefaultPerformanceConfig(
+PerformanceConfigPooling2dBackward PoolingBackward2d::GetDefaultPerformanceConfig(
     const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
 {
-    PerformanceConfigPooling2d<OperationType::Backward> config;
+    PerformanceConfigPooling2dBackward config;
     config.HeuristicInit(problem);
     return config;
 }

--- a/projects/miopen/src/solver/pooling/backward2d.cpp
+++ b/projects/miopen/src/solver/pooling/backward2d.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -58,7 +58,7 @@ struct kernel_params
     std::size_t grp_tile1;
 
     kernel_params(const miopen::pooling::ProblemDescription& problem,
-                  const std::optional<PerformanceConfigPooling2dBackward>& config = std::nullopt)
+                  const PerformanceConfigPooling2dBackward& config)
     {
         const auto& pd = problem.GetPooling();
 
@@ -70,45 +70,10 @@ struct kernel_params
         std::tie(batch_sz, n_inputs, in_height, in_width) =
             miopen::tien<4>(problem.GetXDesc().GetLengths(), 1);
 
-        if(config)
-        {
-            out_pix_tile0 = config->out_pix_tile0;
-            out_pix_tile1 = config->out_pix_tile1;
-            grp_tile0     = config->local_size0;
-            grp_tile1     = config->local_size1;
-        }
-        else
-        {
-            out_pix_tile0 = 1;
-            out_pix_tile1 = 1;
-            if(pd.GetMode() == miopenPoolingMax)
-            {
-                out_pix_tile0 = in_width > 8 && in_width <= 24 ? 4 : 1;
-                out_pix_tile1 = in_width <= 24 ? 1 : (in_width > 64 && in_width <= 96 ? 4 : 8);
-            }
-
-            grp_tile0 = 8;
-            grp_tile1 = 8;
-            if(pd.GetMode() == miopenPoolingMax)
-            {
-                grp_tile0 = in_width <= 8     ? 8  //
-                            : in_width <= 16  ? 4  //
-                            : in_width <= 24  ? 8  //
-                            : in_width <= 32  ? 32 //
-                            : in_width <= 64  ? 8  //
-                            : in_width <= 96  ? 16 //
-                            : in_width <= 128 ? 16
-                                              : 32;
-                grp_tile1 = in_width <= 8     ? 8  //
-                            : in_width <= 16  ? 16 //
-                            : in_width <= 24  ? 8  //
-                            : in_width <= 32  ? 4  //
-                            : in_width <= 64  ? 8  //
-                            : in_width <= 96  ? 4  //
-                            : in_width <= 128 ? 16
-                                              : 4;
-            }
-        }
+        out_pix_tile0 = config.out_pix_tile0;
+        out_pix_tile1 = config.out_pix_tile1;
+        grp_tile0     = config.local_size0;
+        grp_tile1     = config.local_size1;
     }
 };
 
@@ -131,9 +96,8 @@ inline std::size_t RoundUpToMultiple(std::size_t v, std::size_t m)
 
 // Compute amount of local memory required for holding the arrays defined
 // in the "mloPoolingAveBwd" and "mloPoolingMaxBwd" kernels.
-std::size_t
-sizeof_local_memory(const miopen::pooling::ProblemDescription& problem,
-                    const std::optional<PerformanceConfigPooling2dBackward>& config = std::nullopt)
+std::size_t sizeof_local_memory(const miopen::pooling::ProblemDescription& problem,
+                                const PerformanceConfigPooling2dBackward& config)
 {
     const kernel_params kp(problem, config);
 
@@ -200,10 +164,9 @@ bool PoolingBackward2d::IsApplicable(const ExecutionContext&,
            problem.GetYDesc().IsPossibleLayout4D5D("NCHW", strict);
 }
 
-ConvSolution PoolingBackward2d::GetSolution(
-    const ExecutionContext&,
-    const miopen::pooling::ProblemDescription& problem,
-    const PerformanceConfigPooling2d<OperationType::Backward>& config) const
+ConvSolution PoolingBackward2d::GetSolution(const ExecutionContext&,
+                                            const miopen::pooling::ProblemDescription& problem,
+                                            const PerformanceConfigPooling2dBackward& config) const
 {
     // check local memory requirement
     if(sizeof_local_memory(problem, config) > TargetProperties::GetMaxLocalMemorySize())

--- a/projects/miopen/src/solver/pooling/backward2d.cpp
+++ b/projects/miopen/src/solver/pooling/backward2d.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/pooling/solvers.hpp>
 

--- a/projects/miopen/src/solver/pooling/backward2d.cpp
+++ b/projects/miopen/src/solver/pooling/backward2d.cpp
@@ -32,6 +32,7 @@
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/mlo_internal.hpp>
 #include <miopen/target_properties.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
 
 namespace miopen {
 
@@ -56,7 +57,9 @@ struct kernel_params
     std::size_t grp_tile0;
     std::size_t grp_tile1;
 
-    kernel_params(const miopen::pooling::ProblemDescription& problem)
+    kernel_params(const miopen::pooling::ProblemDescription& problem,
+                  const std::optional<PerformanceConfigPooling2d<OperationType::Backward>>& config =
+                      std::nullopt)
     {
         const auto& pd = problem.GetPooling();
 
@@ -68,34 +71,44 @@ struct kernel_params
         std::tie(batch_sz, n_inputs, in_height, in_width) =
             miopen::tien<4>(problem.GetXDesc().GetLengths(), 1);
 
-        out_pix_tile0 = 1;
-        out_pix_tile1 = 1;
-        if(pd.GetMode() == miopenPoolingMax)
+        if(config)
         {
-            out_pix_tile0 = in_width > 8 && in_width <= 24 ? 4 : 1;
-            out_pix_tile1 = in_width <= 24 ? 1 : (in_width > 64 && in_width <= 96 ? 4 : 8);
+            out_pix_tile0 = config->out_pix_tile0;
+            out_pix_tile1 = config->out_pix_tile1;
+            grp_tile0     = config->local_size0;
+            grp_tile1     = config->local_size1;
         }
-
-        grp_tile0 = 8;
-        grp_tile1 = 8;
-        if(pd.GetMode() == miopenPoolingMax)
+        else
         {
-            grp_tile0 = in_width <= 8     ? 8  //
-                        : in_width <= 16  ? 4  //
-                        : in_width <= 24  ? 8  //
-                        : in_width <= 32  ? 32 //
-                        : in_width <= 64  ? 8  //
-                        : in_width <= 96  ? 16 //
-                        : in_width <= 128 ? 16
-                                          : 32;
-            grp_tile1 = in_width <= 8     ? 8  //
-                        : in_width <= 16  ? 16 //
-                        : in_width <= 24  ? 8  //
-                        : in_width <= 32  ? 4  //
-                        : in_width <= 64  ? 8  //
-                        : in_width <= 96  ? 4  //
-                        : in_width <= 128 ? 16
-                                          : 4;
+            out_pix_tile0 = 1;
+            out_pix_tile1 = 1;
+            if(pd.GetMode() == miopenPoolingMax)
+            {
+                out_pix_tile0 = in_width > 8 && in_width <= 24 ? 4 : 1;
+                out_pix_tile1 = in_width <= 24 ? 1 : (in_width > 64 && in_width <= 96 ? 4 : 8);
+            }
+
+            grp_tile0 = 8;
+            grp_tile1 = 8;
+            if(pd.GetMode() == miopenPoolingMax)
+            {
+                grp_tile0 = in_width <= 8     ? 8  //
+                            : in_width <= 16  ? 4  //
+                            : in_width <= 24  ? 8  //
+                            : in_width <= 32  ? 32 //
+                            : in_width <= 64  ? 8  //
+                            : in_width <= 96  ? 16 //
+                            : in_width <= 128 ? 16
+                                              : 32;
+                grp_tile1 = in_width <= 8     ? 8  //
+                            : in_width <= 16  ? 16 //
+                            : in_width <= 24  ? 8  //
+                            : in_width <= 32  ? 4  //
+                            : in_width <= 64  ? 8  //
+                            : in_width <= 96  ? 4  //
+                            : in_width <= 128 ? 16
+                                              : 4;
+            }
         }
     }
 };
@@ -124,14 +137,25 @@ std::size_t sizeof_local_memory(const miopen::pooling::ProblemDescription& probl
     const kernel_params kp(problem);
 
     // aliases to ease programming
-    const auto& MLO_POOLING_KERNEL_SZ0      = kp.kernel_size_w;
-    const auto& MLO_POOLING_KERNEL_SZ1      = kp.kernel_size_h;
-    const auto& MLO_POOLBWD_N_HORIZ_OUT_PIX = kp.out_pix_tile0;
-    const auto& MLO_POOLBWD_N_VERT_OUT_PIX  = kp.out_pix_tile1;
-    const auto& MLO_POOLING_STRIDE0         = kp.kernel_stride_w;
-    const auto& MLO_POOLING_STRIDE1         = kp.kernel_stride_h;
-    const auto& MLO_POOLBWD_GROUP_SZ0       = kp.grp_tile0;
-    const auto& MLO_POOLBWD_GROUP_SZ1       = kp.grp_tile1;
+    const auto& MLO_POOLING_KERNEL_SZ0 = kp.kernel_size_w;
+    const auto& MLO_POOLING_KERNEL_SZ1 = kp.kernel_size_h;
+    const auto& MLO_POOLING_STRIDE0    = kp.kernel_stride_w;
+    const auto& MLO_POOLING_STRIDE1    = kp.kernel_stride_h;
+    // safer estimates of memory with max values of tunable parameters
+    assert(kp.out_pix_tile0 <=
+           PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile0);
+    const auto& MLO_POOLBWD_N_HORIZ_OUT_PIX =
+        PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile0;
+    assert(kp.out_pix_tile1 <=
+           PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile1);
+    const auto& MLO_POOLBWD_N_VERT_OUT_PIX =
+        PerformanceConfigPooling2d<OperationType::Backward>::max_out_pix_tile1;
+    assert(kp.grp_tile0 <= PerformanceConfigPooling2d<OperationType::Backward>::max_local_size0);
+    const auto& MLO_POOLBWD_GROUP_SZ0 =
+        PerformanceConfigPooling2d<OperationType::Backward>::max_local_size0;
+    assert(kp.grp_tile1 <= PerformanceConfigPooling2d<OperationType::Backward>::max_local_size1);
+    const auto& MLO_POOLBWD_GROUP_SZ1 =
+        PerformanceConfigPooling2d<OperationType::Backward>::max_local_size1;
 
     const auto MLO_POOLBWD_LCL_DATA_WIDTH =
         (static_cast<std::size_t>(MLO_POOLBWD_GROUP_SZ0) * MLO_POOLBWD_N_HORIZ_OUT_PIX +
@@ -187,13 +211,14 @@ bool PoolingBackward2d::IsApplicable(const ExecutionContext&,
            sizeof_local_memory(problem) <= TargetProperties::GetMaxLocalMemorySize();
 }
 
-ConvSolution
-PoolingBackward2d::GetSolution(const ExecutionContext&,
-                               const miopen::pooling::ProblemDescription& problem) const
+ConvSolution PoolingBackward2d::GetSolutionImpl(
+    const ExecutionContext&,
+    const miopen::pooling::ProblemDescription& problem,
+    const std::optional<PerformanceConfigPooling2d<OperationType::Backward>>& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
-    const kernel_params kp(problem);
+    const kernel_params kp(problem, config);
 
     {
         auto kernel = KernelInfo{};
@@ -305,6 +330,22 @@ PoolingBackward2d::GetWorkspaceSize(const ExecutionContext&,
     if(problem.GetPooling().GetMode() != miopenPoolingMax)
         return 0;
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
+}
+
+bool PoolingBackward2d::IsValidPerformanceConfig(
+    const ExecutionContext& context,
+    const miopen::pooling::ProblemDescription& problem,
+    const PerformanceConfigPooling2d<OperationType::Backward>& config) const
+{
+    return config.IsValid(context, problem);
+}
+
+PerformanceConfigPooling2d<OperationType::Backward> PoolingBackward2d::GetDefaultPerformanceConfig(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+    PerformanceConfigPooling2d<OperationType::Backward> config;
+    config.HeuristicInit(problem);
+    return config;
 }
 
 } // namespace pooling

--- a/projects/miopen/src/solver/pooling/backward2d.cpp
+++ b/projects/miopen/src/solver/pooling/backward2d.cpp
@@ -200,10 +200,10 @@ bool PoolingBackward2d::IsApplicable(const ExecutionContext&,
            problem.GetYDesc().IsPossibleLayout4D5D("NCHW", strict);
 }
 
-ConvSolution PoolingBackward2d::GetSolutionImpl(
+ConvSolution PoolingBackward2d::GetSolution(
     const ExecutionContext&,
     const miopen::pooling::ProblemDescription& problem,
-    const std::optional<PerformanceConfigPooling2dBackward>& config) const
+    const PerformanceConfigPooling2d<OperationType::Backward>& config) const
 {
     // check local memory requirement
     if(sizeof_local_memory(problem, config) > TargetProperties::GetMaxLocalMemorySize())

--- a/projects/miopen/src/solver/pooling/backwardNd.cpp
+++ b/projects/miopen/src/solver/pooling/backwardNd.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -124,8 +124,8 @@ ConvSolution PoolingBackwardNd::GetSolution(const ExecutionContext&,
 #if WORKAROUND_ISSUE_MIFIN_80
     const std::size_t lcl_work = config.local_size;
 #else
-    const std::size_t wavesize = context.GetStream().GetWavefrontWidth();
-    const std::size_t lcl_work = wavesize;
+    const std::size_t wavesize     = context.GetStream().GetWavefrontWidth();
+    const std::size_t lcl_work     = wavesize;
 #endif
     size_t grp_num = (activ_work + lcl_work - 1) / lcl_work;
 
@@ -270,8 +270,7 @@ PoolingBackwardNd::GetWorkspaceSize(const ExecutionContext&,
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
 }
 
-bool PerformanceConfigPoolingNdBackward::SetNextValue(
-    const miopen::pooling::ProblemDescription&)
+bool PerformanceConfigPoolingNdBackward::SetNextValue(const miopen::pooling::ProblemDescription&)
 {
 #if !MIOPEN_BACKEND_HIP
     return false;

--- a/projects/miopen/src/solver/pooling/backwardNd.cpp
+++ b/projects/miopen/src/solver/pooling/backwardNd.cpp
@@ -31,6 +31,7 @@
 #include <miopen/pooling.hpp>
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/mlo_internal.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
 
 #define WORKAROUND_ISSUE_MIFIN_80 1 // https://github.com/ROCm/MIFin/issues/80
 
@@ -67,9 +68,9 @@ bool PoolingBackwardNd::IsApplicable(const ExecutionContext&,
                 && problem.GetPooling().GetWorkspaceIndexMode() == miopenPoolingWorkspaceIndexMask);
 }
 
-ConvSolution
-PoolingBackwardNd::GetSolution(const ExecutionContext&,
-                               const miopen::pooling::ProblemDescription& problem) const
+ConvSolution PoolingBackwardNd::GetSolution(const ExecutionContext&,
+                                            const miopen::pooling::ProblemDescription& problem,
+                                            const PerformanceConfigPoolingNdBackward& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -99,9 +100,9 @@ PoolingBackwardNd::GetSolution(const ExecutionContext&,
                                           ? MLO_POOLING_OP_AVE
                                           : MLO_POOLING_OP_AVE_INCLUSIVE);
 
-    int pix_w_per_work = 1;
-    int pix_h_per_work = 4;
-    int pix_d_per_work = 2;
+    int pix_w_per_work = config.pix_w_per_work;
+    int pix_h_per_work = config.pix_h_per_work;
+    int pix_d_per_work = config.pix_d_per_work;
 
     int batch = top.GetLengths()[0];
     int chal  = top.GetLengths()[1];
@@ -121,11 +122,12 @@ PoolingBackwardNd::GetSolution(const ExecutionContext&,
     int activ_work         = std::min(total_work, max_activ_workitem);
 
 #if WORKAROUND_ISSUE_MIFIN_80
-    const std::size_t wavesize = 64;
+    const std::size_t lcl_work = config.local_size;
 #else
     const std::size_t wavesize = context.GetStream().GetWavefrontWidth();
+    const std::size_t lcl_work = wavesize;
 #endif
-    size_t grp_num = (activ_work + wavesize - 1) / wavesize;
+    size_t grp_num = (activ_work + lcl_work - 1) / lcl_work;
 
     auto strides = problem.GetPooling().strides;
     auto lens    = problem.GetPooling().lens;
@@ -151,7 +153,7 @@ PoolingBackwardNd::GetSolution(const ExecutionContext&,
         KernelBuildParameters{
             {"MLO_POOLING_OP_ID", pooling_method},
             {"MAX_ACTIV_WORKITEM", max_activ_workitem},
-            {"MLO_POOLING_GROUP_SZ0", wavesize},
+            {"MLO_POOLING_GROUP_SZ0", lcl_work},
             {"MLO_POOLING_GROUP_SZ1", 1},
             {"MLO_POOLING_GROUP_SZ2", 1},
             {"PIX_W_PER_WORK", pix_w_per_work},
@@ -171,8 +173,8 @@ PoolingBackwardNd::GetSolution(const ExecutionContext&,
 
     kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
 
-    kernel.l_wk = {wavesize, 1, 1};
-    kernel.g_wk = {wavesize * grp_num, 1, 1};
+    kernel.l_wk = {lcl_work, 1, 1};
+    kernel.g_wk = {lcl_work * grp_num, 1, 1};
 
     result.construction_params.push_back(kernel);
 
@@ -266,6 +268,63 @@ PoolingBackwardNd::GetWorkspaceSize(const ExecutionContext&,
     if(problem.GetPooling().GetMode() != miopenPoolingMax)
         return 0;
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
+}
+
+bool PerformanceConfigPoolingNdBackward::SetNextValue(
+    const miopen::pooling::ProblemDescription&)
+{
+#if !MIOPEN_BACKEND_HIP
+    return false;
+#else
+#if WORKAROUND_ISSUE_MIFIN_80
+    constexpr std::size_t wavesize = 64;
+    if(!NextTwoPower<min_pix_per_work, max_pix_per_work>(pix_w_per_work))
+        return true;
+    if(!NextTwoPower<min_pix_per_work, max_pix_per_work>(pix_h_per_work))
+        return true;
+    if(!NextTwoPower<min_pix_per_work, max_pix_per_work>(pix_d_per_work))
+        return true;
+    if(!NextTwoPower<1, wavesize>(local_size))
+        return true;
+    return false;
+#else
+    return false;
+#endif
+#endif
+}
+
+bool PerformanceConfigPoolingNdBackward::IsValidValue() const
+{
+#if WORKAROUND_ISSUE_MIFIN_80
+    constexpr std::size_t wavesize = 64;
+    if(!IsTwoPower<min_pix_per_work, max_pix_per_work>(pix_w_per_work))
+        return false;
+    if(!IsTwoPower<min_pix_per_work, max_pix_per_work>(pix_h_per_work))
+        return false;
+    if(!IsTwoPower<min_pix_per_work, max_pix_per_work>(pix_d_per_work))
+        return false;
+    if(!IsTwoPower<1, wavesize>(local_size))
+        return false;
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool PoolingBackwardNd::IsValidPerformanceConfig(
+    const ExecutionContext& context,
+    const miopen::pooling::ProblemDescription& problem,
+    const PerformanceConfigPoolingNdBackward& config) const
+{
+    return config.IsValid(context, problem);
+}
+
+PerformanceConfigPoolingNdBackward PoolingBackwardNd::GetDefaultPerformanceConfig(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+    PerformanceConfigPoolingNdBackward config;
+    config.HeuristicInit(problem);
+    return config;
 }
 
 } // namespace pooling

--- a/projects/miopen/src/solver/pooling/backwardNd.cpp
+++ b/projects/miopen/src/solver/pooling/backwardNd.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/pooling/solvers.hpp>
 

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -71,11 +71,8 @@ struct kernel_params
         }
         else
         {
-            out_pix_tile1 = out_height <= 8    ? 1 //
-                            : out_height <= 32 ? 4 //
-                                               : 8;
-            if(out_height > 16 && out_height % 32 > 16)
-                out_pix_tile1 = std::min(16, std::max(1, prePow2(out_pix_tile1 * kernel_stride_h)));
+            // set to max value for safer memory estimations
+            out_pix_tile1 = PerformanceConfigPooling2d<OperationType::Forward>::max_out_pix_tile1;
         }
     }
 };
@@ -122,11 +119,7 @@ std::size_t sizeof_private_memory(const miopen::pooling::ProblemDescription& pro
     const auto& MLO_POOLING_KERNEL_SZ0      = kp.kernel_size_w;
     const auto& MLO_POOLING_STRIDE0         = kp.kernel_stride_w;
     const auto& MLO_POOLING_N_HORIZ_OUT_PIX = kp.out_pix_tile0;
-    // safer estimate of memory with max_out_pix_tile1
-    assert(kp.out_pix_tile1 <=
-           PerformanceConfigPooling2d<OperationType::Forward>::max_out_pix_tile1);
-    const auto& MLO_POOLING_N_VERT_OUT_PIX =
-        PerformanceConfigPooling2d<OperationType::Forward>::max_out_pix_tile1;
+    const auto& MLO_POOLING_N_VERT_OUT_PIX  = kp.out_pix_tile1;
 
     const auto MLO_BOT_DATA_SZ0 =
         (static_cast<std::size_t>(MLO_POOLING_N_HORIZ_OUT_PIX) - 1) * MLO_POOLING_STRIDE0 +

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/pooling/solvers.hpp>
 

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -161,10 +161,9 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
                TargetProperties::GetMaxWaveScratchSize() / context.GetStream().GetWavefrontWidth();
 }
 
-ConvSolution PoolingForward2d::GetSolution(
-    const ExecutionContext&,
-    const miopen::pooling::ProblemDescription& problem,
-    const PerformanceConfigPooling2d<OperationType::Forward>& config) const
+ConvSolution PoolingForward2d::GetSolution(const ExecutionContext&,
+                                           const miopen::pooling::ProblemDescription& problem,
+                                           const PerformanceConfigPooling2dForward& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -272,7 +271,7 @@ bool PerformanceConfigPooling2dForward::IsValidValue(
         return false;
     if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
         return false;
-    // this constraint is enforced to avoid grp_tile1 becoming zero in GetSolutionImpl method
+    // this constraint is enforced to avoid grp_tile1 becoming zero in GetSolution
     if(local_size1 / out_pix_tile1 < 1)
         return false;
     return true;

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -31,6 +31,7 @@
 #include <miopen/pooling.hpp>
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/mlo_internal.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
 
 namespace miopen {
 
@@ -51,7 +52,9 @@ struct kernel_params
     int out_pix_tile0;
     int out_pix_tile1;
 
-    kernel_params(const miopen::pooling::ProblemDescription& p)
+    kernel_params(const miopen::pooling::ProblemDescription& p,
+                  const std::optional<PerformanceConfigPooling2d<OperationType::Forward>>& config =
+                      std::nullopt)
     {
         const auto& pd  = p.GetPooling();
         const auto& yd  = p.GetYDesc();
@@ -62,11 +65,18 @@ struct kernel_params
         out_height      = yd.GetLengths()[2];
         out_width       = yd.GetLengths()[3];
         out_pix_tile0   = 1;
-        out_pix_tile1   = out_height <= 8    ? 1 //
-                          : out_height <= 32 ? 4 //
-                                             : 8;
-        if(out_height > 16 && out_height % 32 > 16)
-            out_pix_tile1 = std::min(16, std::max(1, prePow2(out_pix_tile1 * kernel_stride_h)));
+        if(config)
+        {
+            out_pix_tile1 = config->out_pix_tile1;
+        }
+        else
+        {
+            out_pix_tile1 = out_height <= 8    ? 1 //
+                            : out_height <= 32 ? 4 //
+                                               : 8;
+            if(out_height > 16 && out_height % 32 > 16)
+                out_pix_tile1 = std::min(16, std::max(1, prePow2(out_pix_tile1 * kernel_stride_h)));
+        }
     }
 };
 
@@ -112,7 +122,11 @@ std::size_t sizeof_private_memory(const miopen::pooling::ProblemDescription& pro
     const auto& MLO_POOLING_KERNEL_SZ0      = kp.kernel_size_w;
     const auto& MLO_POOLING_STRIDE0         = kp.kernel_stride_w;
     const auto& MLO_POOLING_N_HORIZ_OUT_PIX = kp.out_pix_tile0;
-    const auto& MLO_POOLING_N_VERT_OUT_PIX  = kp.out_pix_tile1;
+    // safer estimate of memory with max_out_pix_tile1
+    assert(kp.out_pix_tile1 <=
+           PerformanceConfigPooling2d<OperationType::Forward>::max_out_pix_tile1);
+    const auto& MLO_POOLING_N_VERT_OUT_PIX =
+        PerformanceConfigPooling2d<OperationType::Forward>::max_out_pix_tile1;
 
     const auto MLO_BOT_DATA_SZ0 =
         (static_cast<std::size_t>(MLO_POOLING_N_HORIZ_OUT_PIX) - 1) * MLO_POOLING_STRIDE0 +
@@ -150,8 +164,10 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
                TargetProperties::GetMaxWaveScratchSize() / context.GetStream().GetWavefrontWidth();
 }
 
-ConvSolution PoolingForward2d::GetSolution(const ExecutionContext&,
-                                           const miopen::pooling::ProblemDescription& problem) const
+ConvSolution PoolingForward2d::GetSolutionImpl(
+    const ExecutionContext&,
+    const miopen::pooling::ProblemDescription& problem,
+    const std::optional<PerformanceConfigPooling2d<OperationType::Forward>>& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -161,7 +177,7 @@ ConvSolution PoolingForward2d::GetSolution(const ExecutionContext&,
         kernel.kernel_file = "MIOpenPooling.cpp";
         kernel.kernel_name = "mloPoolingG";
 
-        const kernel_params kp(problem);
+        const kernel_params kp(problem, config);
 
         int batch_sz, n_outputs;
         std::tie(batch_sz, n_outputs, std::ignore, std::ignore) =
@@ -170,12 +186,21 @@ ConvSolution PoolingForward2d::GetSolution(const ExecutionContext&,
         const auto& pool_d   = problem.GetPooling();
         const auto wsp_index = pool_d.GetWorkspaceIndexMode();
 
-        int grp_tile0 = kp.out_width <= 8 ? 8 : (kp.out_width % 32 <= 16 ? 16 : 32);
-        int grp_tile1 = kp.out_height <= 8    ? 8
+        int grp_tile0, grp_tile1;
+        if(config)
+        {
+            grp_tile0 = config->local_size0;
+            grp_tile1 = config->local_size1;
+        }
+        else
+        {
+            grp_tile0 = kp.out_width <= 8 ? 8 : (kp.out_width % 32 <= 16 ? 16 : 32);
+            grp_tile1 = kp.out_height <= 8    ? 8
                         : kp.out_height < 16  ? 16
                         : kp.out_height <= 32 ? 32
                         : kp.out_height <= 64 ? 64
                                               : 128;
+        }
         grp_tile1 /= kp.out_pix_tile1;
         while(grp_tile0 * grp_tile1 > 256 && grp_tile0 > 1)
             grp_tile0 >>= 1;
@@ -261,6 +286,22 @@ PoolingForward2d::GetWorkspaceSize(const ExecutionContext&,
     if(problem.GetPooling().GetMode() != miopenPoolingMax)
         return 0;
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
+}
+
+bool PoolingForward2d::IsValidPerformanceConfig(
+    const ExecutionContext& context,
+    const miopen::pooling::ProblemDescription& problem,
+    const PerformanceConfigPooling2d<OperationType::Forward>& config) const
+{
+    return config.IsValid(context, problem);
+}
+
+PerformanceConfigPooling2d<OperationType::Forward> PoolingForward2d::GetDefaultPerformanceConfig(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+    PerformanceConfigPooling2d<OperationType::Forward> config;
+    config.HeuristicInit(problem);
+    return config;
 }
 
 } // namespace pooling

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -53,8 +53,7 @@ struct kernel_params
     int out_pix_tile1;
 
     kernel_params(const miopen::pooling::ProblemDescription& p,
-                  const std::optional<PerformanceConfigPooling2d<OperationType::Forward>>& config =
-                      std::nullopt)
+                  const std::optional<PerformanceConfigPooling2dForward>& config = std::nullopt)
     {
         const auto& pd  = p.GetPooling();
         const auto& yd  = p.GetYDesc();
@@ -71,8 +70,11 @@ struct kernel_params
         }
         else
         {
-            // set to max value for safer memory estimations
-            out_pix_tile1 = PerformanceConfigPooling2d<OperationType::Forward>::max_out_pix_tile1;
+            out_pix_tile1 = out_height <= 8    ? 1 //
+                            : out_height <= 32 ? 4 //
+                                               : 8;
+            if(out_height > 16 && out_height % 32 > 16)
+                out_pix_tile1 = std::min(16, std::max(1, prePow2(out_pix_tile1 * kernel_stride_h)));
         }
     }
 };
@@ -119,7 +121,9 @@ std::size_t sizeof_private_memory(const miopen::pooling::ProblemDescription& pro
     const auto& MLO_POOLING_KERNEL_SZ0      = kp.kernel_size_w;
     const auto& MLO_POOLING_STRIDE0         = kp.kernel_stride_w;
     const auto& MLO_POOLING_N_HORIZ_OUT_PIX = kp.out_pix_tile0;
-    const auto& MLO_POOLING_N_VERT_OUT_PIX  = kp.out_pix_tile1;
+    // safer estimate of memory with max_out_pix_tile1
+    assert(kp.out_pix_tile1 <= PerformanceConfigPooling2dForward::max_out_pix_tile1);
+    const auto& MLO_POOLING_N_VERT_OUT_PIX = PerformanceConfigPooling2dForward::max_out_pix_tile1;
 
     const auto MLO_BOT_DATA_SZ0 =
         (static_cast<std::size_t>(MLO_POOLING_N_HORIZ_OUT_PIX) - 1) * MLO_POOLING_STRIDE0 +
@@ -160,7 +164,7 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
 ConvSolution PoolingForward2d::GetSolutionImpl(
     const ExecutionContext&,
     const miopen::pooling::ProblemDescription& problem,
-    const std::optional<PerformanceConfigPooling2d<OperationType::Forward>>& config) const
+    const std::optional<PerformanceConfigPooling2dForward>& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -272,6 +276,21 @@ ConvSolution PoolingForward2d::GetSolutionImpl(
     return result;
 }
 
+bool PerformanceConfigPooling2dForward::IsValidValue(
+    const miopen::pooling::ProblemDescription&) const
+{
+    if(!IsTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+        return false;
+    if(!IsTwoPower<min_local_size0, max_local_size0>(local_size0))
+        return false;
+    if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
+        return false;
+    // this constraint is enforced to avoid grp_tile1 becoming zero in GetSolutionImpl method
+    if(local_size1 / out_pix_tile1 < 1)
+        return false;
+    return true;
+}
+
 std::size_t
 PoolingForward2d::GetWorkspaceSize(const ExecutionContext&,
                                    const miopen::pooling::ProblemDescription& problem) const
@@ -284,15 +303,15 @@ PoolingForward2d::GetWorkspaceSize(const ExecutionContext&,
 bool PoolingForward2d::IsValidPerformanceConfig(
     const ExecutionContext& context,
     const miopen::pooling::ProblemDescription& problem,
-    const PerformanceConfigPooling2d<OperationType::Forward>& config) const
+    const PerformanceConfigPooling2dForward& config) const
 {
     return config.IsValid(context, problem);
 }
 
-PerformanceConfigPooling2d<OperationType::Forward> PoolingForward2d::GetDefaultPerformanceConfig(
+PerformanceConfigPooling2dForward PoolingForward2d::GetDefaultPerformanceConfig(
     const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
 {
-    PerformanceConfigPooling2d<OperationType::Forward> config;
+    PerformanceConfigPooling2dForward config;
     config.HeuristicInit(problem);
     return config;
 }

--- a/projects/miopen/src/solver/pooling/forward2d.cpp
+++ b/projects/miopen/src/solver/pooling/forward2d.cpp
@@ -161,10 +161,10 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
                TargetProperties::GetMaxWaveScratchSize() / context.GetStream().GetWavefrontWidth();
 }
 
-ConvSolution PoolingForward2d::GetSolutionImpl(
+ConvSolution PoolingForward2d::GetSolution(
     const ExecutionContext&,
     const miopen::pooling::ProblemDescription& problem,
-    const std::optional<PerformanceConfigPooling2dForward>& config) const
+    const PerformanceConfigPooling2d<OperationType::Forward>& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -183,21 +183,8 @@ ConvSolution PoolingForward2d::GetSolutionImpl(
         const auto& pool_d   = problem.GetPooling();
         const auto wsp_index = pool_d.GetWorkspaceIndexMode();
 
-        int grp_tile0, grp_tile1;
-        if(config)
-        {
-            grp_tile0 = config->local_size0;
-            grp_tile1 = config->local_size1;
-        }
-        else
-        {
-            grp_tile0 = kp.out_width <= 8 ? 8 : (kp.out_width % 32 <= 16 ? 16 : 32);
-            grp_tile1 = kp.out_height <= 8    ? 8
-                        : kp.out_height < 16  ? 16
-                        : kp.out_height <= 32 ? 32
-                        : kp.out_height <= 64 ? 64
-                                              : 128;
-        }
+        int grp_tile0 = config.local_size0;
+        int grp_tile1 = config.local_size1;
         grp_tile1 /= kp.out_pix_tile1;
         while(grp_tile0 * grp_tile1 > 256 && grp_tile0 > 1)
             grp_tile0 >>= 1;

--- a/projects/miopen/src/solver/pooling/forwardNaive.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNaive.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -222,7 +222,7 @@ PoolingForwardNaive::GetSolution(const ExecutionContext& context,
     work_left /= w0;
     w1 = (g1 < work_left) ? g1 : work_left;
     work_left /= w1;
-    w2 = (g2 < work_left) ? g2 : work_left;
+    w2                     = (g2 < work_left) ? g2 : work_left;
 #endif
 
     {
@@ -341,8 +341,7 @@ void PerformanceConfigPoolingForwardNaive::HeuristicInit(
 #endif
 }
 
-bool PerformanceConfigPoolingForwardNaive::SetNextValue(
-    const miopen::pooling::ProblemDescription&)
+bool PerformanceConfigPoolingForwardNaive::SetNextValue(const miopen::pooling::ProblemDescription&)
 {
 #if !MIOPEN_BACKEND_HIP
     return false;

--- a/projects/miopen/src/solver/pooling/forwardNaive.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNaive.cpp
@@ -94,7 +94,7 @@ bool PoolingForwardNaive::IsApplicable(const ExecutionContext&,
 }
 
 ConvSolution
-PoolingForwardNaive::GetSolution(const ExecutionContext& context,
+PoolingForwardNaive::GetSolution(const ExecutionContext&,
                                  const miopen::pooling::ProblemDescription& problem,
                                  const PerformanceConfigPoolingForwardNaive& config) const
 {

--- a/projects/miopen/src/solver/pooling/forwardNaive.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNaive.cpp
@@ -30,6 +30,7 @@
 #include <miopen/pooling.hpp>
 #include <miopen/pooling/invoke_params.hpp>
 #include <miopen/pooling/solvers.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
 
 #define WORKAROUND_ISSUE_MIFIN_80 1 // https://github.com/ROCm/MIFin/issues/80
 
@@ -49,6 +50,7 @@ bool IsPower2(T v)
 }
 #endif
 
+#if !WORKAROUND_ISSUE_MIFIN_80
 template <typename T>
 T RoundUpNearestPower2Positive(T v) = delete;
 
@@ -63,6 +65,7 @@ inline uint32_t RoundUpNearestPower2Positive(uint32_t v)
     v |= v >> 16;
     return std::max(++v, 1U); // Shut clang-tidy.
 }
+#endif
 
 } // namespace
 
@@ -92,7 +95,8 @@ bool PoolingForwardNaive::IsApplicable(const ExecutionContext&,
 
 ConvSolution
 PoolingForwardNaive::GetSolution(const ExecutionContext& context,
-                                 const miopen::pooling::ProblemDescription& problem) const
+                                 const miopen::pooling::ProblemDescription& problem,
+                                 const PerformanceConfigPoolingForwardNaive& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -189,25 +193,37 @@ PoolingForwardNaive::GetSolution(const ExecutionContext& context,
     /// The workgroup size does not have the restrictions imposed by synchronization between
     /// workitems because the kernel does not require synchronization.
 
-#if WORKAROUND_ISSUE_MIFIN_80
-    const uint32_t wavesize = 64;
-    std::ignore             = context;
-#else
+#if !WORKAROUND_ISSUE_MIFIN_80
     const auto wavesize = static_cast<uint32_t>(context.GetStream().GetWavefrontWidth());
+#if !MIOPEN_NDEBUG
     assert(IsPower2(wavesize));
+#endif
 #endif
 
     const auto is2d_kernel = (top_d == 1); // For 2D + optimize for 3D where the 1st dim is 1.
-    const auto g0          = RoundUpNearestPower2Positive(all_n);
-    const auto g1          = RoundUpNearestPower2Positive(all_c);
-    const auto g2          = RoundUpNearestPower2Positive(is2d_kernel ? top_h : top_d);
+    uint32_t g0, g1, g2, w0, w1, w2;
+#if WORKAROUND_ISSUE_MIFIN_80
+    w0 = static_cast<uint32_t>(config.local_size0);
+    w1 = static_cast<uint32_t>(config.local_size1);
+    w2 = static_cast<uint32_t>(config.local_size2);
 
+    // compute global sizes from local sizes
+    g0 = ((all_n + w0 - 1) / w0) * w0;
+    g1 = ((all_c + w1 - 1) / w1) * w1;
+    g2 = (((is2d_kernel ? top_h : top_d) + w2 - 1) / w2) * w2;
+#else
+    g0 = RoundUpNearestPower2Positive(all_n);
+    g1 = RoundUpNearestPower2Positive(all_c);
+    g2 = RoundUpNearestPower2Positive(is2d_kernel ? top_h : top_d);
+
+    // determine w0, w1, w2 such that w0 * w1 * w2 == wavesize
     auto work_left = wavesize / 1;
-    const auto w0  = (g0 < work_left) ? g0 : work_left;
+    w0             = (g0 < work_left) ? g0 : work_left;
     work_left /= w0;
-    const auto w1 = (g1 < work_left) ? g1 : work_left;
+    w1 = (g1 < work_left) ? g1 : work_left;
     work_left /= w1;
-    const auto w2 = (g2 < work_left) ? g2 : work_left;
+    w2 = (g2 < work_left) ? g2 : work_left;
+#endif
 
     {
         auto kernel = KernelInfo{};
@@ -295,6 +311,122 @@ PoolingForwardNaive::GetWorkspaceSize(const ExecutionContext&,
     if(problem.GetPooling().GetMode() != miopenPoolingMax || !problem.SaveIndex())
         return 0;
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
+}
+
+void PerformanceConfigPoolingForwardNaive::Init(const miopen::pooling::ProblemDescription&)
+{
+    // initialize with minimum values
+    local_size0 = 1;
+    local_size1 = 1;
+    local_size2 = 1;
+}
+
+void PerformanceConfigPoolingForwardNaive::HeuristicInit(
+    [[maybe_unused]] const miopen::pooling::ProblemDescription& problem)
+{
+#if MIOPEN_BACKEND_HIP
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat: Init(problem); break;
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+#endif
+}
+
+bool PerformanceConfigPoolingForwardNaive::SetNextValue(
+    const miopen::pooling::ProblemDescription&)
+{
+#if !MIOPEN_BACKEND_HIP
+    return false;
+#else
+#if WORKAROUND_ISSUE_MIFIN_80
+    constexpr int wavesize = 64;
+    if(!NextTwoPower<1, wavesize>(local_size0))
+        return true;
+    if(!NextTwoPower<1, wavesize>(local_size1))
+        return true;
+    if(!NextTwoPower<1, wavesize>(local_size2))
+        return true;
+    return false;
+#else
+    return false;
+#endif
+#endif
+}
+
+bool PerformanceConfigPoolingForwardNaive::IsValidValue() const
+{
+#if WORKAROUND_ISSUE_MIFIN_80
+    constexpr int wavesize = 64;
+    if(!IsTwoPower<1, wavesize>(local_size0))
+        return false;
+    if(!IsTwoPower<1, wavesize>(local_size1))
+        return false;
+    if(!IsTwoPower<1, wavesize>(local_size2))
+        return false;
+    // block size must be equal to wavesize
+    if(local_size0 * local_size1 * local_size2 != wavesize)
+        return false;
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool PerformanceConfigPoolingForwardNaive::IsValid(
+    const ExecutionContext&,
+    [[maybe_unused]] const miopen::pooling::ProblemDescription& problem) const
+{
+#if !MIOPEN_BACKEND_HIP
+    return false;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat:
+        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+    return false;
+#endif
+}
+
+bool PerformanceConfigPoolingForwardNaive::operator==(
+    const PerformanceConfigPoolingForwardNaive& other) const
+{
+    return local_size0 == other.local_size0 && local_size1 == other.local_size1 &&
+           local_size2 == other.local_size2;
+}
+
+bool PoolingForwardNaive::IsValidPerformanceConfig(
+    const ExecutionContext& context,
+    const miopen::pooling::ProblemDescription& problem,
+    const PerformanceConfigPoolingForwardNaive& config) const
+{
+    return config.IsValid(context, problem);
+}
+
+PerformanceConfigPoolingForwardNaive PoolingForwardNaive::GetDefaultPerformanceConfig(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+    PerformanceConfigPoolingForwardNaive config;
+    config.HeuristicInit(problem);
+    return config;
 }
 
 } // namespace pooling

--- a/projects/miopen/src/solver/pooling/forwardNaive.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNaive.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/datatype.hpp>
 #include <miopen/kernel_build_params.hpp>

--- a/projects/miopen/src/solver/pooling/forwardNaive.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNaive.cpp
@@ -305,8 +305,8 @@ void PerformanceConfigPoolingForwardNaive::HeuristicInit(
     switch(problem.GetXDesc().GetType())
     {
     case miopenHalf:
-    case miopenFloat: Init(problem); break;
-    case miopenBFloat16:
+    case miopenFloat:
+    case miopenBFloat16: Init(problem); break;
     case miopenDouble:
     case miopenFloat8_fnuz:
     case miopenBFloat8_fnuz:
@@ -368,8 +368,7 @@ bool PerformanceConfigPoolingForwardNaive::IsValid(
     {
     case miopenHalf:
     case miopenFloat:
-        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
-    case miopenBFloat16:
+    case miopenBFloat16: return IsValidValue();
     case miopenDouble:
     case miopenFloat8_fnuz:
     case miopenBFloat8_fnuz:

--- a/projects/miopen/src/solver/pooling/forwardNd.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNd.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/pooling/solvers.hpp>
 

--- a/projects/miopen/src/solver/pooling/forwardNd.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNd.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -89,14 +89,11 @@ std::size_t sizeof_private_memory(const miopen::pooling::ProblemDescription& pro
 
     // safer estimate of memory with max_pix_per_work
     const std::size_t bot_tile_w =
-        ((PerformanceConfigPoolingNdForward::max_pix_per_work - 1) * kp.stride_w +
-         kp.kernel_sz_w);
+        ((PerformanceConfigPoolingNdForward::max_pix_per_work - 1) * kp.stride_w + kp.kernel_sz_w);
     const std::size_t bot_tile_h =
-        ((PerformanceConfigPoolingNdForward::max_pix_per_work - 1) * kp.stride_h +
-         kp.kernel_sz_h);
+        ((PerformanceConfigPoolingNdForward::max_pix_per_work - 1) * kp.stride_h + kp.kernel_sz_h);
     const std::size_t bot_tile_d =
-        ((PerformanceConfigPoolingNdForward::max_pix_per_work - 1) * kp.stride_d +
-         kp.kernel_sz_d);
+        ((PerformanceConfigPoolingNdForward::max_pix_per_work - 1) * kp.stride_d + kp.kernel_sz_d);
 
     const auto sizeof_bot_data =
         sizeof_kernel_FLOAT(problem) * bot_tile_d * bot_tile_h * bot_tile_w;
@@ -267,8 +264,7 @@ PoolingForwardNd::GetWorkspaceSize(const ExecutionContext&,
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
 }
 
-bool PerformanceConfigPoolingNdForward::SetNextValue(
-    const miopen::pooling::ProblemDescription&)
+bool PerformanceConfigPoolingNdForward::SetNextValue(const miopen::pooling::ProblemDescription&)
 {
 #if !MIOPEN_BACKEND_HIP
     return false;

--- a/projects/miopen/src/solver/pooling/forwardNd.cpp
+++ b/projects/miopen/src/solver/pooling/forwardNd.cpp
@@ -31,6 +31,7 @@
 #include <miopen/pooling.hpp>
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/mlo_internal.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
 
 namespace miopen {
 
@@ -39,10 +40,6 @@ namespace solver {
 namespace pooling {
 
 namespace {
-
-constexpr int top_w_per_work = 1;
-constexpr int top_h_per_work = 4;
-constexpr int top_d_per_work = 2;
 
 struct kernel_params
 {
@@ -90,9 +87,16 @@ std::size_t sizeof_private_memory(const miopen::pooling::ProblemDescription& pro
 {
     const kernel_params kp(problem);
 
-    const std::size_t bot_tile_w = ((top_w_per_work - 1) * kp.stride_w + kp.kernel_sz_w);
-    const std::size_t bot_tile_h = ((top_h_per_work - 1) * kp.stride_h + kp.kernel_sz_h);
-    const std::size_t bot_tile_d = ((top_d_per_work - 1) * kp.stride_d + kp.kernel_sz_d);
+    // safer estimate of memory with max_pix_per_work
+    const std::size_t bot_tile_w =
+        ((PerformanceConfigPoolingNdForward::max_pix_per_work - 1) * kp.stride_w +
+         kp.kernel_sz_w);
+    const std::size_t bot_tile_h =
+        ((PerformanceConfigPoolingNdForward::max_pix_per_work - 1) * kp.stride_h +
+         kp.kernel_sz_h);
+    const std::size_t bot_tile_d =
+        ((PerformanceConfigPoolingNdForward::max_pix_per_work - 1) * kp.stride_d +
+         kp.kernel_sz_d);
 
     const auto sizeof_bot_data =
         sizeof_kernel_FLOAT(problem) * bot_tile_d * bot_tile_h * bot_tile_w;
@@ -130,7 +134,8 @@ bool PoolingForwardNd::IsApplicable(const ExecutionContext& context,
 }
 
 ConvSolution PoolingForwardNd::GetSolution(const ExecutionContext&,
-                                           const miopen::pooling::ProblemDescription& problem) const
+                                           const miopen::pooling::ProblemDescription& problem,
+                                           const PerformanceConfigPoolingNdForward& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -142,6 +147,10 @@ ConvSolution PoolingForwardNd::GetSolution(const ExecutionContext&,
     const int top_d = *(problem.GetYDesc().GetLengths().rbegin() + 2);
     const int top_h = *(problem.GetYDesc().GetLengths().rbegin() + 1);
     const int top_w = *(problem.GetYDesc().GetLengths().rbegin());
+
+    const int top_w_per_work = config.pix_w_per_work;
+    const int top_h_per_work = config.pix_h_per_work;
+    const int top_d_per_work = config.pix_d_per_work;
 
     const int top_blk_w = std::max((top_w + top_w_per_work - 1) / top_w_per_work, 1);
     const int top_blk_h = std::max((top_h + top_h_per_work - 1) / top_h_per_work, 1);
@@ -163,7 +172,7 @@ ConvSolution PoolingForwardNd::GetSolution(const ExecutionContext&,
                                         ? MLO_POOLING_OP_AVE
                                         : MLO_POOLING_OP_AVE_INCLUSIVE);
 
-        const size_t lcl_work = 64;
+        const size_t lcl_work = config.local_size;
         const size_t grp_num  = (activ_work + lcl_work - 1) / lcl_work;
 
         auto build_params = KernelBuildParameters{
@@ -256,6 +265,53 @@ PoolingForwardNd::GetWorkspaceSize(const ExecutionContext&,
     if(problem.GetPooling().GetMode() != miopenPoolingMax)
         return 0;
     return problem.GetYDesc().GetElementSize() * get_data_size(problem.GetPooling().GetIndexType());
+}
+
+bool PerformanceConfigPoolingNdForward::SetNextValue(
+    const miopen::pooling::ProblemDescription&)
+{
+#if !MIOPEN_BACKEND_HIP
+    return false;
+#else
+    if(!NextTwoPower<min_pix_per_work, max_pix_per_work>(pix_w_per_work))
+        return true;
+    if(!NextTwoPower<min_pix_per_work, max_pix_per_work>(pix_h_per_work))
+        return true;
+    if(!NextTwoPower<min_pix_per_work, max_pix_per_work>(pix_d_per_work))
+        return true;
+    if(!NextTwoPower<1, 64>(local_size))
+        return true;
+    return false;
+#endif
+}
+
+bool PerformanceConfigPoolingNdForward::IsValidValue() const
+{
+    if(!IsTwoPower<min_pix_per_work, max_pix_per_work>(pix_w_per_work))
+        return false;
+    if(!IsTwoPower<min_pix_per_work, max_pix_per_work>(pix_h_per_work))
+        return false;
+    if(!IsTwoPower<min_pix_per_work, max_pix_per_work>(pix_d_per_work))
+        return false;
+    if(!IsTwoPower<1, 64>(local_size))
+        return false;
+    return true;
+}
+
+bool PoolingForwardNd::IsValidPerformanceConfig(
+    const ExecutionContext& context,
+    const miopen::pooling::ProblemDescription& problem,
+    const PerformanceConfigPoolingNdForward& config) const
+{
+    return config.IsValid(context, problem);
+}
+
+PerformanceConfigPoolingNdForward PoolingForwardNd::GetDefaultPerformanceConfig(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+    PerformanceConfigPoolingNdForward config;
+    config.HeuristicInit(problem);
+    return config;
 }
 
 } // namespace pooling

--- a/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
+++ b/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
@@ -45,8 +45,7 @@ void PerformanceConfigPooling2d<OpType>::HeuristicInit(
 }
 
 template <OperationType OpType>
-bool PerformanceConfigPooling2d<OpType>::SetNextValue(
-    const miopen::pooling::ProblemDescription&)
+bool PerformanceConfigPooling2d<OpType>::SetNextValue(const miopen::pooling::ProblemDescription&)
 {
 #if !MIOPEN_BACKEND_HIP
     return false;

--- a/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
+++ b/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
@@ -23,11 +23,9 @@ void PerformanceConfigPooling2d<OpType>::Init(const miopen::pooling::ProblemDesc
 
 template <OperationType OpType>
 void PerformanceConfigPooling2d<OpType>::HeuristicInit(
-    const miopen::pooling::ProblemDescription& problem)
+    [[maybe_unused]] const miopen::pooling::ProblemDescription& problem)
 {
-#if !MIOPEN_BACKEND_HIP
-    std::ignore = problem;
-#else
+#if MIOPEN_BACKEND_HIP
     switch(problem.GetXDesc().GetType())
     {
     case miopenHalf:
@@ -50,32 +48,28 @@ bool PerformanceConfigPooling2d<OpType>::SetNextValue(const miopen::pooling::Pro
 #if !MIOPEN_BACKEND_HIP
     return false;
 #else
-    do
+    if constexpr(OpType == OperationType::Backward)
     {
-        if constexpr(OpType == OperationType::Backward)
-        {
-            // tune out_pix_tile0 only for the backward solver
-            if(!NextTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
-                break;
-        }
-        if(!NextTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
-            break;
-        if(!NextTwoPower<min_local_size0, max_local_size0>(local_size0))
-            break;
-        if(!NextTwoPower<min_local_size1, max_local_size1>(local_size1))
-            break;
-        return false;
-    } while(false);
-    return true;
+        // tune out_pix_tile0 only for the backward solver
+        if(!NextTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
+            return true;
+    }
+    if(!NextTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+        return true;
+    if(!NextTwoPower<min_local_size0, max_local_size0>(local_size0))
+        return true;
+    if(!NextTwoPower<min_local_size1, max_local_size1>(local_size1))
+        return true;
+    return false;
 #endif
 }
 
 template <OperationType OpType>
 bool PerformanceConfigPooling2d<OpType>::IsValid(
-    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+    const ExecutionContext&,
+    [[maybe_unused]] const miopen::pooling::ProblemDescription& problem) const
 {
 #if !MIOPEN_BACKEND_HIP
-    std::ignore = problem;
     return false;
 #else
     switch(problem.GetXDesc().GetType())

--- a/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
+++ b/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
@@ -29,8 +29,8 @@ void PerformanceConfigPooling2d<OpType>::HeuristicInit(
     switch(problem.GetXDesc().GetType())
     {
     case miopenHalf:
-    case miopenFloat: Init(problem); break;
-    case miopenBFloat16:
+    case miopenFloat:
+    case miopenBFloat16: Init(problem); break;
     case miopenDouble:
     case miopenFloat8_fnuz:
     case miopenBFloat8_fnuz:
@@ -76,9 +76,7 @@ bool PerformanceConfigPooling2d<OpType>::IsValid(
     {
     case miopenHalf:
     case miopenFloat:
-        return IsValidValue(
-            problem); // perform further checks for problem & parameter set compatibility?
-    case miopenBFloat16:
+    case miopenBFloat16: return IsValidValue(problem);
     case miopenDouble:
     case miopenFloat8_fnuz:
     case miopenBFloat8_fnuz:

--- a/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
+++ b/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
@@ -1,0 +1,141 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <miopen/pooling/solvers.hpp>
+#include <miopen/mlo_internal.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
+
+namespace miopen {
+
+namespace solver {
+
+namespace pooling {
+
+template <OperationType OpType>
+void PerformanceConfigPooling2d<OpType>::Init(const miopen::pooling::ProblemDescription&)
+{
+    // initialize with minimum values
+    out_pix_tile0 = min_out_pix_tile0;
+    out_pix_tile1 = min_out_pix_tile1;
+    local_size0   = min_local_size0;
+    local_size1   = min_local_size1;
+}
+
+template <OperationType OpType>
+void PerformanceConfigPooling2d<OpType>::HeuristicInit(
+    const miopen::pooling::ProblemDescription& problem)
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat: Init(problem); break;
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+#endif
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPooling2d<OpType>::SetNextValue(
+    const miopen::pooling::ProblemDescription&)
+{
+#if !MIOPEN_BACKEND_HIP
+    return false;
+#else
+    do
+    {
+        if constexpr(OpType == OperationType::Backward)
+        {
+            // tune out_pix_tile0 only for the backward solver
+            if(!NextTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
+                break;
+        }
+        if(!NextTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+            break;
+        if(!NextTwoPower<min_local_size0, max_local_size0>(local_size0))
+            break;
+        if(!NextTwoPower<min_local_size1, max_local_size1>(local_size1))
+            break;
+        return false;
+    } while(false);
+    return true;
+#endif
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPooling2d<OpType>::IsValidValue() const
+{
+    if constexpr(OpType == OperationType::Backward)
+    {
+        // check out_pix_tile0 only for the backward solver
+        if(!IsTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
+            return false;
+    }
+    if(!IsTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
+        return false;
+    if(!IsTwoPower<min_local_size0, max_local_size0>(local_size0))
+        return false;
+    if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
+        return false;
+    if constexpr(OpType == OperationType::Forward)
+    {
+        // this constraint is enforced to avoid grp_tile1 becoming zero in GetSolutionImpl in the
+        // PoolingForward2d solver
+        if(local_size1 / out_pix_tile1 < 1)
+            return false;
+    }
+    return true;
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPooling2d<OpType>::IsValid(
+    const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+    return false;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat:
+        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+    return false;
+#endif
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPooling2d<OpType>::operator==(
+    const PerformanceConfigPooling2d<OpType>& other) const
+{
+    return out_pix_tile0 == other.out_pix_tile0 && out_pix_tile1 == other.out_pix_tile1 &&
+           local_size0 == other.local_size0 && local_size1 == other.local_size1;
+}
+
+// explicit template instantiations
+template struct PerformanceConfigPooling2d<OperationType::Forward>;
+template struct PerformanceConfigPooling2d<OperationType::Backward>;
+
+} // namespace pooling
+
+} // namespace solver
+
+} // namespace miopen

--- a/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
+++ b/projects/miopen/src/solver/pooling/performanceConfig2d.cpp
@@ -71,31 +71,6 @@ bool PerformanceConfigPooling2d<OpType>::SetNextValue(const miopen::pooling::Pro
 }
 
 template <OperationType OpType>
-bool PerformanceConfigPooling2d<OpType>::IsValidValue() const
-{
-    if constexpr(OpType == OperationType::Backward)
-    {
-        // check out_pix_tile0 only for the backward solver
-        if(!IsTwoPower<min_out_pix_tile0, max_out_pix_tile0>(out_pix_tile0))
-            return false;
-    }
-    if(!IsTwoPower<min_out_pix_tile1, max_out_pix_tile1>(out_pix_tile1))
-        return false;
-    if(!IsTwoPower<min_local_size0, max_local_size0>(local_size0))
-        return false;
-    if(!IsTwoPower<min_local_size1, max_local_size1>(local_size1))
-        return false;
-    if constexpr(OpType == OperationType::Forward)
-    {
-        // this constraint is enforced to avoid grp_tile1 becoming zero in GetSolutionImpl in the
-        // PoolingForward2d solver
-        if(local_size1 / out_pix_tile1 < 1)
-            return false;
-    }
-    return true;
-}
-
-template <OperationType OpType>
 bool PerformanceConfigPooling2d<OpType>::IsValid(
     const ExecutionContext&, const miopen::pooling::ProblemDescription& problem) const
 {
@@ -107,7 +82,8 @@ bool PerformanceConfigPooling2d<OpType>::IsValid(
     {
     case miopenHalf:
     case miopenFloat:
-        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
+        return IsValidValue(
+            problem); // perform further checks for problem & parameter set compatibility?
     case miopenBFloat16:
     case miopenDouble:
     case miopenFloat8_fnuz:

--- a/projects/miopen/src/solver/pooling/performanceConfigNd.cpp
+++ b/projects/miopen/src/solver/pooling/performanceConfigNd.cpp
@@ -29,8 +29,8 @@ void PerformanceConfigPoolingNd<OpType>::HeuristicInit(
     switch(problem.GetXDesc().GetType())
     {
     case miopenHalf:
-    case miopenFloat: Init(problem); break;
-    case miopenBFloat16:
+    case miopenFloat:
+    case miopenBFloat16: Init(problem); break;
     case miopenDouble:
     case miopenFloat8_fnuz:
     case miopenBFloat8_fnuz:
@@ -54,8 +54,7 @@ bool PerformanceConfigPoolingNd<OpType>::IsValid(
     {
     case miopenHalf:
     case miopenFloat:
-        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
-    case miopenBFloat16:
+    case miopenBFloat16: return IsValidValue();
     case miopenDouble:
     case miopenFloat8_fnuz:
     case miopenBFloat8_fnuz:

--- a/projects/miopen/src/solver/pooling/performanceConfigNd.cpp
+++ b/projects/miopen/src/solver/pooling/performanceConfigNd.cpp
@@ -1,0 +1,87 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <miopen/pooling/solvers.hpp>
+#include <miopen/mlo_internal.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
+
+namespace miopen {
+
+namespace solver {
+
+namespace pooling {
+
+template <OperationType OpType>
+void PerformanceConfigPoolingNd<OpType>::Init(const miopen::pooling::ProblemDescription&)
+{
+    // initialize with minimum values
+    pix_w_per_work = min_pix_per_work;
+    pix_h_per_work = min_pix_per_work;
+    pix_d_per_work = min_pix_per_work;
+    local_size     = 1;
+}
+
+template <OperationType OpType>
+void PerformanceConfigPoolingNd<OpType>::HeuristicInit(
+    [[maybe_unused]] const miopen::pooling::ProblemDescription& problem)
+{
+#if MIOPEN_BACKEND_HIP
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat: Init(problem); break;
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+#endif
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPoolingNd<OpType>::IsValid(
+    const ExecutionContext&,
+    [[maybe_unused]] const miopen::pooling::ProblemDescription& problem) const
+{
+#if !MIOPEN_BACKEND_HIP
+    return false;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat:
+        return IsValidValue(); // perform further checks for problem & parameter set compatibility?
+    case miopenBFloat16:
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+    return false;
+#endif
+}
+
+template <OperationType OpType>
+bool PerformanceConfigPoolingNd<OpType>::operator==(
+    const PerformanceConfigPoolingNd<OpType>& other) const
+{
+    return pix_w_per_work == other.pix_w_per_work && pix_h_per_work == other.pix_h_per_work &&
+           pix_d_per_work == other.pix_d_per_work && local_size == other.local_size;
+}
+
+// explict template instantiation
+template struct PerformanceConfigPoolingNd<OperationType::Forward>;
+template struct PerformanceConfigPoolingNd<OperationType::Backward>;
+
+} // namespace pooling
+
+} // namespace solver
+
+} // namespace miopen


### PR DESCRIPTION
## Motivation

This PR merges the complete tuning support for **all pooling solver variants** in MIOpen into the `develop` branch. This includes `2D`, `ND`, `ForwardNaive`, and transposed pooling solvers, completing the broader effort to make pooling solvers fully tunable. The implementation was developed and validated incrementally on a feature branch and is now ready to merge into `develop`.

## Technical Details

- Adds tuning infrastructure for **2D pooling**, **ND pooling**  and **PoolingForwardNaive** solvers.
- Integrates performance config classes for different pooling solver types.
- Ensures **transposed pooling** solvers correctly reuse tuning parameters from standard pooling solvers.
- Enables consistent tuning behavior across all pooling variants.

## Test Plan

- Ran tests for the pooling solvers through the `MIOpenDriver` to confirm correctness.
- Validated the tuning infrastructure works correctly through the output from the `MIOpenDriver` with `MIOPEN_LOG_LEVEL=6` and `MIOPEN_FIND_ENFORCE=4`.
- Compared the performance results before and after implementing tuning to determine whether tuning provides any improvement.

## Test Result

- All tests passed with the updated pooling solvers.
- The tuning process ran successfully without errors and generated valid parameters.
- The tunable solvers performed better than the untunable solvers with static parameters.

## Review History

The detailed implementation and internal reviews for this work can be found in the following PRs:

- https://github.com/ROCm/rocm-libraries/pull/2956  
- https://github.com/ROCm/rocm-libraries/pull/3285

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
